### PR TITLE
git-submodule: Add tldr page for the git-submodule command.

### DIFF
--- a/pages/common/git-submodule.md
+++ b/pages/common/git-submodule.md
@@ -1,0 +1,15 @@
+# git submodule
+
+> Inspects, updates and manages submodules.
+
+- Install a repository's specified submodules:
+
+`git submodule update --init --recursive`
+
+- Add a git repository as a submodule:
+
+`git submodule add {{repository-url}}`
+
+- Update every submodule to its latest commit:
+
+`git submodule foreach git pull`


### PR DESCRIPTION
I think this pretty well covers the basics. I'm not including removing a submodule because you use `git-rm` instead of `git-submodule` for that, but I would be happy to add it in if it's something that makes sense here.