### PR TITLE
Update lpstat command: add 2 examples

### DIFF
--- a/pages/common/lpstat.md
+++ b/pages/common/lpstat.md
@@ -1,11 +1,19 @@
 # lpstat
 
-> print status information about printers
+> show status information about printers
 
 - List printers present on the machine and whether they are enabled for printing.
 
 `lpstat -p`
 
-- Print the default printer name.
+- Show the default printer.
 
 `lpstat -d`
+
+- Display all available status information.
+
+`lpstat -t`
+
+- Show a list of print jobs queued by the specified user.
+
+`lpstat -u {{user}}`


### PR DESCRIPTION
I took those examples from PR #324 (kudos to @Qtrain).

However I do not like the original PR because of several reasons:

* it has `lpstat` example in `lp`-page, which breaks the [guidelines](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md)
* it fixes `lint-changed.sh`, which must be done in separate commit
* it has index.json, which makes it harder to merge

So I took 2 missing examples of `lpstat` from original commit, also reworded it a little bit.