### PR TITLE
Added download tools

### DIFF
--- a/pages/common/lwp-request.md
+++ b/pages/common/lwp-request.md
@@ -1,6 +1,7 @@
 # lwp-request
 
-> Simple Perl-based command-line HTTP client.
+> Simple command-line HTTP client.
+> Built with libwww-perl.
 
 - Make a simple GET request:
 

--- a/pages/common/lwp-request.md
+++ b/pages/common/lwp-request.md
@@ -1,0 +1,27 @@
+# lwp-request
+
+> Simple Perl-based command-line HTTP client.
+
+- Make a simple GET request:
+
+`lwp-request -m GET {{http://example.com/some/path}}`
+
+- Upload a file with a POST request:
+
+`cat {{/path/to/file}} | lwp-request -m POST {{http://example.com/some/path}}`
+
+- Make a request with a custom user agent:
+
+`lwp-request -H 'User-Agent: {{user_agent}} -m {{METHOD}} {{http://example.com/some/path}}`
+
+- Make a request with HTTP authentication:
+
+`lwp-request -C {{username}}:{{password}} -m {{METHOD}} {{http://example.com/some/path}}`
+
+- Make a request and print request headers:
+
+`lwp-request -U -m {{METHOD}} {{http://example.com/some/path}}`
+
+- Make a request and print response headers and status chain:
+
+`lwp-request -E -m {{METHOD}} {{http://example.com/some/path}}`

--- a/pages/common/skicka.md
+++ b/pages/common/skicka.md
@@ -4,24 +4,24 @@
 
 - Upload a file/folder to Google Drive:
 
-`skicka upload {{/path/to/local}} {{/path/to/remote}}`
+`skicka upload {{path/to/local}} {{path/to/remote}}`
 
 - Download a file/folder from Google Drive:
 
-`skicka download {{/path/to/remote}} {{/path/to/local}}`
+`skicka download {{path/to/remote}} {{path/to/local}}`
 
 - List files:
 
-`skicka ls {{/path/to/folder}}`
+`skicka ls {{path/to/folder}}`
 
 - Show amount of space used by children folders:
 
-`skicka du {{/path/to/parent_folder}}`
+`skicka du {{path/to/parent/folder}}`
 
 - Create a folder:
 
-`skicka mkdir {{/path/to/folder}}`
+`skicka mkdir {{path/to/folder}}`
 
 - Delete a file:
 
-`skicka rm {{/path/to/file}}`
+`skicka rm {{path/to/file}}`

--- a/pages/common/skicka.md
+++ b/pages/common/skicka.md
@@ -1,6 +1,6 @@
 # skicka
 
-> Command-line utility for Google Drive.
+> Manage your Google Drive.
 
 - Upload a file/folder to Google Drive:
 

--- a/pages/common/skicka.md
+++ b/pages/common/skicka.md
@@ -1,0 +1,27 @@
+# skicka
+
+> Command-line utility for Google Drive.
+
+- Upload a file/folder to Google Drive:
+
+`skicka upload {{/path/to/local}} {{/path/to/remote}}`
+
+- Download a file/folder from Google Drive:
+
+`skicka download {{/path/to/remote}} {{/path/to/local}}`
+
+- List files:
+
+`skicka ls {{/path/to/folder}}`
+
+- Show amount of space used by children folders:
+
+`skicka du {{/path/to/parent_folder}}`
+
+- Create a folder:
+
+`skicka mkdir {{/path/to/folder}}`
+
+- Delete a file:
+
+`skicka rm {{/path/to/file}}`

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -6,7 +6,7 @@
 
 `youtube-dl {{https://www.youtube.com/watch?v=oHg5SJYRHA0}}`
 
-- Download the audio from a video as an MP3:
+- Download the audio from a video and convert it to an MP3:
 
 `youtube-dl -x --audio-format {{mp3}} {{url}}`
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -1,0 +1,23 @@
+# youtube-dl
+
+> Download videos from YouTube and other websites.
+
+- Download a video or playlist:
+
+`youtube-dl {{https://www.youtube.com/watch?v=oHg5SJYRHA0}}`
+
+- Download the audio from a video as an MP3:
+
+`youtube-dl -x --audio-format {{mp3}} {{url}}`
+
+- Download video(s) as MP4 files with custom filenames:
+
+`youtube-dl --format {{mp4}} --output {{"%(title) by %(uploader) on %(upload_date) in %(playlist).%(ext)"}} {{url}}`
+
+- Download a video and save its description, metadata, annotations, subtitles, and thumbnail:
+
+`youtube-dl --write-description --write-info-json --write-annotations --write-sub --write-thumbnail {{url}}`
+
+- From a playlist, download all "Let's Play" videos that aren't marked "NSFW" or age-restricted for 7 year-olds:
+
+`youtube-dl --match-title {{"let's play"}} --age-limit {{7}} --reject-title {{"nsfw"}} {{playlist_url}}`


### PR DESCRIPTION
Added three tools for downloading remote files:

* [skicka](https://github.com/google/skicka), a CLI tool for working with Google Drive
* [youtube-dl](https://rg3.github.io/youtube-dl/), a very complex/versatile tool for downloading videos and playlists from YouTube and other sites
* [lwp-request](http://search.cpan.org/dist/libwww-perl/bin/lwp-request), a simple HTTP client (this ships with OS X, but you can actually install it on any platform, so I put it in _common_)

lwp-request also typically is installed with aliases GET, POST, and HEAD, which are the equivalent to doing `lwp-request -m METHOD`. I wasn't sure how I might mention these, so at present, my lwp-request.md file doesn't mention these. But they are quite handy and common, so maybe they should be worked in somehow.