### PR TITLE
added gcc option

### DIFF
--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -13,3 +13,7 @@
 - Include libraries from a different path:
 
 `gcc {{source.c}} -o {{executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`
+
+- Compile source code into Assembler instructions:
+
+`gcc -S {{source.c}}`


### PR DESCRIPTION
Added the option for "converting" C* source code into assembler instructions.

Provided we have source.c, the output will be written to a new file called source.s.