### PR TITLE
Add tldr for installing a specific version of a python package

### DIFF
--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -6,6 +6,10 @@
 
 `pip install {{somepackage}}`
 
+- Install a specific version of a package
+
+`pip install {{somepackage}}=={{someversion}}`
+
 - Upgrade a package
 
 `pip install -U {{somepackage}}`


### PR DESCRIPTION
Add tldr for installing a specific version of a python package, useful for working with python packages with annoying compatibility issues.