### PR TITLE
autojump: adding 'jo' command to open directory in OS file manager

### DIFF
--- a/pages/common/autojump.md
+++ b/pages/common/autojump.md
@@ -18,3 +18,7 @@
 - Show the entries in the autojump database:
 
 `j -s`
+
+- Open a directory that contains the given pattern in the operating system file manager:
+
+`jo {{pattern}}`


### PR DESCRIPTION
From the autojump readme: https://github.com/wting/autojump

"Open File Manager To Directories (instead of jumping):

Instead of jumping to a directory, you can open a file explorer window (Mac Finder, Windows Explorer, GNOME Nautilus, etc.) to the directory instead.

jo music"

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
