### PR TITLE
OpenSSL condensing.

### DIFF
--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -10,9 +10,9 @@
 
 `openssl req -new -sha256 -key {{filename.key}} -out {{filename.csr}}`
 
-- Read contents of a signed certificate:
+- Generate a self-signed certificate from a certificate signing request valid for some number of days:
 
-`openssl x509 -text -noout -in {{certificate.crt}}`
+`openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
 
 - Display the certificate presented by an SSL/TLS server:
 

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -1,35 +1,23 @@
 # openssl
 
-> OpenSSL is a cryptography toolkit.
+> OpenSSL cryptographic toolkit.
 
-- Check an SSL connection:
+- Generate a 2048bit RSA private key and save it to a file:
 
-`openssl s_client -connect {{domain}}:{{port}}`
+`openssl genrsa -out {{filename.key}} 2048`
 
-- Generate new private key and CSR:
+- Generate a certificate signing request to be sent to a certificate authority:
 
-`openssl req -out {{path/to/CSR.csr}} -new -newkey rsa:2048 -nodes -keyout {{path/to/pivate.key}}`
+`openssl req -new -sha256 -key {{filename.key}} -out {{filename.csr}}`
 
-- Read contents of a certificate:
+- Read contents of a signed certificate:
 
-`openssl x509 -text -noout -in {{path/to/certificate.crt}}`
+`openssl x509 -text -noout -in {{certificate.crt}}`
 
-- Read contents of a private key:
+- Display the certificate presented by an SSL/TLS server:
 
-`openssl rsa -check -in {{path/to/pivate.key}}`
+`openssl s_client -connect {{host}}:{{port}} </dev/null`
 
-- Verify a CSR file:
+- Display the complete certificate chain of an HTTPS server:
 
-`openssl req -text -noout -verify -in {{path/to/CSR.csr}}`
-
-- Check MD5 hash of a certificate:
-
-`openssl x509 -noout -modulus -in {{path/to/certificate.crt}} | openssl md5`
-
-- Check MD5 hash of a private key:
-
-`openssl rsa -noout -modulus -in {{path/to/pivate.key}} | openssl md5`
-
-- Check MD5 hash of a CSR file:
-
-`openssl req -noout -modulus -in {{path/to/CSR.csr}} | openssl md5`
+`openssl s_client -connect {{google.com}}:{{443}} -showcerts </dev/null`

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -20,4 +20,4 @@
 
 - Display the complete certificate chain of an HTTPS server:
 
-`openssl s_client -connect {{google.com}}:{{443}} -showcerts </dev/null`
+`openssl s_client -connect {{host}}:443 -showcerts </dev/null`


### PR DESCRIPTION
Shorten OpenSSL to 24 lines. Split keygen and csr to distinct examples. Standardize pathing. Remove commands which are just md5 verifying csr/key/csr.

The </dev/null are there because otherwise openssl waits for more input (batch mode) like a jerk until you send it an EOF.

Also switch to signing the CSR with SHA256 because SHA1 cert signing is deprecated for most browsers.