### PR TITLE
Add examples for exporting GPG keys

### DIFF
--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -21,3 +21,11 @@
 - Import a public key:
 
 `gpg --import {{public.gpg}}`
+
+- Export public key for alice@example.com (output to STDOUT):
+
+`gpg --export --armor {{alice@example.com}}`
+
+- Export private key for alice@example.com (output to STDOUT):
+
+`gpg --export-secret-keys --armor {{alice@example.com}}`


### PR DESCRIPTION
This chage adds examples for exporting public and private GPG keys.

This is particularly useful for backing up keys. In both cases they have
been output as ASCII armored text with the `--armor` flag to make the
output easier to work with.