### PR TITLE
Fix the ls command sorting options

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -23,11 +23,11 @@
 `ls {{prefix}}*`
 `ls *{{suffix}}`
 
-- Sort the results size
+- Sort the results by size, last modified date, or creation date
 
-`ls -s   # by size`
-`ls -t   # by last modified date`
-`ls -U   # by creation date`
+`ls -S`
+`ls -t`
+`ls -U`
 
 - Reverse the order of the results
 


### PR DESCRIPTION
The -s option should be -S for sorting the results by size :)
