### PR TITLE
stolonctl: add page

### DIFF
--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -4,16 +4,16 @@
 
 - Get cluster status:
 
-`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} status`
+`stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} status`
 
 - Get cluster data:
 
-`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} clusterdata`
+`stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} clusterdata`
 
 - Get cluster specification:
 
-`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} spec`
+`stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} spec`
 
 - Update cluster specification with a patch in json format:
 
-`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} update --patch '{{cluster_spec}}'`
+`stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} update --patch '{{cluster_spec}}'`

--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -1,19 +1,19 @@
 # Stolon
 
-> Stolon is a cloud native PostgreSQL manager for PostgreSQL high availability.
+> A cloud native PostgreSQL manager for PostgreSQL high availability.
 
 - Get cluster status:
 
-`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} status`
+`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} status`
 
 - Get cluster data:
 
-`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} clusterdata`
+`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} clusterdata`
 
 - Get cluster specification:
 
-`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} spec`
+`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} spec`
 
-- Update cluster specification:
+- Update cluster specification with a patch in json format:
 
-`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} update --patch '{{cluster_spec_to_be_updated_as_json}}'`
+`stolonctl --cluster-name ${{cluster_name}} --store-backend ${{store_backend}} --store-endpoints ${{store_endpoints}} update --patch '{{cluster_spec}}'`

--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -1,0 +1,19 @@
+# Stolon
+
+> Stolon is a cloud native PostgreSQL manager for PostgreSQL high availability.
+
+- Get cluster status:
+
+`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} status`
+
+- Get cluster data:
+
+`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} clusterdata`
+
+- Get cluster specification:
+
+`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} spec`
+
+- Update cluster specification:
+
+`stolonctl --cluster-name ${{stolon_cluster_name}} --store-backend ${{stolon_store_backend}} --store-endpoints ${{stolon_store_endpoints}} update --patch '{{cluster_spec_to_be_updated_as_json}}'`


### PR DESCRIPTION
Stolon is a cloud native PostgreSQL manager for PostgreSQL high availability, and stolonctl is the command line tool for it.

Ref: https://github.com/sorintlab/stolon