### PR TITLE
Deploy: run all commands separately to avoid unnoticed errors.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script is executed by Travis CI when a PR is merged (i.e. in the `deploy` step).
-set -ev
+set -ex
 
 function initialize {
   if [ -z "$TLDRHOME" ]; then
@@ -27,12 +27,14 @@ function initialize {
 
 function rebuild_index {
   npm run build-index
+  echo "Rebuilding index done."
 }
 
 function build_archive {
   rm -f $TLDR_ARCHIVE
   cd $TLDRHOME/
   zip -r $TLDR_ARCHIVE pages*/ LICENSE.md
+  echo "Pages archive created."
 }
 
 function upload_assets {
@@ -44,6 +46,8 @@ function upload_assets {
   git add -A
   git commit -m "[TravisCI] uploaded assets after commits ${TRAVIS_COMMIT_RANGE}"
   git push -q
+
+  echo "Assets (pages archive, index) deployed to static site."
 }
 
 ###################################
@@ -51,6 +55,6 @@ function upload_assets {
 ###################################
 
 initialize
-rebuild_index && echo "Rebuilding index done."
-build_archive && echo "Pages archive created."
-upload_assets && echo "Assets (pages archive, index) deployed to static site."
+rebuild_index
+build_archive
+upload_assets


### PR DESCRIPTION
As it can be seen in [this previous build](https://travis-ci.org/tldr-pages/tldr/jobs/488514400#L546): the [`deploy.sh`](https://github.com/tldr-pages/tldr/blob/master/scripts/deploy.sh) script was executing a command which failed, which was:

    rebuild_index && echo "Rebuilding index done."

However the build did not fail as it should have, hiding the error and pushing an invalid empty `index.json` file to the site repo. This is something more dangerous than a failing build because it can go unnoticed. Fortunately I was looking at the build log and noticed it so I wrote #2752 to quickly fix and push a correct `index.json` to the site.

I did not understand why the build didn't fail until now. So what happened in that build? The `deploy.sh` script does `set -ev` at the beginning so it should exit as soon as any subcommand in the script fails (non zero exit code). The command `rebuild_index` did indeed fail, however as it turns out since it is paired with an `echo` using the `&&` operator, **its failure is ignored by `set -e`**, as documented [in the Bash manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html):

> The shell does not exit if the command that fails is part of the command list immediately following a `while` or `until` keyword, part of the test in an `if` statement, part of any command executed in a `&&` or `||` list except the command following the final `&&` or `||`, any command in a pipeline but the last, or if the command’s return status is being inverted with `!`.

So today I learned that `set -e` ignores a bunch of stuff, like `false && false`. The more you know, right?

---

To fix this potentially dangerous bug, any command in `deploy.sh` should be executed alone, which is exactly what I did in this PR.

Secondly I also changed `set -ev` to `set -ex`, which logs every executed command to make it easier to trace errors (if they happen), and doesn't log unneeded stuff like function definitions, comments etc. An example output with this change applied can be seen [here](https://travis-ci.org/mebeim/tldr/builds/488748050#L481) (it obviously fails because I don't have SSH keys to deploy on my fork, but it's only a demo).

Hopefully this is the last change to the build process at least for now :sweat_smile:.