### PR TITLE
rg: add page

### DIFF
--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -1,0 +1,19 @@
+# ripgrep (rg)
+
+> A fast commandline search tool.
+
+- Recursively search the current directory for a regex pattern:
+
+`rg {{pattern}}`
+
+- Search in all .gitignored and hidden files:
+
+`rg -uu {{pattern}}`
+
+- Search only in html or css files for a pattern:
+
+`rg -thtml -tcss {{pattern}}`
+
+- Only search for a pattern in files matching a glob (e.g., 'README.*'):
+
+`rg {{pattern}} -g {{glob}}`

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -1,4 +1,4 @@
-# ripgrep (rg)
+# ripgrep
 
 > A fast commandline search tool.
 

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -1,19 +1,19 @@
 # ripgrep
 
-> A fast commandline search tool.
+> A fast command-line search tool.
 
 - Recursively search the current directory for a regex pattern:
 
 `rg {{pattern}}`
 
-- Search in all .gitignored and hidden files:
+- Search for pattern including all .gitignored and hidden files:
 
 `rg -uu {{pattern}}`
 
-- Search only in html or css files for a pattern:
+- Search for a pattern only in a certain filetype (e.g., html, css, etc.):
 
-`rg -thtml -tcss {{pattern}}`
+`rg -t {{filetype}} {{pattern}}`
 
-- Only search for a pattern in files matching a glob (e.g., 'README.*'):
+- Search for a pattern in files matching a glob (e.g., `README.*`):
 
 `rg {{pattern}} -g {{glob}}`

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -14,6 +14,10 @@
 
 `rg -t {{filetype}} {{pattern}}`
 
+- Search for a pattern only in a subset of directories:
+
+`rg {{pattern}} {{set_of_subdirs}}`
+
 - Search for a pattern in files matching a glob (e.g., `README.*`):
 
 `rg {{pattern}} -g {{glob}}`


### PR DESCRIPTION
ripgrep is a fast command line searcher like awk or the silver searcher that is implemented in rust.