### PR TITLE
Stlink pages

### DIFF
--- a/pages/common/st-flash.md
+++ b/pages/common/st-flash.md
@@ -2,13 +2,13 @@
 
 > Flash binary files to STM32 ARM Cortex microcontrollers.
 
-- Read 4096 bytes of the firmware:
+- Read 4096 bytes from the device starting from 0x8000000:
 
-`st-flash read {{firmware.bin}} 0x8000000 4096`
+`st-flash read {{firmware}}.bin {{0x8000000}} {{4096}}`
 
-- Write firmware to device:
+- Write firmware to device starting from 0x8000000:
 
-`st-flash write {{firmware.bin}} 0x8000000`
+`st-flash write {{firmware}}.bin {{0x8000000}}`
 
 - Erase firmware from device:
 

--- a/pages/common/st-flash.md
+++ b/pages/common/st-flash.md
@@ -1,0 +1,15 @@
+# st-flash
+
+> Flash binary files to STM32 ARM Cortex microcontrollers.
+
+- Read 4096 bytes of the firmware:
+
+`st-flash read {{firmware.bin}} 0x8000000 4096`
+
+- Write firmware to device:
+
+`st-flash write {{firmware.bin}} 0x8000000`
+
+- Erase firmware from device:
+
+`st-flash erase`

--- a/pages/common/st-info.md
+++ b/pages/common/st-info.md
@@ -1,0 +1,15 @@
+# st-info
+
+> Provides information about connected STLink and STM32 devices.
+
+- Display about of program memory available:
+
+`st-info --flash`
+
+- Display about of sram memory available:
+
+`st-info --sram`
+
+- Display summarized information of the device:
+
+`st-info --probe`

--- a/pages/common/st-info.md
+++ b/pages/common/st-info.md
@@ -2,11 +2,11 @@
 
 > Provides information about connected STLink and STM32 devices.
 
-- Display about of program memory available:
+- Display amount of program memory available:
 
 `st-info --flash`
 
-- Display about of sram memory available:
+- Display amount of sram memory available:
 
 `st-info --sram`
 

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -1,6 +1,6 @@
 # st-util
 
-> Run GDB server to interact with STM32 ARM Cortex microcontoller.
+> Run GDB (GNU Debugger) server to interact with STM32 ARM Cortex microcontoller.
 
 - Run GDB server on port 4500:
 

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -4,7 +4,7 @@
 
 - Run GDB server on port 4500:
 
-`st-util -p 4500`
+`st-util --listen_port {{4500}}`
 
 - Connect to GDB server:
 

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -8,7 +8,7 @@
 
 - Connect to GDB server:
 
-`(gdb) target extended-remote {{localhost}}:4500`
+`(gdb) target extended-remote {{localhost}}:{{4500}}`
 
 - Write firmware to device:
 

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -1,0 +1,15 @@
+# st-util
+
+> Run GDB server to interact with STM32 ARM Cortex microcontoller.
+
+- Run GDB server on port 4500:
+
+`st-util -p 4500`
+
+- Connect to GDB server:
+
+`(gdb) target extended-remote localhost:4500`
+
+- Write firmware to device:
+
+`(gdb) load {{firmware.elf}}`

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -4,11 +4,11 @@
 
 - Run GDB server on port 4500:
 
-`st-util --listen_port {{4500}}`
+`st-util -p {{4500}}`
 
 - Connect to GDB server:
 
-`(gdb) target extended-remote localhost:4500`
+`(gdb) target extended-remote {{localhost}}:4500`
 
 - Write firmware to device:
 


### PR DESCRIPTION
[STLink](https://github.com/texane/stlink) provides some tools for developing on STM32 ARM Cortex microcontrollers.

- st-flash
- st-util
- st-info

Those are the standard open source tools for STM32.