### PR TITLE
Workflow: add pre-commit hook to automatically lint files upon commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: tldr-lint
+        name: tldrl-lint
+        entry: tldrl
+        language: system
+        files: \.(md)$
+        args: ['-style=file', '-i']
+        files: 'pages/.*\.md$'


### PR DESCRIPTION
----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [X] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [X] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

The framework [pre-commit](https://pre-commit.com) allows to set up git commit hooks.
I created a configuration file that runs [tldr-lint](https://github.com/tldr-pages/tldr-lint) against all changed/new pages-files (Markdown) upon a commit. The commit is aborted if tldr-lint reports a mistake.

Usage:

1. Install pre-commit (Example: `brew install pre-commit`, or any other installation method on the website)
2. Initialize hooks in tldr repository: `pre-commit install`
3. Normally use `git commit`, which runs the linter upon changed files.

If you choose not to use pre-commit nothing changes to the workflow before.
This reduces the amount of pull-requests with lint-warnings.
This reduces the frustration of realising a mistake after a commit.

Example output of a `git commit`:

```
tldrl-lint...............................................................Failed
hookid: tldr-lint

Files were modified by this hook. Additional output:

pages/linux/my_new_command.md:3: TLDR004 Command descriptions should end in a period
```