### PR TITLE
Recursive scp arguments reversed

### DIFF
--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -13,7 +13,7 @@
 
 - Recursively copy the contents of a directory on a remote host to a local directory:
 
-`scp -r {{path/to/local_dir}} {{remote_host}}:{{path/to/remote_dir}}`
+`scp -r {{remote_host}}:{{path/to/remote_dir}} {{path/to/local_dir}}`
 
 - Copy a file between two remote hosts transferring through the local host:
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -11,7 +11,7 @@
 
 `scp {{remote_host}}:{{path/to/remote_file}} {{path/to/local_dir}}`
 
-- Recursively copy the contents of a directory on a remote host to a local directory:
+- Recursively copy the contents of a directory from a remote host to a local directory:
 
 `scp -r {{remote_host}}:{{path/to/remote_dir}} {{path/to/local_dir}}`
 


### PR DESCRIPTION
The command to "copy [...] on a remote host to a local
directory" in the current scp tldr page was backwards.

scp arguments take the form `scp from to`.