### PR TITLE
ssh reverse tunneling added

### DIFF
--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -30,3 +30,7 @@
 - SSH enable agent forward:
 
 `ssh -A {{username}}@{{remote_host}}`
+
+- SSH reverse tunneling: Open a listening port on the remote server to forward it back to localhost (remote-server.com:22 to your-personal-machine:2222)
+
+`ssh -R {{2222}}:localhost:22 {{username}}@{{remote_host}}`


### PR DESCRIPTION
I've added an example to do a reverse tunneling through ssh. Reverse tunneling used to access a personal machine from a remote server. It common to use this feature to bypass corporate firewalls so the user can access its machine from remote server. This example will complete the tunneling options list:
* -L
* -D
* -R (the added item)

Thanks,