### PR TITLE
Add pacman line for installing tldr-python-client on arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can access these pages on your computer using one of the following clients:
   `composer global require brainmaestro/tldr`
 - Python clients:
   - [tldr-python-client](https://github.com/tldr-pages/tldr-python-client):
-    `pip install tldr`
+    `pip install tldr` or `pacman -S tldr`
   - [tldr.py](https://github.com/lord63/tldr.py):
     `pip install tldr.py`
 - [R client](https://github.com/kirillseva/tldrrr):


### PR DESCRIPTION
Adds a line for installing the python client onto arch, mirroring my [PR to the github.io site](https://github.com/tldr-pages/tldr-pages.github.io/pull/33)