### PR TITLE
fswatch: Fix broken commands + simplifications

### DIFF
--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -4,16 +4,16 @@
 
 - Run a bash command on file creation, update or deletion:
 
-`fswatch -0 {{path/to/file}} | xargs -0 {{bash_command}}`
+`fswatch {{path/to/file}} | xargs -n 1 {{bash_command}}`
 
 - Watch one or more files and/or directories:
 
-`fswatch -0 {{path/to/file}} {{path/to/directory}} {{path/to/another_directory/**/*.js}} | xargs -0 {{bash_command}}`
+`fswatch {{path/to/file}} {{path/to/directory}} {{path/to/another_directory/**/*.js}} | xargs -n 1 {{bash_command}}`
 
-- Use `{}` in your bash command as a placeholder for the absolute path to the changed file:
+- Print the absolute paths of the changed files:
 
-`fswatch -0 {{path/to/directory}} | xargs -0 -I {} {{bash_command}}`
+`fswatch {{path/to/directory}} | xargs -n 1 -I {} echo {}`
 
 - Filter by event type, eg. Updated, Deleted or Created:
 
-`fswatch -0 --event {{Updated}} {{path/to/directory}} | xargs -0 {{bash_command}}`
+`fswatch --event {{Updated}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`


### PR DESCRIPTION
Without the `-n 1` argument to `xargs`, fswatch will will not trigger on
events.

Fixes #2119 

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
