### PR TITLE
COMMUNITY-ROLES: fix usage of angle brackets

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -113,7 +113,7 @@ using one of the template messages below as a base.
 
 3. Open a PR adding their name to the "Current repository collaborators" section
    in [MAINTAINERS.md](MAINTAINERS.md).
-   Make sure to include "Closes #<issue number>" in the PR description.
+   Make sure to include `Closes #<issue number>` in the PR description.
    The issue will then be automatically closed once the PR is merged.
 
 ### Adding new organization members
@@ -138,7 +138,7 @@ using one of the template messages below as a base.
 
 3. Open a PR moving their name to the "Current organization members" section
    in [MAINTAINERS.md](MAINTAINERS.md).
-   Make sure to include "Closes #<issue number>" in the PR description.
+   Make sure to include `Closes #<issue number>` in the PR description.
    The issue will then be automatically closed once the PR is merged.
 
 ### Adding new organization owners
@@ -164,7 +164,7 @@ using one of the template messages below as a base.
 
 3. Open a PR moving their name to the "Current organization owners" section
    in [MAINTAINERS.md](MAINTAINERS.md).
-   Make sure to include "Closes #<issue number>" in the PR description.
+   Make sure to include `Closes #<issue number>` in the PR description.
    The issue will then be automatically closed once the PR is merged.
 
 ### Removing inactive organization members
@@ -191,7 +191,7 @@ using one of the template messages below as a base.
 
 3. Open a PR moving their name to the "Past organization owners" section
    in [MAINTAINERS.md](MAINTAINERS.md).
-   Make sure to include "Closes #<issue number>" in the PR description.
+   Make sure to include `Closes #<issue number>` in the PR description.
    The issue will then be automatically closed once the PR is merged.
 
 


### PR DESCRIPTION
Without wrapping in code spans using backticks, angle brackets are interpreted as HTML tags, and stripped out from the rendered version.

Hopefully this will be the last update in the recent series of changes to this page. (Maybe I should stop re-reading the page once the PRs are merged :P)