### PR TITLE
New command: hostnamectl

### DIFF
--- a/pages/linux/hostnamectl.md
+++ b/pages/linux/hostnamectl.md
@@ -1,0 +1,11 @@
+# hostnamectl
+
+> Get or set the hostname of the computer.
+
+- Get the hostname of the computer:
+
+`hostnamectl`
+
+- Set the hostname of the computer:
+
+`sudo hostnamectl set-hostname "{{some_hostname}}"`


### PR DESCRIPTION
I've been setting up a raspberry pi just now, and I noticed that `hostnamectl` isn't in tldr-pages! This PR rectifies the problem :P