### PR TITLE
column: add page

### DIFF
--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -3,9 +3,9 @@
 > Format standard input or file into multiple columns.
 > Rows are filled before columns; default separator is whitespace.
 
-- Format output for a 10 columns wide display:
+- Format output for a 30 characters wide display:
 
-`printf "header1 header2\nbar foo\n" | column -c {{10}}`
+`printf "header1 header2\nbar foo\n" | column -c {{30}}`
 
 - Specify column delimiter character for the -t option (i.e. "," for csv); default is whitespace:
 
@@ -17,4 +17,4 @@
 
 - Fill columns before filling rows:
 
-`printf "header1\nbar\nfoobar\n" | column -c {{20}} -x`
+`printf "header1\nbar\nfoobar\n" | column -c {{30}} -x`

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -1,0 +1,19 @@
+# column
+
+> Format standard or file input into multiple columns, rows are filled before columns.
+
+- Output is formatted for a display columns wide:
+
+`printf "header1 header2\nbar foo\n" | column -c 10`
+
+- Specify a set of characters to be used to delimit columns for the -t option, default is whitespace:
+
+`printf "header1,header2\nbar,foo\n" | column -s,`
+
+- Determine the number of columns the input contains and create a table:
+
+`printf "header1 header2\nbar foo\n" | column -t`
+
+- Fill columns before filling rows:
+
+`printf "header1\nbar\nfoobar\n" | column -c 20 -x`

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -4,7 +4,7 @@
 
 - Output is formatted for a display columns wide:
 
-`printf "header1 header2\nbar foo\n" | column -c 10`
+`printf "header1 header2\nbar foo\n" | column -c {{10}}`
 
 - Specify a set of characters to be used to delimit columns for the -t option, default is whitespace:
 
@@ -16,4 +16,4 @@
 
 - Fill columns before filling rows:
 
-`printf "header1\nbar\nfoobar\n" | column -c 20 -x`
+`printf "header1\nbar\nfoobar\n" | column -c {{20}} -x`

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -2,15 +2,15 @@
 
 > Format standard or file input into multiple columns, rows are filled before columns.
 
-- Output is formatted for a display columns wide:
+- Output is formatted for a 10 columns wide display:
 
 `printf "header1 header2\nbar foo\n" | column -c {{10}}`
 
-- Specify a set of characters to be used to delimit columns for the -t option, default is whitespace:
+- Specify characters to use to delimit columns for the -t option (i.e. "," for csv), default is whitespace:
 
-`printf "header1,header2\nbar,foo\n" | column -s,`
+`printf "header1,header2\nbar,foo\n" | column -s{{,}}`
 
-- Determine the number of columns the input contains and create a table:
+- Determine the number of columns and auto-align the output in a tabular format:
 
 `printf "header1 header2\nbar foo\n" | column -t`
 

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -1,16 +1,17 @@
 # column
 
-> Format standard or file input into multiple columns, rows are filled before columns.
+> Format standard input or file into multiple columns.
+> Rows are filled before columns; default separator is whitespace.
 
-- Output is formatted for a 10 columns wide display:
+- Format output for a 10 columns wide display:
 
 `printf "header1 header2\nbar foo\n" | column -c {{10}}`
 
-- Specify characters to use to delimit columns for the -t option (i.e. "," for csv), default is whitespace:
+- Specify column delimiter character for the -t option (i.e. "," for csv); default is whitespace:
 
 `printf "header1,header2\nbar,foo\n" | column -s{{,}}`
 
-- Determine the number of columns and auto-align the output in a tabular format:
+- Split columns automatically and auto-align in a tabular format:
 
 `printf "header1 header2\nbar foo\n" | column -t`
 


### PR DESCRIPTION
Built following this man page : [column(1): columnate lists - Linux man page](http://linux.die.net/man/1/column)

Sadly the options don't have a long format, that's why is so hard for me to remember.

It is similar to [tldr/csvlook.md](https://github.com/tldr-pages/tldr/blob/aa60fa0f7ad3c9d5471b77329686a3e40e270106/pages/common/csvlook.md), but way quicker.

After some trouble, I installed  the linter/formatter locally via the [arch-npm/](https://hub.docker.com/r/nfnty/arch-npm/) docker image and aliased `tldrl` as
 `alias tldrl "docker exec npm tldrl"`, work like a charm :-)

Thanks for tldr!