### PR TITLE
Make tar page consistent

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -29,4 +29,4 @@
 
 - list the contents of a tar file
 
-`tar -tvf {{source.tar}}`
+`tar tvf {{source.tar}}`


### PR DESCRIPTION
It might confuse users if everything has no dash in front but the last command does. tar doesn't need the dash so let's keep it that way.