### PR TITLE
xmllint: various fixes

### DIFF
--- a/pages/common/xmllint.md
+++ b/pages/common/xmllint.md
@@ -6,7 +6,7 @@
 
 `xmllint --xpath "//{{foo}}" {{source_file.xml}}`
 
-- Return, as a string, the contents of the first node named "foo":
+- Return the contents of the first node named "foo" as a string:
 
 `xmllint --xpath "string(//{{foo}})" {{source_file.xml}}`
 

--- a/pages/common/xmllint.md
+++ b/pages/common/xmllint.md
@@ -1,24 +1,24 @@
 # xmllint
 
-> XML parser and linter.
+> XML parser and linter that supports XPath, a syntax for navigating XML trees.
 
-- Return all nodes named "foo":
+- Return all nodes (tags) named "foo":
 
 `xmllint --xpath "//{{foo}}" {{source_file.xml}}`
 
-- Return as string the contents of first node named "foo":
+- Return, as a string, the contents of the first node named "foo":
 
-`xmllint --xpath "string//{{foo}}" {{source_file.xml}}`
+`xmllint --xpath "string(//{{foo}})" {{source_file.xml}}`
 
-- Use other xpath (a syntax for navigating xml trees) expressions for more options in navigating xml tree:
+- Return the href attribute of the second anchor element in an html file:
 
-`xmllint --xpath "{{xpath_expression}}" {{source_file.xml}}`
+`xmllint --html --xpath "string(//a[2]/@href)" webpage.xhtml`
 
-- Return human-readable (indented) xml from file:
+- Return human-readable (indented) XML from file:
 
 `xmllint --format {{source_file.xml}}`
 
-- Check that XML meets requirements of its built-in doctype. This is the part starting with `<!DOCTYPE...>`:
+- Check that a XML file meets the requirements of its DOCTYPE declaration:
 
 `xmllint --valid {{source_file.xml}}`
 


### PR DESCRIPTION
- fix string example, and improve its description
- move xpath information to the main description
- add "tags" synonym for "nodes"
- add a html example
- simplify description of doctype example
- capitalize "xml" consistently

----

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      "command: add page" for new pages, or "command: description of changes" for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
