### PR TITLE
ss: add page

### DIFF
--- a/pages/linux/ss.md
+++ b/pages/linux/ss.md
@@ -6,13 +6,21 @@
 
 `ss -a {{-t/-u/-w/-x}}`
 
+- Show process(es) that using socket
+
+`ss -p`
+
 - Filter TCP sockets by states, only/exclude
 
 `ss {{state/exclude}} {{bucket/big/connected/synchronized/...}}`
 
 - Filter sockets by address and/or port
 
-`ss {{dst/src/dport/sport}} {{==/!=/>/</...}} {{prefix:port/unix:STRING/:port/...}}`
+`ss -t dst 1.2.3.4:80`
+`ss -u src 127/8`
+`ss -t 'dport >= :1024'`
+`ss -x "src /tmp/.X11-unix/*"`
+`ss -t state established '( dport = :ssh or sport = :ssh )'`
 
 - Only list IPv4 or IPv6 sockets
 


### PR DESCRIPTION
An alternative tool in the iproute2 toolset, to replace the functionality of netstat (deprecated). For multiple distributions.
