### PR TITLE
make: GNU Make does not support -J option

### DIFF
--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -13,7 +13,7 @@
 
 - Call a specific target, executing 4 jobs at a time in parallel:
 
-`make -J{{4}} {{target}}`
+`make -j{{4}} {{target}}`
 
 - Use a specific Makefile:
 


### PR DESCRIPTION
----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->
- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

GNU Make does not support -J option and looking at BSD man page, the use of -J is discouraged anyway*.

* https://www.freebsd.org/cgi/man.cgi?make(1)

