### PR TITLE
[lsof] Fixed typo after reformatted

### DIFF
--- a/pages/common/lsof.md
+++ b/pages/common/lsof.md
@@ -11,14 +11,14 @@
 
 `lsof -i :{{port}}`
 
-- Only output the process PI:
+- Only output the process PID:
 
 `lsof -t {{/path/to/file}}`
 
-- List files opened by the given use:
+- List files opened by the given user:
 
 `lsof -u {{username}}`
 
-- List files opened by the given command or proces:
+- List files opened by the given command or process:
 
 `lsof -c {{process_or_command_name}}`


### PR DESCRIPTION
The last letter of last word of [the three lines](https://github.com/tldr-pages/tldr/commit/9676334119847078e5e05fec393a3fe36991dbc2#diff-fe9ad5b63478a92eaf51544c5808ee6cL14) was omitted after reformatted.