### PR TITLE
nc: correct syntax for listen example

### DIFF
--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -4,7 +4,7 @@
 
 - Listen on a specified port:
 
-`nc  -l {{port}}`
+`nc  -l -p {{port}}`
 
 - Connect to a certain port (you can then write to this port):
 


### PR DESCRIPTION
On my machine the nc command requires the `-p` argument