### PR TITLE
git-show: various tweaks

### DIFF
--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -2,7 +2,7 @@
 
 > Show various types of git objects (commits, tags, etc.).
 
-- Show information about the latest commit (message, differences, and other metadata):
+- Show information about the latest commit (message, changes, and other metadata):
 
 `git show`
 
@@ -10,7 +10,7 @@
 
 `git show {{commit}}`
 
-- Show information about the commit associated to a given tag:
+- Show information about the commit associated with a given tag:
 
 `git show {{tag}}`
 

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -1,19 +1,23 @@
 # git show
 
-> Show various types of git objects(commits, tags etc.).
+> Show various types of git objects (commits, tags, etc.).
 
-- Show changes made in the latest commit:
+- Show information about the latest commit (message, differences, and other metadata):
 
 `git show`
 
-- Show changes made in a given commit:
+- Show information about a given commit:
 
 `git show {{commit}}`
 
-- Show changes made in the commit with a given tag:
+- Show information about the commit associated to a given tag:
 
 `git show {{tag}}`
 
-- Show the changes made n commits ago on a branch:
+- Show information about the 3rd commit from the tip of a branch:
 
-`git show {{branch}}~{{n}}`
+`git show {{branch}}~{{3}}`
+
+- Show a commit's hash and message in a single line, suppressing the diff output:
+
+`git show --oneline -s {{commit}}`


### PR DESCRIPTION
- adjust punctuation & spacing in main description
- adjust descriptions ("changes" --> "information", and explicitly list which info is returned in the first example)
- use a concrete example for the tilde notation
- add abbreviated example

Follow-up of #1331.