### PR TITLE
hugo: add page

### DIFF
--- a/pages/common/hugo.md
+++ b/pages/common/hugo.md
@@ -1,31 +1,31 @@
 # hugo
 
-> Hugo is a Fast and Flexible Static Site Generator.
+> Hugo is a fast and flexible static site generator.
 
-- Create a new hugo site:
+- Create a new Hugo site:
 
 `hugo new site {{path/to/site}}`
 
-- Create a new hugo theme (you may also download one from [https://themes.gohugo.io/]()):
+- Create a new Hugo theme (you may also download one from https://themes.gohugo.io/):
 
 `hugo new theme {{theme_name}}`
 
 - Create a new page:
 
-`hugo new {{section_name}}/{{filename}}{{.ext}}`
+`hugo new {{section_name}}/{{filename}}`
 
 - Build your site to the `./public/` directory:
 
 `hugo`
 
-- Build your site to a different destination:
+- Build your site including pages that are marked as a "draft":
+
+`hugo --buildDrafts`
+
+- Build your site to a given directory:
 
 `hugo --destination {{path/to/destination}}`
 
-- Build your site, start up a webserver to serve it, and watch for changes:
+- Build your site, start up a webserver to serve it, and automatically reload when pages are edited:
 
 `hugo server`
-
-- Build and serve content marked as draft:
-
-`hugo server --buildDrafts`

--- a/pages/common/hugo.md
+++ b/pages/common/hugo.md
@@ -6,7 +6,7 @@
 
 `hugo new site {{path/to/site}}`
 
-- Create a new Hugo theme (you may also download one from https://themes.gohugo.io/):
+- Create a new Hugo theme (themes may also be downloaded from https://themes.gohugo.io/):
 
 `hugo new theme {{theme_name}}`
 
@@ -14,18 +14,18 @@
 
 `hugo new {{section_name}}/{{filename}}`
 
-- Build your site to the `./public/` directory:
+- Build a site to the `./public/` directory:
 
 `hugo`
 
-- Build your site including pages that are marked as a "draft":
+- Build a site including pages that are marked as a "draft":
 
 `hugo --buildDrafts`
 
-- Build your site to a given directory:
+- Build a site to a given directory:
 
 `hugo --destination {{path/to/destination}}`
 
-- Build your site, start up a webserver to serve it, and automatically reload when pages are edited:
+- Build a site, start up a webserver to serve it, and automatically reload when pages are edited:
 
 `hugo server`

--- a/pages/common/hugo.md
+++ b/pages/common/hugo.md
@@ -1,0 +1,31 @@
+# hugo
+
+> Hugo is a Fast and Flexible Static Site Generator.
+
+- Create a new hugo site:
+
+`hugo new site {{path/to/site}}`
+
+- Create a new hugo theme (you may also download one from [https://themes.gohugo.io/]()):
+
+`hugo new theme {{theme_name}}`
+
+- Create a new page:
+
+`hugo new {{section_name}}/{{filename}}{{.ext}}`
+
+- Build your site to the `./public/` directory:
+
+`hugo`
+
+- Build your site to a different destination:
+
+`hugo --destination {{path/to/destination}}`
+
+- Build your site, start up a webserver to serve it, and watch for changes:
+
+`hugo server`
+
+- Build and serve content marked as draft:
+
+`hugo server --buildDrafts`


### PR DESCRIPTION
Hi there!

Hugo is kind of weird in that there's a bit of setup necessary to get up and running, the general flow is defined below in the commit message. 

I added the note on 

>you may also download one from

since it takes quite a bit of effort to create a theme from scratch, yet you need one as stated when you build a site for the first time:

```
[~/d/l/hugo]-> hugo new site mywebsite

Congratulations! Your new Hugo site is created in /home/dhaynes/development/lang-tutorials/hugo/mywebsite.

Just a few more steps and you're ready to go:

1. Download a theme into the same-named folder.
   Choose a theme from https://themes.gohugo.io/, or
   create your own with the "hugo new theme <THEMENAME>" command.
2. Perhaps you want to add some content. You can add single files
   with "hugo new <SECTIONNAME>/<FILENAME>.<FORMAT>".
3. Start the built-in live server via "hugo server".

Visit https://gohugo.io/ for quickstart guide and full documentation.
```
Downloading one from the official site is just doing a `git clone` on a repo and I didn't want to explicitly state that, it's described on theme pages.

Happy to make edits if necessary.

This PR closes #1183 

---

- Add in `hugo` commands essential to getting a site up and running.
- This is defined as:
    - A site existing
    - A theme existing
    - A page existing
    - The site being built in some manner (optionally being served through the webserver)

First pass on verbage.