### PR TITLE
fortune: reword description of -f option, reorder

### DIFF
--- a/pages/common/fortune.md
+++ b/pages/common/fortune.md
@@ -6,14 +6,6 @@
 
 `fortune`
 
-- Print a quotation from a given database:
-
-`fortune {{database}}`
-
-- Print a list of quotation databases:
-
-`fortune -f`
-
 - Print an offensive quotation:
 
 `fortune -o`
@@ -25,3 +17,11 @@
 - Print a short quotation:
 
 `fortune -s`
+
+- List the available quotation database files:
+
+`fortune -f`
+
+- Print a quotation from one of the database files listed by `fortune -f`:
+
+`fortune {{filename}}`


### PR DESCRIPTION
As I've commented in #373, I think the description of the -f example should use the word "file" because it matches with the short option name.
I've also updated the `fortune {{database}}` example to match the terminology, and reordered the examples in an order that I believe is more intuitive.