### PR TITLE
virtualenv: add python version example

### DIFF
--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -11,7 +11,7 @@
 
 `virtualenv --prompt={{prompt_prefix}} {{path/to/venv}}`
 
-- Use different Python version with virtualenv:
+- Use a different version of Python with virtualenv:
 
 `virtualenv --python={{path/to/pythonbin}} {{path/to/venv}}`
 

--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -12,7 +12,7 @@
 `virtualenv --prompt={{prompt_prefix}} {{path/to/venv}}`
 
 - Use different Python version with virtualenv:
-  
+
 `virtualenv --python={{path/to/pythonbin}} {{path/to/venv}}`
 
 - Start (select) the environment:

--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -11,6 +11,10 @@
 
 `virtualenv --prompt={{prompt_prefix}} {{path/to/venv}}`
 
+- Use different Python version with virtualenv:
+  
+`virtualenv --python={{path/to/pythonbin}} {{path/to/venv}}`
+
 - Start (select) the environment:
 
 `source {{path/to/venv}}/bin/activate`


### PR DESCRIPTION

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

adds instructions for specifying different Python version with virtualenv
source: https://stackoverflow.com/a/1534343
