### PR TITLE
mycli: move from linux to common; add uri example.

### DIFF
--- a/pages/common/mycli.md
+++ b/pages/common/mycli.md
@@ -13,3 +13,11 @@
 - Connect to a database on the specified host with the specified user:
 
 `mycli -u {{user}} -h {{host}} {{database_name}}`
+
+- Connect to a database with URI:
+
+`mycli mysql://{{user}}@{{host}}`
+
+- Connect to a database with URI more directly:
+
+`mycli mysql://{{user}}{{password}}@{{host}}:{{port}}/{{database_name}}`


### PR DESCRIPTION
~~- [ ] The page (if new), does not already exist in the repo.~~

~~- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.~~

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

About moving: mycli is python based which is also available for macOS.