### PR TITLE
sudo: Add example to run an interactive shell

### DIFF
--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -17,7 +17,3 @@
 - Repeat the last command as sudo:
 
 `sudo !!`
-
-- Run an interactive shell with superuser privileges
-
-`sudo -i`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -18,6 +18,6 @@
 
 `sudo !!`
 
-- Run an interactive shell as sudo:
+- Launch a shell with root privileges:
 
 `sudo -i`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -18,6 +18,6 @@
 
 `sudo !!`
 
-- Launch a shell with root privileges:
+- Launch the default shell with root privileges:
 
 `sudo -i`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -20,4 +20,4 @@
 
 - Run an interactive shell as sudo:
 
-`sudo --login`
+`sudo -i`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -17,3 +17,7 @@
 - Repeat the last command as sudo:
 
 `sudo !!`
+
+- Run an interactive shell as sudo:
+
+`sudo --login`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -17,3 +17,7 @@
 - Repeat the last command as sudo:
 
 `sudo !!`
+
+- Run an interactive shell with superuser privileges
+
+`sudo -i`


### PR DESCRIPTION
This adds the example `sudo -i`, which allows the user to enter an interactive shell with sudo.

Running sudo version 1.8.21p2 on Arch Linux, there is also a spelled flag `--login`, but this doesn't work on my macOS 10.11.6 system (sudo 1.7.10p9), hence using the syntax above.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] ~~The page (if new), does not already exist in the repo.~~

- [ ] ~~The page (if new), has been added to the correct platform folder:~~
    ~~`common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
