### PR TITLE
Add usage for getting a time-slice

### DIFF
--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -18,6 +18,6 @@
 
 `ffmpeg -i {{in.avi}} -acodec libfaac -ab 128k -vcodec mpeg4 -b 1250K {{out.mp4}}`
 
-- Extract part of a video between given timestamps. `-t` for length instead of end time.  Omit to copy through end.
+- Extract part of a video between given timestamps. Replace `-to` with `-t` for length instead of end time.  Omit `-to` to copy through end.
 
 `ffmpeg -i {{in.mp4}} -ss {{1:30}} -to {{2:45}} -acodec copy {{out.mp4}}`

--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -20,4 +20,4 @@
 
 - Extract part of a video between given timestamps. `-t` for length instead of end time.  Omit to copy through end.
 
-`ffmpeg -i {{in.mp4}} -ss 1:30 -to 2:45 -acodec copy {{out.mp4}}`
+`ffmpeg -i {{in.mp4}} -ss {{1:30}} -to {{2:45}} -acodec copy {{out.mp4}}`

--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -17,3 +17,7 @@
 - Convert AVI video to MP4. AAC Audio @ 128kbit, Video @ 1250Kbit:
 
 `ffmpeg -i {{in.avi}} -acodec libfaac -ab 128k -vcodec mpeg4 -b 1250K {{out.mp4}}`
+
+- Extract part of a video between given timestamps. `-t` for length instead of end time.  Omit to copy through end.
+
+`ffmpeg -i {{in.mp4}} -ss 1:30 -to 2:45 -acodec copy {{out.mp4}}`


### PR DESCRIPTION
Not sure how best to elaborate on -t.  There's also -sseof to start offset from the end of the file, but that seems beyond scope, and -ss should be enough to find that in the man page.