### PR TITLE
Translate first 6 windows pages in Brazilian Portuguese

### DIFF
--- a/pages.pt-BR/windows/cls.md
+++ b/pages.pt-BR/windows/cls.md
@@ -1,7 +1,7 @@
 # cls
 
-> Limpa a tela de saída.
+> Limpar a tela de saída.
 
-- Limpa a tela:
+- Limpar a tela:
 
 `cls`

--- a/pages.pt-BR/windows/cls.md
+++ b/pages.pt-BR/windows/cls.md
@@ -1,0 +1,7 @@
+# cls
+
+> Limpa a tela de saída.
+
+- Limpa a tela:
+
+`cls`

--- a/pages.pt-BR/windows/cmd.md
+++ b/pages.pt-BR/windows/cmd.md
@@ -1,0 +1,35 @@
+# cmd
+
+> O interpretador de comandos do Windows.
+
+- Iniciar nova instância do interpretador de comandos:
+
+`cmd`
+
+- Executar o comando especificado e sair do interpretador:
+
+`cmd /c "{{comando}}"`
+
+- Executar o comando especificado e entrar no shell interativo:
+
+`cmd /k "{{comando}}"`
+
+- Desabilitar o uso do comando `echo` na saída dos comandos:
+
+`cmd /q`
+
+- Habilitar ou desabilitar extensão de comandos:
+
+`cmd /e:{{on|off}}`
+
+- Habilitar ou desabilitar a ferramenta que completa automaticamente o nome de arquivos ou diretórios:
+
+`cmd /f:{{on|off}}`
+
+- Habilitar ou desabilitar a expansão de variáveis de ambiente:
+
+`cmd /v:{{on|off}}`
+
+- Forçar que a saída de comandos use o padrão unicode:
+
+`cmd /u`

--- a/pages.pt-BR/windows/dir.md
+++ b/pages.pt-BR/windows/dir.md
@@ -1,19 +1,19 @@
 # dir
 
-> Lista os conteúdos de um diretório.
+> Listar os conteúdos de um diretório.
 
-- Mostra o conteúdo do diretório atual:
+- Mostrar o conteúdo do diretório atual:
 
 `dir`
 
--  Mostra o conteúdo do diretório no caminho provido pelo usuário:
+-  Mostrar o conteúdo do diretório no caminho provido pelo usuário:
 
 `dir {{caminho/para/diretório}}`
 
-- Mostra o conteúdo do diretório atual, incluindo arquivos e pastas escondidas:
+- Mostrar o conteúdo do diretório atual, incluindo arquivos e pastas escondidas:
 
 `dir /A`
 
-- Mostra o conteúdo do diretório provido pelo usuário, incluindo arquivos e pastas escondidas:
+- Mostrar o conteúdo do diretório provido pelo usuário, incluindo arquivos e pastas escondidas:
 
 `dir {{caminho/para/diretório}}} /A`

--- a/pages.pt-BR/windows/dir.md
+++ b/pages.pt-BR/windows/dir.md
@@ -1,0 +1,19 @@
+# dir
+
+> Lista os conteúdos de um diretório.
+
+- Mostra o conteúdo do diretório atual:
+
+`dir`
+
+-  Mostra o conteúdo do diretório no caminho provido pelo usuário:
+
+`dir {{caminho/para/diretório}}`
+
+- Mostra o conteúdo do diretório atual, incluindo arquivos e pastas escondidas:
+
+`dir /A`
+
+- Mostra o conteúdo do diretório no caminho provido pelo usuário, incluindo arquivos e pastas escondidas:
+
+`dir {{caminho/para/diretório}}} /A`

--- a/pages.pt-BR/windows/dir.md
+++ b/pages.pt-BR/windows/dir.md
@@ -14,6 +14,6 @@
 
 `dir /A`
 
-- Mostra o conteúdo do diretório no caminho provido pelo usuário, incluindo arquivos e pastas escondidas:
+- Mostra o conteúdo do diretório provido pelo usuário, incluindo arquivos e pastas escondidas:
 
 `dir {{caminho/para/diretório}}} /A`

--- a/pages.pt-BR/windows/mkdir.md
+++ b/pages.pt-BR/windows/mkdir.md
@@ -1,0 +1,11 @@
+# mkdir
+
+> Cria um diretório.
+
+- Criar diretório:
+
+`mkdir {{nome_do_diretorio}}`
+
+- Recursivamente cria uma árvore de diretórios aninhados:
+
+`mkdir {{caminho/para/subdiretorio}}`

--- a/pages.pt-BR/windows/mkdir.md
+++ b/pages.pt-BR/windows/mkdir.md
@@ -6,6 +6,6 @@
 
 `mkdir {{nome_do_diretorio}}`
 
-- Recursivamente cria uma árvore de diretórios aninhados:
+- Criar recursivamente uma árvore de diretórios aninhados:
 
 `mkdir {{caminho/para/subdiretorio}}`

--- a/pages.pt-BR/windows/mkdir.md
+++ b/pages.pt-BR/windows/mkdir.md
@@ -2,7 +2,7 @@
 
 > Cria um diretório.
 
-- Criar diretório:
+- Criar um diretório:
 
 `mkdir {{nome_do_diretorio}}`
 

--- a/pages.pt-BR/windows/mkdir.md
+++ b/pages.pt-BR/windows/mkdir.md
@@ -1,6 +1,6 @@
 # mkdir
 
-> Cria um diretório.
+> Criar um diretório.
 
 - Criar um diretório:
 

--- a/pages.pt-BR/windows/print.md
+++ b/pages.pt-BR/windows/print.md
@@ -1,0 +1,11 @@
+# print
+
+> Imprime um arquivo de texto em uma impressora.
+
+- Imprimir um arquivo de texto na impressora padrão:
+
+`print {{caminho/para/arquivo}}`
+
+- Imprimir arquivo de texto em uma impressora específica:
+
+`print /d:{{impressora}} {{caminho/para/arquivo}}`

--- a/pages.pt-BR/windows/print.md
+++ b/pages.pt-BR/windows/print.md
@@ -1,6 +1,6 @@
 # print
 
-> Imprime um arquivo de texto em uma impressora.
+> Imprimir um arquivo de texto em uma impressora.
 
 - Imprimir um arquivo de texto na impressora padrão:
 

--- a/pages.pt-BR/windows/type.md
+++ b/pages.pt-BR/windows/type.md
@@ -1,0 +1,7 @@
+# type
+
+> Mostra o conteúdo de um arquivo.
+
+- Mostrar o conteúdo de um arquivo específico:
+
+`type {{caminho/para/arquivo}}`

--- a/pages.pt-BR/windows/type.md
+++ b/pages.pt-BR/windows/type.md
@@ -1,6 +1,6 @@
 # type
 
-> Mostra o conteúdo de um arquivo.
+> Mostrar o conteúdo de um arquivo.
 
 - Mostrar o conteúdo de um arquivo específico:
 


### PR DESCRIPTION
Translated first six windows pages in Portuguese. 
List: 
cls.md
cmd.md
dir.md
mkdir.md
print.md
type.md