### PR TITLE
various tweaks to grep

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -7,33 +7,33 @@
 
 `grep {{something}} {{file_path}}`
 
-- Search without case-sensitivity:
+- Search in case-insensitive mode:
 
-`grep -i {{something}} {{file_path}}`
+`grep -i {{something}} {{path/to/file}}`
 
 - Search recursively in current directory for an exact string:
 
 `grep -r {{something}} .`
 
-- Use a regex:
+- Use a regular expression (`-E` for extended regex, supporting `?`, `+`, `{`, `|`, `(`, and `)`):
 
-`grep -e {{^regex$}} {{file_path}}`
+`grep -e {{^regex$}} {{path/to/file}}`
 
-- See 3 lines of context:
+- Print 3 lines of context around each match:
 
-`grep -C 3 {{something}} {{file_path}}`
+`grep -C 3 {{something}} {{path/to/file}}`
 
 - Print the count of matches instead of the matching text:
 
-`grep -c {{something}} {{file_path}}`
+`grep -c {{something}} {{path/to/file}}`
 
 - Print line number for each match:
 
-`grep -n {{something}} {{file_path}}`
+`grep -n {{something}} {{path/to/file}}`
 
 - Use the standard input instead of a file:
 
-`cat {{file_path}} | grep {{something}}`
+`cat {{path/to/file}} | grep {{something}}`
 
 - Invert match for excluding specific strings:
 


### PR DESCRIPTION
- use "case-insensitive" in the description of the -i option to make the initialism clear
- use path/to/file instead of file_path
- mention extended regex syntax and expand first occurrence to spell "regular expression"
- clarify wording of the -C example description