### PR TITLE
[RFC] new syntax for pages

### DIFF
--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -1,4 +1,5 @@
-# inkscape
+inkscape
+========
 
 > An SVG (Scalable Vector Graphics) editing program.
 > Use -z to not open the GUI and only process files in the console.

--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -26,4 +26,4 @@ Export an SVG document to PDF, converting all texts to paths:
 
 Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
-   inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit
+    inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit

--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -3,26 +3,26 @@
 > An SVG (Scalable Vector Graphics) editing program.
 > Use -z to not open the GUI and only process files in the console.
 
-- Open an SVG file in the Inkscape GUI:
+Open an SVG file in the Inkscape GUI:
 
-`inkscape {{filename.svg}}`
+    inkscape {{filename.svg}}
 
-- Export an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):
+Export an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):
 
-`inkscape {{filename.svg}} -e {{filename.png}}`
+    inkscape {{filename.svg}} -e {{filename.png}}
 
-- Export an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):
+Export an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):
 
-`inkscape {{filename.svg}} -e {{filename.png}} -w {{600}} -h {{400}}`
+    inkscape {{filename.svg}} -e {{filename.png}} -w {{600}} -h {{400}}
 
-- Export a single object, given its ID, into a bitmap:
+Export a single object, given its ID, into a bitmap:
 
-`inkscape {{filename.svg}} -i {{id}} -e {{object.png}}`
+    inkscape {{filename.svg}} -i {{id}} -e {{object.png}}
 
-- Export an SVG document to PDF, converting all texts to paths:
+Export an SVG document to PDF, converting all texts to paths:
 
-`inkscape {{filename.svg}} --export-pdf={{filename.pdf}} --export-text-to-path`
+    inkscape {{filename.svg}} --export-pdf={{filename.pdf}} --export-text-to-path
 
-- Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
+Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
-`inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit`
+   inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit


### PR DESCRIPTION
I'm opening this to serve as a discussion thread to decide whether we might want to simplify the pages' syntax.

The proposal is inspired on [Inkscape's man page](https://inkscape.org/en/doc/inkscape-man.html#examples) ([source code](https://github.com/inkscape/inkscape/blob/5e7291b/man/inkscape.pod.in#L426-L481)), and uses a format that I believe is more readable for humans and machines alike, for several reasons:
- the **main heading is changed from a `#` prefix to a row of `====` underneath**, which makes it stand out more in plain text mode;
- the current syntax involves bullet (unordered) lists of command descriptions with code samples --the actual commands-- _between_ them (rather than within each list item), which is both visually distracting in most markdown renderers, and semantically incorrect;
- **the bullet list syntax was changed to plain paragraphs**, which solves both the semantic issue, and a syntactic issue with some renderers not recognizing the code block if preceded by a list entry ([case in point](https://github.com/jedahan/tldr/blob/48e1286/pages/common/7za.md), from PR #758)
- **the example code is now indented**, so each description/code pair stands out better in the markdown source, and we can easily jump visually from example to example;
- the adding of indentation triggers markdown's code block formatting, so **now we don't have to wrap the examples in backticks** (which have been the source of many linting errors)
- by forgoing the backticks, the examples can be directly copied from the source markdown without the need to remove the backticks manually, which is more cumbersome than e.g. replacing tokens;
- since the markdown is more readable, clients don't need to be as sophisticated, opening the door to dumb "clients" like the one proposed in #527.

All in all, I believe this makes the pages be more inline with the markdown philosophy, which is to be human-readable, without the need for a renderer/client. Compare the plaintext source: [before](https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/common/inkscape.md), [after](https://raw.githubusercontent.com/tldr-pages/tldr/waldyrious/alt-syntax/pages/common/inkscape.md); and the github-rendered output: [before](https://github.com/tldr-pages/tldr/blob/master/pages/common/inkscape.md), [after](https://github.com/tldr-pages/tldr/blob/waldyrious/alt-syntax/pages/common/inkscape.md).

But before this is discussed, we must come to agreement regarding which clients are officially supported, and what benchmark we'll hold third-party clients to in order to consider them semi-supported (i.e. we'd pledge not to break them without ample prior warning). Such an agreement might result in the clients currently in the tldr-pages umbrella going back to their original authors, or important third-party adopted under the tldr-pages umbrella (e.g. @ostera's tldr.jsx). Either option would simplify the way the project handles clients, by having a single client management model and a clear standard for clients to match. I'll open the discussion later (probably in a few weeks, as I currently don't have the time to get involved too deeply).
