### PR TITLE
Remove notice about tldr not working on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ What about:
 
 ![tldr screenshot](http://raw.github.com/rprieto/tldr/master/screenshot.png)
 
-*Note:* sorry for now there are no Linux entries. Please come contribute [over here](https://github.com/rprieto/tldr/issues/21) if you have ideas how we can handle multiple platforms efficiently!
 
 # Installing
 


### PR DESCRIPTION
I've just tried tldr out on my laptop running Ubuntu and it works!

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 13.04
Release:    13.04
Codename:   raring

$ tldr curl

  Transfers data from or to a server
  Supports most protocols including HTTP, FTP, POP

  - send form-encoded data

    curl --data name=bob http://localhost/form

  - send JSON data

    curl -X POST -H "Content-Type: application/json" -d '{"name":"bob"}' http://localhost/login

  - specify an HTTP method

    curl -X DELETE http://localhost/item/123

  - head request

    curl --head http://localhost
```

Let's not make Linux users sad by leaving them out of this awesome tool!  :-)
