### PR TITLE
gzip: Remove gz extension from output file

### DIFF
--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -12,7 +12,7 @@
 
 - Compress a file specifying the output filename:
 
-`gzip -c {{file.ext}} > {{compressed_file.ext}}.gz`
+`gzip -c {{file.ext}} > {{compressed_file.ext}}`
 
 - Uncompress a gzipped file specifying the output filename:
 
@@ -20,4 +20,4 @@
 
 - Specify the compression level. 1=Fastest (Worst), 9=Slowest (Best), Default level is 6:
 
-`gzip -9 -c {{file.ext}} > {{compressed_file.ext}}.gz`
+`gzip -9 -c {{file.ext}} > {{compressed_file.ext}}`

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -12,7 +12,7 @@
 
 - Compress a file specifying the output filename:
 
-`gzip -c {{file.ext}} > {{compressed_file.ext}}`
+`gzip -c {{file.ext}} > {{compressed_file.ext.gz}}`
 
 - Uncompress a gzipped file specifying the output filename:
 
@@ -20,4 +20,4 @@
 
 - Specify the compression level. 1=Fastest (Worst), 9=Slowest (Best), Default level is 6:
 
-`gzip -9 -c {{file.ext}} > {{compressed_file.ext}}`
+`gzip -9 -c {{file.ext}} > {{compressed_file.ext.gz}}`


### PR DESCRIPTION
From my testing in Ubuntu 16.04, the compressed files do not have the gz extension. Removed this to alleviate a little confusion.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
