### PR TITLE
Remove suffix & prefix example, remove -s from ls -ls

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -12,7 +12,7 @@
 
 - List all files with their rights, groups, owner
 
-`ls -ls`
+`ls -l`
 
 - List all files and display the file size in a human readable format
 


### PR DESCRIPTION
This commit removes 2 things from `ls` command:

- I removed suffix and prefix example (`ls *files`), because it is against the rule to avoid explaining general UNIX concepts

- I removed -s from `ls -ls`, so it becomes `ls -l`. Rule 2 of Contributing Guidelines says "When in doubt, keep new command-line users in mind". `-s` shows the number of file system blocks actually used by each. I don't think CLI newcomers need this in 2015. Actually I think a few people still need to know this info.