### PR TITLE
Make extended regular expressions clearer

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -15,9 +15,9 @@
 
 `grep -rI {{search_string}} .`
 
-- Use a regular expression (`-E` for extended regex, supporting `?`, `+`, `{}`, `()` and `|`):
+- Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`):
 
-`grep -e {{^regex$}} {{path/to/file}}`
+`grep -E {{^regex$}} {{path/to/file}}`
 
 - Print 3 lines of context around each match:
 


### PR DESCRIPTION
By default, grep already uses regular expressions when searching.

The example `grep -e {{^regex$}} {{path/to/file}}` is the same as `grep {{^regex$}} {{path/to/file}}`.

However, because of the comment about extended regular expressions, I mistakenly assumed `-e` was the option to enable it.

I believe most people would refer to `tldr` in this use case looking for the `-E` extended regular expressions.

With this in mind, I believe that example would be better rephrased as this pull request makes it.