### PR TITLE
chown: reference file

### DIFF
--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -17,3 +17,7 @@
 - change the owner of a symbolic link
  
 `chown -h {{user}} {{path/to/symlink}}`
+
+- use the owner and group of a reference file and apply those values to another file
+
+`chown --reference={{reference-file}} {{path/to/file}}`


### PR DESCRIPTION
use the owner and group of a reference file and apply those values to another file

Example:

``` bash
    chown --reference=foobar.txt *.txt
```
