### PR TITLE
Add license

### DIFF
--- a/pages/common/license.md
+++ b/pages/common/license.md
@@ -16,4 +16,4 @@
 
 - Create a license with explicitly-set name and year:
 
-`license --name {{custom_name}} --year {{custom_year}} {{license_name}}`
+`license --name {{author}} --year {{release_year}} {{license_name}}`

--- a/pages/common/license.md
+++ b/pages/common/license.md
@@ -1,0 +1,19 @@
+# license
+
+> Create license files for open-source projects.
+
+- Create a license:
+
+`license {{license_name}}`
+
+- Create a license with custom filename:
+
+`license -o {{filename.txt}} {{license_name}}`
+
+- List all locally available licenses:
+
+`license ls`
+
+- Create a license with explicitly-set name and year:
+
+`license --name {{custom_name}} --year {{custom_year}} {{license_name}}`


### PR DESCRIPTION
[license](https://github.com/nishanths/license) is a tool for quickly/easily adding a license file to an open source project.

In the last example, you might wonder why I say "explicitly-set name and year". By default, license pulls your name from your git/mercurial config files (or the environment variable `LICENSE_FULL_NAME`), and just uses the current year. Thus, you only need to use those command flags if you specifically don't want your git/mercurial name or the current year. I can't really think of a succinct way to explain that in the tldr page, unfortunately.