### PR TITLE
carthage: description tweaks

### DIFF
--- a/pages/osx/carthage.md
+++ b/pages/osx/carthage.md
@@ -1,20 +1,20 @@
 # carthage
 
-> Carthage is a dependency management tool for Cocoa applications.
+> A dependency management tool for Cocoa applications.
 
-- Download and build all dependencies mentioned in Cartfile. Also used to update dependencies to their latest version:
+- Download the latest version of all dependencies mentioned in Cartfile, and build them:
 
 `carthage update`
 
-- Update dependencies and only build for iOS:
+- Update dependencies, but only build for iOS:
 
 `carthage update --platform ios`
 
-- Update dependencies but don't build:
+- Update dependencies, but don't build any of them:
 
 `carthage update --no-build`
 
-- Download and rebuild the current dependency set without updating:
+- Download and rebuild the current version of dependencies (without updating them):
 
 `carthage bootstrap`
 


### PR DESCRIPTION
- changed the main command description to match the project's standards
- reduced the size of the first example's description
- reworded example descriptions for clarity and consistency

Follow-up of #1278.