### PR TITLE
vim: Normal mode is the normal mode

### DIFF
--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,7 +1,7 @@
 # vim
 
 > Vi IMproved, a programmer's text editor, providing several modes for different kinds of text manipulation.
-> Pressing `i` enters edit mode; the normal mode (accessed via `<Esc>`) doesn't allow regular text editing.
+> Pressing `i` enters edit mode. `<Esc>` goes back to normal mode, which doesn't allow regular text insertion.
 
 - Open a file:
 
@@ -9,24 +9,28 @@
 
 - Enter text editing mode (insert mode):
 
-`<Esc> i`
+`<Esc>i`
 
 - Copy ("yank") or cut ("delete") the current line (paste it with `P`):
 
-`<Esc> {{yy|dd}}`
+`<Esc>{{yy|dd}}`
 
 - Undo the last operation:
 
-`<Esc> u`
+`<Esc>u`
 
-- Search for a pattern in the file (press `n` to go to the next result):
+- Search for a pattern in the file:
 
-`<Esc> /{{search_pattern}} <Enter>`
+`<Esc>/{{search_pattern}}<Enter>   then   n (next), N (previous)`
 
-- Perform a regex substitution in the whole file (from the start, `1`, to the end, `$`):
+- Perform a regex substitution in the whole file:
 
-`<Esc> :1,$s/{{pattern}}/{{replacement}}/g <Enter>`
+`<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
 
-- Save (write) the file, and quit vim:
+- Save (write) the file, and quit:
 
-`<Esc> :wq <Enter>`
+`<Esc>:wq<Enter>`
+
+- Quit without saving:
+
+`<Esc>:q!<Enter>`

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -19,13 +19,13 @@
 
 `<Esc>u`
 
-- Search for a pattern in the file:
+- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
 
-`<Esc>/{{search_pattern}}<Enter>   then   n (next), N (previous)`
+`<Esc>/{{search_pattern}}<Enter>`
 
-- Perform a regex substitution in the whole file:
+- Perform a regex substitution in the whole file (from the start, `1`, to the end, `$`):
 
-`<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
+`<Esc>:1,$s/{{pattern}}/{{replacement}}/g<Enter>`
 
 - Save (write) the file, and quit:
 


### PR DESCRIPTION
Once in normal mode, which is the mode user should stay most of the time in vim, one does not need to press `<Esc>` before each command. Insert mode is a temporary mode.
Make this more explicit in the examples (using the ...then... format also present in `less`, `more`, etc.) Also use ...then... for the search example.
Remove the yand and delete example, due to the complexity and the fact that there's `P` to paste before and `p` to paste after the cursor, and in favor of the quit without saving example.