### PR TITLE
find: Delete files older than 'x' days

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -19,3 +19,7 @@
 - find files using case insensitive name matching, of a certain size
 
 `find {{root_path}} -size +500k -size -10MB -iname {{'*.TaR.gZ'}}`
+
+- delete files by name, older than a certain number of days
+
+`find {{root_path}} -name {{'*.py'}} -mtime {{-180d}} -delete`


### PR DESCRIPTION
A simple way to find and delete files older than a certain number of days.
This is something I use frequently to clean up old log files (sometimes setup as a cron).