### PR TITLE
git-tag: Clarified how to create annotation

### DIFF
--- a/pages/common/git-tag.md
+++ b/pages/common/git-tag.md
@@ -11,7 +11,7 @@
 
 `git tag {{tag_name}}`
 
-- Create a tag with the given message:
+- Create an annotated tag with the given message:
 
 `git tag {{tag_name}} -m {{tag_message}}`
 


### PR DESCRIPTION
I think I somehow managed to create this in this repository instead of in my own.

Anyway, I was looking up how to create an annotated tag since only those will be pushed to GitHub. Couldn't find it in the tldr page. Except it was really just hidden.