### PR TITLE
curl: display header information

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -19,6 +19,10 @@
 
 `curl -d {{'name=bob'}} {{http://example.com/form}}`
 
+- Only display header information:
+
+`curl -vo /dev/null {{http://example.com}}`
+
 - Send a request with an extra header, using a custom HTTP method:
 
 `curl -H {{'X-My-Header: 123'}} -X {{PUT}} {{http://example.com}}`


### PR DESCRIPTION
* Knowing how to only display request & response header information is pretty key imho. 
* Saw some related discussion over here: https://github.com/tldr-pages/tldr/issues/1406, and I think this addresses most concerns raised there.

r/ @waldyrious 