### PR TITLE
git-remote: unicode quotes to ascii quotes

### DIFF
--- a/pages/common/git-remote.md
+++ b/pages/common/git-remote.md
@@ -1,6 +1,6 @@
 # git remote
 
-> Manage set of tracked repositories (“remotes”).
+> Manage set of tracked repositories ("remotes").
 
 - Show a list of existing remotes, their names and URL:
 


### PR DESCRIPTION
`git-remote` is the only file with unicode characters (two of them), both of which can be replaced with their ascii counterparts.

Living in 2016 this shouldn't pose a problem, but then again many terminals are ascii only.