### PR TITLE
Refactor: fix incorrect and/or inconsistent usage of the word "folder" (pt. 1)

### DIFF
--- a/pages.it/common/7z.md
+++ b/pages.it/common/7z.md
@@ -10,7 +10,7 @@
 
 `7z a {{archivio_criptato.7z}} -p {{password}} -mhe {{archivio.7z}}`
 
-- Estrai un archivio mantenendo la gerarchia delle cartelle:
+- Estrai un archivio mantenendo la gerarchia delle directory:
 
 `7z x {{archivio.7z}}`
 

--- a/pages.it/common/7zr.md
+++ b/pages.it/common/7zr.md
@@ -7,7 +7,7 @@
 
 `7zr a {{archivio.7z}} {{percorso/a/file_o_directory}}`
 
-- Estrai un archivio mantenendo la gerarchia delle cartelle:
+- Estrai un archivio mantenendo la gerarchia delle directory:
 
 `7zr x {{archivio.7z}}`
 

--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -18,13 +18,13 @@
 
 `adb install -r {{path/to/file.apk}}`
 
-- Copy a file/folder from the target device:
+- Copy a file/directory from the target device:
 
-`adb pull {{path/to/device_file_or_folder}} {{path/to/local_destination_folder}}`
+`adb pull {{path/to/device_file_or_directory}} {{path/to/local_destination_directory}}`
 
-- Copy a file/folder to the target device:
+- Copy a file/directory to the target device:
 
-`adb push {{path/to/local_file_or_folder}} {{path/to/device_destination_folder}}`
+`adb push {{path/to/local_file_or_directory}} {{path/to/device_destination_directory}}`
 
 - Get a list of connected devices:
 

--- a/pages/common/atom.md
+++ b/pages/common/atom.md
@@ -3,17 +3,17 @@
 > A cross-platform pluggable text editor.
 > Plugins are managed by `apm`.
 
-- Open a file or folder:
+- Open a file or directory:
 
-`atom {{path/to/file_or_folder}}`
+`atom {{path/to/file_or_directory}}`
 
-- Open a file or folder in a new window:
+- Open a file or directory in a new window:
 
-`atom -n {{path/to/file_or_folder}}`
+`atom -n {{path/to/file_or_directory}}`
 
-- Open a file or folder in an existing window:
+- Open a file or directory in an existing window:
 
-`atom --add {{path/to/file_or_folder}}`
+`atom --add {{path/to/file_or_directory}}`
 
 - Open atom in safe mode (does not load any additional packages):
 

--- a/pages/common/aws-s3.md
+++ b/pages/common/aws-s3.md
@@ -6,17 +6,17 @@
 
 `aws s3 ls {{bucket_name}}`
 
-- Sync files and folders from local to bucket:
+- Sync files and directories from local to bucket:
 
 `aws s3 sync {{path/to/files}} s3://{{bucket_name}}`
 
-- Sync files and folders from bucket to local:
+- Sync files and directories from bucket to local:
 
 `aws s3 sync s3://{{bucket_name}} {{path/to/target}}`
 
-- Sync files and folders with exclusions:
+- Sync files and directories with exclusions:
 
-`aws s3 sync {{path/to/files}} s3://{{bucket_name}} --exclude {{path/to/file}} --exclude {{path/to/folder}}/*`
+`aws s3 sync {{path/to/files}} s3://{{bucket_name}} --exclude {{path/to/file}} --exclude {{path/to/directory}}/*`
 
 - Remove file from bucket:
 

--- a/pages/common/bashmarks.md
+++ b/pages/common/bashmarks.md
@@ -6,15 +6,15 @@
 
 `l`
 
-- Save the current folder as "bookmark_name":
+- Save the current directory as "bookmark_name":
 
 `s {{bookmark_name}}`
 
-- Go to a bookmarked folder:
+- Go to a bookmarked directory:
 
 `g {{bookmark_name}}`
 
-- Print a bookmarked folder's contents:
+- Print a bookmarked directory's contents:
 
 `p {{bookmark_name}}`
 

--- a/pages/common/blender.md
+++ b/pages/common/blender.md
@@ -11,13 +11,13 @@
 
 `blender -b {{filename}}.blend -o //{{render/frame_###.png}} -a`
 
-- Render the 10th frame of an animation as a single image, saved to an existing folder (absolute path):
+- Render the 10th frame of an animation as a single image, saved to an existing directory (absolute path):
 
-`blender -b {{filename}}.blend -o {{/path/to/output_folder}} -f {{10}}`
+`blender -b {{filename}}.blend -o {{/path/to/output_directory}} -f {{10}}`
 
-- Render the second last frame in an animation as a JPEG image, saved to an existing folder (relative path):
+- Render the second last frame in an animation as a JPEG image, saved to an existing directory (relative path):
 
-`blender -b {{filename}}.blend -o //{{output_folder}} -F {{JPEG}} -f {{-2}}`
+`blender -b {{filename}}.blend -o //{{output_directory}} -F {{JPEG}} -f {{-2}}`
 
 - Render the animation of a specific scene, starting at frame 10 and ending at frame 500:
 

--- a/pages/common/borg.md
+++ b/pages/common/borg.md
@@ -5,27 +5,27 @@
 
 - Initialise a (local) repository:
 
-`borg init {{/path/to/repo_folder}}`
+`borg init {{/path/to/repo_directory}}`
 
-- Backup a folder into the repository, creating an archive called "Monday":
+- Backup a directory into the repository, creating an archive called "Monday":
 
-`borg create --progress {{/path/to/repo_folder}}::{{Monday}} {{/path/to/source_folder}}`
+`borg create --progress {{/path/to/repo_directory}}::{{Monday}} {{/path/to/source_directory}}`
 
 - List all archives in a repository:
 
