### PR TITLE
pv -d does not exist

### DIFF
--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -14,10 +14,6 @@
 
 `pv -cN in {{big_text_file}} | grep {{pattern}} | pv -cN out > {{filtered_file}}`
 
-- Attach to an already running process and see its file reading progress:
-
-`pv -d {{PID}}`
-
 - Read an erroneous file, skip errors as `dd conv=sync,noerror` would:
 
 `pv -EE {{path_to_faulty_media}} > image.img`


### PR DESCRIPTION
Not sure what was the original intention, but the -d option does not exist. 

[Source](http://linux.die.net/man/1/pv)

@d33tah? 
