### PR TITLE
pbcopy, pbpaste: add pages

### DIFF
--- a/pages/osx/pbcopy.md
+++ b/pages/osx/pbcopy.md
@@ -1,7 +1,6 @@
 # pbcopy
 
 > Place standard output in the clipboard
-> (OS X only)
 
 - Place the contents of a file in the clipboard.
 

--- a/pages/osx/pbpaste.md
+++ b/pages/osx/pbpaste.md
@@ -1,7 +1,6 @@
 # pbpaste
 
 > Send the contents of the clipboard to standard output
-> (OS X only)
 
 - Write the contents of the clipboard to a file.
 


### PR DESCRIPTION
Two pages for a couple of useful OS X-specific commands: pbcopy and pbpaste
