### PR TITLE
Fix lint-changed to lint both cached and and non-cached files

### DIFF
--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-MD_FILES=`git diff --cached --name-only | tr " " "\n" | egrep ^.*\.md$`
+MD_FILES=`( git diff --name-only ; git diff --cached --name-only; )\
+ | cat | tr " " "\n" | egrep ^.*\.md$`
 
 # Execute Markdown lint if any markdown files have been changed and added to git
-[[ -z "$MD_FILES" ]] || GEM_PATH=.gem .gem/bin/mdl "$MD_FILES"
+[[ -z "$MD_FILES" ]] || GEM_PATH=.gem mdl $MD_FILES

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -4,4 +4,4 @@ MD_FILES=`( git diff --name-only ; git diff --cached --name-only; )\
  | cat | tr " " "\n" | egrep ^.*\.md$`
 
 # Execute Markdown lint if any markdown files have been changed and added to git
-[[ -z "$MD_FILES" ]] || GEM_PATH=.gem mdl $MD_FILES
+[[ -z "$MD_FILES" ]] || GEM_PATH=.gem bundle exec mdl $MD_FILES


### PR DESCRIPTION
Currently lint-changed task/script lints only committed files.
I changed it so it lints both committed and saved files.

Additionally it fixes linting with mdl to use bundler instead of direct path.