### PR TITLE
git-rebase: add --onto option

### DIFF
--- a/pages/common/git-rebase.md
+++ b/pages/common/git-rebase.md
@@ -20,4 +20,4 @@
 
 - Rebase your local branch by specifying new base commit and old base commit:
 
-`git rebase --onto {{NEW-BASE-COMMIT}} {{OLD-BASE-COMMIT}}`
+`git rebase --onto {{new_base_commit}} {{old_base_commit}}`

--- a/pages/common/git-rebase.md
+++ b/pages/common/git-rebase.md
@@ -6,7 +6,7 @@
 
 `git rebase -i master`
 
-- Rebase your local branch  interactively with the latest changes from upstream:
+- Rebase your local branch interactively with the latest changes from upstream:
 
 `git fetch origin; git rebase -i origin/master`
 
@@ -17,3 +17,7 @@
 - Abort a rebase in-progress:
 
 `git rebase --abort`
+
+- Rebase your local branch by specifying new base commit and old base commit:
+
+`git rebase --onto {{NEW-BASE-COMMIT}} {{OLD-BASE-COMMIT}}`


### PR DESCRIPTION
`git rebase --onto <NEW_BASE> <OLD_BASE>` is a common usage if you want to keep history tidy.