### PR TITLE
make markup format consistent

### DIFF
--- a/pages/common/host.md
+++ b/pages/common/host.md
@@ -1,6 +1,6 @@
 # host
 
-Lookup Domain Name Server
+> Lookup Domain Name Server
 
 - Lookup A, AAAA, and MX records of a domain
 

--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -2,18 +2,18 @@
 
 > passwd is a tool used to change a user's password.
 
-* Change the password of the current user
+- Change the password of the current user
 
 `passwd {{new password}}`
 
-* Change the password of the specified user
+- Change the password of the specified user
 
 `passwd {{username}} {{new password}}`
 
-* Get the current statuts of the user
+- Get the current statuts of the user
 
 `passwd -S`
 
-* Make the password of the account blank (it will set the named account passwordless)
+- Make the password of the account blank (it will set the named account passwordless)
 
 `passwd -d`

--- a/pages/common/salt.md
+++ b/pages/common/salt.md
@@ -8,12 +8,12 @@
 
 - Execute a highstate on all connected minions:
 
-`salt '*' state.highstate
+`salt '*' state.highstate`
 
 - Upgrade packages using the OS package manager (apt, yum, brew) on a subset of minions
 
-`salt '*.domain.com' pkg.upgrade
+`salt '*.domain.com' pkg.upgrade`
 
 - Execute an arbitrary command on a particular minion:
 
-`salt '{{minion_id}}' cmd.run "ls "
+`salt '{{minion_id}}' cmd.run "ls "`

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -6,8 +6,7 @@
 
 `sed 's/{{find}}/{{replace}}/g' {{filename}}`
 
-- replace all occurrences of a string in a file, and overwrite the file
-  contents
+- replace all occurrences of a string in a file, and overwrite the file contents
 
 `sed -i 's/{{find}}/{{replace}}/g' {{filename}}`
 

--- a/pages/common/touch.md
+++ b/pages/common/touch.md
@@ -2,14 +2,14 @@
 
 > Change a file access and modification times (atime, mtime)
 
-- Create a new empty file(s) or change the times for existing file(s) to current time.`
+- Create a new empty file(s) or change the times for existing file(s) to current time
 
 `touch {{filename}}`
 
 - Set the times on a file to those specified
 
-`touch -t 201412250801.59 {{filename}}
-`touch -t {{YYYYMMDDHHMM.SS}} {{filename}}
+`touch -t 201412250801.59 {{filename}}`
+`touch -t {{YYYYMMDDHHMM.SS}} {{filename}}`
 
 - Set the times on a file to match those on second file
 

--- a/pages/linux/hostname.md
+++ b/pages/linux/hostname.md
@@ -1,6 +1,6 @@
 # hostname
 
-Show or set the system's host name
+> Show or set the system's host name
 
 - Show current host name
 

--- a/pages/osx/hostname.md
+++ b/pages/osx/hostname.md
@@ -1,6 +1,6 @@
 # hostname
 
-Show or set the system's host name
+> Show or set the system's host name
 
 - Show current host name
 


### PR DESCRIPTION
Page format consistency should be enforced to allow/facilitate parsing.
I made sure it matches the following template (I've used `+` as 'one or more',  parenthesis for grouping, and ignored empty lines):
```
# {command_name}

(>{command_description})+

(
- {example_description}

(`{example_command}`)+
)+
```