### PR TITLE
phpize: add page

### DIFF
--- a/pages/common/phpize.md
+++ b/pages/common/phpize.md
@@ -1,0 +1,11 @@
+# phpize
+
+> Prepare a PHP extension for compiling.
+
+* Prepare the PHP extension in the current directory for compiling:
+
+`phpize`
+
+* Delete files previously created by phpize:
+
+`phpize --clean`

--- a/pages/common/phpize.md
+++ b/pages/common/phpize.md
@@ -2,10 +2,10 @@
 
 > Prepare a PHP extension for compiling.
 
-* Prepare the PHP extension in the current directory for compiling:
+- Prepare the PHP extension in the current directory for compiling:
 
 `phpize`
 
-* Delete files previously created by phpize:
+- Delete files previously created by phpize:
 
 `phpize --clean`


### PR DESCRIPTION
phpize is a little script you have to run in the process of compiling a PHP extension from source. Not a very frequently used or complex tool, but hey, it was one I knew how to use that wasn't already in the tldr pages.