### PR TITLE
standardize format of keyboard shortcuts

### DIFF
--- a/pages/common/elinks.md
+++ b/pages/common/elinks.md
@@ -8,7 +8,7 @@
 
 - Quit elinks:
 
-`ctrl+c`
+`Ctrl+C`
 
 - Dump output of webpage to console, colorizing the text with ANSI control codes:
 

--- a/pages/common/screen.md
+++ b/pages/common/screen.md
@@ -24,7 +24,7 @@
 
 - Detach from inside a screen:
 
-`ctrl+A D`
+`Ctrl+A D`
 
 - Kill a detached screen:
 

--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -14,6 +14,6 @@
 
 `tail -c {{num}} {{file}}`
 
-- Keep reading file until ctrl-c:
+- Keep reading file until `Ctrl+C`:
 
 `tail -f {{file}}`

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -24,7 +24,7 @@
 
 - Detach from session:
 
-`ctrl+b d`
+`Ctrl+B D`
 
 - Kill session:
 

--- a/pages/linux/xsel.md
+++ b/pages/linux/xsel.md
@@ -2,7 +2,7 @@
 
 > X11 selection and clipboard manipulation tool.
 
-- Use a command's output as input of the clip[b]oard (equivalent to Ctrl+C):
+- Use a command's output as input of the clip[b]oard (equivalent to `Ctrl+C`):
 
 `echo 123 | xsel -ib`
 
@@ -10,7 +10,7 @@
 
 `cat {{file}} | xsel -ib`
 
-- Output the clipboard's contents into the terminal (equivalent to Ctrl+V):
+- Output the clipboard's contents into the terminal (equivalent to `Ctrl+V`):
 
 `xsel -ob`
 


### PR DESCRIPTION
Title case, + sign as separator, wrapped in backticks.