### PR TITLE
ls: add `--quoting-style=shell-escape`

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -25,3 +25,7 @@
 - Long format list of all files, sorted by modification date (oldest first):
 
 `ls -ltr`
+
+- Quote strange filenames (delete using `rm -- NAME`):
+
+`ls --quoting-style=shell-escape`


### PR DESCRIPTION
Most of the quoting styles put `?` instead of non-printable characters. This one works.

----

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
