### PR TITLE
trawl: add page

### DIFF
--- a/pages/common/trawl.md
+++ b/pages/common/trawl.md
@@ -1,0 +1,19 @@
+# trawl
+
+> Prints out network interface information to the console, much like ifconfig/ipconfig/ip/ifdata.
+
+- Show column names:
+
+`trawl -n`
+
+- Filter interface names using a case insensitive regular expression:
+
+`trawl -f wi`
+
+- Get a list of available interfaces:
+
+`trawl -i`
+
+- Include the loopback interface:
+
+`trawl -l`

--- a/pages/common/trawl.md
+++ b/pages/common/trawl.md
@@ -1,6 +1,7 @@
 # trawl
 
 > Prints out network interface information to the console, much like ifconfig/ipconfig/ip/ifdata.
+> Homepage: <https://github.com/robphoenix/trawl>.
 
 - Show column names:
 


### PR DESCRIPTION
I have added [trawl](https://github.com/robphoenix/trawl) - The package that does pretty printing network interface information to the console, much like `ifconfig/ipconfig/ip/ifdata`.