### PR TITLE
Formatted all pages according to guidelines.

### DIFF
--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -1,19 +1,19 @@
 # 7za
 
-> A file archiver with high compression ratio
+> A file archiver with high compression ratio.
 
-- compress directory or file
+- Compress directory or file:
 
 `7za a {{compressed.7z}} {{directory_or_file_to_compress}}`
 
-- decompress an existing 7z file with original directory structure
+- Decompress an existing 7z file with original directory structure:
 
 `7za x {{compressed.7z}}`
 
-- compress to zip format
+- Compress to zip format:
 
 `7za a -tzip {{compressed.zip}} {{directory_or_file_to_compress}}`
 
-- create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes.
+- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
 
 `7za -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`

--- a/pages/common/ab.md
+++ b/pages/common/ab.md
@@ -2,10 +2,10 @@
 
 > Apache Benchmarking tool. The simplest tool to perform a load testing.
 
-- Execute 100 HTTP GET requests to given URL.
+- Execute 100 HTTP GET requests to given URL:
 
 `ab -n 100 {{url}}`
 
-- Execute 100 HTTP GET requests, processing up to 10 requests concurrently, to given URL.
+- Execute 100 HTTP GET requests, processing up to 10 requests concurrently, to given URL:
 
 `ab -n 100 -c 10 {{url}}`

--- a/pages/common/ack.md
+++ b/pages/common/ack.md
@@ -2,18 +2,18 @@
 
 > A search tool like grep, optimized for programmers.
 
-- Find files containing "foo"
+- Find files containing "foo":
 
 `ack {{foo}}`
 
-- Find files in a specific language
+- Find files in a specific language:
 
 `ack --ruby {{each_with_object}}`
 
-- Count the total number of matches for the term "foo"
+- Count the total number of matches for the term "foo":
 
 `ack -ch {{foo}}`
 
-- Show the file names containing "foo" and number of matches in each file
+- Show the file names containing "foo" and number of matches in each file:
 
 `ack -cl {{foo}}`

--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -1,19 +1,19 @@
 # Android Debug Bridge
 
-> Communicate with an Android emulator instance or connected Android devices
+> Communicate with an Android emulator instance or connected Android devices.
 
-- Check whether the adb server process is running and start it
+- Check whether the adb server process is running and start it:
 
 `adb start-server`
 
-- Terminate the adb server process
+- Terminate the adb server process:
 
 `adb kill-server`
 
-- Start a remote shell in the target emulator/device instance
+- Start a remote shell in the target emulator/device instance:
 
 `adb shell`
 
-- Push an Android application to an emulator/device
+- Push an Android application to an emulator/device:
 
 `adb install -r {{apk.path}}`

--- a/pages/common/ag.md
+++ b/pages/common/ag.md
@@ -2,11 +2,11 @@
 
 > The Silver Searcher. Like ack, but faster.
 
-- Find files containing "foo"
+- Find files containing "foo":
 
 `ag foo`
 
-- Find "foo" in files with a name matching "bar"
+- Find "foo" in files with a name matching "bar":
 
 `ag foo -G bar`
 
@@ -14,6 +14,6 @@
 
 `ag '^ba(r|z)$'`
 
-- Find files with a name matching "foo"
+- Find files with a name matching "foo":
 
 `ag -g foo`

--- a/pages/common/alias.md
+++ b/pages/common/alias.md
@@ -1,24 +1,24 @@
 # alias
 
-> Creates an alias for a word when used
-> as the first word of a command
+> Creates an alias for a word when used.
+> As the first word of a command.
 
-- creating a generic alias
+- Creating a generic alias:
 
 `alias {{word}}="{{command}}"`
 
-- remove an aliased command
+- Remove an aliased command:
 
 `unalias {{word}}`
 
-- full list of aliased words
+- Full list of aliased words:
 
 `alias -p`
 
-- turning rm an interative command
+- Turning rm an interative command:
 
 `alias {{rm}}="{{rm -i}}"`
 
-- overriding la as ls -a
+- Overriding la as ls -a:
 
 `alias {{la}}="{{ls -a}}"`

--- a/pages/common/apropos.md
+++ b/pages/common/apropos.md
@@ -1,12 +1,12 @@
 # apropos
 
-> Search in manpages
-> for example to find a new command
+> Search in manpages.
+> For example to find a new command.
 
-- search for keyword
+- Search for keyword:
 
 `apropos {{regular_expression}}`
 
-- search without restricting output to terminal width
+- Search without restricting output to terminal width:
 
 `apropos -l {{regular_expression}}`

--- a/pages/common/ar.md
+++ b/pages/common/ar.md
@@ -1,23 +1,23 @@
 # ar
 
-> Create, modify, and extract from archives (.a .so .o)
+> Create, modify, and extract from archives (.a .so .o).
 
-- Extract all members from an archive
+- Extract all members from an archive:
 
 `ar -x {{libfoo.a}}`
 
-- List the members of an archive
+- List the members of an archive:
 
 `ar -t {{libfoo.a}}`
 
-- Replace or add files to an archive
+- Replace or add files to an archive:
 
 `ar -r {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`
 
-- Insert an object file index (equivalent to using `ranlib`)
+- Insert an object file index (equivalent to using `ranlib`):
 
 `ar -s {{libfoo.a}}`
 
-- Create an archive with files and an accompanying object file index
+- Create an archive with files and an accompanying object file index:
 
 `ar -rs {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`

--- a/pages/common/awk.md
+++ b/pages/common/awk.md
@@ -1,19 +1,19 @@
 # awk
 
-> A versatile programming language for working on files
+> A versatile programming language for working on files.
 
-- Print the fifth column in a space separated file
+- Print the fifth column in a space separated file:
 
 `awk '{print $5}' {{filename}}`
 
-- Print the third column in a comma separated file
+- Print the third column in a comma separated file:
 
 `awk -F ',' '{print $3}' {{filename}}`
 
-- Sum the values in the first column and print the total
+- Sum the values in the first column and print the total:
 
 `awk '{s+=$1} END {print s}' {{filename}}`
 
-- Sum the values in the first column and pretty-print the values and then the total
+- Sum the values in the first column and pretty-print the values and then the total:
 
 `awk '{s+=$1; print $1} END {print "--------"; print s}' {{filename}}`

--- a/pages/common/bash.md
+++ b/pages/common/bash.md
@@ -1,20 +1,20 @@
 # bash
 
-> Bourne-Again SHell
+> Bourne-Again SHell.
 > `sh`-compatible command line interpreter.
 
-- Start interactive command line interpreter
+- Start interactive command line interpreter:
 
 `bash`
 
-- Execute command passed as parameter
+- Execute command passed as parameter:
 
 `bash -c {{command}}`
 
-- Run commands from file (script)
+- Run commands from file (script):
 
 `bash {{file}}`
 
-- Run commands from file and print them as they are executed
+- Run commands from file and print them as they are executed:
 
 `bash -x {{file}}`

--- a/pages/common/bashmarks.md
+++ b/pages/common/bashmarks.md
@@ -2,22 +2,22 @@
 
 > Save and jump to commonly used directories using 1 character commands.
 
-- List available bookmarks
+- List available bookmarks:
 
 `l`
 
-- Save the current folder as "bookmark_name"
+- Save the current folder as "bookmark_name":
 
 `s {{bookmark_name}}`
 
-- Go to a bookmarked folder
+- Go to a bookmarked folder:
 
 `g {{bookmark_name}}`
 
-- Print a bookmarked folder's contents
+- Print a bookmarked folder's contents:
 
 `p {{bookmark_name}}`
 
-- Delete a bookmark
+- Delete a bookmark:
 
 `d {{bookmark_name}}`

--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -2,18 +2,18 @@
 
 > Calculator.
 
-- Run calculator in interactive mode
+- Run calculator in interactive mode:
 
 `bc -i`
 
-- Calculate the result of an expression
+- Calculate the result of an expression:
 
 `bc <<< "(1 + 2) * 2 ^ 2"`
 
-- Calculate with the given precision
+- Calculate with the given precision:
 
 `bc <<< "scale=10; 5 / 3"`
 
-- Calculate expression with sine and cosine using mathlib
+- Calculate expression with sine and cosine using mathlib:
 
 `bc -l <<< "s(1) + c(1)"`

--- a/pages/common/bundle.md
+++ b/pages/common/bundle.md
@@ -2,18 +2,18 @@
 
 > Dependency manager for the Ruby programming language.
 
-- Installs all gems defined in the gemfile expected in the working directory.
+- Installs all gems defined in the gemfile expected in the working directory:
 
 `bundle install`
 
-- Update all gems by the rules defined in the gemfile and regenerate gemfile.lock
+- Update all gems by the rules defined in the gemfile and regenerate gemfile.lock:
 
 `bundle update`
 
-- Update one specific gem defined in the gemfile
+- Update one specific gem defined in the gemfile:
 
 `bundle update --source {{gemname}}`
 
-- Create a new gem skeleton
+- Create a new gem skeleton:
 
 `bundle gem {{gemname}}`

--- a/pages/common/cal.md
+++ b/pages/common/cal.md
@@ -1,23 +1,19 @@
 # cal
 
-> Prints calendar information
+> Prints calendar information.
 
-- Display a calendar for the current month or specified month
+- Display a calendar for the current month or specified month:
 
 `cal`
-
 `cal -m {{12}}`
-
 `cal -m {{Dec}}`
 
-- Display a calendar for the current year or a specified year
+- Display a calendar for the current year or a specified year:
 
 `cal -y`
-
 `cal 2013`
 
-- Display date of Easter (western churches)
+- Display date of Easter (western churches):
 
 `ncal -e`
-
 `ncal -e 2013`

--- a/pages/common/calibre-server.md
+++ b/pages/common/calibre-server.md
@@ -4,14 +4,14 @@
 > Ebooks must be imported into the library using the GUI or calibredb before.
 > Part of the Calibre ebook library.
 
-- Start a server to distribute ebooks. Access at http://localhost:8080
+- Start a server to distribute ebooks. Access at http://localhost:8080:
 
 `calibre-server`
 
-- Start server on different port. Access at http://localhost:port
+- Start server on different port. Access at http://localhost:port:
 
 `calibre-server --port {{port}}`
 
-- Password protect the server.
+- Password protect the server:
 
 `calibre-server --username {{username}} --password {{password}}`

--- a/pages/common/calibredb.md
+++ b/pages/common/calibredb.md
@@ -3,22 +3,22 @@
 > Tool to manipulate the your ebook database.
 > Part of the Calibre ebook library.
 
-- List ebooks in the library with additional information.
+- List ebooks in the library with additional information:
 
 `calibredb list`
 
-- Search for ebooks displaying additional information.
+- Search for ebooks displaying additional information:
 
 `calibredb list --search {{search-term}}`
 
-- Search for just ids of ebooks.
+- Search for just ids of ebooks:
 
 `calibredb search {{search term}}`
 
-- Add one or more ebooks to the library.
+- Add one or more ebooks to the library:
 
 `calibredb add {{file1 file2 …}}`
 
-- Remove one or more ebooks from the library. You need ebook-ids (see above)
+- Remove one or more ebooks from the library. You need ebook-ids (see above):
 
 `calibredb remove {{id1 id2 …}}`

--- a/pages/common/cat.md
+++ b/pages/common/cat.md
@@ -2,14 +2,14 @@
 
 > Print and concatenate files.
 
-- Print the contents of a file to the standard output
+- Print the contents of a file to the standard output:
 
 `cat {{file}}`
 
-- Concatenate several files into the target file.
+- Concatenate several files into the target file:
 
 `cat {{file1}} {{file2}} > {{target-file}}`
 
-- Append serveral files into the target file.
+- Append serveral files into the target file:
 
 `cat {{file1}} {{file2}} >> {{target-file}}`

--- a/pages/common/cd.md
+++ b/pages/common/cd.md
@@ -1,19 +1,19 @@
 # cd
 
-> Change the current working directory
+> Change the current working directory.
 
-- Go to the given directory
+- Go to the given directory:
 
 `cd {{/path/to/directory}}`
 
-- Go to home directory of current user
+- Go to home directory of current user:
 
 `cd`
 
-- Go up to the parent of the current directory
+- Go up to the parent of the current directory:
 
 `cd ..`
 
-- Go to the previously chosen directory
+- Go to the previously chosen directory:
 
 `cd -`

--- a/pages/common/chmod.md
+++ b/pages/common/chmod.md
@@ -1,23 +1,23 @@
 # chmod
 
-> Change the access permissions of a file or directory
+> Change the access permissions of a file or directory.
 
-- Give the (u)ser who owns a file the right to e(x)ecute it
+- Give the (u)ser who owns a file the right to e(x)ecute it:
 
 `chmod u+x {{file}}`
 
-- Give the user rights to (r)ead and (w)rite to a file/directory
+- Give the user rights to (r)ead and (w)rite to a file/directory:
 
 `chmod u+rw {{file}}`
 
-- Remove executable rights from the (g)roup
+- Remove executable rights from the (g)roup:
 
 `chmod g-x {{file}}`
 
-- Give (a)ll users rights to read and execute
+- Give (a)ll users rights to read and execute:
 
 `chmod a+rx {{file}}`
 
