### PR TITLE
apt-get: add pointer to apt-cache when searching for pacakges

### DIFF
--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -1,6 +1,7 @@
 # apt-get
 
 > Debian and Ubuntu package management utility.
+> Search for packages using `apt-cache`.
 
 - Update the list of available packages and versions (it's recommended to run this before other `apt-get` commands):
 
@@ -25,7 +26,3 @@
 - Upgrade installed packages (like `upgrade`), but remove obsolete packages and install additional packages to meet new dependencies:
 
 `apt-get dist-upgrade`
-
-- Search for a package (use apt-cache instead):
-
-`tldr apt-cache`

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -25,3 +25,7 @@
 - Upgrade installed packages (like `upgrade`), but remove obsolete packages and install additional packages to meet new dependencies:
 
 `apt-get dist-upgrade`
+
+- Search for a package (use apt-cache instead):
+
+`tldr apt-cache`


### PR DESCRIPTION
----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

I realize this is a bit of a stretch, but I have personally had to repeatedly google how to search for a package w/ apt-get only to re-learn it was apt-cache many times.  I suspect I'm not the only person who has had this expectation of apt-get.

- [x ] The page has 8 or fewer examples.

- [x ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
