### PR TITLE
xfce4-screenshooter: add page.

### DIFF
--- a/pages/linux/xfce4-screenshooter.md
+++ b/pages/linux/xfce4-screenshooter.md
@@ -1,0 +1,31 @@
+# xfce4-screenshooter
+
+> The XFCE4 screenshot tool.
+
+- Launch the screenshooter GUI:
+
+`xfce4-screenshooter`
+
+- Take a screenshot of the entire screen and launch the GUI to ask how to proceed:
+
+`xfce4-screenshooter --fullscreen`
+
+- Take a screenshot of the entire screen and save it in the specified directory:
+
+`xfce4-screenshooter --fullscreen --save {{path/to/directory}}`
+
+- Wait some time before taking the screenshot:
+
+`xfce4-screenshooter --delay {{seconds}}`
+
+- Take a screenshot of a region of the screen (select using the mouse):
+
+`xfce4-screenshooter --region`
+
+- Take a screenshot of the active window, and copy it to the clipboard:
+
+`xfce4-screenshooter --window --clipboard`
+
+- Take a screenshot of the active window, and open it with a choosen program:
+
+`xfce4-screenshooter --window --open {{gimp}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

---

I decided to add 7 examples because I personally use each one of them regularly to take screenshots (mostly combined with `--delay`) and I feel like they are quite essential to know.

I use these commands as keyboard shortcuts, and I added the first one (option-less) just because it's the simplest, but I actually think it is very rarely used from command line. Would it be better to remove it?

Options not covered are:

- `--mouse`: to show the mouse pointer. You usually don't want your mouse in a screenshot.
- `--display`: to change display. You usually take a screenshot of the current display.
- `--upload`: to launch a GUI for uploading to ZimageZ (requires user/passw).
- `--imgur`: same for Imgur but no user/passw required.