-- Give (o)thers (not in the file owner's group) the same rights as the group
+- Give (o)thers (not in the file owner's group) the same rights as the group:
 
 `chmod o=g {{file}}`

--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -1,23 +1,23 @@
 # chown
 
-> Change the owning user/group of the specified files
+> Change the owning user/group of the specified files.
 
-- change the user of a file
+- Change the user of a file:
 
 `chown {{user}} {{path/to/file}}`
 
-- change the user and group of a file
+- Change the user and group of a file:
 
 `chown {{user}}:{{group}} {{path/to/file}}`
 
-- recursively change the owner of an entire folder
+- Recursively change the owner of an entire folder:
 
 `chown -R {{user}} {{path/to/folder}}`
 
-- change the owner of a symbolic link
+- Change the owner of a symbolic link:
 
 `chown -h {{user}} {{path/to/symlink}}`
 
-- use the owner and group of a reference file and apply those values to another file
+- Use the owner and group of a reference file and apply those values to another file:
 
 `chown --reference={{reference-file}} {{path/to/file}}`

--- a/pages/common/chsh.md
+++ b/pages/common/chsh.md
@@ -1,7 +1,7 @@
 # chsh
 
-> Change user's login shell
+> Change user's login shell.
 
-- change shell
+- Change shell:
 
 `chsh -s {{path/to/shell_binary}} {{username}}`

--- a/pages/common/cksum.md
+++ b/pages/common/cksum.md
@@ -1,8 +1,8 @@
 # cksum
 
-> Calculates CRC checksums and byte counts of a file
+> Calculates CRC checksums and byte counts of a file.
 > Note, on old UNIX systems the CRC implementation may differ.
 
-- Display a 32 bit checksum, size in bytes and filename
+- Display a 32 bit checksum, size in bytes and filename:
 
 `cksum {{filename}}`

--- a/pages/common/clang.md
+++ b/pages/common/clang.md
@@ -2,14 +2,14 @@
 
 > Compiler for C, C++, and Objective-C source files. Can be used as a drop-in replacement for GCC.
 
-- Compile a source code file into an executable binary
+- Compile a source code file into an executable binary:
 
 `clang {{input_source.c}} -o {{output_executable}}`
 
-- Activate output of all errors and warnings
+- Activate output of all errors and warnings:
 
 `clang {{input_source.c}} -Wall -o {{output_executable}}`
 
-- Include libraries located at a different path than the source file
+- Include libraries located at a different path than the source file:
 
 `clang {{input_source.c}} -o {{output_executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`

--- a/pages/common/comm.md
+++ b/pages/common/comm.md
@@ -2,22 +2,22 @@
 
 > Select or reject lines common to two files. Both files must be sorted.
 
-- Produce three tab-separated columns: lines only in first file, lines only in second file and common lines.
+- Produce three tab-separated columns: lines only in first file, lines only in second file and common lines:
 
 `comm {{file1}} {{file2}}`
 
-- Print only lines common to both files.
+- Print only lines common to both files:
 
 `comm -12 {{file1}} {{file2}}`
 
-- Print only lines common to both files, read one file from stdin.
+- Print only lines common to both files, read one file from stdin:
 
 `cat {{file1}} | comm -12 - {{file2}}`
 
-- Print lines only found in first file.
+- Print lines only found in first file:
 
 `comm -23 {{file1}} {{file2}}`
 
-- Print lines only found in second file.
+- Print lines only found in second file:
 
 `comm -13 {{file1}} {{file2}}`

--- a/pages/common/convert.md
+++ b/pages/common/convert.md
@@ -1,19 +1,19 @@
 # convert
 
-> Imagemagick image conversion tool
+> Imagemagick image conversion tool.
 
-- Convert an image from JPG to PNG
+- Convert an image from JPG to PNG:
 
 `convert {{image.jpg}} {{image.png}}`
 
-- Scale an image 50% it's original size
+- Scale an image 50% it's original size:
 
 `convert {{image.png}} -resize 50% {{image2.png}}`
 
-- Scale an image keeping the original aspect ratio to a maximum dimension of 640x480.
+- Scale an image keeping the original aspect ratio to a maximum dimension of 640x480:
 
 `convert {{image.png}} -resize 640x480 {{image2.png}}`
 
-- Horizontally append images
+- Horizontally append images:
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} +append {{image123.png}}`

--- a/pages/common/cordova.md
+++ b/pages/common/cordova.md
@@ -1,27 +1,27 @@
 # cordova
 
-> Mobile apps with HTML, CSS & JS
+> Mobile apps with HTML, CSS & JS.
 
-- Create a cordova project
+- Create a cordova project:
 
 `cordova create {{path}} {{package.name}} {{project.name}}`
 
-- Display the current workspace status
+- Display the current workspace status:
 
 `cordova info`
 
-- Add a cordova platform
+- Add a cordova platform:
 
 `cordova platform add {{platform}}`
 
-- Remove a cordova platform
+- Remove a cordova platform:
 
 `cordova platform remove {{platform}}`
 
-- Add a cordova plugin
+- Add a cordova plugin:
 
 `cordova plugin add {{pluginid}}`
 
-- Remove a cordova plugin
+- Remove a cordova plugin:
 
 `cordova plugin remove {{pluginid}}`

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -1,15 +1,15 @@
 # cowsay
 
-> Generate an ASCII character like a cow or sheep saying or thinking something
+> Generate an ASCII character like a cow or sheep saying or thinking something.
 
-- Print an ASCII cow saying "Hello world!"
+- Print an ASCII cow saying "Hello world!":
 
 `cowsay "Hello world!"`
 
-- Print an ASCII dragon saying "Hello!"
+- Print an ASCII dragon saying "Hello!":
 
 `echo "Hello!" | cowsay -f dragon`
 
-- Print a stoned thinking ASCII cow
+- Print a stoned thinking ASCII cow:
 
 `cowthink -s "I'm just a cow, not a great thinker ..."`

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -1,27 +1,27 @@
 # cp
 
-> Copy files
+> Copy files.
 
-- Copy files in arbitrary locations
+- Copy files in arbitrary locations:
 
 `cp {{/path/to/original}} {{/path/to/copy}}`
 
-- Copy a file to a parent directory
+- Copy a file to a parent directory:
 
 `cp {{/path/to/original}} ../{{path/to/copy}}`
 
-- Copy directories recursive using the option -r
+- Copy directories recursive using the option -r:
 
 `cp -r {{/path/to/original}} {{/path/to/copy}}`
 
-- Show files as they are copied
+- Show files as they are copied:
 
 `cp -vr {{/path/to/original}} {{/path/to/copy}}`
 
-- Make a copy of a file, adding an extension
+- Make a copy of a file, adding an extension:
 
 `cp {{file.html}}{,.backup}`
 
-- Make a copy of a file, changing the extension
+- Make a copy of a file, changing the extension:
 
 `cp {{file.}}{html,backup}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -1,28 +1,28 @@
 # curl
 
-> Transfers data from or to a server
-> Supports most protocols including HTTP, FTP, POP
+> Transfers data from or to a server.
+> Supports most protocols including HTTP, FTP, POP.
 
-- Download a URL to a file
+- Download a URL to a file:
 
 `curl "{{URL}}" -o {{filename}}`
 
-- send form-encoded data
+- Send form-encoded data:
 
 `curl --data {{name=bob}} {{http://localhost/form}}`
 
-- send JSON data
+- Send JSON data:
 
 `curl -X POST -H "Content-Type: application/json" -d {{'{"name":"bob"}'}} {{http://localhost/login}}`
 
-- specify an HTTP method
+- Specify an HTTP method:
 
 `curl -X {{DELETE}} {{http://localhost/item/123}}`
 
-- head request
+- Head request:
 
 `curl --head {{http://localhost}}`
 
-- pass a user name and password for server authentication
+- Pass a user name and password for server authentication:
 
 `curl -u myusername:mypassword {{http://localhost}}`

--- a/pages/common/cut.md
+++ b/pages/common/cut.md
@@ -1,27 +1,27 @@
 # cut
 
-> Cut out fields from STDIN or files
+> Cut out fields from STDIN or files.
 
-- Cut out the first sixteen characters of each line of STDIN
+- Cut out the first sixteen characters of each line of STDIN:
 
 `cut -c {{1-16}}`
 
-- Cut out the first sixteen characters of each line of the given files
+- Cut out the first sixteen characters of each line of the given files:
 
 `cut -c {{1-16}} {{file}}`
 
-- Cut out everything from the 3rd character to the end of each line
+- Cut out everything from the 3rd character to the end of each line:
 
 `cut -c{{3-}}`
 
-- Cut out the fifth field, split on the colon character of each line
+- Cut out the fifth field, split on the colon character of each line:
 
 `cut -d'{{:}}' -f{{5}}`
 
-- Cut out the fields five and 10, split on the colon character of each line
+- Cut out the fields five and 10, split on the colon character of each line:
 
 `cut -d'{{:}}' -f{{5,10}}`
 
-- Cut out the fields five through 10, split on the colon character of each line
+- Cut out the fields five through 10, split on the colon character of each line:
 
 `cut -d'{{:}}' -f{{5-10}}`

--- a/pages/common/date.md
+++ b/pages/common/date.md
@@ -1,11 +1,11 @@
 # date
 
-> Set or display the system date
+> Set or display the system date.
 
-- Display the date using the default locale
+- Display the date using the default locale:
 
 `date +"%c"`
 
-- Display the date in UTC and ISO 8601 format
+- Display the date in UTC and ISO 8601 format:
 
 `date -u +"%Y-%m-%dT%H:%M:%SZ"`

--- a/pages/common/deluser.md
+++ b/pages/common/deluser.md
@@ -1,15 +1,15 @@
 # deluser
 
-> Remove a user account or remove a user from a group
+> Remove a user account or remove a user from a group.
 
-- Remove a user
+- Remove a user:
 
 `deluser {{name}}`
 
-- Remove a user along with their home directory and mail spool
+- Remove a user along with their home directory and mail spool:
 
 `deluser -r {{name}}`
 
-- Remove a user from a group
+- Remove a user from a group:
 
 `deluser {{name}} {{group}}`

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -1,11 +1,11 @@
 # df
 
-> gives an overview of the file system disk space usage
+> Gives an overview of the file system disk space usage.
 
-- display all file systems and their disk usage
+- Display all file systems and their disk usage:
 
 `df`
 
-- display all file systems and their disk usage in human readable form
+- Display all file systems and their disk usage in human readable form:
 
 `df -h`

--- a/pages/common/diff.md
+++ b/pages/common/diff.md
@@ -1,23 +1,23 @@
 # diff
 
-> Compare files and directories
+> Compare files and directories.
 
-- Compare files
+- Compare files:
 
 `diff {{file1}} {{file2}}`
 
-- Compare files, ignoring white spaces
+- Compare files, ignoring white spaces:
 
 `diff -w {{file1}} {{file2}}`
 
-- Compare files, showing differences side by side
+- Compare files, showing differences side by side:
 
 `diff -y {{file1}} {{file2}}`
 
-- Compare directories recursively
+- Compare directories recursively:
 
 `diff -r {{directory1}} {{directory2}}`
 
-- Compare directories, only showing the names of files that differ
+- Compare directories, only showing the names of files that differ:
 
 `diff -rq {{directory1}} {{directory2}}`

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -1,15 +1,15 @@
 # dig
 
-> DNS Lookup utility
+> DNS Lookup utility.
 
-- Lookup the IP(s) associated with a hostname (A records)
+- Lookup the IP(s) associated with a hostname (A records):
 
 `dig +short {{hostname.com}}`
 
-- Lookup the mail server associated with a given domain name (MX record)
+- Lookup the mail server associated with a given domain name (MX record):
 
 `dig +short {{hostname.com}} MX`
 
-- Specify an alternate DNS server to query (8.8.8.8 is google's public DNS)
+- Specify an alternate DNS server to query (8.8.8.8 is google's public DNS):
 
 `dig @8.8.8.8 {{hostname.com}}`

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -1,28 +1,28 @@
 # docker
 
-> Docker allows you to package an application with all of its
-> dependencies into a standardized unit for software development.
+> Docker allows you to package an application with all of its.
+> Dependencies into a standardized unit for software development.
 
-- List of running docker containers
+- List of running docker containers:
 
 `docker ps`
 
-- List all docker containers (running and stopped)
+- List all docker containers (running and stopped):
 
 `docker ps -a`
 
-- Start a container
+- Start a container:
 
 `docker start {{container}}`
 
-- Stop a container
+- Stop a container:
 
 `docker stop {{container}}`
 
-- Start a container from an image and get a shell inside of it
+- Start a container from an image and get a shell inside of it:
 
 `docker run -it {{image}} bash`
 
-- Run a command inside of an already running container
+- Run a command inside of an already running container:
 
 `docker exec {{container}} {{command}}`

--- a/pages/common/drush.md
+++ b/pages/common/drush.md
@@ -2,26 +2,26 @@
 
 > A command-line shell and scripting interface for Drupal.
 
-- Download module "foo"
+- Download module "foo":
 
 `drush dl {{foo}}`
 
-- Download version 7.x-2.1-beta1 of module "foo"
+- Download version 7.x-2.1-beta1 of module "foo":
 
 `drush dl {{foo}}-7.x-2.1-beta1`
 
-- Enable module "foo"
+- Enable module "foo":
 
 `drush en {{foo}}`
 
-- Disable module "foo"
+- Disable module "foo":
 
 `drush dis {{foo}}`
 
-- Clear all caches
+- Clear all caches:
 
 `drush cc all`
 
-- Clear CSS and JavaScript caches
+- Clear CSS and JavaScript caches:
 
 `drush cc css-js`

--- a/pages/common/ebook-convert.md
+++ b/pages/common/ebook-convert.md
@@ -3,6 +3,6 @@
 > Can be used to convert ebooks between common formats, e.g., pdf, epub and mobi.
 > Part of the Calibre ebook library tool.
 
-- Convert an ebook into another format.
+- Convert an ebook into another format:
 
 `ebook-convert {{source}} {{destination}}`

--- a/pages/common/echo.md
+++ b/pages/common/echo.md
@@ -1,11 +1,11 @@
 # echo
 
-> Print given arguments
+> Print given arguments.
 
-- Print a text message. Note: quotes are optional.
+- Print a text message. Note: quotes are optional:
 
 `echo {{"Hello World"}}`
 
-- Print a message with environment variables
+- Print a message with environment variables:
 
 `echo {{"My path is $PATH"}}`

--- a/pages/common/electrum.md
+++ b/pages/common/electrum.md
@@ -1,31 +1,31 @@
 # electrum
 
-> Ergonomic Bitcoin wallet and private key management
+> Ergonomic Bitcoin wallet and private key management.
 
-- Create a new wallet
+- Create a new wallet:
 
 `electrum -w {{new-wallet.dat}} create`
 
-- Restore an existing wallet from seed offline
+- Restore an existing wallet from seed offline:
 
 `electrum -w {{recovery-wallet.dat}} restore -o`
 
-- Create a signed transaction offline
+- Create a signed transaction offline:
 
 `electrum mktx {{recipient}} {{amount}} -f 0.0000001 -F {{from}} -o`
 
-- Display all wallet receiving addresses
+- Display all wallet receiving addresses:
 
 `electrum listaddresses -a`
 
-- Sign a message
+- Sign a message:
 
 `electrum signmessage {{address}} {{message}}`
 
-- Verify a message
+- Verify a message:
 
 `electrum verifymessage {{address}} {{signature}} {{message}}`
 
-- Connect only to a specific electrum-server instance
+- Connect only to a specific electrum-server instance:
 
 `electrum -p socks5:{{127.0.0.1}}:9050 -s {{56ckl5obj37gypcu.onion}}:50001:t -1`

--- a/pages/common/emacs.md
+++ b/pages/common/emacs.md
@@ -1,15 +1,15 @@
 # emacs
 
-> The extensible, customizable, self-documenting, real-time display editor
+> The extensible, customizable, self-documenting, real-time display editor.
 
-- Open emacs in console mode (without X window)
+- Open emacs in console mode (without X window):
 
 `emacs -nw`
 
-- Open a file in emacs
+- Open a file in emacs:
 
 `emacs {{filename}}`
 
-- Exit emacs
+- Exit emacs:
 
 `C-x C-c`

--- a/pages/common/enca.md
+++ b/pages/common/enca.md
@@ -1,19 +1,19 @@
 # enca
 
-> Detect and convert encoding of text files
+> Detect and convert encoding of text files.
 
-- detect file(s) encoding according to your system's locale
+- Detect file(s) encoding according to your system's locale:
 
 `enca {{file(s)}}`
 
-- detect file(s) encoding; -L option tells enca the current language; language is in the POSIX/C locale format, e.g. zh_CN, en_US etc.
+- Detect file(s) encoding; -L option tells enca the current language; language is in the POSIX/C locale format, e.g. zh_CN, en_US etc:
 
 `enca -L {{language}} {{file(s)}}`
 
-- convert file(s) to specified encoding
+- Convert file(s) to specified encoding:
 
 `enca -L {{language}} -x {{to_encoding}} {{file(s)}}`
 
-- save original_file as new_file and convert new_file to specified encoding
+- Save original_file as new_file and convert new_file to specified encoding:
 
 `enca -L {{language}} -x {{to_encoding}} < {{original_file}} > {{new_file}}`

--- a/pages/common/env.md
+++ b/pages/common/env.md
@@ -1,19 +1,19 @@
 # env
 
-> Show the environment or run a program in a modified environment
+> Show the environment or run a program in a modified environment.
 
-- Show the environment
+- Show the environment:
 
 `env`
 
-- Clear the environment and run a program
+- Clear the environment and run a program:
 
 `env -i {{program}}`
 
-- Remove variable from the environment and run a program
+- Remove variable from the environment and run a program:
 
 `env -u {{variable}} {{program}}`
 
-- Set a variable and run a program
+- Set a variable and run a program:
 
 `env {{variable}}={{value}} {{program}}`

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -1,7 +1,7 @@
 # exiftool
 
-> Read and write meta information in files
+> Read and write meta information in files.
 
-- Remove all EXIF metadata from the given files
+- Remove all EXIF metadata from the given files:
 
 `exiftool -All= {{file}}`

--- a/pages/common/fdupes.md
+++ b/pages/common/fdupes.md
@@ -1,20 +1,20 @@
 # fdupes
 
-> Finds duplicate files in a given
-> set of directories
+> Finds duplicate files in a given.
+> Set of directories.
 
-- search a single directory
+- Search a single directory:
 
 `fdupes {{directory}}`
 
-- search multiple directories
+- Search multiple directories:
 
 `fdupes {{directory1}} {{directory2}}`
 
-- search all directories recursively
+- Search all directories recursively:
 
 `fdupes -r {{directory}}`
 
-- search multiple directories, one recursively
+- Search multiple directories, one recursively:
 
 `fdupes {{directory1}} -R {{directory2}}`

--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -1,19 +1,19 @@
 # ffmpeg
 
-> Video conversion tool
+> Video conversion tool.
 
-- Extract the sound from a video and save it as MP3
+- Extract the sound from a video and save it as MP3:
 
 `ffmpeg -i {{video-filename}} -vn -ar 44100 -ac 2 -ab 192 -f mp3 {{sound.mp3}}`
 
-- Convert frames from a video into individual numbered images
+- Convert frames from a video into individual numbered images:
 
 `ffmpeg -i {{video-filename}} {{image%d.png}}`
 
-- Combine numbered images (image1.jpg, image2.jpg, etc) into a video
+- Combine numbered images (image1.jpg, image2.jpg, etc) into a video:
 
 `ffmpeg -f image2 -i {{image%d.jpg}} {{video.mpg}}`
 
-- Convert AVI video to MP4. AAC Audio @ 128kbit, Video @ 1250Kbit
+- Convert AVI video to MP4. AAC Audio @ 128kbit, Video @ 1250Kbit:
 
 `ffmpeg -i {{in.avi}} -acodec libfaac -ab 128k -vcodec mpeg4 -b 1250K {{out.mp4}}`

--- a/pages/common/file.md
+++ b/pages/common/file.md
@@ -1,11 +1,11 @@
 # file
 
-> Determine file type
+> Determine file type.
 
-- Give a description of the type of the specified file.  Works fine for files with no file extension.
+- Give a description of the type of the specified file.  Works fine for files with no file extension:
 
 `file {{filename}}`
 
-- Look inside a zipped file and determine the file type(s) inside
+- Look inside a zipped file and determine the file type(s) inside:
 
 `file -z {{foo.zip}}`

--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -1,27 +1,27 @@
 # find
 
-> Find files under the given directory tree, recursively
+> Find files under the given directory tree, recursively.
 
-- find files by extension
+- Find files by extension:
 
 `find {{root_path}} -name {{'*.py'}}`
 
-- find files matching path pattern
+- Find files matching path pattern:
 
 `find {{root_path}} -path {{'**/lib/**/*.py'}}`
 
-- run a command for each file, use {} within the command to access the filename
+- Run a command for each file, use {} within the command to access the filename:
 
 `find {{root_path}} -name {{'*.py'}} -exec {{wc -l {} }}\;`
 
-- find files modified since a certain time
+- Find files modified since a certain time:
 
 `find {{root_path}} -name {{'*.py'}} -mtime {{-1d}}`
 
-- find files using case insensitive name matching, of a certain size
+- Find files using case insensitive name matching, of a certain size:
 
 `find {{root_path}} -size +500k -size -10MB -iname {{'*.TaR.gZ'}}`
 
-- delete files by name, older than a certain number of days
+- Delete files by name, older than a certain number of days:
 
 `find {{root_path}} -name {{'*.py'}} -mtime {{-180d}} -delete`

--- a/pages/common/fortune.md
+++ b/pages/common/fortune.md
@@ -1,27 +1,27 @@
 # fortune
 
-> Print a random quotation (fortune-cookie style)
+> Print a random quotation (fortune-cookie style).
 
-- Print a quotation
+- Print a quotation:
 
 `fortune`
 
-- Print a quotation from a given database
+- Print a quotation from a given database:
 
 `fortune {{database}}`
 
-- Print a list of quotation databases
+- Print a list of quotation databases:
 
 `fortune -f`
 
-- Print an offensive quotation
+- Print an offensive quotation:
 
 `fortune -o`
 
-- Print a long quotation
+- Print a long quotation:
 
 `fortune -l`
 
-- Print a short quotation
+- Print a short quotation:
 
 `fortune -s`

--- a/pages/common/fswebcam.md
+++ b/pages/common/fswebcam.md
@@ -1,19 +1,19 @@
 # fswebcam
 
-> small and simple webcam for *nix
+> Small and simple webcam for *nix.
 
-- Take a picture
+- Take a picture:
 
 `fswebcam {{filename}}`
 
-- Take a picture with custom resolution
+- Take a picture with custom resolution:
 
 `fswebcam -r {{width}}x{{height}} {{filename}}`
 
-- Take a picture from selected device(Default is /dev/vidoe0)
+- Take a picture from selected device(Default is /dev/vidoe0):
 
 `fswebcam -d {{device}} {{filename}}`
 
-- Take a picture with timestamp(timestamp string is formatted by strftime)
+- Take a picture with timestamp(timestamp string is formatted by strftime):
 
 `fswebcam --timestamp {{timestamp}} {{filename}}`

--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -2,14 +2,14 @@
 
 > Preprocesses and compiles C and C++ source files, then assembles and links them together.
 
-- Compile multiple source files into executable
+- Compile multiple source files into executable:
 
 `gcc {{source1.c}} {{source2.c}} -o {{executable}}`
 
-- Allow warnings, debug symbols in output
+- Allow warnings, debug symbols in output:
 
 `gcc {{source.c}} -Wall -Og -o {{executable}}`
 
-- Include libraries from a different path
+- Include libraries from a different path:
 
 `gcc {{source.c}} -o {{executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`

--- a/pages/common/gem.md
+++ b/pages/common/gem.md
@@ -2,22 +2,22 @@
 
 > Interact with the package manager for the Ruby programming language.
 
-- Install latest version of a gem
+- Install latest version of a gem:
 
 `gem install {{gemname}}`
 
-- Install specific version of a gem
+- Install specific version of a gem:
 
 `gem install {{gemname}} -v {{1.0.0}}`
 
-- Update a gem
+- Update a gem:
 
 `gem update {{gemname}}`
 
-- List all gems
+- List all gems:
 
 `gem list`
 
-- Uninstall a gem
+- Uninstall a gem:
 
 `gem uninstall {{gemname}}`

--- a/pages/common/gifsicle.md
+++ b/pages/common/gifsicle.md
@@ -1,15 +1,15 @@
 # gifsicle
 
-> Create gifs
+> Create gifs.
 
-- Making a GIF animation with gifsicle
+- Making a GIF animation with gifsicle:
 
 `gifsicle --delay={{10}} --loop *.gif > {{anim.gif}}`
 
-- Extracting frames from an animation
+- Extracting frames from an animation:
 
 `gifsicle {{anim.gif}} '#0' > {{firstframe.gif}}`
 
-- You can also edit animations by replacing, deleting, or inserting frames
+- You can also edit animations by replacing, deleting, or inserting frames:
 
 `gifsicle -b {{anim.gif}} --replace '#0' {{new.gif}}`

--- a/pages/common/git-add.md
+++ b/pages/common/git-add.md
@@ -1,19 +1,19 @@
 # git add
 
-> Adds changed files to the index
+> Adds changed files to the index.
 
-- Add a file to the index
+- Add a file to the index:
 
 `git add {{PATHSPEC}}`
 
-- Add all files (tracked and untracked)
+- Add all files (tracked and untracked):
 
 `git add .`
 
-- Only add already tracked files
+- Only add already tracked files:
 
 `git add -u`
 
-- Also add ignored files
+- Also add ignored files:
 
 `git add -f`

--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -1,11 +1,11 @@
 # git blame
 
-> Show commit hash and last author on each line of a file
+> Show commit hash and last author on each line of a file.
 
-- Print file with author name and commit hash on each line
+- Print file with author name and commit hash on each line:
 
 `git blame {{file}}`
 
-- Print file with author email and commit hash on each line
+- Print file with author email and commit hash on each line:
 
 `git blame -e {{file}}`

--- a/pages/common/git-branch.md
+++ b/pages/common/git-branch.md
@@ -1,23 +1,23 @@
 # git branch
 
-> Main command for working with branches
+> Main command for working with branches.
 
-- List local branches. The current branch is highlighted by `*`.
+- List local branches. The current branch is highlighted by `*`:
 
 `git branch`
 
-- List all local and remote branches
+- List all local and remote branches:
 
 `git branch -a`
 
-- Create new branch based on current branch
+- Create new branch based on current branch:
 
 `git branch {{BRANCH-NAME}}`
 
-- Delete a local branch
+- Delete a local branch:
 
 `git branch -d {{BRANCH-NAME}}`
 
-- Move/Rename a branch
+- Move/Rename a branch:
 
 `git branch -m`

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -1,15 +1,15 @@
 # git checkout
 
-> Checkout a branch or paths to the working tree
+> Checkout a branch or paths to the working tree.
 
-- Switch to another branch
+- Switch to another branch:
 
 `git checkout {{BRANCH-NAME}}`
 
-- Create and switch to a new branch
+- Create and switch to a new branch:
 
 `git checkout -b {{BRANCH-NAME}}`
 
-- Undo unstaged local modification
+- Undo unstaged local modification:
 
 `git checkout .`

--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -1,19 +1,19 @@
 # git clone
 
-> Clone an existing repository
+> Clone an existing repository.
 
-- Clone an existing repository
+- Clone an existing repository:
 
 `git clone {{REMOTE-REPOSITORY-LOCATION}}`
 
-- For cloning from the local machine
+- For cloning from the local machine:
 
 `git clone -l`
 
-- Do it quietly
+- Do it quietly:
 
 `git clone -q`
 
-- Clone an existing repository, and truncate to the specified number of revisions, save your time mostly
+- Clone an existing repository, and truncate to the specified number of revisions, save your time mostly:
 
 `git clone --depth 10 {{REMOTE-REPOSITORY-LOCATION}}`

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -1,11 +1,11 @@
 # git commit
 
->Commit staged files to the repository
+> Commit staged files to the repository.
 
-- Commit staged files to the repository with comment
+- Commit staged files to the repository with comment:
 
 `git commit -m {{MESSAGE}}`
 
-- Replace the last commit with currently staged changes
+- Replace the last commit with currently staged changes:
 
 `git commit --amend`

--- a/pages/common/git-config.md
+++ b/pages/common/git-config.md
@@ -1,27 +1,27 @@
 # git config
 
-> Get and set repository or global options
+> Get and set repository or global options.
 
-- Print list of options for current repository
+- Print list of options for current repository:
 
 `git config --list --local`
 
-- Print global list of options, set in ~/.gitconfig
+- Print global list of options, set in ~/.gitconfig:
 
 `git config --list --global`
 
-- Get full list of options
+- Get full list of options:
 
 `git config --list`
 
-- Get value of alias.ls option
+- Get value of alias.ls option:
 
 `git config alias.st`
 
-- Set option alias.ls=status in file ~/.gitconfig
+- Set option alias.ls=status in file ~/.gitconfig:
 
 `git config --global alias.ls "status"`
 
-- Remove option alias.st from ~/.gitconfig
+- Remove option alias.st from ~/.gitconfig:
 
 `git config --global --unset alias.st`

--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -1,19 +1,19 @@
 # git diff
 
-> Show changes to tracked files
+> Show changes to tracked files.
 
-- Show changes to tracked files
+- Show changes to tracked files:
 
 `git diff {{PATHSPEC}}`
 
-- Show only names of changed files.
+- Show only names of changed files:
 
 `git diff --name-only {{PATHSPEC}}`
 
-- Output a condensed summary of extended header information.
+- Output a condensed summary of extended header information:
 
 `git diff --summary {{PATHSPEC}}`
 
-- Show staged (added, but not yet committed) changes only.
+- Show staged (added, but not yet committed) changes only:
 
 `git diff --staged`

--- a/pages/common/git-init.md
+++ b/pages/common/git-init.md
@@ -1,11 +1,11 @@
 # git init
 
-> Initializes a new local Git repository
+> Initializes a new local Git repository.
 
-- Initialize a new local repository
+- Initialize a new local repository:
 
 `git init`
 
-- Initialize a barebones repository
+- Initialize a barebones repository:
 
 `git init --bare`

--- a/pages/common/git-log.md
+++ b/pages/common/git-log.md
@@ -1,15 +1,15 @@
 # git log
 
->Show a history of commits
+> Show a history of commits.
 
-- Show a history of commits
+- Show a history of commits:
 
 `git log`
 
-- Show the history of a particular file or directory, including differences
+- Show the history of a particular file or directory, including differences:
 
 `git log -p {{path}}`
 
-- Show only the first line of each commits
+- Show only the first line of each commits:
 
 `git log --oneline`

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -1,11 +1,11 @@
 # git merge
 
-> Merge branches
+> Merge branches.
 
-- Merge a branch with your current branch
+- Merge a branch with your current branch:
 
 `git merge {{BRANCH-NAME}}`
 
-- Edit the merge message
+- Edit the merge message:
 
 `git merge -e {{BRANCH-NAME}}`

--- a/pages/common/git-mv.md
+++ b/pages/common/git-mv.md
@@ -2,14 +2,14 @@
 
 > Move or rename files and update the git index.
 
-- Move file inside the repo and add the movement to the next commit
+- Move file inside the repo and add the movement to the next commit:
 
 `git mv {{path/to/file}} {{new/path/to/file}}`
 
-- Rename file and add renaming to the next commit
+- Rename file and add renaming to the next commit:
 
 `git mv {{filename}} {{new_filename}}`
 
-- Overwrite the file in the target path if it exists
+- Overwrite the file in the target path if it exists:
 
 `git mv --force {{file}} {{target}}`

--- a/pages/common/git-pull.md
+++ b/pages/common/git-pull.md
@@ -1,15 +1,15 @@
 # git pull
 
-> Fetch branch from a remote repository and merge it to local repository
+> Fetch branch from a remote repository and merge it to local repository.
 
-- Download changes from default remote repository and merge it
+- Download changes from default remote repository and merge it:
 
 `git pull`
 
-- Download changes from default remote repository and use fast forward
+- Download changes from default remote repository and use fast forward:
 
 `git pull --rebase`
 
-- Download changes from given remote repository and branch, then merge them into HEAD
+- Download changes from given remote repository and branch, then merge them into HEAD:
 
 `git pull {{remote_name}} {{branch}}`

--- a/pages/common/git-push.md
+++ b/pages/common/git-push.md
@@ -1,23 +1,23 @@
 # git push
 
-> Push commits to a remote repository
+> Push commits to a remote repository.
 
-- Publish local changes on a remote branch
+- Publish local changes on a remote branch:
 
 `git push {{REMOTE-NAME}} {{LOCAL-BRANCH}}`
 
-- Publish local changes on a remote branch of different name
+- Publish local changes on a remote branch of different name:
 
 `git push {{REMOTE-NAME}} {{LOCAL-BRANCH}}:{{REMOTE-BRANCH}}`
 
-- Remove remote branch
+- Remove remote branch:
 
 `git push {{REMOTE-NAME}} :{{REMOTE-BRANCH}}`
 
-- Remove remote branches which don't exist locally
+- Remove remote branches which don't exist locally:
 
 `git push --prune {{REMOTE-NAME}}`
 
-- Publish tags
+- Publish tags:
 
 `git push --tags`

--- a/pages/common/git-remote.md
+++ b/pages/common/git-remote.md
@@ -1,23 +1,23 @@
 # git remote
 
-> Manage set of tracked repositories (“remotes”)
+> Manage set of tracked repositories (“remotes”).
 
-- Show a list of existing remotes, their names and URL
+- Show a list of existing remotes, their names and URL:
 
 `git remote -v`
 
-- Add a remote
+- Add a remote:
 
 `git remote add {{remote_name}} {{remote_url}}`
 
-- Change the URL of a remote
+- Change the URL of a remote:
 
 `git remote set-url {{remote_name}} {{new_url}}`
 
-- Remove a remote
+- Remove a remote:
 
 `git remote remove {{remote_name}}`
 
-- Rename a remote
+- Rename a remote:
 
 `git remote rename {{old_name}} {{new_name}}`

--- a/pages/common/git-rm.md
+++ b/pages/common/git-rm.md
@@ -1,15 +1,15 @@
 # git rm
 
-> Remove files from repository index and local filesystem
+> Remove files from repository index and local filesystem.
 
-- Remove file from repository index and filesystem
+- Remove file from repository index and filesystem:
 
 `git rm {{file}}`
 
-- Remove directory
+- Remove directory:
 
 `git rm -r {{directory}}`
 
-- Remove file from repository index but keep it untouched locally
+- Remove file from repository index but keep it untouched locally:
 
 `git rm --cached {{file}}`

--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -1,27 +1,27 @@
 # git stash
 
-> Stash local Git changes in a temporary area
+> Stash local Git changes in a temporary area.
 
-- stash current changes (except new files)
+- Stash current changes (except new files):
 
 `git stash save {{optional_stash_name}}`
 
-- include new files in the stash (leaves the index completely clean)
+- Include new files in the stash (leaves the index completely clean):
 
 `git stash save -u {{optional_stash_name}}`
 
-- list all stashes
+- List all stashes:
 
 `git stash list`
 
-- re-apply the latest stash
+- Re-apply the latest stash:
 
 `git stash pop`
 
-- re-apply a stash by name
+- Re-apply a stash by name:
 
 `git stash apply {{stash_name}}`
 
-- drop a stash by an index
+- Drop a stash by an index:
 
 `git stash drop stash@{index}`

--- a/pages/common/git-status.md
+++ b/pages/common/git-status.md
@@ -1,11 +1,11 @@
 # git status
 
-> Show the index (changed files)
+> Show the index (changed files).
 
-- Show changed files which are not yet added for commit
+- Show changed files which are not yet added for commit:
 
 `git status`
 
-- Give output in short format
+- Give output in short format:
 
 `git status -s`

--- a/pages/common/git-svn.md
+++ b/pages/common/git-svn.md
@@ -1,15 +1,15 @@
 # git svn
 
-> Bidirectional operation between a Subversion repository and Git
+> Bidirectional operation between a Subversion repository and Git.
 
-- clone an SVN repository
+- Clone an SVN repository:
 
 `git svn clone {{http://example.com/my_subversion_repo}} {{local_dir}}`
 
-- update local clone from the upstream SVN repository
+- Update local clone from the upstream SVN repository:
 
 `git svn rebase`
 
-- commit back to SVN repository
+- Commit back to SVN repository:
 
 `git svn dcommit`

--- a/pages/common/git-tag.md
+++ b/pages/common/git-tag.md
@@ -3,18 +3,18 @@
 > Create, list, delete or verify tags.
 > Tag is reference to specific commit.
 
-- List all tags
+- List all tags:
 
 `git tag`
 
-- Create a tag with the given name pointing to the current commit
+- Create a tag with the given name pointing to the current commit:
 
 `git tag {{tag_name}}`
 
-- Create a tag with the given message
+- Create a tag with the given message:
 
 `git tag {{tag_name}} -m {{tag_message}}`
 
-- Delete the tag with the given name
+- Delete the tag with the given name:
 
 `git tag -d {{tag_name}}`

--- a/pages/common/git.md
+++ b/pages/common/git.md
@@ -1,19 +1,19 @@
 # git
 
-> Main command for all git commands
+> Main command for all git commands.
 
-- Check the Git version
+- Check the Git version:
 
 `git --version`
 
-- Call general help
+- Call general help:
 
 `git --help`
 
-- Call help on a command
+- Call help on a command:
 
 `git help {{COMMAND}}`
 
-- Execute Git command
+- Execute Git command:
 
 `git {{COMMAND}}`

--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -1,23 +1,23 @@
 # gpg
 
-> Gnu Privacy Guard
+> Gnu Privacy Guard.
 
-- sign doc.txt without encryption (writes output to doc.txt.asc)
+- Sign doc.txt without encryption (writes output to doc.txt.asc):
 
 `gpg --clearsign {{doc.txt}}`
 
-- encrypt doc.txt for alice@example.com (output to doc.txt.gpg)
+- Encrypt doc.txt for alice@example.com (output to doc.txt.gpg):
 
 `gpg --encrypt --recipient {{alice@example.com}} {{doc.txt}}`
 
-- encrypt doc.txt with only a passphrase (output to doc.txt.gpg)
+- Encrypt doc.txt with only a passphrase (output to doc.txt.gpg):
 
 `gpg --symmetric {{doc.txt}}`
 
-- decrypt doc.txt.gpg (output to STDOUT)
+- Decrypt doc.txt.gpg (output to STDOUT):
 
 `gpg --decrypt {{doc.txt.gpg}}`
 
-- Import a public key
+- Import a public key:
 
 `gpg --import {{public.gpg}}`

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -1,15 +1,15 @@
 # Gradle
 
-> Gradle is the official build system for Android Studio
+> Gradle is the official build system for Android Studio.
 
-- Compile a package
+- Compile a package:
 
 `gradle build`
 
-- Clear the build folder
+- Clear the build folder:
 
 `gradle clean`
 
-- Compile and Release package
+- Compile and Release package:
 
 `gradle assembleRelease`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -1,36 +1,36 @@
 # grep
 
-> Matches patterns in input text
-> Supports simple patterns and regular expressions
+> Matches patterns in input text.
+> Supports simple patterns and regular expressions.
 
-- search for an exact string
+- Search for an exact string:
 
 `grep {{something}} {{file_path}}`
 
-- search recursively in current directory for an exact string
+- Search recursively in current directory for an exact string:
 
 `grep -r {{something}} .`
 
-- use a regex
+- Use a regex:
 
 `grep -e {{^regex$}} {{file_path}}`
 
-- see 3 lines of context
+- See 3 lines of context:
 
 `grep -C 3 {{something}} {{file_path}}`
 
-- print the count of matches instead of the matching text
+- Print the count of matches instead of the matching text:
 
 `grep -c {{something}} {{file_path}}`
 
-- print line number for each match
+- Print line number for each match:
 
 `grep -n {{something}} {{file_path}}`
 
-- use the standard input instead of a file
+- Use the standard input instead of a file:
 
 `cat {{file_path}} | grep {{something}}`
 
-- invert match for excluding specific strings
+- Invert match for excluding specific strings:
 
 `grep -v {{something}}`

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -1,23 +1,23 @@
 # gzip
 
-> Compress/uncompress files with gzip compression (LZ77)
+> Compress/uncompress files with gzip compression (LZ77).
 
-- compress a file, replacing it with a gzipped compressed version
+- Compress a file, replacing it with a gzipped compressed version:
 
 `gzip {{file.ext}}`
 
-- decompress a file, replacing it with the original uncompressed version
+- Decompress a file, replacing it with the original uncompressed version:
 
 `gzip -d {{file.ext.gz}}`
 
-- compress a file specifying the output filename
+- Compress a file specifying the output filename:
 
 `gzip -c {{file.ext}} > compressed-file.ext.gz`
 
-- uncompress a gzipped file specifying the output filename
+- Uncompress a gzipped file specifying the output filename:
 
 `gzip -c -d {{file.ext.gz}} > uncompressed-file.ext`
 
-- specify the compression level. 1=Fastest (Worst), 9=Slowest (Best), Default level is 6
+- Specify the compression level. 1=Fastest (Worst), 9=Slowest (Best), Default level is 6:
 
 `gzip -9 -c {{file.ext}} > compressed-file.ext.gz`

--- a/pages/common/handbrakecli.md
+++ b/pages/common/handbrakecli.md
@@ -1,19 +1,19 @@
 # HandBrakeCLI
 
-> Video conversion tool
+> Video conversion tool.
 
-- Convert a video file to MKV (AAC 160kbit audio and x264 CRF20 video)
+- Convert a video file to MKV (AAC 160kbit audio and x264 CRF20 video):
 
 `HandBrakeCLI -i {{input.avi}} -o {{output.mkv}} -e x264 -q 20 -B 160`
 
-- Resize a video file to 320x240
+- Resize a video file to 320x240:
 
 `HandBrakeCLI -i {{input.mp4}} -o {{output.mp4} -w 320 -l 240`
 
-- List available presets
+- List available presets:
 
 `HandBrakeCLI --preset-list`
 
-- Convert an AVI video to MP4 using the Android preset
+- Convert an AVI video to MP4 using the Android preset:
 
 `HandBrakeCLI --preset="Android" -i {{input.ext}} -o {{output.mp4}}`

--- a/pages/common/haxelib.md
+++ b/pages/common/haxelib.md
@@ -1,19 +1,19 @@
 # haxelib
 
-> Haxe Library Manager
+> Haxe Library Manager.
 
-- Search for a Haxe library
+- Search for a Haxe library:
 
 `haxelib search {{keyword}}`
 
-- Install a Haxe library
+- Install a Haxe library:
 
 `haxelib install {{libname}}`
 
-- Upgrade all installed Haxe libraries
+- Upgrade all installed Haxe libraries:
 
 `haxelib upgrade`
 
-- Install the development version of a library from a Git repository
+- Install the development version of a library from a Git repository:
 
 `haxelib git {{libname}} {{GIT-URL}}`

--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -2,10 +2,10 @@
 
 > Command Line history.
 
-- Display the commands history list with line numbers
+- Display the commands history list with line numbers:
 
 `history`
 
-- Clear the commands history list (only for `bash`)
+- Clear the commands history list (only for `bash`):
 
 `history -c`

--- a/pages/common/host.md
+++ b/pages/common/host.md
@@ -1,15 +1,15 @@
 # host
 
-> Lookup Domain Name Server
+> Lookup Domain Name Server.
 
-- Lookup A, AAAA, and MX records of a domain
+- Lookup A, AAAA, and MX records of a domain:
 
 `host {{domain}}`
 
-- Lookup a field (CNAME, TXT,...) of a domain
+- Lookup a field (CNAME, TXT,...) of a domain:
 
 `host -t {{field}} {{domain}}`
 
-- Reverse lookup an IP
+- Reverse lookup an IP:
 
 `host {{ip_address}}`

--- a/pages/common/iconv.md
+++ b/pages/common/iconv.md
@@ -1,15 +1,15 @@
 # iconv
 
-> Converts text from one encoding to another
+> Converts text from one encoding to another.
 
-- convert file and print to stdout
+- Convert file and print to stdout:
 
 `iconv -f {{from_encoding}} -t {{to_encoding}} {{input_file}}`
 
-- convert file to current locale
+- Convert file to current locale:
 
 `iconv -f {{from_encoding}} {{input_file}} > {{output_file}}`
 
-- list supported encodings
+- List supported encodings:
 
 `iconv -l`

--- a/pages/common/ifconfig.md
+++ b/pages/common/ifconfig.md
@@ -1,23 +1,23 @@
 # ifconfig
 
-> ifconfig - Interface Configurator, used to configure network interfaces.
+> Ifconfig - Interface Configurator, used to configure network interfaces.
 
-- View network settings of an ethernet adapter.
+- View network settings of an ethernet adapter:
 
 `ifconfig eth0`
 
-- Display details of all interfaces, including disabled interfaces.
+- Display details of all interfaces, including disabled interfaces:
 
 `ifconfig -a`
 
-- Disable eth0 interface.
+- Disable eth0 interface:
 
 `ifconfig eth0 down`
 
-- Enable eth0 interface.
+- Enable eth0 interface:
 
 `ifconfig eth0 up`
 
-- Assign IP address to eth0 interface.
+- Assign IP address to eth0 interface:
 
 `ifconfig eth0 {{ip_address}}`

--- a/pages/common/ionice.md
+++ b/pages/common/ionice.md
@@ -4,14 +4,14 @@
 > Scheduling classes: 1 (realtime), 2 (best-effort), 3 (idle).
 > Priority levels: 0 (the highest) - 7 (the lowest).
 
-- Set I/O scheduling class of a running process
+- Set I/O scheduling class of a running process:
 
 `ionice -c {{scheduling_class}} -p {{pid}}`
 
-- Run a command with custom I/O scheduling class and priority
+- Run a command with custom I/O scheduling class and priority:
 
 `ionice -c {{scheduling_class}} -n {{priority}} {{command}}`
 
-- Print the I/O scheduling class and priority of a running process
+- Print the I/O scheduling class and priority of a running process:
 
 `ionice -p {{pid}}`

--- a/pages/common/ioping.md
+++ b/pages/common/ioping.md
@@ -1,19 +1,19 @@
 # ioping
 
-> monitor I/O latency in real time
+> Monitor I/O latency in real time.
 
-- Show disk I/O latency using the default values and the current directory
+- Show disk I/O latency using the default values and the current directory:
 
 `ioping .`
 
-- Measure latency on /tmp using 10 requests of 1 megabyte each.
+- Measure latency on /tmp using 10 requests of 1 megabyte each:
 
 `ioping -c 10 -s 1M /tmp`
 
-- Measure disk seek rate on /dev/sda.
+- Measure disk seek rate on /dev/sda:
 
 `ioping -R /dev/sda`
 
-- Measure disk sequential speed on /dev/sda.
+- Measure disk sequential speed on /dev/sda:
 
 `ioping -RL /dev/sda`

--- a/pages/common/ipcs.md
+++ b/pages/common/ipcs.md
@@ -1,11 +1,11 @@
 # ipcs
 
-> Display information about ressources used in IPC (Inter-process Communication)
+> Display information about ressources used in IPC (Inter-process Communication).
 
-- Specific information about the Message Queue which has the id 32768
+- Specific information about the Message Queue which has the id 32768:
 
 `ipcs -qi 32768`
 
-- General information about all the IPC
+- General information about all the IPC:
 
 `ipcs -a`

--- a/pages/common/java.md
+++ b/pages/common/java.md
@@ -2,15 +2,14 @@
 
 > Java Application Launcher.
 
-- Execute a java .class file that contains a main method by using just the class name.
+- Execute a java .class file that contains a main method by using just the class name:
 
 `java {{filename}}`
 
-- Execute a .jar program.
+- Execute a .jar program:
 
 `java -jar {{filename.jar}}`
 
-- Display JDK, JRE and HotSpot versions.
+- Display JDK, JRE and HotSpot versions:
 
 `java -version`
-

--- a/pages/common/javac.md
+++ b/pages/common/javac.md
@@ -2,6 +2,6 @@
 
 > Java Application Compiler.
 
-- Compile a .java file.
+- Compile a .java file:
 
 `javac {{filename.java}}`

--- a/pages/common/kill.md
+++ b/pages/common/kill.md
@@ -1,12 +1,12 @@
 # kill
 
-> Sends a signal to a process
-> Mostly used for stopping processes
+> Sends a signal to a process.
+> Mostly used for stopping processes.
 
-- kill the process
+- Kill the process:
 
 `kill {{process_id}}`
 
-- list signal names
+- List signal names:
 
 `kill -l`

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -1,27 +1,27 @@
 # last
 
-> View the last logged in users
+> View the last logged in users.
 
-- view last logins, their duration  and other information as read from /var/log/wtmp
+- View last logins, their duration  and other information as read from /var/log/wtmp:
 
 `last`
 
-- specify how many of the last logins to show
+- Specify how many of the last logins to show:
 
 `last -n {{login_count}}`
 
-- view full login times and dates
+- View full login times and dates:
 
 `last -F`
 
-- view the last login by a specific user
+- View the last login by a specific user:
 
 `last {{user_name}}`
 
-- view the last reboot (last login of the pseudo user reboot)
+- View the last reboot (last login of the pseudo user reboot):
 
 `last reboot`
 
-- view the last shutdown (last login of the pseudo user shutdown)
+- View the last shutdown (last login of the pseudo user shutdown):
 
 `last shutdown`

--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -1,25 +1,25 @@
 # less
 
-> Opens a file for reading
-> Allows movement and search
-> Doesn't read the entire file (suitable for logs)
+> Opens a file for reading.
+> Allows movement and search.
+> Doesn't read the entire file (suitable for logs).
 
-- open a file
+- Open a file:
 
 `less {{source_file}}`
 
-- page up / down
+- Page up / down:
 
 `d (next), D (previous)`
 
-- go to start / end of file
+- Go to start / end of file:
 
 `g (start), G (end)`
 
-- search for a string
+- Search for a string:
 
 `/{{something}}   then   n (next), N (previous)`
 
-- exit
+- Exit:
 
 `q`

--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -1,15 +1,15 @@
 # ln
 
-> Creates links to files and folders
+> Creates links to files and folders.
 
-- create a symbolic link to a file or folder
+- Create a symbolic link to a file or folder:
 
 `ln -s {{path/to/original/file}} {{path/to/link}}`
 
-- overwrite a symbolic link to a file
+- Overwrite a symbolic link to a file:
 
 `ln -sf {{path/to/new/original/file}} {{path/to/file/link}}`
 
-- create a hard link to a file
+- Create a hard link to a file:
 
 `ln {{path/to/original/file}} {{path/to/link}}`

--- a/pages/common/lp.md
+++ b/pages/common/lp.md
@@ -1,23 +1,23 @@
 # lp
 
-> print files.
+> Print files.
 
-- Print the output of a command to the default printer (see `lpstat` command).
+- Print the output of a command to the default printer (see `lpstat` command):
 
 `echo "test" | lp`
 
-- Print a file to the default printer.
+- Print a file to the default printer:
 
 `lp {{path/to/filename}}`
 
-- Print a file to a named printer (see `lpstat` command).
+- Print a file to a named printer (see `lpstat` command):
 
 `lp -d {{printer_name}} {{path/to/filename}}`
 
-- Print N copies of file to default printer (replace N with desired number of copies).
+- Print N copies of file to default printer (replace N with desired number of copies):
 
 `lp -n {{N}} {{path/to/filename}}`
 
-- Print only certain pages to the default printer (print pages 1, 3-5, and 16).
+- Print only certain pages to the default printer (print pages 1, 3-5, and 16):
 
 `lp -P 1,3-5,16 {{path/to/filename}}`

--- a/pages/common/lpstat.md
+++ b/pages/common/lpstat.md
@@ -1,19 +1,19 @@
 # lpstat
 
-> show status information about printers
+> Show status information about printers.
 
-- List printers present on the machine and whether they are enabled for printing.
+- List printers present on the machine and whether they are enabled for printing:
 
 `lpstat -p`
 
-- Show the default printer.
+- Show the default printer:
 
 `lpstat -d`
 
-- Display all available status information.
+- Display all available status information:
 
 `lpstat -t`
 
-- Show a list of print jobs queued by the specified user.
+- Show a list of print jobs queued by the specified user:
 
 `lpstat -u {{user}}`

--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -1,37 +1,34 @@
 # ls
 
-> List directory contents
+> List directory contents.
 
-- List all files, even hidden
+- List all files, even hidden:
 
 `ls -a`
 
-- List all file names (no extra info)
+- List all file names (no extra info):
 
 `ls -A1`
 
-- List all files with their rights, groups, owner
+- List all files with their rights, groups, owner:
 
 `ls -l`
 
-- List all files and display the file size in a human readable format
+- List all files and display the file size in a human readable format:
 
 `ls -lh`
 
-- List all files with a prefix/suffix
+- List all files with a prefix/suffix:
 
 `ls {{prefix}}*`
-
 `ls *{{suffix}}`
 
-- Sort the results by size, last modified date, or creation date
+- Sort the results by size, last modified date, or creation date:
 
 `ls -S`
-
 `ls -t`
-
 `ls -U`
 
-- Reverse the order of the results
+- Reverse the order of the results:
 
 `ls -r`

--- a/pages/common/lsof.md
+++ b/pages/common/lsof.md
@@ -1,15 +1,15 @@
 # lsof
 
-> Lists open files and the corresponding processes
+> Lists open files and the corresponding processes.
 
-- find the processes that have a given file open
+- Find the processes that have a given file open:
 
 `lsof {{/path/to/file}}`
 
-- find the process that opened a local internet port
+- Find the process that opened a local internet port:
 
 `lsof -i :{{8080}}`
 
-- only output the process PID (e.g. to pipe into kill)
+- Only output the process PID (e.g. to pipe into kill):
 
 `lsof -t {{/path/to/file}} | xargs kill -9`

--- a/pages/common/mailx.md
+++ b/pages/common/mailx.md
@@ -2,26 +2,26 @@
 
 > Send and receive mail.
 
-- To send mail, the content is typed after the command and ended with Control-D
+- To send mail, the content is typed after the command and ended with Control-D:
 
 `mailx -s "{{subject}}" {{to_addr}}`
 
-- Send mail with short content.
+- Send mail with short content:
 
 `echo "{{content}}" | mailx -s "{{subject}}" {{to_addr}}`
 
-- Send mail with content which written in a file.
+- Send mail with content which written in a file:
 
 `mailx -s "{{subject}}" {{to_addr}} < {{content.txt}}`
 
-- Send mail to a recipient and CC to another address.
+- Send mail to a recipient and CC to another address:
 
 `mailx -s "{{subject}}" -c {{cc_addr}} {{to_addr}}`
 
-- Send mail and set sender address.
+- Send mail and set sender address:
 
 `mailx -s "{{subject}}" -r {{from_addr}} {{to_addr}}`
 
-- Send mail with an attachment.
+- Send mail with an attachment:
 
 `mailx -a {{file}} -s "{{subject}}" {{to_addr}}`

--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -3,19 +3,18 @@
 > Task runner for rules described in Makefile.
 > Mostly used to control the compilation of an executable from source code.
 
-- Call the all rule
+- Call the all rule:
 
 `make`
 
-- Call a specific rule
+- Call a specific rule:
 
 `make {{rule}}`
 
-- Use specific Makefile
+- Use specific Makefile:
 
 `make -f {{file}}`
 
-- Execute make from another directory
+- Execute make from another directory:
 
 `make -C {{directory}}`
-

--- a/pages/common/man.md
+++ b/pages/common/man.md
@@ -1,19 +1,19 @@
 # man
 
-> Format and display manual pages
+> Format and display manual pages.
 
-- Display man page for a command
+- Display man page for a command:
 
 `man {{command}}`
 
-- Display path searched for manpages
+- Display path searched for manpages:
 
 `man --path`
 
-- Display location of a manpage rather than the manpage itself
+- Display location of a manpage rather than the manpage itself:
 
 `man -w {{command}}`
 
-- Do a keyword search for manpages containing a search string
+- Do a keyword search for manpages containing a search string:
 
 `man -k {{keyword}}`

--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -1,11 +1,11 @@
 # mkdir
 
-> Creates a directory
+> Creates a directory.
 
-- creates a directory in current folder or given path
+- Creates a directory in current folder or given path:
 
 `mkdir {{directory}}`
 
-- creates directories recursively (useful for creating nested dirs)
+- Creates directories recursively (useful for creating nested dirs):
 
 `mkdir -p {{path}}`

--- a/pages/common/mocha.md
+++ b/pages/common/mocha.md
@@ -1,23 +1,23 @@
 # mocha
 
-> Execute Mocha JavaScript test runner
+> Execute Mocha JavaScript test runner.
 
-- Run tests with default configuration or as configured in `mocha.opts`
+- Run tests with default configuration or as configured in `mocha.opts`:
 
 `mocha`
 
-- Run tests contained at a specific location
+- Run tests contained at a specific location:
 
 `mocha {{folder/with/tests}}`
 
-- Run tests that match a specific grep pattern
+- Run tests that match a specific grep pattern:
 
 `mocha --grep {{^regex$}}`
 
-- Run tests on changes to JavaScript files in the current directory and once initially
+- Run tests on changes to JavaScript files in the current directory and once initially:
 
 `mocha --watch`
 
-- Run tests with a specific reporter
+- Run tests with a specific reporter:
 
 `mocha --reporter {{reporter}}`

--- a/pages/common/more.md
+++ b/pages/common/more.md
@@ -2,20 +2,20 @@
 
 > Opens a file for reading.
 > Allows movement and search in forward direction only.
-> Doesn't read the entire file (suitable for logs)
+> Doesn't read the entire file (suitable for logs).
 
-- open a file
+- Open a file:
 
 `more {{source_file}}`
 
-- page down
+- Page down:
 
 `d (next)`
 
-- search for a string
+- Search for a string:
 
 `/{{something}}   then   n (next)`
 
-- exit
+- Exit:
 
 `q`

--- a/pages/common/mount.md
+++ b/pages/common/mount.md
@@ -2,22 +2,22 @@
 
 > Provides access to an entire filesystem in one directory.
 
-- Show all mounted filesystems
+- Show all mounted filesystems:
 
 `mount`
 
-- Mount a device
+- Mount a device:
 
 `mount -t {{filesystem_type}} {{path_to_device_file}} {{directory_to_mount_to}}`
 
-- Mount a CD-ROM device (with the filetype ISO9660) to /cdrom (readonly)
+- Mount a CD-ROM device (with the filetype ISO9660) to /cdrom (readonly):
 
 `mount -t {{iso9660}} -o ro {{/dev/cdrom}} {{/cdrom}}`
 
-- Mount all the filesystem defined in /etc/fstab
+- Mount all the filesystem defined in /etc/fstab:
 
 `mount -a`
 
-- Mount a specific filesystem described in /etc/fstab (e.g. "/dev/sda1 /my_drive ext2 defaults 0 2")
+- Mount a specific filesystem described in /etc/fstab (e.g. "/dev/sda1 /my_drive ext2 defaults 0 2"):
 
 `mount {{/my_drive}}`

--- a/pages/common/mp4box.md
+++ b/pages/common/mp4box.md
@@ -1,15 +1,15 @@
 # MP4Box
 
-> MPEG-4 Systems Toolbox - Muxes streams into MP4 container
+> MPEG-4 Systems Toolbox - Muxes streams into MP4 container.
 
-- Display information about an existing MP4 file
+- Display information about an existing MP4 file:
 
 `MP4Box -info {{filename}}`
 
-- Add an SRT subtitle file into an MP4 file
+- Add an SRT subtitle file into an MP4 file:
 
 `MP4Box -add {{input-subs.srt}}:lang=eng -add {{input.mp4}} {{output.mp4}}`
 
-- Combine audio from one file and video from another
+- Combine audio from one file and video from another:
 
 `MP4Box -add {{input1.mp4}}#audio -add {{input2.mp4}}#video {{output.mp4}`

--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -1,19 +1,19 @@
 # mtr
 
-> Combined traceroute and ping tool
+> Combined traceroute and ping tool.
 
-- Traceroute to a host and continuously ping all intermediary hops
+- Traceroute to a host and continuously ping all intermediary hops:
 
 `mtr {{host}}`
 
-- Disable IP address and host name mapping
+- Disable IP address and host name mapping:
 
 `mtr -n {{host}}`
 
-- Generate output after pinging each hop 10 times
+- Generate output after pinging each hop 10 times:
 
 `mtr -w {{host}}`
 
-- Force IP IPv4 or IPV6
+- Force IP IPv4 or IPV6:
 
 `mtr -4 {{host}}`

--- a/pages/common/mv.md
+++ b/pages/common/mv.md
@@ -1,19 +1,19 @@
 # mv
 
-> Move or rename files and directories
+> Move or rename files and directories.
 
-- Move files in abitrary locations
+- Move files in abitrary locations:
 
 `mv {{source}} {{target}}`
 
-- Do not prompt for confirmation before overwriting existing files
+- Do not prompt for confirmation before overwriting existing files:
 
 `mv -f {{source}} {{target}}`
 
-- Do not prompt for confirmation before overwriting existing files but write to standard error before overriding
+- Do not prompt for confirmation before overwriting existing files but write to standard error before overriding:
 
 `mv -fi {{source}} {{target}}`
 
-- Move files in verbose mode, showing files after they are moved
+- Move files in verbose mode, showing files after they are moved:
 
 `mv -v {{source}} {{target}}`

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -1,15 +1,15 @@
 # mysql
 
-> the MySQL command-line tool
+> The MySQL command-line tool.
 
-- Connect to a database
+- Connect to a database:
 
 `mysql {{database_name}}`
 
-- Connect to a database, user will be prompted for a password
+- Connect to a database, user will be prompted for a password:
 
 `mysql -u {{user}} --password {{database_name}}`
 
-- Execute SQL statements in a script file (batch file)
+- Execute SQL statements in a script file (batch file):
 
 `mysql {{database_name}} < {{script.sql}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -1,11 +1,11 @@
 # mysqldump
 
-> Backups mysql databases
+> Backups mysql databases.
 
-- Create a backup, user will be prompted for a password
+- Create a backup, user will be prompted for a password:
 
 `mysqldump -u {{user}} --password {{database_name}} > {{filename.sql}}`
 
-- Restoring a backup, user will be prompted for a password
+- Restoring a backup, user will be prompted for a password:
 
 `mysql -u {{user}} --password {{database_name}} < {{filename.sql}}`

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -1,31 +1,31 @@
 # nc
 
-> reads and writes tcp or udp data
+> Reads and writes tcp or udp data.
 
-- listen on a specified port
+- Listen on a specified port:
 
 `nc  -l {{port}}`
 
-- connect to a certain port (you can then write to this port)
+- Connect to a certain port (you can then write to this port):
 
 `nc {{ip_address}} {{port}}`
 
-- set a timeout
+- Set a timeout:
 
 `nc -w {{timeout_in_seconds}} {{ipaddress}} {{port}}`
 
-- serve a file
+- Serve a file:
 
 `cat somefile.txt | nc -l {{port}}`
 
-- receive a file
+- Receive a file:
 
 `nc {{ip_address}} {{port}} > somefile.txt`
 
-- server stay up after client detach
+- Server stay up after client detach:
 
 `nc -k -l {{port}}`
 
-- client stay up after EOF
+- Client stay up after EOF:
 
 `nc -q {{timeout}} {{ip_address}}`

--- a/pages/common/nginx.md
+++ b/pages/common/nginx.md
@@ -1,19 +1,19 @@
 # nginx
 
-> nginx web server
+> Nginx web server.
 
-- Start server with default config
+- Start server with default config:
 
 `nginx`
 
-- Start server with custom config file
+- Start server with custom config file:
 
 `nginx -c {{config_file}}`
 
-- Start server with a prefix for all relative paths in config file
+- Start server with a prefix for all relative paths in config file:
 
 `nginx -c {{config_file}} -p {{prefix/for/relative/paths}}`
 
-- Test configuration without affecting the running server
+- Test configuration without affecting the running server:
 
 `nginx -t`

--- a/pages/common/nice.md
+++ b/pages/common/nice.md
@@ -3,6 +3,6 @@
 > Execute a program with a custom scheduling priority (niceness).
 > Niceness values range from -20 (the highest priority) to 19 (the lowest).
 
-- Launch a program with altered priority.
+- Launch a program with altered priority:
 
 `nice -n {{niceness_value}} {{command}}`

--- a/pages/common/nmap.md
+++ b/pages/common/nmap.md
@@ -3,15 +3,15 @@
 > Network exploration tool and security / port scanner.
 > Some features only activate when Nmap is run with privileges.
 
-- Try to determine whether the specified hosts are up and what are their names.
+- Try to determine whether the specified hosts are up and what are their names:
 
 `nmap -sn {{ip_or_hostname}} {{optional_another_address}}`
 
-- Like above, but also run a default 1000-port TCP scan if host seems up.
+- Like above, but also run a default 1000-port TCP scan if host seems up:
 
 `nmap {{ip_or_hostname}} {{optional_another_address}}`
 
-- Also enable service detection, OS fingerprinting and traceroute.
+- Also enable service detection, OS fingerprinting and traceroute:
 
 `nmap -A {{address_or_addresses}}`
 
@@ -19,7 +19,7 @@
 
 `nmap -T4 {{address_or_addresses}}`
 
-- Scan a specific list of ports (use -p- for all ports 1-65535)
+- Scan a specific list of ports (use -p- for all ports 1-65535):
 
 `nmap -p {{port1,port2,...,portN}} {{address_or_addresses}}`
 

--- a/pages/common/node.md
+++ b/pages/common/node.md
@@ -1,15 +1,15 @@
 # node
 
-> Server-side JavaScript platform (Node.js)
+> Server-side JavaScript platform (Node.js).
 
-- Run a JavaScript file
+- Run a JavaScript file:
 
 `node {{file}}.js`
 
-- Start a REPL loop (interactive shell)
+- Start a REPL loop (interactive shell):
 
 `node`
 
-- Evaluate JavaScript by passing it in the command
+- Evaluate JavaScript by passing it in the command:
 
 `node -e "{{code}}"`

--- a/pages/common/nohup.md
+++ b/pages/common/nohup.md
@@ -1,7 +1,7 @@
 # nohup
 
-> Allows for a process to live when the terminal gets killed
+> Allows for a process to live when the terminal gets killed.
 
-- Run process that can live beyond the terminal
+- Run process that can live beyond the terminal:
 
 `nohup {{command options}}`

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -2,30 +2,30 @@
 
 > Node package manager, to manage Node.js projects and install module dependencies.
 
-- Create a new project in the current folder
+- Create a new project in the current folder:
 
 `npm init`
 
-- Download all dependencies referenced in package.json
+- Download all dependencies referenced in package.json:
 
 `npm install`
 
-- Download and install a module globally
+- Download and install a module globally:
 
 `npm install -g {{module_name}}`
 
-- Download a given dependency, and add it to the package.json
+- Download a given dependency, and add it to the package.json:
 
 `npm install {{module_name}}@{{version}} --save`
 
-- Set the version of the current project
+- Set the version of the current project:
 
 `npm version {{1.2.3}}`
 
-- Publish the current project
+- Publish the current project:
 
 `npm publish`
 
-- Cleanup packages (removes packages which are installed but are not listed in `package.json`)
+- Cleanup packages (removes packages which are installed but are not listed in `package.json`):
 
 `npm prune`

--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -3,26 +3,26 @@
 > Node.js version manager.
 > Switch between NodeJS versions: system, node, 0.10, 0.12, 4.2 etc.
 
-- Install a specific version of NodeJS
+- Install a specific version of NodeJS:
 
 `nvm install {{node_version}}`
 
-- Use a specific version NodeJS in the current shell
+- Use a specific version NodeJS in the current shell:
 
 `nvm use {{node_version}}`
 
-- Set the default NodeJS version
+- Set the default NodeJS version:
 
 `nvm alias default {{node_version}}`
 
-- List all available NodeJS versions and print the default one
+- List all available NodeJS versions and print the default one:
 
 `nvm list`
 
-- Run a specific version NodeJS REPL
+- Run a specific version NodeJS REPL:
 
 `nvm run {{node_version}} --version`
 
-- Run app in a specific version of NodeJS
+- Run app in a specific version of NodeJS:
 
 `nvm exec {{node_version}} node {{app.js}}`

--- a/pages/common/pandoc.md
+++ b/pages/common/pandoc.md
@@ -1,7 +1,7 @@
 # pandoc
 
-> General markup converter
+> General markup converter.
 
-- Convert file to pdf (the output format is automatically determined from the output file's extension)
+- Convert file to pdf (the output format is automatically determined from the output file's extension):
 
 `pandoc {{input.md}} -o {{output.pdf}}`

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -1,27 +1,27 @@
 # GNU Parallel
 
-> Run commands on multiple CPU cores
+> Run commands on multiple CPU cores.
 
-- gzip several files at once, using all cores
+- Gzip several files at once, using all cores:
 
 `parallel gzip ::: {{file1}} {{file2}} {{file3}}`
 
-- read arguments from stdin, run 4 jobs at once
+- Read arguments from stdin, run 4 jobs at once:
 
 `ls *.txt | parallel -j4 gzip`
 
-- Convert JPG images to PNG using replacement strings
+- Convert JPG images to PNG using replacement strings:
 
 `parallel convert {} {.}.png ::: *.jpg`
 
-- parallel xargs, cram as many args as possible onto one command
+- Parallel xargs, cram as many args as possible onto one command:
 
 `{{args}} | parallel -X {{command}}`
 
-- break stdin into ~1M blocks, feed each block to stdin of new command
+- Break stdin into ~1M blocks, feed each block to stdin of new command:
 
 `cat {{bigfile.txt}} | parallel --pipe --block 1M {{command}}`
 
-- run on multiple machines via SSH
+- Run on multiple machines via SSH:
 
 `parallel -S {{machine1}},{{machine2}} {{command}} ::: {{arg1}} {{arg2}}`

--- a/pages/common/pass.md
+++ b/pages/common/pass.md
@@ -1,28 +1,28 @@
 # pass
 
-> safely store and read passwords or other sensitive data easily
-> all data is GPG-encrypted, and managed with a git repository
+> Safely store and read passwords or other sensitive data easily.
+> All data is GPG-encrypted, and managed with a git repository.
 
-- initialize the storage using a gpg-id for encryption
+- Initialize the storage using a gpg-id for encryption:
 
 `pass init {{gpg_id}}`
 
-- save a new password (prompts you for the value without echoing it)
+- Save a new password (prompts you for the value without echoing it):
 
 `pass insert {{path/to/data}}`
 
-- copy a password (first line of the data file) to the clipboard
+- Copy a password (first line of the data file) to the clipboard:
 
 `pass -c {{path/to/data}}`
 
-- list the whole store tree
+- List the whole store tree:
 
 `pass`
 
-- generate a new random password with a given length, and copy it to the clipboard
+- Generate a new random password with a given length, and copy it to the clipboard:
 
 `pass generate -c {{path/to/data}} {{num}}`
 
-- run any git command against the underlying store repository
+- Run any git command against the underlying store repository:
 
 `pass git {{git-arguments}}`

--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -1,19 +1,19 @@
 # passwd
 
-> passwd is a tool used to change a user's password.
+> Passwd is a tool used to change a user's password.
 
-- Change the password of the current user
+- Change the password of the current user:
 
 `passwd {{new password}}`
 
-- Change the password of the specified user
+- Change the password of the specified user:
 
 `passwd {{username}} {{new password}}`
 
-- Get the current statuts of the user
+- Get the current statuts of the user:
 
 `passwd -S`
 
-- Make the password of the account blank (it will set the named account passwordless)
+- Make the password of the account blank (it will set the named account passwordless):
 
 `passwd -d`

--- a/pages/common/paste.md
+++ b/pages/common/paste.md
@@ -2,22 +2,22 @@
 
 > Merge lines of files.
 
-- join all the lines into a single line, using TAB as delimiter.
+- Join all the lines into a single line, using TAB as delimiter:
 
 `paste -s {{file}}`
 
-- join all the lines into a single line, using the specified delimiter.
+- Join all the lines into a single line, using the specified delimiter:
 
 `paste -s -d {{delimiter}} {{file}}`
 
-- merge two files side by side, each in its column, using TAB as delimiter.
+- Merge two files side by side, each in its column, using TAB as delimiter:
 
 `paste {{file1}} {{file2}}`
 
-- merge two files side by side, each in its column, using the specified delimiter.
+- Merge two files side by side, each in its column, using the specified delimiter:
 
 `paste -d {{delimiter}} {{file1}} {{file2}}`
 
-- merge two files, with lines added alternatively.
+- Merge two files, with lines added alternatively:
 
 `paste -d '\n' {{file1}} {{file2}}`

--- a/pages/common/patch.md
+++ b/pages/common/patch.md
@@ -3,14 +3,14 @@
 > Patch a file (or files) with a diff file.
 > Note that diff files contain both the target filenames and list of changes.
 
-- apply a patch
+- Apply a patch:
 
 `patch < {{patchfile}}.diff`
 
-- apply a patch to current directory
+- Apply a patch to current directory:
 
 `patch -p1 < {{patchfile}}.diff`
 
-- apply the reverse of a patch
+- Apply the reverse of a patch:
 
 `patch -R < {{patchfile}}.diff`

--- a/pages/common/pgrep.md
+++ b/pages/common/pgrep.md
@@ -1,15 +1,15 @@
 # pgrep
 
-> Find or signal process by name
+> Find or signal process by name.
 
-- return PIDs of any running processes with a matching command string
+- Return PIDs of any running processes with a matching command string:
 
 `pgrep {{process_name}}`
 
-- search full command line with parameters instead of just the process name
+- Search full command line with parameters instead of just the process name:
 
 `pgrep -f "{{process_name}} {{parameter}}"`
 
-- search for process run by a specific user
+- Search for process run by a specific user:
 
 `pgrep -u root {{process_name}}`

--- a/pages/common/php.md
+++ b/pages/common/php.md
@@ -1,23 +1,23 @@
 # php
 
-> PHP Command Line Interface 'CLI'
+> PHP Command Line Interface 'CLI'.
 
-- Parse and execute a file
+- Parse and execute a file:
 
 `php {{file}}`
 
-- Check syntax (lint)
+- Check syntax (lint):
 
 `php -l {{file}}`
 
-- Run PHP interactively
+- Run PHP interactively:
 
 `php -a`
 
-- Run PHP code. Notes: a) Don't use <? ?> tags; b) Escape double quotes with backslash
+- Run PHP code. Notes: a) Don't use <? ?> tags; b) Escape double quotes with backslash:
 
 `php -r "{{code}}"`
 
-- Start a PHP built-in web server in the current directory.
+- Start a PHP built-in web server in the current directory:
 
 `php -S {{host:port}}`

--- a/pages/common/phpunit.md
+++ b/pages/common/phpunit.md
@@ -1,19 +1,19 @@
 # phpunit
 
-> PHPUnit command-line test runner
+> PHPUnit command-line test runner.
 
-- Run tests in the current direcotry. Note: Expects you to have a 'phpunit.xml'
+- Run tests in the current direcotry. Note: Expects you to have a 'phpunit.xml':
 
 `phpunit`
 
-- Run tests in a specific file.
+- Run tests in a specific file:
 
 `phpunit {{path/to/TestFile.php}}`
 
-- Run tests annotated with the given group.
+- Run tests annotated with the given group:
 
 `phpunit --group {{name}}`
 
-- Run tests and generate a coverage report in HTML.
+- Run tests and generate a coverage report in HTML:
 
 `phpunit --coverage-html {{directory}}`

--- a/pages/common/ping.md
+++ b/pages/common/ping.md
@@ -1,19 +1,19 @@
 # ping
 
-> send ICMP ECHO_REQUEST packets to network hosts
+> Send ICMP ECHO_REQUEST packets to network hosts.
 
-- Ping host
+- Ping host:
 
 `ping {{host}}`
 
-- Ping host limiting the number of packages to be send to four
+- Ping host limiting the number of packages to be send to four:
 
 `ping -c 4 {{host}}`
 
-- Ping host, waiting for 0.5 s between each request (default is 1 s)
+- Ping host, waiting for 0.5 s between each request (default is 1 s):
 
 `ping -i 0.5 {{host}}`
 
-- Ping host without trying to lookup symbolic names for addresses
+- Ping host without trying to lookup symbolic names for addresses:
 
 `ping -n {{host}}`

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -1,27 +1,27 @@
 # pip
 
-> Python package manager
+> Python package manager.
 
-- Install a package
+- Install a package:
 
 `pip install {{package_name}}`
 
-- Install a specific version of a package
+- Install a specific version of a package:
 
 `pip install {{package_name}}=={{package_version}}`
 
-- Upgrade a package
+- Upgrade a package:
 
 `pip install -U {{package_name}}`
 
-- Uninstall a package
+- Uninstall a package:
 
 `pip uninstall {{package_name}}`
 
-- Save installed packages to file
+- Save installed packages to file:
 
 `pip freeze > {{requirements.txt}}`
 
-- Install packages from file
+- Install packages from file:
 
 `pip install -r {{requirements.txt}}`

--- a/pages/common/pkill.md
+++ b/pages/common/pkill.md
@@ -1,12 +1,12 @@
 # pkill
 
-> Signal process by name
-> Mostly used for stopping processes
+> Signal process by name.
+> Mostly used for stopping processes.
 
-- kill all processes which match
+- Kill all processes which match:
 
 `pkill -9 {{process_name}}`
 
-- send SIGUSR1 signal to processes which match
+- Send SIGUSR1 signal to processes which match:
 
 `pkill -USR1 {{process_name}}`

--- a/pages/common/play.md
+++ b/pages/common/play.md
@@ -1,21 +1,21 @@
 # play
 
-> Audio player of SoX - Sound eXchange
-> Plays any audio from the command line
-> Audioformats are identified by extension
+> Audio player of SoX - Sound eXchange.
+> Plays any audio from the command line.
+> Audioformats are identified by extension.
 
-- Play the given audio file
+- Play the given audio file:
 
 `play {{audiofile}}`
 
-- Play the given audio files
+- Play the given audio files:
 
 `play {{audiofile1}} {{audiofile2}}`
 
-- Play the given audio at twice the speed
+- Play the given audio at twice the speed:
 
 `play {{audiofile}} speed 2.0`
 
-- Play the given audio in reverse
+- Play the given audio in reverse:
 
 `play {{audiofile}} reverse`

--- a/pages/common/printf.md
+++ b/pages/common/printf.md
@@ -1,23 +1,23 @@
 # printf
 
-> Format and print text
+> Format and print text.
 
-- Print a text message
+- Print a text message:
 
 `printf {{"%s\n"}} {{"Hello world"}}`
 
-- Print an integer in bold blue
+- Print an integer in bold blue:
 
 `printf {{"\e[1;34m%.3d\e[0m\n"}} {{42}}`
 
-- Print a float number with the unicode Euro sign
+- Print a float number with the unicode Euro sign:
 
 `printf {{"\u20AC %.2f\n"}} {{123.4}}`
 
-- Print a text message composed with environment variables
+- Print a text message composed with environment variables:
 
 `printf {{"var1: %s\tvar2: %s\n"}} {{"$VAR1"}} {{"$VAR2"}}`
 
-- Store a formatted message in a variable (does not work on zsh)
+- Store a formatted message in a variable (does not work on zsh):
 
 `printf -v {{myvar}} {{"This is %s = %d\n" "a year" 2016}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -1,15 +1,15 @@
 # ps
 
-> Information about running processes
+> Information about running processes.
 
-- list all running processes
+- List all running processes:
 
 `ps aux`
 
-- list all running processes including the full command string
+- List all running processes including the full command string:
 
 `ps auxww`
 
-- search for a process that matches a string
+- Search for a process that matches a string:
 
 `ps aux | grep {{string}}`

--- a/pages/common/psql.md
+++ b/pages/common/psql.md
@@ -1,23 +1,23 @@
 # psql
 
-> PostgreSQL command-line client
+> PostgreSQL command-line client.
 
-- Connect to *database*. It connects to localhost using default port *5432* with default user
+- Connect to *database*. It connects to localhost using default port *5432* with default user:
 
 `psql {{database}}`
 
-- Connect to *database* on given server *host* running on given *port* with *username* given, no password prompt
+- Connect to *database* on given server *host* running on given *port* with *username* given, no password prompt:
 
 `psql -h {{host}} -p {{port}} -U {{username}} {{database}}`
 
-- Connect to *database*, user will be prompted for password
+- Connect to *database*, user will be prompted for password:
 
 `psql -h {{host}} -p {{port}} -U {{username}} -W {{database}}`
 
-- Run single *query* against the given *database*. Note: useful in shell scripts
+- Run single *query* against the given *database*. Note: useful in shell scripts:
 
 `psql -c '{{query}}' {{database}}`
 
-- Run several queries against the given *database*. Note: useful in shell scripts
+- Run several queries against the given *database*. Note: useful in shell scripts:
 
 `echo '{{query1}}; {{query2}}' | psql {{database}}`

--- a/pages/common/pushd.md
+++ b/pages/common/pushd.md
@@ -1,15 +1,15 @@
 # pushd
 
-> Place a directory on a stack so it can be accessed later
+> Place a directory on a stack so it can be accessed later.
 
-- Switch to directory and push it on the stack
+- Switch to directory and push it on the stack:
 
 `pushd < {{directory}}`
 
-- Switch first and second directories on the stack
+- Switch first and second directories on the stack:
 
 `pushd`
 
-- Rotate stack by making the 5th element the top of the stack
+- Rotate stack by making the 5th element the top of the stack:
 
 `pushd +4`

--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -1,11 +1,11 @@
 # pwd
 
-> Print name of current/working directory
+> Print name of current/working directory.
 
-- Print the current directory
+- Print the current directory:
 
 `pwd`
 
-- Print the current directory, and resolve all symlinks (e.g. show the "physical" path)
+- Print the current directory, and resolve all symlinks (e.g. show the "physical" path):
 
 `pwd -P`

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -1,19 +1,19 @@
 # Python
 
-> Python language interpeter
+> Python language interpeter.
 
-- Call a Python interactive shell (REPL)
+- Call a Python interactive shell (REPL):
 
 `python`
 
-- Execute script in a given Python file
+- Execute script in a given Python file:
 
 `python {{script.py}}`
 
-- Execute Python language single command
+- Execute Python language single command:
 
 `python -c {{command}}`
 
-- Run library module as a script (terminates option list)
+- Run library module as a script (terminates option list):
 
 `python -m {{module}} {{arguments}}`

--- a/pages/common/redis-cli.md
+++ b/pages/common/redis-cli.md
@@ -1,20 +1,20 @@
 # redis-cli
 
-> Opens a connection to a Redis server
+> Opens a connection to a Redis server.
 
-- Connect to the local server
+- Connect to the local server:
 
 `redis-cli`
 
-- Connect to a remote server
+- Connect to a remote server:
 
 `redis-cli -h {{host}}`
 `redis-cli -h {{host}} -p {{port}}`
 
-- Specify a password
+- Specify a password:
 
 `redis-cli -a {{password}}`
 
-- Executes Redis command
+- Executes Redis command:
 
 `redis-cli {{redis command}}`

--- a/pages/common/rename.md
+++ b/pages/common/rename.md
@@ -1,20 +1,20 @@
 # rename
 
-> renames multiple files
+> Renames multiple files.
 
-- Change foo to bar in matching filenames
+- Change foo to bar in matching filenames:
 
 `rename {{'s/foo/bar/'}} {{*.txt}}`
 
-- Convert to lower case
+- Convert to lower case:
 
 `rename -c {{*.txt}}`
 
-- Replace whitespace with underscores
+- Replace whitespace with underscores:
 
 `rename --nows {{*.txt}}`
 `rename 's/\s+/_/g' {{*.txt}}`
 
-- No action, just show what renames would occur
+- No action, just show what renames would occur:
 
 `rename -n {{'s/foo/bar/'}} {{*.txt}}`

--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -2,14 +2,14 @@
 
 > Alters the scheduling priority/nicenesses of one or more running processes. Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 
-- Change priority of a running process.
+- Change priority of a running process:
 
 `renice -n {{niceness_value}} -p {{pid}}`
 
-- Change priority of all processes owned by a user.
+- Change priority of all processes owned by a user:
 
 `renice -n {{niceness_value}} -u {{user}}`
 
-- Change priority of all processes that belongs to a group.
+- Change priority of all processes that belongs to a group:
 
 `renice -n {{niceness_value}} -g {{group}}`

--- a/pages/common/rm.md
+++ b/pages/common/rm.md
@@ -1,15 +1,15 @@
 # rm
 
-> Remove files or directories
+> Remove files or directories.
 
-- Remove files from arbitrary locations
+- Remove files from arbitrary locations:
 
 `rm {{/path/to/file}} {{/otherpath/to/file2}}`
 
-- Remove recursively a directory and all it's subdirectories
+- Remove recursively a directory and all it's subdirectories:
 
 `rm -r {{/path/to/folder}}`
 
-- Prompt before every removal
+- Prompt before every removal:
 
 `rm -i {{\*}}`

--- a/pages/common/rmdir.md
+++ b/pages/common/rmdir.md
@@ -1,11 +1,11 @@
 # rmdir
 
-> Removes a directory
+> Removes a directory.
 
-- removes directory, provided it is empty. Use `rm` to remove not empty directories.
+- Removes directory, provided it is empty. Use `rm` to remove not empty directories:
 
 `rmdir {{directory}}`
 
-- removes directories recursively (useful for nested dirs)
+- Removes directories recursively (useful for nested dirs):
 
 `rmdir -p {{path}}`

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -1,29 +1,29 @@
 # rsync
 
-> Transfers a file either to or from a remote host
-> Does not allow transfer between two remote hosts
-> Can transfer single files or files matched by pattern
+> Transfers a file either to or from a remote host.
+> Does not allow transfer between two remote hosts.
+> Can transfer single files or files matched by pattern.
 
-- transfer file from local to remote host
+- Transfer file from local to remote host:
 
 `rsync {{path_to_file}} {{remote_host_name}}:{{remote_host_location}}`
 
-- transfer file from remote host to local
+- Transfer file from remote host to local:
 
 `rsync {{remote_host_name}}:{{remote_file_location}} {{local_file_location}}`
 
-- transfer all *.js files in current directory to host 'devbox' as user 'mike'
+- Transfer all *.js files in current directory to host 'devbox' as user 'mike':
 
 `rsync *.js mike@devbox:~/projects/cakeStore/styles/`
 
-- transfer a directory and all its children from a remote to local
+- Transfer a directory and all its children from a remote to local:
 
 `rsync -r mike@devbox:~/projects/cakeStore /Users/mike/devProjects/`
 
-- transfer only updated files from remote host
+- Transfer only updated files from remote host:
 
 `rsync -ru mike@devbox:~/projects/ ./projects/`
 
-- transfer file over SSH and show progress
+- Transfer file over SSH and show progress:
 
 `rsync -e ssh --progress {{remote_host_name}}:{{remote_file}} {{local_file}}`

--- a/pages/common/salt-call.md
+++ b/pages/common/salt-call.md
@@ -2,18 +2,18 @@
 
 > Invoke salt locally on a salt minion.
 
-- Perform a highstate on this minion
+- Perform a highstate on this minion:
 
 `salt-call state.highstate`
 
-- Perform a highstate dry-run, compute all changes but don't actually perform them
+- Perform a highstate dry-run, compute all changes but don't actually perform them:
 
 `salt-call state.highstate test=true`
 
-- Perform a highstate with verbose debugging output
+- Perform a highstate with verbose debugging output:
 
 `salt-call -l debug state.highstate`
 
-- List this minion's grains
+- List this minion's grains:
 
 `salt-call grains.items`

--- a/pages/common/salt-key.md
+++ b/pages/common/salt-key.md
@@ -1,17 +1,17 @@
 # salt-key
 
-> Manages salt minion keys on the salt master
-> Needs to be run on the salt master, likely as root or with sudo
+> Manages salt minion keys on the salt master.
+> Needs to be run on the salt master, likely as root or with sudo.
 
-- List all accepted, unaccepted and rejected minion keys
+- List all accepted, unaccepted and rejected minion keys:
 
 `salt-key -L`
 
-- Accept or reject a minion key by name
+- Accept or reject a minion key by name:
 
 `salt-key -a {{MINION_ID}}`
 `salt-key -r {{MINION_ID}}`
 
-- Print fingerprints of all public keys
+- Print fingerprints of all public keys:
 
 `salt-key -F`

--- a/pages/common/salt-run.md
+++ b/pages/common/salt-run.md
@@ -1,11 +1,11 @@
 # salt-run
 
->Frontend for executing salt-runners on minions
+> Frontend for executing salt-runners on minions.
 
-- Show status of all minions
+- Show status of all minions:
 
 `salt-run manage.status`
 
-- Show all minions which are disconnected
+- Show all minions which are disconnected:
 
 `salt-run manage.up`

--- a/pages/common/salt.md
+++ b/pages/common/salt.md
@@ -1,8 +1,8 @@
 # salt
 
->Execute commands and assert state on remote salt minions.
+> Execute commands and assert state on remote salt minions.
 
-- List connected minions
+- List connected minions:
 
 `salt '*' test.ping`
 
@@ -10,7 +10,7 @@
 
 `salt '*' state.highstate`
 
-- Upgrade packages using the OS package manager (apt, yum, brew) on a subset of minions
+- Upgrade packages using the OS package manager (apt, yum, brew) on a subset of minions:
 
 `salt '*.domain.com' pkg.upgrade`
 

--- a/pages/common/sass.md
+++ b/pages/common/sass.md
@@ -1,19 +1,19 @@
 # Sass
 
-> Converts SCSS or Sass files to CSS
+> Converts SCSS or Sass files to CSS.
 
-- Output converted file to stdout
+- Output converted file to stdout:
 
 `sass {{inputfile.(scss|sass)}}`
 
-- Immediately convert SCSS or Sass file to CSS to specified output file
+- Immediately convert SCSS or Sass file to CSS to specified output file:
 
 `sass {{inputfile.(scss|sass)}} {{outputfile.css}}`
 
-- Watch SCSS or Sass file for changes and output or update CSS file with same filename
+- Watch SCSS or Sass file for changes and output or update CSS file with same filename:
 
 `sass --watch {{inputfile.(scss|sass)}}`
 
-- Watch SCSS or Sass file for changes and output or update CSS file with specified filename
+- Watch SCSS or Sass file for changes and output or update CSS file with specified filename:
 
 `sass --watch {{inputfile.(scss|sass)}}:{{outputfile.css}}`

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -1,32 +1,30 @@
 # scp
 
-> Copies files between hosts on a network
-> Works over a secure connection (SSH)
+> Copies files between hosts on a network.
+> Works over a secure connection (SSH).
 
-- upload a file, or upload and rename a file
+- Upload a file, or upload and rename a file:
 
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/}}`
-
 `scp {{/local/file.txt}} {{10.0.0.1}}:{{/remote/path/newname.txt}}`
 
-- download a file
+- Download a file:
 
 `scp {{10.0.0.1}}:{{/remote/path/file.txt}} {{/local/folder}}`
 
-- upload or download a directory
+- Upload or download a directory:
 
 `scp -r {{/local/folder}} {{10.0.0.1}}:{{/remote/path/}}`
-
 `scp -r {{10.0.0.1}}:{{/remote/path}} {{/local/folder}}`
 
-- specify username on host
+- Specify username on host:
 
 `scp {{/local/file.txt}} {{my_user}}@{{10.0.0.1}}:{{/remote/path}}`
 
-- copy a file from one host to another
+- Copy a file from one host to another:
 
 `scp {{10.0.0.1}}:{{/remote/path/file.txt}} {{20.0.0.2}}:{{/other/remote/path}}`
 
-- download a file with ssh key
+- Download a file with ssh key:
 
 `scp -i {{/local/key}} {{10.0.0.1}}:{{/remote/path/file.txt}} {{/local/folder}}`

--- a/pages/common/screen.md
+++ b/pages/common/screen.md
@@ -2,26 +2,26 @@
 
 > Hold a session open on a remote server. Manage multiple windows with a single SSH connection.
 
-- Start a new screen session
+- Start a new screen session:
 
 `screen`
 
-- Start a new named screen session
+- Start a new named screen session:
 
 `screen -S {{name}}`
 
-- Show open screen sessions
+- Show open screen sessions:
 
 `screen -ls`
 
-- Reattach to an open screen
+- Reattach to an open screen:
 
 `screen -r {{screen id}}`
 
-- Detach from inside a screen
+- Detach from inside a screen:
 
 `ctrl+A D`
 
-- Kill a detached screen
+- Kill a detached screen:
 
 `screen -X -S {{screen id}} quit`

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -1,19 +1,19 @@
 # sed
 
-> Run replacements based on regular expressions
+> Run replacements based on regular expressions.
 
-- replace all occurrences of a string in a file, and print the result
+- Replace all occurrences of a string in a file, and print the result:
 
 `sed 's/{{find}}/{{replace}}/g' {{filename}}`
 
-- replace all occurrences of a string in a file, and overwrite the file contents
+- Replace all occurrences of a string in a file, and overwrite the file contents:
 
 `sed -i 's/{{find}}/{{replace}}/g' {{filename}}`
 
-- replace all occurrences of an extended regular expression in a file
+- Replace all occurrences of an extended regular expression in a file:
 
 `sed -E 's/{{regex}}/{{replace}}/g' {{filename}}`
 
-- replace all occurrences of multiple strings in a file
+- Replace all occurrences of multiple strings in a file:
 
 `sed -e 's/{{find}}/{{replace}}/g' -e 's/{{find}}/{{replace}}/g' {{filename}}`

--- a/pages/common/sl.md
+++ b/pages/common/sl.md
@@ -2,14 +2,14 @@
 
 > Steam locomotive running through your terminal.
 
-- Let a steam locomotive run through your terminal.
+- Let a steam locomotive run through your terminal:
 
 `sl`
 
-- The train burns, people scream.
+- The train burns, people scream:
 
 `sl -a`
 
-- Let the train fly.
+- Let the train fly:
 
 `sl -F`

--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -1,15 +1,15 @@
 # sort
 
-> sort lines of text files
+> Sort lines of text files.
 
-- Sort a file in ascending order
+- Sort a file in ascending order:
 
 `sort {{filename}}`
 
-- Sort a file in descending order
+- Sort a file in descending order:
 
 `sort -r {{filename}}`
 
-- Sort passwd file by the 3rd field
+- Sort passwd file by the 3rd field:
 
 `sort -t: -k 3n /etc/passwd`

--- a/pages/common/sox.md
+++ b/pages/common/sox.md
@@ -1,25 +1,25 @@
 # sox
 
-> SoX - Sound eXchange
-> Play, record and convert audio files
-> Audioformats are identified by extension
+> SoX - Sound eXchange.
+> Play, record and convert audio files.
+> Audioformats are identified by extension.
 
-- Merge two audio files into one
+- Merge two audio files into one:
 
 `sox -m {{input_audiofile1}} {{input_audiofile2}} {{output_audiofile}}`
 
-- Trim an audio file to the specified times
+- Trim an audio file to the specified times:
 
 `sox {{input_audiofile}} {{output_audiofile}} trim {{start}} {{end}}`
 
-- Normalize an audio file (adjust volume to the maximum peak level, without clipping)
+- Normalize an audio file (adjust volume to the maximum peak level, without clipping):
 
 `sox --norm {{input_audiofile}} {{output_audiofile}}`
 
-- Reverse and save an audio file
+- Reverse and save an audio file:
 
 `sox {{input_audiofile}} {{output_audiofile}} reverse`
 
-- Print statistical data of an audio file
+- Print statistical data of an audio file:
 
 `sox {{input_audiofile}} -n stat`

--- a/pages/common/split.md
+++ b/pages/common/split.md
@@ -1,15 +1,15 @@
 # split
 
-> Split a file into pieces
+> Split a file into pieces.
 
-- Split a file, each split having 10 lines (except the last split)
+- Split a file, each split having 10 lines (except the last split):
 
 `split -l 10 {{filename}}`
 
-- Split a file into 5 files. File is split such that each split has same size (except the last split)
+- Split a file into 5 files. File is split such that each split has same size (except the last split):
 
 `split -n 5 {{filename}}`
 
-- Split a file with at most 512 bytes of lines in each split.
+- Split a file with at most 512 bytes of lines in each split:
 
 `split -C 512 {{filename}}`

--- a/pages/common/srm.md
+++ b/pages/common/srm.md
@@ -1,20 +1,18 @@
 # srm
 
-> Securely remove files or directories
+> Securely remove files or directories.
 > Overwrites the existing data one or multiple. Drop in replacement for rm.
 
-- Removes a file after overwriting (single pass, 7 pass, 35 pass)
+- Removes a file after overwriting (single pass, 7 pass, 35 pass):
 
 `srm -s {{/path/to/file}}`
-
 `srm -m {{/path/to/file}}`
-
 `srm {{/path/to/file}}`
 
-- Scurely remove recursively a directory and all it's subdirectories
+- Scurely remove recursively a directory and all it's subdirectories:
 
 `srm -r {{/path/to/folder}}`
 
-- Prompt before every removal
+- Prompt before every removal:
 
 `srm -i {{\*}}`

--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -3,30 +3,30 @@
 > Secure Shell is a protocol used to securely log onto remote systems.
 > It can be used for logging or executing commands on a remote server.
 
-- connecting to a remote server
+- Connecting to a remote server:
 
 `ssh {{username}}@{{remote_host}}`
 
-- connecting to a remote server with a specific identity (private key)
+- Connecting to a remote server with a specific identity (private key):
 
 `ssh -i {{/path/to/key_file}} {{username}}@{{remote_host}}`
 
-- connecting to a remote server with specific port
+- Connecting to a remote server with specific port:
 
 `ssh {{username}}@{{remote_host}} -p {{2222}}`
 
-- run a command on a remote server
+- Run a command on a remote server:
 
 `ssh {{remote_host}} {{command -with -flags}}`
 
-- ssh tunneling: dynamic port forwarding (SOCKS proxy on localhost:9999)
+- Ssh tunneling: dynamic port forwarding (SOCKS proxy on localhost:9999):
 
 `ssh -D {{9999}} -C {{username}}@{{remote_host}}`
 
-- ssh tunneling: forward a specific port (localhost:9999 to slashdot.org:80)
+- Ssh tunneling: forward a specific port (localhost:9999 to slashdot.org:80):
 
 `ssh -L {{9999}}:slashdot.org:80 {{username}}@{{remote_host}}`
 
-- ssh enable agent forward
+- Ssh enable agent forward:
 
 `ssh -A {{username}}@{{remote_host}}`

--- a/pages/common/sshfs.md
+++ b/pages/common/sshfs.md
@@ -1,19 +1,19 @@
 # SSHFS
 
-> filesystem client based on ssh
+> Filesystem client based on ssh.
 
-- mounting remote directory
+- Mounting remote directory:
 
 `sshfs {{username}}@{{remote_host}}:{{remote_directory}} {{mountpoint}}`
 
-- unmounting remote directory
+- Unmounting remote directory:
 
 `fusermount -u {{mountpoint}}`
 
-- mounting remote directory from server with specific port
+- Mounting remote directory from server with specific port:
 
 `sshfs {{username}}@{{remote_host}}:{{remote_directory}} -p {{2222}}`
 
-- use compression
+- Use compression:
 
 `sshfs {{username}}@{{remote_host}}:{{remote_directory}} -C`

--- a/pages/common/strings.md
+++ b/pages/common/strings.md
@@ -1,19 +1,19 @@
 # strings
 
-> Find printable strings in an object file or binary
+> Find printable strings in an object file or binary.
 
-- Print all strings in a binary
+- Print all strings in a binary:
 
 `strings {{file}}`
 
-- Limit results to strings at least *length* characters long
+- Limit results to strings at least *length* characters long:
 
 `strings -n {{length}} {{file}}`
 
-- Prefix each result with its offset within the file
+- Prefix each result with its offset within the file:
 
 `strings -t d {{file}}`
 
-- Prefix each result with its offset within the file in hexadecimal
+- Prefix each result with its offset within the file in hexadecimal:
 
 `strings -t x {{file}}`

--- a/pages/common/su.md
+++ b/pages/common/su.md
@@ -1,6 +1,6 @@
 # su
 
-> switch shell to another user
+> Switch shell to another user.
 
 - Switch to user {{username}} (password required):
 

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -1,6 +1,6 @@
 # sudo
 
-> execute a command as another user
+> Execute a command as another user.
 
 - Listing of an unreadable directory:
 
@@ -14,6 +14,6 @@
 
 `sudo {{shutdown}} -r +10 {{"Cya soon!"}}`
 
-- To repeat the last command as sudo
+- To repeat the last command as sudo:
 
 `sudo {{!!}}`

--- a/pages/common/svn.md
+++ b/pages/common/svn.md
@@ -1,23 +1,23 @@
 # svn
 
-> Subversion command line client tool
+> Subversion command line client tool.
 
-- Check out a working copy from a repository
+- Check out a working copy from a repository:
 
 `svn co {{url/to/repository}}`
 
-- Bring changes from the repository into the working copy
+- Bring changes from the repository into the working copy:
 
 `svn up`
 
-- Put files and directories under version control, scheduling them for addition to repository. They will be added in next commit.
+- Put files and directories under version control, scheduling them for addition to repository. They will be added in next commit:
 
 `svn add PATH...`
 
-- Send changes from your working copy to the repository
+- Send changes from your working copy to the repository:
 
 `svn ci -m {{commit log message}} {{[PATH...]}}`
 
-- Show detailed help
+- Show detailed help:
 
 `svn help`

--- a/pages/common/tac.md
+++ b/pages/common/tac.md
@@ -2,10 +2,10 @@
 
 > Print and concatenate files in reverse.
 
-- Print the contents of *file1* reversed to the standard output
+- Print the contents of *file1* reversed to the standard output:
 
 `tac {{file1}}`
 
-- Concatenate several files reversed into the target file.
+- Concatenate several files reversed into the target file:
 
 `tac {{file1}} {{file2}} > {{target-file}}`

--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -1,19 +1,19 @@
 # tail
 
-> Display the last part of a file
+> Display the last part of a file.
 
-- show last 'num' lines in file
+- Show last 'num' lines in file:
 
 `tail -n {{num}} {{file}}`
 
-- show all file since line 'num'
+- Show all file since line 'num':
 
 `tail -n +{{num}} {{file}}`
 
-- show last 'num' bytes in file
+- Show last 'num' bytes in file:
 
 `tail -c {{num}} {{file}}`
 
-- keep reading file until ctrl-c
+- Keep reading file until ctrl-c:
 
 `tail -f {{file}}`

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -1,32 +1,32 @@
 # tar
 
-> Archiving utility
-> Optional compression with gzip / bzip
+> Archiving utility.
+> Optional compression with gzip / bzip.
 
-- create an archive from files
+- Create an archive from files:
 
 `tar cf {{target.tar}} {{file1 file2 file3}}`
 
-- create a gzipped archive
+- Create a gzipped archive:
 
 `tar czf {{target.tar.gz}} {{file1 file2 file3}}`
 
-- extract an archive in a target folder
+- Extract an archive in a target folder:
 
 `tar xf {{source.tar}} -C {{folder}}`
 
-- extract a gzipped archive in the current directory
+- Extract a gzipped archive in the current directory:
 
 `tar xzf {{source.tar.gz}}`
 
-- extract a bzipped archive in the current directory
+- Extract a bzipped archive in the current directory:
 
 `tar xjf {{source.tar.bz2}}`
 
-- create a compressed archive, using archive suffix to determine the compression program
+- Create a compressed archive, using archive suffix to determine the compression program:
 
 `tar caf {{target.tar.xz}} {{file1 file2 file3}}`
 
-- list the contents of a tar file
+- List the contents of a tar file:
 
 `tar tvf {{source.tar}}`

--- a/pages/common/tcpdump.md
+++ b/pages/common/tcpdump.md
@@ -1,27 +1,27 @@
 # tcpdump
 
-> Dump traffic on a network
+> Dump traffic on a network.
 
-- capture the traffic of a specific interface
+- Capture the traffic of a specific interface:
 
 `tcpdump -i {{eth0}}`
 
-- capture all TCP traffic showing contents (ASCII) in console
+- Capture all TCP traffic showing contents (ASCII) in console:
 
 `tcpdump -A tcp`
 
-- capture the traffic from or to a host
+- Capture the traffic from or to a host:
 
 `tcpdump host {{www.example.com}}`
 
-- capture the traffic from a specific interface, source, destination and destination port
+- Capture the traffic from a specific interface, source, destination and destination port:
 
 `tcpdump -i {{eth0}} src {{192.168.1.1}} and dst {{192.168.1.2}} and dst port 80`
 
-- capture the traffic of a network
+- Capture the traffic of a network:
 
 `tcpdump net {{192.168.1.0/24}}`
 
-- capture all traffic except traffic over port 22 and save to a dump file
+- Capture all traffic except traffic over port 22 and save to a dump file:
 
 `tcpdump -w dumpfile.pcap not port 22`

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -1,11 +1,11 @@
 # tee
 
-> read from standard input and write to standard output and files
+> Read from standard input and write to standard output and files.
 
-- Copy standard input to each FILE, and also to standard output.
+- Copy standard input to each FILE, and also to standard output:
 
 `echo "example" | tee {{FILE}}`
 
-- append to the given FILEs, do not overwrite
+- Append to the given FILEs, do not overwrite:
 
 `echo "example" | tee -a {{FILE}}`

--- a/pages/common/telnet.md
+++ b/pages/common/telnet.md
@@ -1,19 +1,19 @@
 # telnet
 
-> telnet is used to connect to a specified port of a host
+> Telnet is used to connect to a specified port of a host.
 
-- telnet to a certain port
+- Telnet to a certain port:
 
 `telnet  {{ip_address}} {{port}}`
 
-- to exit a telnet session
+- To exit a telnet session:
 
 `quit`
 
-- default escape character
+- Default escape character:
 
 `CTRL` + `]`
 
-- specify an escape character (x is the escape character)
+- Specify an escape character (x is the escape character):
 
 `telnet -e x {{ip_address}} {{port}}`

--- a/pages/common/test.md
+++ b/pages/common/test.md
@@ -3,22 +3,22 @@
 > Evaluate condition.
 > If it is true, returns 0 exit status, otherwise returns 1.
 
-- Test if given variable is equal to given string
+- Test if given variable is equal to given string:
 
 `test $MY_VAR == '/bin/zsh'`
 
-- Test if given variable is empty
+- Test if given variable is empty:
 
 `test -z $GIT_BRANCH`
 
-- Test if file exists
+- Test if file exists:
 
 `test -e {{filename}}`
 
-- Test if directory not exists
+- Test if directory not exists:
 
 `test ! -d {{path/to/directory}}`
 
-- If-else statement
+- If-else statement:
 
 `test {{condition}} && echo "true" || echo "false"`

--- a/pages/common/time.md
+++ b/pages/common/time.md
@@ -1,7 +1,7 @@
 # time
 
-> See how long a command takes
+> See how long a command takes.
 
-- Time "ls"
+- Time "ls":
 
 `time ls`

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -1,7 +1,7 @@
 # tldr
 
-> Simplified man pages
+> Simplified man pages.
 
-- get typical usages of a command (hint: this is how you got here!)
+- Get typical usages of a command (hint: this is how you got here!):
 
 `tldr {{command}}`

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -1,31 +1,31 @@
 # tmux
 
-> Multiplex several virtual consoles
+> Multiplex several virtual consoles.
 
-- Start a new tmux session
+- Start a new tmux session:
 
 `tmux`
 
-- Start a new named tmux session
+- Start a new named tmux session:
 
 `tmux new -s {{name}}`
 
-- List sessions
+- List sessions:
 
 `tmux ls`
 
-- Attach to a session
+- Attach to a session:
 
 `tmux a`
 
-- Attach to a named session
+- Attach to a named session:
 
 `tmux a -t {{name}}`
 
-- Detach from session
+- Detach from session:
 
 `ctrl+b d`
 
-- Kill session
+- Kill session:
 
 `tmux kill-session -t {{name}}`

--- a/pages/common/touch.md
+++ b/pages/common/touch.md
@@ -1,16 +1,16 @@
 # touch
 
-> Change a file access and modification times (atime, mtime)
+> Change a file access and modification times (atime, mtime).
 
-- Create a new empty file(s) or change the times for existing file(s) to current time
+- Create a new empty file(s) or change the times for existing file(s) to current time:
 
 `touch {{filename}}`
 
-- Set the times on a file to those specified
+- Set the times on a file to those specified:
 
 `touch -t 201412250801.59 {{filename}}`
 `touch -t {{YYYYMMDDHHMM.SS}} {{filename}}`
 
-- Set the times on a file to match those on second file
+- Set the times on a file to match those on second file:
 
 `touch -r {{filename2}} {{filename}}`

--- a/pages/common/tr.md
+++ b/pages/common/tr.md
@@ -1,27 +1,27 @@
 # tr
 
-> translate characters - run replacements based on single characters and character sets
+> Translate characters - run replacements based on single characters and character sets.
 
-- Replace all occurrences of a character in a file, and print the result
+- Replace all occurrences of a character in a file, and print the result:
 
 `tr {{find_characters}} {{replace_characters}} < {{filename}}`
 
-- Map each character of the first set to the corresponding character of the second set.
+- Map each character of the first set to the corresponding character of the second set:
 
 `tr 'abcd' 'jkmn' < {{filename}}`
 
-- Delete all occurances of the specified set of characters from the input.
+- Delete all occurances of the specified set of characters from the input:
 
 `tr -d '{{input_characters}}'`
 
-- Compress a series of identical characters to a single character.
+- Compress a series of identical characters to a single character:
 
 `tr -s '\n'`
 
-- Translate the contents of the file to upper-case and print result.
+- Translate the contents of the file to upper-case and print result:
 
 `tr "[:lower:]" "[:upper:]" < {{filename}}`
 
-- Strip out non-printable characters from the file and print result.
+- Strip out non-printable characters from the file and print result:
 
 `tr -cd "[:print:]" < {{filename}}`

--- a/pages/common/traceroute.md
+++ b/pages/common/traceroute.md
@@ -1,19 +1,19 @@
 # traceroute
 
-> Print the route packets trace to network host
+> Print the route packets trace to network host.
 
-- Traceroute to a host
+- Traceroute to a host:
 
 `traceroute {{host}}`
 
-- Disable IP address and host name mapping
+- Disable IP address and host name mapping:
 
 `traceroute -n {{host}}`
 
-- Specify wait time for response
+- Specify wait time for response:
 
 `traceroute -w 0.5 {{host}}`
 
-- Specify number of queries per hop
+- Specify number of queries per hop:
 
 `traceroute -q 5 {{host}}`

--- a/pages/common/transcode.md
+++ b/pages/common/transcode.md
@@ -1,16 +1,16 @@
 # transcode
 
-> Suite of command line utilities for transcoding video and audio codecs
-> and converting between formats.
+> Suite of command line utilities for transcoding video and audio codecs.
+> And converting between formats.
 
-- Create stabilisation file to be able to remove camera shakes.
+- Create stabilisation file to be able to remove camera shakes:
 
 `transcode -J stabilize -i {{inputfile}}`
 
-- Remove camera shakes after creating stabilisation file, transform video using xvid.
+- Remove camera shakes after creating stabilisation file, transform video using xvid:
 
 `transcode -J transform -i {{inputfile}} -y xvid -o {{outputfile}}`
 
-- Resize the video to 640x480 pixels and convert to MPEG4 codec using xvid.
+- Resize the video to 640x480 pixels and convert to MPEG4 codec using xvid:
 
 `transcode -Z 640x480 -i {{inputfile}} -y xvid -o {{outputfile}}`

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -2,26 +2,26 @@
 
 > Show the contents of the current directory as a tree.
 
-- Show files and directories with a depth of 'num'
+- Show files and directories with a depth of 'num':
 
 `tree -L {{num}}`
 
-- Show directories only
+- Show directories only:
 
 `tree -d`
 
-- Show hidden files too
+- Show hidden files too:
 
 `tree -a`
 
-- Print human readable size of files
+- Print human readable size of files:
 
 `tree -h`
 
-- Print the full path for each file
+- Print the full path for each file:
 
 `tree -f`
 
-- Print the tree without lines and indentation. Useful when used with -f
+- Print the tree without lines and indentation. Useful when used with -f:
 
 `tree -i`

--- a/pages/common/ufraw-batch.md
+++ b/pages/common/ufraw-batch.md
@@ -2,18 +2,18 @@
 
 > Convert RAW files from cameras into standard image files.
 
-- Simply convert RAW files to jpg.
+- Simply convert RAW files to jpg:
 
 `ufraw-batch --out-type=jpg {{input-file(s)}}`
 
-- Simply convert RAW files to png.
+- Simply convert RAW files to png:
 
 `ufraw-batch --out-type=png {{input-file(s)}}`
 
-- Extract the preview image from the raw file.
+- Extract the preview image from the raw file:
 
 `ufraw-batch --embedded-image {{input-file(s)}}`
 
-- Save the file with size up to the given maximums MAX1 and MAX2.
+- Save the file with size up to the given maximums MAX1 and MAX2:
 
 `ufraw-batch --size=MAX1,MAX2 {{input-file(s)}}`

--- a/pages/common/umount.md
+++ b/pages/common/umount.md
@@ -3,14 +3,14 @@
 > Revokes access to an entire filesystem mounted to a directory.
 > A filesystem cannot be unmounted when it is busy.
 
-- Unmount a filesystem
+- Unmount a filesystem:
 
 `umount {{path_to_device_file}}`
 
-- OR
+- OR:
 
 `umount {{path_to_mounted_directory}}`
 
-- Unmount all mounted filesystems (dangerous!)
+- Unmount all mounted filesystems (dangerous!):
 
 `umount -a`

--- a/pages/common/uname.md
+++ b/pages/common/uname.md
@@ -3,18 +3,18 @@
 > Print details about the current machine and the operating system running on it.
 > Note: If you're on Linux, try also the `lsb_release` command.
 
-- Print hardware-related information: machine and processor
+- Print hardware-related information: machine and processor:
 
 `uname -mp`
 
-- Print software-related information: operating system, release number, and version
+- Print software-related information: operating system, release number, and version:
 
 `uname -srv`
 
-- Print the nodename (hostname) of the system
+- Print the nodename (hostname) of the system:
 
 `uname -n`
 
-- Print all available system information (hardware, software, nodename)
+- Print all available system information (hardware, software, nodename):
 
 `uname -a`

--- a/pages/common/unrar.md
+++ b/pages/common/unrar.md
@@ -1,19 +1,19 @@
 # unrar
 
-> Extract RAR archives
+> Extract RAR archives.
 
-- extract files with original directory structure
+- Extract files with original directory structure:
 
 `unrar x {{compressed.rar}}`
 
-- extract files into current directory, losing directory structure in the archive
+- Extract files into current directory, losing directory structure in the archive:
 
 `unrar e {{compressed.rar}}`
 
-- test integrity of each file inside the archive file
+- Test integrity of each file inside the archive file:
 
 `unrar t {{compressed.rar}}`
 
-- list files inside the archive file without decompressing it
+- List files inside the archive file without decompressing it:
 
 `unrar l {{compressed.rar}}`

--- a/pages/common/unzip.md
+++ b/pages/common/unzip.md
@@ -1,15 +1,15 @@
 # unzip
 
-> Extract compressed files in a ZIP archive
+> Extract compressed files in a ZIP archive.
 
-- extract zip file(s) (for multiple files, seperate file paths by spaces)
+- Extract zip file(s) (for multiple files, seperate file paths by spaces):
 
 `unzip {{file(s)}}`
 
-- extract zip files(s) to given path
+- Extract zip files(s) to given path:
 
 `unzip {{files(s)}} -d {{/path/to/put/extracted/files}}`
 
-- list the contents of a zip file without extracting
+- List the contents of a zip file without extracting:
 
 `unzip -l {{file}}`

--- a/pages/common/uptime.md
+++ b/pages/common/uptime.md
@@ -1,7 +1,7 @@
 # uptime
 
-> Tell how long the system has been running and other information
+> Tell how long the system has been running and other information.
 
-- Print current time, uptime, number of logged-in users and other information
+- Print current time, uptime, number of logged-in users and other information:
 
 `uptime`

--- a/pages/common/vagrant.md
+++ b/pages/common/vagrant.md
@@ -1,23 +1,23 @@
 # vagrant
 
-> Manage lightweight, reproducible, and portable development environments
+> Manage lightweight, reproducible, and portable development environments.
 
-- Create Vagrantfile in current folder with the base Vagrant box
+- Create Vagrantfile in current folder with the base Vagrant box:
 
 `vagrant init`
 
-- Create Vagrantfile with the Ubuntu 14.04 (Trusty Tahr) box from HashiCorp Atlas
+- Create Vagrantfile with the Ubuntu 14.04 (Trusty Tahr) box from HashiCorp Atlas:
 
 `vagrant init ubuntu/trusty32`
 
-- Start and provision the vagrant environment
+- Start and provision the vagrant environment:
 
 `vagrant up`
 
-- Suspend the machine
+- Suspend the machine:
 
 `vagrant suspend`
 
-- Connect to machine via SSH
+- Connect to machine via SSH:
 
 `vagrant ssh`

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,19 +1,19 @@
 # vim
 
-> Vi IMproved, a programmer's text editor
+> Vi IMproved, a programmer's text editor.
 
-- open a file with cursor at the given line number
+- Open a file with cursor at the given line number:
 
 `vim {{file}} +{{linenumber}}`
 
-- open multiple files at once, each file in it's own tab page
+- Open multiple files at once, each file in it's own tab page:
 
 `vim -p {{file1}} {{file2}} {{file3}}`
 
-- open a file in read-only mode
+- Open a file in read-only mode:
 
 `view {{file}}`
 
-- exiting vim
+- Exiting vim:
 
 `[Esc] (to switch to normal mode), then :q`

--- a/pages/common/vimtutor.md
+++ b/pages/common/vimtutor.md
@@ -1,11 +1,11 @@
 # vimtutor
 
-> Vim tutor, teaching the basic vim commands
+> Vim tutor, teaching the basic vim commands.
 
-- launch the vim tutor using the given language (en, fr, de, ...)
+- Launch the vim tutor using the given language (en, fr, de, ...):
 
 `vimtutor {{language}}`
 
-- exiting the tutor
+- Exiting the tutor:
 
 `[Esc] (to switch to normal mode), then :q`

--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -1,16 +1,15 @@
 # virtualenv
 
-> Create virtual isolated Python environments
+> Create virtual isolated Python environments.
 
-- Create a new environment
+- Create a new environment:
 
 `virtualenv {{path/to/venv}}`
 
-- Start (select) the environment
+- Start (select) the environment:
 
 `source {{path/to/venv}}/bin/activate`
 
-- Stop the environment
+- Stop the environment:
 
 `deactivate`
-

--- a/pages/common/w.md
+++ b/pages/common/w.md
@@ -3,10 +3,10 @@
 > Show who is logged on and what they are doing.
 > Print user login, TTY, remote host, login time, idle time, current process.
 
-- Show logged-in users info
+- Show logged-in users info:
 
 `w`
 
-- Show logged-in users info without a header
+- Show logged-in users info without a header:
 
 `w -h`

--- a/pages/common/wc.md
+++ b/pages/common/wc.md
@@ -1,15 +1,15 @@
 # wc
 
-> Count words, bytes, or lines
+> Count words, bytes, or lines.
 
-- count lines in file
+- Count lines in file:
 
 `wc -l {{file}}`
 
-- count bytes in file
+- Count bytes in file:
 
 `wc -c {{file}}`
 
-- count characters in file (taking multi-byte character sets into account)
+- Count characters in file (taking multi-byte character sets into account):
 
 `wc -m {{file}}`

--- a/pages/common/wget.md
+++ b/pages/common/wget.md
@@ -1,24 +1,24 @@
 # wget
 
-> Download files from the Web
-> Supports HTTP, HTTPS, and FTP
+> Download files from the Web.
+> Supports HTTP, HTTPS, and FTP.
 
-- Download a URL to a file
+- Download a URL to a file:
 
 `wget -O filename "{{url}}"`
 
-- Limit download speed
+- Limit download speed:
 
 `wget --limit-rate={{200k}} {{url}}`
 
-- Continue an incomplete download
+- Continue an incomplete download:
 
 `wget -c {{url}}`
 
-- Download a full website
+- Download a full website:
 
 `wget --mirror -p --convert-links -P {{target_folder}} {{url}}`
 
-- FTP download with username and password
+- FTP download with username and password:
 
 `wget --ftp-user={{username}} --ftp-password={{password}} {{url}}`

--- a/pages/common/which.md
+++ b/pages/common/which.md
@@ -1,12 +1,12 @@
 # which
 
-> Locate the a program in the user's path
+> Locate the a program in the user's path.
 
-- Display the path of an executable program
+- Display the path of an executable program:
 
 `which {{ls}}`
 `which {{executable}}`
 
-- If there are multiple executables which match, display all
+- If there are multiple executables which match, display all:
 
 `which -a {{executable}}`

--- a/pages/common/whoami.md
+++ b/pages/common/whoami.md
@@ -1,7 +1,7 @@
 # whoami
 
-> Show the username of the current user
+> Show the username of the current user.
 
-- Display currently logged user name
+- Display currently logged user name:
 
 `whoami`

--- a/pages/common/yes.md
+++ b/pages/common/yes.md
@@ -1,11 +1,11 @@
 # yes
 
-> Output something repeatedly
+> Output something repeatedly.
 
-- Repeatedly output "message"
+- Repeatedly output "message":
 
 `yes {{message}}`
 
-- Repeatedly output "y"
+- Repeatedly output "y":
 
 `yes`

--- a/pages/common/zbarimg.md
+++ b/pages/common/zbarimg.md
@@ -1,7 +1,7 @@
 # zbarimg
 
-> scan and decode bar codes from image file(s)
+> Scan and decode bar codes from image file(s).
 
-- process an image file
+- Process an image file:
 
 `zbarimg {{image file}}`

--- a/pages/common/zfs.md
+++ b/pages/common/zfs.md
@@ -1,27 +1,27 @@
 # zfs
 
-> Manage ZFS filesystems
+> Manage ZFS filesystems.
 
-- List all available zfs filesystems
+- List all available zfs filesystems:
 
 `zfs list`
 
-- Create a new ZFS filesystem
+- Create a new ZFS filesystem:
 
 `zfs create poolname/newfsname`
 
-- Delete a ZFS filesystem
+- Delete a ZFS filesystem:
 
 `zfs destroy {{poolname/newfsname}}`
 
-- Create a Snapshot of a ZFS filesystem
+- Create a Snapshot of a ZFS filesystem:
 
 `zfs snapshot {{poolname/filesystem@snapshot-name}}`
 
-- Enable compression on a filesystem
+- Enable compression on a filesystem:
 
 `zfs set compression=on {{poolname/fileystem}}`
 
-- Change mountpoint for a filesytem
+- Change mountpoint for a filesytem:
 
 `zfs set mountpoint={{/my/mount/path}} {{poolname/filesystem}}`

--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -1,15 +1,15 @@
 # zip
 
-> Package and compress (archive) files into zip file
+> Package and compress (archive) files into zip file.
 
-- package and compress multiple directories and files
+- Package and compress multiple directories and files:
 
 `zip -r {{compressed.zip}} {{/path/to/dir1 /path/to/dir2 /path/to/file}}`
 
-- add files to an existing zip file
+- Add files to an existing zip file:
 
 `zip {{compressed.zip}} {{path/to/file}}`
 
-- remove unwanted files from an existing zip file
+- Remove unwanted files from an existing zip file:
 
 `zip -d {{compressed.zip}} "{{foo/*.tmp}}"`

--- a/pages/common/zpool.md
+++ b/pages/common/zpool.md
@@ -1,33 +1,33 @@
 # zpool
 
-> Manage ZFS pools
+> Manage ZFS pools.
 
-- Show the configuration and status of all ZFS zpools
+- Show the configuration and status of all ZFS zpools:
 
 `zpool status [{{poolname}}]`
 
-- Check a ZFS pool for errors (verifies the checksum of EVERY block). Very CPU and disk intensive.
+- Check a ZFS pool for errors (verifies the checksum of EVERY block). Very CPU and disk intensive:
 
 `zpool scrub {{poolname}}`
 
-- List zpools available for import
+- List zpools available for import:
 
 `zpool import`
 
-- Import a zpool, optionally specifying a new name
+- Import a zpool, optionally specifying a new name:
 
 `zpool import {{poolname}}`
 `zpool import {{poolname}} {{newpoolname}}`
 
-- Export a zpool (unmount all filesystems)
+- Export a zpool (unmount all filesystems):
 
 `zpool export {{poolname}}`
 
-- Show the history of all pool operations
+- Show the history of all pool operations:
 
 `zpool histrory {{poolname}}`
 
-- Create a mirrored pool.
+- Create a mirrored pool:
 
 `zpool create {{poolname}} mirror {{disk1}} {{disk2}}`
 `zpool create {{poolname}} mirror {{disk1}} {{disk2}} mirror {{disk3}} {{disk4}}`

--- a/pages/linux/apt-cache.md
+++ b/pages/linux/apt-cache.md
@@ -1,15 +1,15 @@
 # apt-cache
 
-> Debian and Ubuntu package query tool
+> Debian and Ubuntu package query tool.
 
-- Search for a package in your current sources
+- Search for a package in your current sources:
 
 `apt-cache search {{query}}`
 
-- Show information about a package
+- Show information about a package:
 
 `apt-cache show {{package}}`
 
-- Show whether a package is installed and up to date
+- Show whether a package is installed and up to date:
 
 `apt-cache policy {{package}}`

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -1,23 +1,23 @@
 # apt-get
 
-> Debian and Ubuntu package management utility
+> Debian and Ubuntu package management utility.
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent apt-get commands.
+- Synchronize list of packages and versions available. This should be run first, before running subsequent apt-get commands:
 
 `apt-get update`
 
-- install a new package
+- Install a new package:
 
 `apt-get install {{package}}`
 
-- remove a package
+- Remove a package:
 
 `apt-get remove {{package}}`
 
-- Upgrade installed packages to newest available versions
+- Upgrade installed packages to newest available versions:
 
 `apt-get upgrade`
 
-- Upgrade installed packages (like "upgrade"), but remove obsolete packages and install additional packages to meet new dependencies
+- Upgrade installed packages (like "upgrade"), but remove obsolete packages and install additional packages to meet new dependencies:
 
 `apt-get dist-upgrade`

--- a/pages/linux/aptitude.md
+++ b/pages/linux/aptitude.md
@@ -1,27 +1,27 @@
 # aptitude
 
-> Debian and Ubuntu package management utility
+> Debian and Ubuntu package management utility.
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent aptitude commands.
+- Synchronize list of packages and versions available. This should be run first, before running subsequent aptitude commands:
 
 `aptitude update`
 
-- install a new package
+- Install a new package:
 
 `aptitude install {{package}}`
 
-- search for a package
+- Search for a package:
 
 `aptitude search {{package}}`
 
-- remove a package
+- Remove a package:
 
 `aptitude remove {{package}}`
 
-- Upgrade installed packages to newest available versions
+- Upgrade installed packages to newest available versions:
 
 `aptitude upgrade`
 
-- Upgrade installed packages (like `aptitude upgrade`) including removing obsolete packages and installing additional packages to meet new package dependencies.
+- Upgrade installed packages (like `aptitude upgrade`) including removing obsolete packages and installing additional packages to meet new package dependencies:
 
 `aptitude full-upgrade`

--- a/pages/linux/base64.md
+++ b/pages/linux/base64.md
@@ -2,18 +2,18 @@
 
 > Encode or decode file or standard input, to standard output.
 
-- Encode a file
+- Encode a file:
 
 `base64 {{filename}}`
 
-- Decode a file
+- Decode a file:
 
 `base64 -d {{filename}}`
 
-- Encode from stdin
+- Encode from stdin:
 
 `{{somecommand}} | base64`
 
-- Decode from stdin
+- Decode from stdin:
 
 `{{somecommand}} | base64 -d`

--- a/pages/linux/dd.md
+++ b/pages/linux/dd.md
@@ -1,19 +1,19 @@
 # dd
 
-> convert and copy a file
+> Convert and copy a file.
 
-- Make a bootable usb drive from an isohybrid file (such like archlinux-xxx.iso)
+- Make a bootable usb drive from an isohybrid file (such like archlinux-xxx.iso):
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}}`
 
-- Clone a drive to another drive with 4MB block and ignore error
+- Clone a drive to another drive with 4MB block and ignore error:
 
 `dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs=4M conv=noerror`
 
-- Generating a file of 100 random bytes by using kernel random driver
+- Generating a file of 100 random bytes by using kernel random driver:
 
 `dd if=/dev/urandom of={{random_file}} bs=100 count=1`
 
-- Benchmark the write performance of a disk
+- Benchmark the write performance of a disk:
 
 `dd if=/dev/zero of={{file_1GB}} bs=1024 count=1000000`

--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -1,24 +1,23 @@
 # dnf
 
->Package management utility for RHEL, Feodra, and CentOS (replaces yum)
+> Package management utility for RHEL, Feodra, and CentOS (replaces yum).
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent dnf commands.
+- Synchronize list of packages and versions available. This should be run first, before running subsequent dnf commands:
 
 `dnf update`
 
-- Install a new package
+- Install a new package:
 
 `dnf install {{package}}`
 
-- Install a new package and assume yes to all questions
+- Install a new package and assume yes to all questions:
 
 `dnf -y install {{package}}`
 
-- Remove a package
+- Remove a package:
 
 `dnf remove {{package}}`
 
-- Upgrade installed packages to newest available versions
+- Upgrade installed packages to newest available versions:
 
 `dnf upgrade`
-

--- a/pages/linux/dpkg-query.md
+++ b/pages/linux/dpkg-query.md
@@ -2,18 +2,18 @@
 
 > A tool that shows information about installed packages.
 
-- List all installed packages.
+- List all installed packages:
 
 `dpkg-query -l`
 
-- List installed packages matching a pattern.
+- List installed packages matching a pattern:
 
 `dpkg-query -l '{{pattern}}'`
 
-- List all files installed by a package.
+- List all files installed by a package:
 
 `dpkg-query -L {{package_name}}`
 
-- Show information about a package.
+- Show information about a package:
 
 `dpkg-query -s {{package_name}}`

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -1,19 +1,19 @@
 # dpkg
 
-> debian package manager
+> Debian package manager.
 
-- install a package
+- Install a package:
 
 `dpkg -i {{/path/to/file}}`
 
-- remove a package
+- Remove a package:
 
 `dpkg -r {{package_name}}`
 
-- list installed packages
+- List installed packages:
 
 `dpkg -l {{pattern}}`
 
-- list package contents
+- List package contents:
 
 `dpkg -L {{package_name}}`

--- a/pages/linux/du.md
+++ b/pages/linux/du.md
@@ -1,19 +1,19 @@
 # du
 
-> Estimate file space usage
+> Estimate file space usage.
 
-- get a sum of the total size of a file/folder in human readable units
+- Get a sum of the total size of a file/folder in human readable units:
 
 `du -sh {{file/directory}}`
 
-- list file sizes of a directory and any subdirectories in KB
+- List file sizes of a directory and any subdirectories in KB:
 
 `du -k {{file/directory}}`
 
-- get recursively, individual file/folder sizes in human readable form
+- Get recursively, individual file/folder sizes in human readable form:
 
 `du -ah {{directory}}`
 
-- list the KB sizes of directories for N levels below the specified directory
+- List the KB sizes of directories for N levels below the specified directory:
 
 `du --max-depth=N`

--- a/pages/linux/emerge.md
+++ b/pages/linux/emerge.md
@@ -1,31 +1,31 @@
 # emerge
 
-> Gentoo Linux package manager utility
+> Gentoo Linux package manager utility.
 
-- synchronize all packages
+- Synchronize all packages:
 
 `emerge --sync`
 
-- update all packages, including dependencies
+- Update all packages, including dependencies:
 
 `emerge -uDNav @world`
 
-- resume a failed updated, skipping the failing package
+- Resume a failed updated, skipping the failing package:
 
 `emerge --resume --skipfirst`
 
-- install a new package, with confirmation
+- Install a new package, with confirmation:
 
 `emerge -av {{package-name}}`
 
-- remove a package, with confirmation
+- Remove a package, with confirmation:
 
 `emerge -Cav {{package-name}}`
 
-- remove orphaned packages (that were installed only as dependencies)
+- Remove orphaned packages (that were installed only as dependencies):
 
 `emerge -avc`
 
-- search the package database for a keyword
+- Search the package database for a keyword:
 
 `emerge -S {{keyword}}`

--- a/pages/linux/findmnt.md
+++ b/pages/linux/findmnt.md
@@ -1,23 +1,23 @@
 # findmnt
 
-> Find your filesystem
+> Find your filesystem.
 
-- List all mounted filesystems
+- List all mounted filesystems:
 
 `findmnt`
 
-- Search for a device
+- Search for a device:
 
 `findmnt {{/dev/sdb1}}`
 
-- Search for a mountpoint
+- Search for a mountpoint:
 
 `findmnt {{/}}`
 
-- Find filesystems in specific type
+- Find filesystems in specific type:
 
 `findmnt -t {{ext4}}`
 
-- Find filesystems with specific label
+- Find filesystems with specific label:
 
 `findmnt LABEL={{BigStorage}}`

--- a/pages/linux/firewall-cmd.md
+++ b/pages/linux/firewall-cmd.md
@@ -1,23 +1,23 @@
 # firewall-cmd
 
-> The firewalld command line client
+> The firewalld command line client.
 
-- View the available firewall zones
+- View the available firewall zones:
 
 `firewall-cmd --get-active-zones`
 
-- View the rules which are currently applied
+- View the rules which are currently applied:
 
 `firewall-cmd --list-all`
 
-- Permanently open the port for a service in the specified zone (like port `443` when in the `public` zone)
+- Permanently open the port for a service in the specified zone (like port `443` when in the `public` zone):
 
 `firewall-cmd --permanent --zone={{public}} --add-service={{https}}`
 
-- Permanently close the port for a service in the specified zone (like port `80` when in the `public` zone)
+- Permanently close the port for a service in the specified zone (like port `80` when in the `public` zone):
 
 `firewall-cmd --permanent --zone={{public}} --remove-service={{http}}`
 
-- Reload firewalld to force rule changes to take effect
+- Reload firewalld to force rule changes to take effect:
 
 `firewall-cmd --reload`

--- a/pages/linux/free.md
+++ b/pages/linux/free.md
@@ -1,19 +1,19 @@
 # free
 
-> Display amount of free and used memory in the system
+> Display amount of free and used memory in the system.
 
-- Display system memory
+- Display system memory:
 
 `free`
 
-- Display memory in Bytes/KB/MB/GB
+- Display memory in Bytes/KB/MB/GB:
 
 `free {{-b/-k/-m/-g}}`
 
-- Display memory in human readable units
+- Display memory in human readable units:
 
 `free -h`
 
-- Continuous monitor memory (refresh every X seconds)
+- Continuous monitor memory (refresh every X seconds):
 
 `free -s {{X}}`

--- a/pages/linux/head.md
+++ b/pages/linux/head.md
@@ -1,19 +1,19 @@
 # head
 
-> Output the first part of files
+> Output the first part of files.
 
-- Output the first few lines of a file
+- Output the first few lines of a file:
 
 `head -n {{count_of_lines}} {{filename}}`
 
-- Output the first few bytes of a file
+- Output the first few bytes of a file:
 
 `head -c {{size_in_bytes}} {{filename}}`
 
-- Output everything but the last few lines of a file
+- Output everything but the last few lines of a file:
 
 `head -n -{{count_of_lines}} {{filename}}`
 
-- Output everything but the last few bytes of a file
+- Output everything but the last few bytes of a file:
 
 `head -c -{{size_in_bytes}} {{filename}}`

--- a/pages/linux/hostname.md
+++ b/pages/linux/hostname.md
@@ -1,23 +1,23 @@
 # hostname
 
-> Show or set the system's host name
+> Show or set the system's host name.
 
-- Show current host name
+- Show current host name:
 
 `hostname`
 
-- Show the network address of the host name
+- Show the network address of the host name:
 
 `hostname -i`
 
-- Show all network addresses of the host
+- Show all network addresses of the host:
 
 `hostname -I`
 
-- Show the FQDN (Fully Qualified Domain Name)
+- Show the FQDN (Fully Qualified Domain Name):
 
 `hostname --fqdn`
 
-- Set current host name
+- Set current host name:
 
 `hostname {{new_hostname}}`

--- a/pages/linux/iostat.md
+++ b/pages/linux/iostat.md
@@ -1,19 +1,19 @@
 # iostat
 
-> Report stats for devices and partitions
+> Report stats for devices and partitions.
 
-- Display disk statistics with disk IDs in human readable format
+- Display disk statistics with disk IDs in human readable format:
 
 `iostat -h`
 
-- Display disk statistics with disk names (including LVM) in human readable format
+- Display disk statistics with disk names (including LVM) in human readable format:
 
 `iostat -Nh`
 
-- Display CPU statistics
+- Display CPU statistics:
 
 `iostat -c`
 
-- Display extended disk statistics with disk names
+- Display extended disk statistics with disk names:
 
 `iostat -xN`

--- a/pages/linux/ip.md
+++ b/pages/linux/ip.md
@@ -1,23 +1,23 @@
 # ip
 
-> Show / manipulate routing, devices, policy routing and tunnels
+> Show / manipulate routing, devices, policy routing and tunnels.
 
-- List interfaces with detailed info
+- List interfaces with detailed info:
 
 `ip a`
 
-- Display the routing table
+- Display the routing table:
 
 `ip r`
 
-- Make an interface up/down
+- Make an interface up/down:
 
 `ip link set {{interface}} up/down`
 
-- Add/Delete an ip address to an interface
+- Add/Delete an ip address to an interface:
 
 `ip addr add/del {{ip}}/{{mask}} dev {{interface}}`
 
-- Add an default route
+- Add an default route:
 
 `ip route add default via {{ip}} dev {{interface}}`

--- a/pages/linux/jobs.md
+++ b/pages/linux/jobs.md
@@ -2,26 +2,26 @@
 
 > BASH builtin for viewing information about processes spawned by the current shell.
 
-- view jobs spawned by the current shell
+- View jobs spawned by the current shell:
 
 `jobs`
 
-- list jobs and their process ids
+- List jobs and their process ids:
 
 `jobs -l`
 
-- display information about jobs with changed status
+- Display information about jobs with changed status:
 
 `jobs -n`
 
-- display process id of process group leader
+- Display process id of process group leader:
 
 `jobs -p`
 
-- display running processes
+- Display running processes:
 
 `jobs -r`
 
-- display stopped processes
+- Display stopped processes:
 
 `jobs -s`

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -1,27 +1,27 @@
 # journalctl
 
-> Query the systemd journal
+> Query the systemd journal.
 
-- Show all messages from this boot
+- Show all messages from this boot:
 
 `journalctl -b`
 
-- Show all messages from last boot
+- Show all messages from last boot:
 
 `journalctl -b -1`
 
-- Follow new messages (like `tail -f` for traditional syslog)
+- Follow new messages (like `tail -f` for traditional syslog):
 
 `journalctl -f`
 
-- Show all messages by a specific unit
+- Show all messages by a specific unit:
 
 `journalctl -u {{unit}}`
 
-- Show all messages by a specific process
+- Show all messages by a specific process:
 
 `journalctl _PID={{pid}}`
 
-- Show all messages by a specific executable
+- Show all messages by a specific executable:
 
 `journalctl {{/path/to/executable}}`

--- a/pages/linux/locate.md
+++ b/pages/linux/locate.md
@@ -1,11 +1,11 @@
 # locate
 
-> find filenames quickly
+> Find filenames quickly.
 
-- Look for pattern in the database. Note: the database is recomputed periodically (usually weekly or daily).
+- Look for pattern in the database. Note: the database is recomputed periodically (usually weekly or daily):
 
 `locate {{pattern}}`
 
-- Recompute the database. You need to do it if you want to find recently added files.
+- Recompute the database. You need to do it if you want to find recently added files:
 
 `sudo updatedb`

--- a/pages/linux/lsb_release.md
+++ b/pages/linux/lsb_release.md
@@ -1,19 +1,19 @@
 # lsb_release
 
-> Provides certain LSB (Linux Standard Base) and distribution-specific information
+> Provides certain LSB (Linux Standard Base) and distribution-specific information.
 
-- Print all available information
+- Print all available information:
 
 `lsb_release -a`
 
-- Print a description (usually the full name) of the operating system
+- Print a description (usually the full name) of the operating system:
 
 `lsb_release -d`
 
-- Print only the operating system name (ID), suppressing the field name
+- Print only the operating system name (ID), suppressing the field name:
 
 `lsb_release -i -s`
 
-- Print the release number and codename of the distribution, suppressing the field names
+- Print the release number and codename of the distribution, suppressing the field names:
 
 `lsb_release -rcs`

--- a/pages/linux/md5sum.md
+++ b/pages/linux/md5sum.md
@@ -1,13 +1,13 @@
 # md5sum
 
-> Calculate MD5 cryptographic checksums
+> Calculate MD5 cryptographic checksums.
 
-- Calculate the MD5 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the MD5 checksum for file(s) or files in a directory, one checksum per file:
 
 `md5sum {{filename1}}`
 `md5sum {{filename1}} {{filename2}}`
 `md5sum {{directory/\*}}`
 
-- Read a file of MD5SUMs and verify all files have matching checksums
+- Read a file of MD5SUMs and verify all files have matching checksums:
 
 `md5sum -c {{filename.md5}}`

--- a/pages/linux/mdadm.md
+++ b/pages/linux/mdadm.md
@@ -1,27 +1,27 @@
 # mdadm
 
-> RAID management utility
+> RAID management utility.
 
-- create array
+- Create array:
 
 `mdadm --create {{/path/to/raid_device_file}} --level {{ raid level }} --raid-devices {{ number of disks}} {{/path/to/disk_device_file}}`
 
-- stop array
+- Stop array:
 
 `mdadm -S {{/path/to/raid_device_file}}`
 
-- mark disk as failed
+- Mark disk as failed:
 
 `mdadm {{/path/to/raid_device_file}} -f {{/path/to/disk_device_file}}`
 
-- remove disk
+- Remove disk:
 
 `mdadm {{/path/to/raid_device_file}} -r {{/path/to/disk_device_file}}`
 
-- add disk to array
+- Add disk to array:
 
 `mdadm {{/path/to/raid_device_file}} -a {{/path/to/disk_device_file}}`
 
-- show RAID info
+- Show RAID info:
 
 `mdadm -D {{/path/to/raid_device_file}}`

--- a/pages/linux/nethogs.md
+++ b/pages/linux/nethogs.md
@@ -1,19 +1,19 @@
 # nethogs
 
-> Monitor bandwidth usage per process
+> Monitor bandwidth usage per process.
 
-- Start nethogs as root (default device is eth0)
+- Start nethogs as root (default device is eth0):
 
 `sudo nethogs`
 
-- Monitor bandwidth on specific device
+- Monitor bandwidth on specific device:
 
 `sudo nethogs {{device}}`
 
-- Monitor bandwidth on multiple devices
+- Monitor bandwidth on multiple devices:
 
 `sudo nethogs {{device1}} {{device2}}`
 
-- Specify refresh rate
+- Specify refresh rate:
 
 `sudo nethogs -t {{seconds}}`

--- a/pages/linux/netstat.md
+++ b/pages/linux/netstat.md
@@ -1,23 +1,23 @@
 # netstat
 
-> Displays various networks related information such as open connections, open socket ports etc
+> Displays various networks related information such as open connections, open socket ports etc.
 
-- List all ports
+- List all ports:
 
 `netstat -a`
 
-- List all listening ports
+- List all listening ports:
 
 `netstat -l`
 
-- List listening TCP ports
+- List listening TCP ports:
 
 `netstat -t`
 
-- Display PID and program names
+- Display PID and program names:
 
 `netstat -p`
 
-- List information continuously
+- List information continuously:
 
 `netstat -c`

--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -1,35 +1,35 @@
 # pacman
 
-> Arch Linux package manager utility
+> Arch Linux package manager utility.
 
-- synchronize and update all packages
+- Synchronize and update all packages:
 
 `pacman -Syu`
 
-- install a new package
+- Install a new package:
 
 `pacman -S package-name`
 
-- remove a package and its dependencies
+- Remove a package and its dependencies:
 
 `pacman -Rs package-name`
 
-- search the package database for a keyword
+- Search the package database for a keyword:
 
 `pacman -Ss icon theme`
 
-- list installed packages and versions
+- List installed packages and versions:
 
 `pacman -Q`
 
-- list only the explicitly installed packages and versions
+- List only the explicitly installed packages and versions:
 
 `pacman -Qe`
 
-- find which package owns a certain file
+- Find which package owns a certain file:
 
 `pacman -Qo filename`
 
-- empty package cache to free up space
+- Empty package cache to free up space:
 
 `pacman -Scc`

--- a/pages/linux/sha1sum.md
+++ b/pages/linux/sha1sum.md
@@ -1,13 +1,13 @@
 # sha1sum
 
-> Calculate SHA1 cryptographic checksums
+> Calculate SHA1 cryptographic checksums.
 
-- Calculate the SHA1 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the SHA1 checksum for file(s) or files in a directory, one checksum per file:
 
 `sha1sum {{filename1}}`
 `sha1sum {{filename1}} {{filename2}}`
 `sha1sum {{directory/\*}}`
 
-- Read a file of SHA1 sums and verify all files have matching checksums
+- Read a file of SHA1 sums and verify all files have matching checksums:
 
 `sha1sum -c {{filename.sha1}}`

--- a/pages/linux/sha224sum.md
+++ b/pages/linux/sha224sum.md
@@ -1,13 +1,13 @@
 # sha224sum
 
-> Calculate SHA224 cryptographic checksums
+> Calculate SHA224 cryptographic checksums.
 
-- Calculate the SHA224 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the SHA224 checksum for file(s) or files in a directory, one checksum per file:
 
 `sha224sum {{filename1}}`
 `sha224sum {{filename1}} {{filename2}}`
 `sha224sum {{directory/\*}}`
 
-- Read a file of SHA224 sums and verify all files have matching checksums
+- Read a file of SHA224 sums and verify all files have matching checksums:
 
 `sha224sum -c {{filename.sha224}}`

--- a/pages/linux/sha256sum.md
+++ b/pages/linux/sha256sum.md
@@ -1,13 +1,13 @@
 # sha256sum
 
-> Calculate SHA256 cryptographic checksums
+> Calculate SHA256 cryptographic checksums.
 
-- Calculate the SHA256 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the SHA256 checksum for file(s) or files in a directory, one checksum per file:
 
 `sha256sum {{filename1}}`
 `sha256sum {{filename1}} {{filename2}}`
 `sha256sum {{directory/\*}}`
 
-- Read a file of SHA256 sums and verify all files have matching checksums
+- Read a file of SHA256 sums and verify all files have matching checksums:
 
 `sha256sum -c {{filename.sha256}}`

--- a/pages/linux/sha384sum.md
+++ b/pages/linux/sha384sum.md
@@ -1,13 +1,13 @@
 # sha384sum
 
-> Calculate SHA384 cryptographic checksums
+> Calculate SHA384 cryptographic checksums.
 
-- Calculate the SHA384 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the SHA384 checksum for file(s) or files in a directory, one checksum per file:
 
 `sha384sum {{filename1}}`
 `sha384sum {{filename1}} {{filename2}}`
 `sha384sum {{directory/\*}}`
 
-- Read a file of SHA384 sums and verify all files have matching checksums
+- Read a file of SHA384 sums and verify all files have matching checksums:
 
 `sha384sum -c {{filename.sha384}}`

--- a/pages/linux/sha512sum.md
+++ b/pages/linux/sha512sum.md
@@ -1,13 +1,13 @@
 # sha512sum
 
-> Calculate SHA512 cryptographic checksums
+> Calculate SHA512 cryptographic checksums.
 
-- Calculate the SHA512 checksum for file(s) or files in a directory, one checksum per file
+- Calculate the SHA512 checksum for file(s) or files in a directory, one checksum per file:
 
 `sha512sum {{filename1}}`
 `sha512sum {{filename1}} {{filename2}}`
 `sha512sum {{directory/\*}}`
 
-- Read a file of SHA512 sums and verify all files have matching checksums
+- Read a file of SHA512 sums and verify all files have matching checksums:
 
 `sha512sum -c {{filename.sha512}}`

--- a/pages/linux/shuf.md
+++ b/pages/linux/shuf.md
@@ -1,19 +1,19 @@
 # shuf
 
-> generate random permutations
+> Generate random permutations.
 
-- randomize the order of lines in a file and output the result
+- Randomize the order of lines in a file and output the result:
 
 `shuf {{filename}}`
 
-- only output the first n entries of the result
+- Only output the first n entries of the result:
 
 `shuf -n {{n}} {{filename}}`
 
-- write output to another file
+- Write output to another file:
 
 `shuf -o {{another_filename}} {{filename}}`
 
-- generate random numbers in range
+- Generate random numbers in range:
 
 `shuf -i {{low}}-{{high}}`

--- a/pages/linux/shutdown.md
+++ b/pages/linux/shutdown.md
@@ -1,23 +1,23 @@
 # shutdown
 
-> Shutdown and reboot the system
+> Shutdown and reboot the system.
 
-- Power off (halt) immediately
+- Power off (halt) immediately:
 
 `shutdown -h now`
 
-- Reboot immediately
+- Reboot immediately:
 
 `shutdown -r now`
 
-- Reboot in 5 minutes
+- Reboot in 5 minutes:
 
 `shutdown -r +{{5}} &`
 
-- Shutdown at 1:00 pm (Uses 24h clock)
+- Shutdown at 1:00 pm (Uses 24h clock):
 
 `shutdown -h 13:00`
 
-- Cancel a pending shutdown/reboot operation
+- Cancel a pending shutdown/reboot operation:
 
 `shutdown -c`

--- a/pages/linux/ss.md
+++ b/pages/linux/ss.md
@@ -1,31 +1,27 @@
 # ss
 
-> Utility to investigate sockets
+> Utility to investigate sockets.
 
-- Dump all TCP/UDP/RAW/UNIX sockets
+- Dump all TCP/UDP/RAW/UNIX sockets:
 
 `ss -a {{-t/-u/-w/-x}}`
 
-- Show process(es) that using socket
+- Show process(es) that using socket:
 
 `ss -p`
 
-- Filter TCP sockets by states, only/exclude
+- Filter TCP sockets by states, only/exclude:
 
 `ss {{state/exclude}} {{bucket/big/connected/synchronized/...}}`
 
-- Filter sockets by address and/or port
+- Filter sockets by address and/or port:
 
 `ss -t dst 1.2.3.4:80`
-
 `ss -u src 127/8`
-
 `ss -t 'dport >= :1024'`
-
 `ss -x "src /tmp/.X11-unix/*"`
-
 `ss -t state established '( dport = :ssh or sport = :ssh )'`
 
-- Only list IPv4 or IPv6 sockets
+- Only list IPv4 or IPv6 sockets:
 
 `ss {{-4/-6}}`

--- a/pages/linux/ssh-copy-id.md
+++ b/pages/linux/ssh-copy-id.md
@@ -2,10 +2,10 @@
 
 > Install your public key in a remote machine's authorized_keys.
 
-- Copy the given public key to the remote
+- Copy the given public key to the remote:
 
 `ssh-copy-id -i {{path/to/certificate}} {{username}}@{{remote_host}}`
 
-- Copy the given public key to the remote with specific port
+- Copy the given public key to the remote with specific port:
 
 `ssh-copy-id -i {{path/to/certificate}} -p {{port}} {{username}}@{{remote_host}}`

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -1,19 +1,19 @@
 # strace
 
-> Troubleshooting tool for tracing system calls
+> Troubleshooting tool for tracing system calls.
 
-- Start tracing a specific process by its PID
+- Start tracing a specific process by its PID:
 
 `strace -p {{pid}}`
 
-- Trace a process and filter output by system call
+- Trace a process and filter output by system call:
 
 `strace -p {{pid}} -e {{system call name}}`
 
-- Count time, calls, and errors for each system call and report a summary on program exit.
+- Count time, calls, and errors for each system call and report a summary on program exit:
 
 `strace -p {{pid}} -c`
 
-- Show the time spent in every system call
+- Show the time spent in every system call:
 
 `strace -p {{pid}} -T`

--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -1,23 +1,23 @@
 # systemctl
 
-> Control the systemd system and service manager
+> Control the systemd system and service manager.
 
-- List failed units
+- List failed units:
 
 `systemctl --failed`
 
-- Start/Stop/Restart a service
+- Start/Stop/Restart a service:
 
 `systemctl start/stop/restart {{unit}}`
 
-- Show the status of a unit
+- Show the status of a unit:
 
 `systemctl status {{unit}}`
 
-- Enable/Disable a unit to be started on bootup
+- Enable/Disable a unit to be started on bootup:
 
 `systemctl enable/disable {{unit}}`
 
-- Reload systemd, scanning for new or changed units
+- Reload systemd, scanning for new or changed units:
 
 `systemctl daemon-reload`

--- a/pages/linux/tcpflow.md
+++ b/pages/linux/tcpflow.md
@@ -1,7 +1,7 @@
 # tcpflow
 
-> Capture TCP traffic for debugging and analysis
+> Capture TCP traffic for debugging and analysis.
 
-- Show all data on the given interface and port
+- Show all data on the given interface and port:
 
 `tcpflow -c -i {{eth0}} port {{80}}`

--- a/pages/linux/timedatectl.md
+++ b/pages/linux/timedatectl.md
@@ -1,19 +1,19 @@
 # timedatectl
 
-> Control the system time and date
+> Control the system time and date.
 
-- To check the current system clock time
+- To check the current system clock time:
 
 `timedatectl`
 
-- To set the local time of the system clock directly
+- To set the local time of the system clock directly:
 
 `timedatectl set-time {{"yyyy-MM-dd hh:mm:ss"}}`
 
-- To list available timezones
+- To list available timezones:
 
 `timedatectl list-timezones`
 
-- To change timezones
+- To change timezones:
 
 `timedatectl set-timezone {{timezone}}`

--- a/pages/linux/top.md
+++ b/pages/linux/top.md
@@ -2,18 +2,18 @@
 
 > Display dynamic real-time information about running processes.
 
-- Start top
+- Start top:
 
 `top`
 
-- Start top ignoring any idle or zombie processes
+- Start top ignoring any idle or zombie processes:
 
 `top -i`
 
-- Start top displaying only processes owned by given user
+- Start top displaying only processes owned by given user:
 
 `top -u {{user-name}}`
 
-- Get help about interactive commands
+- Get help about interactive commands:
 
 `?`

--- a/pages/linux/ulimit.md
+++ b/pages/linux/ulimit.md
@@ -1,19 +1,19 @@
 # ulimit
 
-> Get and set user limits
+> Get and set user limits.
 
-- get the properties of all the user limits
+- Get the properties of all the user limits:
 
 `ulimit -a`
 
-- get hard limit for the number of simultaneously opened files
+- Get hard limit for the number of simultaneously opened files:
 
 `ulimit -H -n`
 
-- get soft limit for the number of simultaneously opened files
+- Get soft limit for the number of simultaneously opened files:
 
 `ulimit -S -n`
 
-- set max per-user process limit
+- Set max per-user process limit:
 
 `ulimit -u 30`

--- a/pages/linux/useradd.md
+++ b/pages/linux/useradd.md
@@ -1,19 +1,19 @@
 # useradd
 
-> Create a new user
+> Create a new user.
 
-- Create new user
+- Create new user:
 
 `useradd {{name}}`
 
-- Create new user with a default home directory
+- Create new user with a default home directory:
 
 `useradd -m {{name}}`
 
-- Create new user with specified shell
+- Create new user with specified shell:
 
 `useradd -s {{/path/to/shell}} {{name}}`
 
-- Create new user with supplementary groups (mind the lack of whitespace)
+- Create new user with supplementary groups (mind the lack of whitespace):
 
 `useradd -G {{group1,group2}} {{name}}`

--- a/pages/linux/userdel.md
+++ b/pages/linux/userdel.md
@@ -1,7 +1,7 @@
 # userdel
 
-> Remove a user
+> Remove a user.
 
-- Remove a user and their home directory
+- Remove a user and their home directory:
 
 `userdel -r {{name}}`

--- a/pages/linux/usermod.md
+++ b/pages/linux/usermod.md
@@ -1,15 +1,15 @@
 # usermod
 
-> Modifies a user account
+> Modifies a user account.
 
-- Change a user's name
+- Change a user's name:
 
 `usermod -l {{newname}} {{user}}`
 
-- Add user to supplementary groups (mind the whitespace)
+- Add user to supplementary groups (mind the whitespace):
 
 `usermod -a -G {{group1,group2}} {{user}}`
 
-- Create a new home directory for a user and move their files to it
+- Create a new home directory for a user and move their files to it:
 
 `usermod -m -d {{/path/to/home}} {{user}}`

--- a/pages/linux/wall.md
+++ b/pages/linux/wall.md
@@ -1,16 +1,16 @@
 # wall
 
-> write a message on the terminals of users currently logged in
-> only available to super-user
+> Write a message on the terminals of users currently logged in.
+> Only available to super-user.
 
-- send a message
+- Send a message:
 
 `echo "{{message}}" | wall`
 
-- send a message from a file
+- Send a message from a file:
 
 `wall {{file}}`
 
-- send a message with timeout (default 300)
+- Send a message with timeout (default 300):
 
 `wall -t {{seconds}} {{file}}`

--- a/pages/linux/watch.md
+++ b/pages/linux/watch.md
@@ -1,15 +1,15 @@
 # watch
 
-> Execute a command repeatedly, and monitor the output in full-screen mode
+> Execute a command repeatedly, and monitor the output in full-screen mode.
 
-- monitor files in the current folder
+- Monitor files in the current folder:
 
 `watch {{ls}}`
 
-- monitor disk space and highlight the changes
+- Monitor disk space and highlight the changes:
 
 `watch -d {{df}}`
 
-- monitor "node" processes, refreshing every 3 seconds
+- Monitor "node" processes, refreshing every 3 seconds:
 
 `watch -n {{3}} "{{ps aux | grep node}}"`

--- a/pages/linux/wpa_cli.md
+++ b/pages/linux/wpa_cli.md
@@ -1,25 +1,25 @@
 # wpa_cli
 
-> add and configure wlan interfaces
+> Add and configure wlan interfaces.
 
-- scan for available networks
+- Scan for available networks:
 
 `wpa_cli scan`
 `wpa_cli scan_results`
 
-- add a network
+- Add a network:
 
 `wpa_cli add_network {{number}}`
 
-- configure the network, e.g. set SSID and passkey
+- Configure the network, e.g. set SSID and passkey:
 
 `wpa_cli set_network {{number}} ssid {{SSID}}`
 `wpa_cli set_network {{number}} psk {{passkey}}`
 
-- enable network
+- Enable network:
 
 `wpa_cli enable_network {{number}}`
 
-- save config
+- Save config:
 
 `wpa_cli save_config`

--- a/pages/linux/xargs.md
+++ b/pages/linux/xargs.md
@@ -1,15 +1,15 @@
 # xargs
 
-> execute a command with piped arguments
+> Execute a command with piped arguments.
 
-- main use
+- Main use:
 
 `{{arguments}} | xargs {{command}}`
 
-- handling whitespace in arguments
+- Handling whitespace in arguments:
 
 `{{arguments_null_terminated}} | xargs -0 {{command}}`
 
-- example: list unneeded packages with deborphan and remove them with apt-get
+- Example: list unneeded packages with deborphan and remove them with apt-get:
 
 `sudo deborphan | xargs sudo apt-get remove`

--- a/pages/linux/xrandr.md
+++ b/pages/linux/xrandr.md
@@ -1,23 +1,23 @@
 # xrandr
 
-> Set the size, orientation and/or reflection of the outputs for a screen
+> Set the size, orientation and/or reflection of the outputs for a screen.
 
-- Display the current state of the system (known screens, resolutions, ...)
+- Display the current state of the system (known screens, resolutions, ...):
 
 `xrandr --query`
 
-- Disable disconnected outputs and enable connected ones with default settings
+- Disable disconnected outputs and enable connected ones with default settings:
 
 `xrandr --auto`
 
-- Change the resolution and update frequency of DisplayPort 1 to 1920x1080, 60Hz
+- Change the resolution and update frequency of DisplayPort 1 to 1920x1080, 60Hz:
 
 `xrandr --output {{DP1}} --mode {{1920x1080}} --rate {{60}}`
 
-- Set the resolution of HDMI2 to 1280x1024 and put it on the right of DP1
+- Set the resolution of HDMI2 to 1280x1024 and put it on the right of DP1:
 
 `xrandr --output {{HDMI2}} --mode {{1280x1024}} --right-of {{DP1}}`
 
-- Disable the VGA1 output
+- Disable the VGA1 output:
 
 `xrandr --output {{VGA1}} --off`

--- a/pages/linux/xsetwacom.md
+++ b/pages/linux/xsetwacom.md
@@ -2,22 +2,22 @@
 
 > Command line tool to change settings for Wacom pen tablets at runtime.
 
-- List all the available wacom devices. The device name is in the first column.
+- List all the available wacom devices. The device name is in the first column:
 
 `xsetwacom list`
 
-- Set Wacom area to specific screen. Get name of the screen with `xrandr`.
+- Set Wacom area to specific screen. Get name of the screen with `xrandr`:
 
 `xsetwacom set "{{device name}}" MapToOutput {{screen}}`
 
-- Set mode to relative (like a mouse) or absolute (like a pen) mode.
+- Set mode to relative (like a mouse) or absolute (like a pen) mode:
 
 `xsetwacom set "{{device name}}" Mode "{{Relative|Absolute}}"`
 
-- Rotate the input (useful for tablet-PC when rotating screen) by 0|90|180|270 degrees from "natural" rotation.
+- Rotate the input (useful for tablet-PC when rotating screen) by 0|90|180|270 degrees from "natural" rotation:
 
 `xsetwacom set "{{device name}}" Rotate {{none|half|cw|ccw}}`
 
-- Set button to only work when the tip of the pen is touching the tablet.
+- Set button to only work when the tip of the pen is touching the tablet:
 
 `xsetwacom set "{{device name}}" TabletPCButton "on"`

--- a/pages/linux/yum.md
+++ b/pages/linux/yum.md
@@ -1,24 +1,23 @@
 # yum
 
->Package management utility for RHEL, Feodra, and CentOS (for older versions)
+> Package management utility for RHEL, Feodra, and CentOS (for older versions).
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent yum commands.
+- Synchronize list of packages and versions available. This should be run first, before running subsequent yum commands:
 
 `yum update`
 
-- Install a new package
+- Install a new package:
 
 `yum install {{package}}`
 
-- Install a new package and assume yes to all questions (also works with update, great for automated updates)
+- Install a new package and assume yes to all questions (also works with update, great for automated updates):
 
 `yum -y install {{package}}`
 
-- Remove a package
+- Remove a package:
 
 `yum remove {{package}}`
 
-- Upgrade installed packages to newest available versions
+- Upgrade installed packages to newest available versions:
 
 `yum upgrade`
-

--- a/pages/linux/zypper.md
+++ b/pages/linux/zypper.md
@@ -1,23 +1,23 @@
 # zypper
 
-> SUSE & openSUSE package management utility
+> SUSE & openSUSE package management utility.
 
-- Synchronize list of packages and versions available
+- Synchronize list of packages and versions available:
 
 `zypper refresh`
 
-- Install a new package
+- Install a new package:
 
 `zypper install {{package}}`
 
-- Remove a package
+- Remove a package:
 
 `zypper remove {{package}}`
 
-- Upgrade installed packages to newest available versions
+- Upgrade installed packages to newest available versions:
 
 `zypper update`
 
-- Search package via keyword
+- Search package via keyword:
 
 `zypper search {{keyword}}`

--- a/pages/osx/airport.md
+++ b/pages/osx/airport.md
@@ -1,15 +1,15 @@
 # Airport
 
-> Airport utility
+> Airport utility.
 
-- Create a symlink so you can easily run 'airport' without specifying a path.
+- Create a symlink so you can easily run 'airport' without specifying a path:
 
 `sudo ln -s /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport /usr/sbin/airport`
 
-- Scan for available wireless networks
+- Scan for available wireless networks:
 
 `airport -s`
 
-- Disassociate from current airport network
+- Disassociate from current airport network:
 
 `sudo airport -z`

--- a/pages/osx/brew.md
+++ b/pages/osx/brew.md
@@ -1,27 +1,27 @@
 # brew
 
-> Package manager for OS X
+> Package manager for OS X.
 
-- Search formula
+- Search formula:
 
 `brew search {{text}}`
 
-- Install formula
+- Install formula:
 
 `brew install {{formula}}`
 
-- List installed formulae [with matching name]
+- List installed formulae [with matching name]:
 
 `brew list {{[text]}}`
 
-- Get latest version of installed formula (passing no formula updates all installed formulae)
+- Get latest version of installed formula (passing no formula updates all installed formulae):
 
 `brew upgrade {{[formula]}}`
 
-- Update brew
+- Update brew:
 
 `brew update`
 
-- Switch version of formula
+- Switch version of formula:
 
 `brew switch {{formula}} {{version}}`

--- a/pages/osx/caffeinate.md
+++ b/pages/osx/caffeinate.md
@@ -1,11 +1,11 @@
 # caffeinate
 
-> Prevent a system from sleeping
+> Prevent a system from sleeping.
 
-- Prevent mac from sleeping for 1 hour (3600 seconds)
+- Prevent mac from sleeping for 1 hour (3600 seconds):
 
 `caffeinate -u -t 3600`
 
-- Prevent mac from sleeping until a command completes
+- Prevent mac from sleeping until a command completes:
 
 `caffeinate -s {{command}}`

--- a/pages/osx/dd.md
+++ b/pages/osx/dd.md
@@ -1,19 +1,19 @@
 # dd
 
-> convert and copy a file
+> Convert and copy a file.
 
-- Make a bootable usb drive from an isohybrid file (such like archlinux-xxx.iso)
+- Make a bootable usb drive from an isohybrid file (such like archlinux-xxx.iso):
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}}`
 
-- Clone a drive to another drive with 4MB block and ignore error
+- Clone a drive to another drive with 4MB block and ignore error:
 
 `dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs=4m conv=noerror`
 
-- Generating a file of 100 random bytes by using kernel random driver
+- Generating a file of 100 random bytes by using kernel random driver:
 
 `dd if=/dev/urandom of={{random_file}} bs=100 count=1`
 
-- Benchmark the write performance of a disk
+- Benchmark the write performance of a disk:
 
 `dd if=/dev/zero of={{file_1GB}} bs=1024 count=1000000`

--- a/pages/osx/diskutil.md
+++ b/pages/osx/diskutil.md
@@ -1,19 +1,19 @@
 # diskutil
 
-> Utility to manage local disks and volumes
+> Utility to manage local disks and volumes.
 
-- List all currently available disks, partitions and mounted volumes.
+- List all currently available disks, partitions and mounted volumes:
 
 `diskutil list`
 
-- Repair the file system data structures of a volume
+- Repair the file system data structures of a volume:
 
 `diskutil repairVolume {{/dev/diskX}}`
 
-- Unmount a volume
+- Unmount a volume:
 
 `diskutil unmountDisk {{/dev/diskX}}`
 
-- Eject a CD/DVD (unmount first)
+- Eject a CD/DVD (unmount first):
 
 `diskutil eject {{/dev/disk1}}`

--- a/pages/osx/ditto.md
+++ b/pages/osx/ditto.md
@@ -1,15 +1,15 @@
 # ditto
 
-> Copy files and folders
+> Copy files and folders.
 
-- Overwrites contents of destination folder with contents of source folder
+- Overwrites contents of destination folder with contents of source folder:
 
 `ditto {{path/to/source}} {{path/to/destination}}`
 
-- print a line to the Terminal window for every file that’s being copied
+- Print a line to the Terminal window for every file that’s being copied:
 
 `ditto -V {{path/to/source}} {{path/to/destination}}`
 
-- copy a given file or folder, while retaining the original file permissions.
+- Copy a given file or folder, while retaining the original file permissions:
 
 `ditto -rsrc {{path/to/source}} {{path/to/destination}}`

--- a/pages/osx/drutil.md
+++ b/pages/osx/drutil.md
@@ -1,11 +1,11 @@
 # drutil
 
-> Interact with DVD burners
+> Interact with DVD burners.
 
-- Eject a disk from the drive
+- Eject a disk from the drive:
 
 `drutil eject`
 
-- Burn a folder as an ISO9660 filesystem onto a DVD. Don't verify and eject when complete.
+- Burn a folder as an ISO9660 filesystem onto a DVD. Don't verify and eject when complete:
 
 `drutil burn -noverify -eject -iso9660`

--- a/pages/osx/du.md
+++ b/pages/osx/du.md
@@ -1,19 +1,19 @@
 # du
 
-> Estimate file space usage
+> Estimate file space usage.
 
-- get a sum of the total size of a file/folder in human readable units
+- Get a sum of the total size of a file/folder in human readable units:
 
 `du -sh {{file/directory}}`
 
-- list file sizes of a directory and any subdirectories in KB
+- List file sizes of a directory and any subdirectories in KB:
 
 `du -k {{file/directory}}`
 
-- get recursively, individual file/folder sizes in human readable form
+- Get recursively, individual file/folder sizes in human readable form:
 
 `du -ah {{directory}}`
 
-- list the KB sizes of directories for N levels below the specified directory
+- List the KB sizes of directories for N levels below the specified directory:
 
 `du -k -depth=1 {{directory}}`

--- a/pages/osx/head.md
+++ b/pages/osx/head.md
@@ -1,11 +1,11 @@
 # head
 
-> Output the first part of files
+> Output the first part of files.
 
-- Output the first few lines of a file
+- Output the first few lines of a file:
 
 `head -n {{count_of_lines}} {{filename}}`
 
-- Output the first few bytes of a file
+- Output the first few bytes of a file:
 
 `head -c {{number_in_bytes}} {{filename}}`

--- a/pages/osx/hostname.md
+++ b/pages/osx/hostname.md
@@ -1,11 +1,11 @@
 # hostname
 
-> Show or set the system's host name
+> Show or set the system's host name.
 
-- Show current host name
+- Show current host name:
 
 `hostname`
 
-- Set current host name
+- Set current host name:
 
 `hostname {{new_hostname}}`

--- a/pages/osx/locate.md
+++ b/pages/osx/locate.md
@@ -1,12 +1,11 @@
-
 # locate
 
-> find filenames quickly
+> Find filenames quickly.
 
-- Look for pattern in the database. Note: the database is recomputed periodically (usually weekly or daily).
+- Look for pattern in the database. Note: the database is recomputed periodically (usually weekly or daily):
 
 `locate {{pattern}}`
 
-- Recompute the database. You need to do it if you want to find recently added files.
+- Recompute the database. You need to do it if you want to find recently added files:
 
 `sudo /usr/libexec/locate.updatedb`

--- a/pages/osx/md5.md
+++ b/pages/osx/md5.md
@@ -1,20 +1,20 @@
 # md5
 
-> Calculate MD5 cryptographic checksums
+> Calculate MD5 cryptographic checksums.
 
-- Print MD5 checksum for a file
+- Print MD5 checksum for a file:
 
 `md5 {{filename}}`
 
-- Print MD5 checksum for each file in a list or directory
+- Print MD5 checksum for each file in a list or directory:
 
 `md5 {{filename1}} {{filename2}}`
 `md5 {{directory/\*}}`
 
-- Output only the md5 checksum (no filename)
+- Output only the md5 checksum (no filename):
 
 `md5 -q {{filename}}`
 
-- Print a checksum of the given string
+- Print a checksum of the given string:
 
 `md5 -s {{string}}`

--- a/pages/osx/mdfind.md
+++ b/pages/osx/mdfind.md
@@ -1,15 +1,15 @@
 # mdfind
 
-> List files matching a given query
+> List files matching a given query.
 
-- Find a file by its name
+- Find a file by its name:
 
 `mdfind -name {{file}}`
 
-- Find a file by its content
+- Find a file by its content:
 
 `mdfind {{query}}`
 
-- Find a file containing a string, in a given directory
+- Find a file containing a string, in a given directory:
 
 `mdfind -onlyin {{directory}} {{query}}`

--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -1,23 +1,23 @@
 # netstat
 
-> Displays various networks related information such as open connections, open socket ports etc
+> Displays various networks related information such as open connections, open socket ports etc.
 
-- List all ports
+- List all ports:
 
 `netstat -a`
 
-- List all listening ports
+- List all listening ports:
 
 `netstat -l`
 
-- List listening TCP ports
+- List listening TCP ports:
 
 `netstat -t`
 
-- Display PID and program names for a specific port
+- Display PID and program names for a specific port:
 
 `netstat -p {PROTOCOL}`
 
-- List information continuously
+- List information continuously:
 
 `netstat -c`

--- a/pages/osx/networksetup.md
+++ b/pages/osx/networksetup.md
@@ -1,19 +1,19 @@
 # networksetup
 
-> Configuration tool for Network System Preferences
+> Configuration tool for Network System Preferences.
 
-- List available network service providers (Ethernet, Wi-Fi, Bluetooth, etc)
+- List available network service providers (Ethernet, Wi-Fi, Bluetooth, etc):
 
 `networksetup -listallnetworkservices`
 
-- Show network settings for a particular networking device
+- Show network settings for a particular networking device:
 
 `networksetup -getinfo {{"Wi-Fi"}}`
 
-- Get currently connected Wi-Fi network name (Wi-Fi device usually en0 or en1)
+- Get currently connected Wi-Fi network name (Wi-Fi device usually en0 or en1):
 
 `networksetup -getairportnetwork {{en0}}`
 
-- Connect to a particular Wi-Fi network
+- Connect to a particular Wi-Fi network:
 
 `networksetup -setairportnetwork {{en0}} {{"Airport Network SSID"}} {{password}}`

--- a/pages/osx/open.md
+++ b/pages/osx/open.md
@@ -1,23 +1,23 @@
 # open
 
-> Opens files, directories and applications
+> Opens files, directories and applications.
 
-- Open a file with the associated application
+- Open a file with the associated application:
 
 `open {{file.ext}}`
 
-- Run a graphical MacOSX application
+- Run a graphical MacOSX application:
 
 `open /Applications/{{Application.app}}`
 
-- Open the current directory in Finder
+- Open the current directory in Finder:
 
 `open .`
 
-- Reveal a file in finder
+- Reveal a file in finder:
 
 `open -R /path/dir/{{file}}`
 
-- Open all the files of a given extension in the current directory with the associated application
+- Open all the files of a given extension in the current directory with the associated application:
 
 `open {{*.ext}}`

--- a/pages/osx/pbcopy.md
+++ b/pages/osx/pbcopy.md
@@ -1,11 +1,11 @@
 # pbcopy
 
-> Place standard output in the clipboard
+> Place standard output in the clipboard.
 
-- Place the contents of a file in the clipboard.
+- Place the contents of a file in the clipboard:
 
 `pbcopy < {{file}}`
 
-- Place the results of a command in the clipboard
+- Place the results of a command in the clipboard:
 
 `find . -type t -name "*.png" | pbcopy`

--- a/pages/osx/pbpaste.md
+++ b/pages/osx/pbpaste.md
@@ -1,11 +1,11 @@
 # pbpaste
 
-> Send the contents of the clipboard to standard output
+> Send the contents of the clipboard to standard output.
 
-- Write the contents of the clipboard to a file.
+- Write the contents of the clipboard to a file:
 
 `pbpaste > {{file}}`
 
-- Use the contents of the clipboard as input to a command.
+- Use the contents of the clipboard as input to a command:
 
 `pbpaste | grep foo`

--- a/pages/osx/qlmanage.md
+++ b/pages/osx/qlmanage.md
@@ -1,11 +1,11 @@
 # qlmanage
 
-> QuickLook server tool
+> QuickLook server tool.
 
-- displays QuickLook for one or multiple files
+- Displays QuickLook for one or multiple files:
 
 `quicklook -p {{filename}} {{filename2}}`
 
-- Compute 300px wide PNG thumbnails of all JPEGs in the current directory and put them in a directory.
+- Compute 300px wide PNG thumbnails of all JPEGs in the current directory and put them in a directory:
 
 `quicklook *.jpg -t -s 300 {{/existing//thumbnail/directory}}`

--- a/pages/osx/route.md
+++ b/pages/osx/route.md
@@ -1,24 +1,24 @@
 # route
 
-> Manually manipulate the routing tables
+> Manually manipulate the routing tables.
 > Necessitates to be root.
 
-- add a route to a destination through a gateway
+- Add a route to a destination through a gateway:
 
 `sudo route add {{dest_ip_address}} {{gateway_address}}`
 
-- add a route to a /24 subnet through a gateway
+- Add a route to a /24 subnet through a gateway:
 
 `sudo route add {{subnet_ip_address}}/24 {{gateway_address}}`
 
-- run in test mode (does not do anything, just print)
+- Run in test mode (does not do anything, just print):
 
 `sudo route -t add {{dest_ip_address}}/24 {{gateway_address}}`
 
-- remove all routes
+- Remove all routes:
 
 `sudo route flush`
 
-- delete a specific route
+- Delete a specific route:
 
 `sudo route delete {{dest_ip_address}}/24`

--- a/pages/osx/say.md
+++ b/pages/osx/say.md
@@ -1,19 +1,19 @@
 # say
 
-> Uses text to speech to speak through the default sound device
+> Uses text to speech to speak through the default sound device.
 
-- Speak a phrase aloud
+- Speak a phrase aloud:
 
 `say "I like to ride my bike."`
 
-- Speak a file aloud
+- Speak a file aloud:
 
 `say -f {{filename}}`
 
-- Create an AAC compressed audio file with the spoken text
+- Create an AAC compressed audio file with the spoken text:
 
 `say -o {{filename.m4a}} "Everyone loves iTunes"`
 
-- List the available voices
+- List the available voices:
 
 `say -v '?'`

--- a/pages/osx/shutdown.md
+++ b/pages/osx/shutdown.md
@@ -1,19 +1,19 @@
 # shutdown
 
-> Shutdown and reboot the system
+> Shutdown and reboot the system.
 
-- Power off (halt) immediately
+- Power off (halt) immediately:
 
 `shutdown -h now`
 
-- Sleep immediately
+- Sleep immediately:
 
 `shutdown -s now`
 
-- Reboot immediately
+- Reboot immediately:
 
 `shutdown -r now`
 
-- Reboot in 5 minutes
+- Reboot in 5 minutes:
 
 `shutdown -r +{{5}}`

--- a/pages/osx/sw_vers.md
+++ b/pages/osx/sw_vers.md
@@ -1,11 +1,11 @@
 # sw_vers
 
-> Print Mac OSX Software versioning information
+> Print Mac OSX Software versioning information.
 
-- Print OSX Version
+- Print OSX Version:
 
 `sw_vers -productVersion`
 
-- Print OSX Build
+- Print OSX Build:
 
 `sw_vers -buildVersion`

--- a/pages/osx/sysctl.md
+++ b/pages/osx/sysctl.md
@@ -1,24 +1,24 @@
 # sysctl
 
-> Access kernel state information
+> Access kernel state information.
 
-- Show all available variables and their values
+- Show all available variables and their values:
 
 `sysctl -a`
 
-- Show Apple model identifier
+- Show Apple model identifier:
 
 `sysctl -n hw.model`
 
-- Show CPU model
+- Show CPU model:
 
 `sysctl -n machdep.cpu.brand_string`
 
-- Show available CPU features (MMX, SSE, SSE2, SSE3, AES, etc)
+- Show available CPU features (MMX, SSE, SSE2, SSE3, AES, etc):
 
 `sysctl -n machdep.cpu.feature`
 
-- Set a changeable kernel state variable
+- Set a changeable kernel state variable:
 
 `sysctl -w name=value`
 `sysctl -w kern.maxfiles=15000`

--- a/pages/osx/system_profiler.md
+++ b/pages/osx/system_profiler.md
@@ -1,15 +1,15 @@
 # system_profiler
 
-> Report system hardware and software configuration
+> Report system hardware and software configuration.
 
-- Display a full system profiler report which can be opened by System Profiler.app
+- Display a full system profiler report which can be opened by System Profiler.app:
 
 `system_profiler -xml > MyReport.spx`
 
-- Display a hardware overview (Model, CPU, Memory, Serial, etc)
+- Display a hardware overview (Model, CPU, Memory, Serial, etc):
 
 `system_profiler SPHardwareDataType`
 
-- Print the system serial number
+- Print the system serial number:
 
 `system_profiler SPHardwareDataType|grep "Serial Number (system)" |awk '{print $4}'`

--- a/pages/osx/systemsetup.md
+++ b/pages/osx/systemsetup.md
@@ -1,29 +1,24 @@
 # systemsetup
 
-> Configure System Preferences machine settings
+> Configure System Preferences machine settings.
 
-- Enable remote login (SSH)
+- Enable remote login (SSH):
 
 `systemsetup -setremotelogin on`
 
-- Specify TimeZone, NTP Server and enable network time
+- Specify TimeZone, NTP Server and enable network time:
 
 `systemsetup -settimezone {{US/Pacific}}`
-
 `systemsetup -setnetworktimeserver {{us.pool.ntp.org}}`
-
 `systemsetup -setusingnetworktime on`
 
-- Make the machine never sleep; restart on freeze & power failure
+- Make the machine never sleep; restart on freeze & power failure:
 
 `systemsetup -setsleep off`
-
 `systemsetup -setrestartpowerfailure on`
-
 `systemsetup -setrestartfreeze on`
 
-- List valid startup disks, specify a new startup disk
+- List valid startup disks, specify a new startup disk:
 
 `systemsetup -liststartupdisks`
-
 `systemsetup -setstartupdisk {{path}}`

--- a/pages/osx/top.md
+++ b/pages/osx/top.md
@@ -2,22 +2,22 @@
 
 > Display dynamic real-time information about running processes.
 
-- Start top, all options are available in the interface
+- Start top, all options are available in the interface:
 
 `top`
 
-- Start top sorting processes by internal memory size (default order - process ID)
+- Start top sorting processes by internal memory size (default order - process ID):
 
 `top -o mem`
 
-- Start top sorting processes first by CPU, then by running time
+- Start top sorting processes first by CPU, then by running time:
 
 `top -o cpu -O time`
 
-- Start top displaying only processes owned by given user
+- Start top displaying only processes owned by given user:
 
 `top -user {{user-name}}`
 
-- Get help about interactive commands
+- Get help about interactive commands:
 
 `?`

--- a/pages/osx/wacaw.md
+++ b/pages/osx/wacaw.md
@@ -1,23 +1,23 @@
 # wacaw
 
-> a little command-line tool for Mac OS X that allows you to capture both still pictures and video from an attached camera.
+> A little command-line tool for Mac OS X that allows you to capture both still pictures and video from an attached camera.
 
-- Take a picture from webcam
+- Take a picture from webcam:
 
 `wacaw {{filename}}`
 
-- Record a video
+- Record a video:
 
 `wacaw --video {{filename}} -D {{duration_in_seconds}}`
 
-- Take a picture with custom resolution
+- Take a picture with custom resolution:
 
 `wacaw -x {{width}} -y {{height}} {{filename}}`
 
-- Copy image just taken to clipboard
+- Copy image just taken to clipboard:
 
 `wacaw --to-clipboard`
 
-- List the devices available
+- List the devices available:
 
 `wacaw -L`

--- a/pages/osx/xctool.md
+++ b/pages/osx/xctool.md
@@ -1,15 +1,15 @@
 # XCTool
 
-> Tool for building Xcode projects
+> Tool for building Xcode projects.
 
-- Build a single project without any workspace
+- Build a single project without any workspace:
 
 `xctool.sh -project {{YourProject.xcodeproj}} -scheme {{YourScheme}} build`
 
-- Build a project that is part of a workspace
+- Build a project that is part of a workspace:
 
 `xctool -workspace {{YourWorkspace.xcworkspace}} -scheme {{YourScheme}} build`
 
-- Clean, build and execute all the tests
+- Clean, build and execute all the tests:
 
 `xctool -workspace {{YourWorkspace.xcworkspace}} -scheme {{YourScheme}} clean build test`

--- a/pages/osx/xed.md
+++ b/pages/osx/xed.md
@@ -1,16 +1,16 @@
 # xed
 
-> Opens files for editing in XCode
+> Opens files for editing in XCode.
 
-- Open file(s) in XCode
+- Open file(s) in XCode:
 
 `xed {{file1}}`
 `xed {{/path/to/file1}} {{/path/to/file2}}`
 
-- Open file(s) in XCode, create if it doesn't exist
+- Open file(s) in XCode, create if it doesn't exist:
 
 `xed -c {{filename1}}`
 
-- Open a file in XCode and jump to line number 75
+- Open a file in XCode and jump to line number 75:
 
 `xed -l 75 {{filename}}`

--- a/pages/osx/xsltproc.md
+++ b/pages/osx/xsltproc.md
@@ -1,11 +1,11 @@
 # xsltproc
 
-> Transform XML with XSLT to produce output (usually HTML or XML)
+> Transform XML with XSLT to produce output (usually HTML or XML).
 
-- Transform an XML file with a specific XSLT stylesheet
+- Transform an XML file with a specific XSLT stylesheet:
 
 `xsltproc --output {{output.html}} {{stylesheet.xslt}} {{xmlfile.xml}}`
 
-- Pass a value to a parameter in the stylesheet
+- Pass a value to a parameter in the stylesheet:
 
 `xsltproc --output {{output.html}} --stringparam {{name}} {{value}} {{stylesheet.xslt}} {{xmlfile.xml}}`

--- a/pages/sunos/prctl.md
+++ b/pages/sunos/prctl.md
@@ -1,16 +1,16 @@
 # prctl
 
-> Get or set the resource controls of running processes,
-> tasks, and projects
+> Get or set the resource controls of running processes,.
+> Tasks, and projects.
 
-- examine process limits and permissions
+- Examine process limits and permissions:
 
 `prctl {{PID}}`
 
-- examine process limits and permissions in machine parseable format
+- Examine process limits and permissions in machine parseable format:
 
 `prctl -P {{PID}}`
 
-- Get specific limit for a running process
+- Get specific limit for a running process:
 
 `prctl -n process.max-file-descriptor {{PID}}`

--- a/pages/sunos/prstat.md
+++ b/pages/sunos/prstat.md
@@ -1,23 +1,23 @@
 # prstat
 
-> Report active process statistics
+> Report active process statistics.
 
-- examine all processes and reports statistics sorted by CPU usage
+- Examine all processes and reports statistics sorted by CPU usage:
 
 `prstat`
 
-- examine all processes and reports statistics sorted by memory usage
+- Examine all processes and reports statistics sorted by memory usage:
 
 `prstat -s rss`
 
-- report total usage summary for each user
+- Report total usage summary for each user:
 
 `prstat -t`
 
-- report microstate process accounting information
+- Report microstate process accounting information:
 
 `prstat -m`
 
-- Print out a list of top 5 cpu using processes every second.
+- Print out a list of top 5 cpu using processes every second:
 
 `prstat -c -n 5 -s cpu 1`

--- a/pages/sunos/svcadm.md
+++ b/pages/sunos/svcadm.md
@@ -1,23 +1,23 @@
 # svcadm
 
-> Manipulate service instances
+> Manipulate service instances.
 
-- enable a service in the service database
+- Enable a service in the service database:
 
 `svcadm enable {{service_name}}`
 
-- disable service
+- Disable service:
 
 `svcadm disable {{service_name}}`
 
-- restart a running service
+- Restart a running service:
 
 `svcadm restart {{service_name}}`
 
-- command service to re-read configuration files
+- Command service to re-read configuration files:
 
 `svcadm refresh {{service_name}}`
 
-- clear a service from maintenance state and command it to start
+- Clear a service from maintenance state and command it to start:
 
 `svcadm clear {{service_name}}`

--- a/pages/sunos/svccfg.md
+++ b/pages/sunos/svccfg.md
@@ -1,15 +1,15 @@
 # svccfg
 
-> Import, export, and modify service configurations
+> Import, export, and modify service configurations.
 
-- validate configuration file
+- Validate configuration file:
 
 `svccfg validate {{smf.xml}}`
 
-- export service configurations to file
+- Export service configurations to file:
 
 `svccfg export {{servicename}} > {{smf.xml}}`
 
-- import/update service configurations from file.
+- Import/update service configurations from file:
 
 `svccfg import {{smf.xml}}`

--- a/pages/sunos/svcs.md
+++ b/pages/sunos/svcs.md
@@ -1,23 +1,23 @@
 # svcs
 
-> List information about running services
+> List information about running services.
 
-- list all running services
+- List all running services:
 
 `svcs`
 
-- list services that are not running
+- List services that are not running:
 
 `svcs -vx`
 
-- list information about a service
+- List information about a service:
 
 `svcs apache`
 
-- show location of service log file
+- Show location of service log file:
 
 `svcs -L apache`
 
-- display end of a service log file
+- Display end of a service log file:
 
 `tail $(svcs -L apache)`


### PR DESCRIPTION
Alright, don't merge this in yet. I will after due discussion.

All pages are now formatted according to discussion in #622. It's not final, as not everyone has had their say yet.

It's important that once this gets merged in we update `CONTRIBUTING.md`, and be very vigilant when merging in new changes. At least until I get time to incorporate my linter. It's best to have it start with a clean slate though, so Travis can play with it after every PR.

Summary of changes: Whitespace, top descriptions are full sentences and example description are sentences ending in a colon. The last is still under debate.


Hurray [`tldr-lint`](https://github.com/rubenvereecken/tldr-lint) and its new brother, `tldr-format`. Soon available through `npm`.