### PR TITLE
git-svn: add `fetch` subcommand

### DIFF
--- a/pages/common/git-svn.md
+++ b/pages/common/git-svn.md
@@ -6,6 +6,10 @@
 
 `git svn clone {{http://example.com/my_subversion_repo}} {{local_dir}}`
 
+- Fetch new revisions from remote SVN repository:
+
+`git svn fetch`
+
 - Update local clone from the upstream SVN repository:
 
 `git svn rebase`

--- a/pages/common/git-svn.md
+++ b/pages/common/git-svn.md
@@ -6,13 +6,13 @@
 
 `git svn clone {{http://example.com/my_subversion_repo}} {{local_dir}}`
 
-- Fetch new revisions from remote SVN repository:
-
-`git svn fetch`
-
 - Update local clone from the upstream SVN repository:
 
 `git svn rebase`
+
+- Fetch updates from remote SVN repository without changing the GIT HEAD:
+
+`git svn fetch`
 
 - Commit back to SVN repository:
 


### PR DESCRIPTION
The fetch command is as essential as the rebase command when working with remote SVN repos