### PR TITLE
airport: added sniff and status info commands

### DIFF
--- a/pages/osx/airport.md
+++ b/pages/osx/airport.md
@@ -6,6 +6,14 @@
 
 `sudo ln -s /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport /usr/sbin/airport`
 
+- Show current wireless status information:
+
+`airport -I`
+
+- Sniff wireless traffic on channel 1:
+
+`airport sniff {{1}}`
+
 - Scan for available wireless networks:
 
 `airport -s`

--- a/pages/osx/airport.md
+++ b/pages/osx/airport.md
@@ -2,10 +2,6 @@
 
 > Wireless network configuration utility.
 
-- Create a symlink so you can easily run 'airport' without specifying a path:
-
-`sudo ln -s /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport /usr/sbin/airport`
-
 - Show current wireless status information:
 
 `airport -I`

--- a/pages/osx/airport.md
+++ b/pages/osx/airport.md
@@ -1,6 +1,6 @@
-# Airport
+# airport
 
-> Airport utility.
+> Wireless network configuration utility.
 
 - Create a symlink so you can easily run 'airport' without specifying a path:
 


### PR DESCRIPTION
Just noticed the two commands I find most useful in `airport` are both excluded from `airport`'s tldr page! Here's a quick revision adding these commands.