### PR TITLE
dep: add page

### DIFF
--- a/pages/common/dep.md
+++ b/pages/common/dep.md
@@ -1,12 +1,12 @@
 # dep
 
-> Tool for dependency management in the Go ecosystem.
+> Tool for dependency management in Go projects.
 
-- Initialize a directory to be a project:
+- Initialize the current directory as the root of a Go project:
 
 `dep init`
 
-- Install the project dependencies:
+- Install any missing dependencies (Scans Gopkg.toml and your .go files):
 
 `dep ensure`
 
@@ -14,7 +14,7 @@
 
 `dep status`
 
-- Add a new depedency:
+- Add a dependency to the project:
 
 `dep ensure -add {{project_url}}`
 

--- a/pages/common/dep.md
+++ b/pages/common/dep.md
@@ -1,0 +1,23 @@
+# dep
+
+> Tool for dependency management in the Go ecosystem.
+
+- Initialize a directory to be a project:
+
+`dep init`
+
+- Install the project dependencies:
+
+`dep ensure`
+
+- Report the status of the project's depedencies:
+
+`dep status`
+
+- Add a new depedency:
+
+`dep ensure -add {{project_url}}`
+
+- Update the locked versions of all dependencies:
+
+`dep ensure -update`

--- a/pages/common/dep.md
+++ b/pages/common/dep.md
@@ -10,13 +10,13 @@
 
 `dep ensure`
 
-- Report the status of the project's depedencies:
+- Report the status of the project's dependencies:
 
 `dep status`
 
 - Add a dependency to the project:
 
-`dep ensure -add {{project_url}}`
+`dep ensure -add {{package_url}}`
 
 - Update the locked versions of all dependencies:
 


### PR DESCRIPTION
dep is a tool for dependency management in the Go ecosystem.

Fixes #1659.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
