### PR TITLE
ip: add page

### DIFF
--- a/pages/linux/ip.md
+++ b/pages/linux/ip.md
@@ -16,7 +16,7 @@
 
 - Add/Delete an ip address to an interface
 
-`ip addr add {{ip}}/{{mask}} dev {{interface}}`
+`ip addr add/del {{ip}}/{{mask}} dev {{interface}}`
 
 - Add an default route
 


### PR DESCRIPTION
`ip` command of the iproute2 toolset.

Only listed the most basic usages, enough for set up a static interface manually.
