### PR TITLE
fkill: add page

### DIFF
--- a/pages/common/fkill.md
+++ b/pages/common/fkill.md
@@ -8,4 +8,4 @@
 
 - Kill the process by pid, name or port:
 
-`fkill [<pid|name|:port> ...]`
+`fkill {{pid|name|:port}}`

--- a/pages/common/fkill.md
+++ b/pages/common/fkill.md
@@ -1,0 +1,11 @@
+# fkill
+
+> Fabulously kill processes. Cross-platform.
+
+- Run without arguments to use the interactive interface:
+
+`fkill`
+
+- Kill the process by pid, name or port:
+
+`fkill [<pid|name|:port> ...]`


### PR DESCRIPTION
This adds a page for fkill command.

[Fkill](https://github.com/sindresorhus/fkill) is cross-platform CLI tool that "fabulously" kill processes.
