### PR TITLE
cut: Show syntax for n-to the end of a line

### DIFF
--- a/pages/common/cut.md
+++ b/pages/common/cut.md
@@ -22,6 +22,6 @@
 
 `cut -d'{{;}}' -f{{2,10}}`
 
-- Cut out the fields 3 through 7 of each line, using a space as a delimiter:
+- Cut out the fields 3 through to the end of each line, using a space as a delimiter:
 
-`cut -d'{{ }}' -f{{3-7}}`
+`cut -d'{{ }}' -f{{3-}}`


### PR DESCRIPTION
Found myself using this after consulting the tldr-page to refresh my memory on the arguments to `cut`, and thought I'd add it the page.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
