### PR TITLE
kubens: add page

### DIFF
--- a/pages/common/kubens.md
+++ b/pages/common/kubens.md
@@ -1,6 +1,6 @@
 # kubens
 
-> Utility which is able to switch between Kubernetes namespaces.
+> Utility to switch between Kubernetes namespaces.
 
 - List the namespaces:
 

--- a/pages/common/kubens.md
+++ b/pages/common/kubens.md
@@ -1,0 +1,15 @@
+# kubens
+
+> Utility which is able to switch between Kubernetes namespaces.
+
+- List the namespaces:
+
+`kubens`
+
+- Change the active namespace:
+
+`kubens {{name}}`
+
+- Switch to the previous namespace:
+
+`kubens -`


### PR DESCRIPTION
I have added `kubens`. An utility to switch between `kubectl` namespaces.