### PR TITLE
zpool: added zpool add {{pool_name}} cache

### DIFF
--- a/pages/common/zpool.md
+++ b/pages/common/zpool.md
@@ -29,3 +29,7 @@
 - Create a mirrored pool:
 
 `zpool create {{pool_name}} mirror {{disk1}} {{disk2}} mirror {{disk3}} {{disk4}}`
+
+- Add a cache (L2ARC) device to a zpool
+
+`zpool add {{pool_name}} cache {{cache_disk}}`

--- a/pages/common/zpool.md
+++ b/pages/common/zpool.md
@@ -30,6 +30,6 @@
 
 `zpool create {{pool_name}} mirror {{disk1}} {{disk2}} mirror {{disk3}} {{disk4}}`
 
-- Add a cache (L2ARC) device to a zpool
+- Add a cache (L2ARC) device to a zpool:
 
 `zpool add {{pool_name}} cache {{cache_disk}}`


### PR DESCRIPTION
This command is used to add cache (L2ARC) devices to zpools

- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
