### PR TITLE
cal: Add use case for spanning date

### DIFF
--- a/pages/linux/cal.md
+++ b/pages/linux/cal.md
@@ -6,7 +6,7 @@
 
 `cal`
 
-- Display previous, current and next month: 
+- Display previous, current and next month:
 
 `cal --three`
 

--- a/pages/linux/cal.md
+++ b/pages/linux/cal.md
@@ -6,13 +6,13 @@
 
 `cal`
 
+- Display previous, current and next month: 
+
+`cal --three`
+
 - Use monday as the first day of the week:
 
-`cal -m`
-
-- Display a calendar for the current year:
-
-`cal -y`
+`cal --monday`
 
 - Display a calendar for a specific year (4 digits):
 


### PR DESCRIPTION
For clarity I changed "-m" to "--monday".
Also, I've removed the "cal -y" for simplicity.
You could just user "cal {year}" to get the same information.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

~~- [ ] The page (if new), does not already exist in the repo.~~

~~- [ ] The page (if new), has been added to the correct platform folder:  ~~
~~      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
