### PR TITLE
say: lots of cleanup

### DIFF
--- a/pages/osx/say.md
+++ b/pages/osx/say.md
@@ -1,19 +1,23 @@
 # say
 
-> Uses text-to-speech to speak through the default sound device.
+> Converts text to speech.
 
 - Speak a phrase aloud:
 
-`say "I like to ride my bike."`
+`say {{"I like to ride my bike."}}`
 
 - Speak a file aloud:
 
 `say -f {{filename}}`
 
-- Create an AAC compressed audio file with the spoken text:
+- Speak a phrase with a custom voice and speech rate:
 
-`say -o {{filename.m4a}} "Everyone loves iTunes"`
+`say -v {{voice}} -r {{words_per_minute}} {{"I'm sorry Dave, I can't let you do that."}}`
 
 - List the available voices:
 
-`say -v '?'`
+`say -v ?`
+
+- Create an audio file of the spoken text:
+
+`say -o {{filename.aiff}} {{"Everyone loves iTunes."}}`

--- a/pages/osx/say.md
+++ b/pages/osx/say.md
@@ -8,7 +8,7 @@
 
 - Speak a file aloud:
 
-`say -f {{filename}}`
+`say -f {{filename.txt}}`
 
 - Speak a phrase with a custom voice and speech rate:
 


### PR DESCRIPTION
The tldr page for `say` seemed like it needed some revision. I corrected the audio file command (it creates an AIFF file, not an M4A file). I added an example of how to use a custom voice and speech rate (it told you how to list the voices, but it didn't tell you how to actually use them!). Then there are just a couple of other formatting things and clarifications I made.