### PR TITLE
fg: add page

### DIFF
--- a/pages/common/fg.md
+++ b/pages/common/fg.md
@@ -1,0 +1,11 @@
+# fg
+
+> Run jobs in foreground.
+
+- Brings most recently suspended background job to foreground:
+
+`fg`
+
+- Brings a specific job to foreground:
+
+`fg {{job_id}}`

--- a/pages/common/fg.md
+++ b/pages/common/fg.md
@@ -2,10 +2,10 @@
 
 > Run jobs in foreground.
 
-- Brings most recently suspended background job to foreground:
+- Bring most recently suspended background job to foreground:
 
 `fg`
 
-- Brings a specific job to foreground:
+- Bring a specific job to foreground:
 
 `fg {{job_id}}`


### PR DESCRIPTION
[fg](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/fg.html) is the POSIX standardized utility for bringing suspended/background jobs to the foreground. If you run a job in the background with `somecommand &`, or if you suspend a job by pressing ^Z, you use fg to resume it.