### PR TITLE
dotnet: add page

### DIFF
--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -4,7 +4,7 @@
 
 - Initialize a new .NET project:
 
-`dotnet new project-type`
+`dotnet new template-short-name`
 
 - Restore nuget packages:
 

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,6 +1,6 @@
 # dotnet
 
-> .NET Command Line Tools
+> Cross Platform .NET Command Line Tools for .NET Core
 
 - Initialize a new .NET project:
 

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,6 +1,6 @@
 # dotnet
 
-> Cross Platform .NET Command Line Tools for .NET Core
+> Cross Platform .NET Command Line Tools for .NET Core.
 
 - Initialize a new .NET project:
 

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -14,6 +14,6 @@
 
 `dotnet run`
 
-- Run a packaged dotnet application (only needs the runtime, the rest require the .NET Core SDK installed):
+- Run a packaged dotnet application (only needs the runtime, the rest of the commands require the .NET Core SDK installed):
 
 `dotnet {{path/to/application.dll}}`

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -4,7 +4,7 @@
 
 - Initialize a new .NET project:
 
-`dotnet new template-short-name`
+`dotnet new {{template_short_name}}`
 
 - Restore nuget packages:
 

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,6 +1,6 @@
 # dotnet
 
-> Cross Platform .NET Command Line Tools for .NET Core.
+> Cross platform .NET command line tools for .NET Core.
 
 - Initialize a new .NET project:
 

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -2,18 +2,18 @@
 
 > .NET Command Line Tools
 
-- Initialize a new .NET project
+- Initialize a new .NET project:
 
 `dotnet new project-type`
 
-- Restore nuget packages
+- Restore nuget packages:
 
 `dotnet restore`
 
-- Build and execute the .NET project in the current directory
+- Build and execute the .NET project in the current directory:
 
 `dotnet run`
 
-- Run a packaged dotnet application (only needs the runtime, the rest require the .NET Core SDK installed)
+- Run a packaged dotnet application (only needs the runtime, the rest require the .NET Core SDK installed):
 
 `dotnet {{path/to/application.dll}}`

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,0 +1,19 @@
+# dotnet
+
+> .NET Command Line Tools
+
+- Initialize a new .NET project
+
+`dotnet new project-type`
+
+- Restore nuget packages
+
+`dotnet restore`
+
+- Build and execute the .NET project in the current directory
+
+`dotnet run`
+
+- Run a packaged dotnet application (only needs the runtime, the rest require the .NET Core SDK installed)
+
+`dotnet {{path/to/application.dll}}`


### PR DESCRIPTION
The CLI is quite extensive, I've tried to cover the most frequently used commands.
A similar page could be added for `mono`.

----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
