### PR TITLE
more: Remove redundant `(next)` for Page down

### DIFF
--- a/pages/common/more.md
+++ b/pages/common/more.md
@@ -10,7 +10,7 @@
 
 - Page down:
 
-`<Space> (next)`
+`<Space>`
 
 - Search for a string:
 


### PR DESCRIPTION
- This makes sense in the less page, where there are examples for both
  Page down and up, but not here.