### PR TITLE
Translate 50+ common pages in Italian.

### DIFF
--- a/pages.it/common/ansiweather.md
+++ b/pages.it/common/ansiweather.md
@@ -1,0 +1,15 @@
+# ansiweather
+
+> Uno script per mostrare le attuali condizioni meteo nel tuo terminale.
+
+- Mostra una previsione usando unità SI per i prossimi cinque giorni in Rzeszow (Polonia):
+
+`ansiweather -u {{metric}} -f {{5}} -l {{Rzeszow,PL}}`
+
+- Mostra una previsione con simboli e informazioni sulla luce solare per la tua posizione attuale:
+
+`ansiweather -s {{true}} -d {{true}}`
+
+- Mostra una previsione con informazioni su vento ed umidità per la tua posizione attuale:
+
+`ansiweather -w {{true}} -h {{true}}`

--- a/pages.it/common/apg.md
+++ b/pages.it/common/apg.md
@@ -1,0 +1,23 @@
+# apg
+
+> Crea password randomiche arbitrariamente complesse.
+
+- Genera password randomiche (la lunghezza predefinita è 8):
+
+`apg`
+
+- Crea una password con almeno 1 simbolo (S), 1 numero (N), 1 lettera maiuscola (C) e una minuscola (L):
+
+`apg -M SNCL`
+
+- Crea una password di 16 caratteri:
+
+`apg -m {{16}}`
+
+- Crea una password di massimo 16 caratteri:
+
+`apg -x {{16}}`
+
+- Crea una password che non è già presente in un dizionario (file dizionario fornito come argomento):
+
+`apg -r {{dizionario}}`

--- a/pages.it/common/apm.md
+++ b/pages.it/common/apm.md
@@ -1,0 +1,16 @@
+# apm
+
+> Manager di pacchetti per l'editor di testo Atom.
+> Vedi `atom`.
+
+- Installa pacchetti da http://atom.io/packages e temi da http://atom.io/themes:
+
+`apm install {{nome_pacchetto}}`
+
+- Rimuovi pacchetti/temi:
+
+`apm remove {{nome_pacchetto}}`
+
+- Aggiorna pacchetti/temi:
+
+`apm upgrade {{nome_pacchetto}}`

--- a/pages.it/common/apropos.md
+++ b/pages.it/common/apropos.md
@@ -1,0 +1,11 @@
+# apropos
+
+> Cerca nelle pagine di manuale, ad esempio per trovare un nuovo comando.
+
+- Cerca una parola chiave:
+
+`apropos {{qualcosa}}`
+
+- Cerca senza limitare l'output alla larghezza del terminale:
+
+`apropos -l {{qualcosa}}`

--- a/pages.it/common/ar.md
+++ b/pages.it/common/ar.md
@@ -1,0 +1,23 @@
+# ar
+
+> Crea, modifica ed estrai da archivi (.a, .so, .o).
+
+- Estrai tutti i membri da un archivio:
+
+`ar -x {{libfoo.a}}`
+
+- Lista tutti i membri di un archivio:
+
+`ar -t {{libfoo.a}}`
+
+- Sostituisci o aggiungi file ad un archvio:
+
+`ar -r {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`
+
+- Inserisci o sostituisci un indice in un archivio (equivalente ad usare `ranlib`):
+
+`ar -s {{libfoo.a}}`
+
+- Crea un archivio con dei file creando anche il relativo indice:
+
+`ar -rs {{libfoo.a}} {{foo.o}} {{bar.o}} {{baz.o}}`

--- a/pages.it/common/aria2c.md
+++ b/pages.it/common/aria2c.md
@@ -1,0 +1,28 @@
+# aria2c
+
+> Veloce utilità di download.
+> Supporta HTTP(S), FTP, SFTP, BitTorrent, e Metalink.
+
+- Scarica un file da un URI:
+
+`aria2c {{url}}`
+
+- Scarica più file da diverse sorgenti:
+
+`aria2c {{url_1}} {{url_2}}`
+
+- Scarica gli URI elencati in un file:
+
+`aria2c -i {{filename}}`
+
+- Esegui il download con connessioni multiple:
+
+`aria2c -s {{numero_connessioni}} {{url}}`
+
+- Scarica via FTP con username e password:
+
+`aria2c --ftp-user={{username}} --ftp-passwd={{password}} {{url}}`
+
+- Limita la valocità di download (in byte al secondo):
+
+`aria2c --max-download-limit={{velocità}} {{url}}`

--- a/pages.it/common/arp.md
+++ b/pages.it/common/arp.md
@@ -1,0 +1,19 @@
+# arp
+
+> Mostra e gestisci la cache ARP di sistema.
+
+- Mostra la tabella ARP corrente:
+
+`arp -a`
+
+- Elimina l'intera cache:
+
+`sudo arp -a -d`
+
+- Elimina una specifica voce:
+
+`arp -d {{indirizzo}}`
+
+- Crea una nuova voce:
+
+`arp -s {{indirizzo}} {{indirizzo_mac}}`

--- a/pages.it/common/asar.md
+++ b/pages.it/common/asar.md
@@ -1,0 +1,19 @@
+# asar
+
+> Gestore di archivi per la piattaforma Electron.
+
+- Archivia un file o una cartella:
+
+`asar pack {{percorso/al/file}} {{archivio.asar}}`
+
+- Estrai un archivio:
+
+`asar extract {{archivio.asar}}`
+
+- Estrai uno specifico file da un archivio:
+
+`asar extract-file {{archivio.asar}} {{nome_file}}`
+
+- Elenca i contenuti in un archivio:
+
+`asar list {{archivio.asar}}`

--- a/pages.it/common/asciinema.md
+++ b/pages.it/common/asciinema.md
@@ -1,0 +1,35 @@
+# asciinema
+
+> Registra e riproduci sessioni di terminale, condividendole opzionalmente su asciiname.org.
+
+- Associa l'installazione locale di `asciiname` ad un account di asciiname.org:
+
+`asciinema auth`
+
+- Avvia una nuova registrazione (una volta terminata, verrà chiesto se caricarla o salvarla localmente):
+
+`asciinema rec`
+
+- Avvia una nuova registrazione e salvala come file locale:
+
+`asciinema rec {{nome_registrazione}}.cast`
+
+- Riproduci una sessione da un file locale:
+
+`asciinema play {{percorso/al/file}}.cast`
+
+- Riproducei una sessione da asciinema.org:
+
+`asciinema play https://asciinema.org/a/{{id_registrazione}}`
+
+- Avvia una nuova registrazione, limitando qualsiasi periodo di inattività a 2.5 secondi:
+
+`asciinema rec -i {{2.5}}`
+
+- Stampa l'output completo di una sessione locale:
+
+`asciinema cat {{percorso/al/file}}.cast`
+
+- Carica una sessione locale su asciinama.org:
+
+`asciinema upload {{percorso/al/file}}.cast`

