### PR TITLE
Add Brazilian Portuguese translation for some common pages

### DIFF
--- a/pages.pt-BR/common/ack.md
+++ b/pages.pt-BR/common/ack.md
@@ -14,6 +14,6 @@
 
 `ack -ch {{foo}}`
 
-- Mostrar o nome dos arquivos contendo o termo "foo" e o número de correspondencias em cada arquivo:
+- Mostrar o nome dos arquivos contendo o termo "foo" e o número de correspondências em cada arquivo:
 
 `ack -cl {{foo}}`

--- a/pages.pt-BR/common/ack.md
+++ b/pages.pt-BR/common/ack.md
@@ -1,0 +1,19 @@
+# ack
+
+> Uma ferramenta de pesquisa similar ao grep, otimizada para programadores.
+
+- Procurar por arquivos que contenham o termo "foo":
+
+`ack {{foo}}`
+
+- Procurar por arquivos em uma linguagem específica:
+
+`ack --ruby {{cada_objeto}}`
+
+- Contar o número total de correspondencias para o termo "foo":
+
+`ack -ch {{foo}}`
+
+- Mostrar o nome dos arquivos contendo o termo "foo" e o número de correspondencias em cada arquivo:
+
+`ack -cl {{foo}}`

--- a/pages.pt-BR/common/ack.md
+++ b/pages.pt-BR/common/ack.md
@@ -10,7 +10,7 @@
 
 `ack --ruby {{cada_objeto}}`
 
-- Contar o número total de correspondencias para o termo "foo":
+- Contar o número total de correspondências para o termo "foo":
 
 `ack -ch {{foo}}`
 

--- a/pages.pt-BR/common/ack.md
+++ b/pages.pt-BR/common/ack.md
@@ -8,7 +8,7 @@
 
 - Procurar por arquivos em uma linguagem específica:
 
-`ack --ruby {{cada_objeto}}`
+`ack --ruby {{each_with_object}}`
 
 - Contar o número total de correspondências para o termo "foo":
 

--- a/pages.pt-BR/common/airpaste.md
+++ b/pages.pt-BR/common/airpaste.md
@@ -2,7 +2,7 @@
 
 > Compartilhar mensagens e arquivos na mesma rede:
 
-- Esperar por mensagens e mostra-las quando recebidas:
+- Esperar por mensagens e mostrá-las quando recebidas:
 
 `airpaste`
 

--- a/pages.pt-BR/common/airpaste.md
+++ b/pages.pt-BR/common/airpaste.md
@@ -1,0 +1,23 @@
+# airpaste
+
+> Compartilhe mensagens e arquivos na mesma rede:
+
+- Esperar por mensagens e mostra-las quando recebidas:
+
+`airpaste`
+
+- Enviar texto:
+
+`echo {{textp}} | airpaste`
+
+- Enviar arquivo:
+
+`airpaste < {{caminho/para/arquivo}}`
+
+- Receber arquivo:
+
+`airpaste > {{caminho/para/arquivo}}`
+
+- Criar/Entrar em canal:
+
+`airpaste {{nome_do_canal}}`

--- a/pages.pt-BR/common/airpaste.md
+++ b/pages.pt-BR/common/airpaste.md
@@ -8,7 +8,7 @@
 
 - Enviar texto:
 
-`echo {{textp}} | airpaste`
+`echo {{texto}} | airpaste`
 
 - Enviar arquivo:
 

--- a/pages.pt-BR/common/airpaste.md
+++ b/pages.pt-BR/common/airpaste.md
@@ -1,6 +1,6 @@
 # airpaste
 
-> Compartilhe mensagens e arquivos na mesma rede:
+> Compartilhar mensagens e arquivos na mesma rede:
 
 - Esperar por mensagens e mostra-las quando recebidas:
 

--- a/pages.pt-BR/common/apg.md
+++ b/pages.pt-BR/common/apg.md
@@ -1,0 +1,23 @@
+# apg
+
+> Creates arbitrarily complex random passwords.
+
+- Create random passwords (default password length is 8):
+
+`apg`
+
+- Create a password with at least 1 symbol (S), 1 number (N), 1 uppercase (C), 1 lowercase (L):
+
+`apg -M SNCL`
+
+- Create a password with 16 characters:
+
+`apg -m {{16}}`
+
+- Create a password with maximum length of 16:
+
+`apg -x {{16}}`
+
+- Create a password that doesn't appear in a dictionary (the dictionary file has to be provided):
+
+`apg -r {{dictionary_file}}`

