### PR TITLE
microcom: add page

### DIFF
--- a/pages/linux/microcom.md
+++ b/pages/linux/microcom.md
@@ -1,11 +1,11 @@
 # microcom
 
-> A minimalistic terminal program.
+> A minimalistic terminal program, used to access remote devices via a serial, CAN or telnet connection from the console.
 
-- Open a serial port using the specified baudrate:
+- Open a serial port using the specified baud rate:
 
-`microcom --port {{path/to/serial-port}} --speed {{baudrate}}`
+`microcom --port {{path/to/serial_port}} --speed {{baud_rate}}`
 
-- Establish a telnet connection (rfc2217) to the specified host:
+- Establish a telnet connection to the specified host:
 
 `microcom --telnet {{hostname}}:{{port}}`

--- a/pages/linux/microcom.md
+++ b/pages/linux/microcom.md
@@ -1,0 +1,11 @@
+# microcom
+
+> A minimalistic terminal program.
+
+- Open a serial port using the specified baudrate:
+
+`microcom --port {{path/to/serial-port}} --speed {{baudrate}}`
+
+- Establish a telnet connection (rfc2217) to the specified host:
+
+`microcom --telnet {{hostname}}:{{port}}`


### PR DESCRIPTION
I noticed the [microcom](http://manpages.ubuntu.com/manpages/xenial/man1/microcom.1.html) tool was missing from tldr. It's not a complicated tool, so the number of examples is limited.

----
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
