### PR TITLE
ln: remove overwrite option

### DIFF
--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -6,14 +6,6 @@
 
 `ln -s {{path/to/original/file}} {{path/to/link}}`
 
-- overwrite a symbolic link to a file
-
-`ln -sf {{path/to/new/original/file}} {{path/to/file/link}}`
-
-- overwrite a symbolic link to a folder
-
-`ln -sfT {{path/to/new/original/file}} {{path/to/folder/link}}`
-
 - create a hard link to a file or folder
 
 `ln {{path/to/original/file}} {{path/to/link}}`


### PR DESCRIPTION
TL;DR project is meant to contain shortest possible lists of common operations.
`-f` is a corner-case that has a trivial workaround: `unlink && ln`