### PR TITLE
cppcheck: simplify example

### DIFF
--- a/pages/common/cppcheck.md
+++ b/pages/common/cppcheck.md
@@ -15,9 +15,9 @@
 
 `cppcheck --enable={{error|warning|style|performance|portability|information|all}} {{path/to/file.cpp}}`
 
-- List available tests, filtered by a given search pattern:
+- List available tests:
 
-`cppcheck --errorlist | grep "{{search_pattern}}"`
+`cppcheck --errorlist`
 
 - Check a given file, ignoring specific tests:
 


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/blob/0ec75ee9a21f53d0d366ec64ff653460accb5088/pages/common/cppcheck.md#L18-L20

I don't think the additional piping into `grep` is needed here, it just makes the example unnecessarily more complex: of course whenever there's a program that lists something it can be piped into `grep` to search for keywords, but that's not what the example should focus on IMHO. I'd propose to remove it, what do you guys think?