### PR TITLE
tput: add page

### DIFF
--- a/pages/common/tput.md
+++ b/pages/common/tput.md
@@ -1,0 +1,23 @@
+# tput
+
+> View and modify terminal settings and capabilities.
+
+- Move the cursor to a screen location:
+
+`tput cup {{y_coordinate}} {{x_coordinate}}`
+
+- Set foreground (af) or background (ab) color:
+
+`tput {{setaf|setab}} {{ansi_color_code}}`
+
+- Show number of columns, lines, or colors:
+
+`tput {{cols|lines|colors}}`
+
+- Ring the terminal bell:
+
+`tput bel`
+
+- Reset all terminal attributes:
+
+`tput sgr0`


### PR DESCRIPTION
tput is a utility for showing and modifying terminal capabilities. It can do a TON of stuff, and I'm not sure I did it justice. I tried picking some of the most common/useful commands, but it's entirely arbitrary. There are about a million capabilities you can pass to `tput` -- check out the list of cap-names in [the man page for terminfo](http://manpages.debian.org/cgi-bin/man.cgi?query=terminfo&sektion=5).