### PR TITLE
Remove markown md038 warning, close #314

### DIFF
--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -12,4 +12,4 @@
 
 - Sort passwd file by the 3rd field
 
-`sort -t: -k 3n /etc/passwd `
+`sort -t: -k 3n /etc/passwd`

--- a/scripts/markdown-style.rb
+++ b/scripts/markdown-style.rb
@@ -2,4 +2,3 @@
 all
 
 exclude_rule 'MD013'	# Lengthy lines (80+ chars)
-exclude_rule 'MD038'	# Spaces inside code backticks


### PR DESCRIPTION
The discussion is in #314 ,  there is no need for excluding md038 warning now, so remove it :)