### PR TITLE
xsv: add page

### DIFF
--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -1,0 +1,27 @@
+# xsv
+
+> A fast CSV command line toolkit written in Rust.
+
+- Inspect the headers of a file:
+
+`xsv headers {{worldcities.csv}}`
+
+- Count the number of entries:
+
+`xsv count {{worldcities.csv}}`
+
+- Get an overview of the shape of entries:
+
+`xsv stats {{worldcities.csv}} | xsv table`
+
+- Select a few columns:
+
+`xsv select {{Country,AccentCity}} {{worldcities.csv}}`
+
+- Show 10 random sample of entries:
+
+`xsv sample {{10}} {{worldcities.csv}}`
+
+- Join a column from one file to another:
+
+`xsv join --no-case {{Country}} {{worldcities.csv}} {{Abbrev}} {{countrynames.csv}} | xsv table`

--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -4,24 +4,24 @@
 
 - Inspect the headers of a file:
 
-`xsv headers {{worldcities.csv}}`
+`xsv headers {{path/to/worldcities.csv}}`
 
 - Count the number of entries:
 
-`xsv count {{worldcities.csv}}`
+`xsv count {{path/to/worldcities.csv}}`
 
 - Get an overview of the shape of entries:
 
-`xsv stats {{worldcities.csv}} | xsv table`
+`xsv stats {{path/to/worldcities.csv}} | xsv table`
 
 - Select a few columns:
 
-`xsv select {{Country,AccentCity}} {{worldcities.csv}}`
+`xsv select {{Country,AccentCity}} {{path/to/worldcities.csv}}`
 
-- Show 10 random sample of entries:
+- Show 10 random entries:
 
-`xsv sample {{10}} {{worldcities.csv}}`
+`xsv sample {{10}} {{path/to/worldcities.csv}}`
 
 - Join a column from one file to another:
 
-`xsv join --no-case {{Country}} {{worldcities.csv}} {{Abbrev}} {{countrynames.csv}} | xsv table`
+`xsv join --no-case {{Country}} {{path/to/worldcities.csv}} {{Abbrev}} {{path/to/countrynames.csv}} | xsv table`

--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -16,7 +16,7 @@
 
 - Select a few columns:
 
-`xsv select {{Column_A,Column_B}} {{path/to/file.csv}}`
+`xsv select {{column_a,column_b}} {{path/to/file.csv}}`
 
 - Show 10 random entries:
 
@@ -24,4 +24,4 @@
 
 - Join a column from one file to another:
 
-`xsv join --no-case {{Key_A}} {{path/to/file/a.csv}} {{Column_B}} {{path/to/file/b.csv}} | xsv table`
+`xsv join --no-case {{key_a}} {{path/to/file/a.csv}} {{column_b}} {{path/to/file/b.csv}} | xsv table`

--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -24,4 +24,4 @@
 
 - Join a column from one file to another:
 
-`xsv join --no-case {{key_a}} {{path/to/file/a.csv}} {{column_b}} {{path/to/file/b.csv}} | xsv table`
+`xsv join --no-case {{column_a}} {{path/to/file/a.csv}} {{column_b}} {{path/to/file/b.csv}} | xsv table`

--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -4,24 +4,24 @@
 
 - Inspect the headers of a file:
 
-`xsv headers {{path/to/worldcities.csv}}`
+`xsv headers {{path/to/file.csv}}`
 
 - Count the number of entries:
 
-`xsv count {{path/to/worldcities.csv}}`
+`xsv count {{path/to/file.csv}}`
 
 - Get an overview of the shape of entries:
 
-`xsv stats {{path/to/worldcities.csv}} | xsv table`
+`xsv stats {{path/to/file.csv}} | xsv table`
 
 - Select a few columns:
 
-`xsv select {{Country,AccentCity}} {{path/to/worldcities.csv}}`
+`xsv select {{Column_A,Column_B}} {{path/to/file.csv}}`
 
 - Show 10 random entries:
 
-`xsv sample {{10}} {{path/to/worldcities.csv}}`
+`xsv sample {{10}} {{path/to/file.csv}}`
 
 - Join a column from one file to another:
 
-`xsv join --no-case {{Country}} {{path/to/worldcities.csv}} {{Abbrev}} {{path/to/countrynames.csv}} | xsv table`
+`xsv join --no-case {{Key_A}} {{path/to/file/a.csv}} {{Column_B}} {{path/to/file/b.csv}} | xsv table`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

---

A first crack at #2333

- Should this use `{{path/to/worldcities.csv}}` instead of `{{worldcities.csv}}`?
- Should I describe that worldcities.csv can be downloaded with `curl -LO http://burntsushi.net/stuff/worldcitiespop.csv`?
