### PR TITLE
nmap: added examples for scanning a host with nse scripts and scanning enabled SSL/TLS ciphers/protocols on a host on port 443

### DIFF
--- a/pages/common/nmap.md
+++ b/pages/common/nmap.md
@@ -26,3 +26,11 @@
 - Perform TCP and UDP scanning (use -sU for UDP only, -sZ for SCTP, -sO for IP):
 
 `nmap -sSU {{address_or_addresses}}`
+
+- Perform scan using an nmap nse script:
+
+`nmap --script {{script_name_without_nse_extension}} {{address_or_addresses}}`
+
+- Perform TLS cipher scan against a host to determine supported ciphers and SSL/TLS protocols:
+
+`nmap --script ssl-enum-ciphers {{address_or_addresses}} -p 443`

--- a/pages/common/nmap.md
+++ b/pages/common/nmap.md
@@ -27,10 +27,6 @@
 
 `nmap -sSU {{address_or_addresses}}`
 
-- Perform scan using an nmap nse script:
-
-`nmap --script {{script_name_without_nse_extension}} {{address_or_addresses}}`
-
 - Perform TLS cipher scan against a host to determine supported ciphers and SSL/TLS protocols:
 
 `nmap --script ssl-enum-ciphers {{address_or_addresses}} -p 443`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
