### PR TITLE
smartctl: Fix link to Wikipedia

### DIFF
--- a/pages/common/smartctl.md
+++ b/pages/common/smartctl.md
@@ -1,7 +1,7 @@
 # smartctl
 
 > View a disk's SMART data and other information.
-> See https://en.wikipedia.org/wiki/S.M.A.R.T for more information.
+> See [en.wikipedia.org/wiki/S.M.A.R.T.](https://en.wikipedia.org/wiki/S.M.A.R.T.) for more information.
 
 - View SMART health summary:
 

--- a/pages/common/smartctl.md
+++ b/pages/common/smartctl.md
@@ -1,7 +1,7 @@
 # smartctl
 
 > View a disk's SMART data and other information.
-> See [en.wikipedia.org/wiki/S.M.A.R.T.](https://en.wikipedia.org/wiki/S.M.A.R.T.) for more information.
+> More information: <https://en.wikipedia.org/wiki/S.M.A.R.T.>.
 
 - View SMART health summary:
 


### PR DESCRIPTION
There is a redirection on Wikipedia from `S.M.A.R.T` to `S.M.A.R.T.`, but it's nicer to get to `S.M.A.R.T.` directly.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
