### PR TITLE
curl: simplify last example (#1246)

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -27,6 +27,6 @@
 
 `curl -u myusername:mypassword -I {{http://example.com}}`
 
-- Pass client certificate and key for a secure resource:
+- Pass client certificate and key for a (possibly insecure) resource:
 
 `curl --cert {{client.pem}} --key {{key.pem}} --insecure {{https://example.com}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -29,4 +29,4 @@
 
 - Pass client certificate and key for a secure resource:
 
-`curl --key {{key.pem}} --cacert {{ca.pem}} --cert {{client.pem}} -k {{https://example.com}}`
+`curl --cert {{client.pem}} --key {{key.pem}} -k {{https://example.com}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -29,4 +29,4 @@
 
 - Pass client certificate and key for a secure resource:
 
-`curl --cert {{client.pem}} --key {{key.pem}} -k {{https://example.com}}`
+`curl --cert {{client.pem}} --key {{key.pem}} --insecure {{https://example.com}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -27,6 +27,6 @@
 
 `curl -u myusername:mypassword -I {{http://example.com}}`
 
-- Pass client certificate and key for a (possibly insecure) resource:
+- Pass client certificate and key for a resource, skipping certificate validation:
 
 `curl --cert {{client.pem}} --key {{key.pem}} --insecure {{https://example.com}}`


### PR DESCRIPTION
I wonder if `-k` is needed here. If so, should we use the spelled-out version (`--insecure`)?