### PR TITLE
mitmdump: add page

### DIFF
--- a/pages/common/mitmdump.md
+++ b/pages/common/mitmdump.md
@@ -1,0 +1,16 @@
+# mitmdump
+
+> View, record, and programmatically transform HTTP traffic.
+> The command-line counterpart to mitmproxy.
+
+- Start a proxy and save all output to a file:
+
+`mitmdump -w {{filename}}`
+
+- Filter a saved traffic file to just POST requests:
+
+`mitmdump -nr {{input_filename}} -w {{output_filename}} {{"~m post"}}`
+
+- Replay a saved traffic file:
+
+`mitmdump -nc {{filename}}`


### PR DESCRIPTION
[mitmdump](http://docs.mitmproxy.org/en/stable/mitmdump.html) is a tool for monitoring, recording, and transforming HTTP traffic on your local machine.