### PR TITLE
getent: correct typo in group example

### DIFF
--- a/pages/linux/getent.md
+++ b/pages/linux/getent.md
@@ -8,7 +8,7 @@
 
 - See the members of a group:
 
-`getenet group {{group_name}}`
+`getent group {{group_name}}`
 
 - Get list of all services:
 


### PR DESCRIPTION
Correction of a little typo for getent page