### PR TITLE
hub: overhaul the page for improved clarify

### DIFF
--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -1,24 +1,24 @@
 # hub
 
-> A command-line wrapper for git that makes you better at GitHub.
+> A wrapper for git that adds commands for working with github-based projects.
 > The commands can also be used using "git" instead of "hub".
 
-- Clone a repository you own:
+- Clone a repository you own, using just the repository name rather than the full URL:
 
 `hub clone {{repo_name}}`
 
-- Clone another user's repository:
+- Clone another user's repository, using their github username and the repository name:
 
-`hub clone {{github_username}}/{{repo_name}}`
+`hub clone {{username}}/{{repo_name}}`
 
-- Fork your own copy of a repository cloned from another user (must be in the cloned repository folder, creates a remote named after your GitHub username):
+- Create a fork of the current repository (cloned directly from another user) under your github profile:
 
 `hub fork`
 
-- Create a pull request from your fork (first pushing the changes to your fork remote, named after your GitHub username):
+- Create a pull request of the current branch in the upstream project (after sending the changes to your fork on github):
 
-`git push {{your_github_username}} {{current_branch}} && hub pull-request`
+`hub pull-request`
 
-- Open the current project's issues page:
+- Upload the current repository to your github account:
 
-`hub browse -- issues`
+`hub create`


### PR DESCRIPTION
- make main description and command descriptions more specific
- simplify the fork command description
- simplify the pull-request example (both the command and description) hopefully without sacrificing information
- replace the browse issues example (which opens a page in the web browser) with one create a github remote for the current repo