### PR TITLE
COMMUNITY-ROLES: update list of owners

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -199,14 +199,14 @@ The following people are the current owners of the tldr-pages organization,
 have admin access to all of its repositories,
 and are responsible for performing role changes in the community.
 
-- Romain Prieto `<romain.prieto@gmail.com>` (@rprieto)
-- Igor Shubovych `<igor.shubovych@gmail.com>` (@igorshubovych)
-- Ruben Vereecken `<rubenvereecken@gmail.com>` (@rubenvereecken)
-- Waldir Pimenta `<waldyrious@gmail.com>` (@waldyrious)
-- Felix Yan `<felixonmars@archlinux.org>` (@felixonmars)
-- Leandro Ostera `<leandro@ostera.io>` (@ostera)
-- Agniva De Sarker `<agnivade@yahoo.co.in>` (@agnivade)
-- Starbeamrainbowlabs `<feedback@starbeamrainbowlabs.com>` (@sbrl)
+- Romain Prieto ([@rprieto](https://github.com/rprieto)):
+  created the the project on [8 December 2013](https://github.com/tldr-pages/tldr/commit/11264d9)
+- Waldir Pimenta ([@waldyrious](https://github.com/waldyrious)):
+  3 July 2016 — present
+- Agniva De Sarker ([@agnivade](https://github.com/agnivade)):
+  [27 September 2016](https://gitter.im/tldr-pages/tldr?at=57eaedefe4e41c6a4afc2f47) — present
+- Starbeamrainbowlabs ([@sbrl](https://github.com/sbrl)):
+  [23 April 2017](https://gitter.im/tldr-pages/tldr?at=58fc6fce3e27cac331b5c397) — present
 
 ### Past owners
 
@@ -214,3 +214,18 @@ The following people used to be owners in the tldr-pages organization,
 and have since moved on to other projects.
 Their contributions and dedication have ensured the success of the tldr project,
 and for that they'll always be appreciated.
+
+- Igor Shubovych ([@igorshubovych](https://github.com/igorshubovych)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Ruben Vereecken ([@rubenvereecken](https://github.com/rubenvereecken)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Felix Yan ([@felixonmars](https://github.com/felixonmars)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Dan Zimmerman ([@danzimm](https://github.com/danzimm)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Eduardo Gurgel ([@edgurgel](https://github.com/edgurgel)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Arvid Gerstmann ([@Leandros](https://github.com/Leandros)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
+- Leandro Ostera ([@ostera](https://github.com/ostera)):
+  until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)


### PR DESCRIPTION
This completes the recent updates to the owners of the tldr-pages organization, following the actions described at https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454

I managed to dig up public references for the invitations for @agnivade and @sbrl, and for @rprieto it was easy: I simply located the first commit in the repo. From now on, [according to the documented procedure](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md#for-adding-new-organization-owners), there will be issues we can refer to, so the next additions should be easier.

I couldn't find public discussions about my own addition, but I had the invitation email so I could get the date. That said, if I recall correctly, @rubenvereecken added me and @ostera at the same time, or at least in close succession. Could any of you let me know more exact dates for your addition, and hopefully a link to (or vague memory about) a discussion in this repo, possibly in an unrelated PR, where we decided on the addition of both of us? I already searched the Gitter logs, but found nothing there.

I'd ask the same of the others: @igorshubovych, @felixonmars, @danzimm, @edgurgel, @Leandros: dates, and hopefully also the context, of your additions, would be great to make this document more complete.