### PR TITLE
dirname: add page

### DIFF
--- a/pages/common/dirname.md
+++ b/pages/common/dirname.md
@@ -10,6 +10,6 @@
 
 `dirname --zero {{/path/to/file_or_folder}}`
 
-- If no '/' in path, the current directory (.) is printed:
+- If no '/' is in path, the current directory (.) is printed:
 
 `dirname {{file_or_folder}}`

--- a/pages/common/dirname.md
+++ b/pages/common/dirname.md
@@ -8,7 +8,7 @@
 
 - Print pathname without newline:
 
-`dirname -z {{/path/to/file_or_folder}}`
+`dirname --zero {{/path/to/file_or_folder}}`
 
 - If no '/' in path, the current directory (.) is printed:
 

--- a/pages/common/dirname.md
+++ b/pages/common/dirname.md
@@ -1,0 +1,15 @@
+# dirname 
+
+> Prints the directory-path from a pathname.
+
+- Print pathname:
+
+`dirname {{/path/to/file_or_folder}}`
+
+- Print pathname without newline:
+
+`dirname -z {{/path/to/file_or_folder}}`
+
+- If no '/' in path, the current directory (.) is printed:
+
+`dirname {{file_or_folder}}`


### PR DESCRIPTION
----
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

I'm a bit unsure about the description for the command without any slash in the directory-path. Any preferences on how to express that the dot is for the current directory?