### PR TITLE
Fix markdown lint warnings for linux man pages

### DIFF
--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -3,16 +3,15 @@
 > Debian and Ubuntu package management utility
 
 - Synchronize list of packages and versions available. This should be run first, before running subsequent apt-get commands.
- 
+
 `apt-get update`
 
 - install a new package
 
 `apt-get install {{package}}`
 
-
 - remove a package
- 
+
 `apt-get remove {{package}}`
 
 - Upgrade installed packages to newest available versions

--- a/pages/linux/aptitude.md
+++ b/pages/linux/aptitude.md
@@ -3,7 +3,7 @@
 > Debian and Ubuntu package management utility
 
 - Synchronize list of packages and versions available. This should be run first, before running subsequent aptitude commands.
- 
+
 `aptitude update`
 
 - install a new package
@@ -15,13 +15,13 @@
 `aptitude search {{package}}`
 
 - remove a package
- 
+
 `aptitude remove {{package}}`
 
 - Upgrade installed packages to newest available versions
 
 `aptitude upgrade`
 
-- Upgrade installed packages (like `aptitude upgrade`) including removing obsolete packages and installing additional packages to meet new package dependencies. 
+- Upgrade installed packages (like `aptitude upgrade`) including removing obsolete packages and installing additional packages to meet new package dependencies.
 
 `aptitude full-upgrade`

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -1,4 +1,4 @@
-#dpkg
+# dpkg
 
 > debian package manager
 

--- a/pages/linux/du.md
+++ b/pages/linux/du.md
@@ -14,6 +14,6 @@
 
 `du -ah {{directory}}`
 
-- list the KB sizes of directories for N levels below the specified directory 
+- list the KB sizes of directories for N levels below the specified directory
 
 `du --max-depth=1`

--- a/pages/linux/ip.md
+++ b/pages/linux/ip.md
@@ -10,7 +10,7 @@
 
 `ip r`
 
-- Make an interface up/down 
+- Make an interface up/down
 
 `ip link set {{interface}} up/down`
 

--- a/pages/linux/mdadm.md
+++ b/pages/linux/mdadm.md
@@ -1,4 +1,4 @@
-#mdadm
+# mdadm
 
 > RAID management utility
 

--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -3,7 +3,7 @@
 > Arch Linux package manager utility
 
 - synchronize and update all packages
- 
+
 `pacman -Syyu`
 
 - install a new package
@@ -11,7 +11,7 @@
 `pacman -S package-name`
 
 - remove a package and its dependencies
- 
+
 `pacman -Rs package-name`
 
 - search the package database for a keyword

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -1,8 +1,8 @@
-# strace 
+# strace
 
 > Troubleshooting tool for tracing system calls
 
-- Start tracing a specific process by its PID 
+- Start tracing a specific process by its PID
 
 `strace -p {{pid}}`
 
@@ -13,4 +13,3 @@
 - Count time, calls, and errors for each system call and report a summary on program exit.
 
 `strace -p {{pid}} -c`
-

--- a/pages/linux/wpa_cli.md
+++ b/pages/linux/wpa_cli.md
@@ -16,7 +16,7 @@
 `wpa_cli set_network {{number}} ssid {{SSID}}`
 `wpa_cli set_network {{number}} psk {{passkey}}`
 
-- enable network 
+- enable network
 
 `wpa_cli enable_network {{number}}`
 


### PR DESCRIPTION
This topic is discussed in #278 

```
pages/linux/apt-get.md:6: MD009 Trailing spaces
pages/linux/apt-get.md:15: MD009 Trailing spaces
pages/linux/apt-get.md:13: MD012 Multiple consecutive blank lines
pages/linux/ip.md:13: MD009 Trailing spaces
pages/linux/aptitude.md:6: MD009 Trailing spaces
pages/linux/aptitude.md:18: MD009 Trailing spaces
pages/linux/aptitude.md:25: MD009 Trailing spaces
pages/linux/dpkg.md:1: MD018 No space after hash on atx style header
pages/linux/strace.md:1: MD009 Trailing spaces
pages/linux/strace.md:5: MD009 Trailing spaces
pages/linux/wpa_cli.md:19: MD009 Trailing spaces
pages/linux/mdadm.md:1: MD018 No space after hash on atx style header
pages/linux/pacman.md:6: MD009 Trailing spaces
pages/linux/pacman.md:14: MD009 Trailing spaces
pages/linux/du.md:17: MD009 Trailing spaces
```

If this PR looks good, I'll continue this work and try to fix all the warnings(249 actually).