### PR TITLE
curl: fix example according to style guide.

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -5,7 +5,7 @@
 
 - Download a URL to a file
 
-`curl "{{URL}}" -o filename`
+`curl "{{URL}}" -o {{filename}}`
 
 - send form-encoded data
 


### PR DESCRIPTION
According user contributing guidelines: User-provided values should use the {{token}} syntax.