### PR TITLE
Add `apt-get autoremove`

### DIFF
--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -18,6 +18,10 @@
 
 `apt-get upgrade`
 
+- Remove no longer needed packages:
+
+`apt-get autoremove`
+
 - Upgrade installed packages (like "upgrade"), but remove obsolete packages and install additional packages to meet new dependencies:
 
 `apt-get dist-upgrade`


### PR DESCRIPTION
`apt-get autoremove` is surely one of the six most used `apt-get` commands, so it should be here among the others. For example, it is more common than `apt-get dist-upgrade`.