### PR TITLE
crontab: add page

### DIFF
--- a/pages/common/crontab.md
+++ b/pages/common/crontab.md
@@ -1,0 +1,15 @@
+# crontab
+
+> Schedule cron jobs to run on a time interval for the current user.
+
+- Edit the crontab file for the current user:
+
+`crontab -e`
+
+- View a list of existing cron jobs for current user:
+
+`crontab -l`
+
+- Remove all cron jobs for the current user:
+
+`crontab -r`


### PR DESCRIPTION
Add a page to `common` for `crontab` command.

I found the most useful use cases were to:
* __edit__ crontab
* __list__ cron jobs
* __remove__ cron jobs

Tested on Ubuntu and OSX.