### PR TITLE
docker: simplify examples

### DIFF
--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -4,19 +4,19 @@
 
 - List currently running docker containers:
 
-`docker container ls`
+`docker ps`
 
 - List all docker containers (running and stopped):
 
-`docker container ls -a`
+`docker ps -a`
 
 - Start a container from an image, with a custom name:
 
-`docker container run --name={{container_name}} {{image}}`
+`docker run --name {{container_name}} {{image}}`
 
 - Start or stop an existing container:
 
-`docker container {{start|stop}} {{container_name}}`
+`docker {{start|stop}} {{container_name}}`
 
 - Pull an image from a docker registry:
 
@@ -24,16 +24,16 @@
 
 - Start a container from an image and get a shell inside of it:
 
-`docker container run -it {{image}} bash`
+`docker run -it {{image}} sh`
 
 - Run a command inside of an already running container:
 
-`docker container exec {{container_name}} {{command}}`
+`docker exec {{container_name}} {{command}}`
 
 - Remove a stopped container:
 
-`docker container rm {{container_name}}`
+`docker rm {{container_name}}`
 
 - Fetch and follow the logs of a container:
 
-`docker container logs -f {{container_name}}`
+`docker logs -f {{container_name}}`

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -24,7 +24,7 @@
 
 - Open a shell inside of an already running container:
 
-`docker exec -it {{container_name}} sh`
+`docker exec -it {{container_name}} {{sh}}`
 
 - Remove a stopped container:
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -12,7 +12,7 @@
 
 - Start a container from an image, with a custom name:
 
-`docker run --name {{container_name}} {{image}}`
+`docker run -it --name {{container_name}} {{image}}`
 
 - Start or stop an existing container:
 
@@ -22,13 +22,9 @@
 
 `docker pull {{image}}`
 
-- Start a container from an image and get a shell inside of it:
-
-`docker run -it {{image}} sh`
-
 - Run a command inside of an already running container:
 
-`docker exec {{container_name}} {{command}}`
+`docker exec -it {{container_name}} {{command}}`
 
 - Remove a stopped container:
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -22,9 +22,9 @@
 
 `docker pull {{image}}`
 
-- Run a command inside of an already running container:
+- Open a shell inside of an already running container:
 
-`docker exec -it {{container_name}} {{command}}`
+`docker exec -it {{container_name}} sh`
 
 - Remove a stopped container:
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -12,7 +12,7 @@
 
 - Start a container from an image, with a custom name:
 
-`docker run -it --name {{container_name}} {{image}}`
+`docker run --name {{container_name}} {{image}}`
 
 - Start or stop an existing container:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](../blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](../blob/master/CONTRIBUTING.md#guidelines).

This is the first of PRs that is attached to the raised issue #2592, reverting the changes of #1505 to the more common real-world suggested usage, with the intent to create further docker command specific pages. 

I'm not sure how you'd want to handle the fact that it has 9 examples though. You could probably merge the two run examples, but not sure how to specify an optional `{{command}}` parameter.