--- a/pages.it/common/assimp.md
+++ b/pages.it/common/assimp.md
@@ -1,0 +1,32 @@
+# assimp
+
+> Client da linea di comando per la Open Asset Import Library.
+> Supporta il caricamento di 40+ formati di file per modelli 3D, e l'espoerazione di diversi formati 3D popolari.
+
+- Elenca tutti i formati supportati:
+
+`assimp listext`
+
+- Elenca tutti i formati supportati per l'esportazione:
+
+`assimp listexport`
+
+- Converti un file a uno dei tipi supportati, utilizzando i parametri predefiniti:
+
+`assimp export {{file_input.stl}} {{file_output.obj}}`
+
+- Converti un file utilizzando parametri personalizzati (il file dox_cmd.h nel source code di assimp contiene una lista di parametri disponibili):
+
+`assimp export {{file_input.stl}} {{file_output.obj}} {{parametri}}`
+
+- Mostra un riepilogo del contenuto di un file:
+
+`assimp info {{percordo/al/file}}`
+
+- Elenca tutti i sottocomandi disponibili (detti "verbs"):
+
+`assimp help`
+
+- Chiedi aiuto per uno specifico sottocomando (ad esempio riguardo i suoi parametri):
+
+`assimp {{sottocomando}} --help`

--- a/pages.it/common/astyle.md
+++ b/pages.it/common/astyle.md
@@ -1,0 +1,24 @@
+# astyle
+
+> Identificatore di codice sorgente, formattatore e beautifier per i linguaggi C, C++, C# e Java.
+> Quando eseguito, una copia del file originale è creata con l'estensione ".orig" aggiunta come suffisso.
+
+- Applica lo stile di default di 4 spazi per livello di indentazione e nessun cambiamento alla formattazione:
+
+`astyle {{file_sorgente}}`
+
+- Applica lo stile java con parentesi graffe aperte sulla stessa riga (attached braces):
+
+`astyle --style=java {{percorso/al/file}}`
+
+- Applica lo stile allman per parantesi graffe su linee separate (broken braces):
+
+`astyle --style=allman {{percorso/al/file}}`
+
+- Applica un'indentazione personalizzata utilizzando spazi. Scegli tra 2 e 20 spazi:
+
+`astyle --indent=spaces={{numero_spazi}} {{percorso/al/file}}`
+
+- Applica un'indentazione personalizzata utilizzando tab. Scegli tra 2 e 20 tab:
+
+`astyle --indent=tab={{numero_tab}} {{percorso/al/file}}`

--- a/pages.it/common/at.md
+++ b/pages.it/common/at.md
@@ -1,0 +1,16 @@
+# at
+
+> Programma l'esecuzione di comandi nel futuro.
+> Il servizio atd (o atrun) deve essere attivo per eseguire i comandi.
+
+- Esegui i comandi inseriti standard input tra 5 minuti (premere `Ctrl + D` dopo aver inserito i comandi):
+
+`at now + 5 minutes`
+
+- Esegui un comando passato da standard input alle 10:00 di mattina:
+
+`echo "{{./mio_script.sh}}" | at 1000`
+
+- Esegui comandi contenuti in un dato file il prossimo martedì alle 9:30 di sera:
+
+`at -f {{percorso/al/file}} 9:30 PM Tue`

--- a/pages.it/common/atom.md
+++ b/pages.it/common/atom.md
@@ -1,0 +1,24 @@
+# atom
+
+> Un editor di testo cross-platform personalizzabile.
+> I plugin sono gestiti da `apm`.
+
+- Apri un file o una cartella:
+
+`atom {{percorso/a/file_o_cartella}}`
+
+- Apri un file o una cartella in una nuova finestra:
+
+`atom -n {{percorso/a/file_o_cartella}}`
+
+- Apri un file o una cartella in una finestra esistente:
+
+`atom --add {{percorso/a/file_o_cartella}}`
+
+- Avvia Atom in safe mode (non carica nessun pacchetto):
+
+`atom --safe`
+
+- Impedisci ad Atom di creare un nuovo processo in background, lasciandolo in esecuzione nel terminale:
+
+`atom --foreground`

--- a/pages.it/common/atq.md
+++ b/pages.it/common/atq.md
@@ -1,0 +1,15 @@
+# atq
+
+> Mostra job programmati dai comandi `at` o `batch`.
+
+- Mostra i job programmati per l'utente corrente:
+
+`atq`
+
+- Mostra i job della coda 'a' (le code hanno nomi di un singolo carattere):
+
+`atq -q {{a}}`
+
+- Mostra i job di tutti gli utenti (da eseguire come super user):
+
+`sudo atq`

--- a/pages.it/common/atrm.md
+++ b/pages.it/common/atrm.md
@@ -1,0 +1,12 @@
+# atrm
+
+> Rimuovi job programmati dai comandi `at` o `batch`.
+> Per trovare i numeri dei job utilizzare `atq`.
+
+- Rimuovi il job numero 10:
+
+`atrm {{10}}`
+
+- Rimuovi più job, separati da spazi:
+
+`atrm {{15}} {{17}} {{22}}`

--- a/pages.it/common/autoflake.md
+++ b/pages.it/common/autoflake.md
@@ -1,0 +1,19 @@
+# autoflake
+
+> Uno strumento per rimuovere import e variabili inutilizzati da codice Python.
+
+- Rimuovi le variabili inutilizzate da un file e mostra la differenza:
+
+`autoflake --remove-unused-variables {{file.py}}`
+
+- Rimuovi gli import inutilizzati da multipli file mostrando le differenze:
+
+`autoflake --remove-all-unused-imports {{file1.py}} {{file2.py}} {{file3.py}}`
+
+- Rimuovi le variabili inutilizzate da un file, sovrascrivendolo:
+
+`autoflake --remove-unused-variables --in-place {{file.py}}`
+
+- Rimuovi le variabili inutilizzate da tutti i file in una cartella, ricorsivamente e sovrascrivendoli:
+
+`autoflake --remove-unused-variables --in-place --recursive {{percorso/a/cartella}}`

