### PR TITLE
Adding compatibility with Node v0.8.x's os.tmpDir()

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,7 +5,7 @@ var async  = require('async');
 var mkdirp = require('mkdirp');
 var config  = require('./config');
 
-var FOLDER = path.join(os.tmpdir(), 'tldr-cache');
+var FOLDER = path.join((os.tmpdir) ? os.tmpdir() : os.tmpDir(), 'tldr-cache');
 
 exports.get = function(filename, done) {
   var filepath = path.join(FOLDER, filename);


### PR DESCRIPTION
Running 'tldr' with Node v0.8.21 reports: 

```
.../tldr/lib/cache.js:8
var FOLDER = path.join(os.tmpdir(), 'tldr-cache');
                          ^
TypeError: Object #<Object> has no method 'tmpdir'
```

This commit adds a check to call either tmpDir() or tmpdir() [renamed in Node v0.10.x].

tldr runs and passes tests with Node v0.8.21 with this commit.
