### PR TITLE
expr, bzip2: add page. Typo fixed in iptables

### DIFF
--- a/pages/linux/bzip2.md
+++ b/pages/linux/bzip2.md
@@ -1,0 +1,15 @@
+# bzip2
+
+> A block-sorting file compressor.
+
+- Compress file:
+
+`bzip2 {{path/to/file_to_compress}}`
+
+- Decompress file:
+
+`bzip2 -d {{path/to/compressed_file.bz2}}`
+
+- Decompress to STDOUT:
+
+`bzip2 -dc {{path/to/compressed_file.bz2}}`

--- a/pages/linux/expr.md
+++ b/pages/linux/expr.md
@@ -1,0 +1,23 @@
+# expr
+
+> Evaluate expressions and manipulate strings.
+
+- Get string length:
+
+`expr length {{string}}`
+
+- Evaluate logical or math expression with an operator( '+', '-', '*', '&', '|', etc. ). Special symbols should be escaped:
+
+`expr {{ARG1}} {{operator}} {{ARG2}}`
+
+- Get position of the first character in 'string' that matches 'substring':
+
+`echo $(expr index {{string}} {{substring}})`
+
+- Extract part of the string:
+
+`echo $(expr substr {{string}} {{position_to_start}} {{number_of_characters}}`
+
+- Extract part of the string which matches a regular expression:
+
+`echo $(expr {{string}} : '\({{regular_expression}}\)')`

--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -22,6 +22,6 @@
 
 `sudo iptables -D {{chain}} {{rule_line_number}}`
 
-- Savin iptables configuration:
+- Save iptables configuration:
 
 `sudo iptables-save > {{path_to_iptables_file}}`


### PR DESCRIPTION
Two new pages: expr and bzip2.
Fixed type on iptables.md page.