### PR TITLE
maintainers-guide: cleanup msg when squashing

### DIFF
--- a/contributing-guides/maintainers-guide.md
+++ b/contributing-guides/maintainers-guide.md
@@ -84,9 +84,10 @@ as a guideline for current and future maintainers.
   If there's a single commit in the PR,
   or if the multiple commits are not semantically independent changes,
   use the `Squash and merge` method.
-  If the PR author took the time to craft
+  (Don't forget to clean up the body of the squashed commit message.)
+  If instead the PR author took the time to craft
   individual, informative messages for each commit,
-  use the `Rebase and merge` method,
+  then use the `Rebase and merge` method,
   to honor that work and preserve the history of the changes.
   For less clear-cut cases, a simple heuristic you can follow
   is that if there are more "dirty" commits than "clean" commits,

--- a/contributing-guides/maintainers-guide.md
+++ b/contributing-guides/maintainers-guide.md
@@ -54,7 +54,7 @@ as a guideline for current and future maintainers.
 
 ## II. Handling PRs
 
-- PRs will be merged once they
+- PRs should be merged once they
   (1) **pass the automated tests** (Travis CI, CLA signing, etc.),
   (2) have the **review comments addressed**, and
   (3) get **approved reviews by two maintainers**


### PR DESCRIPTION
Just a small addition to the maintainers' guide about how to handle squash-type merges, plus small wording changes in the PR merging section.