### PR TITLE
isoinfo: add page

### DIFF
--- a/pages/linux/isoinfo.md
+++ b/pages/linux/isoinfo.md
@@ -1,0 +1,15 @@
+# isoinfo
+
+> Utility programs for dumping and verifying iso images.
+
+- List all the files packed into an iso:
+
+`isoinfo -f -i {{path/to/image.iso}}`
+
+- Extract a specific file to stdout:
+
+`isoinfo -i {{path/to/image.iso}} -x {{/PATH/TO/FILE/INSIDE/ISO.EXT}}`
+
+- Show header information for an iso:
+
+`isoinfo -d -i {{path/to/image.iso}}`

--- a/pages/linux/isoinfo.md
+++ b/pages/linux/isoinfo.md
@@ -1,15 +1,15 @@
 # isoinfo
 
-> Utility programs for dumping and verifying iso images.
+> Utility programs for dumping and verifying ISO disk images.
 
-- List all the files packed into an iso:
+- List all the files included in an ISO image:
 
 `isoinfo -f -i {{path/to/image.iso}}`
 
-- Extract a specific file to stdout:
+- E[x]tract a specific file from an ISO image and send it out stdout:
 
 `isoinfo -i {{path/to/image.iso}} -x {{/PATH/TO/FILE/INSIDE/ISO.EXT}}`
 
-- Show header information for an iso:
+- Show header information for an ISO disk image:
 
 `isoinfo -d -i {{path/to/image.iso}}`


### PR DESCRIPTION
Another strange one! You probably don't need this. Mounting isos instead is much more convenient! Still, it's useful for scripts, I think.