### PR TITLE
Added command 'pacman -Qe'

### DIFF
--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -21,3 +21,7 @@
 - list installed packages and versions
 
 `pacman -Q`
+
+- list only the explicitly installed packages and versions
+
+`pacman -Qe`


### PR DESCRIPTION
Hey there,

I took the liberty to add the command `pacman -Qe` for listing all and only the explicitly installed packages (`-e` option), still showing versions. Useful when you want a concise list of the packages you have without all the dependencies.