### PR TITLE
cowsay: remove overly complex example, reword desc

### DIFF
--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -1,8 +1,7 @@
 # cowsay
 
 > Generate an ASCII character like a cow or sheep saying or thinking something.
-> Available characters are stored in the /usr/share/cowsay on Linux.
-> And /usr/local/share/cows/ on Mac.
+> Available characters are stored in /usr/share/cowsay on Linux, and /usr/local/share/cows/ on Mac.
 
 - Print an ASCII cow saying "Hello world!":
 
@@ -15,7 +14,3 @@
 - Print a stoned thinking ASCII cow:
 
 `cowthink -s "I'm just a cow, not a great thinker ..."`
-
-- Print out a list of all characters with cowsay:
-
-`ls -1 {{cowsay_character_directory}}  | rev | cut -c 5- | rev | xargs -I _ cowsay -f _ cowsay -f _`


### PR DESCRIPTION
I'm sorry @jeeftor, but I don't think the example introduced in #1266 adheres to the spirit of tldr-pages. It seems to be overly complex, too specific, and making use of way more commands than we normally accept as auxiliary to demonstrate the main command's functionality.

Looking forward to hear what you guys think.