### PR TITLE
Added more notes on tldr-lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,14 @@ The format of each page should match the following:
 `command -opt1 -opt2`
 ```
 
+We actually have a linter/formatter that enforces our format.
+It even automatically cleans up your pages for you! Installing it is easy:
+
+```
+npm install
+tldr tldrl
+```
+
 ### Token Syntax
 User-provided values should use the `{{token}}` syntax in order to allow clients
 to highlight them. 


### PR DESCRIPTION
Added a note on our linter/formatter right after mentioning our syntax. It's also somewhere in the step-by-step instructions but it looks like people hardly read those. This way it's near the bits that people _probably_ read if they read the page at all. No guarantees.