### PR TITLE
dig: remove google's mention

### DIFF
--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -14,7 +14,7 @@
 
 `dig {{hostname.com}} ANY`
 
-- Specify an alternate DNS server to query (8.8.8.8 is google's public DNS):
+- Specify an alternate DNS server to query:
 
 `dig @{{8.8.8.8}} {{hostname.com}}`
 


### PR DESCRIPTION
Remove google's mention, as proposed in 
https://github.com/tldr-pages/tldr/pull/2435#discussion_r224964020

----
- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
