### PR TITLE
silentcast: add page

### DIFF
--- a/pages/linux/silentcast.md
+++ b/pages/linux/silentcast.md
@@ -1,0 +1,12 @@
+# silentcast
+
+> Silent screencast creator. Saves in `.mkv` and animated gif formats.
+> Homepage: <https://github.com/colinkeenan/silentcast>.
+
+- Launch silentcast:
+
+`silentcast`
+
+- Launch silentcast on a specific display:
+
+`silentcast --display={{display}}`


### PR DESCRIPTION
Although I mainly use [OBS](https://obsproject.com/) for my screen recording needs now (which also deserves its own page), silentcast is still a great program that deserves it's own page (hey, @colinkeenan!).