### PR TITLE
dd: state that /dev/urandom is not secure

### DIFF
--- a/pages/linux/dd.md
+++ b/pages/linux/dd.md
@@ -10,7 +10,7 @@
 
 `dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs=4M conv=noerror status=progress`
 
-- Generate a file of 100 random bytes by using kernel random driver:
+- Generate a file of 100 (non-secure) random bytes by using kernel random driver:
 
 `dd if=/dev/urandom of={{random_file}} bs=100 count=1`
 


### PR DESCRIPTION
Using /dev/urandom is not recommended to securely generate random bytes.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
