### PR TITLE
ISSUE_TEMPLATE: add missing placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thank you for reporting an issue! Please review the following notes before submitting it.
 
-Most issues on this repo are requests for new commands. If it's the case, make sure to use the standard title ("page request: "), and include a link to a web page about the command, and if possible, to an existing source of example-style documentation.
+Most issues on this repo are requests for new commands. If it's the case, make sure to use the standard title ("page request: <command name>"), and include a link to a web page about the command, and if possible, to an existing source of example-style documentation.
 
 If your issue is with a particular client of tldr, please raise the issue in the repo for that client. For example, if you are using the node client, you would report the issue here: https://github.com/tldr-pages/tldr-node-client/issues
 


### PR DESCRIPTION
The placeholder was inadvertently made invisible by Github's HTML sanitization while rendering the text [here](https://github.com/tldr-pages/tldr/pull/1504#issuecomment-354375185). I've updated that comment to escape the `<` and `>`, and this PR fixes the actual template file.