### PR TITLE
Expand git-diff page

### DIFF
--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -5,3 +5,11 @@
 - Show changes to tracked files
 
 `git diff {{PATHSPEC}}`
+
+- Show only names of changed files.
+
+`git diff --names-only {{PATHSPEC}}`
+
+- Output a condensed summary of extended header information.
+
+`git diff --summary {{PATHSPEC}}`


### PR DESCRIPTION
Added:
- `—names-only` option.
- `—summary` option.
