### PR TITLE
elm: update page, add elm make example

### DIFF
--- a/pages/common/elm.md
+++ b/pages/common/elm.md
@@ -22,6 +22,6 @@
 
 `elm repl`
 
-- Start local server that compiles Elm files on page load:
+- Start local web server that compiles Elm files on page load:
 
 `elm reactor`

--- a/pages/common/elm.md
+++ b/pages/common/elm.md
@@ -1,6 +1,6 @@
 # elm
 
-> Compile and run Elm source files
+> Compile and run Elm source files.
 
 - Compile an Elm file, output the result to an index.html file:
 
@@ -10,7 +10,7 @@
 
 `elm make {{source}} --output={{destination}}.js`
 
-- Install Elm package from https://package.elm-lang.org
+- Install Elm package from https://package.elm-lang.org:
 
 `elm install {{author}}/{{package}}`
 

--- a/pages/common/elm.md
+++ b/pages/common/elm.md
@@ -1,15 +1,27 @@
 # elm
 
-> Run and manage programs in Elm programming language.
+> Compile and run Elm source files
 
-- Start an interactive Elm shell (REPL):
+- Compile an Elm file, output the result to an index.html file:
 
-`elm --repl`
+`elm make {{source}}`
 
-- Initialize an empty Elm project:
+- Compile an Elm file, output the result to a Javascript file:
 
-`elm --init`
+`elm make {{source}} --output={{destination}}.js`
 
-- Compile the current project and serve it via the local web server:
+- Install Elm package from https://package.elm-lang.org
 
-`elm --reactor`
+`elm install {{author}}/{{package}}`
+
+- Initialize an Elm project, generates an elm.json file:
+
+`elm init`
+
+- Start interactive Elm shell:
+
+`elm repl`
+
+- Start local server that compiles Elm files on page load:
+
+`elm reactor`

--- a/pages/common/elm.md
+++ b/pages/common/elm.md
@@ -2,18 +2,6 @@
 
 > Compile and run Elm source files.
 
-- Compile an Elm file, output the result to an index.html file:
-
-`elm make {{source}}`
-
-- Compile an Elm file, output the result to a Javascript file:
-
-`elm make {{source}} --output={{destination}}.js`
-
-- Install Elm package from https://package.elm-lang.org:
-
-`elm install {{author}}/{{package}}`
-
 - Initialize an Elm project, generates an elm.json file:
 
 `elm init`
@@ -22,6 +10,18 @@
 
 `elm repl`
 
+- Compile an Elm file, output the result to an index.html file:
+
+`elm make {{source}}`
+
+- Compile an Elm file, output the result to a Javascript file:
+
+`elm make {{source}} --output={{destination}}.js`
+
 - Start local web server that compiles Elm files on page load:
 
 `elm reactor`
+
+- Install Elm package from https://package.elm-lang.org:
+
+`elm install {{author}}/{{package}}`


### PR DESCRIPTION
Update the Elm tldr to the most recent (0.19) version of Elm and add examples

- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
