### PR TITLE
pkill: add page

### DIFF
--- a/pages/common/pkill.md
+++ b/pages/common/pkill.md
@@ -1,0 +1,12 @@
+# pkill
+
+> Signal process by name
+> Mostly used for stopping processes
+
+- kill all processes which match
+
+`pkill -9 {{process_name}}`
+
+- send SIGUSR1 signal to processes which match
+
+`pkill -USR1 {{process_name}}`


### PR DESCRIPTION
There is already an example of `pkill` on the `pgrep` page but I assume we want users to be able to look things up directly wherever possible. For that reason I have created a standalone page for `pkill` with an additional example.