### PR TITLE
PULL_REQUEST_TEMPLATE: simplify instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
 - [ ] The page has 8 or fewer examples.
 
 - [ ] The PR is appropriately titled:  
-      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited
+      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.
 
-- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines 
+- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 ----
 <!-- Thank you for sending a PR! -->
 <!-- Please perform the following checks and check all the boxes that apply. -->
-<!-- If a particular point is not applicable to your PR,
-     strike-through the line by wrapping the text in ~~double tildes~~. -->
-<!-- If your PR does not create or edit a command page (e.g. README edits, etc.)
+<!-- If your PR does not create a command page,
+     you can remove the first two checklist items. -->
+<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
      you can simply remove the entire checklist. -->
 
 - [ ] The page (if new), does not already exist in the repo.


### PR DESCRIPTION
It's easier (and nicer-looking) to just remove entries than to format them with strike-through.

I'm not 100% sure this is better than the previous wording, but I personally feel (as a contributor) that this is easier.

(Also added punctuation to the last two entries, which was inconsistent with the first ones.)