### PR TITLE
cmake: use -H -B trick for out-of-source build

### DIFF
--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -9,7 +9,7 @@
 
 - Generate a Makefile and use it to compile a project in a separate "build" folder (out-of-source build):
 
-`mkdir -p {{build}} && cd {{build}} && cmake ../ && make`
+`cmake -H. -B{{build}} && make -C {{build}}`
 
 - Run cmake in interactive mode (it will ask for each variable, instead of using defaults):
 


### PR DESCRIPTION
As initially discussed in #1379. This removes the need to use `mkdir` and `cd`.

Inspired by this post:
https://www.reddit.com/r/programming/comments/6b9r19/how_to_build_a_cmakebased_project/dhlfh05/