### PR TITLE
chmod: Use brackets instead of parenthesis

### DIFF
--- a/pages/common/chmod.md
+++ b/pages/common/chmod.md
@@ -2,22 +2,22 @@
 
 > Change the access permissions of a file or directory.
 
-- Give the (u)ser who owns a file the right to e(x)ecute it:
+- Give the [u]ser who owns a file the right to e[x]ecute it:
 
 `chmod u+x {{file}}`
 
-- Give the user rights to (r)ead and (w)rite to a file/directory:
+- Give the user rights to [r]ead and [w]rite to a file/directory:
 
 `chmod u+rw {{file}}`
 
-- Remove executable rights from the (g)roup:
+- Remove executable rights from the [g]roup:
 
 `chmod g-x {{file}}`
 
-- Give (a)ll users rights to read and execute:
+- Give [a]ll users rights to read and execute:
 
 `chmod a+rx {{file}}`
 
-- Give (o)thers (not in the file owner's group) the same rights as the group:
+- Give [o]thers (not in the file owner's group) the same rights as the group:
 
 `chmod o=g {{file}}`


### PR DESCRIPTION
- To specify which single-letter parameter is being referenced
- As per #1018
- [grep](https://tldr.ostera.io/grep) also uses brackets