### PR TITLE
Update URL of Web Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A collection of simplified and community-driven man pages.
 
-Install it with `npm install -g tldr` or [try the web client](https://ostera.github.io/tldr.jsx).
+Install it with `npm install -g tldr` or [try the web client](http://tldr.ostera.io).
 
 ## What is tldr?
 
@@ -40,6 +40,7 @@ for the most common UNIX / Linux / OSX / SunOS commands.
 
 You can access these pages on your computer using one of the following clients:
 
+- [Alfred Workflow](https://github.com/cs1707/tldr-alfred)
 - Android clients:
   - [tldr-viewer](https://github.com/gianasista/tldr-viewer), available on
     [Google Play](https://play.google.com/store/apps/details?id=de.gianasista.tldr_viewer)
@@ -65,8 +66,7 @@ You can access these pages on your computer using one of the following clients:
 - Rust clients:
     - [rust-tldr](https://github.com/rilut/rust-tldr) (online lookup): `cargo install tldr`
     - [tealdeer](https://github.com/dbrgn/tealdeer) (fully featured client with offline cache): `cargo install tealdeer`
-- [Web client](https://github.com/ostera/tldr.jsx): https://ostera.github.io/tldr.jsx
-- [Alfred Workflow](https://github.com/cs1707/tldr-alfred)
+- [Web client](https://github.com/ostera/tldr.jsx): http://tldr.ostera.io/
 
 There is also a comprehensive [list of clients in our Wiki](https://github.com/tldr-pages/tldr/wiki/TLDR-clients).
 


### PR DESCRIPTION
Hey guys, I've rebuilt the web client in a nicer way, with nicer tools and a better design.

I've also hosted it elsewhere so it can use HTML5 PushState (now url's look like `tldr.ostera.io/linux/du` instead of the scrambled mess it was before).

Would be great to have it merged ASAP so I can get rid of the old one :)