### PR TITLE
find: improve -mtime example

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -14,9 +14,9 @@
 
 `find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }}\;`
 
-- Find files modified since a certain time:
+- Find files modified in the last 24-hour period:
 
-`find {{root_path}} -name '{{}}' -mtime {{-1}}`
+`find {{root_path}} -mtime {{-1}}`
 
 - Find files using case insensitive name matching, of a certain size:
 


### PR DESCRIPTION
Make the description clearer and more specific to the given `-1` parameter. Remove unnecessary `-name '{{}}'` from example.