### PR TITLE
make: add multithreading example

### DIFF
--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -11,6 +11,10 @@
 
 `make {{target}}`
 
+- Call a specific target, executing 4 jobs at a time in parallel:
+
+`make -J{{4}} {{target}}`
+
 - Use a specific Makefile:
 
 `make --file {{file}}`


### PR DESCRIPTION
Personally, I find myself always forgetting the letter to run jobs in parallel (I don't use it often enough! :P).