### PR TITLE
Add extra newline between consecutive commands examples.

### DIFF
--- a/pages/common/cal.md
+++ b/pages/common/cal.md
@@ -5,15 +5,19 @@
 - Display a calendar for the current month or specified month
 
 `cal`
+
 `cal -m {{12}}`
+
 `cal -m {{Dec}}`
 
 - Display a calendar for the current year or a specified year
 
 `cal -y`
+
 `cal 2013`
 
 - Display date of Easter (western churches)
 
 `ncal -e`
+
 `ncal -e 2013`

--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -21,12 +21,15 @@
 - List all files with a prefix/suffix
 
 `ls {{prefix}}*`
+
 `ls *{{suffix}}`
 
 - Sort the results by size, last modified date, or creation date
 
 `ls -S`
+
 `ls -t`
+
 `ls -U`
 
 - Reverse the order of the results

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -6,6 +6,7 @@
 - upload a file, or upload and rename a file
 
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/}}`
+
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/newname.txt}}`
 
 - download a file
@@ -15,6 +16,7 @@
 - upload or download a directory
 
 `scp -r {{/local/folder}} {{10.0.0.1}}:{{/remote/path/}}`
+
 `scp -r {{10.0.0.1}}:{{/remote/path}} {{/local/folder}}`
 
 - specify username on host

--- a/pages/common/srm.md
+++ b/pages/common/srm.md
@@ -6,7 +6,9 @@
 - Removes a file after overwriting (single pass, 7 pass, 35 pass)
 
 `srm -s {{/path/to/file}}`
+
 `srm -m {{/path/to/file}}`
+
 `srm {{/path/to/file}}`
 
 - Scurely remove recursively a directory and all it's subdirectories

--- a/pages/linux/ss.md
+++ b/pages/linux/ss.md
@@ -17,9 +17,13 @@
 - Filter sockets by address and/or port
 
 `ss -t dst 1.2.3.4:80`
+
 `ss -u src 127/8`
+
 `ss -t 'dport >= :1024'`
+
 `ss -x "src /tmp/.X11-unix/*"`
+
 `ss -t state established '( dport = :ssh or sport = :ssh )'`
 
 - Only list IPv4 or IPv6 sockets

--- a/pages/osx/systemsetup.md
+++ b/pages/osx/systemsetup.md
@@ -9,16 +9,21 @@
 - Specify TimeZone, NTP Server and enable network time
 
 `systemsetup -settimezone {{US/Pacific}}`
+
 `systemsetup -setnetworktimeserver {{us.pool.ntp.org}}`
+
 `systemsetup -setusingnetworktime on`
 
 - Make the machine never sleep; restart on freeze & power failure
 
 `systemsetup -setsleep off`
+
 `systemsetup -setrestartpowerfailure on`
+
 `systemsetup -setrestartfreeze on`
 
 - List valid startup disks, specify a new startup disk
 
 `systemsetup -liststartupdisks`
+
 `systemsetup -setstartupdisk {{path}}`


### PR DESCRIPTION
These 6 files had multiple examples all separated by a single newline.
While rendering it in markdown, the examples all come up in a single
line.
Adding another newline makes rendering better.
Also will help in easier copying (double click on the line to copy).