### PR TITLE
docker: combine start/stop, add basic run example

### DIFF
--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -10,13 +10,13 @@
 
 `docker container ls -a`
 
-- Start a container:
+- Start a container from an image, with a custom name:
 
-`docker container start {{container}}`
+`docker container run --name={{container_name}} {{image}}`
 
-- Stop a container:
+- Start or stop an existing container:
 
-`docker container stop {{container}}`
+`docker container {{start|stop}} {{container_name}}`
 
 - Start a container from an image and get a shell inside of it:
 
@@ -24,12 +24,12 @@
 
 - Run a command inside of an already running container:
 
-`docker container exec {{container}} {{command}}`
+`docker container exec {{container_name}} {{command}}`
 
 - Remove a stopped container:
 
-`docker container rm {{container}}`
+`docker container rm {{container_name}}`
 
 - Fetch and follow the logs of a container:
 
-`docker container logs -f {{container}}`
+`docker container logs -f {{container_name}}`


### PR DESCRIPTION
The start and stop examples are pretty much identical, so it doesn't make sense to use up the space of two examples in the limited length of a tldr page (especially for such a complex command as docker).

In the slot left by combining the two entries, a new one is added mentioning how to launch a container from an image. Placing this example before the start/stop commands (and naming the parameter "container_name" consistently trhoughout the page) also makes the sequence more logical, by first explaining how containers are instantiated, and only then mentioning how they are managed.

----

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
