### PR TITLE
kubectx: add page

### DIFF
--- a/pages/common/kubectx.md
+++ b/pages/common/kubectx.md
@@ -1,0 +1,19 @@
+# kubectx
+
+> Utility which is able to manage and switch between kubectl contexts.
+
+- List the contexts:
+
+`kubectx`
+
+- Switch to context:
+
+`kubectx {{name}}`
+
+- Switch to previous context:
+
+`kubectx -`
+
+- Delete context:
+
+`kubectx -d {{name}}`


### PR DESCRIPTION
I add `kubectx`. An utility to manage and switch between `kubectl` contexts.