### PR TITLE
README: add DistroWatch web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ You can access these pages on your computer using one of the following clients:
 - Rust clients:
     - [rust-tldr](https://github.com/rilut/rust-tldr) (online lookup): `cargo install tldr`
     - [tealdeer](https://github.com/dbrgn/tealdeer) (fully featured client with offline cache): `cargo install tealdeer`
-- [Web client](https://github.com/ostera/tldr.jsx): http://tldr.ostera.io/
+- Web clients:
+    - [tldr.jsx](https://github.com/ostera/tldr.jsx): http://tldr.ostera.io/
+    - [DistroWatch](https://distrowatch.com/dwres.php?resource=man-pages)
 
 There is also a comprehensive [list of clients in our Wiki](https://github.com/tldr-pages/tldr/wiki/TLDR-clients).
 


### PR DESCRIPTION
I just found out about this -- it looks like DistroWatch has put together a [web client](https://distrowatch.com/dwres.php?resource=man-pages) for tldr pages!

This was first announced on [DistroWatch Weekly, Issue 697, 30 January 2017](https://distrowatch.com/weekly.php?issue=20170130#sitenews), and is linked in the [Contributing to DistroWatch](https://distrowatch.com/dwres.php?resource=contributing#manpage) page.