### PR TITLE
Client certificate in cURL example

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -30,3 +30,7 @@
 - Pass a user name and password for server authentication:
 
 `curl -u myusername:mypassword {{http://localhost}}`
+
+- Pass client certificate and key for a secure resource:
+
+`curl -v –key {{key.pem}} –cacert {{ca.pem}} –cert {{client.pem}} -k {{https://localhost}}`


### PR DESCRIPTION
Passing client certificates to access protected resources is something I find myself commonly doing in cURL and is something difficult to decipher solely from the `man` pages.