### PR TITLE
update tail to indicate -F

### DIFF
--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -17,3 +17,8 @@
 - Keep reading file until `Ctrl + C`:
 
 `tail -f {{file}}`
+
+- Keep reading file until `Ctrl + C` even if the file is rotated:
+
+`tail -F {{file}}`
+


### PR DESCRIPTION
If I open the file with tail like this:

$ tail -f /var/log/messages
... and if the log rotation facility on my machine decides to rotate that log file while I'm watching messages being written to it ("rotate" means delete or move to another location etc.), the output that I see will just stop.

If I open the file with tail like this:

$ tail -F /var/log/messages
... and again, the file is rotated, the output would continue to flow in my console because tail would reopen the file as soon as it became available again, i.e. when the program(s) writing to the log started writing to the new /var/log/messages.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
