### PR TITLE
ss: add listening socket example

### DIFF
--- a/pages/linux/ss.md
+++ b/pages/linux/ss.md
@@ -14,6 +14,10 @@
 
 `ss -t src :{{443}}`
 
+- Show all TCP sockets listening on the local 8080 port:
+
+`ss -lt src :{{8080}}`
+
 - Show all TCP sockets along with processes connected to a remote ssh port:
 
 `ss -pt dst :{{ssh}}`


### PR DESCRIPTION
I changed a "connected socket" example to a "listening" one. The next example is also about "connected" ones.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
