### PR TITLE
Fix typo: Remove extra, incorrect space

### DIFF
--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -9,7 +9,7 @@
 - replace all occurrences of a string in a file, and overwrite the file
   contents
 
-`sed -i '' 's/{{find}}/{{replace}}/g' {{filename}}`
+`sed -i'' 's/{{find}}/{{replace}}/g' {{filename}}`
 
 - replace all occurrences of an extended regular expression in a file
 


### PR DESCRIPTION
The `-i` flag expects to see the backup suffix immediately after the flag. If there's a space between them, then `sed` will think the 's/{{find}}/{{replace}}/g' string is a file name.