### PR TITLE
rsync: add example with exclude file

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -27,3 +27,8 @@
 - Transfer file over SSH and show progress:
 
 `rsync -e ssh --progress {{remote_host_name}}:{{remote_file}} {{local_file}}`
+
+- Transfer a directory and all its children from a remote to local and respect all excludes defined in a file:
+
+`rsync -r --exclude-from=/path/to/exclude.list {remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
+

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -31,4 +31,3 @@
 - Transfer a directory and all its children from a remote to local and respect all excludes defined in a file:
 
 `rsync -r --exclude-from=/path/to/exclude.list {remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
-


### PR DESCRIPTION
Add an example where `excludes` are defined in a `exclude list`.