### PR TITLE
nimble: add page

### DIFF
--- a/pages/common/nimble.md
+++ b/pages/common/nimble.md
@@ -1,0 +1,28 @@
+# nimble
+
+> Package manager for the Nim programming language.
+> Manage Nim projects and their dependencies.
+
+- Search for packages:
+
+`nimble search {{search_string}}`
+
+- Install a package:
+
+`nimble install {{package_name}}`
+
+- List installed packages:
+
+`nimble list -i`
+
+- Create a new Nimble package in the current directory:
+
+`nimble init`
+
+- Build the Nimble package in the current directory:
+
+`nimble build`
+
+- Install the Nimble package in the current directory:
+
+`nimble install`

--- a/pages/common/nimble.md
+++ b/pages/common/nimble.md
@@ -19,10 +19,10 @@
 
 `nimble init`
 
-- Build the Nimble package in the current directory:
+- Build a Nimble package:
 
 `nimble build`
 
-- Install the Nimble package in the current directory:
+- Install a Nimble package:
 
 `nimble install`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

Nimble is the official package manager for Nim. Follow-up to https://github.com/tldr-pages/tldr/pull/2207 :smiley: