### PR TITLE
conda: source deactivate is deprecated

### DIFF
--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -12,7 +12,7 @@
 
 - Load or unload an environment:
 
-`source {{activate|deactivate}} {{environment_name}}`
+`conda {{activate|deactivate}} {{environment_name}}`
 
 - Delete an environment (remove all packages):
 


### PR DESCRIPTION
When one uses `conda` and unload an environment with the `source deactivate` command, he receives the following message `DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.`

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
