### PR TITLE
iostat: Added some flags

### DIFF
--- a/pages/linux/iostat.md
+++ b/pages/linux/iostat.md
@@ -1,19 +1,23 @@
 # iostat
 
-> Report stats for devices and partitions.
+> Report statistics for devices and partitions.
 
-- Display disk statistics with disk IDs in human readable format:
+- Display a report of CPU and disk statistics since system startup:
 
-`iostat -h`
-
-- Display disk statistics with disk names (including LVM) in human readable format:
-
-`iostat -Nh`
+`iostat`
 
 - Display CPU statistics:
 
 `iostat -c`
 
-- Display extended disk statistics with disk names:
+- Display disk statistics with disk names (including LVM):
 
-`iostat -xN`
+`iostat -N`
+
+- Display extended disk statistics with disk names for device "sda":
+
+`iostat -xN {{sda}}`
+
+- Display incremental reports of CPU and disk statistics every "interval" second(s) with units converted to megabytes:
+
+`iostat -m {{interval}}`

--- a/pages/linux/iostat.md
+++ b/pages/linux/iostat.md
@@ -6,6 +6,10 @@
 
 `iostat`
 
+- Display a report of CPU and disk statistics since system startup with units converted to megabytes:
+
+`iostat -m`
+
 - Display CPU statistics:
 
 `iostat -c`
@@ -18,6 +22,6 @@
 
 `iostat -xN {{sda}}`
 
-- Display incremental reports of CPU and disk statistics every "interval" second(s) with units converted to megabytes:
+- Display incremental reports of CPU and disk statistics every "2" second(s):
 
-`iostat -m {{interval}}`
+`iostat {{2}}`

--- a/pages/linux/iostat.md
+++ b/pages/linux/iostat.md
@@ -6,7 +6,7 @@
 
 `iostat`
 
-- Display a report of CPU and disk statistics since system startup with units converted to megabytes:
+- Display a report of CPU and disk statistics with units converted to megabytes:
 
 `iostat -m`
 
@@ -18,10 +18,10 @@
 
 `iostat -N`
 
-- Display extended disk statistics with disk names for device "sda":
+- Display extended disk statistics with disk names for device sda:
 
 `iostat -xN {{sda}}`
 
-- Display incremental reports of CPU and disk statistics every "2" second(s):
+- Display incremental reports of CPU and disk statistics every 2 second(s):
 
 `iostat {{2}}`


### PR DESCRIPTION
- Added basic command usage without any flags.
- Removed the '-h' flag as it seems to be added implicitly by the cmd.
- Added the interval parameter.
- Added the '-m' flag.