### PR TITLE
fuck: add page

### DIFF
--- a/pages/common/fuck.md
+++ b/pages/common/fuck.md
@@ -1,6 +1,7 @@
 # fuck
 
 > Corrects your previous console command.
+> Often repeated multiple times until it reaches a matched rule.
 
 - Try to match a rule for the previous command:
 

--- a/pages/common/fuck.md
+++ b/pages/common/fuck.md
@@ -1,0 +1,8 @@
+# fuck
+
+> Corrects your previous console command.
+
+- Try to match a rule for the previous command:
+
+`fuck`
+

--- a/pages/common/fuck.md
+++ b/pages/common/fuck.md
@@ -2,6 +2,10 @@
 
 > Corrects your previous console command.
 
+- Set the `fuck` alias to `thefuck` tool:
+
+`eval "$(thefuck --alias)"`
+
 - Try to match a rule for the previous command:
 
 `fuck`

--- a/pages/common/fuck.md
+++ b/pages/common/fuck.md
@@ -1,7 +1,6 @@
 # fuck
 
 > Corrects your previous console command.
-> Often repeated multiple times until it reaches a matched rule.
 
 - Try to match a rule for the previous command:
 

--- a/pages/common/fuck.md
+++ b/pages/common/fuck.md
@@ -5,4 +5,3 @@
 - Try to match a rule for the previous command:
 
 `fuck`
-


### PR DESCRIPTION
fuck command has no options.
However, you should consider setting the alias first (for example in ~/.bashrc) as specified in 'thefuck' repository.
fixes #1097 