### PR TITLE
Setting cache to false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ language: node_js
 node_js:
   - 'stable'
 
-cache:
-  directories:
-    - node_modules
+cache: false
 
 after_success:
 - bash scripts/build.sh


### PR DESCRIPTION
- This was not letting new changes from tldr-lint repo to be fetched.
Therefore, preventing new checks like trailing spaces to appear.
- Also, its a good practice to get possible updates from npm packages.