### PR TITLE
ncat: add -k option

### DIFF
--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -6,7 +6,7 @@
 
 `ncat -l {{port}} > {{/path/to/file}}`
 
-- Accept multiple connections and keep them open after they have been closed:
+- Accept multiple connections and keep ncat open after they have been closed:
 
 `ncat -lk {{port}}`
 

--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -4,7 +4,7 @@
 
 - Listen for input on the specified port and write it to the specified file:
 
-`ncat -l {{port}} > {{/path/to/file}}`
+`ncat -l {{port}} > {{path/to/file}}`
 
 - Accept multiple connections and keep ncat open after they have been closed:
 
@@ -12,4 +12,4 @@
 
 - Write output of specified file to the specified host on the specified port:
 
-`ncat {{address}} {{port}} < {{/path/to/file}}`
+`ncat {{address}} {{port}} < {{path/to/file}}`

--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -6,10 +6,10 @@
 
 `ncat -l {{port}} > {{/path/to/file}}`
 
-- Write output of specified file to the specified host on the specified port:
-
-`ncat {{address}} {{port}} < {{/path/to/file}}`
-
 - Accept multiple connections and keep them open after they have been closed:
 
 `ncat -lk {{port}}`
+
+- Write output of specified file to the specified host on the specified port:
+
+`ncat {{address}} {{port}} < {{/path/to/file}}`

--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -9,3 +9,7 @@
 - Write output of specified file to the specified host on the specified port:
 
 `ncat {{address}} {{port}} < {{/path/to/file}}`
+
+- Accept multiple connections and keep them open after they have been closed:
+
+`ncat -lk {{port}}`


### PR DESCRIPTION
This option let ncat accept multiple connections and keep them open after they are closed.