### PR TITLE
Applying the 'path/to/item' convention uniformly

### DIFF
--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -16,4 +16,4 @@
 
 - Push an Android application to an emulator/device:
 
-`adb install -r {{apk.path}}`
+`adb install -r {{path/to/file.apk}}`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -5,7 +5,7 @@
 
 - Search for an exact string:
 
-`grep {{search_string}} {{file_path}}`
+`grep {{search_string}} {{path/to/file}}`
 
 - Search in case-insensitive mode:
 

--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -8,4 +8,4 @@
 
 - Create directories recursively (useful for creating nested dirs):
 
-`mkdir -p {{path}}`
+`mkdir -p {{path/to/directory}}`

--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -20,7 +20,7 @@
 
 - Read an erroneous file, skip errors as `dd conv=sync,noerror` would:
 
-`pv -EE {{path_to_faulty_media}} > image.img`
+`pv -EE {{path/to/faulty_media}} > image.img`
 
 - Stop reading after reading specified amount of data, rate limit to 1K/s:
 

--- a/pages/common/rmdir.md
+++ b/pages/common/rmdir.md
@@ -4,8 +4,8 @@
 
 - Remove directory, provided it is empty. Use `rm` to remove not empty directories:
 
-`rmdir {{directory}}`
+`rmdir {{path/to/directory}}`
 
 - Remove directories recursively (useful for nested dirs):
 
-`rmdir -p {{path}}`
+`rmdir -p {{path/to/directory}}`

--- a/pages/common/umount.md
+++ b/pages/common/umount.md
@@ -5,11 +5,11 @@
 
 - Unmount a filesystem:
 
-`umount {{path_to_device_file}}`
+`umount {{path/to/device_file}}`
 
 - OR:
 
-`umount {{path_to_mounted_directory}}`
+`umount {{path/to/mounted_directory}}`
 
 - Unmount all mounted filesystems (dangerous!):
 

--- a/pages/linux/cryptsetup.md
+++ b/pages/linux/cryptsetup.md
@@ -4,8 +4,8 @@
 
 - Format a drive (or a file) to make it a LUKS volume:
 
-`cryptsetup luksFormat {{path_to_luks_volume_to_be}}`
+`cryptsetup luksFormat {{path/to/luks_volume_to_be}}`
 
 - Open a volume so that you can access it decrypted on the fly at /dev/mapper/{{a}}:
 
-`cryptsetup luksOpen {{path_to_luks_volume_to_be}} {{a}}`
+`cryptsetup luksOpen {{path/to/luks_volume_to_be}} {{a}}`

--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -24,4 +24,4 @@
 
 - Save iptables configuration:
 
-`sudo iptables-save > {{path_to_iptables_file}}`
+`sudo iptables-save > {{path/to/iptables_file}}`

--- a/pages/osx/open.md
+++ b/pages/osx/open.md
@@ -16,7 +16,7 @@
 
 - Reveal a file in finder:
 
-`open -R {{/path/to/file}}`
+`open -R {{path/to/file}}`
 
 - Open all the files of a given extension in the current directory with the associated application:
 

--- a/pages/osx/open.md
+++ b/pages/osx/open.md
@@ -16,7 +16,7 @@
 
 - Reveal a file in finder:
 
-`open -R /path/dir/{{file}}`
+`open -R {{/path/to/file}}`
 
 - Open all the files of a given extension in the current directory with the associated application:
 


### PR DESCRIPTION
All pages follow a "path/to/some_file" convention. 

Its better to follow a single convention throughout. So fixed a few pages, which were not following it.