### PR TITLE
xcv: add page

### DIFF
--- a/pages/common/xcv.md
+++ b/pages/common/xcv.md
@@ -1,0 +1,19 @@
+# xcv
+
+> Cut, copy, and paste in the command-line.
+
+- Cut a file:
+
+`xcv x {{input_file}}`
+
+- Copy a file:
+
+`xcv c {{input_file}}`
+
+- Paste a file:
+
+`xcv v {{output_file}}`
+
+- List files available for pasting:
+
+`xcv l`


### PR DESCRIPTION
[xcv](https://github.com/busterc/xcv) is a tool for cut/copy/paste on the command-line (unlike mv/cp, you don't have to specify a destination when cutting/copying, or a source when pasting -- it works just like Ctrl+X/C/V on your keyboard).