### PR TITLE
jobs: add page

### DIFF
--- a/pages/common/jobs.md
+++ b/pages/common/jobs.md
@@ -10,6 +10,10 @@
 
 `jobs {{job_id}}`
 
-- Print process IDs of all jobs:
+- Show status and process IDs of all jobs:
+
+`jobs -l`
+
+- Show process IDs of all jobs:
 
 `jobs -p`

--- a/pages/common/jobs.md
+++ b/pages/common/jobs.md
@@ -1,0 +1,15 @@
+# jobs
+
+> Display status of jobs in the current session.
+
+- Show status of all jobs:
+
+`jobs`
+
+- Show status of a particular job:
+
+`jobs {{job_id}}`
+
+- Print process IDs of all jobs:
+
+`jobs -p`


### PR DESCRIPTION
[jobs](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/jobs.html) is the POSIX utility for viewing status info on jobs running in the current shell environment. I pretty much only included arguments specified in the POSIX standard, but [Bash has some additional arguments](https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-jobs).