### PR TITLE
Fix issue where common won't be required if os is detected

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,7 +4,6 @@ var os      = require('os');
 var async   = require('async');
 
 var osDirectories = {
-    common  : "common",
     darwin  : 'osx',
     linux   : 'linux'
 };
@@ -14,7 +13,7 @@ function path(command, platform) {
 }
 
 function getForPlatform(repository, command, platform, done) {
-  var pathCommon = path(command);
+  var pathCommon = path(command, "common");
   var pathPlatform = path(command, platform);
 
   async.parallel([


### PR DESCRIPTION
Erratum in last pull request #44
Must specify default platform "common" otherwise it will not be requested.
