### PR TITLE
uniq: add sorting example

### DIFF
--- a/pages/common/uniq.md
+++ b/pages/common/uniq.md
@@ -17,3 +17,7 @@
 - Display number of occurences of each line along with that line:
 
 `uniq -c {{file}}`
+
+- Display number of occurences of each line, sorted by the most frequent:
+
+`uniq -c {{file}} | sort -nr`


### PR DESCRIPTION
This involves another command, but it's such a natural extension of uniq's `-c` functionality that I feel it's warranted to show here.

We should probably add a sort to the -c example too, because uniq only deals with *sequential* line repetitions.