### PR TITLE
guile: add page

### DIFF
--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -6,7 +6,7 @@
 
 `guile`
 
-- Execute script in a given Scheme file:
+- Execute the script in a given Scheme file:
 
 `guile {{script.scm}}`
 
@@ -14,6 +14,6 @@
 
 `guile -c "{{expression}}"`
 
-- Listen on a port or socket (if the port argument is unspecified, the default is port 37146) for remote REPL connections:
+- Listen on a port or socket (the default port is 37146) for remote REPL connections:
 
 `guile --listen={{port_or_socket}}`

--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -1,0 +1,20 @@
+# guile
+
+> Guile Scheme interpreter.
+
+- Start the Guile Scheme REPL:
+
+`guile`
+
+- Execute script in a given Scheme file:
+
+`guile {{script.scm}}`
+
+- Execute a Scheme expression:
+
+`guile -c "{{expression}}"`
+
+- Listen on a port or socket (if the port argument is unspecified, the
+  default is port 37146) for remote REPL connections:
+
+`guile --listen={{port_or_socket}}`

--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -14,7 +14,6 @@
 
 `guile -c "{{expression}}"`
 
-- Listen on a port or socket (if the port argument is unspecified, the
-  default is port 37146) for remote REPL connections:
+- Listen on a port or socket (if the port argument is unspecified, the default is port 37146) for remote REPL connections:
 
 `guile --listen={{port_or_socket}}`

--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -14,6 +14,6 @@
 
 `guile -c "{{expression}}"`
 
-- Listen on a port or socket (the default port is 37146) for remote REPL connections:
+- Listen on a port or a Unix domain socket (the default is port 37146) for remote REPL connections:
 
 `guile --listen={{port_or_socket}}`


### PR DESCRIPTION
I have added a tldr page for guile, the scheme interpreter.

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
