### PR TITLE
pathchk: add page

### DIFF
--- a/pages/linux/pathchk.md
+++ b/pages/linux/pathchk.md
@@ -1,0 +1,19 @@
+# pathchk
+
+> Check the validity and portability of one or more pathnames.
+
+- Check pathames for validity in the current system:
+
+`pathchk {{path1 path2 …}}`
+
+- Check pathnames for validity on a wider range of POSIX compliant systems:
+
+`pathchk -p {{path1 path2 …}}`
+
+- Check pathnames for validity on all POSIX compliant systems:
+
+`pathchk --portability {{path1 path2 …}}`
+
+- Only check for empty pathnames or leading dashes (-):
+
+`pathchk -P {{path1 path2 …}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

---

Part of #2213.

Short options `-p` and `-P` don't have a `--long` counterpart.

<sup>whoops, mixed some italian translations by mistake haha, fixed</sup>