### PR TITLE
TravisCI: Include languages in index file.

### DIFF
--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -24,7 +24,9 @@ function buildPagesIndex(files) {
       if (!index[page].platform.includes(os)) {
         index[page].platform.push(os);
       }
-      index[page].language.push(language);
+      if (!index[page].language.includes(language)) {
+        index[page].language.push(language);
+      }
     } else {
       index[page] = {name: page, platform: [os], language: [language]};
     }

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -11,8 +11,8 @@ function parsePagename(pagefile) {
 }
 
 function parseLanguage(pagefile) {
-  var language = pagefile.split(/\//)[0].replace(/^pages/, '');
-  return language == '' ? 'en' : 'ta';
+  var pagesFolder = pagefile.split(/\//)[0];
+  return pagesFolder == 'pages' ? 'en' : pagesFolder.replace(/^pages./, '');
 }
 
 function buildPagesIndex(files) {

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -10,30 +10,27 @@ function parsePagename(pagefile) {
   return pagefile.split(/\//)[2].replace(/\.md$/, '');
 }
 
-function buildShortPagesIndex(files) {
+function parseLanguage(pagefile) {
+  var language = pagefile.split(/\//)[0].replace(/^pages/, '');
+  return language == '' ? 'en' : 'ta';
+}
+
+function buildPagesIndex(files) {
   var reducer = function (index, file) {
     var os = parsePlatform(file);
     var page = parsePagename(file);
+    var language = parseLanguage(file);
     if (index[page]) {
-      index[page].push(os);
+      if (!index[page].platform.includes(os))
+        index[page].platform.push(os);
+      index[page].language.push(language);
     } else {
-      index[page] = [os];
+      index[page] = {name: page, platform: [os], language: [language]};
     }
     return index;
   };
 
-  return files.reduce(reducer, {});
-}
-
-function buildPagesIndex(shortIndex) {
-  return Object.keys(shortIndex)
-    .sort()
-    .map(function (page) {
-      return {
-        name: page,
-        platform: shortIndex[page]
-      };
-    });
+  return Object.values(files.reduce(reducer, {}));
 }
 
 function saveIndex(index) {
@@ -43,8 +40,7 @@ function saveIndex(index) {
   console.log(JSON.stringify(indexFile));
 }
 
-glob('pages/**/*.md', function (er, files) {
-  var shortIndex = buildShortPagesIndex(files);
-  var index = buildPagesIndex(shortIndex);
+glob('pages*/**/*.md', function (er, files) {
+  var index = buildPagesIndex(files);
   saveIndex(index);
 });

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -21,8 +21,9 @@ function buildPagesIndex(files) {
     var page = parsePagename(file);
     var language = parseLanguage(file);
     if (index[page]) {
-      if (!index[page].platform.includes(os))
+      if (!index[page].platform.includes(os)) {
         index[page].platform.push(os);
+      }
       index[page].language.push(language);
     } else {
       index[page] = {name: page, platform: [os], language: [language]};


### PR DESCRIPTION
This PR includes a `language` field in the `index.json` file as discussed in #2339. I have kept the field name singular (`language` instead of `languages`) because `platform` is also in the singular.

Since this `index.json` file is now common to all languages, should it not be outside the `pages` folder in the top level directory of the archive? I do realize this will break existing clients...