### PR TITLE
mosh: add page

### DIFF
--- a/pages/common/mosh.md
+++ b/pages/common/mosh.md
@@ -1,16 +1,11 @@
 # mosh
 
-> Mobile Shell (`mosh`) is remote terminal application that allows roaming.
-> `mosh` is a more robust and responsive replacement for SSH.
-> Visit <https://mosh.org> for more information.
+> Mobile Shell (`mosh`) is a robust and responsive replacement for SSH.
+> `mosh` persists connections to remote servers while roaming between networks.
 
 - Typical usage:
 
 `mosh {{username}}@{{remote_host}}`
-
-- Usage when `mosh-server` binary is outside standard path:
-
-`mosh --server={{/path/to/bin/}}mosh-server {{remote_host}}`
 
 - Connect to a remote server with a specific identity (private key):
 
@@ -28,6 +23,6 @@
 
 `mosh -p {{124}} {{username}}@{{remote_host}}`
 
-- Disable instant echo:
+- Usage when `mosh-server` binary is outside standard path:
 
-`mosh --predict=never {{remote_host}}`
+`mosh --server={{/path/to/bin/}}mosh-server {{remote_host}}`

--- a/pages/common/mosh.md
+++ b/pages/common/mosh.md
@@ -1,0 +1,33 @@
+# mosh
+
+> Mobile Shell (`mosh`) is remote terminal application that allows roaming.
+> `mosh` is a more robust and responsive replacement for SSH.
+> Visit <https://mosh.org> for more information.
+
+- Typical usage:
+
+`mosh {{username}}@{{remote_host}}`
+
+- Usage when `mosh-server` binary is outside standard path:
+
+`mosh --server={{/path/to/bin/}}mosh-server {{remote_host}}`
+
+- Connect to a remote server with a specific identity (private key):
+
+`mosh --ssh="ssh -i {{/path/to/key_file}}" {{username}}@{{remote_host}}`
+
+- Connect to a remote server using a specific port:
+
+`mosh --ssh="ssh -p {{2222}}" {{username}}@{{remote_host}}`
+
+- Run a command on a remote server:
+
+`mosh {{remote_host}} -- {{command -with -flags}}`
+
+- Select Mosh UDP port (useful when `{{remote_host}}` is behind a NAT):
+
+`mosh -p {{124}} {{username}}@{{remote_host}}`
+
+- Disable instant echo:
+
+`mosh --predict=never {{remote_host}}`

--- a/pages/common/mosh.md
+++ b/pages/common/mosh.md
@@ -3,7 +3,7 @@
 > Mobile Shell (`mosh`) is a robust and responsive replacement for SSH.
 > `mosh` persists connections to remote servers while roaming between networks.
 
-- Typical usage:
+- Connect to a remote server:
 
 `mosh {{username}}@{{remote_host}}`
 


### PR DESCRIPTION
This PR adds example commands for the `mosh` mobile shell (https://mosh.org) application (a replacement to SSH).

Mosh is [primarily available](https://mosh.org/#getting) on MacOS and Linux (various distros) and also on Windows (via Chrome), which is why this document was added to `common`. If you think otherwise, please let me know, and I can duplicate it into `osx` and `linux`, and remove from `common`.