### PR TITLE
fc-match: add page

### DIFF
--- a/pages/linux/fc-match.md
+++ b/pages/linux/fc-match.md
@@ -1,0 +1,7 @@
+# fc-match
+
+> Match available fonts.
+
+- Return a sorted list of best matching fonts:
+
+`fc-match -s '{{Font Name}}'`


### PR DESCRIPTION
The `fc-match` command is invaluable for diagnosing font problems in linux.  It describes the fall-back fonts that will be used for glyphs not in your current font.  For instance, I discovered that Debian Jessie wasn't detecting my font Monoid as Monospace and using standard book fonts with incorrect spacing.  I also have a PR for `fc-pattern` which displays extended information about a font.