-`borg list {{/path/to/repo_folder}}`
+`borg list {{/path/to/repo_directory}}`
 
-- Extract a specific folder from the "Monday" archive in a remote repository, excluding all *.ext files:
+- Extract a specific directory from the "Monday" archive in a remote repository, excluding all *.ext files:
 
-`borg extract {{user}}@{{host}}:{{/path/to/repo_folder}}::{{Monday}} {{path/to/target_folder}} --exclude '{{*.ext}}'`
+`borg extract {{user}}@{{host}}:{{/path/to/repo_directory}}::{{Monday}} {{path/to/target_directory}} --exclude '{{*.ext}}'`
 
 - Prune a repository by deleting all archives older than 7 days, listing changes:
 
-`borg prune --keep-within {{7d}} --list {{/path/to/repo_folder}}`
+`borg prune --keep-within {{7d}} --list {{/path/to/repo_directory}}`
 
 - Mount a repository as a FUSE filesystem:
 
-`borg mount {{/path/to/repo_folder}}::{{Monday}} {{/path/to/mountpoint}}`
+`borg mount {{/path/to/repo_directory}}::{{Monday}} {{/path/to/mountpoint}}`
 
 - Display help on creating archives:
 

--- a/pages/common/bup.md
+++ b/pages/common/bup.md
@@ -6,13 +6,13 @@
 
 `bup -d {{path/to/repository}} init`
 
-- Prepare a given folder before taking a backup:
+- Prepare a given directory before taking a backup:
 
-`bup -d {{path/to/repository}} index {{path/to/folder}}`
+`bup -d {{path/to/repository}} index {{path/to/directory}}`
 
-- Backup a folder to the repository:
+- Backup a directory to the repository:
 
-`bup -d {{path/to/repository}} save -n {{backup_name}} {{path/to/folder}}`
+`bup -d {{path/to/repository}} save -n {{backup_name}} {{path/to/directory}}`
 
 - Show the backup snapshots currently stored in the repository:
 

--- a/pages/common/chgrp.md
+++ b/pages/common/chgrp.md
@@ -1,14 +1,14 @@
 # chgrp
 
-> Change group ownership of files and folders.
+> Change group ownership of files and directories.
 
 - Change the owner group of a file/directory:
 
 `chgrp {{group}} {{path/to/file_or_directory}}`
 
-- Recursively change the owner group of a folder and its contents:
+- Recursively change the owner group of a directory and its contents:
 
-`chgrp -R {{group}} {{path/to/folder}}`
+`chgrp -R {{group}} {{path/to/directory}}`
 
 - Change the owner group of a symbolic link:
 

--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -1,6 +1,6 @@
 # chown
 
-> Change user and group ownership of files and folders.
+> Change user and group ownership of files and directories.
 
 - Change the owner user of a file/directory:
 
@@ -10,9 +10,9 @@
 
 `chown {{user}}:{{group}} {{path/to/file_or_directory}}`
 
-- Recursively change the owner of a folder and its contents:
+- Recursively change the owner of a directory and its contents:
 
-`chown -R {{user}} {{path/to/folder}}`
+`chown -R {{user}} {{path/to/directory}}`
 
 - Change the owner of a symbolic link:
 

--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -3,11 +3,11 @@
 > Cross-platform build system generator.
 > It generates Makefiles, Visual Studio projects or others, depending on the target system.
 
-- Generate a Makefile and use it to compile a project in the same folder as the source:
+- Generate a Makefile and use it to compile a project in the same directory as the source:
 
 `cmake && make`
 
-- Generate a Makefile and use it to compile a project in a separate "build" folder (out-of-source build):
+- Generate a Makefile and use it to compile a project in a separate "build" directory (out-of-source build):
 
 `cmake -H. -B{{build}} && make -C {{build}}`
 

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -1,27 +1,27 @@
 # cp
 
-> Copy files and folders.
+> Copy files and directories.
 
 - Copy a file to another location:
 
 `cp {{path/to/file.ext}} {{path/to/copy.ext}}`
 
-- Copy a file into another folder, keeping the filename:
+- Copy a file into another directory, keeping the filename:
 
-`cp {{path/to/file.ext}} {{path/to/target_parent_folder}}`
+`cp {{path/to/file.ext}} {{path/to/target_parent_directory}}`
 
-- Copy a folder recursively to another location:
+- Copy a directory recursively to another location:
 
-`cp -r {{path/to/folder}} {{path/to/copy}}`
+`cp -r {{path/to/directory}} {{path/to/copy}}`
 
-- Copy a folder recursively, in verbose mode (shows files as they are copied):
+- Copy a directory recursively, in verbose mode (shows files as they are copied):
 
-`cp -vr {{path/to/folder}} {{path/to/copy}}`
+`cp -vr {{path/to/directory}} {{path/to/copy}}`
 
-- Copy the contents of a folder into another folder:
+- Copy the contents of a directory into another directory:
 
-`cp -r {{path/to/source_folder/*}} {{path/to/target_folder}}`
+`cp -r {{path/to/source_directory/*}} {{path/to/target_directory}}`
 
 - Copy text files to another location, in interactive mode (prompts user before overwriting):
 
-`cp -i {{*.txt}} {{path/to/target_folder}}`
+`cp -i {{*.txt}} {{path/to/target_directory}}`

--- a/pages/common/cppcheck.md
+++ b/pages/common/cppcheck.md
@@ -3,13 +3,13 @@
 > A static analysis tool for C/C++ code.
 > Instead of syntax errors, it focuses on the types of bugs that compilers normally do not detect.
 
