### PR TITLE
f5fpc: Prepend all examples with sudo

### DIFF
--- a/pages/linux/f5fpc.md
+++ b/pages/linux/f5fpc.md
@@ -4,20 +4,20 @@
 
 - Open a new VPN connection:
 
-`f5fpc --start`
+`sudo f5fpc --start`
 
 - Open a new VPN connection to a specific host:
 
-`f5fpc --start --host {{host.example.com}}`
+`sudo f5fpc --start --host {{host.example.com}}`
 
 - Specify a username (user will be prompted for a password):
 
-`f5fpc --start --host {{host.example.com}} --username {{user}}`
+`sudo f5fpc --start --host {{host.example.com}} --username {{user}}`
 
 - Show the current VPN status:
 
-`f5fpc --info`
+`sudo f5fpc --info`
 
 - Shutdown the VPN connection:
 
-`f5fpc --stop`
+`sudo f5fpc --stop`


### PR DESCRIPTION
Had some issues with f5fpc and connecting via VPN to my university today. Long story short: I needed to `sudo` the `f5fpc` commands. Thought I'd update the tldr-page accordingly :slightly_smiling_face: 

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
