### PR TITLE
ssh: use -N on port forwards

### DIFF
--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -21,11 +21,11 @@
 
 - ssh tunneling: dynamic port forwarding (SOCKS proxy on localhost:9999)
 
-`ssh -D {{9999}} -C {{username}}@{{remote_host}}`
+`ssh -D {{9999}} -C {{username}}@{{remote_host}} -N`
 
 - ssh tunneling: forward a specific port (localhost:9999 to slashdot.org:80)
 
-`ssh -L {{9999}}:slashdot.org:80 {{username}}@{{remote_host}}`
+`ssh -L {{9999}}:slashdot.org:80 {{username}}@{{remote_host}} -N`
 
 - ssh enable agent forward
 


### PR DESCRIPTION
A prompt is confusing when the terminal is meant for forwarding.
A "stuck" shell realistically represents something being "busy".