### PR TITLE
Traefik: add page

### DIFF
--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -12,7 +12,7 @@
 
 - Start server with a cluster mode enabled:
 
-`traefik --cluster
+`traefik --cluster`
 
 - Start server with web ui enabled:
 

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -1,0 +1,19 @@
+# traefik
+
+> Traefik HTTP reverse proxy and load balance.
+
+- Start server with default config:
+
+`traefik`
+
+- Start server with custom config file:
+
+`traefik --c {{config_file}}.toml`
+
+- Start server with a cluster mode enabled:
+
+`traefik --cluster
+
+- Start server with web ui enabled:
+
+`traefik --web`


### PR DESCRIPTION
Adds the page for Traefik as requested on #1184

----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
