### PR TITLE
apt: add page

### DIFF
--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -1,0 +1,31 @@
+# apt
+
+> Package management utility for Debian based distributions. 
+
+- Synchronize list of packages and versions available. This should be run first, before running subsequent apt commands:
+
+`apt update`
+
+- Search for packages:
+
+`apt search {{package}}`
+
+- Install a new package:
+
+`apt install {{package}}`
+
+- Remove a package (using "purge" instead also removes configuration files):
+
+`apt remove {{package}}`
+
+- Upgrade installed packages to newest available versions:
+
+`apt upgrade`
+
+- Remove no longer needed packages:
+
+`apt autoremove`
+
+- Upgrade installed packages (like "upgrade"), but remove obsolete packages and install additional packages to meet new dependencies:
+
+`apt full-upgrade`

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -2,7 +2,7 @@
 
 > Package management utility for Debian based distributions. 
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent apt commands:
+- Update list of packages and versions available. This should be run before running further apt commands:
 
 `apt update`
 
@@ -14,11 +14,11 @@
 
 `apt install {{package}}`
 
-- Remove a package (using "purge" instead also removes configuration files):
+- Remove a package (using "purge" instead also removes its configuration files):
 
 `apt remove {{package}}`
 
-- Upgrade installed packages to newest available versions:
+- Upgrade installed packages to the newest available versions:
 
 `apt upgrade`
 
@@ -26,6 +26,6 @@
 
 `apt autoremove`
 
-- Upgrade installed packages (like "upgrade"), but remove obsolete packages and install additional packages to meet new dependencies:
+- Upgrade installed packages and remove no longer needed packages:
 
 `apt full-upgrade`

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -1,6 +1,6 @@
 # apt
 
-> Package management utility for Debian based distributions. 
+> Package management utility for Debian based distributions.
 
 - Update list of packages and versions available. This should be run before running further apt commands:
 


### PR DESCRIPTION
Since #1164 was closed I thought I might give it a try. I included the `purge` command in the description of `remove` because the page already has more than the recommended amount of commands (5-6).
Also included the `search` command, since @agnivade mentioned it in #1164. Most of the other commands are adapted or taken directly from the `apt-get` page.

Thanks for reviewing