### PR TITLE
pwd: add page

### DIFF
--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -1,0 +1,11 @@
+# pwd
+
+> Print name of current/working directory
+
+- Print the current directory
+
+`pwd`
+
+- Print the current directory, and resolve all symlinks (e.g. show the "physical" path)
+
+`pwd -P`


### PR DESCRIPTION
Although Linux version of `pwd` defaults to `pwd -P`, the builtin version provided by bash, zsh, or even busybox sh defaults to `pwd -L`, same for Mac. So I'm adding only `pwd` and `pwd -P` into the page, as `pwd -L` should be the same as `pwd` for most people.
