### PR TITLE
unrar: reorder examples

### DIFF
--- a/pages/common/unrar.md
+++ b/pages/common/unrar.md
@@ -2,13 +2,13 @@
 
 > Extract RAR archives
 
-- extract files into current directory, losing directory structure in the archive
-
-`unrar e {{compressed.rar}}`
-
 - extract files with original directory structure
 
 `unrar x {{compressed.rar}}`
+
+- extract files into current directory, losing directory structure in the archive
+
+`unrar e {{compressed.rar}}`
 
 - test integrity of each file inside the archive file
 


### PR DESCRIPTION
extracting with original directory structure is arguably a more common use case than extracting the files in a flattened manner.