### PR TITLE
peerflix: expand based on official docs

### DIFF
--- a/pages/common/peerflix.md
+++ b/pages/common/peerflix.md
@@ -1,15 +1,23 @@
 # peerflix
 
-> Stream video or audio based torrents to your favorite player.
+> Stream video- or audio-based torrents to a media player.
 
-- Stream a torrent:
+- Stream the largest media file in a torrent given as a magnet link:
 
-`peerflix "{{magnet:?xt=urn:btih:00112233445566}}"`
+`peerflix "{{magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567}}"`
 
-- Stream a torrent to VLC:
+- Stream the largest file in a torrent, given as a torrent URL, to VLC:
 
-`peerflix "{{torrent url|magnet link}}" --vlc`
+`peerflix "{{http://example.net/music.torrent}}" --vlc`
+
+- Stream the largest file in a torrent to MPlayer, with subtitles:
+
+`peerflix "{{torrent_url|magnet_link}}" --mplayer --subtitles subtitle-file.srt`
 
 - Stream all files from a torrent to Airplay:
 
-`peerflix "{{torrent url|magnet link}}" --all --airplay`
+`peerflix "{{torrent_url|magnet_link}}" --all --airplay`
+
+- List the files in a torrent that are available for streaming:
+
+`peerflix "{{torrent_url|magnet_link}}" --list`

--- a/pages/common/peerflix.md
+++ b/pages/common/peerflix.md
@@ -2,9 +2,13 @@
 
 > Stream video- or audio-based torrents to a media player.
 
-- Stream the largest media file in a torrent given as a magnet link:
+- Stream the largest media file in a torrent:
 
-`peerflix "{{magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567}}"`
+`peerflix "{{torrent_url|magnet_link}}"`
+
+- List all streamable files contained in a torrent (given as a magnet link):
+
+`peerflix "{{magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567}}" --list`
 
 - Stream the largest file in a torrent, given as a torrent URL, to VLC:
 
@@ -12,12 +16,8 @@
 
 - Stream the largest file in a torrent to MPlayer, with subtitles:
 
-`peerflix "{{torrent_url|magnet_link}}" --mplayer --subtitles subtitle-file.srt`
+`peerflix "{{torrent_url|magnet_link}}" --mplayer --subtitles {{subtitle-file.srt}}`
 
 - Stream all files from a torrent to Airplay:
 
 `peerflix "{{torrent_url|magnet_link}}" --all --airplay`
-
-- List the files in a torrent that are available for streaming:
-
-`peerflix "{{torrent_url|magnet_link}}" --list`


### PR DESCRIPTION
- add a torrent url example (previously requested [here](https://github.com/tldr-pages/tldr/pull/1457#discussion_r135743311))
- add the --list and --subtitles options (given as examples in the [official documentation](https://github.com/mafintosh/peerflix/blob/master/README.md))
- make the magnet link example more realistic:
  BitTorrent info hashes (BTIH) are hex-encoded SHA-1 hash sums of the "info" sections of BitTorrent metafiles;
  SHA-1 hash values are typically rendered as a hexadecimal number, 40 digits long.
- replace "your favorite player" with "a media player" in the main description
- clarify which files from the torrent will be streamed in each case
- use snake_case in tokens

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [_] ~~The page (if new), does not already exist in the repo.~~

- [_] ~~The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
