### PR TITLE
pacman: add -Ql (List all files owned by a given package.) example

### DIFF
--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -30,6 +30,10 @@
 
 `pacman -Qo {{filename}}`
 
+- List all files owned by a given package:
+
+`pacman -Ql {{package_name}}`
+
 - Empty package cache to free up space:
 
 `pacman -Scc`


### PR DESCRIPTION
Example output:

```
$ pacman -Ql hexedit
hexedit /usr/
hexedit /usr/bin/
hexedit /usr/bin/hexedit
hexedit /usr/share/
hexedit /usr/share/man/
hexedit /usr/share/man/man1/
hexedit /usr/share/man/man1/hexedit.1.gz
```