### PR TITLE
dhcpwn: add page

### DIFF
--- a/pages/common/dhcpwn.md
+++ b/pages/common/dhcpwn.md
@@ -1,0 +1,11 @@
+# dhcpwn
+
+> Test DHCP IP exhaustion attacks and sniff local DHCP traffic.
+
+- Flood the network with IP requests:
+
+`dhcpwn --interface {{network_interface}} flood --count {{number_of_requests}}`
+
+- Sniff local DHCP traffic:
+
+`dhcpwn --interface {{network_interface}} sniff`


### PR DESCRIPTION
[DHCPwn](https://github.com/mschwager/dhcpwn) is a pentesting tool for attempting IP exhaustion attacks and for sniffing DHCP traffic.

I'm a bit worried that the meaning of `{{network_interface}}` might not be clear enough to some people. You're meant to use the standard interface names that are used system-wide, e.g. eth0, wlan0, lp, etc. I thought about including a command to get the list of network interfaces, but that differs between OSes and so forth. I thought about using a common placeholder interface name, but that too would be OS-specific (example: on Linux, your wifi card is probably `wlan0`, but on OS X it's probably `en0`). Maybe it's just clear enough as is? Chances are, if you're savvy enough to even know/understand what DHCPwn does, then you probably already know how your machine identifies network interfaces.