### PR TITLE
fzf: add page

### DIFF
--- a/pages/common/fzf.md
+++ b/pages/common/fzf.md
@@ -1,0 +1,27 @@
+# fzf
+
+> Command line fuzzy finder.
+
+- Start finder on all files from arbitrary locations:
+
+`find {{path/to/search}} -type f | fzf`
+
+- Start finder on running processes:
+
+`ps axu | fzf`
+
+- Select mutliple files with `Shift-TAB` and write to a file:
+
+`find {{path/to/search_files}} -type f | fzf -m > {{filename}}`
+
+- Start finder with a given query:
+
+`fzf -q "{{query}}"`
+
+- Start finder on entries that start with core and end with either go, rb, or py:
+
+`fzf -q "^core go$ | rb$ | py$"`
+
+- Start finder on entries that not match pyc and match exactly travis:
+
+`fzf -q "!pyc 'travis"`


### PR DESCRIPTION
# ❯ fzf

An awesome command-line fuzzy finder, here is the [homepage of FZF](https://github.com/junegunn/fzf).

Can fuzzy find quite everything, the [wiki](https://github.com/junegunn/fzf/wiki/examples) is a great place to discover this. 
It's also a great alternative to `ctrl-p` or `command-t` for vim users.