### PR TITLE
sshfs: use umount instead of fusermount

### DIFF
--- a/pages/common/sshfs.md
+++ b/pages/common/sshfs.md
@@ -8,7 +8,7 @@
 
 - Unmount remote directory:
 
-`umount -f {{mountpoint}}`
+`umount {{mountpoint}}`
 
 - Mount remote directory from server with specific port:
 

--- a/pages/common/sshfs.md
+++ b/pages/common/sshfs.md
@@ -8,7 +8,7 @@
 
 - Unmount remote directory:
 
-`fusermount -u {{mountpoint}}`
+`umount -f {{mountpoint}}`
 
 - Mount remote directory from server with specific port:
 


### PR DESCRIPTION
`umount` is [recommended](https://github.com/osxfuse/osxfuse/wiki/FAQ#48-how-should-i-unmount-my-fuse-for-os-x-file-system-i-cannot-find-the-fusermount-program-anywhere) according to the official wiki, `fusermount` is not found on recent versions of macOS.

Related: [this StackOverflow question](https://stackoverflow.com/questions/14057830/unmount-the-directory-which-is-mounted-by-sshfs-in-mac). Despite the (wrong) accepted answer, there are quite a few confirmations that `umount` should be used now.