### PR TITLE
subl: add page

### DIFF
--- a/pages/common/subl.md
+++ b/pages/common/subl.md
@@ -1,0 +1,19 @@
+# subl
+
+> Sublime Text editor.
+
+- Open the current directory in Sublime Text:
+
+`subl {{.}}`
+
+- Open a file or directory in Sublime Text:
+
+`subl {{path/to/file_or_folder}}`
+
+- Open a file or directory in the currently open window:
+
+`subl -a {{path/to/file}}`
+
+- Open a file or directory in a new window:
+
+`subl -n {{path/to/file}}`


### PR DESCRIPTION
This adds a page for the command line interface for the popular text editing software [Sublime Text](https://www.sublimetext.com/)

-----

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
