### PR TITLE
yum: added "provides" as it is incredibly useful

### DIFF
--- a/pages/linux/yum.md
+++ b/pages/linux/yum.md
@@ -14,6 +14,10 @@
 
 `yum -y install {{package}}`
 
+- Find the package that provides a particular command:
+
+`yum provides {{command}}`
+
 - Remove a package:
 
 `yum remove {{package}}`


### PR DESCRIPTION
"yum provides" is incredibly useful when you come from a different distro, and you don't know exactly what package provides a particular command.