### PR TITLE
netstat: fix token naming and curly braces

### DIFF
--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -16,7 +16,7 @@
 
 - Display PID and program names for a specific port:
 
-`netstat -p {PROTOCOL}`
+`netstat -p {{protocol}}`
 
 - List information continuously:
 

--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -14,7 +14,7 @@
 
 `netstat -t`
 
-- Display PID and program names for a specific port:
+- Display PID and program names for a specific protocol:
 
 `netstat -p {{protocol}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

When looking at #2841, I noticed that the `netstat` page was using single curly-braces for token syntax.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
