### PR TITLE
ip: add page

### DIFF
--- a/pages/ip.md
+++ b/pages/ip.md
@@ -1,0 +1,27 @@
+# ip
+
+> Networking utilities collection.
+
+- Check address of all interfaces:
+
+`ip {{addr}}`
+
+- Add IPv4 address for eth1:
+
+`ip {{addr}} add 1.2.3.4/24 dev eth1`
+
+- Bring eth1 up:
+
+`ip {{link}} set eth1 up`
+
+- Add subnet route for eth1:
+
+`ip {{route}} add 1.2.3.0/24 dev eth1`
+
+- Given destination IP show which route wll be used:
+
+`ip {{route}} get 8.8.8.8`
+
+- Using shortcut:
+
+`ip {{a}}`


### PR DESCRIPTION
iproute2(command name `ip`) is a great collection of utilities for working with networking.

It is considered the successor of `ifconfig`. It has many features designed for the complex modern network environment(especially in virtualization environment), like VXLAN tunneling, network namespace, ip rules, etc..

More and more Linux distro began to ship with iproute2.  On MacOS you can install using Homebrew:

```
brew install iproute2mac
``` 

See also introduction section [here](https://wiki.linuxfoundation.org/networking/iproute2)