### PR TITLE
npm: removed some examples and added others

### DIFF
--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -1,10 +1,7 @@
 # npm
 
-> Node package manager, to manage Node.js projects and install module dependencies.
-
-- Create a new project in the current folder:
-
-`npm init`
+> JavaScript and Node.js package manager.
+> Manage Node.js projects and their module dependencies.
 
 - Download all dependencies referenced in package.json:
 
@@ -18,14 +15,14 @@
 
 `npm install {{module_name}}@{{version}} --save`
 
-- Set the version of the current project:
+- Uninstall a module:
 
-`npm version {{1.2.3}}`
+`npm uninstall {{module_name}}`
 
-- Publish the current project:
+- List a tree of installed modules:
 
-`npm publish`
+`npm list`
 
-- Cleanup packages (removes packages which are installed but are not listed in `package.json`):
+- Interactively create a package.json file:
 
-`npm prune`
+`npm init`

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -3,13 +3,13 @@
 > JavaScript and Node.js package manager.
 > Manage Node.js projects and their module dependencies.
 
-- Download all dependencies referenced in package.json:
-
-`npm install`
-
 - Download and install a module globally:
 
 `npm install -g {{module_name}}`
+
+- Download all dependencies referenced in package.json:
+
+`npm install`
 
 - Download a given dependency, and add it to the package.json:
 


### PR DESCRIPTION
- 2 lines description, mentioned that it is not only Node.js package manager, but also JavaScript package manager (see official docs)
- Moved `npm init` to the bottom, it is the rarest command in the list. Change its description to more obvious one.
- Removed `npm prune`, this command is for hackers, not for regular users
- Removed `npm version`, it is useless
- Removed `npm publish`. It is for those who have npm modules published. Well in fact, even them do not do it every day.
- Added `npm uninstall` example
- Added `npm list` example