### PR TITLE
php yii: add page

### DIFF
--- a/pages/common/php-yii.md
+++ b/pages/common/php-yii.md
@@ -1,0 +1,15 @@
+# php yii
+
+> Yii Framework's command line interface.
+
+- Display a list of all available commands:
+
+`php yii {{help}}`
+
+- Start PHP's built-in web server for the current Yii application:
+
+`php yii {{serve}}`
+
+- Generate a controller, views and related files for the CRUD actions on the specified model class:
+
+`php yii {{gii/crud}} --modelClass={{ModelName}} --controllerClass={{ControllerName}}`


### PR DESCRIPTION
This adds a page for [Yii Framework's command line interface](https://www.yiiframework.com/doc/guide/2.0/en/tutorial-console)

-----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
