### PR TITLE
ln: remove overwrite option for directories

### DIFF
--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -10,10 +10,6 @@
 
 `ln -sf {{path/to/new/original/file}} {{path/to/file/link}}`
 
-- overwrite a symbolic link to a folder
-
-`ln -sfT {{path/to/new/original/file}} {{path/to/folder/link}}`
-
 - create a hard link to a file or folder
 
 `ln {{path/to/original/file}} {{path/to/link}}`


### PR DESCRIPTION
-T is not present on my system, and the behavior itself is completely unintuitive.
How exactly do you overwrite a directory? Do you recursively delete its children?