### PR TITLE
whereis: add page to osx folder

### DIFF
--- a/pages/osx/whereis.md
+++ b/pages/osx/whereis.md
@@ -1,0 +1,7 @@
+# whereis
+
+> Locate the binary, source, and manual page files for a command.
+
+- Locate binary, source and man pages for ssh:
+
+`whereis {{ssh}}`


### PR DESCRIPTION
`whereis` added without flags which don't exist for `osx`