### PR TITLE
token definitions: improve consistency of tokens containing "name"

### DIFF
--- a/pages/common/bosh.md
+++ b/pages/common/bosh.md
@@ -4,7 +4,7 @@
 
 - Create local alias for director:
 
-`bosh alias-env {{environment-name}} -e {{ip address or url}} --ca-cert {{ca_certificate}}`
+`bosh alias-env {{environment}} -e {{ip address or url}} --ca-cert {{ca_certificate}}`
 
 - List environments:
 

--- a/pages/common/composer.md
+++ b/pages/common/composer.md
@@ -4,7 +4,7 @@
 
 - Add a package as a dependency for this project, adding it to `composer.json`:
 
-`composer require {{user/package-name}}`
+`composer require {{user/package_name}}`
 
 - Install all the dependencies in this project's `composer.json`:
 
@@ -12,7 +12,7 @@
 
 - Uninstall a package from this project, removing it as a dependency from `composer.json`:
 
-`composer remove {{user/package-name}}`
+`composer remove {{user/package_name}}`
 
 - Update all the dependencies in this project's `composer.json`:
 

--- a/pages/common/cordova.md
+++ b/pages/common/cordova.md
@@ -4,7 +4,7 @@
 
 - Create a cordova project:
 
-`cordova create {{path}} {{package.name}} {{project.name}}`
+`cordova create {{path}} {{package_name}} {{project_name}}`
 
 - Display the current workspace status:
 

--- a/pages/common/gist.md
+++ b/pages/common/gist.md
@@ -24,7 +24,7 @@
 
 - List all gists for the currently logged in user:
 
-`gist -l {{user_name}}`
+`gist -l {{username}}`
 
 - Use the id from the gist URL to modify or include a file:
 

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -20,8 +20,8 @@
 
 - Discard unstaged changes to a given file:
 
-`git checkout {{file_name}}`
+`git checkout {{filename}}`
 
 - Replace a file in the current folder with the version of it committed in a given branch:
 
-`git checkout {{branch_name}} -- {{file_name}}`
+`git checkout {{branch_name}} -- {{filename}}`

--- a/pages/common/htpasswd.md
+++ b/pages/common/htpasswd.md
@@ -4,20 +4,20 @@
 
 - Create/overwrite htpasswd file:
 
-`htpasswd -c {{path/to/file}} {{user_name}}`
+`htpasswd -c {{path/to/file}} {{username}}`
 
 - Add user to htpasswd file or update existing user:
 
-`htpasswd {{path/to/file}} {{user_name}}`
+`htpasswd {{path/to/file}} {{username}}`
 
 - Add user to htpasswd file in batch mode without an interactive password prompt (for script usage):
 
-`htpasswd -b {{path/to/file}} {{user_name}} {{password}}`
+`htpasswd -b {{path/to/file}} {{username}} {{password}}`
 
 - Delete user from htpasswd file:
 
-`htpasswd -D {{path/to/file}} {{user_name}}`
+`htpasswd -D {{path/to/file}} {{username}}`
 
 - Verify user password:
 
-`htpasswd -v {{path/to/file}} {{user_name}}`
+`htpasswd -v {{path/to/file}} {{username}}`

--- a/pages/common/ignite.md
+++ b/pages/common/ignite.md
@@ -8,7 +8,7 @@
 
 - Generate file from a plugin:
 
-`ignite generate {{plugin_name}} {{file_name}}`
+`ignite generate {{plugin_name}} {{filename}}`
 
 - Add an Ignite plugin to the project:
 

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -16,7 +16,7 @@
 
 - View all logins by a specific user and show the ip address instead of the hostname:
 
-`last {{user_name}} -i`
+`last {{username}} -i`
 
 - View all recorded reboots (i.e., the last logins of the pseudo user "reboot"):
 

--- a/pages/common/odps-auth.md
+++ b/pages/common/odps-auth.md
@@ -4,15 +4,15 @@
 
 - Add a user to the current project:
 
-`add user {{user_name}};`
+`add user {{username}};`
 
 - Grant a set of authorities to a user:
 
-`grant {{action_list}} on {{object_type}} {{object_name}} to user {{user_name}};`
+`grant {{action_list}} on {{object_type}} {{object_name}} to user {{username}};`
 
 - Show authorities of a user:
 
-`show grants for {{user_name}};`
+`show grants for {{username}};`
 
 - Create a user role:
 
@@ -28,4 +28,4 @@
 
 - Grant a role to a user:
 
-`grant {{role_name}} to {{user_name}};`
+`grant {{role_name}} to {{username}};`

--- a/pages/common/odps-resource.md
+++ b/pages/common/odps-resource.md
@@ -8,7 +8,7 @@
 
 - Add file resource:
 
-`add file {{file_name}} as {{alias}};`
+`add file {{filename}} as {{alias}};`
 
 - Add archive resource:
 

--- a/pages/common/p4.md
+++ b/pages/common/p4.md
@@ -20,7 +20,7 @@
 
 - Open a file to edit:
 
-`p4 edit -c {{changelist_number}} {{file_name}}`
+`p4 edit -c {{changelist_number}} {{filename}}`
 
 - Open a new file to add it to the depot:
 

--- a/pages/common/pg_ctl.md
+++ b/pages/common/pg_ctl.md
@@ -4,7 +4,7 @@
 
 - Start a PostgreSQL server:
 
-`pg_ctl -D {{data_directory}} -l {{log_file_name}}`
+`pg_ctl -D {{data_directory}} -l {{log_filename}}`
 
 - Initialize a PostgreSQL database cluster:
 

--- a/pages/common/php-yii.md
+++ b/pages/common/php-yii.md
@@ -12,4 +12,4 @@
 
 - Generate a controller, views and related files for the CRUD actions on the specified model class:
 
-`php yii {{gii/crud}} --modelClass={{ModelName}} --controllerClass={{ControllerName}}`
+`php yii {{gii/crud}} --modelClass={{model_name}} --controllerClass={{controller_name}}`

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -5,28 +5,28 @@
 
 - Transfer file from local to remote host:
 
-`rsync {{path/to/file}} {{remote_host_name}}:{{remote_host_location}}`
+`rsync {{path/to/file}} {{remote_hostname}}:{{remote_host_location}}`
 
 - Transfer file from remote host to local:
 
-`rsync {{remote_host_name}}:{{remote_file_location}} {{local_file_location}}`
+`rsync {{remote_hostname}}:{{remote_file_location}} {{local_file_location}}`
 
 - Transfer file in archive (to preserve attributes) and compressed (zipped) mode:
 
-`rsync -az {{path/to/file}} {{remote_host_name}}:{{remote_host_location}}`
+`rsync -az {{path/to/file}} {{remote_hostname}}:{{remote_host_location}}`
 
 - Transfer a directory and all its children from a remote to local:
 
