### PR TITLE
crystal: fix typos and add homepage

### DIFF
--- a/pages/common/crystal.md
+++ b/pages/common/crystal.md
@@ -1,8 +1,8 @@
 # crystal
 
-> Tool for managing crystal source code.
+> Tool for managing Crystal source code.
 
-- Run a crystal file:
+- Run a Crystal file:
 
 `crystal {{path/to/file.cr}}`
 
@@ -14,7 +14,7 @@
 
 `crystal play`
 
-- Create a project directory for a crystal application:
+- Create a project directory for a Crystal application:
 
 `crystal init app {{application_name}}`
 

--- a/pages/common/crystal.md
+++ b/pages/common/crystal.md
@@ -1,6 +1,7 @@
 # crystal
 
 > Tool for managing Crystal source code.
+> Homepage: <https://crystal-lang.org/reference/using_the_compiler>.
 
 - Run a Crystal file:
 


### PR DESCRIPTION
Fixed the language name in the page, which is "Crysatl" with a capital C, and also added a homepage link.