### PR TITLE
uname: split page to provide contextually-relevant info in the main desc.

### DIFF
--- a/pages/linux/uname.md
+++ b/pages/linux/uname.md
@@ -1,7 +1,7 @@
 # uname
 
 > Print details about the current machine and the operating system running on it.
-> Note: If you're on Linux, try also the `lsb_release` command.
+> Note: for additional information about the operating system, try the `lsb_release` command.
 
 - Print hardware-related information: machine and processor:
 

--- a/pages/osx/uname.md
+++ b/pages/osx/uname.md
@@ -1,0 +1,20 @@
+# uname
+
+> Print details about the current machine and the operating system running on it.
+> Note: for additional information about the operating system, try the `sw_vers` command.
+
+- Print hardware-related information: machine and processor:
+
+`uname -mp`
+
+- Print software-related information: operating system, release number, and version:
+
+`uname -srv`
+
+- Print the nodename (hostname) of the system:
+
+`uname -n`
+
+- Print all available system information (hardware, software, nodename):
+
+`uname -a`


### PR DESCRIPTION
Instead of a "if you're on Linux, which is irrelevant to those who aren't, this change uses tldr-pages' platform-specific support to provide relevant information for Linux and OS X users.