### PR TITLE
sn: add page

### DIFF
--- a/pages/common/sn.md
+++ b/pages/common/sn.md
@@ -8,7 +8,7 @@
 
 - Re-sign an assembly with the specified private key:
 
-`sn -R {{path/to/assembly.dll}} {{path/to/keypair.exe}}`
+`sn -R {{path/to/assembly.dll}} {{path/to/keypair.snk}}`
 
 - Show the public key of the private key that was used to sign an assembly:
 

--- a/pages/common/sn.md
+++ b/pages/common/sn.md
@@ -1,0 +1,19 @@
+# sn
+
+> Mono StrongName utility for signing assemblies.
+
+- Generate a new StrongNaming key:
+
+`sn -k {{path/to/key.snk}}`
+
+- Re-sign an assembly with the specified private key:
+
+`sn -R {{path/to/assembly.dll}} {{path/to/keypair.exe}}`
+
+- Show the public key of the private key that was used to sign an assembly:
+
+`sn -T {{path/to/assembly.exe}}`
+
+- Extract the public key to a file:
+
+`sn -e {{path/to/assembly.dll}} {{path/to/output.pub}}`

--- a/pages/common/sn.md
+++ b/pages/common/sn.md
@@ -1,6 +1,6 @@
 # sn
 
-> Mono StrongName utility for signing assemblies.
+> Mono StrongName utility for signing and verifying IL assemblies.
 
 - Generate a new StrongNaming key:
 


### PR DESCRIPTION
Another mono-related page! This time, it's for `sn`, the Mono StrongNaming signing tool.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