--- a/pages.it/common/autojump.md
+++ b/pages.it/common/autojump.md
@@ -1,0 +1,24 @@
+# autojump
+
+> Salta velocemente tra le directory che usi più spesso.
+> Alias come j o jc sono disponibili per una maggiore velocità di scrittura.
+
+- Muoviti in una directory il cui nome contiene una parola chiave:
+
+`j {{parola_chiave}}`
+
+- Salta in una sotto-directory della directory corrente il quale nome contiene una parola chiave:
+
+`jc {{parola_chiave}}`
+
+- Apri una directory il cui nome contiene una parola chiave nel gestore file di sistema:
+
+`jo {{parola_chiave}}`
+
+- Rimuovi directory non esistenti dal database di autojump:
+
+`j --purge`
+
+- Mostra le voci nel database di autojump:
+
+`j -s`

--- a/pages.it/common/autossh.md
+++ b/pages.it/common/autossh.md
@@ -1,0 +1,28 @@
+# autossh
+
+> Esegue, monitora e riavvia connessioni SSH.
+> Si riconnette automaticamente per tenere attivi tunnel di port forwarding. Accetta tutte le flag di ssh.
+
+- Apri una sessione SSH, riavviandola quando una porta monitorata smette di rispondere:
+
+`autossh -M {{porta_monitorata}} {{comando_ssh}}`
+
+- Apri una sessione ssh che forwarda una porta locale verso una remota, riavviandola se necessario:
+
+`autossh -M {{porta_monitorata}} -L {{porta_locale}}:localhost:{{porta_remota}} {{utente}}@{{host}}`
+
+- Forka prima di eseguire il comando ssh (si avvia in background) e non aprire una shell remota:
+
+`autossh -f -M {{porta_monitorata}} -N {{comando_ssh}}`
+
+- Esegui autossh in background, senza una porta da monitorare, utilizzando i keep-alive di SSH ogni 10 secondi per rilevare una disconnessione:
+
+`autossh -f -M 0 -N -o "ServerAliveInterval 10" -o "ServerAliveCountMax 3"  {{comando_ssh}}`
+
+- Esegui autossh in background, senza una porta da monitorare, senza una shell remota, uscendo se il port forwarding fallisce:
+
+`autossh -f -M 0 -N -o "ServerAliveInterval 10" -o "ServerAliveCountMax 3" -o ExitOnForwardFailure=yes -L {{porta_locale}}:localhost:{{porta_remota}} {{utente}}@{{host}}`
+
+- Esegui autossh in background con output di debug su un file e output verboso di ssh su un altro file:
+
+`AUTOSSH_DEBUG=1 AUTOSSH_LOGFILE={{file_log}} autossh -f -M {{porta_monitorata}} -v -E {{file_log_ssh}} {{comando_ssh}}`

--- a/pages.it/common/avrdude.md
+++ b/pages.it/common/avrdude.md
@@ -1,0 +1,19 @@
+# avrdude
+
+> Driver per il programmatore di microcontrollori Atmel AVR.
+
+- Leggi dal microcontrollore AVR:
+
+`avrdude -p {{dispositivo_AVR}} -c {{id_programmatore}} -U flash:r:{{file.hex}}:i`
+
+- Scrivi sul microcontrollore AVR:
+
+`avrdude -p {{dispositivo_AVR}} -c {{id_programmatore}} -U flash:w:{{file.hex}}`
+
+- Elenca dispositivi AVR disponibili:
+
+`avrdude -p \?`
+
+- Elenca programmatori AVR disponibili:
+
+`avrdude -c \?`

--- a/pages.it/common/awk.md
+++ b/pages.it/common/awk.md
@@ -1,0 +1,27 @@
+# awk
+
+> Un versatile linguaggio di programmazione per elaborare file.
+
+- Stampa la quinta colonna (field) in un file di linee separate da spazi:
+
+`awk '{print $5}' {{nome_file}}`
+
+- Stampa la seconda colonna delle linee contenenti "qualcosa":
+
+`awk '/{{qualcosa}}/ {print $2}' {{nome_file}}`
+
+- Stampa l'ultima colonna di ogni linea di un file, utilizzando la virgola (invece dello spazio) come separatore di colonne:
+
+`awk -F ',' '{print $NF}' {{nome_file}}`
+
+- Somma i valori nella prima colonna di un file e stampa il totale:
+
+`awk '{s+=$1} END {print s}' {{nome_file}}`
+
+- Somma i valori nella prima colonna e stampali seguiti dal totale:
+
+`awk '{s+=$1; print $1} END {print "--------"; print s}' {{nome_file}}`
+
+- Stampa una liena ogni tre iniziando dalla prima:
+
+`awk 'NR%3==1' {{nome_file}}`

--- a/pages.it/common/aws-s3.md
+++ b/pages.it/common/aws-s3.md
@@ -1,0 +1,27 @@
+# aws s3
+
+> CLI per AWS S3 - fornisce spazio di archiviazione tramite le interfacce di Amazon Web Services.
+
+- Mostra file in un bucket:
+
+`aws s3 ls {{nome_bucket}}`
+
+- Sincronizza file e directory locali su un bucket:
+
+`aws s3 sync {{percorso/ai/file}} s3://{{nome_bucket}}`
+
+- Sincronizza file e directory da un bucket in locle:
+
+`aws s3 sync s3://{{nome_bucket}} {{path/to/target}}`
+
+- Sincronizza file e directory escludendo alcuni file o directory:
+
+`aws s3 sync {{percorso/ai/file}} s3://{{nome_bucket}} --exclude {{percorso/al/file}} --exclude {{directory}}/*`
+
+- Rimuovi un file dal bucket:
+
+`aws s3 rm s3://{{bucket}}/{{percorso/al/file}}`
+
+- Mostra solo un'anteprima dei cambiamenti:
+
+`aws s3 {{qualsiasi_comando}} --dryrun`

--- a/pages.it/common/aws.md
+++ b/pages.it/common/aws.md
@@ -1,0 +1,23 @@
+# aws
+
+> Il tool da linea di comando ufficiale per Amazon Web Services.
+
+- Lista tutti gli utenti IAM (Identity and Access Management):
+
+`aws iam list-users`
+
+- Lista tutte le instanze EC2 per una specifica regione:
+
+`aws ec2 describe-instances --region {{us-east-1}}`
+
+- Ricevi un messaggio da una specifica coda SQS:
+
+`aws sqs receive-message --queue-url {{https://queue.amazonaws.com/546123/Test}}`
+
+- Pubblica un messaggio SNS su uno specifico argomento:
+
+`aws sns publish --topic-arn {{arn:aws:sns:us-east-1:54633:Agomento}} --message "Message"`
+
+- Mostra la pagina di aiuto per uno specifico comando AWS:
+
+`aws {{comando}} help`

