### PR TITLE
zramctl: add page

### DIFF
--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -1,7 +1,7 @@
 # zramctl
 
 > Setup and control zram devices.
-> Use `mke2fs` to format zram devices to partitions.
+> Use `mke2fs` or `mkswap` to format zram devices to partitions.
 
 - Check if zram is enabled:
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -1,12 +1,13 @@
 # zramctl
 
 > Setup and control zram devices.
+> Use `mke2fs` to format zram devices to partitions.
 
 - Check if zram is enabled:
 
 `lsmod | grep -i zram`
 
-- Enable zram with 2 devices:
+- Enable zram with 2 devices. Use `zramctl` to configure the devices further:
 
 `sudo modprobe zram num_devices={{2}}`
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -1,0 +1,23 @@
+# zramctl
+
+> Setup and control zram devices
+
+- Check if zram is enabled:
+
+`lsmod | grep -i zram`
+
+- Enable zram with 2 devices:
+
+`sudo modprobe zram num_devices={{2}}`
+
+- Initialise the next free zram device to a 2GB virtual drive:
+
+`sudo zramctl --find --streams {{compression_streams_count}} --size {{2GB}} --algorithm lz4`
+
+- List currently initialised devices:
+
+`zramctl`
+
+- Format a zram device to ext4:
+
+`sudo mkfs.ext4 {{/dev/zram0}}`

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -12,7 +12,7 @@
 
 - Initialise the next free zram device to a 2GB virtual drive:
 
-`sudo zramctl --find --streams {{compression_streams_count}} --size {{2GB}} --algorithm lz4`
+`sudo zramctl --find --streams {{4}} --size {{2GB}} --algorithm lz4`
 
 - List currently initialised devices:
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -1,6 +1,6 @@
 # zramctl
 
-> Setup and control zram devices
+> Setup and control zram devices.
 
 - Check if zram is enabled:
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -10,14 +10,10 @@
 
 `sudo modprobe zram num_devices={{2}}`
 
-- Initialise the next free zram device to a 2GB virtual drive:
+- Find and initialise the next free zram device to a 2GB virtual drive using lz4 compression:
 
-`sudo zramctl --find --streams {{4}} --size {{2GB}} --algorithm lz4`
+`sudo zramctl --find --size {{2GB}} --algorithm {{lz4}}`
 
 - List currently initialised devices:
 
 `zramctl`
-
-- Format a zram device to ext4:
-
-`sudo mkfs.ext4 {{/dev/zram0}}`


### PR DESCRIPTION
zram is a linux kernel module, available since 3.14 and installed by default, that allows you to create virtual disks that are compressed on the fly and stored in ram.

While this PR adds a page about it, I don't expect it to be anywhere near perfect at first :P

http://karelzak.blogspot.co.uk/2014/08/zramctl.html