### PR TITLE
page format: lowercase command names consistently

### DIFF
--- a/pages/common/c99.md
+++ b/pages/common/c99.md
@@ -1,4 +1,4 @@
-# C99
+# c99
 
 > Compiles C programs according to the ISO C standard.
 

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -1,4 +1,4 @@
-# Gradle
+# gradle
 
 > Gradle is the official build system for Android Studio.
 

--- a/pages/common/handbrakecli.md
+++ b/pages/common/handbrakecli.md
@@ -1,19 +1,19 @@
-# HandBrakeCLI
+# handbrakecli
 
-> Video conversion tool.
+> Command-line interface to the HandBrake video conversion tool.
 
 - Convert a video file to MKV (AAC 160kbit audio and x264 CRF20 video):
 
-`HandBrakeCLI -i {{input.avi}} -o {{output.mkv}} -e x264 -q 20 -B 160`
+`handbrakecli -i {{input.avi}} -o {{output.mkv}} -e x264 -q 20 -B 160`
 
 - Resize a video file to 320x240:
 
-`HandBrakeCLI -i {{input.mp4}} -o {{output.mp4} -w 320 -l 240`
+`handbrakecli -i {{input.mp4}} -o {{output.mp4} -w 320 -l 240`
 
 - List available presets:
 
-`HandBrakeCLI --preset-list`
+`handbrakecli --preset-list`
 
 - Convert an AVI video to MP4 using the Android preset:
 
-`HandBrakeCLI --preset="Android" -i {{input.ext}} -o {{output.mp4}}`
+`handbrakecli --preset="Android" -i {{input.ext}} -o {{output.mp4}}`

--- a/pages/common/mp4box.md
+++ b/pages/common/mp4box.md
@@ -1,15 +1,15 @@
-# MP4Box
+# mp4box
 
 > MPEG-4 Systems Toolbox - Muxes streams into MP4 container.
 
 - Display information about an existing MP4 file:
 
-`MP4Box -info {{filename}}`
+`mp4box -info {{filename}}`
 
 - Add an SRT subtitle file into an MP4 file:
 
-`MP4Box -add {{input_subs.srt}}:lang=eng -add {{input.mp4}} {{output.mp4}}`
+`mp4box -add {{input_subs.srt}}:lang=eng -add {{input.mp4}} {{output.mp4}}`
 
 - Combine audio from one file and video from another:
 
-`MP4Box -add {{input1.mp4}}#audio -add {{input2.mp4}}#video {{output.mp4}`
+`mp4box -add {{input1.mp4}}#audio -add {{input2.mp4}}#video {{output.mp4}`

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -1,6 +1,6 @@
 # parallel
 
-> GNU Parallel: Run commands on multiple CPU cores.
+> Run commands on multiple CPU cores.
 
 - Gzip several files at once, using all cores:
 

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -1,6 +1,6 @@
-# GNU Parallel
+# parallel
 
-> Run commands on multiple CPU cores.
+> GNU Parallel: Run commands on multiple CPU cores.
 
 - Gzip several files at once, using all cores:
 

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -1,4 +1,4 @@
-# Python
+# python
 
 > Python language interpreter.
 

--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -1,4 +1,4 @@
-# SSH
+# ssh
 
 > Secure Shell is a protocol used to securely log onto remote systems.
 > It can be used for logging or executing commands on a remote server.

--- a/pages/common/sshfs.md
+++ b/pages/common/sshfs.md
@@ -1,4 +1,4 @@
-# SSHFS
+# sshfs
 
 > Filesystem client based on ssh.
 

--- a/pages/osx/xctool.md
+++ b/pages/osx/xctool.md
@@ -1,10 +1,10 @@
-# XCTool
+# xctool
 
 > Tool for building Xcode projects.
 
 - Build a single project without any workspace:
 
-`xctool.sh -project {{YourProject.xcodeproj}} -scheme {{YourScheme}} build`
+`xctool -project {{YourProject.xcodeproj}} -scheme {{YourScheme}} build`
 
 - Build a project that is part of a workspace:
 


### PR DESCRIPTION
Inspired by @liuderchi's #1081 and others before that: #967, #965, #947, #699, #658, #534, #313, #312, #309, and #308 (Phew! I think I got them all. Maybe we should create a new label for large-scale cleanups like these).