### PR TITLE
Use unhtml module to unescape HTML entities in console output.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1,4 +1,5 @@
 var markit = require('markit');
+var unhtml = require('unhtml');
 var colors = require('ansicolors');
 var styles = require('ansistyles');
 
@@ -48,8 +49,8 @@ exports.fromMarkdown = function(markdown) {
     var highlighted = code.replace(TOKEN_REGEX, highlightToken);
     return '    ' + colors.red(colors.bgBlack(highlighted)) + '';
   };
-  
-  return '\n' + markit(markdown, {renderer: r}) + '\n';
+
+  return '\n' + unhtml(markit(markdown, {renderer: r})) + '\n';
 
 };
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",
     "async": "~0.2.9",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "unhtml": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "~1.15.1",


### PR DESCRIPTION
Could be better to ensure that markit doesn't escape these entities in the first place, but this should save trying to navigate that codebase in the meantime.

Hope it helps! Cool project :)
