### PR TITLE
COMMUNITY-ROLES.md: format messages as quotes

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -203,7 +203,7 @@ and are responsible for performing role changes in the community.
 ### Past owners
 
 The following people used to be owners in the tldr-pages organization,
-and have reduced their participation or otherise moved on to other projects.
+and have reduced their participation or otherwise moved on to other projects.
 Their contributions and dedication have ensured the success of the tldr project,
 and for that they'll always be appreciated.
 

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -87,25 +87,23 @@ using one of the template messages below as a base.
 
 Open an issue with the following message:
 
-```
-Hi, @username(s)! You seem to be enjoying contributing to the tldr-pages project.
-You now have had five distinct pull requests merged ([LINKS TO THE RELEVANT PRs]),
+> Hi, \@username(s)! You seem to be enjoying contributing to the tldr-pages project.
+You now have had five distinct pull requests merged (\[LINKS TO THE RELEVANT PRs]),
 which qualifies you to become a collaborator in this repository,
 as explained in our
-[governance guidelines](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md).
-
-As a collaborator, you will have commit access
+\[governance guidelines](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md).
+>
+> As a collaborator, you will have commit access
 and can therefore merge pull requests from others, label and close issues,
 and perform various other maintenance tasks that are needed here and there.
 Of course, all of this is voluntary
 — you're welcome to contribute to the project in whatever ways suit your liking.
-
-If you do decide to start performing maintenance tasks, though,
+>
+> If you do decide to start performing maintenance tasks, though,
 we only ask you to get familiar with the
-[maintainer's guide](https://github.com/tldr-pages/tldr/blob/master/contributing-guides/maintainers-guide.md).
-
-Thanks for all your work so far!
-```
+\[maintainer's guide](https://github.com/tldr-pages/tldr/blob/master/contributing-guides/maintainers-guide.md).
+>
+> Thanks for all your work so far!
 
 Once they acknowledge the message,
 go to https://github.com/tldr-pages/tldr/settings/collaboration
@@ -115,20 +113,18 @@ and add them to the repository as collaborator with write permissions.
 
 Open an issue with the following message:
 
-```
-Hi, @username(s)! After joining as a collaborator in the repository,
+> Hi, \@username(s)! After joining as a collaborator in the repository,
 you have been regularly performing maintenance tasks. Thank you for that!
 According to
-[GOVERNANCE.md](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md),
+\[GOVERNANCE.md](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md),
 you've now met the thresholds to be effectively considered
-an active maintainer of the project ([LINKS TO THE RELEVANT PRs]).
+an active maintainer of the project (\[LINKS TO THE RELEVANT PRs]).
 To publicly acknowledge that fact, we'll add you to the tldr-pages organization.
-
-If you accept the invitation, we ask you to make your membership public,
+>
+> If you accept the invitation, we ask you to make your membership public,
 and (in case you don't already) start hanging out in our Gitter chat room.
 You'll now be one of the public faces of the tldr-pages project.
 Welcome aboard!
-```
 
 Once they acknowledge the message,
 go to https://github.com/orgs/tldr-pages/people
@@ -138,21 +134,19 @@ and add them to the organization as a member.
 
 Open an issue with the following message:
 
-```
-Hi, @username(s)! You've been an active tldr-pages org member for over 6 months.
+> Hi, \@username(s)! You've been an active tldr-pages org member for over 6 months.
 Thanks for sticking around this far and helping out!
 According to
-[GOVERNANCE.md](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md),
+\[GOVERNANCE.md](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md),
 you're now eligible for becoming an owner of the organization.
-
-That means you will, from now on, be part of the team
+>
+> That means you will, from now on, be part of the team
 responsible for performing role changes (like this one!) in the community.
 Before performing such role transitions, make sure to review the
-[COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md)
+\[COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md)
 document.
-
-Thanks for all the work you've done so far. You rock!
-```
+>
+> Thanks for all the work you've done so far. You rock!
 
 Once they acknowledge the message,
 go to https://github.com/orgs/tldr-pages/people
@@ -164,28 +158,26 @@ Afterwards, add their name to the list of current organization owners below.
 
 Open an issue with the following message:
 
-```
-Hi, @username(s)! As you know, our
-[governance guidelines](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md)
+> Hi, @username(s)! As you know, our
+\[governance guidelines](https://github.com/tldr-pages/tldr/blob/master/GOVERNANCE.md)
 define processes for keeping the list of organization members
 in sync with the actual maintenance team.
 Since you haven't been active in the project for a while now,
 we'll be moving you to the status of former maintainer.
-
-In practice, not much will change on your side,
+>
+> In practice, not much will change on your side,
 since you'll remain a collaborator in the repos you have been active in,
-so **you will keep the ability to commit, merge PRs, label and close issues, etc.**,
+so \*\*you will keep the ability to commit, merge PRs, label and close issues, etc.\*\*,
 if you feel so inclined. But even if you don't,
 keep in mind that every bit of work you already did for the tldr-pages project
 was a voluntary gift of your time to this community.
 Your efforts have contributed to a project
 which helps hundreds of people every day — be proud of it!
-
-And of course, you're welcome back anytime as a maintainer, if you so choose
+>
+> And of course, you're welcome back anytime as a maintainer, if you so choose
 — in which case we'll re-add you to the organization,
 as is also described in the guidelines.
 In any case, we wish you the best of luck in your new endeavors!
-```
 
 Once the role change is completed,
 make sure to update the lists below accordingly.
@@ -211,7 +203,7 @@ and are responsible for performing role changes in the community.
 ### Past owners
 
 The following people used to be owners in the tldr-pages organization,
-and have since moved on to other projects.
+and have reduced their participation or otherise moved on to other projects.
 Their contributions and dedication have ensured the success of the tldr project,
 and for that they'll always be appreciated.
 


### PR DESCRIPTION
This allows the template messages to retain the semantic line-breaking
that improves the readability of their source code version control diffs,
while at the same time they can be copy-pasted to issues
without the line breaks (which is slightly problematic
because github includes the line breaks
even when rendering content as rich-text prose).

(Case in point: this very PR, which reuses the extended commit message.)

Also, slightly reword a sentence in the "Past owners" section,
to make it more general and cover more cases.