### PR TITLE
grep: add line number

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -23,6 +23,10 @@
 
 `grep -c {{something}} {{file_path}}`
 
+- print line number for each match
+
+`grep -n {{something}} {{file_path}}`
+
 - use the standard input instead of a file
 
 `cat {{file_path}} | grep {{something}}`


### PR DESCRIPTION
Option to print line number when a match is found.  If you are a VIM user, it's common to grep -> show line number -> open file and go directly to the line number in the file instead of having to grep for the matches once again once in vim.