### PR TITLE
fallocate: add page

### DIFF
--- a/pages/linux/fallocate.md
+++ b/pages/linux/fallocate.md
@@ -1,0 +1,16 @@
+# fallocate 
+
+> Reserve or deallocate disk space to files.
+> The utility allocates space without zeroing.
+
+- Reserve a file taking up 700MB of disk space:
+
+`fallocate --length 700M {{path/to/file}}`
+
+- Shrink an already allocated file by 200MB:
+
+`fallocate --collapse-range --length 200M {{path/to/file}}`
+
+- Deallocate 20MB of space after 100MB in a file:
+
+`fallocate --collapse-range --offset 100M --length 20M {{path/to/file}}`

--- a/pages/linux/fallocate.md
+++ b/pages/linux/fallocate.md
@@ -5,12 +5,12 @@
 
 - Reserve a file taking up 700MB of disk space:
 
-`fallocate --length 700M {{path/to/file}}`
+`fallocate --length {{700M}} {{path/to/file}}`
 
 - Shrink an already allocated file by 200MB:
 
-`fallocate --collapse-range --length 200M {{path/to/file}}`
+`fallocate --collapse-range --length {{200M}} {{path/to/file}}`
 
 - Deallocate 20MB of space after 100MB in a file:
 
-`fallocate --collapse-range --offset 100M --length 20M {{path/to/file}}`
+`fallocate --collapse-range --offset {{100M}} --length {{20M}} {{path/to/file}}`

--- a/pages/linux/fallocate.md
+++ b/pages/linux/fallocate.md
@@ -11,6 +11,6 @@
 
 `fallocate --collapse-range --length {{200M}} {{path/to/file}}`
 
-- Deallocate 20MB of space after 100MB in a file:
+- Shrink 20MB of space after 100MB in a file:
 
 `fallocate --collapse-range --offset {{100M}} --length {{20M}} {{path/to/file}}`


### PR DESCRIPTION
Linux-specific command line tool to allocate sparse files. Useful for allocating VM images or dummy files without "wasting" write cycles.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
