### PR TITLE
svcs: add page (starts SmartOS/SunOS command reference)

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -5,7 +5,8 @@ var async   = require('async');
 
 var osDirectories = {
     darwin  : 'osx',
-    linux   : 'linux'
+    linux   : 'linux',
+    sunos   : 'sunos'
 };
 
 function path(command, platform) {

--- a/pages/sunos/svcs.md
+++ b/pages/sunos/svcs.md
@@ -1,0 +1,23 @@
+# svcs
+
+> List information about running services
+
+- list all running services
+
+`svcs`
+
+- list services that are not running
+
+`svcs -vx`
+
+- list information about a service
+
+`svcs apache`
+
+- show location of service log file
+
+`svcs -L apache`
+
+- display end of a service log file
+
+`tail $(svcs -L apache)`


### PR DESCRIPTION
Starting the SmartOS (sunos) command repository with one command.