-- Recursively check the current folder, showing progress on the screen and logging error messages to a file:
+- Recursively check the current directory, showing progress on the screen and logging error messages to a file:
 
 `cppcheck . 2> cppcheck.log`
 
-- Recursively check a given folder, and don't print progress messages:
+- Recursively check a given directory, and don't print progress messages:
 
-`cppcheck --quiet {{path/to/folder}}`
+`cppcheck --quiet {{path/to/directory}}`
 
 - Check a given file, specifying which tests to perform (by default only errors are shown):
 
@@ -23,9 +23,9 @@
 
 `cppcheck --suppress={{test_id1}} --suppress={{test_id2}} {{path/to/file.cpp}}`
 
-- Check the current folder, providing paths for include files located outside it (e.g. external libraries):
+- Check the current directory, providing paths for include files located outside it (e.g. external libraries):
 
-`cppcheck -I {{include/folder_1}} -I {{include/folder_2}} .`
+`cppcheck -I {{include/directory_1}} -I {{include/directory_2}} .`
 
 - Check a Microsoft Visual Studio project (`*.vcxproj`) or solution (`*.sln`):
 

--- a/pages/common/cppclean.md
+++ b/pages/common/cppclean.md
@@ -2,11 +2,11 @@
 
 > Find unused code in C++ projects.
 
-- Run in a project's folder:
+- Run in a project's directory:
 
 `cppclean {{path/to/project}}`
 
-- Run on a project where the headers are in the "inc1/" and "inc2/" folders:
+- Run on a project where the headers are in the "inc1/" and "inc2/" directories:
 
 `cppclean {{path/to/project}} --include-path={{inc1}} --include-path={{inc2}}`
 

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -10,6 +10,6 @@
 
 `df -h`
 
-- Display the file system and its disk usage containing the given file or folder:
+- Display the file system and its disk usage containing the given file or directory:
 
-`df {{path/to/file_or_folder}}`
+`df {{path/to/file_or_directory}}`

--- a/pages/common/du.md
+++ b/pages/common/du.md
@@ -1,27 +1,27 @@
 # du
 
-> Disk usage: estimate and summarize file and folder space usage.
+> Disk usage: estimate and summarize file and directory space usage.
 
-- List the sizes of a folder and any subfolders, in the given unit (B/KB/MB):
+- List the sizes of a directory and any subdirectories, in the given unit (B/KB/MB):
 
-`du -{{b|k|m}} {{path/to/folder}}`
+`du -{{b|k|m}} {{path/to/directory}}`
 
-- List the sizes of a folder and any subfolders, in human-readable form (i.e. auto-selecting the appropriate unit for each size):
+- List the sizes of a directory and any subdirectories, in human-readable form (i.e. auto-selecting the appropriate unit for each size):
 
-`du -h {{path/to/folder}}`
+`du -h {{path/to/directory}}`
 
-- Show the size of a single folder, in human readable units:
+- Show the size of a single directory, in human readable units:
 
-`du -sh {{path/to/folder}}`
+`du -sh {{path/to/directory}}`
 
-- List the human-readable sizes of a folder and of all the files and folders within it:
+- List the human-readable sizes of a directory and of all the files and directories within it:
 
-`du -ah {{path/to/folder}}`
+`du -ah {{path/to/directory}}`
 
-- List the human-readable sizes of a folder and any subfolders, up to N levels deep:
+- List the human-readable sizes of a directory and any subdirectories, up to N levels deep:
 
-`du -h --max-depth=N {{path/to/folder}}`
+`du -h --max-depth=N {{path/to/directory}}`
 
-- List the human-readable size of all .jpg files in subfolders of the current folder, and show a cumulative total at the end:
+- List the human-readable size of all .jpg files in subdirectories of the current directory, and show a cumulative total at the end:
 
 `du -ch */*.jpg`

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -7,7 +7,7 @@
 
 `FTP_PASSWORD={{ftp_login_password}} PASSPHRASE={{encryption_password}} duplicity {{path/to/source/directory}} {{ftps://user@hostname/target/directory/path/}}`
 
-- Backup a folder to Amazon S3, doing a full backup every month:
+- Backup a directory to Amazon S3, doing a full backup every month:
 
 `duplicity --full-if-older-than {{1M}} --use-new-style s3://{{bucket_name[/prefix]}}`
 
@@ -17,7 +17,7 @@
 
 - List the available backups:
 
-`duplicity collection-status "file://{{absolute/path/to/backup/folder}}"`
+`duplicity collection-status "file://{{absolute/path/to/backup/directory}}"`
 
 - List the files in a backup stored on a remote machine, via ssh:
 

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -19,7 +19,7 @@
 
 `git checkout --track {{remote_name}}/{{branch_name}}`
 
-- Discard all unstaged changes in the current folder (see `git reset` for more undo-like commands):
+- Discard all unstaged changes in the current directory (see `git reset` for more undo-like commands):
 
 `git checkout .`
 
@@ -27,6 +27,6 @@
 
 `git checkout {{file_name}}`
 
-- Replace a file in the current folder with the version of it committed in a given branch:
+- Replace a file in the current directory with the version of it committed in a given branch:
 
 `git checkout {{branch_name}} -- {{file_name}}`

--- a/pages/common/git-worktree.md
+++ b/pages/common/git-worktree.md
@@ -3,18 +3,18 @@
 > Manage multiple working trees attached to the same repository.
 > Homepage: <https://git-scm.com/docs/git-worktree>.
 
-- Create a new folder with the specified branch checked out into it:
+- Create a new directory with the specified branch checked out into it:
 
-`git worktree add {{path/to/folder}} {{branch}}`
+`git worktree add {{path/to/directory}} {{branch}}`
 
-- Create a new folder with a new branch checked out into it:
+- Create a new directory with a new branch checked out into it:
 
