### PR TITLE
jq: accepts a file as last parameter

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -4,24 +4,24 @@
 
 - Output a JSON file, in pretty-print format:
 
-`cat {{file}} | jq`
+`jq . {{file.json}}`
 
 - Output all elements from arrays (or all key-value pairs from objects) in a JSON file:
 
-`cat {{file}} | jq .[]`
+`jq .[] {{file.json}}`
 
 - Read JSON objects from a file into an array, and output it (inverse of `jq .[]`):
 
-`cat {{file}} | jq --slurp`
+`jq --slurp . {{file.json}}`
 
 - Output the first element in a JSON file:
 
-`cat {{file}} | jq .[0]`
+`jq .[0] {{file.json}}`
 
-- Output the value of a given key of the first element in a JSON file:
+- Output the value of a given key of the first element in a JSON from stdin:
 
-`cat {{file}} | jq .[0].{{key_name}}`
+`cat {{file.json}} | jq .[0].{{key_name}}`
 
-- Output the value of a given key of each element in a JSON file:
+- Output the value of a given key of each element in a JSON from stdin:
 
-`cat {{file}} | jq 'map(.{{key_name}})'`
+`cat {{file.json}} | jq 'map(.{{key_name}})'`

--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -18,10 +18,10 @@
 
 `jq .[0] {{file.json}}`
 
-- Output the value of a given key of the first element in a JSON from stdin:
+- Output the value of a given key of the first element in a JSON text from stdin:
 
 `cat {{file.json}} | jq .[0].{{key_name}}`
 
-- Output the value of a given key of each element in a JSON from stdin:
+- Output the value of a given key of each element in a JSON text from stdin:
 
 `cat {{file.json}} | jq 'map(.{{key_name}})'`


### PR DESCRIPTION
Examples look simpler with file as last parameter than with using `cat`,
also they explicitly show that you must use `.` as the default
all-matching rule.

Keep the last two examples with piping, and change their descriptions
accordingly.