### PR TITLE
uprecords: add page

### DIFF
--- a/pages/linux/uprecords.md
+++ b/pages/linux/uprecords.md
@@ -1,0 +1,23 @@
+# uprecords
+
+> Displays a summary of historical uptime records
+
+- Display a summary of the top 10 historical uptime records:
+
+`uprecords`
+
+- Display the top 25 records:
+
+`uprecords -m {{25}}`
+
+- Display the downtime between reboots instead of the kernel version:
+
+`uprecords -d`
+
+- Show the most recent reboots:
+
+`uprecords -B`
+
+- Don't truncate information:
+
+`uprecords -w`

--- a/pages/linux/uprecords.md
+++ b/pages/linux/uprecords.md
@@ -1,6 +1,6 @@
 # uprecords
 
-> Displays a summary of historical uptime records
+> Displays a summary of historical uptime records.
 
 - Display a summary of the top 10 historical uptime records:
 


### PR DESCRIPTION
With my fancy new bash command, I identified that we didn't have a page for this already. Although uprecords, by default, shows you the top 10 longest uptimes, it's actually really useful as it tracks _every_ reboot you've done, what your kernel version was, and how long you were down for. All it needs to make it perfect is a reason column......

Here's said bash command:

```bash
while read nextcmd; do tldr "${nextcmd}" >/dev/null 2>&1; if [[ $? -ne 0 ]]; then echo $nextcmd; fi done < <(history | awk '{print $2}' | sort | uniq | grep -iP '^[a-zA-Z0-9]+$')
```

It'll search your entire shell history and display a list of all the commands you've used that don't yet have a tldr page.