-`git worktree add {{path/to/folder}} -b {{new_branch}}`
+`git worktree add {{path/to/directory}} -b {{new_branch}}`
 
 - List all the working directories attached to this repository:
 
 `git worktree list`
 
-- Remove a worktree (after deleting worktree folder):
+- Remove a worktree (after deleting worktree directory):
 
 `git worktree prune`

--- a/pages/common/gitk.md
+++ b/pages/common/gitk.md
@@ -7,9 +7,9 @@
 
 `gitk`
 
-- Show repository browser for a specific file or folder:
+- Show repository browser for a specific file or directory:
 
-`gitk {{path/to/file_or_folder}}`
+`gitk {{path/to/file_or_directory}}`
 
 - Show commits made since 1 week ago:
 

--- a/pages/common/gource.md
+++ b/pages/common/gource.md
@@ -1,7 +1,7 @@
 # gource
 
 > Renders an animated tree diagram of Git, SVN, Mercurial and Bazaar repositories.
-> It shows files and folders being created, modified or removed over time.
+> It shows files and directories being created, modified or removed over time.
 
 - Run gource in a directory (if it isn't the repository's root directory, the root is seeked up from there):
 

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -14,7 +14,7 @@
 
 `gradle build --offline`
 
-- Clear the build folder:
+- Clear the build directory:
 
 `gradle clean`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -7,9 +7,9 @@
 
 `ipfs add {{filename}}`
 
-- Add a folder and its files recursively from local to the file system and print the relative hash:
+- Add a directory and its files recursively from local to the file system and print the relative hash:
 
-`ipfs add -r {{folder}}`
+`ipfs add -r {{directory}}`
 
 - Save a remote file and give it a name but not pin it:
 

--- a/pages/common/jekyll.md
+++ b/pages/common/jekyll.md
@@ -10,6 +10,6 @@
 
 `jekyll serve --incremental`
 
-- Generate the current folder into "./_site":
+- Generate the current directory into "./_site":
 
 `jekyll build`

--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -1,6 +1,6 @@
 # ln
 
-> Creates links to files and folders.
+> Creates links to files and directories.
 
 - Create a symbolic link to a file or directory:
 

--- a/pages/common/mc.md
+++ b/pages/common/mc.md
@@ -1,7 +1,7 @@
 # mc
 
 > Midnight Commander, a terminal based file manager.
-> Navigate the folder structure using the arrow keys, the mouse or by typing the commands into the terminal.
+> Navigate the directory structure using the arrow keys, the mouse or by typing the commands into the terminal.
 
 - Start mc:
 

--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -2,7 +2,7 @@
 
 > Creates a directory.
 
-- Create a directory in current folder or given path:
+- Create a directory in current directory or given path:
 
 `mkdir {{directory}}`
 

--- a/pages/common/mocha.md
+++ b/pages/common/mocha.md
@@ -8,7 +8,7 @@
 
 - Run tests contained at a specific location:
 
-`mocha {{folder/with/tests}}`
+`mocha {{directory/with/tests}}`
 
 - Run tests that match a specific grep pattern:
 

--- a/pages/common/mogrify.md
+++ b/pages/common/mogrify.md
@@ -3,7 +3,7 @@
 > Perform operations on multiple images, such as resizing, cropping, flipping, and adding effects.
 > Changes are applied directly to the original file.
 
-- Resize all JPEG images in the folder to 50% of their initial size:
+- Resize all JPEG images in the directory to 50% of their initial size:
 
 `mogrify -resize {{50%}} {{*.jpg}}`
 
@@ -11,7 +11,7 @@
 
 `mogrify -resize {{800x600}} {{DSC*}}`
 
-- Convert all PNG images in the folder to JPEG:
+- Convert all PNG images in the directory to JPEG:
 
 `mogrify -format {{jpg}} {{*.png}}`
 

--- a/pages/common/mongodump.md
+++ b/pages/common/mongodump.md
@@ -2,13 +2,13 @@
 
 > Utility to export the contents of a MongoDB instance.
 
-- Create a dump of all databases (this will place the files inside a folder called "dump"):
+- Create a dump of all databases (this will place the files inside a directory called "dump"):
 
 `mongodump`
 
 - Specify an output location for the dump:
 
-`mongodump --out {{path/to/folder}}`
+`mongodump --out {{path/to/directory}}`
 
 - Create a dump of a given database:
 

--- a/pages/common/mongorestore.md
+++ b/pages/common/mongorestore.md
@@ -2,13 +2,13 @@
 
 > Utility to import a collection or database from a binary dump into a MongoDB instance.
 
-- Import a bson data dump from a folder to a MongoDB database:
+- Import a bson data dump from a directory to a MongoDB database:
 
-`mongorestore --db {{database_name}} {{path/to/folder}}`
+`mongorestore --db {{database_name}} {{path/to/directory}}`
 
-- Import a bson data dump from a folder to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
+- Import a bson data dump from a directory to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
 
-`mongorestore --host {{database_host:port}} --db {{database_name}} --username {{username}} {{path/to/folder}} --password`
+`mongorestore --host {{database_host:port}} --db {{database_name}} --username {{username}} {{path/to/directory}} --password`
 
 - Import a collection from a bson file to a MongoDB database:
 

--- a/pages/common/mvn.md
+++ b/pages/common/mvn.md
@@ -19,7 +19,7 @@
 
 `mvn install`
 
-- Delete build artifacts from the target folder:
+- Delete build artifacts from the target directory:
 
 `mvn clean`
 

--- a/pages/common/ng.md
+++ b/pages/common/ng.md
@@ -2,7 +2,7 @@
 
 > Command Line Interface (CLI) for creating and managing Angular applications.
 
