### PR TITLE
hg-add: add page

### DIFF
--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -15,7 +15,7 @@
 
 `hg add --exclude {{pattern}}`
 
-- Recurse into sub-repositories:
+- Recursively add sub-repositories:
 
 `hg add --subrepos`
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -2,9 +2,9 @@
 
 > Adds specified files to the staging area for the next commit in Mercurial.
 
-- Add all unstaged files to the index:
+- Add files or directories to the staging area:
 
-`hg add`
+`hg add {{path/to/file}}`
 
 - Add all unstaged files matching a specified pattern:
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -1,6 +1,7 @@
 # hg add
 
 > Adds specified files to the staging area for the next commit in Mercurial.
+> See the `hg` page for additional information.
 
 - Add files or directories to the staging area:
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -11,7 +11,7 @@
 
 `hg add --include {{pattern}}`
 
-- Add all unstaged files excluding those that match a specified pattern:
+- Add all unstaged files, excluding those that match a specified pattern:
 
 `hg add --exclude {{pattern}}`
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -2,15 +2,15 @@
 
 > Adds specified files to the staging area for the next commit in Mercurial.
 
-- Add all files to the index:
+- Add all unstaged files to the index:
 
 `hg add`
 
-- Add all files matching a specified pattern:
+- Add all unstaged files matching a specified pattern:
 
 `hg add --include {{pattern}}`
 
-- Add all files excluding those that match a specified pattern:
+- Add all unstaged files excluding those that match a specified pattern:
 
 `hg add --exclude {{pattern}}`
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -1,7 +1,6 @@
 # hg add
 
 > Adds specified files to the staging area for the next commit in Mercurial.
-> See the `hg` page for additional information.
 
 - Add files or directories to the staging area:
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -19,6 +19,6 @@
 
 `hg add --subrepos`
 
-- Test-run without performing any actions:
+- Perform a test-run without performing any actions:
 
 `hg add --dry-run`

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -1,0 +1,23 @@
+# hg add
+
+> Adds specified files to the staging area for the next commit in Mercurial.
+
+- Add all files to the index:
+
+`hg add`
+
+- Add all files matching a specified pattern:
+
+`hg add --include {{pattern}}`
+
+- Add all files excluding those that match a specified pattern:
+
+`hg add --exclude {{pattern}}`
+
+- Recurse into sub-repositories:
+
+`hg add --subrepos`
+
+- Test-run without performing any actions:
+
+`hg add --dry-run`

--- a/pages/common/hg.md
+++ b/pages/common/hg.md
@@ -1,6 +1,7 @@
 # hg
 
 > A command line interface for Mercurial, a distributed source control management system.
+> See the `hg-add` and `hg-commit` pages for additional information.
 
 - Execute Mercurial command:
 


### PR DESCRIPTION
Related to #1728.

I'm not entirely sure where to add the `See also` information in the main `pages/common/hg.md` page. I've looked at PR #1675 but it doesn't mention if it should be on the 2nd line of the description, or at the end of the file.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
