### PR TITLE
ruby: add page

### DIFF
--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -10,14 +10,14 @@
 
 `ruby {{script.rb}}`
 
-- Execute a single command in the command line
+- Execute a single command in the command line:
 
 `ruby -e {{command}}`
 
-- Check if the given Ruby script is written correctly (Syntax check)
+- Check if the given Ruby script is written correctly (Syntax check):
 
 `ruby -c {{script.rb}}`
 
-- Show the version of Ruby you are using
+- Show the version of Ruby you are using:
 
 `ruby -v`

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -1,0 +1,23 @@
+# ruby
+
+> Ruby programming language interpreter.
+
+- Open an Interactive Ruby Shell (REPL):
+
+`irb`
+
+- Execute a Ruby script:
+
+`ruby {{script.rb}}`
+
+- Execute a single command in the command line
+
+`ruby -e {{command}}`
+
+- Check if the given Ruby script is written correctly (Syntax check)
+
+`ruby -c {{script.rb}}`
+
+- Show the version of Ruby you are using
+
+`ruby -v`

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -10,7 +10,7 @@
 
 `ruby {{script.rb}}`
 
-- Execute a single command in the command line:
+- Execute a single Ruby command in the command line:
 
 `ruby -e {{command}}`
 

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -14,7 +14,7 @@
 
 `ruby -e {{command}}`
 
-- Check if the given Ruby script is written correctly (Syntax check):
+- Check for syntax errors on a given Ruby script:
 
 `ruby -c {{script.rb}}`
 


### PR DESCRIPTION
Closes #1601 

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
