### PR TITLE
sed: add example to delete lines

### DIFF
--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -18,6 +18,10 @@
 
 `sed '/{{line_pattern}}/s/{{find}}/{{replace}}/' {{filename}}`
 
+- Delete lines matching the line pattern:
+
+`sed '/{{line_pattern}}/d' {{filename}}`
+
 - Print only text between n-th line till the next empty line:
 
 `sed -n '{{line_number}},/^$/p' {{filename}}`


### PR DESCRIPTION
I think this example is useful here because it allows to **remove** matching lines from the output. Doing so with a replacement is more complicated as you need to enable multi-line matching and add a `\n` at the end of the pattern (or something like that).

A beginner intuition would be to do `sed 's/pattern\n//' filename`, and it would not work. Here the `sed '/{{line_pattern}}/d' {{filename}}` command is simple and easily memorized (delete -> d).

The example could be improved by one of the two following propositions:
1. Add `and print the result` at the end of the description (to emphasize it is not in-place modification)
2. Add the `-i` option and emphasize it will modify the file

Let me know what you think :slightly_smiling_face: !

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](../blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](../blob/master/CONTRIBUTING.md#guidelines).
