### PR TITLE
reword to prevent ambiguity

### DIFF
--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -2,14 +2,14 @@
 
 > Creates links to files and folders.
 
-- Create a symbolic link to a file or folder:
+- Create a symbolic link to a file (or folder):
 
-`ln -s {{path/to/original/file}} {{path/to/link}}`
+`ln -s {{path/to/file}} {{path/to/symlink}}`
 
-- Overwrite a symbolic link to a file:
+- Overwrite an existing symbolic to point to a different file:
 
-`ln -sf {{path/to/new/original/file}} {{path/to/file/link}}`
+`ln -sf {{path/to/new/file}} {{path/to/file/symlink}}`
 
 - Create a hard link to a file:
 
-`ln {{path/to/original/file}} {{path/to/link}}`
+`ln {{path/to/file}} {{path/to/hardlink}}`


### PR DESCRIPTION
"original" can be associated with the origin of the link and lead to confusion if not read carefully. Using "target" instead prevents this ambiguity.

Btw, the third example seems to have been copied from the prior example but not fully adapted: "original/file" should have said (if I'm reading this correctly) "original/folder".

Also, I removed `/file` from the "file or folder" examples, to make it more generic.