### PR TITLE
pygmentize: various tweaks

### DIFF
--- a/pages/common/pygmentize.md
+++ b/pages/common/pygmentize.md
@@ -22,6 +22,6 @@
 
 `pygmentize -L formatters`
 
-- Output to HTML file with line numbers:
+- Output a full (self-contained) HTML file, with line numbers:
 
-`pygmentize -f html -O linenos=1 -o {{output_file.html}} {{input_file}}`
+`pygmentize -f html -O "full,linenos=True" -o {{output_file.html}} {{input_file}}`

--- a/pages/common/pygmentize.md
+++ b/pages/common/pygmentize.md
@@ -1,27 +1,27 @@
 # pygmentize
 
-> Python based syntax highlighter.
+> Python-based syntax highlighter.
 
-- Highlight file syntax and print to standard output. Language is inferred from the file extension:
+- Highlight file syntax and print to standard output (language is inferred from the file extension):
 
 `pygmentize {{file.py}}`
 
 - Highlight syntax for a given language:
 
-`pygmentize -l {{javascript}} {{javascript_file}}`
+`pygmentize -l {{javascript}} {{input_file}}`
 
-- Show avaliable lexers:
+- List avaliable lexers (processors for input languages):
 
 `pygmentize -L lexers`
 
 - Save output to a file in HTML format:
 
-`pygmentize -f html -o {{file.html}} {{file.py}}`
+`pygmentize -f html -o {{output_file.html}} {{input_file.py}}`
 
-- Show avaliable output formats:
+- List avaliable output formats:
 
 `pygmentize -L formatters`
 
-- Output to HTML file with line numbers, specifying a given language:
+- Output to HTML file with line numbers:
 
-`pygmentize -f html -O linenos=1 -l {{language}} -o {{file.html}} {{file}}`
+`pygmentize -f html -O linenos=1 -o {{output_file.html}} {{input_file}}`

--- a/pages/common/pygmentize.md
+++ b/pages/common/pygmentize.md
@@ -6,7 +6,7 @@
 
 `pygmentize {{file.py}}`
 
-- Highlight syntax for a given language:
+- Explicitly set the language for syntax highlighting:
 
 `pygmentize -l {{javascript}} {{input_file}}`
 
@@ -22,6 +22,6 @@
 
 `pygmentize -L formatters`
 
-- Output a full (self-contained) HTML file, with line numbers:
+- Output an HTML file, with additional formatter options (full page, with line numbers):
 
 `pygmentize -f html -O "full,linenos=True" -o {{output_file.html}} {{input_file}}`

--- a/pages/common/pygmentize.md
+++ b/pages/common/pygmentize.md
@@ -10,7 +10,7 @@
 
 `pygmentize -l {{javascript}} {{input_file}}`
 
-- List avaliable lexers (processors for input languages):
+- List available lexers (processors for input languages):
 
 `pygmentize -L lexers`
 
@@ -18,7 +18,7 @@
 
 `pygmentize -f html -o {{output_file.html}} {{input_file.py}}`
 
-- List avaliable output formats:
+- List available output formats:
 
 `pygmentize -L formatters`
 


### PR DESCRIPTION
- adjust punctuation in main description and first example's description
- mention "list" (rather than "show") in the -L examples, to improve memorability
- explain what lexers are
- clarify which of the parameters are input and output filenames
- simplify last example