### PR TITLE
duplicity: various tweaks

### DIFF
--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -23,6 +23,6 @@
 
 `duplicity list-current-files --time {{YYYY-MM-DD}} scp://{{user@hostname}}/path/to/backup/dir`
 
-- Restore a folder from a GnuPG-encrypted local backup to a folder:
+- Restore a subdirectory from a GnuPG-encrypted local backup to a given location:
 
 `PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --file-to-restore {{relative/path/restorefolder}} file://{{absolute/path/to/backup/folder}} {{path/to/directory/to/restore/to}}`

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -1,8 +1,9 @@
 # duplicity
 
-> Creates incremental, compressed, encrypted and versioned backups and optionally uploads them to a variety of backend services.
+> Creates incremental, compressed, encrypted and versioned backups.
+> Can also upload the backups to a variety of backend services.
 
-- Backup a folder via ftps to a remote machine, encrypting with a password:
+- Backup a folder via FTPS to a remote machine, encrypting it with a password:
 
 `FTP_PASSWORD={{ftp_login_password}} PASSPHRASE={{encryption_password}} duplicity {{path/to/source/directory}} {{ftps://user@hostname/target/directory/path/}}`
 
@@ -10,18 +11,18 @@
 
 `duplicity --full-if-older-than {{1M}} --use-new-style s3://{{bucket_name[/prefix]}}`
 
-- Delete versions older than 1 year from a backup stored on a webdav share:
+- Delete versions older than 1 year from a backup stored on a WebDAV share:
 
 `FTP_PASSWORD={{webdav_login_password}} duplicity remove-older-than {{1Y}} --force {{webdav[s]://user@hostname[:port]/some_dir}}`
 
-- List the backups available:
+- List the available backups:
 
 `duplicity collection-status "file://{{absolute/path/to/backup/folder}}"`
 
-- List the files in a backup stored on a remote machine via ssh:
+- List the files in a backup stored on a remote machine, via ssh:
 
 `duplicity list-current-files --time {{YYYY-MM-DD}} scp://{{user@hostname}}/path/to/backup/dir`
 
-- Restore a folder from a gpg-encrypted local backup to a folder:
+- Restore a folder from a GnuPG-encrypted local backup to a folder:
 
 `PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --file-to-restore {{relative/path/restorefolder}} file://{{absolute/path/to/backup/folder}} {{path/to/directory/to/restore/to}}`


### PR DESCRIPTION
I didn't have the chance to comment on #1443. These are some of the changes I'd propose to make the page more readable. I still have some questions -- hopefully @sbrl can answer them:

- In the WebDAV example, is the variable still FTP_PASSWORD, or was that a copy-paste error?
- In the GPG example, is that meant to be GPG or PGP? I always mix the two. I changed the abbreviation in the description to the less ambiguous GnuPG, but I might have made the wrong assumption.
- In any case, the phrasing of that example feels a little awkward:
  > Restore a **folder** from a gpg-encrypted local backup to a **folder**

  Could it be clarified somehow?

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->

- [ ] ~~The page (if new), does not already exist in the repo.~~

- [ ] ~~The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      "command: add page" for new pages, or "command: description of changes" for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
