### PR TITLE
journalctl: add page

### DIFF
--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -1,0 +1,27 @@
+# journalctl
+
+> Query the systemd journal
+
+- Show all messages from this boot
+
+`journalctl -b`
+
+- Show all messages from last boot
+
+`journalctl -b -1`
+
+- Follow new messages (like `tail -f` for traditional syslog)
+
+`journalctl -f`
+
+- Show all messages by a specific unit
+
+`journalctl -u {{unit}}`
+
+- Show all messages by a specific process
+
+`journalctl _PID={{pid}}`
+
+- Show all messages by a specific executable
+
+`journalctl {{/path/to/executable}}`


### PR DESCRIPTION
The command line interface to query systemd journal, for multiple linux distributions.
