### PR TITLE
git-checkout: correct checkout of remote branch

### DIFF
--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -6,9 +6,13 @@
 
 `git checkout -b {{branch_name}}`
 
-- Switch to an existing local or remote branch:
+- Switch to an existing local branch:
 
 `git checkout {{branch_name}}`
+
+- Switch to an existing remote branch:
+
+`git checkout --track {{remote_name}}/{{branch_name}}`
 
 - Undo unstaged local modification:
 


### PR DESCRIPTION
As described in http://stackoverflow.com/a/9537923 (paraphrased below):

> You need to create a local branch that tracks a remote branch.
> The following command will create a local branch
> tracking the remote branch of the same name.
> When you push your changes the remote branch will be updated.
>
> `git checkout --track [remotename]/[branch]`
>
> This is a shorthand for `git checkout -b [branch] [remotename]/[branch]`.
>
> For git 1.7.2.3 and higher this is enough: `git checkout daves_branch`
>
> Note that with recent git versions,
> **this will command not create a local branch and will put you in a 'detached HEAD' state.**
> If you want a local branch, use the --track option.
> Full details here: http://git-scm.com/book/en/v2/Git-Branching-Remote-Branches#Tracking-Branches

This has bitten me in the rear a few times, and honestly I don't understand why the `--track` behavior is not git's default.

Note: this PR is a follow-up of #1238. /cc @liuderchi (I recall this issue being discussed in a previous PR -- do you?)