### PR TITLE
sl: Include -l and -e examples

### DIFF
--- a/pages/common/sl.md
+++ b/pages/common/sl.md
@@ -18,6 +18,6 @@
 
 `sl -l`
 
-- Let the user quit (CTRL + C)
+- Let the user quit (CTRL + C):
 
 `sl -e`

--- a/pages/common/sl.md
+++ b/pages/common/sl.md
@@ -14,10 +14,10 @@
 
 `sl -F`
 
-- Make the train small:
+- Make the train little:
 
 `sl -l`
 
-- Let the user quit (CTRL + C):
+- Let the user exit (CTRL + C):
 
 `sl -e`

--- a/pages/common/sl.md
+++ b/pages/common/sl.md
@@ -13,3 +13,11 @@
 - Let the train fly:
 
 `sl -F`
+
+- Make the train small:
+
+`sl -l`
+
+- Let the user quit (CTRL + C)
+
+`sl -e`


### PR DESCRIPTION
I came across the sl command recently and noticed that not all of the flags were covered in the TLDR page. This adds the other two possible flags.

- [X] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
