### PR TITLE
svn: add `svn log` example, remove unnecessary `svn help` example

### DIFF
--- a/pages/common/svn.md
+++ b/pages/common/svn.md
@@ -20,4 +20,8 @@
 
 - Display changes from the last 10 revisions, showing modified files for each revision:
 
-`svn log -vl 10`
+`svn log -vl {{10}}`
+
+- Show detailed help:
+
+`svn help`

--- a/pages/common/svn.md
+++ b/pages/common/svn.md
@@ -18,6 +18,6 @@
 
 `svn ci -m {{commit log message}} {{[PATH...]}}`
 
-- Show detailed help:
+- Display changes from the last 10 revisions, showing modified files for each revision:
 
-`svn help`
+`svn log -vl 10`


### PR DESCRIPTION
- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.

The `svn help` example isn't of much use, so I replaced it with a more useful example which describes basic usage of `svn log`.