### PR TITLE
sed: adding remove trailing and leading whitespace commands

### DIFF
--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -25,3 +25,11 @@
 - Replace separator / by any other character not used in the find or replace patterns, e.g., #:
 
 `sed 's#{{find}}#{{replace}}#' {{filename}}`
+
+- Remove all leading whitespace (spaces, tabs) from front of each line, overwriting the file:
+
+`sed -i 's/^[ \t]*//' {{filename}}`
+
+- Remove trailing whitespace (spaces, tabs) from the end of each line, overwriting the file:
+
+`sed -i 's/[ \t]*$//' {{filename}}`


### PR DESCRIPTION
Added removing leading and trailing whitespace [tabs, spaces] from end and beginning of lines.
useful for code cleanup.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
