### PR TITLE
less: Add example for enabling ANSI color output

### DIFF
--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -26,7 +26,7 @@
 
 - Enable output of ANSI colors:
 
-`{{something}} | less -R`
+`git diff --color | less -R`
 
 - Exit:
 

--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -26,7 +26,7 @@
 
 - Enable output of ANSI colors:
 
-`less -R {{source_file}}`
+`{{something}} | less -R`
 
 - Exit:
 

--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -24,6 +24,10 @@
 
 `?{{something}}   then   n (next), N (previous)`
 
+- Enable output of ANSI colors:
+
+`less -R {{source_file}}`
+
 - Exit:
 
 `q`


### PR DESCRIPTION
Example usage of the `-R` flag for enabling the interpretation of ANSI escape "colour" codes by less.