### PR TITLE
dmesg: include flag to follow messages

### DIFF
--- a/pages/linux/dmesg.md
+++ b/pages/linux/dmesg.md
@@ -2,18 +2,18 @@
 
 > Write the kernel messages to standard output.
 
-- Show kernel messages:  
+- Show kernel messages:
 
 `dmesg`
 
-- Show kernel messages and follow output(work as `tail -f` | (since kernel 3.5.0)):  
+- Show kernel messages and follow output(work as `tail -f` | (since kernel 3.5.0)):
 
-`dmesg -w`  
+`dmesg -w`
 
-- Show how much physical memory is available on this system:  
+- Show how much physical memory is available on this system:
 
 `dmesg | grep -i memory`
 
-- Show kernel messages 1 page at a time:  
+- Show kernel messages 1 page at a time:
 
 `dmesg | less`

--- a/pages/linux/dmesg.md
+++ b/pages/linux/dmesg.md
@@ -6,7 +6,7 @@
 
 `dmesg`
 
-- Show kernel messages and follow output(work as `tail -f` | (since kernel 3.5.0)):
+- Show kernel messages and keep reading new ones, similar to `tail -f` (available in kernels 3.5.0 and newer):
 
 `dmesg -w`
 

--- a/pages/linux/dmesg.md
+++ b/pages/linux/dmesg.md
@@ -2,14 +2,18 @@
 
 > Write the kernel messages to standard output.
 
-- Show kernel messages:
+- Show kernel messages:  
 
 `dmesg`
 
-- Show how much physical memory is available on this system:
+- Show kernel messages and follow output(work as `tail -f` | (since kernel 3.5.0)):  
+
+`dmesg -w`  
+
+- Show how much physical memory is available on this system:  
 
 `dmesg | grep -i memory`
 
-- Show kernel messages 1 page at a time:
+- Show kernel messages 1 page at a time:  
 
 `dmesg | less`


### PR DESCRIPTION
This PR introduces `dmesg -w`  which is available since kernel 3.5.0 to follow the output of messages (same kind of `tail -f` for P `dmesg`)