### PR TITLE
Added xinput command for Linux

### DIFF
--- a/pages/linux/xinput.md
+++ b/pages/linux/xinput.md
@@ -1,0 +1,15 @@
+# xinput
+
+> a utility to list available input devices, query information about a device and change input device settings
+
+- List all input devices.
+
+`xinput list`
+
+- Disconnect an input from a master.
+
+`xinput float {{id}}`
+
+- Reattach an input as slave to a master
+
+`xinput float {{id}} {{master id}}`

--- a/pages/linux/xinput.md
+++ b/pages/linux/xinput.md
@@ -6,10 +6,10 @@
 
 `xinput list`
 
-- Disconnect an input from a master.
+- Disconnect an input from its master.
 
 `xinput float {{id}}`
 
 - Reattach an input as slave to a master
 
-`xinput float {{id}} {{master id}}`
+`xinput float {{id}} {{master_id}}`


### PR DESCRIPTION
The xinput utility is useful when you want to turn off a input device (laptop keyboard, for example).