### PR TITLE
keyboard shortcuts: further standardization

### DIFF
--- a/pages/common/elinks.md
+++ b/pages/common/elinks.md
@@ -8,7 +8,7 @@
 
 - Quit elinks:
 
-`Ctrl+C`
+`Ctrl + C`
 
 - Dump output of webpage to console, colorizing the text with ANSI control codes:
 

--- a/pages/common/fzf.md
+++ b/pages/common/fzf.md
@@ -10,7 +10,7 @@
 
 `ps axu | fzf`
 
-- Select mutliple files with `Shift-TAB` and write to a file:
+- Select mutliple files with `Shift + Tab` and write to a file:
 
 `find {{path/to/search_files}} -type f | fzf -m > {{filename}}`
 

--- a/pages/common/kill.md
+++ b/pages/common/kill.md
@@ -15,7 +15,7 @@
 
 `kill -{{1|HUP}} {{process_id}}`
 
-- Terminate a program using the SIGINT (interrupt) signal. This is typically initiated by the user pressing `Ctrl+C`:
+- Terminate a program using the SIGINT (interrupt) signal. This is typically initiated by the user pressing `Ctrl + C`:
 
 `kill -{{2|INT}} {{process_id}}`
 

--- a/pages/common/killall.md
+++ b/pages/common/killall.md
@@ -15,7 +15,7 @@
 
 `killall -i {{process_name}}`
 
-- Terminate a process using the SIGINT (interrupt) signal, which is the same signal sent by pressing `Ctrl+C`:
+- Terminate a process using the SIGINT (interrupt) signal, which is the same signal sent by pressing `Ctrl + C`:
 
 `killall -INT {{process_name}}`
 

--- a/pages/common/screen.md
+++ b/pages/common/screen.md
@@ -24,7 +24,7 @@
 
 - Detach from inside a screen:
 
-`Ctrl+A D`
+`Ctrl + A, D`
 
 - Kill a detached screen:
 

--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -14,6 +14,6 @@
 
 `tail -c {{num}} {{file}}`
 
-- Keep reading file until `Ctrl+C`:
+- Keep reading file until `Ctrl + C`:
 
 `tail -f {{file}}`

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -24,7 +24,7 @@
 
 - Detach from session:
 
-`Ctrl+B D`
+`Ctrl + B, D`
 
 - Kill session:
 

--- a/pages/common/wuzz.md
+++ b/pages/common/wuzz.md
@@ -12,12 +12,12 @@
 
 - Send an HTTP request:
 
-`Ctrl+R`
+`Ctrl + R`
 
 - Switch to the next view:
 
-`Ctrl+J, Tab`
+`Ctrl + J, Tab`
 
 - Switch to the previous view:
 
-`Ctrl+K, Shift+Tab`
+`Ctrl + K, Shift + Tab`

--- a/pages/linux/at.md
+++ b/pages/linux/at.md
@@ -2,7 +2,7 @@
 
 > Executes commands at a specified time.
 
-- Open an `at` prompt to create a new set of scheduled commands, press Ctrl+D to save and exit:
+- Open an `at` prompt to create a new set of scheduled commands, press `Ctrl + D` to save and exit:
 
 `at {{hh:mm:ss}}`
 

--- a/pages/linux/rdesktop.md
+++ b/pages/linux/rdesktop.md
@@ -11,7 +11,7 @@
 
 `rdesktop -u Administrator -p passwd123 192.168.1.111:3389`
 
-- Connect to a remote computer with full screen (press `Ctrl+Alt+Enter` to exist):
+- Connect to a remote computer with full screen (press `Ctrl + Alt + Enter` to exist):
 
 `rdesktop -u {{username}} -p {{password}} -f {{host:port}}`
 

--- a/pages/linux/xsel.md
+++ b/pages/linux/xsel.md
@@ -2,7 +2,7 @@
 
 > X11 selection and clipboard manipulation tool.
 
-- Use a command's output as input of the clip[b]oard (equivalent to `Ctrl+C`):
+- Use a command's output as input of the clip[b]oard (equivalent to `Ctrl + C`):
 
 `echo 123 | xsel -ib`
 
@@ -10,7 +10,7 @@
 
 `cat {{file}} | xsel -ib`
 
-- Output the clipboard's contents into the terminal (equivalent to `Ctrl+V`):
+- Output the clipboard's contents into the terminal (equivalent to `Ctrl + V`):
 
 `xsel -ob`
 


### PR DESCRIPTION
This is a follow up of #1354, after discussion in [#1353](https://github.com/tldr-pages/tldr/pull/1353#discussion_r113900953).

This commit primarily changes all keyboard shortcuts to have spaces around the + sign, but it also adjusts capitalization (fzf.md), combinator symbol (fzf.md) and wrapping in backticks (at.md) that were missed in #1354, and standardizes sequences of shortcuts to be comma-separated (screen.md, tmux.md) as was already the case in wuzz.md.