### PR TITLE
base64: "Decode a file", changed from -d to -D

### DIFF
--- a/pages/osx/base64.md
+++ b/pages/osx/base64.md
@@ -8,7 +8,7 @@
 
 - Decode a file:
 
-`base64 -d -i {{base64_file}}`
+`base64 -D -i {{base64_file}}`
 
 - Encode from stdin:
 


### PR DESCRIPTION
One must use uppercase -D to decode.
Excerpt from the man page:
"base64 [-h | -D] [-b count] [-i input_file] [-o output_file]"
This is on macOS 10.12.6, man page from February 8, 2011.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
