### PR TITLE
ipfs: add page

### DIFF
--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -3,15 +3,15 @@
 > Inter Planetary File System.
 > A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.
 
-- Add a file from local to the file system and pin It:
+- Add a file from local to the file system and pin it:
 
 `ipfs add {{filename}}`
 
-- Add a folder and its files recursively from local to the File System:
+- Add a folder and its files recursively from local to the file system:
 
 `ipfs add -r {{folder}}`
 
-- Save a remote file and give It a name but not pin It:
+- Save a remote file and give it a name but not pin it:
 
 `ipfs get {{hash}} -o {{filename}}`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -7,11 +7,11 @@
 
 `ipfs get {{hash}} -o {{filename}}`
 
-- Add a file from local to the File System with the filename _(-w)_, pin It and print the hash:
+- Add a file from local to the file system with the filename (-w) and pin It:
 
 `ipfs add {{filename}} -w`
 
-- Add a folder and files in It from local to the File System, pin It and print the hash:
+- Add a folder and files in It from local to the File System and pin It:
 
 `ipfs add -r {{folder}}`
 
@@ -27,11 +27,7 @@
 
 `ipfs pin rm {{hash}}`
 
-- Create a new ipfs ID with a given name:
-
-`ifps key gen --type=rsa --size=2048 {{name}}`
-
-- Add an hash to the IPNS with the given ID _(omit --key for default)_. If is the hash of a folder, It will add the whole folder with files:
+- Add an hash to the IPNS with the given ID (omit --key for default). If is the hash of a folder, It will add the whole folder with files:
 
 `ipfs name publish --key={{ID}} {{hash}}`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -3,11 +3,11 @@
 > Inter Planetary File System.
 > A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.
 
-- Add a file from local to the file system and pin it:
+- Add a file from local to the file system, pin it and print the relative hash:
 
 `ipfs add {{filename}}`
 
-- Add a folder and its files recursively from local to the file system:
+- Add a folder and its files recursively from local to the file system and print the relative hash:
 
 `ipfs add -r {{folder}}`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -3,23 +3,23 @@
 > Inter Planetary File System.
 > A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.
 
+- Add a file from local to the file system and pin It:
+
+`ipfs add {{filename}}`
+
+- Add a folder and its files recursively from local to the File System:
+
+`ipfs add -r {{folder}}`
+
 - Save a remote file and give It a name but not pin It:
 
 `ipfs get {{hash}} -o {{filename}}`
 
-- Add a file from local to the file system with the filename (-w) and pin It:
-
-`ipfs add {{filename}} -w`
-
-- Add a folder and files in It from local to the File System and pin It:
-
-`ipfs add -r {{folder}}`
-
-- Pin a remote file, locally:
+- Pin a remote file locally:
 
 `ipfs pin add {{hash}}`
 
-- Check pinned files:
+- Display pinned files:
 
 `ipfs pin ls`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -27,14 +27,6 @@
 
 `ipfs pin rm {{hash}}`
 
-- Add an hash to the IPNS with the given ID (omit --key for default). If is the hash of a folder, It will add the whole folder with files:
-
-`ipfs name publish --key={{ID}} {{hash}}`
-
-- Print a list of available keys:
-
-`ipfs key list`
-
 - Remove unpinned files from local storage:
 
 `ipfs repo gc`

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -8,11 +8,11 @@
 `ipfs get {{hash}} -o {{filename}}`
 
 - Add a file from local to the File System with the filename _(-w)_, pin It and print the hash:
- 
+
 `ipfs add {{filename}} -w`
 
 - Add a folder and files in It from local to the File System, pin It and print the hash:
- 
+
 `ipfs add -r {{folder}}`
 
 - Pin a remote file, locally:

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -1,0 +1,44 @@
+# ipfs
+
+> Inter Planetary File System.
+> A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.
+
+- Save a remote file but not pin It:
+
+`ipfs get {{hash}}`
+
+- Add a file from local to the File System with the filename _(-w)_, pin It and print the hash:
+ 
+`ipfs add {{filename}} -w`
+
+- Add a folder and files in It from local to the File System, pin It and print the hash:
+ 
+`ipfs add -r {{folder}}`
+
+- Pin a remote file, locally:
+
+`ipfs pin add {{hash}}`
+
+- Check pinned files:
+
+`ipfs pin ls`
+
+- Unpin a file from the local storage:
+
+`ipfs pin rm {{hash}}`
+
+- Create a new ipfs ID with a given name:
+
+`ifps key gen --type=rsa --size=2048 {{name}}`
+
+- Add an hash to the IPNS with the given ID _(omit --key for default)_. If is the hash of a folder, It will add the whole folder with files:
+
+`ipfs name publish --key={{ID}} {{hash}}`
+
+- Print a list of available keys:
+
+`ipfs key list`
+
+- Remove unpinned files from local storage:
+
+`ipfs repo gc`

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -3,9 +3,9 @@
 > Inter Planetary File System.
 > A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.
 
-- Save a remote file but not pin It:
+- Save a remote file and give It a name but not pin It:
 
-`ipfs get {{hash}}`
+`ipfs get {{hash}} -o {{filename}}`
 
 - Add a file from local to the File System with the filename _(-w)_, pin It and print the hash:
  


### PR DESCRIPTION
Added ipfs to common.
It actually has 10 examples.. Any suggestion on how to reduce them? Actually, I find important all of them as a not daily user reference .-.
----
- [X] The page (if new), does not already exist in the repo.

- [X] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
