### PR TITLE
kafkacat: add page

### DIFF
--- a/pages/common/kafkacat.md
+++ b/pages/common/kafkacat.md
@@ -6,7 +6,7 @@
 
 `kafkacat -C -t {{topic}} -b {{brokers}}`
 
-- Consume message, start with the oldest offset, exit when last message received:
+- Consume messages starting with the oldest offset and exit after the last message is received:
 
 `kafkacat -C -t {{topic}} -b {{brokers}} -o beginning -e`
 

--- a/pages/common/kafkacat.md
+++ b/pages/common/kafkacat.md
@@ -1,0 +1,35 @@
+# kafkacat
+
+> Apache Kafka producer and consumer tool.
+
+- Consume messages, start with the newest offset:
+
+`kafkacat -C -t {{topic}} -b {{brokers}}`
+
+- Consume message, start with the oldest offset, exit when last message received:
+
+`kafkacat -C -t {{topic}} -b {{brokers}} -o beginning -e`
+
+- Consume messages as a Kafka consumer group:
+
+`kafkacat -G {{group_id}} {{topic}} -b {{brokers}}`
+
+- Produce messages, read from file:
+
+`kafkacat -P -t {{topic}} -b {{brokers}} {{path/to/file}}`
+
+- Produce message, read from STDIN:
+
+` echo {{message}} | kafkacat -P -t {{topic}} -b {{brokers}}`
+
+- List metadata for all topics and brokers:
+
+`kafkacat -L -b {{brokers}}`
+
+- List metadata for a specific topic:
+
+`kafkacat -L -t {{topic}} -b {{brokers}}`
+
+- Get offset for a topic/partition for specific point in time:
+
+`kafkacat -Q -t {{topic}:{{partition}}:{{unix_timestamp}} -b {{brokers}}`

--- a/pages/common/kafkacat.md
+++ b/pages/common/kafkacat.md
@@ -14,13 +14,13 @@
 
 `kafkacat -G {{group_id}} {{topic}} -b {{brokers}}`
 
+- Produce message, read from stdin:
+
+` echo {{message}} | kafkacat -P -t {{topic}} -b {{brokers}}`
+
 - Produce messages, read from file:
 
 `kafkacat -P -t {{topic}} -b {{brokers}} {{path/to/file}}`
-
-- Produce message, read from STDIN:
-
-` echo {{message}} | kafkacat -P -t {{topic}} -b {{brokers}}`
 
 - List metadata for all topics and brokers:
 

--- a/pages/common/kafkacat.md
+++ b/pages/common/kafkacat.md
@@ -2,7 +2,7 @@
 
 > Apache Kafka producer and consumer tool.
 
-- Consume messages, start with the newest offset:
+- Consume messages starting with the newest offset:
 
 `kafkacat -C -t {{topic}} -b {{brokers}}`
 
@@ -14,11 +14,11 @@
 
 `kafkacat -G {{group_id}} {{topic}} -b {{brokers}}`
 
-- Produce message, read from stdin:
+- Publish message read from stdin:
 
 ` echo {{message}} | kafkacat -P -t {{topic}} -b {{brokers}}`
 
-- Produce messages, read from file:
+- Publish messages by reading from a file:
 
 `kafkacat -P -t {{topic}} -b {{brokers}} {{path/to/file}}`
 
@@ -30,6 +30,6 @@
 
 `kafkacat -L -t {{topic}} -b {{brokers}}`
 
-- Get offset for a topic/partition for specific point in time:
+- Get offset for a topic/partition for a specific point in time:
 
 `kafkacat -Q -t {{topic}:{{partition}}:{{unix_timestamp}} -b {{brokers}}`

--- a/pages/common/kafkacat.md
+++ b/pages/common/kafkacat.md
@@ -14,7 +14,7 @@
 
 `kafkacat -G {{group_id}} {{topic}} -b {{brokers}}`
 
-- Publish message read from stdin:
+- Publish message by reading from stdin:
 
 ` echo {{message}} | kafkacat -P -t {{topic}} -b {{brokers}}`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

This is for [kafkacat](https://github.com/edenhill/kafkacat).

There are some more examples on the kafkacat GitHub page. If you feel there should be more complicated examples included, I am happy to replace one or more of the ones already provided.

