### PR TITLE
Adds -m syntax to python page

### DIFF
--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -14,6 +14,6 @@
 
 `python -c {{command}}`
 
-- Execute a Python module (SimpleHTTPServer, json.tool, etc)
+- Run library module as a script (terminates option list)
 
-`python -m {{moduleName}} {{parameters}}`
+`python -m {{module}} {{arguments}}`

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -13,3 +13,7 @@
 - Execute Python language single command
 
 `python -c {{command}}`
+
+- Execute a Python module (SimpleHTTPServer, json.tool, etc)
+
+`python -m {{moduleName}} {{parameters}}`


### PR DESCRIPTION
I'm wondering if it'd make sense to include samples of the actual purposes for running the `-m` syntax, like running a webserver, or parsing json output in the terminal, with examples for those.

```md
* Parse JSON output
`cat raw.json | python -m json.tool`

* Serve the current directory at `localhost:8000`

`python -m SimpleHTTPServer`
```

Any ideas?