### PR TITLE
CONTRIBUTING.md: fix link to CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@
 
 Contributions are most welcome! All `tldr` pages are stored in Markdown right here on GitHub.
 Just open an issue or send a pull request and we'll incorporate it as soon as possible.
-To get started, sign the [Contributor License Agreement](https://cla-assistant.io/tldr-pages/tldr).
+To get started, please [sign](https://cla-assistant.io/tldr-pages/tldr) the
+[Contributor License Agreement](https://gist.github.com/waldyrious/e50feec13683e565769fbd58ce503d4e).
 
 *Note*: when submitting a new command, don't forget to check if there's already a pull request in progress for it.
 


### PR DESCRIPTION
the cla-assistant link leads to a page requesting the user to sign it, which may not be as friendly
since prospective contributors may want to simply read the CLA without a prompt to sign it.