### PR TITLE
Add python3.md

### DIFF
--- a/pages/common/python3.md
+++ b/pages/common/python3.md
@@ -1,0 +1,20 @@
+# Python3
+
+> Python 3 language interpeter
+
+- Call a Python 3 interactive shell
+
+`python`
+
+- Execute a given Python file
+
+`python {{script.py}}`
+
+- Execute Python language single command
+
+`python -c {{command}}`
+
+- Run library module as a script (terminates option list)
+
+`python -m {{module}} {{arguments}}`
+

--- a/pages/common/python3.md
+++ b/pages/common/python3.md
@@ -6,11 +6,11 @@
 
 `python`
 
-- Execute a given Python file
+- Execute a given Python 3 file
 
 `python {{script.py}}`
 
-- Execute Python language single command
+- Execute Python 3 language single command
 
 `python -c {{command}}`
 


### PR DESCRIPTION
I pretty much took the python.md and added a similar python3.md.  Just `python` will call up a python 2 interpreter, but `python3` will call a python 3 interpreter.  Because they are different, I feel having a different page would be appropriate.