### PR TITLE
Improved tail.md

### DIFF
--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -6,6 +6,10 @@
 
 `tail -n {{num}} {{file}}`
 
+- show all file since line 'num'
+
+`tail -n +{{num}} {{file}}`
+
 - show last 'num' bytes in file
 
 `tail -c {{num}} {{file}}`


### PR DESCRIPTION
Added a new example to get a file since line `n` which I think is critical to anyone who wants to chunk a csv or another big file from terminal.

```
tail -n +2 file
```

To skip the first line
