### PR TITLE
airpaste, dir: fix typo.

### DIFF
--- a/pages.pt-BR/common/airpaste.md
+++ b/pages.pt-BR/common/airpaste.md
@@ -1,6 +1,6 @@
 # airpaste
 
-> Compartilhar mensagens e arquivos na mesma rede:
+> Compartilhar mensagens e arquivos na mesma rede.
 
 - Esperar por mensagens e mostrá-las quando recebidas:
 

--- a/pages.pt-BR/windows/dir.md
+++ b/pages.pt-BR/windows/dir.md
@@ -6,7 +6,7 @@
 
 `dir`
 
--  Mostrar o conteúdo do diretório no caminho provido pelo usuário:
+- Mostrar o conteúdo do diretório no caminho provido pelo usuário:
 
 `dir {{caminho/para/diretório}}`
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

---

Fix two typos in `pt-BR` translations. Most probably caused by #2756.