### PR TITLE
Add watch

### DIFF
--- a/pages/common/watch.md
+++ b/pages/common/watch.md
@@ -1,0 +1,15 @@
+# watch
+
+> Execute a program periodically, showing output fullscreen.
+
+- Repeatedly run a command and show the result:
+
+`watch {{command}}`
+
+- Re-run a command every 60 seconds:
+
+`watch -n {{60}} {{command}}`
+
+- Monitor the contents of a directory, highlighting changes as they appear:
+
+`watch -d {{ls -l}}`

--- a/pages/common/watch.md
+++ b/pages/common/watch.md
@@ -10,6 +10,6 @@
 
 `watch -n {{60}} {{command}}`
 
-- Monitor the contents of a directory, highlighting changes as they appear:
+- Monitor the contents of a directory, highlighting differences as they appear:
 
 `watch -d {{ls -l}}`


### PR DESCRIPTION
[watch](http://linux.die.net/man/1/watch) is a simple tool for monitoring stuff by repeatedly running a command and showing the output. Just three simple examples to cover the most useful stuff.