### PR TITLE
TravisCI: don't clean build dir needed for deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ after_failure:
 deploy:
   provider: script
   script: bash scripts/deploy.sh
+  skip_cleanup: true
   on:
+    repo: tldr-pages/tldr
     branch: master


### PR DESCRIPTION
The build dir is being silently cleaned, and the `index.json` script is not being built. This ends up silently not uploading `index.json` to the `tldr-pages/tlrd-pages.github.io` repo. See [here in this build log](https://travis-ci.org/tldr-pages/tldr/jobs/488514400#L546) for example.

Fixed by simply adding `skip_cleanup: true` in Travis' configuration. You can see [it works](https://travis-ci.org/mebeim/tldr/jobs/488522673#L528) and successfully generates the `index.json` on my fork.

I also added `on: repo: tldr-pages/tldr` to prevent unneeded deployment on forks if people want to enable TravisCI on their fork for testing purposes (like I just did on mine).