### PR TITLE
rename: fix display issue

### DIFF
--- a/pages/common/rename.md
+++ b/pages/common/rename.md
@@ -4,20 +4,20 @@
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):
 
-`rename {{'s/foo/bar/'}} {{\*}}`
+`rename {{'s/foo/bar/'}} {{*}}`
 
 - Dry-run - display which renames would occur without performing them:
 
-`rename -n {{'s/foo/bar/'}} {{\*}}`
+`rename -n {{'s/foo/bar/'}} {{*}}`
 
 - Force renaming even if the operation would overwrite existing files:
 
-`rename -f {{'s/foo/bar/'}} {{\*}}`
+`rename -f {{'s/foo/bar/'}} {{*}}`
 
 - Convert filenames to lower case (use `-f` in case-insensitive filesystems to prevent "already exists" errors):
 
-`rename 'y/A-Z/a-z/' {{\*}}`
+`rename 'y/A-Z/a-z/' {{*}}`
 
 - Replace whitespace with underscores:
 
-`rename 's/\s+/_/g' {{\*}}`
+`rename 's/\s+/_/g' {{*}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

I encountered a display issue when looking at the `rename` page, whereby asterisks prefaced by backslashes (`\*`) were actually showing up to the end user like so:

```
$ tldr rename

  rename

  Renames multiple files.

  - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):
    rename 's/foo/bar/' \*

  - Dry-run - display which renames would occur without performing them:
    rename -n 's/foo/bar/' \*

  - Force renaming even if the operation would overwrite existing files:
    rename -f 's/foo/bar/' \*

  - Convert filenames to lower case (use -f in case-insensitive filesystems to prevent "already exists" errors):
    rename 'y/A-Z/a-z/' \*

  - Replace whitespace with underscores:
    rename 's/\s+/_/g' \*
```

I'm assuming this is not the expected behavior, so this PR may fix that issue.

Then again, if backticks are for some reason required for bare `*` strings, then this PR may simply highlight the issue instead. I couldn't find any information that leads me to believe this would be bad, according to the [style guide](https://github.com/ryantuck/tldr/blob/master/contributing-guides/style-guide.md).