### PR TITLE
Added missing p7zip tools (7z and 7zr)

### DIFF
--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -12,7 +12,11 @@
 
 - Archive using a specific archive type:
 
-`7z a -t{{7z|zip|gzip|bzip2|tar}} {{compressed}} {{path/to/file}}`
+`7z a -t{{zip|gzip|bzip2|tar|...}} {{compressed}} {{path/to/file}}`
+
+- List available archive types:
+
+`7z i`
 
 - List the contents of an archive file:
 

--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -1,0 +1,19 @@
+# 7z
+
+> A file archiver with high compression ratio.
+
+- Compress directory or file:
+
+`7z a {{compressed.7z}} {{directory_or_file_to_compress}}`
+
+- Decompress an existing 7z file with original directory structure:
+
+`7z x {{compressed.7z}}`
+
+- Compress to zip format:
+
+`7z a -tzip {{compressed.zip}} {{directory_or_file_to_compress}}`
+
+- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
+
+`7z -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`

--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -2,18 +2,18 @@
 
 > A file archiver with high compression ratio.
 
-- Compress directory or file:
+- Archive a file or folder:
 
-`7z a {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7z a {{compressed.7z}} {{path/to/file}}`
 
-- Decompress an existing 7z file with original directory structure:
+- Extract an existing 7z file with original directory structure:
 
-`7z x {{compressed.7z}}`
+`7z x {{compressed}}`
 
-- Compress to zip format:
+- Archive using a specific archive type:
 
-`7z a -tzip {{compressed.zip}} {{directory_or_file_to_compress}}`
+`7z a -t{{7z|zip|gzip|bzip2|tar}} {{compressed}} {{path/to/file}}`
 
-- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
+- List the contents of an archive file:
 
-`7z -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7z l {{compressed}}`

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -1,6 +1,7 @@
 # 7za
 
 > A file archiver with high compression ratio.
+> A standalone version of `7z` with support for fewer archive types.
 
 - Compress directory or file:
 

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -3,18 +3,18 @@
 > A file archiver with high compression ratio.
 > A standalone version of `7z` with support for fewer archive types.
 
-- Compress directory or file:
+- Archive a file or folder:
 
-`7za a {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7za a {{compressed.7z}} {{path/to/file}}`
 
-- Decompress an existing 7z file with original directory structure:
+- Extract an existing 7z file with original directory structure:
 
-`7za x {{compressed.7z}}`
+`7za x {{compressed}}`
 
-- Compress to zip format:
+- Archive using a specific archive type:
 
-`7za a -tzip {{compressed.zip}} {{directory_or_file_to_compress}}`
+`7za a -t{{7z|zip|gzip|bzip2|tar}} {{compressed}} {{path/to/file}}`
 
-- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
+- List the contents of an archive file:
 
-`7za -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7z l {{compressed}}`

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -17,4 +17,4 @@
 
 - List the contents of an archive file:
 
-`7z l {{compressed}}`
+`7za l {{compressed}}`

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -13,7 +13,11 @@
 
 - Archive using a specific archive type:
 
-`7za a -t{{7z|zip|gzip|bzip2|tar}} {{compressed}} {{path/to/file}}`
+`7za a -t{{zip|gzip|bzip2|tar|...}} {{compressed}} {{path/to/file}}`
+
+- List available archive types:
+
+`7za i`
 
 - List the contents of an archive file:
 

--- a/pages/common/7zr.md
+++ b/pages/common/7zr.md
@@ -3,14 +3,14 @@
 > A file archiver with high compression ratio.
 > A standalone version of `7z` that only supports .7z files.
 
-- Compress directory or file:
+- Archive a file or folder:
 
-`7zr a {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7za a {{compressed.7z}} {{path/to/file}}`
 
-- Decompress an existing 7z file with original directory structure:
+- Extract an existing 7z file with original directory structure:
 
-`7zr x {{compressed.7z}}`
+`7za x {{compressed.7z}}`
 
-- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
+- List the contents of an archive file:
 
-`7zr -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`
+`7z l {{compressed.7z}}`

--- a/pages/common/7zr.md
+++ b/pages/common/7zr.md
@@ -1,0 +1,16 @@
+# 7zr
+
+> A file archiver with high compression ratio.
+> A standalone version of `7z` that only supports .7z files.
+
+- Compress directory or file:
+
+`7zr a {{compressed.7z}} {{directory_or_file_to_compress}}`
+
+- Decompress an existing 7z file with original directory structure:
+
+`7zr x {{compressed.7z}}`
+
+- Create multipart 7zip file; `part_size` specifies part size in Bytes, Kilobytes, Megabytes or Gigabytes:
+
+`7zr -v{{part_size}}{{[b|k|m|g]}} {{compressed.7z}} {{directory_or_file_to_compress}}`

--- a/pages/common/7zr.md
+++ b/pages/common/7zr.md
@@ -5,12 +5,12 @@
 
 - Archive a file or folder:
 
-`7za a {{compressed.7z}} {{path/to/file}}`
+`7zr a {{compressed.7z}} {{path/to/file}}`
 
 - Extract an existing 7z file with original directory structure:
 
-`7za x {{compressed.7z}}`
+`7zr x {{compressed.7z}}`
 
 - List the contents of an archive file:
 
-`7z l {{compressed.7z}}`
+`7zr l {{compressed.7z}}`


### PR DESCRIPTION
There's already a tldr page for `7za`, the 7zip archiving tool from the p7zip package. But actually, the main executable from p7zip is `7z`. `7z` uses plugins to support lots of archive formats, while `7za` is a standalone version that only supports a limited set of archive formats. There's also `7zr`, which is another standalone version that exclusively supports the .7z formats. (I got all this info from [the ever-indispensible Arch Linux wiki](https://wiki.archlinux.org/index.php/p7zip#Differences_between_7z.2C_7za_and_7zr_binaries))

This PR adds a note to 7za.md explaining the relationship to `7z`, and also adds pages for `7z` and `7zr` (both pages are essentially copies of the original 7za.md page).