### PR TITLE
xcodebuild.md: add page

### DIFF
--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -1,15 +1,15 @@
 # xcodebuild
 
-> xcodebuild is build xcode project and generate ipa for command line tools
+> Build Xcode projects.
 
-- Build Workspace (ps: CocoaPods Generate Project)
+- Build workspace (CocoaPods Generate Project):
 
 `xcodebuild -workspace {{YourWorkspace.workspace}} -scheme {{SchemeName}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
 
-- Build Project
+- Build project:
 
 `xcodebuild -target {{targetname}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
 
-- View Sdks
+- Show SDKs:
 
 `xcodebuild -showsdks`

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -4,11 +4,11 @@
 
 - Build workspace (CocoaPods Generate Project):
 
-`xcodebuild -workspace {{YourWorkspace.workspace}} -scheme {{SchemeName}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
+`xcodebuild -workspace {{workspace_name.workspace}} -scheme {{scheme_name}} -configuration {{configuration_name}} clean build SYMROOT={{SYMROOT_path}}`
 
 - Build project:
 
-`xcodebuild -target {{targetname}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
+`xcodebuild -target {{target_name}} -configuration {{configuration_name}} clean build SYMROOT={{SYMROOT_path}}`
 
 - Show SDKs:
 

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -2,7 +2,7 @@
 
 > Build Xcode projects.
 
-- Build workspace (CocoaPods Generate Project):
+- Build workspace:
 
 `xcodebuild -workspace {{workspace_name.workspace}} -scheme {{scheme_name}} -configuration {{configuration_name}} clean build SYMROOT={{SYMROOT_path}}`
 

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -1,0 +1,58 @@
+# xcodebuild
+
+> xcodebuild builds one or more targets contained in an Xcode project, or builds a scheme contained in an
+     Xcode workspace or Xcode project.
+     
+### OS X
+
+- The Mac OS X platform accepts an arch keyword, which can be either x86_64 or i386. x86_64 is the default.
+
+```
+xcodebuild \
+  -workspace MyMacApp.xcworkspace \
+  -scheme MyMacApp \
+  -destination 'platform=OS X,arch=x86_64' \
+  clean test
+```
+
+### iOS
+
+- The iOS platform should be used when you want to run tests on a connected device. It supports two keys, id and name. Either one of the two must be provided, but not both.
+
+```
+xcodebuild \
+  -workspace MyApp.xcworkspace \
+  -scheme MyApp \
+  -destination "platform=iOS,name=Gio's iPhone" \
+  clean test
+```
+
+```
+xcodebuild \
+  -workspace MyApp.xcworkspace \
+  -scheme MyApp \
+  -destination 'platform=iOS,id=YOUR_PHONE_UUID' \
+  clean test
+```
+
+### iOS Simulator
+
+- iOS Simulator is the platform I use more often. It supports the same id and name mutually exclusive keys as iOS, plus an OS key. OS expects a target version number, like 9.1, or latest, which is the default.
+
+```
+xcodebuild \
+  -workspace MyApp.xcworkspace \
+  -scheme MyApp \
+  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
+  clean test
+```
+
+### watchOS and watchOS Simulator
+
+```
+xcodebuild \
+  -workspace MyApp.xcworkspace \
+  -scheme MyWatchKitApp
+  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
+  build
+```

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -1,58 +1,19 @@
 # xcodebuild
 
-> xcodebuild builds one or more targets contained in an Xcode project, or builds a scheme contained in an
-     Xcode workspace or Xcode project.
-     
-### OS X
+> xcodebuild is build xcode project and generate ipa for command line tools
 
-- The Mac OS X platform accepts an arch keyword, which can be either x86_64 or i386. x86_64 is the default.
+- Build Workspace (ps: CocoaPods Generate Project)
 
-```
-xcodebuild \
-  -workspace MyMacApp.xcworkspace \
-  -scheme MyMacApp \
-  -destination 'platform=OS X,arch=x86_64' \
-  clean test
-```
+`xcodebuild -workspace workspacename -scheme schemename -configuration [-configuration configurationname] clean build SYMROOT=(SYMROOT)`
 
-### iOS
+- Build Project
 
-- The iOS platform should be used when you want to run tests on a connected device. It supports two keys, id and name. Either one of the two must be provided, but not both.
+`xcodebuild -target targetname -configuration [-configuration configurationname] clean build SYMROOT=(SYMROOT)`
 
-```
-xcodebuild \
-  -workspace MyApp.xcworkspace \
-  -scheme MyApp \
-  -destination "platform=iOS,name=Gio's iPhone" \
-  clean test
-```
+- View Sdks
 
-```
-xcodebuild \
-  -workspace MyApp.xcworkspace \
-  -scheme MyApp \
-  -destination 'platform=iOS,id=YOUR_PHONE_UUID' \
-  clean test
-```
+`xcodebuild -showsdks`
 
-### iOS Simulator
+- xcrun Generate ipa file 
 
-- iOS Simulator is the platform I use more often. It supports the same id and name mutually exclusive keys as iOS, plus an OS key. OS expects a target version number, like 9.1, or latest, which is the default.
-
-```
-xcodebuild \
-  -workspace MyApp.xcworkspace \
-  -scheme MyApp \
-  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
-  clean test
-```
-
-### watchOS and watchOS Simulator
-
-```
-xcodebuild \
-  -workspace MyApp.xcworkspace \
-  -scheme MyWatchKitApp
-  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
-  build
-```
+`xcrun -sdk iphoneos PackageApplication -v projectName.app -o ipaName.ipa`

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -13,7 +13,3 @@
 - View Sdks
 
 `xcodebuild -showsdks`
-
-- xcrun Generate ipa file 
-
-`xcrun -sdk {{sdk}} PackageApplication -v {{projectName.app}} -o {{ipaName.ipa}}`

--- a/pages/osx/xcodebuild.md
+++ b/pages/osx/xcodebuild.md
@@ -4,11 +4,11 @@
 
 - Build Workspace (ps: CocoaPods Generate Project)
 
-`xcodebuild -workspace workspacename -scheme schemename -configuration [-configuration configurationname] clean build SYMROOT=(SYMROOT)`
+`xcodebuild -workspace {{YourWorkspace.workspace}} -scheme {{SchemeName}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
 
 - Build Project
 
-`xcodebuild -target targetname -configuration [-configuration configurationname] clean build SYMROOT=(SYMROOT)`
+`xcodebuild -target {{targetname}} -configuration {{YourConfiguration}} clean build SYMROOT={{YourSYMROOTPath}}`
 
 - View Sdks
 
@@ -16,4 +16,4 @@
 
 - xcrun Generate ipa file 
 
-`xcrun -sdk iphoneos PackageApplication -v projectName.app -o ipaName.ipa`
+`xcrun -sdk {{sdk}} PackageApplication -v {{projectName.app}} -o {{ipaName.ipa}}`


### PR DESCRIPTION
rebased, squashed and reworded commits from #583 in order to keep only xcodebuild.md (the pod.md changes were picked into #1007) and to provide more informative commit messages.