### PR TITLE
perl: swap -M example with -0, for multiline regex

### DIFF
--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -14,10 +14,6 @@
 
 `perl -e {{perl_statement}}`
 
-- Import module before execution of a perl statement:
-
-`perl -M{{module}} -e {{perl_statement}}`
-
 - Run a Perl script in debug mode, using `perldebug`:
 
 `perl -d {{script.pl}}`
@@ -25,6 +21,10 @@
 - Loo[p] over all lines of a file, editing them [i]n-place using a find/replace [e]xpression:
 
 `perl -p -i -e 's/{{find}}/{{replace}}/g' {{filename}}`
+
+- Run a multi-line find/replace expression on a file (i.e. including line breaks):
+
+`perl -0 -p -i -e 's/{{foo\nbar}}/{{foobar}}/g' {{filename}}`
 
 - Run a find/replace expression on a file, saving the original file with a given extension:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -22,10 +22,10 @@
 
 `perl -p -i -e 's/{{find}}/{{replace}}/g' {{filename}}`
 
-- Run a multi-line find/replace expression on a file (i.e. including line breaks):
-
-`perl -0 -p -i -e 's/{{foo\nbar}}/{{foobar}}/g' {{filename}}`
-
 - Run a find/replace expression on a file, saving the original file with a given extension:
 
 `perl -p -i'.old' -e 's/{{find}}/{{replace}}/g' {{filename}}`
+
+- Run a multi-line find/replace expression on a file, and save the result in another file:
+
+`perl -p0e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`


### PR DESCRIPTION
For completeness: the -0 option is actually used to specify the input record separator
(as an octal or hexadecimal number).
Without it, the record separator is the newline character,
i.e. the files are processed line by line
(which doesn't allow find-replace expressions that include newlines to work).

According to the [documentation](http://perldoc.perl.org/perlrun.html#Command-Switches),
using plain `-0` is not guaranteed to have the effect of parsing the entire file,
because if the file does contain characters
with octal value equal to the parameter passed to (or implied by) the -0 option,
these characters will be treated as line breaks.
However, if the value exceeds 377<sub>8</sub> (i.e. 255),
it won't be matched to characters on the file.
777 is the preferred convention within that exceptional range,
as the highest value that keeps to 3 octal digits.

Here we're forgoing such details and using -0 anyway, since for most cases this will be enough.

See previous discussion in #1239.