### PR TITLE
cmus: edit markup

### DIFF
--- a/pages/linux/cmus.md
+++ b/pages/linux/cmus.md
@@ -1,6 +1,6 @@
 # cmus
 
-> Commandline C* Music Player.
+> Commandline Music Player.
 > Use arrow keys to navigate, `<enter/return>` to select, and numbers 1-8 switch between different views.
 
 - Open cmus from specified directory:

--- a/pages/linux/cmus.md
+++ b/pages/linux/cmus.md
@@ -1,7 +1,7 @@
 # cmus
 
 > Commandline C* Music Player.
-> Arrow keys to navogate, `<enter/return>` to select, numbers 1-8 switch between different views.
+> Use arrow keys to navigate, `<enter/return>` to select, and numbers 1-8 switch between different views.
 
 - Open cmus from specified directory:
 
@@ -15,10 +15,10 @@
 
 `c`
 
-- Toggle shuffle:
+- Toggle shuffle mode on/off:
 
 `s`
 
-- Close cmus:
+- Quit cmus:
 
 `q`

--- a/pages/linux/cmus.md
+++ b/pages/linux/cmus.md
@@ -9,7 +9,7 @@
 
 - Add file/directory to library:
 
-`:add {{/path/to/file_or_directory}}`
+`:add {{path/to/file_or_directory}}`
 
 - Pause/unpause current song:
 

--- a/pages/linux/cmus.md
+++ b/pages/linux/cmus.md
@@ -1,0 +1,24 @@
+# cmus
+
+> Commandline C* Music Player.
+> Arrow keys to navogate, `<enter/return>` to select, numbers 1-8 switch between different views.
+
+- Open cmus from specified directory:
+
+`cmus {{path/to/directory}}`
+
+- Add file/directory to library:
+
+`:add {{/path/to/file_or_directory}}`
+
+- Pause/unpause current song:
+
+`c`
+
+- Toggle shuffle:
+
+`s`
+
+- Close cmus:
+
+`q`


### PR DESCRIPTION
Removed a '/' from one of the path tokens to make it match the community markup guidelines.