### PR TITLE
git-merge: add --abort

### DIFF
--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -13,3 +13,7 @@
 - Merge a branch and create a merge commit:
 
 `git merge --no-ff {{branch_name}}`
+
+- Abort merge:
+
+`git merge --abort`

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -14,6 +14,6 @@
 
 `git merge --no-ff {{branch_name}}`
 
-- Abort merge:
+- Abort a merge in case of conflicts:
 
 `git merge --abort`


### PR DESCRIPTION
Added `git merge --abort` example.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
