### PR TITLE
script: add page

### DIFF
--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -1,0 +1,20 @@
+# script
+
+> Make typescript of terminal session.
+
+- Start recording in new file:
+
+`script logfile.log`
+
+- Stop recording
+
+`exit`
+
+- Append to an existing log file:
+
+`command -a logfile.log`
+
+- Record without start and done messages (quiet):
+
+`script -q logfile.log`
+  

--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -1,6 +1,6 @@
 # script
 
-> Make a typescript file of a terminal session
+> Make a typescript file of a terminal session.
 
 - Start recording in file named "typescript":
 
@@ -20,4 +20,4 @@
 
 - Execute quietly without start and done messages:
 
-`script -q {{logfile.log}}
+`script -q {{logfile.log}}`

--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -6,7 +6,7 @@
 
 `script logfile.log`
 
-- Stop recording
+- Stop recording:
 
 `exit`
 
@@ -17,4 +17,3 @@
 - Record without start and done messages (quiet):
 
 `script -q logfile.log`
-  

--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -10,11 +10,11 @@
 
 `exit`
 
-- Start recording in file filename:
+- Start recording in a given file:
 
-`script {{filename}}`
+`script {{logfile.log}}`
 
-- Append to an existing log file:
+- Append to an existing file:
 
 `script -a {{logfile.log}}`
 

--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -1,19 +1,23 @@
 # script
 
-> Make typescript of terminal session.
+> Make a typescript file of a terminal session
 
-- Start recording in new file:
+- Start recording in file named "typescript":
 
-`script logfile.log`
+`script`
 
 - Stop recording:
 
 `exit`
 
+- Start recording in file filename:
+
+`script {{filename}}`
+
 - Append to an existing log file:
 
-`command -a logfile.log`
+`script -a logfile.log`
 
-- Record without start and done messages (quiet):
+- Execute quietly without start and done messages:
 
 `script -q logfile.log`

--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -16,8 +16,8 @@
 
 - Append to an existing log file:
 
-`script -a logfile.log`
+`script -a {{logfile.log}}`
 
 - Execute quietly without start and done messages:
 
-`script -q logfile.log`
+`script -q {{logfile.log}}


### PR DESCRIPTION
I created a page for the unix command script that records the terminal.

- [x ] The page (if new), does not already exist in the repo.

- [ x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ x] The page has 8 or fewer examples.

- [ x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.
- [ x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
