### PR TITLE
fix: remove a typo in osx sed page

### DIFF
--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -12,7 +12,7 @@
 
 - Replace all occurrences of a string in a file, overwriting the file (i.e. in-place):
 
-`sed -i '' 's/{{find}}/{{replace}}/g' {{filename}}`
+`sed -i 's/{{find}}/{{replace}}/g' {{filename}}`
 
 - Replace only on lines matching the line pattern:
 


### PR DESCRIPTION
## Description

Remove in typo in the osx sed page