### PR TITLE
Update echo.md to correct for possible misuse of english language

### DIFF
--- a/pages/common/echo.md
+++ b/pages/common/echo.md
@@ -2,7 +2,7 @@
 
 > Print given arguments.
 
-- Print a text message. Note: quotes are optional:
+- Print a text message:
 
 `echo {{"Hello World"}}`
 


### PR DESCRIPTION
**I am not sure how to insert additional white spaces between words for display, so I instead inserted `[number of spaces]` to indicate the number of spaces.**

Quotes while using `echo` are not optional. For example, `echo hello[3 spaces here]world` and `echo "hello[3 spaces here]world"` are different. The first outputs "hello world" while the later "hello[3 spaces]world". 

This is because in the first command, `echo` takes two strings, "hello" and "world", while the later takes only one string, "hello[3 spaces]world".