### PR TITLE
curl: remove -I from auth example

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -1,13 +1,13 @@
 # curl
 
 > Transfers data from or to a server.
-> Supports most protocols including HTTP, FTP, POP3.
+> Supports most protocols, including HTTP, FTP, and POP3.
 
 - Download the contents of an URL to a file:
 
 `curl {{http://example.com}} -o {{filename}}`
 
-- Download a file saving the output under the filename indicated by the URL:
+- Download a file, saving the output under the filename indicated by the URL:
 
 `curl -O {{http://example.com/filename}}`
 
@@ -15,11 +15,11 @@
 
 `curl -O -L -C - {{http://example.com/filename}}`
 
-- Send form-encoded data (POST request of type application/x-www-form-urlencoded):
+- Send form-encoded data (POST request of type `application/x-www-form-urlencoded`):
 
 `curl -d {{'name=bob'}} {{http://example.com/form}}`
 
-- Send a request with an extra header using a custom HTTP method:
+- Send a request with an extra header, using a custom HTTP method:
 
 `curl -H {{'X-My-Header: 123'}} -X {{PUT}} {{http://example.com}}`
 
@@ -27,9 +27,9 @@
 
 `curl -d {{'{"name":"bob"}'}} -H {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
 
-- Pass a user name and password for server authentication and show headers info only:
+- Pass a user name and password for server authentication:
 
-`curl -u myusername:mypassword -I {{http://example.com}}`
+`curl -u myusername:mypassword {{http://example.com}}`
 
 - Pass client certificate and key for a resource, skipping certificate validation:
 


### PR DESCRIPTION
(also, minor tweaks to some of the descriptions)

fixes #1406 