### PR TITLE
monodevelop: add page

### DIFF
--- a/pages/common/monodevelop.md
+++ b/pages/common/monodevelop.md
@@ -1,0 +1,28 @@
+# monodevelop
+
+> Cross platform IDE for C#, F# and more.
+> Homepage: <https://www.monodevelop.com/>.
+
+- Start Monodevelop:
+
+`monodevelop`
+
+- Open a specific file:
+
+`monodevelop {{path/to/file}}`
+
+- Open a specific file with the caret at a specific position:
+
+`monodevelop {{path/to/file}};{{line_number}};{{column_number}}`
+
+- Force a new window instead of switching to an existing one:
+
+`monodevelop --new-window`
+
+- Disable redirection of stdout and stderr to a log file:
+
+`monodevelop --no-redirect`
+
+- Enable performance monitoring:
+
+`monodevelop --perf-log`

--- a/pages/common/monodevelop.md
+++ b/pages/common/monodevelop.md
@@ -15,7 +15,7 @@
 
 `monodevelop {{path/to/file}};{{line_number}};{{column_number}}`
 
-- Force a new window instead of switching to an existing one:
+- Force opening a new window instead of switching to an existing one:
 
 `monodevelop --new-window`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

With my [new improved missing pages detector](https://gitlab.com/sbrl/bin/blob/master/tldr-missing-pages), I discovered we didn't have a page for Monodevelop O.o

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
