### PR TITLE
Update building of index.json to be at the top level of the generated ZIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-markdown": "markdownlint pages/**/*.md",
     "lint-tldr": "tldr-lint ./pages",
     "test": "bash -c 'markdownlint pages/ && tldr-lint ./pages 2>&1 | tee test_result; test ${PIPESTATUS[0]} -eq 0'",
-    "build-index": "node ./scripts/build-index.js > pages/index.json"
+    "build-index": "node ./scripts/build-index.js | tee pages/index.json > index.json"
   },
   "repository": "tldr-pages/tldr",
   "author": "Romain Prieto",

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var glob = require('glob');
+const glob = require('glob');
 
 function parsePlatform(pagefile) {
   return pagefile.split(/\//)[1];
@@ -11,29 +11,33 @@ function parsePagename(pagefile) {
 }
 
 function parseLanguage(pagefile) {
-  var pagesFolder = pagefile.split(/\//)[0];
+  let pagesFolder = pagefile.split(/\//)[0];
   return pagesFolder == 'pages' ? 'en' : pagesFolder.replace(/^pages./, '');
 }
 
 function buildPagesIndex(files) {
-  var reducer = function (index, file) {
-    var os = parsePlatform(file);
-    var page = parsePagename(file);
-    var language = parseLanguage(file);
+  let reducer = function (index, file) {
+    let os = parsePlatform(file);
+    let page = parsePagename(file);
+    let language = parseLanguage(file);
+
     if (index[page]) {
       if (!index[page].platform.includes(os)) {
         index[page].platform.push(os);
       }
+
       if (!index[page].language.includes(language)) {
         index[page].language.push(language);
       }
     } else {
       index[page] = {name: page, platform: [os], language: [language]};
     }
+
     return index;
   };
 
-  var obj = files.reduce(reducer, {});
+  let obj = files.reduce(reducer, {});
+
   return Object.keys(obj)
       .sort()
       .map(function(page) {
@@ -46,13 +50,14 @@ function buildPagesIndex(files) {
 }
 
 function saveIndex(index) {
-  var indexFile = {
+  let indexFile = {
     commands: index
   };
+
   console.log(JSON.stringify(indexFile));
 }
 
 glob('pages*/**/*.md', function (er, files) {
-  var index = buildPagesIndex(files);
+  let index = buildPagesIndex(files);
   saveIndex(index);
 });

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -12,7 +12,7 @@ function parsePagename(pagefile) {
 
 function parseLanguage(pagefile) {
   let pagesFolder = pagefile.split(/\//)[0];
-  return pagesFolder == 'pages' ? 'en' : pagesFolder.replace(/^pages./, '');
+  return pagesFolder == 'pages' ? 'en' : pagesFolder.replace(/^pages\./, '');
 }
 
 function buildPagesIndex(files) {
@@ -58,6 +58,12 @@ function saveIndex(index) {
 }
 
 glob('pages*/**/*.md', function (er, files) {
+  if (er !== null) {
+    console.error('ERROR finding pages!');
+    console.error(er);
+    return;
+  }
+
   let index = buildPagesIndex(files);
   saveIndex(index);
 });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,14 +33,14 @@ function rebuild_index {
 function build_archive {
   rm -f $TLDR_ARCHIVE
   cd $TLDRHOME/
-  zip -r $TLDR_ARCHIVE pages*/ LICENSE.md
+  zip -r $TLDR_ARCHIVE pages*/ LICENSE.md index.json
   echo "Pages archive created."
 }
 
 function upload_assets {
   git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git $SITE_HOME
   mv -f $TLDR_ARCHIVE $SITE_HOME/assets/
-  cp -f $TLDRHOME/pages/index.json $SITE_HOME/assets/
+  cp -f $TLDRHOME/index.json $SITE_HOME/assets/
 
   cd $SITE_HOME
   git add -A


### PR DESCRIPTION
The `index.json` file contains information about *all* the pages and *all* the languages, and it should be located at the top level of the ZIP file which is generated when deploying to tldr-pages.github.io, not inside the `/pages/` folder (which is for English pages only).

I updated the build and deploy scripts to produce a copy of said file and add it at the top of the generated `tldr.zip`. I did not however disable the generation of `/pages/index.json`, since some clients rely on this file. 

Since this is kind of an architectural change, if this is merged I will notify each client by creating an issue on its repository, and also create a new issue in this repo to track which clients are up to date with the change. Once they all are or we think enough time has passed, we can then close said issue creating another PR to completely remove the duplicated `/pages/index.json` file from the ZIP.

PS: @sbrl the fact that the archive as well as the index can be retrieved from tldr-pages.github.io should probably be added into the client spec. When that happens we could also edit/remove the wiki page.

Fixes #2829 