### PR TITLE
mtime argument (find command) expect numeric value

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -16,7 +16,7 @@
 
 - Find files modified since a certain time:
 
-`find {{root_path}} -name '{{}}' -mtime {{-1d}}`
+`find {{root_path}} -name '{{}}' -mtime {{-1}}`
 
 - Find files using case insensitive name matching, of a certain size:
 
@@ -24,7 +24,7 @@
 
 - Delete files by name, older than a certain number of days:
 
-`find {{root_path}} -name '{{*.ext}}' -mtime {{-180d}} -delete`
+`find {{root_path}} -name '{{*.ext}}' -mtime {{-180}} -delete`
 
 - Find empty files or directories:
 


### PR DESCRIPTION
> -mtime n
File's data was last modified n*24 hours ago. See the comments for -atime to understand how rounding affects the interpretation of file modification times.

[source](https://linux.die.net/man/1/find)

You can also search [this page](https://www.gnu.org/software/findutils/manual/html_mono/find.html) for `-mtime` to see some examples:

```
find ~/ -daystart -type f -mtime 1
find /tmp /var/tmp -depth -not -type d -mtime +3 -delete
find /var/tmp/stuff -mtime +90 -exec /bin/rm {} \;
find /var/tmp/stuff -mtime +90 -delete
```