### PR TITLE
sendmail: corrected inaccuracy in example

### DIFF
--- a/pages/common/sendmail.md
+++ b/pages/common/sendmail.md
@@ -6,10 +6,10 @@
 
 `sendmail user_name < message.txt`
 
-- Send an email from you@yourdomain.com (assuming your local mail server is configured for this) to test@gmail.com containing the message in `message.txt`:
+- Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the message in `message.txt`:
 
-`sendmail -f test@gmail.com you@yourdomain.com < message.txt`
+`sendmail -f you@yourdomain.com test@gmail.com < message.txt`
 
-- Send an email from you@yourdomain.com (assuming your local mail server is configured for this) to test@gmail.com containing the file `file.zip`:
+- Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the file `file.zip`:
 
-`sendmail -f test@gmail.com you@yourdomain.com < file.zip`
+`sendmail -f you@yourdomain.com test@gmail.com < file.zip`

--- a/pages/common/sendmail.md
+++ b/pages/common/sendmail.md
@@ -4,12 +4,12 @@
 
 - Send a message with the content of message.txt to the mail folder of local user `user_name`:
 
-`sendmail user_name < message.txt`
+`sendmail {{user_name}} < {{message.txt}}`
 
 - Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the message in `message.txt`:
 
-`sendmail -f you@yourdomain.com test@gmail.com < message.txt`
+`sendmail -f {{you@yourdomain.com}} {{test@gmail.com}} < {{message.txt}}`
 
 - Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the file `file.zip`:
 
-`sendmail -f you@yourdomain.com test@gmail.com < file.zip`
+`sendmail -f {{you@yourdomain.com}} {{test@gmail.com}} < {{file.zip}}`


### PR DESCRIPTION
The syntax in the last two examples was reversed. This fixes those inaccuracies and shortens the notes about the postfix server not being configured for sending non-local emails.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- ~[ ] The page (if new), does not already exist in the repo.~

- ~[ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
