### PR TITLE
bat: fix typo

### DIFF
--- a/pages/common/bat.md
+++ b/pages/common/bat.md
@@ -25,4 +25,4 @@
 
 - Display all supported languages:
 
-`bat --list-language`
+`bat --list-languages`


### PR DESCRIPTION
The CLI argument is plural as seen here:

https://github.com/sharkdp/bat/blob/f9fd5e485173adf71b44888f72980577f16ddcf7/src/clap_app.rs#L55-L61