### PR TITLE
pamac: add page

### DIFF
--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -8,15 +8,15 @@
 
 - Install a new package:
 
-`pamac install package-name`
+`pamac install {{package_name}}`
 
 - Remove a package and its no longer required dependencies (orphans):
 
-`pamac remove -o package-name`
+`pamac remove -o {{package_name}}`
 
 - Search the package database for a package:
 
-`pamac search package-name`
+`pamac search {{package_name}}`
 
 - List installed packages:
 

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,0 +1,23 @@
+# pamac
+
+> Command line utility of the GUI package management pamac.
+
+- Check for package updates:
+
+`pamac checkupdates`
+
+- Install a new package:
+
+`pamac install package-name`
+
+- Remove a package and its no longer required dependencies (orphans):
+
+`pamac remove -o package-name`
+
+- Search the package database for a package:
+
+`pamac search package-name`
+
+- List installed packages:
+
+`pamac list -i`

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,10 +1,6 @@
 # pamac
 
-> Command line utility of the GUI package management pamac.
-
-- Check for package updates:
-
-`pamac checkupdates`
+> A command line utility for the GUI package manager pamac.
 
 - Install a new package:
 
@@ -21,3 +17,7 @@
 - List installed packages:
 
 `pamac list -i`
+
+- Check for package updates:
+
+`pamac checkupdates`


### PR DESCRIPTION
Add a page for the command line utility of the GUI package management pamac which is also called pamac.

----
- [x] The page (if new), does not already exist in the repo.

- [x] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [x] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [x] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
