### PR TITLE
Don't make reindex on commit

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-make index
-git add ./pages/index.json
 make lint-changed


### PR DESCRIPTION
It changes pre-commit hook to only lint, but not reindex.

This is a debatable thing to do, but I think I should do it.

Currently making index causes many issues for contributors, because when public requests are applied in different order, the index causes merging issues. Examples: #328, #325, #331 and many more.

I don't think we should remove index.json at the moment, because several clients still uses it: NodeJS and Web client, from what I know. After clients are switched to built index in [static site](http://tldr-pages.github.io/) and maybe some time after it (so we will give people time to update) we can completely remove index.json from the tree.

Until that one of the collaborators or owners can directly make index and commit it from time to time.
