### PR TITLE
git-push: revamp page

### DIFF
--- a/pages/common/git-push.md
+++ b/pages/common/git-push.md
@@ -1,23 +1,31 @@
 # git push
 
-> Push commits to a remote repository.
+> Push commits to a remote (upstream) repository.
 
-- Publish local changes on a remote branch:
+- Send local changes in the current branch to its remote counterpart:
+
+`git push`
+
+- Send local changes in a given branch to its remote counterpart:
 
 `git push {{remote_name}} {{local_branch}}`
 
-- Publish local changes on a remote branch of different name:
+- Publish the current branch to a remote repository, setting the upstream branch name:
 
-`git push {{remote_name}} {{local_branch}}:{{remote_branch}}`
+`git push {{remote_name}} -u {{remote_branch}}`
 
-- Remove remote branch:
+- Send changes on all local branches to their remote counterparts:
 
-`git push {{remote_name}} :{{remote_branch}}`
+`git push --all`
 
-- Remove remote branches which don't exist locally:
+- Delete a branch in a remote repository:
+
+`git push {{remote_name}} --delete {{remote_branch}}`
+
+- Remove local references to branches that have been deleted in a remote repository:
 
 `git push --prune {{remote_name}}`
 
-- Publish tags:
+- Publish tags that aren't yet in the remote repository:
 
 `git push --tags`

--- a/pages/common/git-push.md
+++ b/pages/common/git-push.md
@@ -1,6 +1,6 @@
 # git push
 
-> Push commits to a remote (upstream) repository.
+> Push commits to a remote repository.
 
 - Send local changes in the current branch to its remote counterpart:
 
@@ -10,7 +10,7 @@
 
 `git push {{remote_name}} {{local_branch}}`
 
-- Publish the current branch to a remote repository, setting the upstream branch name:
+- Publish the current branch to a remote repository, setting the remote branch name:
 
 `git push {{remote_name}} -u {{remote_branch}}`
 

--- a/pages/common/git-push.md
+++ b/pages/common/git-push.md
@@ -14,15 +14,15 @@
 
 `git push {{remote_name}} -u {{remote_branch}}`
 
-- Send changes on all local branches to their remote counterparts:
+- Send changes on all local branches to their counterparts in a given remote repository:
 
-`git push --all`
+`git push --all {{remote_name}}`
 
 - Delete a branch in a remote repository:
 
 `git push {{remote_name}} --delete {{remote_branch}}`
 
-- Remove local references to branches that have been deleted in a remote repository:
+- Remove remote branches that don't have a local counterpart:
 
 `git push --prune {{remote_name}}`
 


### PR DESCRIPTION
Hopefully making it more useful and explicit.

Added a plain `git push` example, a `git push --all`, updated the remote branch deletion example, and reworded the descriptions.