### PR TITLE
last: add example that avoids hostname truncation

### DIFF
--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -18,10 +18,10 @@
 
 `last {{user_name}} -i`
 
-- View all recorded reboots (last logins of the pseudo user reboot):
+- View all recorded reboots (i.e., the last logins of the pseudo user "reboot"):
 
 `last reboot`
 
-- View all recorded shutdowns (last logins of the pseudo user shutdown):
+- View all recorded shutdowns (i.e., the last logins of the pseudo user "shutdown"):
 
 `last shutdown`

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -18,10 +18,10 @@
 
 `last {{user_name}} -i`
 
-- View the last reboot (last login of the pseudo user reboot):
+- View all recorded reboots (last logins of the pseudo user reboot):
 
 `last reboot`
 
-- View the last shutdown (last login of the pseudo user shutdown):
+- View all recorded shutdowns (last logins of the pseudo user shutdown):
 
 `last shutdown`

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -14,9 +14,9 @@
 
 `last -F -a`
 
-- View the last login by a specific user:
+- View all logins by a specific user and show the ip address instead of the hostname:
 
-`last {{user_name}}`
+`last {{user_name}} -i`
 
 - View the last reboot (last login of the pseudo user reboot):
 

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -10,9 +10,9 @@
 
 `last -n {{login_count}}`
 
-- View full login times and dates:
+- Print the full date and time for entries and then display the hostname column last to prevent truncation:
 
-`last -F`
+`last -F -a`
 
 - View the last login by a specific user:
 


### PR DESCRIPTION
Last by default puts its hostname information in a fixed width column. When you are trying to track down a long host name it is really inconvenient to have it truncated. The `-a` flag used in the  example resolves this issue. I have also included an example of using the `-i` flag to just get the ip address associated with the login

The last two examples were worded in such a way as to imply that the most recent entry would be returned, however the complete list of logins would be returned. I have changed the wording to reflect this reality.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] ~~The page (if new), does not already exist in the repo.~~

- [ ] ~~The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
