### PR TITLE
Export to PDF

### DIFF
--- a/scripts/generate-pdf.sh
+++ b/scripts/generate-pdf.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+src=../pages
+target=../tldr-book.pdf
+template=template.tex
+
+function getContent {
+
+    cd $src
+
+    pages=$(ls -d */  | # list directories
+            tr -d '/' | # remove trailing slash
+            tr '[:lower:]' '[:upper:]') # transform to uppercase
+
+    for page in $pages; do
+
+        echo "\n\n# $page" >&1 # add a new chapter
+
+        for file in $(ls $page); do
+
+            echo "\n\n"       | # add some line breaks for latex
+            cat - $page/$file | # get the content of the tldr file
+            sed 's/^#/##/g' >&1 # transform h1 (chapter) to h2 (section)
+
+        done
+   done
+}
+
+getContent | pandoc -o $target --template $template --latex-engine xelatex --listings

--- a/scripts/template.tex
+++ b/scripts/template.tex
@@ -1,0 +1,106 @@
+% -----------------------------------------------
+% Pandoc LaTeX Template for TLDR Pages
+% -----------------------------------------------
+% Partly from The Little MongoDB Book
+% github.com/karlseguin/the-little-mongodb-book
+% -----------------------------------------------
+
+\documentclass[
+    12pt,    % font size
+    DIV12,   % space / margins
+    a4paper, % paper format
+    oneside, % one-sided document
+]{scrreprt}
+
+% Typography
+\usepackage[no-math]{fontspec}
+\defaultfontfeatures{Scale = MatchLowercase}
+
+% Fonts
+\setmainfont[Ligatures = TeX]{Verdana}
+\setsansfont[Ligatures = TeX]{Verdana}
+\setmonofont{Consolas}
+
+% Set Sans font in headings
+\usepackage{sectsty}
+\allsectionsfont{\sffamily}
+
+% Set polyglossia language
+\usepackage{polyglossia}
+\setdefaultlanguage{english}
+
+
+% -----------------------------------------------
+% Project specific changes
+% -----------------------------------------------
+
+% fix for pandoc 1.14 (from https://github.com/mpastell/Pweave/pull/29/)
+\providecommand{\tightlist}{
+    \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+% Disable section numbers
+\setcounter{secnumdepth}{0}
+
+% Print program synopsis as normal but a bit bigger text
+\def\quote{\large}
+
+% Set en dash as list item
+\renewcommand{\labelitemi}{--}
+
+% Decrease indentation of list items
+\usepackage{enumitem}
+\setlist[itemize,1]{
+    leftmargin = 11pt,
+    itemindent = 0pt,
+}
+
+% Align commands with list items
+\setlength{\parindent}{11pt}
+
+
+% -----------------------------------------------
+% Colors, Listings and Links
+% -----------------------------------------------
+
+\usepackage{xcolor}
+\usepackage{listings}
+
+\definecolor{tldrBlue}{HTML}{0074d9}
+
+\lstset{
+    moredelim = *[is][\color{tldrBlue}]{\{\{}{\}\}}, % the magic for the blue
+    basicstyle = \ttfamily, % monospace font for code
+    backgroundcolor = \color{white}, % for multiline code samples (there are none atm)
+    extendedchars = true,
+    breaklines = true,
+    keepspaces = true, % if not set to true, the space between two following variables is removed when setting `basicstyle` (why? WHY?)
+}
+
+\usepackage[
+    linktoc = all % link the text and the page number in the TOC
+]{hyperref}
+
+
+% -----------------------------------------------
+% The Document
+% -----------------------------------------------
+
+\begin{document}
+
+    \thispagestyle{plain}
+
+    \begin{titlepage}
+        \begin{center}
+            \vspace*{11em}
+            \huge{\textbf{TLDR Pages}}\\[1em]
+            \LARGE{The Book}\\[3em]
+            \large{Simplified and community-driven man pages}\\[1em]
+            \ttfamily{\href{https://tldr-pages.github.io}{tldr-pages.github.io}}
+        \end{center}
+    \end{titlepage}
+
+    \tableofcontents % Table of Contents #usefulcomments
+
+    $body$ % this is were pandoc hooks in
+
+\end{document}


### PR DESCRIPTION
Added code to export all current Markdown files as PDF with [pandoc](http://pandoc.org/).

To create the PDF file, go to `scripts` and run `./generate-pdf.sh` (It takes a bit to compile; about 30 seconds on my MacBook Air).