### PR TITLE
Fix example for grep for using standard input instead of a file

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -33,7 +33,7 @@
 
 - Use the standard input instead of a file:
 
-`cat {{file_path}} | grep {{something}}`
+`cat - | grep {{something}}`
 
 - Invert match for excluding specific strings:
 


### PR DESCRIPTION
Currently the example for using `grep` with standard input instead of a file seems wrong. 
The current example is 

`cat {{file_path}} | grep {{something}}`

The example itself mentions {{file_path}}

The following are better examples:

`cat - | grep {{something}}`

or even

`cat | grep {{something}}`

and even a shorter form

`grep {{something}}`

I've included only the first one as it feels best for a new user.