### PR TITLE
virtualenv: add --prompt option

### DIFF
--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -6,6 +6,10 @@
 
 `virtualenv {{path/to/venv}}`
 
+- Customize the prompt prefix:
+
+`virtualenv --prompt={{prompt_prefix}}  {{path/to/venv}}`
+
 - Start (select) the environment:
 
 `source {{path/to/venv}}/bin/activate`


### PR DESCRIPTION
Adding --prompt option to customize the prompt prefix. It's helpful to distinguish between multiple virtualenvs as most of the time `venv` is chosen as the name of  the virtualenv directory and that it's chosen as the prompt prefix by default.