### PR TITLE
aws: add page

### DIFF
--- a/pages/common/aws.md
+++ b/pages/common/aws.md
@@ -1,0 +1,23 @@
+# aws
+
+> The official CLI tool for Amazon Web Services.
+
+- List all IAM users:
+
+`aws iam list-users`
+
+- List all EC2 instances from a specific region:
+
+`aws ec2 describe-instances --region {{us-east-1}}`
+
+- Receive message from a specific SQS queue:
+
+`aws sqs receive-message --queue-url {{https://queue.amazonaws.com/546123/Test}}`
+
+- Publish message to the specific SNS topic:
+
+`aws sns publish --topic-arn {{arn:aws:sns:us-east-1:54633:testTopic}} --message "Message"`
+
+- To see help text for AWS RDS commands:
+
+`aws rds help`

--- a/pages/common/aws.md
+++ b/pages/common/aws.md
@@ -18,6 +18,6 @@
 
 `aws sns publish --topic-arn {{arn:aws:sns:us-east-1:54633:testTopic}} --message "Message"`
 
-- To see help text for AWS RDS commands:
+- To see help text for the AWS command:
 
-`aws rds help`
+`aws {{command}} help`


### PR DESCRIPTION
We already have [`aws-s3`](https://github.com/tldr-pages/tldr/blob/master/pages/common/aws-s3.md) page, but I think there is need for a more general one like `aws`.