### PR TITLE
logger: add page

### DIFF
--- a/pages/linux/logger.md
+++ b/pages/linux/logger.md
@@ -10,7 +10,7 @@
 
 `echo {{log_entry}} | logger`
 
-- Send the output to a remote syslog server running at a given port. Default port is `syslog`:
+- Send the output to a remote syslog server running at a given port. Default port is 514:
 
 `echo {{log_entry}} | logger --server {{hostname}} --port {{port}}`
 

--- a/pages/linux/logger.md
+++ b/pages/linux/logger.md
@@ -1,6 +1,6 @@
 # logger
 
-> Add messages to syslog.
+> Add messages to syslog (/var/log/syslog).
 
 - Log a message to syslog:
 
@@ -8,16 +8,16 @@
 
 - Take input from stdin and log to syslog:
 
-`tail -f {{app.log}} | logger`
+`echo {{log_entry}} | logger`
 
 - Send the output to a remote syslog server running at a given port. Default port is `syslog`:
 
-`tail -f {{app.log}} | logger --server {{hostname}} --port {{port}}`
+`echo {{log_entry}} | logger --server {{hostname}} --port {{port}}`
 
 - Use a specific tag for every line logged. Default is the name of logged in user:
 
-`tail -f {{app.log}} | logger --tag {{tag}}`
+`echo {{log_entry}} | logger --tag {{tag}}`
 
 - Log messages with a given priority. Default is `user.notice`. See `man logger` for all priority options:
 
-`tail -f {{app.log}} | logger --priority {{user.warning}}`
+`echo {{log_entry}} | logger --priority {{user.warning}}`

--- a/pages/linux/logger.md
+++ b/pages/linux/logger.md
@@ -1,0 +1,23 @@
+# logger
+
+> Add messages to syslog.
+
+- Log a message to syslog:
+
+`logger {{message}}`
+
+- Take input from stdin and log to syslog:
+
+`tail -f {{app.log}} | logger`
+
+- Send the output to a remote syslog server running at a given port. Default port is `syslog`:
+
+`tail -f {{app.log}} | logger --server {{hostname}} --port {{port}}`
+
+- Use a specific tag for every line logged. Default is the name of logged in user:
+
+`tail -f {{app.log}} | logger --tag {{tag}}`
+
+- Log messages with a given priority. Default is `user.notice`. See `man logger` for all priority options:
+
+`tail -f {{app.log}} | logger --priority {{user.warning}}`

--- a/pages/osx/logger.md
+++ b/pages/osx/logger.md
@@ -1,0 +1,23 @@
+# logger
+
+> Add messages to syslog.
+
+- Log a message to syslog:
+
+`logger {{message}}`
+
+- Take input from stdin and log to syslog:
+
+`tail -f {{app.log}} | logger`
+
+- Send the output to a remote syslog server running at a given port. Default port is `syslog`:
+
+`tail -f {{app.log}} | logger -h {{hostname}} -P {{port}}`
+
+- Use a specific tag for every line logged. Default is the name of logged in user:
+
+`tail -f {{app.log}} | logger -t {{tag}}`
+
+- Log messages with a given priority. Default is `user.notice`. See `man logger` for all priority options:
+
+`tail -f {{app.log}} | logger -p {{user.warning}}`

--- a/pages/osx/logger.md
+++ b/pages/osx/logger.md
@@ -1,6 +1,6 @@
 # logger
 
-> Add messages to syslog.
+> Add messages to syslog (/var/log/syslog).
 
 - Log a message to syslog:
 
@@ -8,16 +8,16 @@
 
 - Take input from stdin and log to syslog:
 
-`tail -f {{app.log}} | logger`
+`echo {{log_entry}} | logger`
 
 - Send the output to a remote syslog server running at a given port. Default port is `syslog`:
 
-`tail -f {{app.log}} | logger -h {{hostname}} -P {{port}}`
+`echo {{log_entry}} | logger -h {{hostname}} -P {{port}}`
 
 - Use a specific tag for every line logged. Default is the name of logged in user:
 
-`tail -f {{app.log}} | logger -t {{tag}}`
+`echo {{log_entry}} | logger -t {{tag}}`
 
 - Log messages with a given priority. Default is `user.notice`. See `man logger` for all priority options:
 
-`tail -f {{app.log}} | logger -p {{user.warning}}`
+`echo {{log_entry}} | logger -p {{user.warning}}`

--- a/pages/osx/logger.md
+++ b/pages/osx/logger.md
@@ -10,7 +10,7 @@
 
 `echo {{log_entry}} | logger`
 
-- Send the output to a remote syslog server running at a given port. Default port is `syslog`:
+- Send the output to a remote syslog server running at a given port. Default port is 514:
 
 `echo {{log_entry}} | logger -h {{hostname}} -P {{port}}`
 


### PR DESCRIPTION
Splitting page into 2 variants because mac does not have the expanded options. So it's difficult to remember -P (port) and -p (priority). Hence using expanded options in linux, and short options in mac.