-- Create a new Angular application inside a folder:
+- Create a new Angular application inside a directory:
 
 `ng new {{project_name}}`
 

--- a/pages/common/pt.md
+++ b/pages/common/pt.md
@@ -19,6 +19,6 @@
 
 `pt -G='{{\.bar$}}' {{foo}}`
 
-- Find files whose contents match the regular expression, up to 2 folders deep:
+- Find files whose contents match the regular expression, up to 2 directories deep:
 
 `pt --depth={{2}} -e '{{^ba[rz]*$}}'`

--- a/pages/common/rbenv.md
+++ b/pages/common/rbenv.md
@@ -14,7 +14,7 @@
 
 `rbenv global {{version}}`
 
-- Use a specific version of Ruby for an application/project folder:
+- Use a specific version of Ruby for an application/project directory:
 
 `rbenv local {{version}}`
 

--- a/pages/common/rclone.md
+++ b/pages/common/rclone.md
@@ -2,33 +2,33 @@
 
 > CLI program to copy/sync/move files and directories to and from many cloud services.
 
-- List contents of a folder on an rclone remote:
+- List contents of a directory on an rclone remote:
 
-`rclone lsf {{remote_name}}:{{path/to/folder}}`
+`rclone lsf {{remote_name}}:{{path/to/directory}}`
 
-- Copy file or folder from local source to remote destination:
+- Copy file or directory from local source to remote destination:
 
-`rclone copy {{path/to/source_file_or_folder}} {{remote_name}}:{{path/to/destination_folder}}`
+`rclone copy {{path/to/source_file_or_directory}} {{remote_name}}:{{path/to/destination_directory}}`
 
-- Copy file or folder from remote source to local destination:
+- Copy file or directory from remote source to local destination:
 
-`rclone copy {{remote_name}}:{{path/to/source_file_or_folder}} {{path/to/destination_folder}}`
+`rclone copy {{remote_name}}:{{path/to/source_file_or_directory}} {{path/to/destination_directory}}`
 
 - Sync local source to remote destination, changing the destination only:
 
-`rclone sync {{path/to/file_or_folder}} {{remote_name}}:{{path/to/folder}}`
+`rclone sync {{path/to/file_or_directory}} {{remote_name}}:{{path/to/directory}}`
 
-- Move file or folder from local source to remote destination:
+- Move file or directory from local source to remote destination:
 
-`rclone move {{path/to/file_or_folder}} {{remote_name}}:{{path/to/folder}}`
+`rclone move {{path/to/file_or_directory}} {{remote_name}}:{{path/to/directory}}`
 
-- Delete remote file or folder (use `--dry-run` to test, remove it to actually delete):
+- Delete remote file or directory (use `--dry-run` to test, remove it to actually delete):
 
-`rclone --dry-run delete {{remote_name}}:{{path/to/file_or_folder}}`
+`rclone --dry-run delete {{remote_name}}:{{path/to/file_or_directory}}`
 
 - Mount rclone remote (experimental):
 
-`rclone mount {{remote_name}}:{{path/to/folder}} {{path/to/mount_point}}`
+`rclone mount {{remote_name}}:{{path/to/directory}} {{path/to/mount_point}}`
 
 - Unmount rclone remote if CTRL-C fails (experimental):
 

--- a/pages/common/repren.md
+++ b/pages/common/repren.md
@@ -3,15 +3,15 @@
 > Multi-pattern string replacement and file renaming tool.
 > Homepage: <https://github.com/jlevy/repren>.
 
-- Do a dry-run renaming a folder of pngs with a literal string replacement:
+- Do a dry-run renaming a directory of pngs with a literal string replacement:
 
 `repren --dry-run --rename --literal --from '{{find_string}}' --to '{{replacement_string}}' {{*.png}}`
 
-- Do a dry-run renaming a folder of jpegs with a regular expression:
+- Do a dry-run renaming a directory of jpegs with a regular expression:
 
 `repren --rename --dry-run --from '{{regular_expression}}' --to '{{replacement_string}}' {{*.jpg}} {{*.jpeg}}`
 
-- Do a find-and-replace on the contents of a folder of csv files:
+- Do a find-and-replace on the contents of a directory of csv files:
 
 `repren --from '{{([0-9]+) example_string}}' --to '{{replacement_string \1}}' {{*.csv}}`
 

--- a/pages/common/restic.md
+++ b/pages/common/restic.md
@@ -6,9 +6,9 @@
 
 `restic init -r {{path/to/repository}}`
 
-- Backup folder "my_folder" to the repository:
+- Backup a directory to the repository:
 
-`restic -r {{path/to/repository}} backup {{path/to/my_folder}}`
+`restic -r {{path/to/repository}} backup {{path/to/directory}}`
 
 - Show backup snapshots currently stored in the repository:
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -7,9 +7,9 @@
 
 `scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}}`
 
-- Copy a file from a remote host to a local folder:
+- Copy a file from a remote host to a local directory:
 
