### PR TITLE
git-commit: reorder commands

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -6,10 +6,10 @@
 
 `git commit -m {{message}}`
 
-- Replace the last commit with currently staged changes:
-
-`git commit --amend`
-
 - Auto stage all modified files and commit with a message:
 
 `git commit -a -m {{message}}`
+
+- Replace the last commit with currently staged changes:
+
+`git commit --amend`


### PR DESCRIPTION
Reorder commands in a more logical manner

I just moved the last command closer to the first one, because they were both similar.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
