### PR TITLE
Removed 5 cases of useless use of cat

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -37,7 +37,7 @@
 
 - Use the standard input instead of a file:
 
-`cat {{path/to/file}} | grep {{search_string}}`
+`grep {{search_string}}`
 
 - Invert match for excluding specific strings:
 

--- a/pages/common/http.md
+++ b/pages/common/http.md
@@ -28,4 +28,4 @@
 
 - Specify raw request body via stdin:
 
-`cat data.txt | http PUT example.org`
+`http PUT {{example.org}} < {{path/to/file}}`

--- a/pages/common/lwp-request.md
+++ b/pages/common/lwp-request.md
@@ -9,7 +9,7 @@
 
 - Upload a file with a POST request:
 
-`cat {{/path/to/file}} | lwp-request -m POST {{http://example.com/some/path}}`
+`lwp-request -m POST {{http://example.com/some/path}} < {{path/to/file}}`
 
 - Make a request with a custom user agent:
 

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -20,7 +20,7 @@
 
 - Break stdin into ~1M blocks, feed each block to stdin of new command:
 
-`cat {{bigfile.txt}} | parallel --pipe --block 1M {{command}}`
+`parallel --pipe --block 1M {{command}} < {{path/to/bigfile}}`
 
 - Run on multiple machines via SSH:
 

--- a/pages/linux/xsel.md
+++ b/pages/linux/xsel.md
@@ -8,7 +8,7 @@
 
 - Use the contents of a file as input of the clipboard:
 
-`cat {{file}} | xsel -ib`
+`xsel -ib < {{file}}`
 
 - Output the clipboard's contents into the terminal (equivalent to Ctrl+V):
 


### PR DESCRIPTION
This removes some more cases of useless use of `cat`.

Note for `pages/common/grep.md`: Piping the contents of file to stdin defeats the purpose of the example demonstrating how to use the stdin instead of a file.