### PR TITLE
xdotool: added more examples

### DIFF
--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -9,3 +9,19 @@
 - Click the right mouse button:
 
 `xdotool click {{3}}`
+
+- Get the id of the currently active window
+
+`xdotool getactivewindow`
+
+- Focus on window with the id of 12345
+
+`xdotool windowfocus --sync 12345`
+
+- Send a Hello World message with 500ms delay for each letter
+
+`xdotool type --delay 500 "Hello World"`
+
+- Press enter
+
+`xdotool key KP_Enter`

--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -14,14 +14,14 @@
 
 `xdotool getactivewindow`
 
-- Focus on window with the id of 12345:
+- Focus on the window with id of 12345:
 
 `xdotool windowfocus --sync 12345`
 
-- Send a Hello World message with 500ms delay for each letter:
+- Type a message, with a 500ms delay for each letter:
 
-`xdotool type --delay 500 "Hello World"`
+`xdotool type --delay 500 "Hello world"`
 
-- Press enter:
+- Press the enter key:
 
 `xdotool key KP_Enter`

--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -16,12 +16,12 @@
 
 - Focus on the window with id of 12345:
 
-`xdotool windowfocus --sync 12345`
+`xdotool windowfocus --sync {{12345}}`
 
 - Type a message, with a 500ms delay for each letter:
 
-`xdotool type --delay 500 "Hello world"`
+`xdotool type --delay {{500}} "Hello world"`
 
 - Press the enter key:
 
-`xdotool key KP_Enter`
+`xdotool key {{KP_Enter}}`

--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -10,18 +10,18 @@
 
 `xdotool click {{3}}`
 
-- Get the id of the currently active window
+- Get the id of the currently active window:
 
 `xdotool getactivewindow`
 
-- Focus on window with the id of 12345
+- Focus on window with the id of 12345:
 
 `xdotool windowfocus --sync 12345`
 
-- Send a Hello World message with 500ms delay for each letter
+- Send a Hello World message with 500ms delay for each letter:
 
 `xdotool type --delay 500 "Hello World"`
 
-- Press enter
+- Press enter:
 
 `xdotool key KP_Enter`


### PR DESCRIPTION
I have added some more examples to xdotool since i didn't find them in there. Examples include sending text & keystrokes as well as focusing the current window and acquiring the current's window id

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
