### PR TITLE
openssl: display a domain's cert's start and end dates

### DIFF
--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -14,7 +14,7 @@
 
 `openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
 
-- Only display a domain's certificate's start and end dates:
+- Display the start and end dates for a domain's certificate:
 
 `openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`
 

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -14,6 +14,10 @@
 
 `openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
 
+- Only display a domain's certificate's start and end dates:
+
+`openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`
+
 - Display the certificate presented by an SSL/TLS server:
 
 `openssl s_client -connect {{host}}:{{port}} </dev/null`

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -14,7 +14,7 @@
 
 `openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
 
-- Display the start and end dates for a domain's certificate:
+- Display the start and expiry dates for a domain's certificate:
 
 `openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`
 


### PR DESCRIPTION
* Pretty great use case for `openssl` - to check the start and end date of a domain's certificate. 
* Also demonstrates how you can pipe a cert to `openssl x509` to read particular fields from it - which none of the existing commands seem to do. 