### PR TITLE
brctl: add page;  id, history, kill: add examples;  kill: fix a typo 

### DIFF
--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -13,3 +13,7 @@
 - Overwrite history file with history of current `bash` shell (often combined with `history -c` to purge history):
 
 `history -w`
+
+- Delete the history entry at the specified offset:
+
+`history -d {{offset}}`

--- a/pages/common/id.md
+++ b/pages/common/id.md
@@ -2,6 +2,10 @@
 
 > Display current user and group identity.
 
+- Display current user id (UID), group id (GID) and groups of which you are a member:
+
+`id`
+
 - Display the current user identity as a number:
 
 `id -u`
@@ -9,3 +13,7 @@
 - Display the current group identity as a number:
 
 `id -g`
+
+- Display an arbitrary user's id (UID), group id (GID) and groups of which they are a member:
+
+`id {{username}}`

--- a/pages/common/kill.md
+++ b/pages/common/kill.md
@@ -23,6 +23,6 @@
 
 `kill -{{9|KILL}} {{process_id}}`
 
-- Signal the operating system to pause a program, it until a SIGCONT ("continue") signal is received:
+- Signal the operating system to pause a program until a SIGCONT ("continue") signal is received:
 
 `kill -{{17|STOP}} {{process_id}}`

--- a/pages/common/kill.md
+++ b/pages/common/kill.md
@@ -26,3 +26,11 @@
 - Signal the operating system to pause a program until a SIGCONT ("continue") signal is received:
 
 `kill -{{17|STOP}} {{process_id}}`
+
+- Send a signal to all processes with the given GID (group id):
+
+`kill -{{signal_name}} -{{group_id}}`
+
+- Kill every process that can be killed by the current user (except init and kill itself):
+
+`kill -9 -1`

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -2,11 +2,11 @@
 
 > Edit text in a scriptable manner.
 
-- Replace the first occurrence of a string in a file, and print the result:
+- Replace the first occurrence of a regular expression in each line of a file, and print the result:
 
-`sed 's/{{find}}/{{replace}}/' {{filename}}`
+`sed 's/{{regex}}/{{replace}}/' {{filename}}`
 
-- Replace all occurrences of an extended regular expression in a file:
+- Replace all occurrences of an extended regular expression in a file, and print the result:
 
 `sed -r 's/{{regex}}/{{replace}}/g' {{filename}}`
 

--- a/pages/linux/brctl.md
+++ b/pages/linux/brctl.md
@@ -1,0 +1,23 @@
+# brctl
+
+> Ethernet bridge administration.
+
+- Create a new ethernet bridge interface:
+
+`sudo brctl add {{bridge_name}}`
+
+- Delete an existing ethernet bridge interface:
+
+`sudo brctl del {{bridge_name}}`
+
+- Add an interface to an existing bridge:
+
+`sudo brctl addif {{bridge_name}} {{interface_name}}`
+
+- Remove an interface from an existing bridge:
+
+`sudo brctl delif {{bridge_name}} {{interface_name}}`
+
+- Show a list with information about currently existing ethernet bridges:
+
+`sudo brctl show`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

---

- Add new page for the `brctl` linux command, a useful tool for creating and managing netwok ethernet interfaces.
- Add two examples for `id`:

    - The most basic example: `id`
    - An example showing how to check the id of a different user.

- Add one example for `history` on how to delete history entries.
- Add two examples for `kill` on how to work with multiple processes of the same group.
- Fiexed a typo in the `kill` page:

        - pause a program, it until
        + pause a program until
