### PR TITLE
traefik: add page

### DIFF
--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -12,7 +12,7 @@
 
 - Start server with a cluster mode enabled:
 
-`traefik --cluster
+`traefik --cluster`
 
 - Start server with web ui enabled:
 

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -1,6 +1,6 @@
 # traefik
 
-> Traefik HTTP reverse proxy and load balance.
+> A HTTP reverse proxy and load balancer.
 
 - Start server with default config:
 
@@ -10,10 +10,10 @@
 
 `traefik --c {{config_file}}.toml`
 
-- Start server with a cluster mode enabled:
+- Start server with cluster mode enabled:
 
 `traefik --cluster`
 
-- Start server with web ui enabled:
+- Start server with web UI enabled:
 
 `traefik --web`

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -1,0 +1,19 @@
+# traefik
+
+> Traefik HTTP reverse proxy and load balance.
+
+- Start server with default config:
+
+`traefik`
+
+- Start server with custom config file:
+
+`traefik --c {{config_file}}.toml`
+
+- Start server with a cluster mode enabled:
+
+`traefik --cluster
+
+- Start server with web ui enabled:
+
+`traefik --web`

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -6,7 +6,7 @@
 
 `traefik`
 
-- Start server with custom config file:
+- Start server with a custom config file:
 
 `traefik --c {{config_file}}.toml`
 


### PR DESCRIPTION
Closes #1184

----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
