### PR TITLE
yesod: add page

### DIFF
--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -1,11 +1,11 @@
 # yesod
 
 > A framework to develop Haskell web applications.
-> All yesod commands are invoked through the stack project manager.
+> All yesod commands are invoked through the `stack` project manager.
 
-- Create a new scaffolded site:
+- Create a new scaffolded site with sqlite as backend in `my-project` directory:
 
-`stack new my-project yesod-sqlite`
+`stack new {{my-project}} {{yesod-sqlite}}`
 
 - Install the Yesod CLI tool within a Yesod scaffolded site:
 

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -13,12 +13,12 @@
 
 - Start development server:
 
-`stack -- exec yesod devel`
+`stack exec -- yesod devel`
 
 - Touch files with altered Template Haskell dependencies:
 
-`stack -- exec yesod touch`
+`stack exec -- yesod touch`
 
 - Deploy application using Keter (Yesod's deployment manager):
 
-`stack -- exec yesod keter`
+`stack exec -- yesod keter`

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -1,0 +1,19 @@
+# yesod
+
+> Yesod web framework CLI helper.
+
+- Install Yesod CLI tool in a Yesod scaffolding:
+
+`stack build yesod-bin cabal-install --install-ghc`
+
+- Start development server:
+
+`stack -- exec yesod devel`
+
+- Touch files with altered Template Haskell dependencies:
+
+`stack -- exec yesod devel`
+
+- Deploy application using Keter:
+
+`stack -- exec yesod keter`

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -1,8 +1,13 @@
 # yesod
 
-> Yesod web framework CLI helper.
+> A framework to develop Haskell web applications.
+> All yesod commands are invoked through the stack project manager.
 
-- Install Yesod CLI tool in a Yesod scaffolding:
+- Create a new scaffolded site:
+
+`stack new my-project yesod-sqlite`
+
+- Install the Yesod CLI tool within a Yesod scaffolded site:
 
 `stack build yesod-bin cabal-install --install-ghc`
 
@@ -14,6 +19,6 @@
 
 `stack -- exec yesod devel`
 
-- Deploy application using Keter:
+- Deploy application using Keter (Yesod's deployment manager):
 
 `stack -- exec yesod keter`

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -17,7 +17,7 @@
 
 - Touch files with altered Template Haskell dependencies:
 
-`stack -- exec yesod devel`
+`stack -- exec yesod touch`
 
 - Deploy application using Keter (Yesod's deployment manager):
 


### PR DESCRIPTION
The *yesod* CLI has a `--help` option but using it through the *stack* tool is a requirement and thus passing double dash arguments to it is cumbersome. This `TLDR` comes in handy to remember that clumsy commands to actually use the CLI tool.