### PR TITLE
multiple pages: change Unicode characters to ASCII

### DIFF
--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -1,6 +1,6 @@
 # flutter
 
-> Google’s free, open source, and cross-platform mobile app SDK.
+> Google's free, open source, and cross-platform mobile app SDK.
 
 - Check the Flutter version:
 

--- a/pages/common/mpv.md
+++ b/pages/common/mpv.md
@@ -24,4 +24,4 @@
 
 - Play a file using a profile defined in the `mpv.conf` file:
 
-`mpv --profile {{profile_name}} {{file}}`
+`mpv --profile {{profile_name}} {{file}}`

--- a/pages/linux/dmesg.md
+++ b/pages/linux/dmesg.md
@@ -1,6 +1,6 @@
 # dmesg
 
-> Write the kernel messages to standard output.
+> Write the kernel messages to standard output.
 
 - Show kernel messages:
 

--- a/pages/linux/run-mailcap.md
+++ b/pages/linux/run-mailcap.md
@@ -15,7 +15,7 @@
 
 `run-mailcap --action=ACTION --debug {{filename}}`
 
-- Ignore any "copiousoutput" directive and forward output to STD‐OUT:
+- Ignore any "copiousoutput" directive and forward output to standard output:
 
 `run-mailcap --action=ACTION --nopager {{filename}}`
 

--- a/pages/osx/ditto.md
+++ b/pages/osx/ditto.md
@@ -6,7 +6,7 @@
 
 `ditto {{path/to/source}} {{path/to/destination}}`
 
-- Print a line to the Terminal window for every file that’s being copied:
+- Print a line to the Terminal window for every file that's being copied:
 
 `ditto -V {{path/to/source}} {{path/to/destination}}`
 

--- a/pages/osx/dmesg.md
+++ b/pages/osx/dmesg.md
@@ -1,6 +1,6 @@
 # dmesg
 
-> Write the kernel messages to standard output.
+> Write the kernel messages to standard output.
 
 - Show kernel messages:
 

--- a/pages/osx/launchctl.md
+++ b/pages/osx/launchctl.md
@@ -23,10 +23,10 @@
 
 `launchctl unload ~/Library/LaunchAgents/{{my_script}}.plist`
 
-- Manually run a known (loaded) agent/daemon, even if it isn’t the right time (note: this command uses the agent's label, rather than the filename):
+- Manually run a known (loaded) agent/daemon, even if it is not the right time (note: this command uses the agent's label, rather than the filename):
 
 `launchctl start {{my_script}}`
 
-- Manually kill the process associated with a known agent/daemon, if it's running:
+- Manually kill the process associated with a known agent/daemon, if it is running:
 
 `launchctl stop {{my_script}}`

--- a/pages/osx/oathtool.md
+++ b/pages/osx/oathtool.md
@@ -8,7 +8,7 @@
 
 - Generate a TOTP token for a specific time:
 
-`oathtool --totp --now {{2004−02−29 16:21:42}} --base32 {{secret}}`
+`oathtool --totp --now {{2004-02-29 16:21:42}} --base32 {{secret}}`
 
 - Validate a TOTP token:
 

--- a/pages/sunos/dmesg.md
+++ b/pages/sunos/dmesg.md
@@ -1,6 +1,6 @@
 # dmesg
 
-> Write the kernel messages to standard output.
+> Write the kernel messages to standard output.
 
 - Show kernel messages:
 


### PR DESCRIPTION
Change Unicode characters to ASCII:

- non-breaking spaces (\xc2\xa0) to normal spaces (\x20)
- apostrophes (there are only 2 Unicode apostrophes, all others are already ASCII)
- hyphen (−) to minus (-)
- fix wording (STD‐OUT to "standard output")