### PR TITLE
linux/iptables: fix capitalisation of option "-p"

### DIFF
--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -8,7 +8,7 @@
 
 - Set chain policy rule:
 
-`sudo iptables -p {{chain}} {{rule}}`
+`sudo iptables -P {{chain}} {{rule}}`
 
 - Append rule to chain policy for IP:
 


### PR DESCRIPTION
"-p" with small "p" is for protocol

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
