### PR TITLE
Improving scp page

### DIFF
--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -3,24 +3,18 @@
 > Copies files between hosts on a network
 > Works over a secure connection (SSH)
 
-- upload a file
+- upload a file, or upload and rename a file
 
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/}}`
-
-- upload a file and change its name
-
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/newname.txt}}`
-
-- upload a directory
-
-`scp -r {{/local/folder}} {{10.0.0.1}}:{{/remote/path/}}`
 
 - download a file
 
 `scp {{10.0.0.1}}:{{/remote/path/file.txt}} {{/local/folder}}`
 
-- download a directory
+- upload or download a directory
 
+`scp -r {{/local/folder}} {{10.0.0.1}}:{{/remote/path/}}`
 `scp -r {{10.0.0.1}}:{{/remote/path}} {{/local/folder}}`
 
 - specify username on host


### PR DESCRIPTION
In the spirit of making this even more clear to people unfamiliar with the CLI, I attempted to clarify the tl;drs for `scp`.
- Filenames now have an extension to make it especially clear they're not dealing with a directory (I know directories can have extensions and files don't need extensions, but generally this isn't understood as well as it should be)
- Made captions clearer
- Added syntax for copying a file from one host to another, I've needed to do this a few times and used to scp the file down to my local machine and scp it to the other host (the shame!). If you think this isn't a common use case, though, feel free to leave it out, as this file is getting a bit long.
