### PR TITLE
curl: custom hostname resolution & only display header information

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -27,6 +27,10 @@
 
 `curl -d {{'{"name":"bob"}'}} -H {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
 
+- Pass a custom IP address for a specific host and port pair:
+
+`curl --resolve example.com:443:192.168.0.1 -vo /dev/null https://example.com/filename`
+
 - Pass a user name and password for server authentication:
 
 `curl -u myusername:mypassword {{http://example.com}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -27,7 +27,7 @@
 
 `curl -d {{'{"name":"bob"}'}} -H {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
 
-- Pass a custom IP address for a specific host and port pair:
+- Pass a custom IP address for a specific host and port pair, and only display header information:
 
 `curl --resolve example.com:443:192.168.0.1 -vo /dev/null https://example.com/filename`
 


### PR DESCRIPTION
This command combines two curl functionalities that I use very often. 
* The first is to configure hostname resolution to some custom IP - functionally a command line `/etc/hosts` alternative.
* The second is to only display request & response header information. Saw some related discussion over here: #1406, and I think this addresses most concerns raised there.

r/ @waldyrious 