### PR TITLE
Add archey

### DIFF
--- a/pages/linux/archey.md
+++ b/pages/linux/archey.md
@@ -1,0 +1,7 @@
+# archey
+
+> Simple tool for stylishly displaying system information.
+
+- Show system information:
+
+`archey`

--- a/pages/osx/archey.md
+++ b/pages/osx/archey.md
@@ -1,0 +1,19 @@
+# archey
+
+> Simple tool for stylishly displaying system information.
+
+- Show system information in stylish output:
+
+`archey`
+
+- Show system information without colored output:
+
+`archey --nocolor`
+
+- Show system information, using MacPorts instead of Homebrew:
+
+`archey --macports`
+
+- Show system information without IP address check:
+
+`archey --offline`

--- a/pages/osx/archey.md
+++ b/pages/osx/archey.md
@@ -2,7 +2,7 @@
 
 > Simple tool for stylishly displaying system information.
 
-- Show system information in stylish output:
+- Show system information:
 
 `archey`
 


### PR DESCRIPTION
Archey is a tool that displays some basic system information alongside an ASCII version of your OS's logo. The tool exists on both OS X and Linux, but they're separate codebases that work slightly differently, so they get separate pages.

The OS X version has a couple of flags for tweaking the output, while the Linux version has absolutely no options (and I would have never bothered adding it if I wasn't also simultaneously adding the OS X one). I used the long forms of the flags for the OS X page, even though every flag does have a shortcut, simply because I don't think anyone uses archey frequently enough to memorize the flags.