### PR TITLE
logwatch: add page

### DIFF
--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -8,4 +8,4 @@
 
 - Restrict report to only include information for a selected service:
 
-`logwatch --range {{all}} --service {{apache|pam_unix|etc}}
+`logwatch --range {{all}} --service {{apache|pam_unix|etc}}`

--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -1,11 +1,7 @@
 # logwatch
 
-> Analyzes and summarizes system logs.
+> Summarizes many different logs for common services (e.g., apache, SSHD, etc.) in single report.
 
-- Analyze yesterday's logs in medium detail:
+- Analyze logs for a range of dates at certain level of detail:
 
-`logwatch --range yesterday --detail med`
-
-- Get the summarized login information for the last 3 weeks:
-
-`logwatch --range 'since 3 weeks ago' --detail low --service pam_unix `
+`logwatch --range {{yesterday|today|all|help}} --detail {{low|medium|others}}'`

--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -1,0 +1,11 @@
+# logwatch
+
+> Analyzes and summarizes system logs.
+
+- Analyze yesterday's logs in medium detail:
+
+`logwatch --range yesterday --detail med`
+
+- Get the summarized login information for the last 3 weeks:
+
+`logwatch --range 'since 3 weeks ago' --detail low --service pam_unix `

--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -1,7 +1,11 @@
 # logwatch
 
-> Summarizes many different logs for common services (e.g., apache, SSHD, etc.) in single report.
+> Summarizes many different logs for common services (e.g., apache, pam_unix, sshd, etc.) in a single report.
 
 - Analyze logs for a range of dates at certain level of detail:
 
 `logwatch --range {{yesterday|today|all|help}} --detail {{low|medium|others}}'`
+
+- Restrict report to only include information for a selected service:
+
+`logwatch --range {{all}} --service {{apache|pam_unix|etc}}


### PR DESCRIPTION
Logwatch is a useful command to summarize log files. It can be configured to use settings from it's config file and run by cron, but it can also be useful to run ad-hoc from the command line.