### PR TITLE
speedtest-cli: add page

### DIFF
--- a/pages/common/speedtest-cli.md
+++ b/pages/common/speedtest-cli.md
@@ -1,0 +1,19 @@
+# speedtest-cli
+
+> Command line interface for testing internet bandwidth using speedtest.net
+
+- Run a speed test
+
+`speedtest-cli`
+
+- Run a speed test and generate a sharable result picture
+
+`speedtest-cli --share`
+
+- Print a list of all speedtest.net servers, sorted by distance, to file
+
+`speedtest-cli --list > speedtest_servers.txt`
+
+- Run a speed test to the given speedtest.net server number
+
+`speedtest-cli --server {{server_id}}`

--- a/pages/common/speedtest-cli.md
+++ b/pages/common/speedtest-cli.md
@@ -14,6 +14,6 @@
 
 `speedtest-cli --list > speedtest_servers.txt`
 
-- Run a speed test to the given speedtest.net server number:
+- Run a speed test to the given speedtest.net server id:
 
 `speedtest-cli --server {{server_id}}`

--- a/pages/common/speedtest-cli.md
+++ b/pages/common/speedtest-cli.md
@@ -1,19 +1,19 @@
 # speedtest-cli
 
-> Command line interface for testing internet bandwidth using speedtest.net
+> Command line interface for testing internet bandwidth using speedtest.net.
 
-- Run a speed test
+- Run a speed test:
 
 `speedtest-cli`
 
-- Run a speed test and generate a sharable result picture
+- Run a speed test and generate a sharable result picture:
 
 `speedtest-cli --share`
 
-- Print a list of all speedtest.net servers, sorted by distance, to file
+- Print a list of all speedtest.net servers, sorted by distance, to file:
 
 `speedtest-cli --list > speedtest_servers.txt`
 
-- Run a speed test to the given speedtest.net server number
+- Run a speed test to the given speedtest.net server number:
 
 `speedtest-cli --server {{server_id}}`


### PR DESCRIPTION
Fixes #1787 

----
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
