### PR TITLE
Update tmux.md: detach should be lowercase d

### DIFF
--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -24,7 +24,7 @@
 
 - Detach from session:
 
-`Ctrl + B, D`
+`Ctrl + B, d`
 
 - Kill session:
 


### PR DESCRIPTION
Uppercase D chooses which client to detach, mostly used for detaching other users from your session. Lowercase d is for detaching the session being used.