### PR TITLE
use console instead of deprecated util.puts/error

### DIFF
--- a/lib/tldr.js
+++ b/lib/tldr.js
@@ -1,14 +1,13 @@
-var util     = require('util');
 var resolver = require('./resolver');
 var output   = require('./output');
 
 exports.get = function(command, options) {
   resolver.get(command, options, function(err, body) {
     if (err) {
-      util.error('ERROR: ' + err);
+      console.error('ERROR: ' + err);
       process.exit(1);
     } else {
-      util.puts(output.fromMarkdown(body));
+      console.log(output.fromMarkdown(body));
     }
   });
 };


### PR DESCRIPTION
in node  0.11.x and up `util.print`, `util.puts` and `util.error` are deprecated, so I switched them to native console instead which does have the exact behavior as far as I know.

Otherwise I always get `util.puts: Use console.log instead` when i launch tldr.
