### PR TITLE
sudo: general revision of entry

### DIFF
--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -1,23 +1,23 @@
 # sudo
 
-> Executes a single command as another user.
+> Executes a single command as the superuser or another user.
 
-- List the contents of an unreadable directory:
+- Run a command as the superuser:
 
-`sudo {{ls}} {{/usr/local/scrt}}`
+`sudo {{shutdown now}}`
 
-- Edit a file as the user www:
+- Edit a file as the superuser with your default editor:
 
-`sudo -u {{www}} {{vi}} {{/var/www/index.html}}`
+`sudo -e {{/etc/fstab}}`
 
-- Shut down the machine:
+- Run a command as another user and/or group:
 
-`sudo {{shutdown}} -h +10 {{"Cya soon!"}}`
+`sudo -u {{user}} -g {{group}} {{id}}`
 
-- Repeat the last command as sudo:
+- Repeat the last command prefixed with "sudo" (only in bash, zsh, etc.):
 
 `sudo !!`
 
-- Launch the default shell with root privileges:
+- Launch the default shell with superuser privileges:
 
 `sudo -i`

--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -4,7 +4,7 @@
 
 - Run a command as the superuser:
 
-`sudo {{shutdown now}}`
+`sudo {{less /var/log/syslog}}`
 
 - Edit a file as the superuser with your default editor:
 


### PR DESCRIPTION
My changes are as follows:

1. Changed the more complex examples *involving* `sudo` to simple examples showing the *usage* of `sudo`.
2. Separate the examples of editing a file and doing something as another user
3. Standardized the wording to use superuser instead of root
4. Clarified the usage of `sudo !!` which is not a feature of sudo, but the shell you use. I'm half tempted to say we should just take it out, but it is a very useful shortcut that more people should know about.
5. Added the `-e` flag that allows you to edit files using your default editor as specified by the environment variables `VISUAL` or `EDITOR`. This has several other benefits over editing the file directly with a command like `sudo vim /etc/fstab` as well.
6. Fixed the odd syntax for the `shutdown` example which was visually confusing as to which flags were being passed to `shutdown` and which to `sudo`

I'm also don't like using examples like `sudo shutdown now` or anything else that could be harmful if blindly copy and pasted, so I'd be curious if there is a more innocuous command that we could use but still demonstrate the effects of `sudo`.

----

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
