### PR TITLE
rubocop: add page

### DIFF
--- a/pages/osx/rubocop.md
+++ b/pages/osx/rubocop.md
@@ -1,0 +1,31 @@
+# rubocop
+
+> Lint Ruby files.
+
+- Check all files in the current directory:
+
+`rubocop`
+
+- Check specific files or directories:
+
+`rubocop {{path_1}} {{path_2}}`
+
+- Write output to file:
+
+`rubocop --out {{file}}`
+
+- View list of cops:
+
+`rubocop --show-cops`
+
+- Exclude a cop:
+
+`rubocop --except {{cop_1}} {{cop_2}}`
+
+- Run only specified cops:
+
+`rubocop --only {{cop_1}} {{cop_2}}`
+
+- Auto-correct files (experimental):
+
+`rubocop --auto-correct`

--- a/pages/osx/rubocop.md
+++ b/pages/osx/rubocop.md
@@ -8,11 +8,11 @@
 
 - Check one or more specific files or directories:
 
-`rubocop /path/to/file /path/to/directory`
+`rubocop {{/path/to/file}} {{/path/to/directory}}`
 
 - Write output to file:
 
-`rubocop --out /path/to/file`
+`rubocop --out {{/path/to/file}}`
 
 - View list of cops (linter rules):
 

--- a/pages/osx/rubocop.md
+++ b/pages/osx/rubocop.md
@@ -8,11 +8,11 @@
 
 - Check one or more specific files or directories:
 
-`rubocop {{/path/to/file}} {{/path/to/directory}}`
+`rubocop {{path/to/file}} {{path/to/directory}}`
 
 - Write output to file:
 
-`rubocop --out {{/path/to/file}}`
+`rubocop --out {{path/to/file}}`
 
 - View list of cops (linter rules):
 

--- a/pages/osx/rubocop.md
+++ b/pages/osx/rubocop.md
@@ -2,17 +2,17 @@
 
 > Lint Ruby files.
 
-- Check all files in the current directory:
+- Check all files in the current directory (including subdirectories):
 
 `rubocop`
 
-- Check specific files or directories:
+- Check one or more specific files or directories:
 
-`rubocop {{path_1}} {{path_2}}`
+`rubocop /path/to/file /path/to/directory`
 
 - Write output to file:
 
-`rubocop --out {{file}}`
+`rubocop --out /path/to/file`
 
 - View list of cops:
 

--- a/pages/osx/rubocop.md
+++ b/pages/osx/rubocop.md
@@ -14,7 +14,7 @@
 
 `rubocop --out /path/to/file`
 
-- View list of cops:
+- View list of cops (linter rules):
 
 `rubocop --show-cops`
 


### PR DESCRIPTION
I'm scoping this under `osx` because I have not confirmed that the instructions look identical on other platforms.

Resolves #1660 

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
