### PR TITLE
chgrp: fix typo and clarify examples.

### DIFF
--- a/pages/common/chgrp.md
+++ b/pages/common/chgrp.md
@@ -2,18 +2,18 @@
 
 > Change group ownership of files and folders.
 
-- Change the owner of a file/folder:
+- Change the owner group of a file/folder:
 
 `chgrp {{group}} {{path/to/file}}`
 
-- Recursively change the owner of a folder and its contents:
+- Recursively change the owner group of a folder and its contents:
 
 `chgrp -R {{group}} {{path/to/folder}}`
 
-- Change the owner of a symbolic link:
+- Change the owner group of a symbolic link:
 
-`chgrp -h {{user}} {{path/to/symlink}}`
+`chgrp -h {{group}} {{path/to/symlink}}`
 
-- Change the owner of a file/folder to match a reference file:
+- Change the owner group of a file/folder to match a reference file:
 
 `chgrp --reference={{path/to/reference_file}} {{path/to/file}}`


### PR DESCRIPTION
Fixed a typo and also clarified examples' descriptions to specify that the owner _group_, rather than _user_, is affected by the command. More like it is specified in `chown`.