### PR TITLE
 npm: additional module listing use case

### DIFF
--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -27,6 +27,10 @@
 
 `npm list`
 
+- List a tree of globally installed modules:
+
+`npm list -g --depth=0`
+
 - Interactively create a package.json file:
 
 `npm init`

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -27,7 +27,7 @@
 
 `npm list`
 
-- List a tree of globally installed modules:
+- List globally installed modules:
 
 `npm list -g --depth=0`
 

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -23,13 +23,13 @@
 
 `npm uninstall {{module_name}}`
 
-- List a tree of installed modules:
+- List of tree of installed modules referenced in package.json:
 
 `npm list`
 
-- List globally installed modules:
+- List top-level globally installed modules:
 
-`npm list -g --depth=0`
+`npm list -g --depth={{0}}`
 
 - Interactively create a package.json file:
 

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -23,7 +23,7 @@
 
 `npm uninstall {{module_name}}`
 
-- List of tree of installed modules referenced in package.json:
+- List a tree of installed modules referenced in package.json:
 
 `npm list`
 


### PR DESCRIPTION
Added a use case for listing all globally installed modules with a tree depth of 0.