### PR TITLE
updated linux/shuf to match with osx/shuf

### DIFF
--- a/pages/linux/shuf.md
+++ b/pages/linux/shuf.md
@@ -6,14 +6,14 @@
 
 `shuf {{filename}}`
 
-- Only output the first n entries of the result:
+- Only output the first 5 entries of the result:
 
-`shuf -n {{n}} {{filename}}`
+`shuf -n {{5}} {{filename}}`
 
 - Write output to another file:
 
-`shuf -o {{another_filename}} {{filename}}`
+`shuf {{filename}} -o {{output_filename}}`
 
-- Generate random numbers in range:
+- Generate random numbers in range 1-10:
 
-`shuf -i {{low}}-{{high}}`
+`shuf -i {{1-10}}`

--- a/pages/linux/shuf.md
+++ b/pages/linux/shuf.md
@@ -10,10 +10,10 @@
 
 `shuf -n {{5}} {{filename}}`
 
-- Write output to another file:
+- Write the output to another file:
 
 `shuf {{filename}} -o {{output_filename}}`
 
-- Generate random numbers in range 1-10:
+- Generate random numbers in range:
 
 `shuf -i {{1-10}}`


### PR DESCRIPTION
updated linux/shuf  in favour of osx/shuf so that the pages remain consistent across Operating systems.

this happened as we changed osx/shuf in #2186 