### PR TITLE
awk: add /search/ example

### DIFF
--- a/pages/common/awk.md
+++ b/pages/common/awk.md
@@ -6,6 +6,10 @@
 
 `awk '{print $5}' {{filename}}`
 
+- Print the second column of the lines containing "something" in a space separated file:
+
+`awk '/{{something}}/ {print $2}' {{filename}}`
+
 - Print the third column in a comma separated file:
 
 `awk -F ',' '{print $3}' {{filename}}`


### PR DESCRIPTION
Searching for values in lines is a common operation with awk. I didn't specify that "something" is a regexp because it's not really useful at first.