### PR TITLE
jupyter: add jupyter lab command

### DIFF
--- a/pages/common/jupyter.md
+++ b/pages/common/jupyter.md
@@ -22,3 +22,7 @@
 - Stop the currently running server:
 
 `jupyter notebook stop`
+
+- Start JupyterLab, if installed, in the current directory:
+
+`jupyter lab`


### PR DESCRIPTION
Jupyter lab is now available for general use. It's common so might as well add it even though it's an obvious command.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
