### PR TITLE
nm: add page

### DIFF
--- a/pages/linux/nm.md
+++ b/pages/linux/nm.md
@@ -1,0 +1,19 @@
+# nm
+
+> List symbol names in object files
+
+- List global (extern) functions in a file (prefixed with T)
+
+`nm -g {{file.o}}`
+
+- Demangle C++ symbols (make them readable)
+
+`nm --demangle {{file.o}}`
+
+- List only undefined symbols in a file
+
+`nm -u {{file.o}}`
+
+- List all symbols, even debugging symbols
+
+`nm -a {{file.o}}`

--- a/pages/osx/nm.md
+++ b/pages/osx/nm.md
@@ -1,0 +1,15 @@
+# nm
+
+> List symbol names in object files (see c++filt)
+
+- List global (extern) functions in a file (prefixed with T)
+
+`nm -g {{file.o}}`
+
+- List only undefined symbols in a file
+
+`nm -u {{file.o}}`
+
+- List all symbols, even debugging symbols
+
+`nm -a {{file.o}}`


### PR DESCRIPTION
I did not use long options for compatibility between Apple and GNU `nm`. I limited examples to options that are available on both platforms.