### PR TITLE
stow: add page

### DIFF
--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -1,0 +1,24 @@
+# stow
+
+> Symlink manager.
+> Often used to manage dotfiles.
+
+- Symlink all files recursively to {{target}}
+
+`stow --target={{target}} {{file1 folder1 file2 folder2}}`
+
+- Delete symlinks recursively from {{target}}:
+
+`stow --delete --target={{target}} {{file1 folder1 file2 folder2}}`
+
+- Simulate to see what the result would be like:
+
+`stow  --simulate --target={{target}} {{file1 folder1 file2 folder2}}`
+
+- Delete and resymlink:
+
+`stow --restow --target={{target}} {{file1 folder1 file2 folder2}}`
+
+- Exclude files matching a regular expression:
+
+`stow  --ignore={{regex}} --target={{target}} {{file1 folder1 file2 folder2}}`

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -3,7 +3,7 @@
 > Symlink manager.
 > Often used to manage dotfiles.
 
-- Symlink all files recursively to {{target}}
+- Symlink all files recursively to {{target}}:
 
 `stow --target={{target}} {{file1 folder1 file2 folder2}}`
 

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -3,11 +3,11 @@
 > Symlink manager.
 > Often used to manage dotfiles.
 
-- Symlink all files recursively to {{/path/to/target/directory}}:
+- Symlink all files recursively to {{path/to/target_directory}}:
 
 `stow --target={{directory}} {{file1 folder1 file2 folder2}}`
 
-- Delete symlinks recursively from {{/path/to/target/directory}}:
+- Delete symlinks recursively from {{path/to/target_directory}}:
 
 `stow --delete --target={{directory}} {{file1 folder1 file2 folder2}}`
 

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -3,22 +3,22 @@
 > Symlink manager.
 > Often used to manage dotfiles.
 
-- Symlink all files recursively to {{path/to/target_directory}}:
+- Symlink all files recursively to a given directory:
 
-`stow --target={{directory}} {{file1 folder1 file2 folder2}}`
+`stow --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
 
-- Delete symlinks recursively from {{path/to/target_directory}}:
+- Delete symlinks recursively from a given directory:
 
-`stow --delete --target={{directory}} {{file1 folder1 file2 folder2}}`
+`stow --delete --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
 
 - Simulate to see what the result would be like:
 
-`stow --simulate --target={{directory}} {{file1 folder1 file2 folder2}}`
+`stow --simulate --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
 
 - Delete and resymlink:
 
-`stow --restow --target={{directory}} {{file1 folder1 file2 folder2}}`
+`stow --restow --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
 
 - Exclude files matching a regular expression:
 
-`stow --ignore={{regex}} --target={{directory}} {{file1 folder1 file2 folder2}}`
+`stow --ignore={{regex}} --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -3,22 +3,22 @@
 > Symlink manager.
 > Often used to manage dotfiles.
 
-- Symlink all files recursively to {{target}}:
+- Symlink all files recursively to {{/path/to/target/directory}}:
 
-`stow --target={{target}} {{file1 folder1 file2 folder2}}`
+`stow --target={{directory}} {{file1 folder1 file2 folder2}}`
 
-- Delete symlinks recursively from {{target}}:
+- Delete symlinks recursively from {{/path/to/target/directory}}:
 
-`stow --delete --target={{target}} {{file1 folder1 file2 folder2}}`
+`stow --delete --target={{directory}} {{file1 folder1 file2 folder2}}`
 
 - Simulate to see what the result would be like:
 
-`stow  --simulate --target={{target}} {{file1 folder1 file2 folder2}}`
+`stow --simulate --target={{directory}} {{file1 folder1 file2 folder2}}`
 
 - Delete and resymlink:
 
-`stow --restow --target={{target}} {{file1 folder1 file2 folder2}}`
+`stow --restow --target={{directory}} {{file1 folder1 file2 folder2}}`
 
 - Exclude files matching a regular expression:
 
-`stow  --ignore={{regex}} --target={{target}} {{file1 folder1 file2 folder2}}`
+`stow --ignore={{regex}} --target={{directory}} {{file1 folder1 file2 folder2}}`


### PR DESCRIPTION
Gnu Stow - A symlink manager.

More information here: https://www.gnu.org/software/stow/

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
