### PR TITLE
curl.md: add more download examples

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -5,7 +5,15 @@
 
 - Download a URL to a file:
 
-`curl "{{URL}}" -o {{filename}}`
+`curl {{http://localhost}} -o {{filename}}`
+
+- Download file using remote name:
+
+`curl -O {{http://localhost/filename}}`
+
+- Automatically continue/resume previous file transfer:
+
+`curl -O -C - {{http://localhost/filename}}`
 
 - Send form-encoded data:
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -3,17 +3,13 @@
 > Transfers data from or to a server.
 > Supports most protocols including HTTP, FTP, POP.
 
-- Download a URL to a file:
+- Download the contents of an URL to a file:
 
 `curl {{http://example.com}} -o {{filename}}`
 
-- Download file using remote name:
+- Download a file saving it under the same name as indicated in the URL, following redirects, and automatically resuming a previous file transfer:
 
-`curl -O {{http://example.com/filename}}`
-
-- Automatically continue/resume previous file transfer:
-
-`curl -O -C - {{http://example.com/filename}}`
+`curl -O -L -C - {{http://example.com/filename}}`
 
 - Send form-encoded data:
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -3,13 +3,13 @@
 > Transfers data from or to a server.
 > Supports most protocols including HTTP, FTP, POP.
 
-- Download the contents of an URL to a file:
+- Download the [o]utput of an URL to a file, following [L]ocation redirects:
 
-`curl {{http://example.com}} -o {{filename}}`
+`curl -o {{filename}} -L {{http://example.com}}`
 
-- Download a file saving it under the same name as indicated in the URL, following redirects, and automatically resuming a previous file transfer:
+- Download a file saving the [O]utput under the same filename as indicated in the URL, and automatically [C]ontinuing/resuming a previous file transfer:
 
-`curl -O -L -C - {{http://example.com/filename}}`
+`curl -O -C - {{http://example.com/filename}}`
 
 - Send form-encoded data:
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -5,40 +5,40 @@
 
 - Download a URL to a file:
 
-`curl {{http://localhost}} -o {{filename}}`
+`curl {{http://example.com}} -o {{filename}}`
 
 - Download file using remote name:
 
-`curl -O {{http://localhost/filename}}`
+`curl -O {{http://example.com/filename}}`
 
 - Automatically continue/resume previous file transfer:
 
-`curl -O -C - {{http://localhost/filename}}`
+`curl -O -C - {{http://example.com/filename}}`
 
 - Send form-encoded data:
 
-`curl --data {{name=bob}} {{http://localhost/form}}`
+`curl --data {{name=bob}} {{http://example.com/form}}`
 
 - Send JSON data:
 
-`curl -X POST -H "Content-Type: application/json" -d {{'{"name":"bob"}'}} {{http://localhost/login}}`
+`curl -X POST -H "Content-Type: application/json" -d {{'{"name":"bob"}'}} {{http://example.com/login}}`
 
 - Specify an HTTP method:
 
-`curl -X {{DELETE}} {{http://localhost/item/123}}`
+`curl -X {{DELETE}} {{http://example.com/item/123}}`
 
 - Head request:
 
-`curl --head {{http://localhost}}`
+`curl --head {{http://example.com}}`
 
 - Include an extra header:
 
-`curl -H "{{X-MyHeader: 123}}" {{http://localhost}}`
+`curl -H "{{X-MyHeader: 123}}" {{http://example.com}}`
 
 - Pass a user name and password for server authentication:
 
-`curl -u myusername:mypassword {{http://localhost}}`
+`curl -u myusername:mypassword {{http://example.com}}`
 
 - Pass client certificate and key for a secure resource:
 
-`curl -v -key {{key.pem}} -cacert {{ca.pem}} -cert {{client.pem}} -k {{https://localhost}}`
+`curl -v -key {{key.pem}} -cacert {{ca.pem}} -cert {{client.pem}} -k {{https://example.com}}`


### PR DESCRIPTION
- Download using remote file name (instead of using `-o`)
- Download resuming previous file transfer
- Use `example.com` instead of `"URL"` or `localhost` as example host