### PR TITLE
git-stash: Update deprecated commands

### DIFF
--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -4,7 +4,7 @@
 
 - Stash current changes, except new (untracked) files:
 
-`git stash [save {{optional_stash_message}}]`
+`git stash [push {{optional_stash_message}}]`
 
 - Stash current changes, including new (untracked) files:
 


### PR DESCRIPTION
"git stash save" has been deprecated in favour of "git stash push" since
Git 2.15

Ref: https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt#L34

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
