### PR TITLE
cmp: add page

### DIFF
--- a/pages/common/cmp.md
+++ b/pages/common/cmp.md
@@ -1,0 +1,11 @@
+# cmp
+
+> Compare two files.
+
+- Find the byte number and line number of the first difference between the files:
+
+`cmp {{file1}} {{file2}}`
+
+- Find the byte number and differing bytes of every difference:
+
+`cmp -l {{file1}} {{file2}}`


### PR DESCRIPTION
[cmp](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/cmp.html) is a POSIX-standard tool for finding differences between files. I only documented the POSIX-defined options, but there is a useful `-i` flag that pretty much every real world implementation of `cmp` supports (check out [this man page](http://man7.org/linux/man-pages/man1/cmp.1.html)). I was trying to document it but every way I worded it felt too awkward.