### PR TITLE
rsync: add -r example with trailing backslash

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -19,6 +19,10 @@
 
 `rsync -r {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
 
+- Transfer directory contents (but not the directory itself) from a remote into local:
+
+`rsync -r {{remote_host_name}}:{{remote_folder_location}}/ {{local_folder_location}}`
+
 - Transfer only updated files from remote host:
 
 `rsync -ru {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -19,7 +19,7 @@
 
 `rsync -r {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
 
-- Transfer directory contents (but not the directory itself) from a remote into local:
+- Transfer directory contents (but not the directory itself) from a remote to local:
 
 `rsync -r {{remote_host_name}}:{{remote_folder_location}}/ {{local_folder_location}}`
 


### PR DESCRIPTION
rsync -r src/bar /dest
is different from 
rsync -r src/bar/ /dest
and it's hard to remember which is which.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform folder (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
