### PR TITLE
tar.md: Add -C option

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -30,3 +30,7 @@
 - List the contents of a tar file:
 
 `tar tvf {{source.tar}}`
+
+- Change to a different target directory, removing one leading component from file names. Useful in installing archived binary distributions:
+
+`tar -C {{/usr/local}} --strip-components {{1}} -xJf {{source}}.tar.xz`


### PR DESCRIPTION
I use this option very frequently while installing a new version of node or golang, where the binary distribution is a tarball.