### PR TITLE
Optimize make lint task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ gemfile:
 - Gemfile
 
 script:
-- make check
+- make lint
 
 after_success:
 - bash scripts/build.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: check
+default: lint
 
 all: setup index
 
@@ -17,13 +17,10 @@ deps:
 	@bundle
 	@echo "OK"
 
-check:
-	@bundle exec mdl --style ./scripts/markdown-style.rb pages
-
 lint:
-	@GEM_PATH=.gem find pages -exec mdl {} --style ./scripts/markdown-style.rb 1>&2 \;
+	@bundle exec mdl --style ./scripts/markdown-style.rb pages
 
 lint-changed:
 	@./scripts/lint-changed.sh
 
-.PHONY: index setup hooks deps lint lint-changed
+.PHONY: default index setup hooks deps lint lint-changed


### PR DESCRIPTION
Optimize make lint in approximately 80 times.

~~~
$ time make lint
make lint  80.43s user 10.98s system 97% cpu 1:33.85 total

$ time make check
make check  0.99s user 0.12s system 96% cpu 1.136 total
~~~

It is so fast that maybe there is no need for `make lint-changed` anymore.