### PR TITLE
Wrong order of arguments in command

### DIFF
--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -13,7 +13,7 @@
 
 - Recursively copy the contents of a directory on a remote host to a local directory:
 
-`scp -r {{remote_host}}:{{/path/remote_dir}} {{/path/local_dir}}`
+`scp -r {{/path/local_dir}} {{remote_host}}:{{/path/remote_dir}}`
 
 - Copy a file between two remote hosts transferring through the local host:
 


### PR DESCRIPTION
The order of arguments in `scp` was [wrong](http://serverfault.com/a/264598/283749). Thank you, though –this is awesome!