### PR TITLE
sudo: use `shutdown -h` to halt rather than reboot

### DIFF
--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -12,7 +12,7 @@
 
 - To shutdown the machine:
 
-`sudo {{shutdown}} -r +10 {{"Cya soon!"}}`
+`sudo {{shutdown}} -h +10 {{"Cya soon!"}}`
 
 - To repeat the last command as sudo:
 


### PR DESCRIPTION
Makes the example consistent with the command