### PR TITLE
dpkg: add -c option (list local deb file contents)

### DIFF
--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -4,7 +4,7 @@
 
 - Install a package:
 
-`dpkg -i {{/path/to/file}}`
+`dpkg -i {{path/to/file.deb}}`
 
 - Remove a package:
 
@@ -17,6 +17,10 @@
 - List package contents:
 
 `dpkg -L {{package_name}}`
+
+- List contents of a local package file:
+
+`dpkg -c {{path/to/file.deb}}`
 
 - Find out which package owns a file:
 


### PR DESCRIPTION
Add example for listing package contents of a downloaded `.deb` file, because `dpkg -L` only works with the `apt` name of the package (and only when installed).

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
