### PR TITLE
add section in dig.md for reverse DNS lookups

### DIFF
--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -13,3 +13,6 @@
 - Specify an alternate DNS server to query (8.8.8.8 is google's public DNS):
 
 `dig @8.8.8.8 {{hostname.com}}`
+
+- Perform a reverse DNS lookup on an IP address (PTR records):
+`dig -x 8.8.8.8`

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -14,6 +14,6 @@
 
 `dig @8.8.8.8 {{hostname.com}}`
 
-- Perform a reverse DNS lookup on an IP address (PTR records):
+- Perform a reverse DNS lookup on an IP address (PTR record):
 
 `dig -x 8.8.8.8`

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -15,4 +15,5 @@
 `dig @8.8.8.8 {{hostname.com}}`
 
 - Perform a reverse DNS lookup on an IP address (PTR records):
+
 `dig -x 8.8.8.8`


### PR DESCRIPTION
Doing a reverse DNS lookup by typing out the IP address in reverse, plus adding `.in-addr.arpa` to the end is tedious, but fortunately `dig` has the `-x` option which makes that process much simpler as one can just feed it a normal IP address. I figured this should be documented for others who want to do reverse DNS lookups.