### PR TITLE
Change 'ls' example for xargs page to 'find -name'

### DIFF
--- a/pages/common/xargs.md
+++ b/pages/common/xargs.md
@@ -12,4 +12,4 @@
 
 - Delete all files that start with 'M':
 
-`ls M* | xargs rm`
+`find -name 'M*' | xargs rm`

--- a/pages/common/xargs.md
+++ b/pages/common/xargs.md
@@ -12,4 +12,4 @@
 
 - Delete all files that start with 'M':
 
-`find -name 'M*' | xargs rm`
+`find . -name 'M*' | xargs rm`


### PR DESCRIPTION
The use of `ls` for piping is not recommended because of it's tendency to format into columns. It is more user friendly than machine friendly.

See http://stackoverflow.com/a/938052 