### PR TITLE
Added contributing guidelines on tldr-lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Detailed explanation:
    You can use the formatting features of [tldr-lint](https://github.com/tldr-pages/tldr-lint)
    (installed through `make setup` or alternatively `npm install tldr-lint`)
    to automatically fix any mistakes you may have missed.
-   Try `tldr tldr-lint` for a quick how-to.
+   Try `tldr tldrl` for a quick how-to.
 
 6. Please use the following commit message format: 
    `<command>: type of change`.


### PR DESCRIPTION
A few lines on how to use `tldr-lint`, since the automatic formatting could save us a lot of trouble. Basically the best feature it has emerges through `tldrl pages -fi`, short for `tldrl pages --format --in-place`. It can fix pretty much everything except for wording issues and general weirdness. 

Basically I want Travis to be our last line of defense, everything else fixed by contributors before changes get sent in. Maybe I could refactor the linter a bit to make a distinction between normal and fatal (unfixable) errors, then always attempt a format in place in the git hook which errors out when you've messed up too badly and just silently fixes your stuff when you didn't. It's a bit ambitious but we're almost there anyway.

Also tried to think of a good way to mention somewhere "Please check your Travis input when there's a lot of red on your GitHub screen" but didn't figure out how. 