### PR TITLE
gdb: add page

### DIFF
--- a/pages/common/gdb.md
+++ b/pages/common/gdb.md
@@ -1,0 +1,19 @@
+# gdb
+
+> The GNU Debugger.
+
+- Debug an executable:
+
+`gdb {{executable}}`
+
+- Attach a process to gdb:
+
+`gdb -p {{procID}}`
+
+- Execute given GDB commands upon start:
+
+`gdb -ex "{{commands}}" {{executable}}`
+
+- Start gdb and pass arguments:
+
+`gdb --args {{executable}} {{argument1}} {{argument2}}`


### PR DESCRIPTION
Add a page to `common` for `gdb`, the GNU Debugger.

Four examples were added:
* debug an executable,
* attach a process to `gdb`,
* execute given GDB commands upon start,
* start `gdb` and pass arguments.
