### PR TITLE
whiptail: add page

### DIFF
--- a/pages/linux/whiptail.md
+++ b/pages/linux/whiptail.md
@@ -1,0 +1,28 @@
+# whiptail
+
+> Display text-based dialog boxes from shell scripts
+
+- Display a simple message:
+
+`whiptail --title "{{title}}" --msgbox "{{message}}" {{height_in_chars}} {{width_in_chars}}`
+
+- Display a boolean choice, returning the result through the exit code:
+
+`whiptail --title "{{title}}" --yesno "{{message}}" {{height_in_chars}} {{width_in_chars}}`
+
+- Customise the text on the yes / no buttons:
+
+`whiptail --title "{{title}}" --yes-button "{{text}}" --no-button "{{text}}" --yesno "{{message}}" {{height_in_chars}} {{width_in_chars}}`
+
+- Display a text input box:
+
+`{{result_variable_name}}="$(whiptail --title "{{title}}" --inputbox "{{message}}" {{height_in_chars}} {{width_in_chars}} {{default_text}} 3>&1 1>&2 2>&3)"`
+
+- Display a password input box:
+
+`{{result_variable_name}}="$(whiptail --title "{{title}}" --passwordbox "{{message}}" {{height_in_chars}} {{width_in_chars}} 3>&1 1>&2 2>&3)"`
+
+- Display a multiple-choice menu:
+
+`OPTION=$(whiptail --title "{{title}}" --menu "{{message}}" {{height_in_chars}} {{width_in_chars}} {{menu_display_height}} "{{value_1}}" "{{display_text_1}}" "{{value_n}}" "{{display_text_n}}" ..... 3>&1 1>&2 2>&3)`
+

--- a/pages/linux/whiptail.md
+++ b/pages/linux/whiptail.md
@@ -1,6 +1,6 @@
 # whiptail
 
-> Display text-based dialog boxes from shell scripts
+> Display text-based dialog boxes from shell scripts.
 
 - Display a simple message:
 
@@ -25,4 +25,3 @@
 - Display a multiple-choice menu:
 
 `OPTION=$(whiptail --title "{{title}}" --menu "{{message}}" {{height_in_chars}} {{width_in_chars}} {{menu_display_height}} "{{value_1}}" "{{display_text_1}}" "{{value_n}}" "{{display_text_n}}" ..... 3>&1 1>&2 2>&3)`
-

--- a/pages/linux/whiptail.md
+++ b/pages/linux/whiptail.md
@@ -24,4 +24,4 @@
 
 - Display a multiple-choice menu:
 
-`OPTION=$(whiptail --title "{{title}}" --menu "{{message}}" {{height_in_chars}} {{width_in_chars}} {{menu_display_height}} "{{value_1}}" "{{display_text_1}}" "{{value_n}}" "{{display_text_n}}" ..... 3>&1 1>&2 2>&3)`
+`{{result_variable_name}}=$(whiptail --title "{{title}}" --menu "{{message}}" {{height_in_chars}} {{width_in_chars}} {{menu_display_height}} "{{value_1}}" "{{display_text_1}}" "{{value_n}}" "{{display_text_n}}" ..... 3>&1 1>&2 2>&3)`


### PR DESCRIPTION
I bring you `whiptail`, the default TUI dialog box command on most Debian-based systems. It should be installed by default, and you may have seen it when you update via `apt` in the terminal, asking you what you want to do if a configuration file got changed.

[source tutorial](http://xmodulo.com/create-dialog-boxes-interactive-shell-script.html)