### PR TITLE
Add sh

### DIFF
--- a/pages/common/bash.md
+++ b/pages/common/bash.md
@@ -3,18 +3,18 @@
 > Bourne-Again SHell.
 > `sh`-compatible command line interpreter.
 
-- Start interactive command line interpreter:
+- Start interactive shell:
 
 `bash`
 
-- Execute command passed as parameter:
+- Execute a command:
 
 `bash -c {{command}}`
 
-- Run commands from file (script):
+- Run commands from a file:
 
-`bash {{file}}`
+`bash {{file.sh}}`
 
-- Run commands from file and print them as they are executed:
+- Run commands from STDIN:
 
-`bash -x {{file}}`
+`bash -s`

--- a/pages/common/sh.md
+++ b/pages/common/sh.md
@@ -1,0 +1,20 @@
+# sh
+
+> Bourne shell.
+> The standard command language interpreter.
+
+- Start interactive shell:
+
+`sh`
+
+- Execute a command:
+
+`sh -c {{command}}`
+
+- Run commands from a file:
+
+`sh {{file.sh}}`
+
+- Run commands from STDIN:
+
+`sh -s`


### PR DESCRIPTION
Shocked to find that [sh](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html), the classic Bourne shell, didn't already have a tldr page! Created one based on bash's page, but I tweaked the language a little bit, then modified bash.md to match sh.md.