### PR TITLE
php artisan: add page

### DIFF
--- a/pages/common/php-artisan.md
+++ b/pages/common/php-artisan.md
@@ -1,0 +1,19 @@
+# php artisan
+
+> Laravel's Artisan command line interface.
+
+- Display a list of all available commands:
+
+`php artisan help`
+
+- Start PHP's built-in web server for the current Laravel application:
+
+`php artisan serve`
+
+- Start an interactive PHP command line interface:
+
+`php artisan tinker`
+
+- Generate a new Eloquent model class with a migration, factory and resource controller:
+
+`php artisan make:model {{ModelName}} --all`

--- a/pages/common/php-artisan.md
+++ b/pages/common/php-artisan.md
@@ -2,10 +2,6 @@
 
 > Laravel's Artisan command line interface.
 
-- Display a list of all available commands:
-
-`php artisan help`
-
 - Start PHP's built-in web server for the current Laravel application:
 
 `php artisan serve`
@@ -17,3 +13,7 @@
 - Generate a new Eloquent model class with a migration, factory and resource controller:
 
 `php artisan make:model {{ModelName}} --all`
+
+- Display a list of all available commands:
+
+`php artisan help`


### PR DESCRIPTION
This adds a page for the command line interface for the popular PHP framework [Laravel](https://laravel.com/docs/master/artisan)

-----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
