### PR TITLE
dirname: add page

### DIFF
--- a/pages/linux/dirname.md
+++ b/pages/linux/dirname.md
@@ -1,0 +1,15 @@
+# dirname
+
+> Calculates the parent directory of a given file or directory path.
+
+- Calculate the parent directory of a given file path:
+
+`dirname {{path/to/file_or_directory}}`
+
+- Calculate the parent directory of multiple paths:
+
+`dirname {{path/to/file_a}} {{path/to/file_b}}
+
+- Delimit output with a NUL character instead of a newline (useful when combining with `xargs`):
+
+`dirname --zero {{path/to/file_a}} {{path/to/file_b}}`

--- a/pages/linux/dirname.md
+++ b/pages/linux/dirname.md
@@ -8,8 +8,8 @@
 
 - Calculate the parent directory of multiple paths:
 
-`dirname {{path/to/file_a}} {{path/to/file_b}}`
+`dirname {{path/to/file_a}} {{path/to/directory_b}}`
 
 - Delimit output with a NUL character instead of a newline (useful when combining with `xargs`):
 
-`dirname --zero {{path/to/file_a}} {{path/to/file_b}}`
+`dirname --zero {{path/to/directory_a}} {{path/to/file_b}}`

--- a/pages/linux/dirname.md
+++ b/pages/linux/dirname.md
@@ -2,7 +2,7 @@
 
 > Calculates the parent directory of a given file or directory path.
 
-- Calculate the parent directory of a given file path:
+- Calculate the parent directory of a given path:
 
 `dirname {{path/to/file_or_directory}}`
 

--- a/pages/linux/dirname.md
+++ b/pages/linux/dirname.md
@@ -8,7 +8,7 @@
 
 - Calculate the parent directory of multiple paths:
 
-`dirname {{path/to/file_a}} {{path/to/file_b}}
+`dirname {{path/to/file_a}} {{path/to/file_b}}`
 
 - Delimit output with a NUL character instead of a newline (useful when combining with `xargs`):
 


### PR DESCRIPTION
I dropped by #2213, and found that `dirname` wasn't a page yet. Thought I'd fix that!

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
