### PR TITLE
bc: add a line about interactive usage with mathlib

### DIFF
--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -2,11 +2,7 @@
 
 > Calculator.
 
-- Run calculator in interactive mode:
-
-`bc -i`
-
-- Run calculator in interactive mode with floating point support:
+- Run calculator in interactive mode using the standard math library:
 
 `bc -l`
 

--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -6,6 +6,10 @@
 
 `bc -i`
 
+- Run calculator in interactive mode with floating point support:
+
+`bc -l`
+
 - Calculate the result of an expression:
 
 `bc <<< "(1 + 2) * 2 ^ 2"`

--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -10,7 +10,7 @@
 
 `bc <<< "(1 + 2) * 2 ^ 2"`
 
-- Calculate with the given precision:
+- Calculate expression and force number of decimal places to 10:
 
 `bc <<< "scale=10; 5 / 3"`
 


### PR DESCRIPTION
Usually `bc` isn't very useful if it doesn't return floating point numbers where appropriate. e.g., 3/4 returns 0 when started with `-i` but for most users they would expect 0.75 to be returned so the tldr should mention that the argument `-l`does floating point arithmetic.