### PR TITLE
hn: add page

### DIFF
--- a/pages/common/hn.md
+++ b/pages/common/hn.md
@@ -1,0 +1,19 @@
+# hn
+
+> Command-line interface for Hacker News.
+
+- View stories on Hacker News:
+
+`hn`
+
+- View _number_ of stories on Hacker News:
+
+`hn --limit {{number}}`
+
+- View stories on Hacker News, and keep the list open after selecting a link:
+
+`hn --keep-open`
+
+- View stories on Hacker News sorted by submission date:
+
+`hn --latest`


### PR DESCRIPTION
[hn](https://github.com/rafaelrinaldi/hn-cli) is a CLI for browsing Hacker News.