### PR TITLE
Adding git add in contribution-guides/git-terminal.md

### DIFF
--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -12,15 +12,18 @@ The overall process should look somewhat like this:
 3. Create a feature branch, e.g. named after the command you plan to edit:  
   `git checkout -b {{branch_name}}`
 
-4. Make your changes (edit existing files or create new ones)
+4. Make your changes (edit existing files or create new ones) 
 
-5. Commit the changes (following the [commit message guidelines][commit-msg]):  
+5. Add the changes to be staged:
+  `git add {{path_spec}}`
+
+6. Commit the changes (following the [commit message guidelines][commit-msg]):  
   `git commit --all -m "{{commit_message}}"`
 
-6. Push the commit(s) to your fork:  
+7. Push the commit(s) to your fork:  
   `git push origin {{branch_name}}`
 
-7. Go to the github page for your fork and click the green "pull request" button.
+8. Go to the github page for your fork and click the green "pull request" button.
 
 Please only send related changes in the same pull request.
 Typically a pull request will include changes in a single file.


### PR DESCRIPTION
As this is for new comers, mentioning about `git add` should be done here, though `path_spec` is quite misleading but it's from official documentation

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
