### PR TITLE
"system name" --> "operating system", rmv examples

### DIFF
--- a/pages/common/uname.md
+++ b/pages/common/uname.md
@@ -6,7 +6,7 @@
 
 `uname -mp`
 
-- Print software-related information: system name (Linux, Darwin...), release number, and version
+- Print software-related information: operating system, release number, and version
 
 `uname -srv`
 


### PR DESCRIPTION
I think the connection with -s is still reasonably discernible, and the term OS is less ambiguous than just "system", so it doesn't need examples.