### PR TITLE
vim: add new examples for opening vim and refer to vimtutor

### DIFF
--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,36 +1,16 @@
 # vim
 
 > Vi IMproved, a programmer's text editor, providing several modes for different kinds of text manipulation.
-> Pressing `i` enters edit mode. `<Esc>` goes back to normal mode, which doesn't allow regular text insertion.
+> For more information on how to use vim, see [vimtutor](vimtutor.md).
 
 - Open a file:
 
 `vim {{file}}`
 
-- Enter text editing mode (insert mode):
+- Open a file in read-only mode:
 
-`<Esc>i`
+`vim -M {{file}}`
 
-- Copy ("yank") or cut ("delete") the current line (paste it with `P`):
+- Open with no plugins or custom settings:
 
-`<Esc>{{yy|dd}}`
-
-- Undo the last operation:
-
-`<Esc>u`
-
-- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
-
-`<Esc>/{{search_pattern}}<Enter>`
-
-- Perform a regex substitution in the whole file:
-
-`<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
-
-- Save (write) the file, and quit:
-
-`<Esc>:wq<Enter>`
-
-- Quit without saving:
-
-`<Esc>:q!<Enter>`
+`vim -N -u NONE`

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,7 +1,7 @@
 # vim
 
 > Vi IMproved, a programmer's text editor, providing several modes for different kinds of text manipulation.
-> For more information on how to use vim, see [vimtutor](vimtutor.md).
+> For more information on how to use vim, see vimtutor.
 
 - Open a file:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -14,7 +14,7 @@
 
 - Open in read-only mode (see view):
 
-`view -R`
+`vim -R`
 
 - Open with no plugins or custom settings:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,6 +1,7 @@
 # vim
 
 > Vi IMproved, a programmer's text editor, providing several modes for different kinds of text manipulation.
+> Pressing `i` enters edit mode. `<Esc>` goes back to normal mode, which doesn't allow regular text insertion.
 > For more information on how to use vim, see vimtutor.
 
 - Open a file:
@@ -11,6 +12,38 @@
 
 `vim -M {{file}}`
 
+- Open in read-only mode (see view):
+
+`view -R`
+
 - Open with no plugins or custom settings:
 
 `vim -N -u NONE`
+
+- Enter text editing mode (insert mode):
+
+`<Esc>i`
+
+- Copy ("yank") or cut ("delete") the current line (paste it with `P`):
+
+`<Esc>{{yy|dd}}`
+
+- Undo the last operation:
+
+`<Esc>u`
+
+- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
+
+`<Esc>/{{search_pattern}}<Enter>`
+
+- Perform a regex substitution in the whole file:
+
+`<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
+
+- Save (write) the file, and quit:
+
+`<Esc>:wq<Enter>`
+
+- Quit without saving:
+
+`<Esc>:q!<Enter>`


### PR DESCRIPTION
Add a way to start vim cleanly and a way to start in read-only mode. Remove information on how to use vim and add a link to vimtutor.

----

- [ ] ~~The page (if new), does not already exist in the repo.~~

- [ ] ~~The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
