### PR TITLE
ping: add -O example

### DIFF
--- a/pages/common/ping.md
+++ b/pages/common/ping.md
@@ -21,3 +21,7 @@
 - Ping host and ring the bell when a packet is received (if your terminal supports it):
 
 `ping -a {{host}}`
+
+- Also display a message if no response was recieved:
+
+`ping -O {{host}}`

--- a/pages/common/ping.md
+++ b/pages/common/ping.md
@@ -22,6 +22,6 @@
 
 `ping -a {{host}}`
 
-- Also display a message if no response was recieved:
+- Also display a message if no response was received:
 
 `ping -O {{host}}`


### PR DESCRIPTION
When I'm not using `mtr`, I'll often use the `-O` option to see when my server goes down and comes back up again during a reboot.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
