### PR TITLE
pgrep: remove pkill example and correct tokens

### DIFF
--- a/pages/common/pgrep.md
+++ b/pages/common/pgrep.md
@@ -4,16 +4,12 @@
 
 - return PIDs of any running processes with a matching command string
 
-`pgrep {{Finder}}`
+`pgrep {{process_name}}`
 
 - search full command line with parameters instead of just the process name
 
-`pgrep -f "{{ssh root}}"`
+`pgrep -f "{{process_name}} {{parameter}}"`
 
 - search for process run by a specific user
 
-`pgrep -u root {{firefox}}`
-
-- kill all processes which match
-
-`pkill -9 {{Finder}}`
+`pgrep -u root {{process_name}}`


### PR DESCRIPTION
As discussed in https://github.com/tldr-pages/tldr/pull/541, I've removed the `pkill` example from the `pgrep` page.

As was originally the case for my `pkill` page, the `pgrep` command was using the incorrect token style `{{Finder}}`. I've corrected this use throughout. Let me know if you want me to change anything.