### PR TITLE
box: add page

### DIFF
--- a/pages/common/box.md
+++ b/pages/common/box.md
@@ -1,0 +1,31 @@
+# box
+
+> A PHP application for building and managing Phars.
+
+- Build a new Phar file:
+
+`box build`
+
+- Build a new Phar file using a specific config file:
+
+`box build -c {{path/to/config}}`
+
+- Display information about the PHAR PHP extension:
+
+`box info`
+
+- Display information about a specific Phar file:
+
+`box info {{path/to/phar}}`
+
+- Validate the first found config file in the working directory:
+
+`box validate`
+
+- Verify the signature of a specific Phar file:
+
+`box verify {{path/to/phar}}`
+
+- Display all available commands and options:
+
+`box help`

--- a/pages/common/box.md
+++ b/pages/common/box.md
@@ -16,7 +16,7 @@
 
 - Display information about a specific Phar file:
 
-`box info {{path/to/phar}}`
+`box info {{path/to/phar_file}}`
 
 - Validate the first found config file in the working directory:
 
@@ -24,7 +24,7 @@
 
 - Verify the signature of a specific Phar file:
 
-`box verify {{path/to/phar}}`
+`box verify {{path/to/phar_file}}`
 
 - Display all available commands and options:
 


### PR DESCRIPTION
This is tested to work with both versions of Box. Hence the `-c` for config. In `humbug/box` it was changed from `--configuration` to `--config` which breaks compatibility.

----

## Basic Check

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

## References

Unmaintained Repo: https://github.com/box-project/box2
Active Fork: https://github.com/humbug/box