### PR TITLE
List content of tar file

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -26,3 +26,7 @@
 - create a compressed archive, using archive suffix to determine the compression programm
 
 `tar caf {{target.tar.xz}} {{file1 file2 file3}}`
+
+- list the contents of a tar file
+
+`tar -tvf {{source.tar}}`


### PR DESCRIPTION
List content of tar file. 

I recommend reducing amount of options regarding compressed files since on some OS are allowed only in -c mode.
Basically :
-j : bzip2
-J : xz
-z : bzip2

Additionally the extract should manage as tar -xf file no matter which compression.
