### PR TITLE
Partially fix #468: warns that Ruby and Bundler must be installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 default: lint
 
-all: setup index
-
 index:
 	@echo "WARNING!"
 	@echo "Index rebuilding is deprecated."
@@ -10,7 +8,18 @@ index:
 	@TLDRHOME=`pwd` ./scripts/build_index.rb
 	@echo "Index rebuilt."
 
-setup: hooks deps
+setup: prerequisites hooks deps
+
+prerequisites:
+	@echo
+	@echo "IMPORTANT!"
+	@echo "Before setting up hooks, make sure you have read Contributing Guidelines"
+	@echo "https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md#submitting-a-pull-request"
+	@echo
+	@echo "TL;DR:"
+	@echo "1. Install Ruby suitable for your system"
+	@echo "2. Run 'gem install bundler'"
+	@echo
 
 hooks:
 	@cp ./scripts/pre-commit .git/hooks
@@ -24,4 +33,4 @@ deps:
 lint:
 	@bundle exec mdl --style ./scripts/markdown-style.rb pages
 
-.PHONY: default index setup hooks deps lint
+.PHONY: default index setup prerequisites hooks deps lint


### PR DESCRIPTION
- adds prerequisites task to Makefile
- it warns about installation of Ruby and Bundler.
- It does not actually check anything, it just warns

Probably this should fix #468, as I think people were mostly frustrated by lack of messaging.

Actual checks that software is not installed is more complicated, and I might do it later.