### PR TITLE
tldrl: add page

### DIFF
--- a/pages/common/tldrl.md
+++ b/pages/common/tldrl.md
@@ -1,0 +1,15 @@
+# tldrl
+
+> Lint and format TLDR pages.
+
+- Lint all pages:
+
+`tldrl {{pages_directory}}`
+
+- Format a specific page to stdout:
+
+`tldrl -f {{page.md}}`
+
+- Format all pages in place:
+
+`tldrl -fi {{pages_directory}}`


### PR DESCRIPTION
Contributing guidelines in #694 refer to this page, but currently do so using `tldr tldr-lint`. I'm trying to get `tldrl` to become the pedantic way of referring to it.

Let's get this tool used and save us some work like it's supposed to be. It's rather sad Travis is the only audience.