### PR TITLE
curl: Add more download and rewrite data examples

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -3,15 +3,15 @@
 > Transfers data from or to a server.
 > Supports most protocols including HTTP, FTP, POP.
 
-- Download the output of an URL to a file:
+- Download the contents of an URL to a file:
 
 `curl {{http://example.com}} -o {{filename}}`
 
-- Download a file saving the output under the same filename as indicated in the URL:
+- Download a file saving it under the same name as indicated in the URL:
 
 `curl -O {{http://example.com/filename}}`
 
-- Download a file using the filename in the URL, following [L]ocation redirects, and automatically [C]ontinuing/resuming a previous file transfer:
+- Download a file, following [L]ocation redirects, and automatically [C]ontinuing/resuming a previous file transfer:
 
 `curl -O -L -C - {{http://example.com/filename}}`
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -3,34 +3,34 @@
 > Transfers data from or to a server.
 > Supports most protocols including HTTP, FTP, POP.
 
-- Download a URL to a file:
+- Download the output of an URL to a file:
 
-`curl "{{URL}}" -o {{filename}}`
+`curl {{http://example.com}} -o {{filename}}`
 
-- Send form-encoded data:
+- Download a file saving the output under the same filename as indicated in the URL:
 
-`curl --data {{name=bob}} {{http://localhost/form}}`
+`curl -O {{http://example.com/filename}}`
 
-- Send JSON data:
+- Following [L]ocation redirects, download a file using the filename in the URL, and automatically [C]ontinuing/resuming a previous file transfer:
 
-`curl -X POST -H "Content-Type: application/json" -d {{'{"name":"bob"}'}} {{http://localhost/login}}`
+`curl -L -O -C - {{http://example.com/filename}}`
 
-- Specify an HTTP method:
+- POST application/x-www-form-urlencoded data:
 
-`curl -X {{DELETE}} {{http://localhost/item/123}}`
+`curl -d {{'name=bob'}} {{http://example.com/form}}`
+
+- Send data, specifying a custom HTTP method, and including an extra header:
+
+`curl -d {{'{"name":"bob"}'}} -X {{PUT}} -H {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
 
 - Head request:
 
-`curl --head {{http://localhost}}`
-
-- Include an extra header:
-
-`curl -H "{{X-MyHeader: 123}}" {{http://localhost}}`
+`curl --head {{http://example.com}}`
 
 - Pass a user name and password for server authentication:
 
-`curl -u myusername:mypassword {{http://localhost}}`
+`curl -u myusername:mypassword {{http://example.com}}`
 
 - Pass client certificate and key for a secure resource:
 
-`curl -v -key {{key.pem}} -cacert {{ca.pem}} -cert {{client.pem}} -k {{https://localhost}}`
+`curl -v -key {{key.pem}} -cacert {{ca.pem}} -cert {{client.pem}} -k {{https://example.com}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -11,9 +11,9 @@
 
 `curl -O {{http://example.com/filename}}`
 
-- Following [L]ocation redirects, download a file using the filename in the URL, and automatically [C]ontinuing/resuming a previous file transfer:
+- Download a file using the filename in the URL, following [L]ocation redirects, and automatically [C]ontinuing/resuming a previous file transfer:
 
-`curl -L -O -C - {{http://example.com/filename}}`
+`curl -O -L -C - {{http://example.com/filename}}`
 
 - POST application/x-www-form-urlencoded data:
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -1,13 +1,13 @@
 # curl
 
 > Transfers data from or to a server.
-> Supports most protocols including HTTP, FTP, POP.
+> Supports most protocols including HTTP, FTP, POP3.
 
 - Download the contents of an URL to a file:
 
 `curl {{http://example.com}} -o {{filename}}`
 
-- Download a file saving it under the same name as indicated in the URL:
+- Download a file saving the output under the filename indicated by the URL:
 
 `curl -O {{http://example.com/filename}}`
 
@@ -15,17 +15,13 @@
 
 `curl -O -L -C - {{http://example.com/filename}}`
 
-- POST application/x-www-form-urlencoded data:
+- Send form-encoded data (POST request of type application/x-www-form-urlencoded):
 
 `curl -d {{'name=bob'}} {{http://example.com/form}}`
 
 - Send data, specifying a custom HTTP method, and including an extra header:
 
 `curl -d {{'{"name":"bob"}'}} -X {{PUT}} -H {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
-
-- Head request:
-
-`curl --head {{http://example.com}}`
 
 - Pass a user name and password for server authentication:
 


### PR DESCRIPTION
- Based on discussion in #1019
- Download: first example introduces `-o`, second one introduces `-O`,
  third example introduces `-L` and `-C` using brackets as per #1018
- Data: first example introduces `-d` (default method is POST and
  default Content-Type is application/x-www-form-urlencoded), second
  example introduces `-X` and `-H`
- Count of examples is still 8 as before