### PR TITLE
monop: add page

### DIFF
--- a/pages/common/monop.md
+++ b/pages/common/monop.md
@@ -1,8 +1,8 @@
 # monop
 
-> Finds and displays signatures of types and methods inside .NET assemblies.
+> Finds and displays signatures of Types and methods inside .NET assemblies.
 
-- Show the structure of a type built-in of the .NET Framework:
+- Show the structure of a Type built-in of the .NET Framework:
 
 `monop {{System.String}}`
 
@@ -10,11 +10,11 @@
 
 `monop -r:{{path/to/assembly.exe}}`
 
-- Show the structure of a type in a specific assembly:
+- Show the structure of a Type in a specific assembly:
 
 `monop -r:{{path/to/assembly.dll}} {{Namespace.Path.To.Type}}`
 
-- Only show members defined in the specified type:
+- Only show members defined in the specified Type:
 
 `monop -r:{{path/to/assembly.dll}} --only-declared {{Namespace.Path.To.Type}}`
 

--- a/pages/common/monop.md
+++ b/pages/common/monop.md
@@ -2,7 +2,7 @@
 
 > Finds and displays signatures of types and methods inside .NET assemblies.
 
-- Show the structure of a type built-in to the .NET Framework:
+- Show the structure of a type built-in of the .NET Framework:
 
 `monop {{System.String}}`
 

--- a/pages/common/monop.md
+++ b/pages/common/monop.md
@@ -1,0 +1,31 @@
+# monop
+
+> Finds and displays signatures of types and methods inside .NET assemblies.
+
+- Show the structure of a type built-in to the .NET Framework:
+
+`monop {{System.String}}`
+
+- List the types in an assembly:
+
+`monop -r:{{path/to/assembly.exe}}`
+
+- Show the structure of a type in a specific assembly:
+
+`monop -r:{{path/to/assembly.dll}} {{Namespace.Path.To.Type}}`
+
+- Only show members defined in the specified type:
+
+`monop -r:{{path/to/assembly.dll}} --only-declared {{Namespace.Path.To.Type}}`
+
+- Show private members:
+
+`monop -r:{{path/to/assembly.dll}} --private {{Namespace.Path.To.Type}}`
+
+- Hide obsolete members:
+
+`monop -r:{{path/to/assembly.dll}} --filter-obsolete {{Namespace.Path.To.Type}}`
+
+- List the other assemblies that a specified assembly references:
+
+`monop -r:{{path/to/assembly.dll}} --refs`


### PR DESCRIPTION
Following on from my previous 2 pages (#2557 and #2558), I went looking for a .NET assembly browser - and stumbled across this command :P

For my own reference, the Mono project have a [page](https://www.mono-project.com/docs/tools+libraries/tools/) dedicated to the tools that come bundled with `mono`.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [ ] The page (if new), does not already exist in the repo.

- [ ] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [ ] The page has 8 or fewer examples.

- [ ] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
