### PR TITLE
Refactor: fix incorrect and/or inconsistent usage of the word "folder" (pt. 2,3)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 <!-- You can remove the checklist items that don't apply to your PR. -->
 
 - [ ] The page (if new), does not already exist in the repo.
-- [ ] The page is in the correct platform folder (`common/`, `linux/`, etc.)
+- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
 - [ ] The page has 8 or fewer examples.
 - [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
 - [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -49,9 +49,9 @@ Keep the following guidelines in mind when choosing tokens:
 1. Use short but descriptive tokens,
    ex. `{{source_file}}` or `{{wallet.txt}}`.
 2. Use [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) for multi-word tokens.
-3. For any reference to paths to files or folders, use the format `{{path/to/<placeholder>}}`.
+3. For any reference to paths to files or directories, use the format `{{path/to/<placeholder>}}`.
    For example, `ln -s {{path/to/file}} {{path/to/symlink}}`.
-   In case of a possible reference both to a file or a folder, use `{{path/to/file_or_folder}}`
+   In case of a possible reference both to a file or a directory, use `{{path/to/file_or_directory}}`
 4. Follow the `{{path/to/<placeholder>}}` convention for all path-related commands, except when the
    file location is implicit.
 5. If a command expects the file to have a particular extension, use it.

--- a/pages.it/common/7z.md
+++ b/pages.it/common/7z.md
@@ -4,7 +4,7 @@
 
 - Archivia un file o una directory:
 
-`7z a {{archivio.7z}} {{percorso/al/file}}`
+`7z a {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
 - Cripta un archivio esistente (inclusi gli header):
 
@@ -20,7 +20,7 @@
 
 - Archivia utilizzando uno specifico tipo di archivio:
 
-`7z a -t {{zip|gzip|bzip2|tar}} {{archivio.7z}} {{percorso/al/file}}`
+`7z a -t {{zip|gzip|bzip2|tar}} {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
 - Elenca i tipi di archivio supportati:
 

--- a/pages.it/common/7za.md
+++ b/pages.it/common/7za.md
@@ -5,7 +5,7 @@
 
 - Archivia un file o una directory:
 
-`7za a {{archivio.7z}} {{percorso/al/file}}`
+`7za a {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
 - Estrai un archivio mantenendo la gerarchia delle cartelle:
 
@@ -13,7 +13,7 @@
 
 - Archivia utilizzando uno specifico tipo di archivio:
 
-`7za a -t {{zip|gzip|bzip2|tar}} {{archivio.7z}} {{percorso/al/file}}`
+`7za a -t {{zip|gzip|bzip2|tar}} {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
 - Elenca i tipi di archivio supportati:
 

--- a/pages.it/common/7zr.md
+++ b/pages.it/common/7zr.md
@@ -5,7 +5,7 @@
 
 - Archivia un file o una directory:
 
-`7zr a {{archivio.7z}} {{percorso/al/file}}`
+`7zr a {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
 - Estrai un archivio mantenendo la gerarchia delle cartelle:
 

--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -3,9 +3,9 @@
 > A file archiver with high compression ratio.
 > Homepage: <https://www.7-zip.org/>.
 
-- Archive a file or folder:
+- Archive a file or directory:
 
-`7z a {{archived.7z}} {{path/to/file}}`
+`7z a {{archived.7z}} {{path/to/file_or_directory}}`
 
 - Encrypt an existing archive (including headers):
 
@@ -21,7 +21,7 @@
 
 - Archive using a specific archive type:
 
-`7z a -t {{zip|gzip|bzip2|tar}} {{archived.7z}} {{path/to/file}}`
+`7z a -t {{zip|gzip|bzip2|tar}} {{archived.7z}} {{path/to/file_or_directory}}`
 
 - List available archive types:
 

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -4,9 +4,9 @@
 > A standalone version of `7z` with support for fewer archive types.
 > Homepage: <https://www.7-zip.org/>.
 
-- Archive a file or folder:
+- Archive a file or directory:
 
-`7za a {{archived.7z}} {{path/to/file}}`
+`7za a {{archived.7z}} {{path/to/file_or_directory}}`
 
 - Extract an existing 7z file with original directory structure:
 
@@ -14,7 +14,7 @@
 
 - Archive using a specific archive type:
 
-`7za a -t{{zip|gzip|bzip2|tar}} {{archived}} {{path/to/file}}`
+`7za a -t{{zip|gzip|bzip2|tar}} {{archived}} {{path/to/file_or_directory}}`
 
 - List available archive types:
 

--- a/pages/common/7zr.md
+++ b/pages/common/7zr.md
@@ -4,9 +4,9 @@
 > A standalone version of `7z` that only supports .7z files.
 > Homepage: <https://www.7-zip.org/>.
 
-- Archive a file or folder:
+- Archive a file or directory:
 
-`7zr a {{archived.7z}} {{path/to/file}}`
+`7zr a {{archived.7z}} {{path/to/file_or_directory}}`
 
 - Extract an existing 7z file with original directory structure:
 

--- a/pages/common/ag.md
+++ b/pages/common/ag.md
@@ -8,7 +8,7 @@
 
 - Find files containing "foo" in a specific directory:
 
-`ag {{foo}} {{path/to/folder}}`
+`ag {{foo}} {{path/to/directory}}`
 
 - Find files containing "foo", but only list the filenames:
 

--- a/pages/common/asar.md
+++ b/pages/common/asar.md
@@ -2,9 +2,9 @@
 
 > A file archiver for the Electron platform.
 
-- Archive a file or folder:
+- Archive a file or directory:
 
-`asar pack {{path/to/file}} {{archived.asar}}`
+`asar pack {{path/to/file_or_directory}} {{archived.asar}}`
 
 - Extract an archive:
 

--- a/pages/common/chgrp.md
+++ b/pages/common/chgrp.md
@@ -2,9 +2,9 @@
 
 > Change group ownership of files and folders.
 
-- Change the owner group of a file/folder:
+- Change the owner group of a file/directory:
 
-`chgrp {{group}} {{path/to/file}}`
+`chgrp {{group}} {{path/to/file_or_directory}}`
 
 - Recursively change the owner group of a folder and its contents:
 
@@ -14,6 +14,6 @@
 
 `chgrp -h {{group}} {{path/to/symlink}}`
 
-- Change the owner group of a file/folder to match a reference file:
+- Change the owner group of a file/directory to match a reference file:
 
-`chgrp --reference={{path/to/reference_file}} {{path/to/file}}`
+`chgrp --reference={{path/to/reference_file}} {{path/to/file_or_directory}}`

--- a/pages/common/chmod.md
+++ b/pages/common/chmod.md
@@ -8,7 +8,7 @@
 
 - Give the user rights to [r]ead and [w]rite to a file/directory:
 
-`chmod u+rw {{file}}`
+`chmod u+rw {{file_or_directory}}`
 
 - Remove executable rights from the [g]roup:
 

--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -2,13 +2,13 @@
 
 > Change user and group ownership of files and folders.
 
-- Change the owner user of a file/folder:
+- Change the owner user of a file/directory:
 
-`chown {{user}} {{path/to/file}}`
+`chown {{user}} {{path/to/file_or_directory}}`
 
-- Change the owner user and group of a file/folder:
+- Change the owner user and group of a file/directory:
 
-`chown {{user}}:{{group}} {{path/to/file}}`
+`chown {{user}}:{{group}} {{path/to/file_or_directory}}`
 
 - Recursively change the owner of a folder and its contents:
 
@@ -18,6 +18,6 @@
 
 `chown -h {{user}} {{path/to/symlink}}`
 
-- Change the owner of a file/folder to match a reference file:
+- Change the owner of a file/directory to match a reference file:
 
-`chown --reference={{path/to/reference_file}} {{path/to/file}}`
+`chown --reference={{path/to/reference_file}} {{path/to/file_or_directory}}`

--- a/pages/common/code.md
+++ b/pages/common/code.md
@@ -13,11 +13,11 @@
 
 - Open a file or directory in VS Code:
 
-`code {{path/to/file_or_folder}}`
+`code {{path/to/file_or_directory}}`
 
 - Open a file or directory in the currently open VS Code window:
 
-`code --reuse-window {{path/to/file_or_folder}}`
+`code --reuse-window {{path/to/file_or_directory}}`
 
 - Compare two files in VS Code:
 

--- a/pages/common/cpio.md
+++ b/pages/common/cpio.md
@@ -7,7 +7,7 @@
 
 `echo "{{file1}} {{file2}} {{file3}}" | cpio -o > {{archive.cpio}}`
 
-- Copy all files and folders in a directory and add them [o]nto an archive, in [v]erbose mode:
+- Copy all files and directories in a directory and add them [o]nto an archive, in [v]erbose mode:
 
 `find {{path/to/directory}} | cpio -ov > {{archive.cpio}}`
 

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -3,7 +3,7 @@
 > Creates incremental, compressed, encrypted and versioned backups.
 > Can also upload the backups to a variety of backend services.
 
-- Backup a folder via FTPS to a remote machine, encrypting it with a password:
+- Backup a directory via FTPS to a remote machine, encrypting it with a password:
 
 `FTP_PASSWORD={{ftp_login_password}} PASSPHRASE={{encryption_password}} duplicity {{path/to/source/directory}} {{ftps://user@hostname/target/directory/path/}}`
 
@@ -25,4 +25,4 @@
 
 - Restore a subdirectory from a GnuPG-encrypted local backup to a given location:
 
-`PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --file-to-restore {{relative/path/restorefolder}} file://{{absolute/path/to/backup/folder}} {{path/to/directory/to/restore/to}}`
+`PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --file-to-restore {{relative/path/restoredirectory}} file://{{absolute/path/to/backup/directory}} {{path/to/directory/to/restore/to}}`

--- a/pages/common/git-log.md
+++ b/pages/common/git-log.md
@@ -9,7 +9,7 @@
 
 - Show the history of a particular file or directory, including differences:
 
-`git log -p {{path}}`
+`git log -p {{path/to/file_or_directory}}`
 
 - Show only the first line of each commit message:
 

--- a/pages/common/hg-commit.md
+++ b/pages/common/hg-commit.md
@@ -8,7 +8,7 @@
 
 - Commit a specific file or directory:
 
-`hg commit {{path/to/file}}`
+`hg commit {{path/to/file_or_directory}}`
 
 - Commit with a specific message:
 

--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -2,9 +2,9 @@
 
 > Creates links to files and folders.
 
-- Create a symbolic link to a file (or folder):
+- Create a symbolic link to a file or directory:
 
-`ln -s {{path/to/file}} {{path/to/symlink}}`
+`ln -s {{path/to/file_or_directory}} {{path/to/symlink}}`
 
 - Overwrite an existing symbolic to point to a different file:
 

--- a/pages/common/pdfunite.md
+++ b/pages/common/pdfunite.md
@@ -6,6 +6,6 @@
 
 `pdfunite {{path/to/fileA.pdf}} {{path/to/fileB.pdf}} {{path/to/merged_output.pdf}}`
 
-- Merge a folder of PDFs into a single PDF:
+- Merge a directory of PDFs into a single PDF:
 
 `pdfunite {{path/to/directory/*.pdf}} {{path/to/merged_output.pdf}}`

--- a/pages/common/rm.md
+++ b/pages/common/rm.md
@@ -8,11 +8,11 @@
 
 - Recursively remove a directory and all its subdirectories:
 
-`rm -r {{path/to/folder}}`
+`rm -r {{path/to/directory}}`
 
 - Forcibly remove a directory, without prompting for confirmation or showing error messages:
 
-`rm -rf {{path/to/folder}}`
+`rm -rf {{path/to/directory}}`
 
 - Interactively remove multiple files, with a prompt before every removal:
 
@@ -20,4 +20,4 @@
 
 - Remove files in verbose mode, printing a message for each removed file:
 
-`rm -v {{path/to/folder/*}}`
+`rm -v {{path/to/directory/*}}`

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -17,11 +17,11 @@
 
 - Transfer a directory and all its children from a remote to local:
 
-`rsync -r {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
+`rsync -r {{remote_host_name}}:{{remote_directory_location}} {{local_directory_location}}`
 
 - Transfer only updated files from remote host:
 
-`rsync -ru {{remote_host_name}}:{{remote_folder_location}} {{local_folder_location}}`
+`rsync -ru {{remote_host_name}}:{{remote_directory_location}} {{local_directory_location}}`
 
 - Transfer file over SSH and delete local files that do not exist on remote host:
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -13,7 +13,7 @@
 
 - Recursively copy the contents of a directory from a remote host to a local directory:
 
-`scp -r {{remote_host}}:{{path/to/remote_dir}} {{path/to/local_dir}}`
+`scp -r {{remote_host}}:{{path/to/remote_directory}} {{path/to/local_directory}}`
 
 - Copy a file between two remote hosts transferring through the local host:
 

--- a/pages/common/srm.md
+++ b/pages/common/srm.md
@@ -13,7 +13,7 @@
 
 - Recursively remove a directory and its contents overwriting each file with a single-pass of random data:
 
-`srm -r -s {{/path/to/folder}}`
+`srm -r -s {{/path/to/directory}}`
 
 - Prompt before every removal:
 

--- a/pages/common/subl.md
+++ b/pages/common/subl.md
@@ -8,7 +8,7 @@
 
 - Open a file or directory in Sublime Text:
 
-`subl {{path/to/file_or_folder}}`
+`subl {{path/to/file_or_directory}}`
 
 - Open a file and jump to a specific line number:
 

--- a/pages/linux/chattr.md
+++ b/pages/linux/chattr.md
@@ -2,13 +2,13 @@
 
 > Change attributes of files or folders.
 
-- Make a file or folder immutable to changes and deletion, even by superuser:
+- Make a file or directory immutable to changes and deletion, even by superuser:
 
-`chattr +i {{path}}`
+`chattr +i {{path/to/file_or_directory}}`
 
-- Make a file or folder mutable:
+- Make a file or directory mutable:
 
-`chattr -i {{path}}`
+`chattr -i {{path/to/file_or_directory}}`
 
 - Recursively make an entire folder and contents immutable:
 


### PR DESCRIPTION
This PR partially fixes the issues described in #2751; in particular, points 2 and 3 of the numbered list.

- Commit [`1b35d43`](https://github.com/mebeim/tldr/commit/1b35d4313c52d9dc67e662e78e90f61abba2b76b) addresses point 2:

    > "directory" used in the example description, but "folder" used in the example code, or vice versa.

- Commit [`aa32f71`](https://github.com/mebeim/tldr/commit/aa32f718e524829fd72f6d9fb5c3659144815c22) addresses point 3: 

    > descriptions saying "in a file or folder" and example code showing `path/to/file` instead of `path/to/file_or_folder`, as recommended by the [style guide](https://github.com/tldr-pages/tldr/blob/master/contributing-guides/style-guide.md).

In addition to the above, "folder" becomes "directory" in both the [style guide](https://github.com/tldr-pages/tldr/blob/master/contributing-guides/style-guide.md) and the [pull request template](https://github.com/tldr-pages/tldr/blob/master/.github/PULL_REQUEST_TEMPLATE.md).