### PR TITLE
[grep] Added invert match parameter.

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -29,4 +29,4 @@
 
 - invert match for excluding specific strings
 
-`grep -v {something}`
+`grep -v {{something}}`


### PR DESCRIPTION
Example:

Search for files in the current directory that does not match a specific string.

``` bash
find . | grep -v "npm-*"
```
