### PR TITLE
cmake: add mkdir to the out-of-source build example

### DIFF
--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -7,9 +7,9 @@
 
 `cmake && make`
 
-- Generate a Makefile and use it to compile a project in a separate folder (out-of-source build):
+- Generate a Makefile and use it to compile a project in a separate "build" folder (out-of-source build):
 
-`cd {{build_folder}} && cmake ../ && make`
+`mkdir -p {{build}} && cd {{build}} && cmake ../ && make`
 
 - Run cmake in interactive mode (it will ask for each variable, instead of using defaults):
 


### PR DESCRIPTION
This makes the command slightly more complex, but it better reflects the use case of when the project is first generated.

In any case, the `-p` in `mkdir` ensures the command does not error out if the build folder already exists, so now both cases are supported.

I'm considering a further PR replacing this command by a version using the [-H -B trick](https://www.reddit.com/r/programming/comments/6b9r19/how_to_build_a_cmakebased_project/dhlfh05/), which would change the command to be:

    cmake -H. -B{{build}} && make -C {{build}}

but that can be discussed separately.