### PR TITLE
git-fetch: --prune doesn't delete local branches

### DIFF
--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -18,6 +18,6 @@
 
 `git fetch --tags`
 
-- Delete local remote-tracking branches that have been deleted upstream:
+- Delete local references to remote branches that have been deleted upstream:
 
 `git fetch --prune`


### PR DESCRIPTION
`git fetch --prune` deletes the local *references* to upstream branches (i.e. entries in `.git/refs/remotes/`), but the local *branches* that tracked them (i.e. entries in `.git/refs/heads/`) are kept.