### PR TITLE
Better example for reading from stdin

### DIFF
--- a/pages/common/comm.md
+++ b/pages/common/comm.md
@@ -10,13 +10,13 @@
 
 `comm -12 {{file1}} {{file2}}`
 
-- Print only lines common to both files, reading one file from stdin:
+- Print only lines common to both files, reading one file from stdin (Note the hyphen):
 
-`cat {{file1}} | comm -12 - {{file2}}`
+`comm -12 - {{file1}}`
 
 - Get lines only found in first file, saving the result to a third file:
 
-`comm -23 {{file1}} {{file2}} > file1-only.txt`
+`comm -23 {{file1}} {{file2}} > {{file1-only.txt}}`
 
 - Print lines only found in second file, when the files aren't sorted:
 


### PR DESCRIPTION
The previous example piped the contents of a file in the example which says "reading one file from stdin".
I understand that the command `comm` is still reading from stdin in this case but piping the contents of a file defeats the purpose of this example.