### PR TITLE
ag: move text to make it the 2nd example

### DIFF
--- a/pages/common/ag.md
+++ b/pages/common/ag.md
@@ -6,6 +6,10 @@
 
 `ag {{foo}}`
 
+- Find files containing "foo" in a specific directory:
+
+`ag {{foo}} {{path/to/folder}}`
+
 - Find files containing "foo", but only list the filenames:
 
 `ag -l {{foo}}`
@@ -25,7 +29,3 @@
 - Find files with a name matching "foo":
 
 `ag -g {{foo}}`
-
-- Find files containing "foo" in a specific directory:
-
-`ag {{foo}} {{path/to/folder}}`


### PR DESCRIPTION
Hi all,

I move the example introduced in #2491 to make it the 2nd example, as requested by @agnivade.

----
- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
