### PR TITLE
x11vnc: wording tweaks

### DIFF
--- a/pages/linux/x11vnc.md
+++ b/pages/linux/x11vnc.md
@@ -1,6 +1,6 @@
 # x11vnc
 
-> A VNC server that will enable VNC on an existing display.
+> A VNC server that will enable VNC on an existing display ser.
 > By default, the server will automatically terminate once all clients disconnect from it.
 
 - Launch a VNC server that allows multiple clients to connect:
@@ -11,14 +11,14 @@
 
 `x11vnc -forever -viewonly`
 
-- Launch a VNC server on a specific display and screen:
+- Launch a VNC server on a specific display and screen (both starting at index zero):
 
-`x11vnc -display :{{screen}}.{{display}}`
+`x11vnc -display :{{display}}.{{screen}}`
 
-- Launch a VNC server on screen 2 with the default display:
+- Launch a VNC server on the third display's default screen:
 
 `x11vnc -display :{{2}}`
 
-- Launch a VNC server on the second monitor:
+- Launch a VNC server on the first display's second screen:
 
 `x11vnc -display :{{0}}.{{1}}`

--- a/pages/linux/x11vnc.md
+++ b/pages/linux/x11vnc.md
@@ -1,13 +1,13 @@
 # x11vnc
 
 > A VNC server that will enable VNC on an existing display.
-> By default, once a client disconnects the server will terminate.
+> By default, the server will automatically terminate once all clients disconnect from it.
 
 - Launch a VNC server that allows multiple clients to connect:
 
 `x11vnc -shared`
 
-- Launch the server where the user can only view the screen, and will continue to run even after the last client disconnects:
+- Launch a VNC server in view-only mode, and which won't terminate once the last client disconnects:
 
 `x11vnc -forever -viewonly`
 


### PR DESCRIPTION
Follow-up of #1264.

I would also like to clarify the last example: it's not clear to me what "monitor" means here (screen or display?) and why the description says 2 but the tokens say 0 and 1.