### PR TITLE
rspamc: add page

### DIFF
--- a/pages/linux/rspamc.md
+++ b/pages/linux/rspamc.md
@@ -1,0 +1,19 @@
+# rspamc
+
+> Command line client for rspamd servers.
+
+- Train the bayesian filter to recognise an email as spam:
+
+`rspamc learn_spam {{path/to/email_file}}`
+
+- Train the bayesian filter to recognise an email as ham:
+
+`rspamc learn_ham {{path/to/email_file}}`
+
+- Generate a manual report on an email:
+
+`rspamc symbols {{path/to/email_file}}`
+
+- Show server statistics:
+
+`rspamc stat`


### PR DESCRIPTION
I keep forgetting how to train my spam filter, and I realised the reason was that I hadn't created a tldr page yet :P

Apparently you can even adjust the weighting of individual rules with this command, but I haven't yet had to do that, so I'm not too sure on how it's done - which probably means it's a more advanced usage of the command.


----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
