### PR TITLE
drill: add page

### DIFF
--- a/pages/common/drill.md
+++ b/pages/common/drill.md
@@ -1,0 +1,31 @@
+# drill
+
+> Get information out of DNS.
+
+- Lookup the IP(s) associated with a hostname (A records):
+
+`drill {{hostname.com}}`
+
+- Lookup the mail server(s) associated with a given domain name (MX record):
+
+`drill mx {{hostname.com}}`
+
+- Get all types of records for a given domain name:
+
+`drill any {{hostname.com}}`
+
+- Specify an alternate DNS server to query:
+
+`drill {{hostname.com}} @{{8.8.8.8}}`
+
+- Perform a reverse DNS lookup on an IP address (PTR record):
+
+`drill -x {{8.8.8.8}}`
+
+- Perform DNSSEC trace from root servers down to the domain:
+
+`drill -TD {{hostname.com}}`
+
+- Show DNSKEY record(s) for domain:
+
+`drill -s dnskey {{hostname.com}}`

--- a/pages/common/drill.md
+++ b/pages/common/drill.md
@@ -1,6 +1,6 @@
 # drill
 
-> Get information out of DNS.
+> Perform various DNS queries.
 
 - Lookup the IP(s) associated with a hostname (A records):
 

--- a/pages/common/drill.md
+++ b/pages/common/drill.md
@@ -22,10 +22,10 @@
 
 `drill -x {{8.8.8.8}}`
 
-- Perform DNSSEC trace from root servers down to the domain:
+- Perform DNSSEC trace from root servers down to a domain name:
 
 `drill -TD {{hostname.com}}`
 
-- Show DNSKEY record(s) for domain:
+- Show DNSKEY record(s) for a domain name:
 
 `drill -s dnskey {{hostname.com}}`


### PR DESCRIPTION
Add TL;DR page for a `drill` command from `ldns` package.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
