### PR TITLE
where: add page

### DIFF
--- a/pages/windows/where.md
+++ b/pages/windows/where.md
@@ -1,0 +1,20 @@
+# where
+
+> Display the location of files that match the search pattern.
+> Defaults to current work directory and paths in the PATH environment variable.
+
+- Display the location of file pattern:
+
+`where {{file_pattern}}`
+
+- Display the location of file pattern including file size and date:
+
+`where /T {{file_pattern}}`
+
+- Recursively search for file pattern at specified path:
+
+`where /R {{path/to/directory}} {{file_pattern}}`
+
+- Display only the error code for the location of file pattern:
+
+`where /Q {{file_pattern}}`


### PR DESCRIPTION
I'm not sure whether this is the right way to override `commons/where.md`, but since `where` differs significantly on Windows, it should be treated differently IMHO. It is not limited to executables and has command line options available only Windows.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

