### PR TITLE
Pin down the dependencies to their exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Simplified, community-driven man pages",
   "dependencies": {
-    "glob": "=7.0.0",
-    "markdownlint-cli": "=0.1.0",
-    "tldr-lint": "^0.0.7",
-    "husky": "=0.11.3"
+    "glob": "7.0.0",
+    "markdownlint-cli": "0.1.0",
+    "tldr-lint": "~0.0.7",
+    "husky": "0.11.3"
   },
   "scripts": {
     "precommit": "npm test",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Simplified, community-driven man pages",
   "dependencies": {
-    "glob": "^7.0.0",
-    "markdownlint-cli": "^0.1.0",
+    "glob": "=7.0.0",
+    "markdownlint-cli": "=0.1.0",
     "tldr-lint": "^0.0.7",
-    "husky": "^0.11.3"
+    "husky": "=0.11.3"
   },
   "scripts": {
     "precommit": "npm test",


### PR DESCRIPTION
- And keep tldr-lint on a greater than mode

As discussed in #1095 