### PR TITLE
Add another Rust client to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ You can access these pages on your computer using one of the following clients:
   - [tldroid](https://github.com/hidroh/tldroid), available on
     [Google Play](https://play.google.com/store/apps/details?id=io.github.hidroh.tldroid)
 - [Ruby client](https://github.com/YellowApple/tldrb): `gem install tldrb`
-- [Rust client](https://github.com/rilut/rust-tldr): `cargo install tldr`
+- Rust clients:
+    - [rust-tldr](https://github.com/rilut/rust-tldr) (online lookup): `cargo install tldr`
+    - [tldr-rs](https://github.com/dbrgn/tldr-rs) (offline caching, not yet published)
 - [R client](https://github.com/kirillseva/tldrrr): `devtools::install_github('kirillseva/tldrrr')`
 - [Dart client](https://github.com/hterkelsen/tldr): `pub global activate tldr`
 - [Web client](https://github.com/ostera/tldr.jsx): https://ostera.github.io/tldr.jsx


### PR DESCRIPTION
@rilut beat me to it :) Here's another Rust client that aims to support
offline caching, the way the NodeJS client does it.

Maybe we can merge the two clients somehow (rilut/rust-tldr#1),
otherwise they can coexist as they have a different focus: One fetches
the pages from the net on each command invocation, the other does local
caching.