### PR TITLE
cp: remove redundant example

### DIFF
--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -14,10 +14,6 @@
 
 `cp -r {{path/to/folder}} {{path/to/copy}}`
 
-- Copy a folder recursively into another folder, keeping the folder name:
-
-`cp -r {{path/to/folder}} {{path/to/target/parent/folder}}`
-
 - Copy a folder recursively, in verbose mode (shows files as they are copied):
 
 `cp -vr {{path/to/folder}} {{path/to/copy}}`


### PR DESCRIPTION
Fixes #2484 

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
