### PR TITLE
gcc: add -c option

### DIFF
--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -17,3 +17,7 @@
 - Compile source code into Assembler instructions:
 
 `gcc -S {{source.c}}`
+
+- Compile source code without linking:
+
+`gcc -c {{source.c}}`


### PR DESCRIPTION
Writing `Makefile` usually requires `-c` option of `gcc` to generate object files.

p.s. remote of previous PR #896 was broken by myself, I send this PR again with correct git config. Sorry about the inconvenience.