### PR TITLE
split: remove split into n files, add split by pattern

### DIFF
--- a/pages/osx/split.md
+++ b/pages/osx/split.md
@@ -6,9 +6,9 @@
 
 `split -l {{10}} {{filename}}`
 
-- Split a file into 5 files. File is split such that each split has same size (except the last split):
+- Split a file by a pattern (the pattern is the head of each split):
 
-`split -n {{5}} {{filename}}`
+`split -p {{pattern}} {{filename}}`
 
 - Split a file with 512 bytes in each split (except the last split; use 512k for kilobytes and 512m for megabytes):
 

--- a/pages/osx/split.md
+++ b/pages/osx/split.md
@@ -6,9 +6,9 @@
 
 `split -l {{10}} {{filename}}`
 
-- Split a file by a pattern (the pattern is the head of each split):
+- Split a file by a regular expression. The matching line will be the first line of the next output file:
 
-`split -p {{pattern}} {{filename}}`
+`split -p {{regular expression}} {{filename}}`
 
 - Split a file with 512 bytes in each split (except the last split; use 512k for kilobytes and 512m for megabytes):
 

--- a/pages/osx/split.md
+++ b/pages/osx/split.md
@@ -8,7 +8,7 @@
 
 - Split a file by a regular expression. The matching line will be the first line of the next output file:
 
-`split -p {{cat|[d|h]og}} {{filename}}`
+`split -p {{cat|^[dh]og}} {{filename}}`
 
 - Split a file with 512 bytes in each split (except the last split; use 512k for kilobytes and 512m for megabytes):
 

--- a/pages/osx/split.md
+++ b/pages/osx/split.md
@@ -8,7 +8,7 @@
 
 - Split a file by a regular expression. The matching line will be the first line of the next output file:
 
-`split -p {{regular expression}} {{filename}}`
+`split -p {{cat|[d|h]og}} {{filename}}`
 
 - Split a file with 512 bytes in each split (except the last split; use 512k for kilobytes and 512m for megabytes):
 


### PR DESCRIPTION
osx does not have a `-n` option, but does have a `-p` option

- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
