### PR TITLE
rustup: add override example

### DIFF
--- a/pages/common/rustup.md
+++ b/pages/common/rustup.md
@@ -11,6 +11,10 @@
 
 `rustup default nightly`
 
+- Use the nightly toolchain when inside the current project, but leave global settings unchanged:
+
+`rustup override set nightly`
+
 - Update all toolchains:
 
 `rustup update`


### PR DESCRIPTION
Plenty of Rust crates require the nightly toolchain. Making `rustc` use the nightly toolchain globally has a tldr entry already, but I had to Google how to use nightly for just the current project. Switching back and forth between nightly and stable is done fairly often, so I think this example would be helpful.

([Link](https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#directory-overrides) to command documentation.)

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [X] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
