### PR TITLE
kubetail: add page

### DIFF
--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -6,7 +6,7 @@
 
 `kubetail {{my_app}}`
 
-- To tail only a specific container from multiple pods:
+- Tail only a specific container from multiple pods:
 
 `kubetail my_app -c {{my_container}}`
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -2,7 +2,7 @@
 
 > Utility to tail multiple Kubernetes pod logs at the same time.
 
-- To tail the logs of multiple pods (which name starts with "my_app") in one go simply do:
+- Tail the logs of multiple pods (which name starts with "my_app") in one go:
 
 `kubetail {{my_app}}`
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -2,17 +2,17 @@
 
 > Utility to tail multiple Kubernetes pod logs at the same time.
 
-- Tail the logs of multiple pods (which name starts with "my_app") in one go:
+- Tail the logs of multiple pods (whose name starts with "my_app") in one go:
 
 `kubetail {{my_app}}`
 
 - Tail only a specific container from multiple pods:
 
-`kubetail my_app -c {{my_container}}`
+`kubetail {{my_app}} -c {{my_container}}`
 
 - To tail multiple containers from multiple pods:
 
-`kubetail my_app -c {{my_container_1}} -c {{my_container_2}}`
+`kubetail {{my_app}} -c {{my_container_1}} -c {{my_container_2}}`
 
 - To tail multiple applications at the same time seperate them by comma:
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -1,0 +1,19 @@
+# kubetail
+
+> Utility to tail multiple Kubernetes pod logs at the same time.
+
+- To tail the logs of multiple pods (which name starts with "my_app") in one go simply do:
+
+`kubetail {{my_app}}`
+
+- To tail only a specific container from multiple pods:
+
+`kubetail my_app -c {{my_container}}`
+
+- To tail multiple containers from multiple pods:
+
+`kubetail my_app -c {{my_container_1}} -c {{my_container_2}}`
+
+- To tail multiple applications at the same time seperate them by comma:
+
+`kubetail {{my_app_1}},{{my_app_2}}`


### PR DESCRIPTION
I have add `kubetail` - a [bash script](https://github.com/johanhaleby/kubetail) that enables you to aggregate (tail/follow) logs from multiple kubernetes pods into one stream.