### PR TITLE
wpa_supplicant: add page

### DIFF
--- a/pages/common/wpa_supplicant.md
+++ b/pages/common/wpa_supplicant.md
@@ -1,0 +1,11 @@
+# wpa_supplicant
+
+> Manage protected wireless networks.
+
+- Join a protected wireless network:
+
+`wpa_supplicant -i {{interface}} -c {{path/to/wpa_supplicant_conf.conf}}`
+
+- Join a protected wireless network and run it in a daemon:
+
+`wpa_supplicant -B -i {{interface}} -c {{path/to/wpa_supplicant_conf.conf}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
