### PR TITLE
added BSD column command

### DIFF
--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -1,6 +1,6 @@
 # column
 
-> format input into multiple columns, rows are filled before columns, empty lines are ignored.
+> Format input into multiple columns, rows are filled before columns, empty lines are ignored.
  
 - Output is formatted for a display columns wide.
 

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -1,0 +1,21 @@
+# column
+
+> format input into multiple columns, rows are filled before columns, empty lines are ignored.
+ 
+- Output is formatted for a display columns wide.
+
+`printf "header1 header2\nbar foo\n" | column -c 10`
+
+- Specify a set of characters to be used to delimit columns for the -t option, default is whitespace.
+
+`printf "header1,header2\nbar,foo\n" | column -s,`
+
+- Determine the number of columns the input contains and create a table.
+
+`printf "header1 header2\nbar foo\n" | column -t`
+
+`printf "header1,header2\nbar,foo\n" | column -t -s,`
+
+-x Fill columns before filling rows.
+
+`printf "header1\nbar\nfoobar\n" | column -c 20 -x`

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -1,8 +1,8 @@
 # column
 
-> Format input into multiple columns, rows are filled before columns, empty lines are ignored.
+> Format standard input into multiple columns.
  
-- Output is formatted for a display columns wide.
+- Output is formatted for a display columns wide: 
 
 `printf "header1 header2\nbar foo\n" | column -c 10`
 


### PR DESCRIPTION
Built following this man page : [column(1): columnate lists - Linux man page](http://linux.die.net/man/1/column)

Sadly the options don't have a long format, that's why is so hard for me to remember.

It is similar to [tldr/csvlook.md](https://github.com/tldr-pages/tldr/blob/aa60fa0f7ad3c9d5471b77329686a3e40e270106/pages/common/csvlook.md), but way quicker.

I hope the format is ok, I din't install the linter/formatter locally.

Thanks for tldr!