### PR TITLE
less, more: Don't use ...then... in examples

### DIFF
--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -8,21 +8,21 @@
 
 `less {{source_file}}`
 
-- Page up / down:
+- Page down / up:
 
-`<Space> (next), b (previous)`
+`<Space> (down), b (up)`
 
-- Go to start / end of file:
+- Go to end / start of file:
 
-`g (start), G (end)`
+`G (end), g (start)`
 
-- Forward search for a string:
+- Forward search for a string (press `n`/`N` to go to next/previous match):
 
-`/{{something}}   then   n (next), N (previous)`
+`/{{something}}`
 
-- Backward search for a string:
+- Backward search for a string (press `n`/`N` to go to next/previous match):
 
-`?{{something}}   then   n (next), N (previous)`
+`?{{something}}`
 
 - Enable output of ANSI colors:
 

--- a/pages/common/more.md
+++ b/pages/common/more.md
@@ -12,9 +12,9 @@
 
 `<Space>`
 
-- Search for a string:
+- Search for a string (press `n` to go to the next match):
 
-`/{{something}}   then   n (next)`
+`/{{something}}`
 
 - Exit:
 


### PR DESCRIPTION
Instead, explain additional keystrokes in the example title. See https://github.com/tldr-pages/tldr/pull/1106#discussion_r82836295

Also, change order of page up / down in `less` example to match title and to match the order of the other examples.