### PR TITLE
GOVERNANCE: number principles to allow x-refs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,46 +12,46 @@ with no central authority.
 
 Community members are asked to abide by the following principles:
 
-- **All contributions are welcome**,
-  [no matter how small](https://github.com/kentcdodds/all-contributors).
-  The tldr-pages project is a
-  [do-ocracy](https://communitywiki.org/wiki/DoOcracy),
-  so don't hesitate to get involved
-  — we're happy to welcome you into the community!
-  Please take a look at [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+1. **All contributions are welcome**,
+   [no matter how small](https://github.com/kentcdodds/all-contributors).
+   The tldr-pages project is a
+   [do-ocracy](https://communitywiki.org/wiki/DoOcracy),
+   so don't hesitate to get involved
+   — we're happy to welcome you into the community!
+   Please take a look at [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
-- **All interactions must be respectful and cordial**.
-  Avoid making assumptions about the others' intentions,
-  and make your own intentions clear.
-  When in doubt, provide additional context, or ask for clarification.
-  Remember, it's very hard to convey meaning on a purely written medium,
-  especially between people from different cultures, technical backgrounds,
-  English proficiency levels, etc.
+2. **All interactions must be respectful and cordial**.
+   Avoid making assumptions about the others' intentions,
+   and make your own intentions clear.
+   When in doubt, provide additional context, or ask for clarification.
+   Remember, it's very hard to convey meaning on a purely written medium,
+   especially between people from different cultures, technical backgrounds,
+   English proficiency levels, etc.
 
-- **All communications are public**.
-  There are no permanent private channels
-  where maintainers discuss "internal" matters.
-  Occasional private chat or email messages may be exchanged,
-  e.g. when setting up services that require passwords,
-  but otherwise all communications that impact the project
-  will either happen in issue and PR discussions,
-  or in the [Gitter chat room](https://gitter.im/tldr-pages/tldr)
-  (which is open to all, and publicly logged).
+3. **All communications are public**.
+   There are no permanent private channels
+   where maintainers discuss "internal" matters.
+   Occasional private chat or email messages may be exchanged,
+   e.g. when setting up services that require passwords,
+   but otherwise all communications that impact the project
+   will either happen in issue and PR discussions,
+   or in the [Gitter chat room](https://gitter.im/tldr-pages/tldr)
+   (which is open to all, and publicly logged).
 
-- **All decisions are made by community consensus**.
-  This does not mean there has to be unanimity,
-  nor that decisions result automatically from vote counts.
-  What it means is that
-  all interested members of the community are welcome to voice their thoughts,
-  and incompatible positions will ideally be resolved
-  with participants either agreeing with the final decision, or voluntarily
-  [consenting](https://en.wikipedia.org/wiki/Sociocracy#Consent_vs._consensus)
-  to accept it as "good enough for now, safe enough to try".
+4. **All decisions are made by community consensus**.
+   This does not mean there has to be unanimity,
+   nor that decisions result automatically from vote counts.
+   What it means is that
+   all interested members of the community are welcome to voice their thoughts,
+    and incompatible positions will ideally be resolved
+   with participants either agreeing with the final decision, or voluntarily
+   [consenting](https://en.wikipedia.org/wiki/Sociocracy#Consent_vs._consensus)
+   to accept it as "good enough for now, safe enough to try".
 
-- **Community roles should reflect actual activity**.
-  Community roles in the tldr-project are set up
-  to dynamically reflect organizational work performed by community members,
-  rather than assigned as authority positions by top-down decision-making.
-  The different roles that contributors can take in the community,
-  and the principles that guide the transitions among them,
-  are described in the [COMMUNITY-ROLES.md](COMMUNITY-ROLES.md) document.
+5. **Community roles should reflect actual activity**.
+   Community roles in the tldr-project are set up
+   to dynamically reflect organizational work performed by community members,
+   rather than assigned as authority positions by top-down decision-making.
+   The different roles that contributors can take in the community,
+   and the principles that guide the transitions among them,
+   are described in the [COMMUNITY-ROLES.md](COMMUNITY-ROLES.md) document.


### PR DESCRIPTION
This is a simple change that doesn't affect the actual content in any way; it only changes the presentation, by using a numbered list (rather than a bulleted one) to make it possible to refer directly to specific governance rules.