### PR TITLE
add a separate example for overwriting a symlink

### DIFF
--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -6,9 +6,13 @@
 
 `ln -s {{path/to/original/file}} {{path/to/link}}`
 
+- overwrite a symbolic link to a file
+
+`ln -sf {{path/to/new/original/file}} {{path/to/file/link}}`
+
 - overwrite a symbolic link to a folder
 
-`ln -sfT {{path/to/new/original/file}} {{path/to/link}}`
+`ln -sfT {{path/to/new/original/file}} {{path/to/folder/link}}`
 
 - create a hard link to a file or folder
 


### PR DESCRIPTION
to make it clear what the `-T` option does, as discussed in #180.