### PR TITLE
Sort options for creating archives the way they are sorted for extracting archives

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -9,7 +9,7 @@
 
 - create a gzipped archive
 
-`tar cfz {{target.tar.gz}} {{file1 file2 file3}}`
+`tar czf {{target.tar.gz}} {{file1 file2 file3}}`
 
 - extract an archive in a target folder
 


### PR DESCRIPTION
It's better to sort options the same way for all examples. Since we have `tar xzf` we should also have `tar czf` and not `tar cfz` 
