### PR TITLE
add CLA to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Contributions are most welcome! All `tldr` pages are stored in Markdown right here on GitHub.
 Just open an issue or send a pull request and we'll incorporate it as soon as possible.
+To get started, sign the [Contributor License Agreement](https://www.clahub.com/agreements/tldr-pages/tldr).
 
 *Note*: when submitting a new command, don't forget to check if there's already a pull request in progress for it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are most welcome! All `tldr` pages are stored in Markdown right here on GitHub.
 Just open an issue or send a pull request and we'll incorporate it as soon as possible.
-To get started, sign the [Contributor License Agreement](https://www.clahub.com/agreements/tldr-pages/tldr).
+To get started, sign the [Contributor License Agreement](https://cla-assistant.io/tldr-pages/tldr).
 
 *Note*: when submitting a new command, don't forget to check if there's already a pull request in progress for it.
 


### PR DESCRIPTION
All contributors to this project are invited to voice their opinion about this Contributor License Agreement (CLA) :) I crafted it after doing some research on CLAs, particularly https://github.com/clahub/clahub#whats-a-cla and https://opensource.com/law/11/7/trouble-harmony-part-1

The text of the CLA can be found at https://cla-assistant.io/tldr-pages/tldr. Copied below for convenience:

> ## TDLR Pages contributor agreement

> (1) I assert that any past, present and future contributions I make to the tldr-pages project are my own work, and that I have the right to license them.
>
> (2) I agree to license all my contributions to the tldr-pages project under the terms of the license included in the tldr-pages repository I’m contributing to.
>
> (3) I grant the tldr-pages organization a license to distribute my contributions under any open content license compliant with the Open Definition [a], or any open source software license approved by the Open Source Initiative [b], as applicable.
>
> a. http://opendefinition.org/licenses
>
> b. https://opensource.org/licenses/alphabetical

/cc all the maintainers, and the top 50 contributors (as of today): @igorshubovych, @oxguy3, @rubenvereecken, @rprieto, @notpeter, @onesuper, @ostera, @agnivade, @pando, @felixonmars, @Cvetomird91, @alx741, @dylanrees, @Dahie, @joelhy, @steelywing, @lord63, @sbrl, @akoenig, @naxoc, @sethwoodworth, @Like-all, @slash3b, @britter, @ericbn, @chirag64, @mumumu, @bobstrecansky, @Larry850806, @chuanconggao, @Duologic, @matthewgao, @denis-sokolov, @AloisMahdal, @Leandros, @lagelalegal, @martypenner, @fordhurley, @kuanyui, @pindexis, @egilkh, @d33tah, @bripkens, @Fallon9111, @eddieantonio, @RoryCrispin, @tjwudi, @jlems, @dbrgn, @kumon

(this PR also serves as a test for the cla-assistant integration)