### PR TITLE
ansible: add page

### DIFF
--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -1,0 +1,27 @@
+# ansible
+
+> Manage groups of computers remotely over SSH
+
+- List hosts belonging to a group:
+
+`ansible {{group}} --list-hosts`
+
+- Ping a group of hosts by invoking the ping module:
+
+`ansible {{group}} -m ping`
+
+- Display facts about a group of hosts by invoking the setup module:
+
+`ansible {{group}} -m setup`
+
+- Execute a command on a group of hosts by invoking command module with arguments:
+
+`ansible {{group}} -m command -a '{{my command}}'`
+
+- Execute a command with administrative privileges:
+
+`ansible {{group}} --become --ask-become-pass -m command -a '{{my command}}'`
+
+- Execute a command using a custom inventory file:
+
+`ansible {{group}} -i {{inventory_file}} -m command -a '{{my command}}'`

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -1,6 +1,7 @@
 # ansible
 
-> Manage groups of computers remotely over SSH. Use the /etc/ansible/hosts file to add new groups/hosts
+> Manage groups of computers remotely over SSH.
+> Use the /etc/ansible/hosts file to add new groups/hosts.
 
 - List hosts belonging to a group:
 

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -1,6 +1,6 @@
 # ansible
 
-> Manage groups of computers remotely over SSH
+> Manage groups of computers remotely over SSH. Use the /etc/ansible/hosts file to add new groups/hosts
 
 - List hosts belonging to a group:
 


### PR DESCRIPTION
Add new page for `ansible`.

I've verified the commands listed in the page on my MacBook, with `localhost` as the test group