### PR TITLE
mkfifo: add page

### DIFF
--- a/pages/common/mkfifo.md
+++ b/pages/common/mkfifo.md
@@ -1,0 +1,7 @@
+# mkfifo
+
+> Makes FIFOs (named pipes).
+
+- Create a named pipe at a given path:
+
+`mkfifo {{path/to/pipe}}`


### PR DESCRIPTION
mkfifo is a standard POSIX utility, similar to mkdir, except it makes a named pipe (aka a FIFO; first-in first-out). Documentation for the GNU version of mkfifo is [here](http://www.gnu.org/software/coreutils/mkfifo), and the POSIX specification is [here](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkfifo.html) (this tldr page conforms to both specs \o/)

Could maybe document the --mode flag, which allows you to specify chmod-style file permissions. But I dunno how frequently used that would be, so it's probably fine as-is.