### PR TITLE
redis-cli: add page

### DIFF
--- a/pages/common/redis-cli.md
+++ b/pages/common/redis-cli.md
@@ -14,3 +14,7 @@
 - Specify a password
 
 `redis-cli -a {{password}}`
+
+- Executes Redis command
+
+`redis-cli {{redis command}}`


### PR DESCRIPTION
I needed to use redis-cli today and found out it didn't have any entries on TLDR. I added it to common since it's common for both OS X and Linux.