-`rsync -r {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
+`rsync -r {{remote_hostname}}:{{remote_folder_location}} {{local_folder_location}}`
 
 - Transfer only updated files from remote host:
 
-`rsync -ru {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
+`rsync -ru {{remote_hostname}}:{{remote_folder_location}} {{local_folder_location}}`
 
 - Transfer file over SSH and show progress per file:
 
-`rsync -e ssh --progress {{remote_host_name}}:{{remote_file}} {{local_file}}`
+`rsync -e ssh --progress {{remote_hostname}}:{{remote_file}} {{local_file}}`
 
 - Transfer file over SSH and show global progress:
 
-`rsync -e ssh --info=progress2 {{remote_host_name}}:{{remote_file}} {{local_file}}`
+`rsync -e ssh --info=progress2 {{remote_hostname}}:{{remote_file}} {{local_file}}`

--- a/pages/common/sails.md
+++ b/pages/common/sails.md
@@ -8,7 +8,7 @@
 
 - Create new Sails project:
 
-`sails new {{projectName}}`
+`sails new {{project_name}}`
 
 - Generate Sails API:
 

--- a/pages/common/sc-im.md
+++ b/pages/common/sc-im.md
@@ -5,7 +5,7 @@
 
 - Start SC-IM:
 
-`scim {{file_name}}.csv`
+`scim {{filename}}.csv`
 
 - Enter a string into the current cell:
 

--- a/pages/common/sendmail.md
+++ b/pages/common/sendmail.md
@@ -2,9 +2,9 @@
 
 > Send email from the command line.
 
-- Send a message with the content of message.txt to the mail folder of local user `user_name`:
+- Send a message with the content of message.txt to the mail folder of local user `username`:
 
-`sendmail {{user_name}} < {{message.txt}}`
+`sendmail {{username}} < {{message.txt}}`
 
 - Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the message in `message.txt`:
 

--- a/pages/common/trash-cli.md
+++ b/pages/common/trash-cli.md
@@ -4,7 +4,7 @@
 
 - Trash files and directories:
 
-`trash-put {{file_name}}`
+`trash-put {{filename}}`
 
 - Empty the trashcan:
 
@@ -20,4 +20,4 @@
 
 - Remove individual files from the trashcan:
 
-`trash-rm {{file_name}}`
+`trash-rm {{filename}}`

--- a/pages/linux/chage.md
+++ b/pages/linux/chage.md
@@ -4,15 +4,15 @@
 
 - List password information for the user:
 
-`chage -l {{user_name}}`
+`chage -l {{username}}`
 
 - Enable password expiration in 10 days:
 
-`sudo chage -M {{10}} {{user_name}}`
+`sudo chage -M {{10}} {{username}}`
 
 - Disable password expiration:
 
-`sudo chage -M -1 {{user_name}}`
+`sudo chage -M -1 {{username}}`
 
 - Set account expiration date:
 

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -24,4 +24,4 @@
 
 - Find out which package owns a file:
 
-`dpkg -S {{file_name}}`
+`dpkg -S {{filename}}`

--- a/pages/linux/figlet.md
+++ b/pages/linux/figlet.md
@@ -8,7 +8,7 @@
 
 - Use a custom font file:
 
-`figlet {{input_text}} -f {{font_file_name}}`
+`figlet {{input_text}} -f {{font_filename}}`
 
 - Pipe command output through figlet:
 

--- a/pages/linux/flatpak.md
+++ b/pages/linux/flatpak.md
@@ -20,7 +20,7 @@
 
 - Add a remote source:
 
-`flatpak remote-add --if-not-exists {{remote-name}} {{remote-url}}`
+`flatpak remote-add --if-not-exists {{remote_name}} {{remote_url}}`
 
 - List all configured remote sources:
 

--- a/pages/linux/htop.md
+++ b/pages/linux/htop.md
@@ -8,7 +8,7 @@
 
 - Start htop displaying only processes owned by given user:
 
-`htop -u {{user_name}}`
+`htop -u {{username}}`
 
 - Get help about interactive commands:
 

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -8,7 +8,7 @@
 
 - Trace a process and filter output by system call:
 
-`strace -p {{pid}} -e {{system call name}}`
+`strace -p {{pid}} -e {{system_call_name}}`
 
 - Count time, calls, and errors for each system call and report a summary on program exit:
 

--- a/pages/linux/top.md
+++ b/pages/linux/top.md
@@ -12,7 +12,7 @@
 
 - Show only processes owned by given user:
 
-`top -u {{user_name}}`
+`top -u {{username}}`
 
 - Show only the processes with the given PID(s), passed as a comma-separated list. (Normally you wouldn't know PIDs off hand. This example picks the PIDs from the process name):
 

--- a/pages/linux/xsetwacom.md
+++ b/pages/linux/xsetwacom.md
@@ -8,16 +8,16 @@
 
 - Set Wacom area to specific screen. Get name of the screen with `xrandr`:
 
-`xsetwacom set "{{device name}}" MapToOutput {{screen}}`
+`xsetwacom set "{{device_name}}" MapToOutput {{screen}}`
 
 - Set mode to relative (like a mouse) or absolute (like a pen) mode:
 
-`xsetwacom set "{{device name}}" Mode "{{Relative|Absolute}}"`
+`xsetwacom set "{{device_name}}" Mode "{{Relative|Absolute}}"`
 
 - Rotate the input (useful for tablet-PC when rotating screen) by 0|90|180|270 degrees from "natural" rotation:
 
-`xsetwacom set "{{device name}}" Rotate {{none|half|cw|ccw}}`
+`xsetwacom set "{{device_name}}" Rotate {{none|half|cw|ccw}}`
 
 - Set button to only work when the tip of the pen is touching the tablet:
 
-`xsetwacom set "{{device name}}" TabletPCButton "on"`
+`xsetwacom set "{{device_name}}" TabletPCButton "on"`

--- a/pages/osx/top.md
+++ b/pages/osx/top.md
@@ -16,7 +16,7 @@
 
 - Start top displaying only processes owned by given user:
 
-`top -user {{user_name}}`
+`top -user {{username}}`
 
 - Get help about interactive commands:
 


### PR DESCRIPTION
This PR aims to solve inconsistencies in tokens that contain the substring "name". 
In particular, I renamed ```host_name``` -> ```hostname```, ``` user_name``` -> ```username```, and ```file_name``` -> ```filename```. This is because the version without the underscore was not only correct, but also the most used in TLDR overall.

This PR is related to issue #2509.