### PR TITLE
tput: add two examples

### DIFF
--- a/pages/common/tput.md
+++ b/pages/common/tput.md
@@ -22,10 +22,6 @@
 
 `tput sgr0`
 
-- Disable word wrap:
+- Enable / Disable word wrap:
 
-`tput rmam`
-
-- Enable word wrap:
-
-`tput smam`
+`tput {{smam|rmam}}`

--- a/pages/common/tput.md
+++ b/pages/common/tput.md
@@ -21,3 +21,11 @@
 - Reset all terminal attributes:
 
 `tput sgr0`
+
+- Disable word wrap:
+
+`tput rmam`
+
+- Enable word wrap:
+
+`tput smam`


### PR DESCRIPTION
* Added `word wrap` examples
So I kind of pushed us to 7 examples here - however - i feel like if you have an enable word wrap command you need to also know how to disable it.