### PR TITLE
Sed: adds replace before matching sample

### DIFF
--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -6,6 +6,10 @@
 
 `sed 's/{{find}}/{{replace}}/' {{filename}}`
 
+- Replace the first occurrence on all lines matching a pattern:
+
+`sed '/{{line_pattern}}/s/{{find}}/{{replace}}/'`
+
 - Replace all occurrences of a string in a file, overwriting the file (i.e. in-place):
 
 `sed -i 's/{{find}}/{{replace}}/g' {{filename}}`

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -6,7 +6,7 @@
 
 `sed 's/{{find}}/{{replace}}/' {{filename}}`
 
-- Replace the first occurrence on all lines matching a pattern:
+- Replace only on lines matching the line pattern:
 
 `sed '/{{line_pattern}}/s/{{find}}/{{replace}}/'`
 


### PR DESCRIPTION
Something I find myself doing more and more is to match on a line instead of trying to match all I want with `{{find}}`.

So in a file like:

```erl
{ riak_core, [ {
    {riak_ip, "127.0.0.1"},
    %% ...
}, 
   %% ...
] }
```

Instead of replacing that ip by doing

```zsh
sed 's/riak_ip,"127\.0\.0\.1/riak_ip,"$NEW_IP/'
```

I do

 ```zsh
sed '/riak_ip/s/127\.0\.0\.1/$NEW_IP/'
```

Which has the added benefit of working regardless of whether I use single or double quotes on the file, or  if there's any space between `riak_ip` and the `,` and the actual ip.