### PR TITLE
c99: add page

### DIFF
--- a/pages/common/c99.md
+++ b/pages/common/c99.md
@@ -2,18 +2,18 @@
 
 > Compiles C programs according to the ISO C standard.
 
-- Compile source files and create an executable:
+- Compile source file(s) and create an executable:
 
 `c99 {{file.c}}`
 
-- Compile source files and create an executable with a custom name:
+- Compile source file(s) and create an executable with a custom name:
 
 `c99 -o {{executable_name}} {{file.c}}`
 
-- Compile source files and create object files:
+- Compile source file(s) and create object file(s):
 
 `c99 -c {{file.c}}`
 
-- Compile source files, link with object files, and create an executable:
+- Compile source file(s), link with object file(s), and create an executable:
 
 `c99 {{file.c}} {{file.o}}`

--- a/pages/common/c99.md
+++ b/pages/common/c99.md
@@ -1,0 +1,19 @@
+# C99
+
+> Compiles C programs according to the ISO C standard.
+
+- Compile source files and create an executable:
+
+`c99 {{file.c}}`
+
+- Compile source files and create an executable with a custom name:
+
+`c99 -o {{executable_name}} {{file.c}}`
+
+- Compile source files and create object files:
+
+`c99 -c {{file.c}}`
+
+- Compile source files, link with object files, and create an executable:
+
+`c99 {{file.c}} {{file.o}}`


### PR DESCRIPTION
c99 is the POSIX standard compiler for C that is meant to strictly meet the ISO C standard. This tldr page is based on [this POSIX spec](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/c99.html).