### PR TITLE
darkhttpd: add page

### DIFF
--- a/pages/common/darkhttpd.md
+++ b/pages/common/darkhttpd.md
@@ -1,6 +1,6 @@
 # darkhttpd
 
-> darkhttpd web server.
+> Darkhttpd web server.
 
 - Start server serving the specified document root:
 

--- a/pages/common/darkhttpd.md
+++ b/pages/common/darkhttpd.md
@@ -1,0 +1,15 @@
+# darkhttpd
+
+> darkhttpd web server.
+
+- Start server serving the specified document root:
+
+`darkhttpd {{path/to/docroot}}`
+
+- Start server on specified port (port 8080 by default if running as non-root user):
+
+`darkhttpd {{path/to/docroot}} --port {{port}}`
+
+- Listen only on specified IP address (by default, the server listens on all interfaces):
+
+`darkhttpd {{path/to/docroot}} --addr {{ip_address}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
