### PR TITLE
zip: minor change in -x example

### DIFF
--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -8,7 +8,7 @@
 
 - E[x]clude unwanted files from being added to the compressed archive:
 
-`zip -r {{compressed.zip}} {{path/to/dir}} -x \*.git\* \*node_modules\* ...`
+`zip -r {{compressed.zip}} {{path/to/dir}} -x {{path/to/exclude}}`
 
 - Archive a directory and its contents with the highest level [9] of compression:
 


### PR DESCRIPTION
Use quotes instead of escaping the `*` in the `-x` example. Also making examples more meaningful, and with token highlighting.