### PR TITLE
jq: add 'combines multiple filters' example

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -25,3 +25,7 @@
 - Output the value of a given key of each element in a JSON text from stdin:
 
 `cat {{file.json}} | jq 'map(.{{key_name}})'`
+
+- Combine multiple filters:
+
+`cat {{file.json}} | jq 'unique | sort | reverse`


### PR DESCRIPTION
test with:
`echo '[1, 2, 2, 3, 4]' | jq 'unique | sort | reverse'`

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
