### PR TITLE
git checkout: add example for creating new branch based on remote branch with different name

### DIFF
--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -6,6 +6,10 @@
 
 `git checkout -b {{branch_name}}`
 
+- Create and switch to a new branch based on an existing remote branch:
+
+`git checkout -b {{branch_name}} {{remote/source_branch}}`
+
 - Switch to an existing local branch:
 
 `git checkout {{branch_name}}`

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -6,9 +6,9 @@
 
 `git checkout -b {{branch_name}}`
 
-- Create and switch to a new branch based on an existing remote branch:
+- Create and switch to a new branch based on a specific reference (branch, remote/branch, tag are examples of valid references):
 
-`git checkout -b {{branch_name}} {{remote/source_branch}}`
+`git checkout -b {{branch_name}} {{reference}}`
 
 - Switch to an existing local branch:
 


### PR DESCRIPTION
Adds an example for creating and checking out a new branch that's based on an existing remote/source branch with a different name.

It's similar to https://github.com/tldr-pages/tldr/pull/1359 - but shows the example of allowing the new branch being created having a different branch name than the source.

It's something I don't use super often, but end up having to Google each time because it's not in `tldr git checkout` :)

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
