### PR TITLE
umount: make descriptions more explicit

### DIFF
--- a/pages/common/umount.md
+++ b/pages/common/umount.md
@@ -1,6 +1,6 @@
 # umount
 
-> Revokes access to an entire filesystem mounted to a directory.
+> Unlink a filesystem from its mount point, making it no longer accessible.
 > A filesystem cannot be unmounted when it is busy.
 
 - Unmount a filesystem, by passing the path to the source it is mounted from:

--- a/pages/common/umount.md
+++ b/pages/common/umount.md
@@ -3,14 +3,14 @@
 > Revokes access to an entire filesystem mounted to a directory.
 > A filesystem cannot be unmounted when it is busy.
 
-- Unmount a filesystem:
+- Unmount a filesystem, by passing the path to the source it is mounted from:
 
 `umount {{path/to/device_file}}`
 
-- OR:
+- Unmount a filesystem, by passing the path to the target where it is mounted:
 
 `umount {{path/to/mounted_directory}}`
 
-- Unmount all mounted filesystems (dangerous!):
+- Unmount all mounted filesystems (except the `proc` filesystem):
 
 `umount -a`


### PR DESCRIPTION
Note: the "dangerous" remark was not clear about what the danger is -- we can mention possible caveats, but it's better to be explicit.