### PR TITLE
ping page: add -n param

### DIFF
--- a/pages/common/ping.md
+++ b/pages/common/ping.md
@@ -13,3 +13,7 @@
 - Ping host, waiting for 0.5 s between each request (default is 1 s)
 
 `ping -i 0.5 {{host}}`
+
+- Ping host without trying to lookup symbolic names for addresses
+
+`ping -n {{host}}`


### PR DESCRIPTION
The -n param can be very useful when the lookup process took too long (which is a very common case at least for me). Please merge if you think it worth mentioning in the page :P
