### PR TITLE
timeout: clarify the default signal sent to the process

### DIFF
--- a/pages/common/timeout.md
+++ b/pages/common/timeout.md
@@ -2,7 +2,7 @@
 
 > Run a command with a time limit.
 
-- Run `sleep 10` and kill it, if it's running after 3 seconds:
+- Run `sleep 10` and terminate it, if it's running for more than 3 seconds:
 
 `timeout {{3s}} {{sleep 10}}`
 

--- a/pages/common/timeout.md
+++ b/pages/common/timeout.md
@@ -2,7 +2,7 @@
 
 > Run a command with a time limit.
 
-- Run `sleep 10` and terminate it, if it's running for more than 3 seconds:
+- Run `sleep 10` and terminate it, if it runs for more than 3 seconds:
 
 `timeout {{3s}} {{sleep 10}}`
 


### PR DESCRIPTION
The second example mentioned SIGTERM as the default signal, but the first example was worded in a way that may have implied SIGKILL is sent by default.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).