### PR TITLE
removes no-longer-there diskutil verb

### DIFF
--- a/pages/osx/diskutil.md
+++ b/pages/osx/diskutil.md
@@ -6,10 +6,6 @@
 
 `diskutil list`
 
-- Repair permissions on a volume
-
-`diskutil repairPermissions {{/Volumes/Name}}`
-
 - Repair the file system data structures of a volume
 
 `diskutil repairVolume {{/dev/diskX}}`


### PR DESCRIPTION
As of El Capitan, `sudo diskutil repairPermissions /` returns `diskutil: did not recognize verb "repairPermissions"; type "diskutil" for a list` since repairPermissions has been removed.

In the interest of keeping this tldr-compatible I've removed it. In the interest of not leaving things out, there could instead be a "this no longer works" notice.