### PR TITLE
CONTRIBUTING: add missing args to git push (#1554)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Alternatively, you can do most of the process using the command line:
   `git commit --all -m "{{commit_message}}"`
 
 - push to your fork:  
-  `git push`
+  `git push origin {{branch_name}}`
 
 - go to the github page for your fork and click the green pull request button.
 


### PR DESCRIPTION
git push from a local branch fails if there is no branch of the
same name in the remote repository.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
