### PR TITLE
[RFC] cp: major overhaul of the page

### DIFF
--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -4,24 +4,28 @@
 
 - Copy a file to another location:
 
-`cp {{/path/to/file.ext}} {{/path/to/copy.ext}}`
+`cp {{path/to/file.ext}} {{path/to/copy.ext}}`
 
 - Copy a file into another folder, keeping the filename:
 
-`cp {{/path/to/file.ext}} {{path/to/target/parent/folder}}`
+`cp {{path/to/file.ext}} {{path/to/target/parent/folder}}`
 
 - Copy a folder recursively to another location:
 
-`cp -r {{/path/to/folder}} {{/path/to/copy}}`
+`cp -r {{path/to/folder}} {{path/to/copy}}`
 
 - Copy a folder recursively into another folder, keeping the folder name:
 
-`cp -r {{/path/to/folder}} {{/path/to/target/parent/folder}}`
+`cp -r {{path/to/folder}} {{path/to/target/parent/folder}}`
 
 - Copy a folder recursively, in verbose mode (shows files as they are copied):
 
-`cp -vr {{/path/to/folder}} {{/path/to/copy}}`
+`cp -vr {{path/to/folder}} {{path/to/copy}}`
 
 - Copy the contents of a folder into another folder:
 
-`cp -r {{/path/to/source/folder/*}} {{/path/to/target/folder}}`
+`cp -r {{path/to/source/folder/*}} {{path/to/target/folder}}`
+
+- Interactively copy text files in the current directory to another location:
+
+`cp -i {{*.txt}} {{path/to/source/}}

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -28,4 +28,4 @@
 
 - Copy text files to another location, in interactive mode (prompts user before overwriting):
 
-`cp -i {{*.txt}} {{path/to/source/}}
+`cp -i {{*.txt}} {{path/to/source/}}`

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -1,27 +1,35 @@
 # cp
 
-> Copy files.
+> Copy files and folders.
 
-- Copy files in arbitrary locations:
+- Copy a file to another location:
 
-`cp {{/path/to/original}} {{/path/to/copy}}`
+`cp {{/path/to/file.ext}} {{/path/to/copy.ext}}`
 
-- Copy a file to a parent directory:
+- Copy a file into another folder, keeping the filename:
 
-`cp {{/path/to/original}} ../{{path/to/copy}}`
+`cp {{/path/to/file.ext}} {{path/to/target/parent/folder}}`
 
-- Copy directories recursive using the option -r:
+- Copy a folder recursively to another location:
 
-`cp -r {{/path/to/original}} {{/path/to/copy}}`
+`cp {{/path/to/folder}} {{/path/to/copy}}`
 
-- Show files as they are copied:
+- Copy a folder recursively into another folder, keeping the folder name:
 
-`cp -vr {{/path/to/original}} {{/path/to/copy}}`
+`cp -r {{/path/to/folder}} {{/path/to/target/parent/folder}}`
 
-- Make a copy of a file, adding an extension:
+- Copy a folder recursively, in verbose mode (shows files as they are copied):
+
+`cp -vr {{/path/to/folder}} {{/path/to/copy}}`
+
+- Copy the contents of a folder into another folder:
+
+`cp -r {{/path/to/source/folder/*}} {{/path/to/target/folder}}`
+
+- Copy of a file adding an extension:
 
 `cp {{file.html}}{,.backup}`
 
-- Make a copy of a file, changing the extension:
+- Copy a file, changing the extension:
 
 `cp {{file.}}{html,backup}`

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -26,6 +26,6 @@
 
 `cp -r {{path/to/source/folder/*}} {{path/to/target/folder}}`
 
-- Interactively copy text files in the current directory to another location:
+- Copy text files to another location, in interactive mode (prompts user before overwriting):
 
 `cp -i {{*.txt}} {{path/to/source/}}

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -12,7 +12,7 @@
 
 - Copy a folder recursively to another location:
 
-`cp {{/path/to/folder}} {{/path/to/copy}}`
+`cp -r {{/path/to/folder}} {{/path/to/copy}}`
 
 - Copy a folder recursively into another folder, keeping the folder name:
 
@@ -25,11 +25,3 @@
 - Copy the contents of a folder into another folder:
 
 `cp -r {{/path/to/source/folder/*}} {{/path/to/target/folder}}`
-
-- Copy of a file adding an extension:
-
-`cp {{file.html}}{,.backup}`
-
-- Copy a file, changing the extension:
-
-`cp {{file.}}{html,backup}`


### PR DESCRIPTION
- change "directory" to "folder" (more beginner-friendly)
- change "original" --> "copy" to "file"/"folder" --> "copy", to be more explicit (inspired by #289)
- use an extension to distinguish file paths from folder paths
- reword some of the descriptions for clarity
- include examples to clarify when the target argument defines the actual copy, and when it defines the folder where to put the copy
- add an example to copy contents of a folder into another (existing) folder
