### PR TITLE
xattr: add page

### DIFF
--- a/pages/osx/xattr.md
+++ b/pages/osx/xattr.md
@@ -1,0 +1,23 @@
+# xattr
+
+> Utility for use with extended filesystem attributes.
+
+- List key:value extended attributes for a given file:
+
+`xattr -l {{file}}`
+
+- Write an attribute for a given file:
+
+`xattr -w {{attribute_key}} {{attribute_value}} {{file}}`
+
+- Delete an attribute from a given file:
+
+`xattr -d {{attribute_key}} {{file}}`
+
+- Delete all extended attributes from a given file:
+
+`xattr -c {{file}}`
+
+- Recursively delete an attribute in a given directory:
+
+`xattr -rd {{attribute_key}} {{directory}}`


### PR DESCRIPTION
Added a new page for osx xattr utility which deals with filesystem extended attributes.

http://xattr.sourceforge.net/
http://gotofritz.net/blog/geekery/os-x-extended-attibutes/
https://www.safaribooksonline.com/library/view/macintosh-terminal-pocket/9781449328962/re38.html

