### PR TITLE
Adds not-found page

### DIFF
--- a/pages/not-found.md
+++ b/pages/not-found.md
@@ -1,0 +1,11 @@
+
+# Oops! :(
+
+## Command Not Found
+
+It seems the command you were looking for is not available yet.
+
+Contributing is simple! All done from within Github. Please take a look at our [Contributing Guidelines](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md); then [Add this page](https://github.com/tldr-pages/tldr/new/master/pages).
+
+Questions? [Chat with us on gitter](https://gitter.im/tldr-pages/tldr)!
+


### PR DESCRIPTION
In order to provide a single, consistent not-found message across all clients, we could leverage a not-found page.

There's mainly two things to discuss here:

- [ ] the content of such page
- [ ] the location 

If it was part of the index it'd be very easy to implement since the fallback command would be the not found one. Semantically would be a bit wrong perhaps? But it should fit right in with the current pipeline that packages the rest of the pages.