### PR TITLE
pwd: fixed minor typo

### DIFF
--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -6,6 +6,6 @@
 
 `pwd`
 
-- Print the current directory, and resolve all symlinks (e.g. show the "physical" path):
+- Print the current directory, and resolve all symlinks (i.e. show the "physical" path):
 
 `pwd -P`


### PR DESCRIPTION
Okay this is super trivial but bear with me. The acronym "e.g." means "for example, ", but in this case, an example wasn't being given, so the correct acronym to use is "i.e." (meaning "that is, ").