### PR TITLE
Add `apm` info to `atom.md`

### DIFF
--- a/pages/common/atom.md
+++ b/pages/common/atom.md
@@ -9,3 +9,15 @@
 - Open a file or folder in a new window:
 
 `atom -n {{path/to/file/or/folder}}`
+
+- Install packages from http://atom.io/packages and themes from http://atom.io/themes
+
+`apm install {{package_name}}`
+
+- Remove packages/themes
+
+`apm remove {{package_name}}`
+
+- Upgrade packages/themes
+
+`apm upgrade {{package_name}}`


### PR DESCRIPTION
Add basic commands for `apm` (the package manager for Atom) to `atom.md`.