### PR TITLE
base64: add the -n option of echo in examples

### DIFF
--- a/pages/osx/base64.md
+++ b/pages/osx/base64.md
@@ -12,8 +12,8 @@
 
 - Encode from stdin:
 
-`echo {{plain_text}} | base64`
+`echo -n {{plain_text}} | base64`
 
 - Decode from stdin:
 
-`echo {{base64_text}} | base64 -D`
+`echo -n {{base64_text}} | base64 -D`


### PR DESCRIPTION
Add the `-n` option of `echo` in examples, so we can get expected Base64 data of `plain_text` and not the `plain_text\n`.

For example: 

- `echo tldr | base64` output `dGxkcgo=`
- `echo -n tldr | base64` output `dGxkcg==`

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If a particular point is not applicable to your PR,
     strike-through the line by wrapping the text in ~~double tildes~~. -->
<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
