### PR TITLE
Fix typo in cordova tldr page

### DIFF
--- a/pages/common/cordova.md
+++ b/pages/common/cordova.md
@@ -22,6 +22,6 @@
 
 `cordova plugin add {{pluginid}}`
 
-- Remove a cordova plutin
+- Remove a cordova plugin
 
 `cordova plugin remove {{pluginid}}`


### PR DESCRIPTION
"plutin" -> "plugin"

Noticed it here: https://twitter.com/brianleroux/status/681649386338689024