--- a/pages.it/common/axel.md
+++ b/pages.it/common/axel.md
@@ -1,0 +1,24 @@
+# axel
+
+> Downloader accelerato.
+> Supporta HTTP, HTTPS e FTP.
+
+- Scarica un file da un URL:
+
+`axel {{url}}`
+
+- Scarica specificando il nome del file da creare:
+
+`axel {{url}} -o {{filename}}`
+
+- Scarica sfruttando connessioni multiple:
+
+`axel -n {{numero_connessioni}} {{url}}`
+
+- Cerca dei mirror:
+
+`axel -S {{numero_mirror}} {{url}}`
+
+- Limita la velocità di download (in bytes al secondo):
+
+`axel -s {{limite_velocità}} {{url}}`

--- a/pages.it/common/az.md
+++ b/pages.it/common/az.md
@@ -1,0 +1,27 @@
+# az
+
+> Strumento ufficiale da linea di comando per Microsoft Azure.
+
+- Effettua il log in ad Azure:
+
+`az login`
+
+- Gestisci la tua iscrizione ad Azure:
+
+`az account`
+
+- Elenca tutti i dischi Azure Managed Disks:
+
+`az disk list`
+
+- Elenca tutte le virtual machine Azure:
+
+`az vm list`
+
+- Gestisci i servizi Azure Kubernetes:
+
+`az aks`
+
+- Gestisci le risorse della rete di Azure:
+
+`az network`

--- a/pages.it/common/b2sum.md
+++ b/pages.it/common/b2sum.md
@@ -1,0 +1,19 @@
+# b2sum
+
+> Calcola checksum BLAKE2.
+
+- Calcola il checksum BLAKE2 per un file:
+
+`b2sum {{file1}}`
+
+- Calcola checksum BLAKE2 per più file:
+
+`b2sum {{file1}} {{file2}}`
+
+- Leggi un file di checksum BLAKE2 e nomi di file e verifica che tutti i file abbiano lo stesso checksum:
+
+`b2sum -c {{elenco_checksum.b2}}`
+
+- Calcola il checksum BLAKE2 da standard input:
+
+`{{comando}} | b2sum`

--- a/pages.it/common/babel.md
+++ b/pages.it/common/babel.md
@@ -1,0 +1,35 @@
+# babel
+
+> Un transpiler che converte codice JavaScript da sintassi ES6/ES7 ad ES5.
+
+- Transpila uno specifico file e stampa il risultato su stdout:
+
+`babel {{percorso/al/file}}`
+
+- Transpila un file e scrivi il risultato su uno specifico file di output:
+
+`babel {{percorso/al/file_input}} --out-file {{percorso/al/file_output}}`
+
+- Transpila un file ogni volta che viene modificato:
+
+`babel {{percorso/al/file}} --watch`
+
+- Transpila un'intera directory di file:
+
+`babel {{percorso/a/directory_input}}`
+
+- Transpila un'intera directory ignorando specifici file separati da virgola:
+
+`babel {{percorso/a/directory_input}} --ignore {{file_ignorati}}`
+
+- Transpila minimizzando il codice JavaScript in output:
+
+`babel {{percorso/al/file_input}} --minified`
+
+- Scegli un insieme di preset per formattare l'output:
+
+`babel {{percorso/al/file_input}} --presets {{preset}}`
+
+- Mostra tutte le opzioni disponibili:
+
+`babel --help`

--- a/pages.it/common/badblocks.md
+++ b/pages.it/common/badblocks.md
@@ -1,0 +1,16 @@
+# badblocks
+
+> Cerca blocchi corrotti in un dispositivo.
+> Alcuni utilizzi di badblocks possono avere esiti non reversibili, come perdita dei dati o anche della tabella delle partizioni di un disco.
+
+- Cerca blocchi corrotti in un disco utilizzando un test non distruttivo in sola lettura:
+
+`sudo badblocks {{/dev/sda}}`
+
+- Cerca blocchi corrotti in un disco non montato con un test non distruttivo in lettura e scrittura:
+
+`sudo badblocks -n {{/dev/sda}}`
+
+- Cerca blocchi corrotti in un disco non montato con un test distruttivo in scrittura:
+
+`sudo badblocks -w {{/dev/sda}}`

--- a/pages.it/common/banner.md
+++ b/pages.it/common/banner.md
@@ -1,0 +1,15 @@
+# banner
+
+> Stampa il testo fornito per argomento come un grande banner in ASCII art.
+
+- Stampa il testo come un grande banner (le virgolette sono opzionali):
+
+`banner {{"Hello World"}}`
+
+- Stampa il testo come un banner con una larghezza di 50 caratteri:
+
+`banner -w {{50}} {{"Hello World"}}`
+
+- Leggi testo da stdin:
+
+`banner`

--- a/pages.it/common/base32.md
+++ b/pages.it/common/base32.md
@@ -1,0 +1,19 @@
+# base32
+
+> Codifica o decodifica file o standard input in Base32 su standard output.
+
+- Codifica un file:
+
+`base32 {{nome_file}}`
+
+- Decodifica un file:
+
+`base32 -d {{nome_file}}`
+
+- Codifica da stdin:
+
+`{{comando}} | base32`
+
+- Decodifica da stdin:
+
+`{{comando}} | base32 -d`

--- a/pages.it/common/base64.md
+++ b/pages.it/common/base64.md
@@ -1,0 +1,19 @@
+# base64
+
+> Codifica o decodifica file o standard input in Base64 su standard output.
+
+- Codifica un file:
+
+`base64 {{nome_file}}`
+
+- Decodifica un file:
+
+`base64 -d {{nome_file}}`
+
+- Codifica da stdin:
+
+`{{comando}} | base64`
+
+- Decodifica da stdin:
+
+`{{comando}} | base64 -d`

--- a/pages.it/common/basename.md
+++ b/pages.it/common/basename.md
@@ -1,0 +1,11 @@
+# basename
+
+> Restituisce la parte finale un percorso.
+
+- Mostra solo il nome del file da un percorso:
+
+`basename {{percorso/al/file}}`
+
+- Mostra solo il nome di un file da un percorso, rimuovendo un suffisso:
+
+`basename {{percorso/al/file}} {{suffisso}}`