-`scp {{remote_host}}:{{path/to/remote_file}} {{path/to/local_dir}}`
+`scp {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
 
 - Recursively copy the contents of a directory from a remote host to a local directory:
 
@@ -17,11 +17,11 @@
 
 - Copy a file between two remote hosts transferring through the local host:
 
-`scp -3 {{host1}}:{{path/to/remote_file}} {{host2}}:{{path/to/remote_dir}}`
+`scp -3 {{host1}}:{{path/to/remote_file}} {{host2}}:{{path/to/remote_directory}}`
 
 - Use a specific username when connecting to the remote host:
 
-`scp {{path/to/local_file}} {{remote_username}}@{{remote_host}}:{{path/to/remote_dir}}`
+`scp {{path/to/local_file}} {{remote_username}}@{{remote_host}}:{{path/to/remote_directory}}`
 
 - Use a specific ssh private key for authentication with the remote host:
 

--- a/pages/common/sendmail.md
+++ b/pages/common/sendmail.md
@@ -2,7 +2,7 @@
 
 > Send email from the command line.
 
-- Send a message with the content of message.txt to the mail folder of local user `user_name`:
+- Send a message with the content of message.txt to the mail directory of local user `user_name`:
 
 `sendmail {{user_name}} < {{message.txt}}`
 

--- a/pages/common/sftp.md
+++ b/pages/common/sftp.md
@@ -20,9 +20,9 @@
 
 `put {{/path/local_file}}`
 
-- Transfer remote folder to the local system recursively (works with `put` too):
+- Transfer remote directory to the local system recursively (works with `put` too):
 
-`get -R {{/path/remote_folder}}`
+`get -R {{/path/remote_directory}}`
 
 - Get list of files on local machine:
 

--- a/pages/common/shards.md
+++ b/pages/common/shards.md
@@ -20,4 +20,4 @@
 
 - List version of dependency:
 
-`shards version {{path/to/dependency_folder}}`
+`shards version {{path/to/dependency_directory}}`

--- a/pages/common/spike.md
+++ b/pages/common/spike.md
@@ -10,7 +10,7 @@
 
 `spike watch`
 
-- Compile your project once to the "public" folder:
+- Compile your project once to the "public" directory:
 
 `spike compile`
 

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -5,20 +5,20 @@
 
 - Symlink all files recursively to a given directory:
 
-`stow --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
+`stow --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
 
 - Delete symlinks recursively from a given directory:
 
-`stow --delete --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
+`stow --delete --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
 
 - Simulate to see what the result would be like:
 
-`stow --simulate --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
+`stow --simulate --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
 
 - Delete and resymlink:
 
-`stow --restow --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
+`stow --restow --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
 
 - Exclude files matching a regular expression:
 
-`stow --ignore={{regex}} --target={{path/to/target_directory}} {{file1 folder1 file2 folder2}}`
+`stow --ignore={{regex}} --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`

--- a/pages/common/svgo.md
+++ b/pages/common/svgo.md
@@ -11,13 +11,13 @@
 
 `svgo {{test.svg}} {{test.min.svg}}`
 
-- Optimize all SVG files within a folder (overwrites the original files):
+- Optimize all SVG files within a directory (overwrites the original files):
 
-`svgo -f {{path/to/folder/with/svg/files}}`
+`svgo -f {{path/to/directory/with/svg/files}}`
 
-- Optimize all SVG files within a folder and save the resulting files to another folder:
+- Optimize all SVG files within a directory and save the resulting files to another directory:
 
-`svgo -f {{path/to/input/folder}} -o {{path/to/output/folder}}`
+`svgo -f {{path/to/input/directory}} -o {{path/to/output/directory}}`
 
 - Optimize SVG content passed from another command, and save the result to a file:
 

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -11,9 +11,9 @@
 
 `tar -czf {{target.tar.gz}} {{file1 file2 file3}}`
 
-- Extract an archive in a target folder:
+- Extract an archive in a target directory:
 
-`tar -xf {{source.tar}} -C {{folder}}`
+`tar -xf {{source.tar}} -C {{directory}}`
 
 - Extract a gzipped archive in the current directory:
 

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -14,6 +14,6 @@
 
 `echo "example" | tee {{/dev/tty}} | {{xargs printf "[%s]"}}`
 
-- Create a folder called "example", count the number of characters in "example" and write "example" to the terminal:
+- Create a directory called "example", count the number of characters in "example" and write "example" to the terminal:
 
 `echo "example" | tee >(xargs mkdir) >(wc -c)`

--- a/pages/common/tokei.md
+++ b/pages/common/tokei.md
@@ -2,18 +2,18 @@
 
 > A program that prints out statistics about code.
 
-- Get a report on the code in a folder and all subfolders:
+- Get a report on the code in a directory and all subdirectories:
 
-`tokei {{path/to/folder}}`
+`tokei {{path/to/directory}}`
 
-- Get a report for a folder excluding `.min.js` files:
+- Get a report for a directory excluding `.min.js` files:
 
-`tokei {{path/to/folder}} -e {{*.min.js}}`
+`tokei {{path/to/directory}} -e {{*.min.js}}`
 
-- Print out statistics for individual files in a folder:
+- Print out statistics for individual files in a directory:
 
-`tokei {{path/to/folder}} --files`
+`tokei {{path/to/directory}} --files`
 
 - Get a report for all files of type Rust and Markdown:
 
-`tokei {{path/to/folder}} -t={{Rust}},{{Markdown}}`
+`tokei {{path/to/directory}} -t={{Rust}},{{Markdown}}`

--- a/pages/common/vagrant.md
+++ b/pages/common/vagrant.md
@@ -2,7 +2,7 @@
 
 > Manage lightweight, reproducible, and portable development environments.
 
-- Create Vagrantfile in current folder with the base Vagrant box:
+- Create Vagrantfile in current directory with the base Vagrant box:
 
 `vagrant init`
 

--- a/pages/common/vue.md
+++ b/pages/common/vue.md
@@ -9,7 +9,7 @@
 
 - Create a new project with a local template:
 
-`vue init {{path/to/template_folder}} {{project_name}}`
+`vue init {{path/to/template_directory}} {{project_name}}`
 
 - Create project using template on GitHub:
 

--- a/pages/linux/chattr.md
+++ b/pages/linux/chattr.md
@@ -1,6 +1,6 @@
 # chattr
 
-> Change attributes of files or folders.
+> Change attributes of files or directories.
 
 - Make a file or directory immutable to changes and deletion, even by superuser:
 
@@ -10,6 +10,6 @@
 
 `chattr -i {{path/to/file_or_directory}}`
 
-- Recursively make an entire folder and contents immutable:
+- Recursively make an entire directory and contents immutable:
 
-`chattr -R +i {{folder}}`
+`chattr -R +i {{path/to/directory}}`

--- a/pages/linux/entr.md
+++ b/pages/linux/entr.md
@@ -2,7 +2,7 @@
 
 > Run arbitrary commands when files change.
 
-- Rebuild with `make` if any files in any subfolders change:
+- Rebuild with `make` if any file in any subdirectory changes:
 
 `{{ag -l}} | entr {{make}}`
 

--- a/pages/linux/getfacl.md
+++ b/pages/linux/getfacl.md
@@ -4,12 +4,12 @@
 
 - Display the file access control list:
 
-`getfacl {{path/to/file_or_folder}}`
+`getfacl {{path/to/file_or_directory}}`
 
 - Display the file access control list with numeric user and group IDs:
 
-`getfacl -n {{path/to/file_or_folder}}`
+`getfacl -n {{path/to/file_or_directory}}`
 
 - Display the file access control list with tabular output format:
 
-`getfacl -t {{path/to/file_or_folder}}`
+`getfacl -t {{path/to/file_or_directory}}`

--- a/pages/linux/mkisofs.md
+++ b/pages/linux/mkisofs.md
@@ -1,12 +1,12 @@
 # mkisofs
 
-> Create ISO files from folders.
+> Create ISO files from directories.
 > Also aliased as `genisoimage`.
 
-- Create an ISO from a folder:
+- Create an ISO from a directory:
 
-`mkisofs -o {{filename.iso}} {{path/to/source_folder}}`
+`mkisofs -o {{filename.iso}} {{path/to/source_directory}}`
 
 - Set the disc label when creating an ISO:
 
-`mkisofs -o {{filename.iso}} -V {{"label_name"}} {{path/to/source_folder}}`
+`mkisofs -o {{filename.iso}} -V {{"label_name"}} {{path/to/source_directory}}`

--- a/pages/linux/smbclient.md
+++ b/pages/linux/smbclient.md
@@ -16,8 +16,8 @@
 
 - Download a file from the server:
 
-`smbclient {{//server/share}} --directory {{path/to/folder}} --command "get {{file.txt}}"`
+`smbclient {{//server/share}} --directory {{path/to/directory}} --command "get {{file.txt}}"`
 
 - Upload a file to the server:
 
-`smbclient {{//server/share}} --directory {{path/to/folder}} --command "put {{file.txt}}"`
+`smbclient {{//server/share}} --directory {{path/to/directory}} --command "put {{file.txt}}"`

--- a/pages/linux/tomb.md
+++ b/pages/linux/tomb.md
@@ -1,26 +1,26 @@
 # tomb
 
-> Manage encrypted storage folders that can be safely transported and hidden in a filesystem.
+> Manage encrypted storage directories that can be safely transported and hidden in a filesystem.
 
 - Create a new tomb with an initial size of 100MB:
 
-`tomb dig -s {{100}} {{encrypted_folder.tomb}}`
+`tomb dig -s {{100}} {{encrypted_directory.tomb}}`
 
 - Create a new key file that can be used to lock a tomb; user will be prompted for a password for the key:
 
-`tomb forge {{encrypted_folder.tomb.key}}`
+`tomb forge {{encrypted_directory.tomb.key}}`
 
 - Initialize and lock an empty tomb using a key made with `forge`:
 
-`tomb lock {{encrypted_folder.tomb}} -k {{encrypted_folder.tomb.key}}`
+`tomb lock {{encrypted_directory.tomb}} -k {{encrypted_directory.tomb.key}}`
 
-- Mount a tomb (by default in /media) using its key, making it usable as a regular filesystem folder:
+- Mount a tomb (by default in /media) using its key, making it usable as a regular filesystem directory:
 
-`tomb open {{encrypted_folder.tomb}} -k {{encrypted_folder.tomb.key}}`
+`tomb open {{encrypted_directory.tomb}} -k {{encrypted_directory.tomb.key}}`
 
 - Close a tomb (fails if the tomb is being used by a process):
 
-`tomb close {{encrypted_folder.tomb}}`
+`tomb close {{encrypted_directory.tomb}}`
 
 - Forcefully close all open tombs, killing any applications using them:
 

--- a/pages/linux/watch.md
+++ b/pages/linux/watch.md
@@ -2,7 +2,7 @@
 
 > Execute a command repeatedly, and monitor the output in full-screen mode.
 
-- Monitor files in the current folder:
+- Monitor files in the current directory:
 
 `watch {{ls}}`
 

--- a/pages/osx/ditto.md
+++ b/pages/osx/ditto.md
@@ -1,8 +1,8 @@
 # ditto
 
-> Copy files and folders.
+> Copy files and directories.
 
-- Overwrite contents of destination folder with contents of source folder:
+- Overwrite contents of destination directory with contents of source directory:
 
 `ditto {{path/to/source}} {{path/to/destination}}`
 
@@ -10,6 +10,6 @@
 
 `ditto -V {{path/to/source}} {{path/to/destination}}`
 
-- Copy a given file or folder, while retaining the original file permissions:
+- Copy a given file or directory, while retaining the original file permissions:
 
 `ditto -rsrc {{path/to/source}} {{path/to/destination}}`

--- a/pages/osx/drutil.md
+++ b/pages/osx/drutil.md
@@ -6,6 +6,6 @@
 
 `drutil eject`
 
-- Burn a folder as an ISO9660 filesystem onto a DVD. Don't verify and eject when complete:
+- Burn a directory as an ISO9660 filesystem onto a DVD. Don't verify and eject when complete:
 
 `drutil burn -noverify -eject -iso9660`

--- a/pages/osx/du.md
+++ b/pages/osx/du.md
@@ -1,27 +1,27 @@
 # du
 
-> Disk usage: estimate and summarize file and folder space usage.
+> Disk usage: estimate and summarize file and directory space usage.
 
-- List the sizes of a folder and any subfolders, in the given unit (KB/MB/GB):
+- List the sizes of a directory and any subdirectories, in the given unit (KB/MB/GB):
 
-`du -{{k|m|g}} {{path/to/folder}}`
+`du -{{k|m|g}} {{path/to/directory}}`
 
-- List the sizes of a folder and any subfolders, in human-readable form (i.e. auto-selecting the appropriate unit for each size):
+- List the sizes of a directory and any subdirectories, in human-readable form (i.e. auto-selecting the appropriate unit for each size):
 
-`du -h {{path/to/folder}}`
+`du -h {{path/to/directory}}`
 
-- Show the size of a single folder, in human readable units:
+- Show the size of a single directory, in human readable units:
 
-`du -sh {{path/to/folder}}`
+`du -sh {{path/to/directory}}`
 
-- List the human-readable sizes of a folder and of all the files and folders within it:
+- List the human-readable sizes of a directory and of all the files and directories within it:
 
-`du -ah {{path/to/folder}}`
+`du -ah {{path/to/directory}}`
 
-- List the human-readable sizes of a folder and any subfolders, up to N levels deep:
+- List the human-readable sizes of a directory and any subdirectories, up to N levels deep:
 
-`du -h -d {{N}} {{path/to/folder}}`
+`du -h -d {{N}} {{path/to/directory}}`
 
-- List the human-readable size of all .jpg files in subfolders of the current folder, and show a cumulative total at the end:
+- List the human-readable size of all .jpg files in subdirectories of the current directory, and show a cumulative total at the end:
 
 `du -ch */*.jpg`

--- a/pages/osx/sips.md
+++ b/pages/osx/sips.md
@@ -15,7 +15,7 @@
 
 `sips -Z {{1920}} {{300}} {{image.ext}}`
 
-- Resample all images in a folder to fit a width of 960px (honoring aspect ratio):
+- Resample all images in a directory to fit a width of 960px (honoring aspect ratio):
 
 `sips --resampleWidth {{960}} {{path/to/images}}`
 

--- a/pages/osx/tree.md
+++ b/pages/osx/tree.md
@@ -18,7 +18,7 @@
 
 `tree -i -f`
 
-- Print the size of each node next to it, in human-readable format, with folders displaying their cumulative size (as in the `du` command):
+- Print the size of each node next to it, in human-readable format, with directories displaying their cumulative size (as in the `du` command):
 
 `tree -s -h --du`
 

--- a/pages/windows/attrib.md
+++ b/pages/windows/attrib.md
@@ -10,7 +10,7 @@
 
 `attrib /S`
 
-- Display the attributes of the files and folders in the current directory and sub-directories:
+- Display the attributes of the files and directories in the current directory and sub-directories:
 
 `attrib /S /D`
 
@@ -22,6 +22,6 @@
 
 `attrib -S -H {{document.txt}}`
 
-- Add the hidden attribute to a folder:
+- Add the hidden attribute to a directory:
 
-`attrib +H {{path\to\folder}}`
+`attrib +H {{path\to\directory}}`

--- a/pages/windows/xcopy.md
+++ b/pages/windows/xcopy.md
@@ -4,31 +4,31 @@
 
 - Copy the file(s) to the specified destination:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}}`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}}`
 
 - List files that will be copied before copying:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /p`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /p`
 
 - Copy the directory structure only, excluding files:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /t`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /t`
 
 - Include empty directories when copying:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /e`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /e`
 
 - Keep the source ACL in the destination:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /o`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /o`
 
 - Allow resuming when network connection is lost:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /z`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /z`
 
 - Disable the prompt when the file exists in the destination:
 
