### PR TITLE
qemu.md

### DIFF
--- a/pages/common/qemu.md
+++ b/pages/common/qemu.md
@@ -1,0 +1,28 @@
+# qemu
+
+> Generic machine emulator and virtualizer.
+> Supports a large variety of CPU architectures.
+
+- Create disk image with a specific size (in gigabytes):
+
+`qemu-img create {{image_name.img}} {{gigabites}}G`
+
+- Boot from image emulating i386 architecture:
+
+`qemu-system-i386 -hda {{image_name.img}}`
+
+- Boot from image emulating x64 architecture:
+
+`qemu-system-x86_64 -hda {{image_name.img}}`
+
+- Boot QEMU instance with a live ISO image:
+
+`qemu-system-i386 -hda {{image_name.img}} -cdrom {{os-image.iso}} -boot d`
+
+- Specify amount of RAM for instance:
+
+`qemu-system-i386 -m 256 -hda image_name.img -cdrom os-image.iso -boot d`
+
+- Boot from physical device (e.g. from USB to test bootable medium):
+
+`qemu-system-i386 -hda /dev/{{storage_device}}`


### PR DESCRIPTION
I added a page for the QEMU emulator. 

It usually is operated though CLI and opens a dialog, native to the OS's GUI, in which virtual machine 
displays are shown.

It may be useful for users, who need to create virtual instances on architectures different than x86 and x64, as it supports PowerPC, MIPS, ARM and quite few other CPU architectures.

Update:
It comes with separate commands for each CPU architecture, e.g. qemu-system-ppc64, qemu-system-i386, qemu-system-arm. This is the reason examples in this markdown file are involving separate commands. With qemu-img you can create a virtual HDD device for any of your virtual machines, e.g. on which you can install a particular OS. 

All of those binaries are usually bundled with the standard QEMU package tha you can install on a Debian/Ubuntu system with for example apt-get.