### PR TITLE
ar: add examples and clean-up

### DIFF
--- a/pages/common/ar.md
+++ b/pages/common/ar.md
@@ -2,10 +2,22 @@
 
 > Create, modify, and extract from archives (.a .so .o)
 
-- Extract members of the archive
+- Extract all members from an archive
 
-`ar -x libfoo.a`
+`ar -x {{libfoo.a}}`
 
-- List the content (files) of libfoo.a
+- List the members of an archive
 
-`ar -t libfoo.a`
+`ar -t {{libfoo.a}}`
+
+- Replace or add files to an archive
+
+`ar -r {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`
+
+- Insert an object file index (equivalent to using `ranlib`)
+
+`ar -s {{libfoo.a}}`
+
+- Create an archive with files and an accompanying object file index
+
+`ar -rs {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`


### PR DESCRIPTION
Does notation like `{{libfoo.a}}` and `{{foo.o}}` seem cromulent? Or should it be something like `{{archive.a}}` `{{source1.o}}...`?