### PR TITLE
gcc: add -c option

### DIFF
--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -10,7 +10,7 @@
 
 `passwd {{username}} {{new password}}`
 
-- Get the current statuts of the user:
+- Get the current status of the user:
 
 `passwd -S`
 


### PR DESCRIPTION
writing `Makefile` often involves `-c` option to create object files from source code.