### PR TITLE
npm: remove unnecessary --save flag and simplify descriptions

### DIFF
--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -4,34 +4,34 @@
 > Manage Node.js projects and their module dependencies.
 > Homepage: <https://www.npmjs.com/>.
 
-- Download and install a module globally:
+- Interactively create a package.json file:
 
-`npm install -g {{module_name}}`
+`npm init`
 
-- Download all dependencies referenced in package.json:
+- Download all the packages listed as dependencies in package.json:
 
 `npm install`
 
-- Download a given dependency required for the application to run, and add it to the package.json:
+- Download a specific version of a package and add it to the list of dependencies in package.json:
 
-`npm install {{module_name}}@{{version}} --save`
+`npm install {{module_name}}@{{version}}`
 
-- Download a given dependency for development purposes, and add it to the package.json:
+- Download a package and add it to the list of dev dependencies in package.json:
 
-`npm install {{module_name}}@{{version}} --save-dev`
+`npm install {{module_name}} --save-dev`
 
-- Uninstall a module:
+- Download a package and install it globally:
+
+`npm install -g {{module_name}}`
+
+- Uninstall a package and remove it from the list of dependencies in package.json:
 
 `npm uninstall {{module_name}}`
 
-- List a tree of installed modules referenced in package.json:
+- Print a tree of installed, project-level packages:
 
 `npm list`
 
 - List top-level globally installed modules:
 
 `npm list -g --depth={{0}}`
-
-- Interactively create a package.json file:
-
-`npm init`

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -28,7 +28,7 @@
 
 `npm uninstall {{module_name}}`
 
-- Print a tree of installed, project-level packages:
+- Print a tree of locally-installed dependencies:
 
 `npm list`
 


### PR DESCRIPTION
Updates and simplifies the npm page.
Specifically:
* Removes unnecessary `--save` flag (added by default in npm > 5).
* Adds an example that installs a package wihtout a version since thats a simpler case.
* Moves the global install example down the page since it's a more complicated case
* Switch to the longversion of global option (`--global`) instead of `-g` to comply with guidelines
* Simplified description of adding a dependency
* Switched from the terms "dependency" and "module" to "package" where possible since package is more idiomatic in this context.
* Removed `npm list --global` example to stay under 8 example limit

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
