### PR TITLE
pandoc: add example

### DIFF
--- a/pages/common/pandoc.md
+++ b/pages/common/pandoc.md
@@ -6,7 +6,7 @@
 
 `pandoc {{input.md}} -o {{output.pdf}}`
 
-- Convert a file to a specific output format when the extension is ambiguous:
+- Force conversion to use a specific format:
 
 `pandoc {{input.docx}} --to {{markdown_github}} -o {{output.md}}`
 

--- a/pages/common/pandoc.md
+++ b/pages/common/pandoc.md
@@ -2,13 +2,17 @@
 
 > Convert documents between various formats.
 
-- Convert file to pdf (the output format is automatically determined from the output file's extension):
+- Convert file to pdf (the output format is determined by file extension):
 
 `pandoc {{input.md}} -o {{output.pdf}}`
 
-- Convert a file to a specific output format (useful for when the extension alone is ambiguous):
+- Convert a file to a specific output format when the extension is ambiguous:
 
 `pandoc {{input.docx}} --to {{markdown_github}} -o {{output.md}}`
+
+- Convert to a standalone file with the appropriate headers/footers (for LaTeX, HTML, etc.):
+
+`pandoc {{input.md}} -s -o {{output.tex}}`
 
 - List all supported input formats:
 


### PR DESCRIPTION
Shortened the example descriptions and added another example that shows standalone mode that is especially useful when working with LaTeX.

----

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
