### PR TITLE
dnf: removed bad example

### DIFF
--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -4,16 +4,16 @@
 
 - Install a new package:
 
-`dnf install {{package}}`
+`sudo dnf install {{package}}`
 
 - Install a new package and assume yes to all questions:
 
-`dnf -y install {{package}}`
+`sudo dnf -y install {{package}}`
 
 - Remove a package:
 
-`dnf remove {{package}}`
+`sudo dnf remove {{package}}`
 
 - Upgrade installed packages to newest available versions:
 
-`dnf upgrade`
+`sudo dnf upgrade`

--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -2,10 +2,6 @@
 
 > Package management utility for RHEL, Fedora, and CentOS (replaces yum).
 
-- Synchronize list of packages and versions available. This should be run first, before running subsequent dnf commands:
-
-`dnf update`
-
 - Install a new package:
 
 `dnf install {{package}}`


### PR DESCRIPTION

The `update` command of `dnf` doesn't work like `apt-get`'s : `dnf` automatically handles synchronizing list of packages.
In fact, it is a *deprecated* alias for the `upgrade` command.

Source : https://dnf.readthedocs.io/en/latest/command_ref.html#update-command

I also added `sudo` to all the listed commands, as all of them require root privileges (second point of the `CONTRIBUTING.md` file).