### PR TITLE
tree: add page

### DIFF
--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -1,0 +1,19 @@
+# tree
+
+> Show the contents of the current directory as a tree.
+
+- Show files and directories with a depth of 'num'
+
+`tree -L {{num}}`
+
+- Show directories only
+
+`tree -d`
+
+- Show hidden files too
+
+`tree -a`
+
+- Print human readable size of files
+
+`tree -h`


### PR DESCRIPTION
`tree` can be installed on both Mac and Linux, but is not standard on a mac. I guess it still goes in 'common' though?

Maybe not the most used of commands, but it is great for demonstrations and visualisations.
