### PR TITLE
Update Contribution guidelines and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,9 @@
-----
 <!-- Thank you for sending a PR! -->
-<!-- Please perform the following checks and check all the boxes that apply. -->
-<!-- If your PR does not create a command page,
-     you can remove the first two checklist items. -->
-<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
-     you can simply remove the entire checklist. -->
+<!-- Please perform the following checks and mark all the boxes accordingly. -->
+<!-- You can remove the checklist items that don't apply to your PR. -->
 
 - [ ] The page (if new), does not already exist in the repo.
-
-- [ ] The page (if new), has been added to the correct platform folder:  
-      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.
-
+- [ ] The page is in the correct platform folder (`common/`, `linux/`, etc.)
 - [ ] The page has 8 or fewer examples.
-
-- [ ] The PR is appropriately titled:  
-      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.
-
-- [ ] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
+- [ ] The PR title conforms to the recommended [templates](../blob/master/CONTRIBUTING.md#commit-message).
+- [ ] The page follows the [content guidelines](../blob/master/CONTRIBUTING.md#guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,9 +87,10 @@ For the commit message, use the following format:
     <command>: type of change
 
 Examples:
-  - `ls: add page`
-  - `cat: fix typo`
-  - `git-push: add --force example`
+  - For a new page addition: `ls: add page`
+  - For a page edit: `cat: fix typo`, `git-push: add --force example`
+  - For a new translation of an existing page: `cp: add Tamil translation`
+  - For related changes to several pages: `grep, find, locate: synchronize format of wildcards`
 
 ## Licensing
 


### PR DESCRIPTION
This commit updates the commit message guidelines in CONTRIBUTING.md:
- Add example commit messages for translations and for changes that affect multiple pages;
- Prefix each example with a description of the type of change it refers to.

It also updates the PR template, to make it more compact and reduce duplication of information included in CONTRIBUTING.md:
- Remove horizontal rule at the top
  (the comments are sufficient as visual separation);
- Shorten the comments to make them more compact and more likely to be read;
- Make each checklist entry take a single line;
- Remove blank lines between checklist entries.

This is a follow-up to the discussion at #2512.