### PR TITLE
git-stash: Make examples clearer

### DIFF
--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -2,11 +2,11 @@
 
 > Stash local Git changes in a temporary area.
 
-- Stash current changes, except new files:
+- Stash current changes, except new (untracked) files:
 
 `git stash [save {{optional_stash_message}}]`
 
-- Stash current changes, including new/untracked files:
+- Stash current changes, including new (untracked) files:
 
 `git stash -u`
 
@@ -18,7 +18,7 @@
 
 `git stash apply {{optional_stash_name_or_commit}}`
 
-- Apply a stash (default is stash@{0}), and remove it from the list if applying doesn't cause conflicts:
+- Apply a stash (default is stash@{0}), and remove it from the stash list if applying doesn't cause conflicts:
 
 `git stash pop {{optional_stash_name}}`
 

--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -4,24 +4,24 @@
 
 - Stash current changes (except new files):
 
-`git stash save {{optional_stash_name}}`
+`git stash save {{optional_stash_message}}`
 
 - Include new files in the stash (leaves the index completely clean):
 
-`git stash save -u {{optional_stash_name}}`
+`git stash save -u {{optional_stash_message}}`
 
 - List all stashes:
 
 `git stash list`
 
-- Re-apply the latest stash:
+- Apply a stash (default is the latest, named stash@{0}):
 
-`git stash pop`
+`git stash apply {{optional_stash_name_or_commit}}`
 
-- Re-apply a stash by name:
+- Apply a stash (default is stash@{0}), and remove it from the list if applying doesn't cause conflicts:
 
-`git stash apply {{stash_name}}`
+`git stash pop {{optional_stash_name}}`
 
-- Drop a stash by an index:
+- Drop a stash (default is stash@{0}):
 
-`git stash drop stash@{index}`
+`git stash drop {{optional_stash_name}}`

--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -2,15 +2,15 @@
 
 > Stash local Git changes in a temporary area.
 
-- Stash current changes (except new files):
+- Stash current changes, except new files:
 
-`git stash save {{optional_stash_message}}`
+`git stash [save {{optional_stash_message}}]`
 
-- Include new files in the stash (leaves the index completely clean):
+- Stash current changes, including new/untracked files:
 
-`git stash save -u {{optional_stash_message}}`
+`git stash -u`
 
-- List all stashes:
+- List all stashes (shows stash name, related branch and message):
 
 `git stash list`
 


### PR DESCRIPTION
- Difference between a stash name and a stash message was not clear. For
  example, you cannot do:

      $ git stash save foo
      $ git stash apply foo
      fatal: ambiguous argument 'foo': unknown revision or path not in
      the working tree.

- Difference between stash `apply` and `pop` was not clear
- Make it clearer that all `apply`, `pop` and `drop` can take an
  optional stash name, and that the default name is `stash@{0}`