--- a/pages.it/common/bash.md
+++ b/pages.it/common/bash.md
@@ -1,0 +1,28 @@
+# bash
+
+> Bourne-Again SHell.
+> Interprete da linea di comando compatibile con `sh`.
+
+- Avvia una shell interattiva:
+
+`bash`
+
+- Esegui un comando:
+
+`bash -c "{{comando}}"`
+
+- Esegui dei comandi da un file:
+
+`bash {{file.sh}}`
+
+- Esegui dei comandi da un file, loggando tutti i comandi eseguiti nel terminale:
+
+`bash -x {{file.sh}}`
+
+- Esegui comandi da standard input:
+
+`bash -s`
+
+- Stampa informazioni sulla versione di bash (usa `echo $BASH_VERSION` per mostrare solo la versione):
+
+`bash --version`

--- a/pages.it/common/bashmarks.md
+++ b/pages.it/common/bashmarks.md
@@ -1,0 +1,23 @@
+# bashmarks
+
+> Salva e salta a directory comunemente utilizzate usilizzando comandi di un carattere.
+
+- Elenca i segnalibri disponibili:
+
+`l`
+
+- Salva la cartella corrente come segnalibro:
+
+`s {{nome_segnalibro}}`
+
+- Vai ad una cartella salvata:
+
+`g {{nome_segnalibro}}`
+
+- Lista i contenuti di una cartella salvata:
+
+`p {{nome_segnalibro}}`
+
+- Elimina un segnalibro:
+
+`d {{nome_segnalibro}}`

--- a/pages.it/common/bat.md
+++ b/pages.it/common/bat.md
@@ -1,0 +1,28 @@
+# bat
+
+> Stampa e concatena file.
+> Un clone di `cat` con syntax highlighting e integrazione Git.
+
+- Stampa i contenuti di un file su standard output:
+
+`bat {{file}}`
+
+- Concatena diversi file in un unico file:
+
+`bat {{file1}} {{file2}} > {{file_finale}}`
+
+- Aggiungi il contenuto di diversi file alla fine di un file:
+
+`bat {{file1}} {{file2}} >> {{file_finale}}`
+
+- Numera tutte le linee stampate:
+
+`bat -n {{file}}`
+
+- Evidenzia la sintassi di un file JSON:
+
+`bat --language json {{file.json}}`
+
+- Mostra tutti i linguaggi supportati:
+
+`bat --list-languages`

--- a/pages.it/common/batch.md
+++ b/pages.it/common/batch.md
@@ -1,0 +1,16 @@
+# batch
+
+> Esegui comandi nel futuro quando il carico di lavoro del sistema lo permette.
+> Il servizio atd (o atrun) deve essere attivo per eseguire i comandi.
+
+- Esegui i comandi inseriti standard input (premere `Ctrl + D` dopo aver inserito i comandi):
+
+`batch`
+
+- Esegui un comando da standard input:
+
+`echo "{{./mio_script.sh}}" | batch`
+
+- Esegui comandi contenuti in un dato file:
+
+`batch -f {{percorso/al/file}}`

--- a/pages.it/common/bc.md
+++ b/pages.it/common/bc.md
@@ -1,0 +1,19 @@
+# bc
+
+> Calcolatore.
+
+- Esegui in modalità interattiva utilizzando la libreria math della standard library:
+
+`bc -l`
+
+- Calcola il risultato di un'espressione:
+
+`bc <<< "(1 + 2) * 2 ^ 2"`
+
+- Calcola un'espressione forzando il numero di decimali usati a 10:
+
+`bc <<< "scale=10; 5 / 3"`
+
+- Calcola un'espressione con seno e coseno utilizzando mathlib:
+
+`bc -l <<< "s(1) + c(1)"`

--- a/pages.it/common/beanstalkd.md
+++ b/pages.it/common/beanstalkd.md
@@ -1,0 +1,19 @@
+# beanstalkd
+
+> Un semplice e generico gestore di code di lavoro.
+
+- Avvia beanstalkd, ascoltando sulla porta 11300:
+
+`beanstalkd`
+
+- Avvia beanstalkd ascoltando su porta ed un indirizzo dati:
+
+`beanstalkd -l {{indirizzo_ip}} -p {{numero_porta}}`
+
+- Rendi le code di lavoro persistenti salvandole su disco:
+
+`beanstalkd -b {{percorso/a/directory_persistente}}`
+
+- Sincronizza con una cartella persistente ogni 500 millisecondi:
+
+`beanstalkd -b {{percorso/a/directory_persistente}} -f {{500}}`

--- a/pages.it/common/bedtools.md
+++ b/pages.it/common/bedtools.md
@@ -1,0 +1,28 @@
+# bedtools
+
+> Un coltellino svizzero di strumenti per analisi genomica.
+> Usato per intersecare, raggruppare, convertire e contare dati in formato BAM, BED, GFF/GTF, VCF.
+
+- Interseca i fili genetici delle sequenze contenute in due file diversi e salva il risultato:
+
+`bedtools intersect -a {{percorso/al/file_1}} -b {{percorso/al/file_2}} -s > {{percorso/al/file_output}}`
+
+- Interseca due file unendo il risultato a sinistra, ovvero riporta ogni feature da {{file_1}} e NULL dove non c'è sovrapposizione con {{file_2}}:
+
+`bedtools intersect -a {{percorso/al/file_1}} -b {{percorso/al/file_2}} -lof > {{percorso/al/file_output}}`
+
+- Usa un algoritmo più efficiente per intersecare due file precedentemente ordinati:
+
+`bedtools intersect -a {{percorso/al/file_1}} -b {{percorso/al/file_2}} -sorted > {{percorso/al/file_output}}`
+
+- Raggruppa file in base alle prime tre e la quinta colonna e raggruppa la sesta colonna sommandola:
+
+`bedtools groupby -i {{percorso/al/file}} -c 1-3,5 -g 6 -o sum`
+
+- Converti da formato BAM a BED:
+
+`bedtools bamtobed -i {{percorso/al/file}}.bam > {{percorso/al/file}}.bed`
+
+- Trova per tutte le proprietà in {{file_1}} la più vicina in {{file_2}} e scrivi la loro distanza in una ulteriore colonna (i file in input devono essere ordinati):
+
+`bedtools closest -a {{percorso/al/file_1}}.bed -b {{percorso/al/file_2}}.bed -d`

