### PR TITLE
osx/du.md: fix depth option, plus minor tweaks

### DIFF
--- a/pages/osx/du.md
+++ b/pages/osx/du.md
@@ -4,16 +4,16 @@
 
 - Get a sum of the total size of a file/folder in human readable units:
 
-`du -sh {{file_or_directory}}`
+`du -sh {{path/to/file_or_folder}}`
 
 - List file sizes of a directory and any subdirectories in KB:
 
-`du -k {{file_or_directory}}`
+`du -k {{path/to/file_or_folder}}`
 
 - Get recursively, individual file/folder sizes in human readable form:
 
-`du -ah {{directory}}`
+`du -ah {{path/to/folder}}`
 
-- List the KB sizes of directories for N levels below the specified directory:
+- List the human-readable sizes of directories for 2 levels of depth below the specified directory:
 
-`du -k -depth=1 {{directory}}`
+`du -h -d 2 {{path/to/folder}}`


### PR DESCRIPTION
The version I have uses `-d` for the depth option, not `-depth`. Here's the version string as shown by `man du`:
```
BSD                              June 2, 2004                              BSD
```

In addition to this fix, this commit changes the tokens to clarify that they are paths, and changes "directory" to "folder", which is shorter and more accessible.