### PR TITLE
nginx: add -t example

### DIFF
--- a/pages/common/nginx.md
+++ b/pages/common/nginx.md
@@ -13,3 +13,7 @@
 - Start server with a prefix for all relative paths in config file
 
 `nginx -c {{config_file}} -p {{prefix/for/relative/paths}}`
+
+- Test configuration without affecting the running server
+
+`nginx -t`


### PR DESCRIPTION
Added the syntax for testing nginx configuration without affecting the running server, invaluable for people new to nginx when making configuration changes on a 'live' server.