### PR TITLE
pkill: Add example with -f flag

### DIFF
--- a/pages/common/pkill.md
+++ b/pages/common/pkill.md
@@ -7,6 +7,10 @@
 
 `pkill -9 {{process_name}}`
 
+- Kill all processes which match their full command instead of just the process name:
+
+`pkill -9 -f "{{command_name}}"`
+
 - Send SIGUSR1 signal to processes which match:
 
 `pkill -USR1 {{process_name}}`


### PR DESCRIPTION
Its useful to be able to kill processes by their full command. The pgrep tldr page already has a -f flag example.