### PR TITLE
Adds dpkg note for finding which package owns a file

### DIFF
--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -17,3 +17,7 @@
 - List package contents:
 
 `dpkg -L {{package_name}}`
+
+- Find out which package owns a file
+
+`dpkg -S {{file_name}}`


### PR DESCRIPTION
This is the `apt` equivalent of `yum`'s `what-provides` command.

    dpkg -S `which dpkg`
    -> dpkg: /usr/bin/dpkg
