### PR TITLE
crontab: clarify and simplify job examples

### DIFF
--- a/pages/common/crontab.md
+++ b/pages/common/crontab.md
@@ -15,14 +15,14 @@
 
 `crontab -r`
 
-- Sample job which runs at 10:00 every day. * means any value:
+- Sample job which runs at 10:00 every day (* means any value):
 
-`0 10 * * * {{path/to/script.sh}}`
+`0 10 * * * {{command_to_execute}}`
 
 - Sample job which runs every minute on the 3rd of April:
 
-`* * 3 Apr * {{path/to/script.sh}}`
+`* * 3 Apr * {{command_to_execute}}`
 
-- Sample job which runs at 02:30 every Friday:
+- Sample job which runs a certain script at 02:30 every Friday:
 
-`30 2 * * Fri {{path/to/script.sh}}`
+`30 2 * * Fri {{/absolute/path/to/script.sh}}`


### PR DESCRIPTION
The fact that `{{path/to/script.sh}}` is used in all the jobs' examples gives the wrong impression that cron jobs have to be scripts, when they can actually be any command.

I edited the first two examples to use a more general `{{command_to_execute}}` token, and left the script in the last example, clarifying its description and the fact that the path must be absolute.