### PR TITLE
Added example which displays the size in a human readable format.

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -14,6 +14,10 @@
 
 `ls -ls`
 
+- List all files and display the file size in a human readable format
+
+`ls -lh`
+
 - List all files with a prefix/suffix
 
 `ls {{prefix}}*`


### PR DESCRIPTION
Added the `-h` flag to the listing example, which will display the file size in a human readable format.
