### PR TITLE
Add chgrp (and tweak chown to match)

### DIFF
--- a/pages/common/chgrp.md
+++ b/pages/common/chgrp.md
@@ -1,0 +1,19 @@
+# chgrp
+
+> Change group ownership of files and folders.
+
+- Change the owner of a file/folder:
+
+`chgrp {{group}} {{path/to/file}}`
+
+- Recursively change the owner of a folder and its contents:
+
+`chgrp -R {{group}} {{path/to/folder}}`
+
+- Change the owner of a symbolic link:
+
+`chgrp -h {{user}} {{path/to/symlink}}`
+
+- Change the owner of a file/folder to match a reference file:
+
+`chgrp --reference={{path/to/reference_file}} {{path/to/file}}

--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -1,16 +1,16 @@
 # chown
 
-> Change the owning user/group of the specified files.
+> Change user and group ownership of files and folders.
 
-- Change the user of a file:
+- Change the owner user of a file/folder
 
 `chown {{user}} {{path/to/file}}`
 
-- Change the user and group of a file:
+- Change the owner user and group of a file/folder:
 
 `chown {{user}}:{{group}} {{path/to/file}}`
 
-- Recursively change the owner of an entire folder:
+- Recursively change the owner of a folder and its contents
 
 `chown -R {{user}} {{path/to/folder}}`
 
@@ -18,6 +18,6 @@
 
 `chown -h {{user}} {{path/to/symlink}}`
 
-- Use the owner and group of a reference file and apply those values to another file:
+- Change the owner of a file/folder to match a reference file:
 
-`chown --reference={{reference-file}} {{path/to/file}}`
+`chown --reference={{path/to/reference_file}} {{path/to/file}}`


### PR DESCRIPTION
Was quite surprised to get a "Page not found" error trying to look up a tldr page for chgrp today, so I whipped one up. Originally, I was planning to do an almost direct copy of chown's tldr page (since chown and chgrp have essentially identical syntax), but then I noticed I didn't like some things about the chown page. So, I made chgrp.md the way I thought looked best, and then changed chown.md to match.