### PR TITLE
scoop: add page

### DIFF
--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -30,6 +30,6 @@
 
 `scoop bucket known`
 
-- Add a bucket ({{bucket}} can be a known bucket or a Git repository URL):
+- Add a bucket by its alias or a Git repository URL:
 
 `scoop bucket add {{bucket}}`

--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -1,0 +1,35 @@
+# scoop
+
+> A command-line installer for Windows.
+
+- Install a package:
+
+`scoop install {{package}}`
+
+- Remove a package:
+
+`scoop uninstall {{package}}`
+
+- Update all installed packages:
+
+`scoop update *`
+
+- List installed packages:
+
+`scoop list`
+
+- Display information about a package:
+
+`scoop info {{package}}`
+
+- Search for a package:
+
+`scoop search {{package}}`
+
+- List all known buckets (a bucket is an application repository):
+
+`scoop bucket known`
+
+- Add a bucket ({{bucket}} can be a known bucket or a Git repository URL):
+
+`scoop bucket add {{bucket}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

___

This adds a page for [Scoop](https://scoop.sh), a Windows command-line installer.