### PR TITLE
apt-key: add adv option

### DIFF
--- a/pages/linux/apt-key.md
+++ b/pages/linux/apt-key.md
@@ -17,3 +17,7 @@
 - Add a remote key to the trusted keystore:
 
 `wget -qO - {{https://host.tld/filename.key}} | apt-key add -`
+
+- Add a key from keyserver with only key id:
+
+`apt-key adv --keyserver pgp.mit.edu --recv KEYID`

--- a/pages/linux/apt-key.md
+++ b/pages/linux/apt-key.md
@@ -20,4 +20,4 @@
 
 - Add a key from keyserver with only key id:
 
-`apt-key adv --keyserver pgp.mit.edu --recv KEYID`
+`apt-key adv --keyserver {{pgp.mit.edu}} --recv {{KEYID}}`


### PR DESCRIPTION
It's useful when dealing with errors like:

`There is no public key available for the following key IDs:xxxxx`