--- a/pages.pt-BR/common/apg.md
+++ b/pages.pt-BR/common/apg.md
@@ -6,7 +6,7 @@
 
 `apg`
 
-- Criar senha com pelo menos 1 simbolo (S), 1 número (N), 1 caractere maiúsculo (C), 1 caractere minúsculo (L):
+- Criar senha com pelo menos 1 símbolo (S), 1 número (N), 1 caractere maiúsculo (C), 1 caractere minúsculo (L):
 
 `apg -M SNCL`
 

--- a/pages.pt-BR/common/apg.md
+++ b/pages.pt-BR/common/apg.md
@@ -1,23 +1,23 @@
 # apg
 
-> Creates arbitrarily complex random passwords.
+> Criar senhas aleatórias arbitrariamente complexas.
 
-- Create random passwords (default password length is 8):
+- Criar senha aleatória (tamanho padrão para as senhas é 8 caracteres):
 
 `apg`
 
-- Create a password with at least 1 symbol (S), 1 number (N), 1 uppercase (C), 1 lowercase (L):
+- Criar senha com pelo menos 1 simbolo (S), 1 número (N), 1 caractere maiúsculo (C), 1 caractere minúsculo (L):
 
 `apg -M SNCL`
 
-- Create a password with 16 characters:
+- Criar uma senha com 16 caracteres:
 
 `apg -m {{16}}`
 
-- Create a password with maximum length of 16:
+- Criar senha com tamanho máximo de 16 caracteres:
 
 `apg -x {{16}}`
 
-- Create a password that doesn't appear in a dictionary (the dictionary file has to be provided):
+- Criar uma senha que não aparece em um dicionário provido pelo usuário:
 
-`apg -r {{dictionary_file}}`
+`apg -r {{arquivo_de_dicionario}}`

--- a/pages.pt-BR/common/apg.md
+++ b/pages.pt-BR/common/apg.md
@@ -6,7 +6,7 @@
 
 `apg`
 
-- Criar senha com pelo menos 1 símbolo (S), 1 número (N), 1 caractere maiúsculo (C), 1 caractere minúsculo (L):
+- Criar senha com pelo menos 1 símbolo (S), 1 número (N), 1 letra maiúscula (C), 1 letra minúscula (L):
 
 `apg -M SNCL`
 

--- a/pages.pt-BR/common/apm.md
+++ b/pages.pt-BR/common/apm.md
@@ -1,0 +1,16 @@
+# apm
+
+> Gerenciador de pacotes do editor de texto Atom.
+> Verificar `atom`.
+
+- Instalar pacotes de http://atom.io/packages e temas de http://atom.io/themes:
+
+`apm install {{nome_do_pacote}}`
+
+- Remover pacotes/temas:
+
+`apm remove {{nome_do_pacote}}`
+
+- Atualizar pacotes/temas:
+
+`apm upgrade {{nome_do_pacote}}`

--- a/pages.pt-BR/common/apm.md
+++ b/pages.pt-BR/common/apm.md
@@ -1,7 +1,7 @@
 # apm
 
 > Gerenciador de pacotes do editor de texto Atom.
-> Verificar `atom`.
+> Ver também `atom`.
 
 - Instalar pacotes de http://atom.io/packages e temas de http://atom.io/themes:
 

--- a/pages.pt-BR/common/az.md
+++ b/pages.pt-BR/common/az.md
@@ -1,0 +1,27 @@
+# az
+
+> A interface de linha de comando oficial do Microsoft Azure.
+
+- Fazer log in no Azure:
+
+`az login`
+
+- Gerenciar informações de assinatura do Microsoft Azure:
+
+`az account`
+
+- Listar todos os discos gerenciados pelo Azure:
+
+`az disk list`
+
+- Listar todas as máquinas virtuais do Azure:
+
+`az vm list`
+
+- Gerenciar os serviços do Azure Kubernetes:
+
+`az aks`
+
+- Gerenciar recursos de rede do Azure:
+
+`az network`


### PR DESCRIPTION
Translated first five pages in Portuguese. 

I'm planning to translate more in the near future. 

Regarding the folder name: I have created the folder based on IETF language codes (BCP 47) as it was discussed on gitter. The link for the start of the discussion can be found [here](https://gitter.im/tldr-pages/tldr?at=5c37ceb383c7e377654cb4e4).

As this is my first contribution for this repository I would like to know if there is anything missing from my side. 
Thanks a lot. 