### PR TITLE
Remove tldr keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/rprieto/tldr.git"
   },
   "keywords": [
-    "tldr",
     "man",
     "unix",
     "commands"


### PR DESCRIPTION
npm will find project by name anyway.
