### PR TITLE
FFmpeg: Added trim line and seconds fraction to another line

### DIFF
--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -18,7 +18,7 @@
 
 `ffmpeg -ss {{mm:ss.S}} -i {{video.mp4}} -frames 1 -s {{128x128}} -f image2 {{image.png}}`
 
-- trim a video from a given time (ss) to (t) seconds from that time or just omit -t to trim everything before (ss) seconds:
+- Trim a video from a given time (ss) to (t) seconds from that time or just omit -t to trim everything before (ss) seconds:
 
 `ffmpeg -ss {{mm:ss.S}} -i {{video.mp4}} -codec copy -t {{mm:ss.S}} {{output.mp4}}`
 

--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -16,7 +16,11 @@
 
 - Quickly extract a single frame from a video at time mm:ss and save it as a 128x128 resolution image:
 
-`ffmpeg -ss {{mm:ss}} -i {{video.mp4}} -frames 1 -s {{128x128}} -f image2 {{image.png}}`
+`ffmpeg -ss {{mm:ss.S}} -i {{video.mp4}} -frames 1 -s {{128x128}} -f image2 {{image.png}}`
+
+- trim a video from a given time (ss) to (t) seconds from that time or just omit -t to trim everything before (ss) seconds:
+
+`ffmpeg -ss {{mm:ss.S}} -i {{video.mp4}} -codec copy -t {{mm:ss.S}} {{output.mp4}}`
 
 - Convert AVI video to MP4. AAC Audio @ 128kbit, h264 Video @ CRF 23:
 


### PR DESCRIPTION
Added trim line and seconds fraction precision to the line relative to frame extraction.
----
- [X] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
