### PR TITLE
jpegoptim: added max size param example

### DIFF
--- a/pages/common/jpegoptim.md
+++ b/pages/common/jpegoptim.md
@@ -14,6 +14,10 @@
 
 `jpegoptim --all-progressive {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`
 
+- Force the output images to be fixed max size:
+
+`jpegoptim --size={{250k}} {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`
+
 - Recursive folder optimization:
 
-`find {{.}} -name "{{*.jpg}}" -exec jpegoptim --strip-all --all-progressive {} \;`
+`find {{.}} -name "{{*.jpg}}" -exec jpegoptim --strip-all --all-progressive --size={{250k}} {} \;`

--- a/pages/common/jpegoptim.md
+++ b/pages/common/jpegoptim.md
@@ -13,3 +13,7 @@
 - Force the output images to be progressive:
 
 `jpegoptim --all-progressive {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`
+
+- Recursive folder optimization:
+
+`find {{.}} -name "{{*.jpg}}" -exec jpegoptim --strip-all --all-progressive {} \;`

--- a/pages/common/jpegoptim.md
+++ b/pages/common/jpegoptim.md
@@ -17,7 +17,3 @@
 - Force the output images to be fixed max size:
 
 `jpegoptim --size={{250k}} {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`
-
-- Recursive folder optimization:
-
-`find {{.}} -name "{{*.jpg}}" -exec jpegoptim --strip-all --all-progressive --size={{250k}} {} \;`

--- a/pages/common/jpegoptim.md
+++ b/pages/common/jpegoptim.md
@@ -14,6 +14,6 @@
 
 `jpegoptim --all-progressive {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`
 
-- Force the output images to be fixed max size:
+- Force the output images to have a fixed maximum filesize:
 
 `jpegoptim --size={{250k}} {{image1.jpeg}} {{image2.jpeg}} {{imageN.jpeg}}`


### PR DESCRIPTION
----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

Hi again, I find it useful to have an example of recursive optimization of `jpegoptim`
I use it only this way , also with --size param

`find {{.}} -name "{{*.jpg}}" -exec jpegoptim --strip-all --all-progressive --size={{250k}}  {} \;`

