### PR TITLE
TypeError: Object #<Object> has no method 'tmpdir'

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,7 +5,7 @@ var async  = require('async');
 var mkdirp = require('mkdirp');
 var config  = require('./config');
 
-var FOLDER = path.join(os.tmpdir(), 'tldr-cache');
+var FOLDER = path.join(os.tmpdir ? os.tmpdir() : os.tmpDir(), 'tldr-cache');
 
 exports.get = function(filename, done) {
   var filepath = path.join(FOLDER, filename);


### PR DESCRIPTION
Fixed os.tmpdir for older version of node.

Thanks for the great project.
