### PR TITLE
Update lint-changed.sh

### DIFF
--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-MD_FILES=`git diff --cached --name-only | tr " " "\n" | egrep ^.*\.md$`
+MD_FILES=`git diff --cached --name-only | tr " " "\n" | grep '^.*\.md$'`
 
 # Execute Markdown lint if any markdown files have been changed and added to git
 [[ -z "$MD_FILES" ]] || GEM_PATH=.gem .gem/bin/mdl "$MD_FILES"
+exit 0


### PR DESCRIPTION
- update the command: the original command doesn't work when we edit a
  command page and add it to git, also note that egrep is deprecated.
- add a zero exit code, so that when we run `make lint-changed`, we
  won't get this error: `make: *** [lint-changed] error 1`.