### PR TITLE
Adds command to show SSH key fingerprint

### DIFF
--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -22,6 +22,10 @@
 
 `ssh-keygen -l -F {{remote_host}}`
 
+- Retrieve the fingerprint of a key in MD5 Hex:
+
+`ssh-keygen -l -E md5 -f ~/.ssh/{{filename}}`
+
 - Change the password of a key:
 
 `ssh-keygen -p -f ~/.ssh/{{filename}}`


### PR DESCRIPTION
Adds an ssh-keygen command to show the fingerprint of an SSH key in the same format that is used by Github to list SSH keys that it knows about.