-`xcopy {{path/to/file_or_folder}} {{path/to/destination}} /y`
+`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /y`
 
 - Display detailed usage information:
 


### PR DESCRIPTION
This fixes #2751 addressing the first point: it changes occurrences of the term "folder" to "directory" where it is clear that the term is used to refer to system directories instead of folders. I did not just "find and replace" every occurrence of the word, I reviewed every instance by hand.

The only three pages I found where the term "folder" is correctly used are the following:

- `bw`: the term "folder" is [specifically used by Bitwarden](https://help.bitwarden.com/article/cli/#create) as a resource type.
- `gdrive` and `skicka`: the term "folder" is [specifically used by Google Drive](https://developers.google.com/drive/api/v3/folder) to identify directories in the cloud. Even though it is technically wrong, using "directory" would just be confusing since Google Drive calls them folders.

Affected pages:

    it/com/7z it/com/7zr com/adb com/atom com/aws-s3 com/bashmarks com/blender com/borg com/bup com/chgrp com/chown com/cmake com/cp com/cppcheck com/cppclean com/df com/du com/duplicity com/git-checkout com/git-worktree com/gitk com/gource com/gradle com/ipfs com/jekyll com/ln com/mc com/mkdir com/mocha com/mogrify com/mongodump com/mongorestore com/mvn com/ng com/pt com/rbenv com/rclone com/repren com/restic com/scp com/sendmail com/sftp com/shards com/spike com/stow com/svgo com/tar com/tee com/tokei com/vagrant com/vue linux/chattr linux/entr linux/getfacl linux/mkisofs linux/smbclient linux/tomb linux/watch osx/ditto osx/drutil osx/du osx/sips osx/tree windows/attrib windows/xcopy 