--- a/pages.it/common/berks.md
+++ b/pages.it/common/berks.md
@@ -1,0 +1,19 @@
+# berks
+
+> Gestore di dipendenze per Chef cookbooks.
+
+- Installa dipendenze cookbook in una repo locale:
+
+`berks install`
+
+- Aggiorna uno specifico cookbook e le sue dipendenze:
+
+`berks update {{cookbook}}`
+
+- Carica un cookbook sul server di Chef:
+
+`berks upload {{cookbook}}`
+
+- Mostra le dipendenze di un cookbook:
+
+`berks contingent {{cookbook}}`

--- a/pages.it/common/bg.md
+++ b/pages.it/common/bg.md
@@ -1,0 +1,11 @@
+# bg
+
+> Riprende job che sono stati sospesi (e.g. usando `Ctrl + Z`) mettendoli in esecuzione in background.
+
+- Riprendi il job sospeso più recentemente ed eseguilo in background:
+
+`bg`
+
+- Riprendi uno specifico job (usa `jobs -l` per trovare l'ID) ed eseguilo in background:
+
+`bg {{id_job}}`

--- a/pages.it/common/blender.md
+++ b/pages.it/common/blender.md
@@ -1,0 +1,32 @@
+# blender
+
+> Interfaccia da linea di comando per il programma di grafica Blender 3D.
+> Gli argomenti sono eseguiti nell'ordine in cui sono dati.
+
+- Renderizza tutti i frame di una animazione in background, senza caricare l'interfaccia grafica (l'output è salvato in `/tmp`):
+
+`blender -b {{nome_file}}.blend -a`
+
+- Renderizza un'animazione usando uno specifico pattern, in un percorso relativo (`//`) al file .blend:
+
+`blender -b {{nome_file}}.blend -o //{{render/frame_###.png}} -a`
+
+- Renderizza il decimo frame di un'animazione come singola immagine, salvandolo in una cartella esistente (percorso assoluto):
+
+`blender -b {{nome_file}}.blend -o {{/percorso/a/directory_output}} -f {{10}}`
+
+- Renderizza il penultimo frame di un'animazione come immagine JPEG, salvandolo in una cartella esistente (path relativa al file):
+
+`blender -b {{nome_file}}.blend -o //{{directory_output}} -F {{JPEG}} -f {{-2}}`
+
+- Renderizza l'animazione di una specifica scena, dal frame 10 al 500:
+
+`blender -b {{nome_file}}.blend -S {{nome_scena}} -s {{10}} -e {{500}} -a`
+
+- Renderizza un'animazione ad una specifica risoluzione, attraverso l'utilizzo di uno script python:
+
+`blender -b {{nome_file}}.blend --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' -a`
+
+- Avvia una sessione interattiva di Blender nel terminale con una console python (esegui `import bpy` dopo l'avvio):
+
+`blender -b --python-console`

--- a/pages.it/common/bmaptool.md
+++ b/pages.it/common/bmaptool.md
@@ -1,0 +1,19 @@
+# bmaptool
+
+> Crea o copia blockmap intelligentemente (e quindi più velocemente di `cp` o `dd`).
+
+- Crea una blockmap da un file immagine:
+
+`bmaptool create -o {{blockmap.bmap}} {{sorgente.img}}`
+
+- Copia un file immagine su sdb:
+
+`bmaptool copy --bmap {{blockmap.bmap}} {{sorgente.img}} {{/dev/sdb}}`
+
+- Copia un file immagine compresso su sdb:
+
+`bmaptool copy --bmap {{blockmap.bmap}} {{sorgente.img.gz}} {{/dev/sdb}}`
+
+- Copia un file immagine su sdb senza utilizzare una blockmap:
+
+`bmaptool copy --nobmap {{sorgente.img}} {{/dev/sdb}}`

--- a/pages.it/common/boot.md
+++ b/pages.it/common/boot.md
@@ -1,0 +1,27 @@
+# boot
+
+> Strumenti di build per il linguaggio di programmazione Clojure.
+
+- Avvia una sessione REPL con il progetto o da sola:
+
+`boot repl`
+
+- Builda un singolo "uberjar":
+
+`boot jar`
+
+- Mostra aiuto per un comando:
+
+`boot cljs --help`
+
+- Genera le fondamenta per un nuovo progetto basandoti su una template:
+
+`boot --dependencies boot/new new --template {{nome_template}} --name {{nome_progetto}}`
+
+- Builda per development (se si sta utilizzando il template boot/new):
+
+`boot dev`
+
+- BUilda per produzione (se si sta utilizzando il template boot/new):
+
+`boot prod`

--- a/pages.it/common/borg.md
+++ b/pages.it/common/borg.md
@@ -1,0 +1,32 @@
+# borg
+
+> Strumento di backup con deduplicazione.
+> Crea backup locali o remoti che sono montabili come filesystem.
+
+- Inizializza una repository (locale):
+
+`borg init {{/percorso/a/repo_o_directory}}`
+
+- Esegui il backup di una directory nella repository, creando un archivio chiamato "Lunedi":
+
+`borg create --progress {{/percorso/a/repo_o_directory}}::{{Lunedi}} {{/percorso/a/directory_sorgente}}`
+
+- Lista tutti gli archivi in una repository:
+
+`borg list {{/percorso/a/repo_o_directory}}`
+
+- Estrai una specifica directory dall'archivio "Lunedi" in una repository remota, escludendo tutti i file .ext:
+
+`borg extract {{utente}}@{{host}}:{{/percorso/a/repo_o_directory}}::{{Lunedi}} {{percorso/a/cartella_destinazione}} --exclude '{{*.ext}}'`
+
+- Riduci una repository eliminando tutti gli archivi più vecchi di 7 giorni, elencando i cambiamenti:
+
+`borg prune --keep-within {{7d}} --list {{/percorso/a/repo_o_directory}}`
+
+- Monta una repository come filesystem FUSE:
+
+`borg mount {{/percorso/a/repo_o_directory}}::{{Lunedi}} {{/percorso/a/mountpoint}}`
+
+- Mostra aiuto sul come creare archivi:
+
+`borg create --help`

--- a/pages.it/common/bosh.md
+++ b/pages.it/common/bosh.md
@@ -1,0 +1,35 @@
+# bosh
+
+> Strumento da linea di comando per distribuire e gestire director BOSH.
+
+- Crea un alias locale per un director:
+
+`bosh alias-env {{nome_ambiente}} -e {{indirizzo_ip|url}} --ca-cert {{certificato_ca}}`
+
+- Elenca ambienti:
+
+`bosh environments`
+
+- Esegui il login al director:
+
+`bosh login -e {{ambiente}} `
+
+- Elenca deployment (distribuzioni):
+
+`bosh -e {{ambiente}} deployments`
+
+- Elenca le macchine virtuali in un ambiente:
+
+`bosh -e {{ambiente}} vms -d {{deployment}}`
+
+- Avvia una sessione SSH in una macchina virtuale:
+
+`bosh -e {{ambiente}} ssh {{macchina_virtuale}} -d {{deployment}}`
+
+- Carica una stemcell:
+
+`bosh -e {{ambiente}} upload-stemcell {{file_stemcell|url}}`
+
+- Mostra la configurazione cloud attuale:
+
+`bosh -e {{ambiente}} cloud-config`

--- a/pages.it/common/bower.md
+++ b/pages.it/common/bower.md
@@ -1,0 +1,32 @@
+# bower
+
+> Un manager di pacchetti ottimizzato per sviluppo web front-end.
+> Un pacchetto può essere una abbreviazione utente/repo GitHub, un endpoint Git, un URL o un pacchetto registrato.
+
+- Installa le dipendenze di un progetto, listate nel suo file bower.json:
+
+`bower install`
+
+- Installa pacchetti nella directory bower_components:
+
+`bower install {{pacchetto1}} {{pacchetto2}} ...`
+
+- Disinstalla pacchetti localmente rimuovendolo dalla directory bower_components:
+
+`bower uninstall {{pacchetto1}} {{pacchetto2}}`
+
+- Elenca pacchetti locali e possibili aggiornamenti:
+
+`bower list`
+
+- Mostra aiuto per un comando di bower:
+
+`bower help {{comando}}`
+
+- Crea un file bower.json per i tuoi pacchetti:
+
+`bower init`
+
+- Installa unoa specifica versione di una dipendenza ed aggiungila al file bower.json:
+
+`bower install {{nome_locale}}={{pacchetto}}#{{versione}} --save`

--- a/pages.it/common/box.md
+++ b/pages.it/common/box.md
@@ -1,0 +1,31 @@
+# box
+
+> Una applicazione PHP per creare e gestire Phars.
+
+- Crea un nuovo file Phar:
+
+`box build`
+
+- Crea un nuovo file Phar usando uno specifico file di configurazione:
+
+`box build -c {{percorso/a/configurazione}}`
+
+- Mostra informazioni sulla estensione PHP PHAR:
+
+`box info`
+
+- Mostra informazioni su di uno specifico file Phar:
+
+`box info {{percorso/a/file_phar}}`
+
+- Valida il primo file di configurazione trovato nella directory corrente:
+
+`box validate`
+
+- Verifica la firma di uno specifico file Phar:
+
+`box verify {{percorso/a/file_phar}}`
+
+- Mostra tutti i comandi ed opzioni disponibili:
+
+`box help`

--- a/pages.it/common/browser-sync.md
+++ b/pages.it/common/browser-sync.md
@@ -1,0 +1,19 @@
+# browser-sync
+
+> Avvia un web-server locale che si aggiorna al cambiamento dei file.
+
+- Avvia un server da una specifica directory:
+
+`browser-sync start --server {{percorso/a/directory}} --files {{percorso/a/directory}}`
+
+- Avvia un server da una directory locale, monitorando tutti i file CSS:
+
+`browser-sync start --server --files '{{percorso/a/directory/*.css}}'`
+
+- Crea un file di configurazione:
+
+`browser-sync init`
+
+- Avvia bower-sync da un file di configurazione:
+
+`browser-sync start --config {{file_di_configurazione}}`

--- a/pages.it/common/bundle.md
+++ b/pages.it/common/bundle.md
@@ -1,0 +1,19 @@
+# bundle
+
+> Gestore di dipendenze per il linguaggio di programmazione Ruby.
+
+- Installa tutte le gem definite nel gemfile della directory corrente:
+
+`bundle install`
+
+- Aggiorna tutte le gem secondo le regole definite nel gemfile e genera un gemfile.lock:
+
+`bundle update`
+
+- Aggiorna una specifica gem definita nel gemfile:
+
+`bundle update --source {{nome_gem}}`
+
+- Crea un scheletro per una nuova gem:
+
+`bundle gem {{nome_gem}}`

--- a/pages.it/common/bup.md
+++ b/pages.it/common/bup.md
@@ -1,0 +1,23 @@
+# bup
+
+> Sistema di backup basato sul formato dei packfile git, fornendo salvataggi incrementali veloci e deduplicazione globale.
+
+- Inizializza una repository di backup nella directory locale specificata:
+
+`bup -d {{percorso/a/repository}} init`
+
+- Prepara una certa cartella prima di fare un backup:
+
+`bup -d {{percorso/a/repository}} index {{percorso/a/directory}}`
+
+- Esegui il backup di una cartella in una repository locale:
+
+`bup -d {{percorso/a/repository}} save -n {{nome_backup}} {{percorso/a/directory}}`
+
+- Elenca i di backup attualmente nella repository:
+
+`bup -d {{percorso/a/repository}} ls`
+
+- Ripristina uno specifico backup in una determinata cartella locale:
+
+`bup -d {{percorso/a/repository}} restore -C {{percorso/a/destinazione}} {{nome_backup}}`

--- a/pages.it/common/bw.md
+++ b/pages.it/common/bw.md
@@ -1,0 +1,23 @@
+# bw
+
+> CLI per accedere e gestire vault Bitwarden.
+
+- Esegui il login ad un account Bitwarden:
+
+`bw login`
+
+- Esegui il logout da un account Bitwarden:
+
+`bw logout`
+
+- Cerca e mostra oggetti in un vault Bitwarden:
+
+`bw list items --search {{github}}`
+
+- Mostra un particolare oggetto contenuto in un vault Bitwarden:
+
+`bw get item {{github}}`
+
+- Crea una cartella in un vault bitwarden:
+
+`{{echo -n '{"name":"Nome cartella"}' | base64}} | bw create folder`

--- a/pages.it/common/c99.md
+++ b/pages.it/common/c99.md
@@ -1,0 +1,19 @@
+# c99
+
+> Compila programmi C secondo lo standard ISO C.
+
+- Compila file sorgente/i e crea un eseguibile:
+
+`c99 {{file.c}}`
+
+- Compila file sorgente/i e crea un eseguibile con un nome personalizzato:
+
+`c99 -o {{nome_eseguibile}} {{file.c}}`
+
+- Compila file sorgente/i e crea file oggetto:
+
+`c99 -c {{file.c}}`
+
+- Compila file sorgente/i linkando con file oggetto e crea un eseguibile:
+
+`c99 {{file.c}} {{file.o}}`

--- a/pages.it/common/cabal.md
+++ b/pages.it/common/cabal.md
@@ -1,0 +1,28 @@
+# cabal
+
+> Interfaccia da linea di comando per l'infrastruttura di compilazione di Haskell (Cabal).
+> Gestisce progetti Haskell e pacchetti Cabal dal repository di pacchetti Hackage.
+
+- Cerca ed elenca pacchetti da Hackage:
+
+`cabal list {{termine_di_ricerca}}`
+
+- Mostra informazioni su di un pacchetto:
+
+`cabal info {{nome_pacchetto}}`
+
+- Scarica ed installa un pacchetto:
+
+`cabal install {{nome_pacchetto}}`
+
+- Crea un nuovo progetto Haskell nella directory corrente:
+
+`cabal init`
+
+- Compila il progetto nella directory corrente:
+
+`cabal build`
+
+- Esegui i test del progetto nella directory corrente:
+
+`cabal test`

--- a/pages.it/common/calibre-server.md
+++ b/pages.it/common/calibre-server.md
@@ -1,0 +1,17 @@
+# calibre-server
+
+> Un'applicazione server che può essere usata per distribuire ebook in una rete.
+> Gli ebook devono prima essere importati nella libreria usando la GUI o calibredb.
+> Parte del manager di ebook Calibre.
+
+- Avvia un server per distribuire ebook. Accesso a http://localhost:8080:
+
+`calibre-server`
+
+- Avvia il server su una specifica porta. Accesso a http://localhost:porta:
+
+`calibre-server --port {{porta}}`
+
+- Proteggi il server con username e password:
+
+`calibre-server --username {{username}} --password {{password}}`

--- a/pages.it/common/calibredb.md
+++ b/pages.it/common/calibredb.md
@@ -1,0 +1,24 @@
+# calibredb
+
+> Strumentoi per gestire il tuo database di ebook.
+> Parte del manager di ebook Calibre.
+
+- Elenca gli ebook nella libreria con informazioni aggiuntive:
+
+`calibredb list`
+
+- Cerca tra gli ebook mostrando informazioni aggiuntive:
+
+`calibredb list --search {{termine_di_ricerca}}`
+
+- Cerca mostrando solamente gli ID degli ebook:
+
+`calibredb search {{termine_di_ricerca}}`
+
+- Aggiungi uno o più ebook alla libreria:
+
+`calibredb add {{file1 file2 …}}`
+
+- Rimuovi uno o più ebook dalla libreria. Sono necessari gli ID (vedi sopra):
+
+`calibredb remove {{id1 id2 …}}`

--- a/pages.it/common/cargo.md
+++ b/pages.it/common/cargo.md
@@ -1,0 +1,32 @@
+# cargo
+
+> Gestore di pacchetti di Rust.
+> Gestisce progetti Rust ed i moduli dai quali sono dipendenti (detti crate).
+
+- Cerca una crate:
+
+`cargo search {{termine_di_ricerca}}`
+
+- Installa una crate:
+
+`cargo install {{nome_crate}}`
+
+- Elenca crate installate:
+
+`cargo install --list`
+
+- Crea un nuovo progetto Rust binario o di libreria nella directory corrente:
+
+`cargo init --{{bin|lib}}`
+
+- Crea un nuovo progetto Rust binario o di libreria nella directory specificata:
+
+`cargo new {{path/a/directory}} --{{bin|lib}}`
+
+- Builda il progetto Rust nella cartella corrente:
+
+`cargo build`
+
+- Builda utilizzando più job (thread) paralleli:
+
+`cargo build -j {{numero_job}}`

--- a/pages.it/common/case.md
+++ b/pages.it/common/case.md
@@ -1,0 +1,11 @@
+# case
+
+> Esegui branch diversi in base al valore di un'espressione.
+
+- Esegui il match di una variabile su diverse stringhe per decidere che comando eseguire:
+
+`case {{$metrica}} in {{parole}}) {{wc -w README}}; ;; {{linee}}) {{wc -l README}}; ;; esac`
+
+- Combina pattern con |, utilizzando * come pattern di fallback:
+
+`case {{$metrica}} in {{[pP]|parole}}) {{wc -w README}}; ;; {{[lL]|linee}}) {{wc -l README}}; ;; *) {{echo "cosa?"}}; ;; esac`

--- a/pages.it/common/cat.md
+++ b/pages.it/common/cat.md
@@ -1,0 +1,19 @@
+# cat
+
+> Stampa e concatena file.
+
+- Stampa i contenuti di un file su standard output:
+
+`cat {{file}}`
+
+- Concatena più file in un unico file:
+
+`cat {{file1}} {{file2}} > {{file_finale}}`
+
+- Aggiungi il contenuto di diversi file alla fine di un file:
+
+`cat {{file1}} {{file2}} >> {{file_finale}}`
+
+- Numera tutte le linee stampate:
+
+`cat -n {{file}}`

--- a/pages.it/common/cd.md
+++ b/pages.it/common/cd.md
@@ -1,0 +1,19 @@
+# cd
+
+> Cambia la directory corrente.
+
+- Vai alla directory specificata:
+
+`cd {{percorso/a/directory}}`
+
+- Vai alla directory home dell'utente corrente:
+
+`cd`
+
+- Vai alla directory madre della corrente:
+
+`cd ..`
+
+- Vai alla directory precedentemente scelta:
+
+`cd -`


### PR DESCRIPTION
Added Italian translation for 50+ pages of the `common` section:

    ansiweather apd apm apropos ar aria2c arp asar asciinema assimp astyle at atom atq atrm autoflake autojump autossh avrdude awk aws aws-s3 axel az b2sum babel badblocks banner base32 base64 basename bash bashmarks bat batch bc beanstalkd bedtools berks bg blender bmaptool boot borg bosh bower box browser-sync bundle bup bw c99 cabal calibre-server calibredb cargo case cat cd

---

Let me know if you want to keep all the commits or squash them somehow.