### PR TITLE
sha1sum, sha224sum, sha256sum, sha384sum, sha512sum: add pages

### DIFF
--- a/pages/linux/sha1sum.md
+++ b/pages/linux/sha1sum.md
@@ -1,0 +1,13 @@
+# sha1sum
+
+> Calculate SHA1 cryptographic checksums
+
+- Calculate the SHA1 checksum for file(s) or files in a directory, one checksum per file
+
+`sha1sum {{filename1}}`
+`sha1sum {{filename1}} {{filename2}}`
+`sha1sum {{directory/\*}}`
+
+- Read a file of SHA1 sums and verify all files have matching checksums
+
+`sha1sum -c {{filename.sha1}}`

--- a/pages/linux/sha224sum.md
+++ b/pages/linux/sha224sum.md
@@ -1,0 +1,13 @@
+# sha224sum
+
+> Calculate SHA224 cryptographic checksums
+
+- Calculate the SHA224 checksum for file(s) or files in a directory, one checksum per file
+
+`sha224sum {{filename1}}`
+`sha224sum {{filename1}} {{filename2}}`
+`sha224sum {{directory/\*}}`
+
+- Read a file of SHA224 sums and verify all files have matching checksums
+
+`sha224sum -c {{filename.sha224}}`

--- a/pages/linux/sha256sum.md
+++ b/pages/linux/sha256sum.md
@@ -1,0 +1,13 @@
+# sha256sum
+
+> Calculate SHA256 cryptographic checksums
+
+- Calculate the SHA256 checksum for file(s) or files in a directory, one checksum per file
+
+`sha256sum {{filename1}}`
+`sha256sum {{filename1}} {{filename2}}`
+`sha256sum {{directory/\*}}`
+
+- Read a file of SHA256 sums and verify all files have matching checksums
+
+`sha256sum -c {{filename.sha256}}`

--- a/pages/linux/sha384sum.md
+++ b/pages/linux/sha384sum.md
@@ -1,0 +1,13 @@
+# sha384sum
+
+> Calculate SHA384 cryptographic checksums
+
+- Calculate the SHA384 checksum for file(s) or files in a directory, one checksum per file
+
+`sha384sum {{filename1}}`
+`sha384sum {{filename1}} {{filename2}}`
+`sha384sum {{directory/\*}}`
+
+- Read a file of SHA384 sums and verify all files have matching checksums
+
+`sha384sum -c {{filename.sha384}}`

--- a/pages/linux/sha512sum.md
+++ b/pages/linux/sha512sum.md
@@ -1,0 +1,13 @@
+# sha512sum
+
+> Calculate SHA512 cryptographic checksums
+
+- Calculate the SHA512 checksum for file(s) or files in a directory, one checksum per file
+
+`sha512sum {{filename1}}`
+`sha512sum {{filename1}} {{filename2}}`
+`sha512sum {{directory/\*}}`
+
+- Read a file of SHA512 sums and verify all files have matching checksums
+
+`sha512sum -c {{filename.sha512}}`


### PR DESCRIPTION
I just copied the md5sum page to the five different sha?sum variants, since all of them have the same parameters and same use cases.
