### PR TITLE
csc: clarify example

### DIFF
--- a/pages/common/csc.md
+++ b/pages/common/csc.md
@@ -20,7 +20,7 @@
 
 - Embed a resource:
 
-`csc /resource:{{path/to/target_file.cs}},{{namespace.string.name}} {{path/to/input_file.cs}}`
+`csc /resource:{{path/to/resource_file}} {{path/to/input_file.cs}}`
 
 - Automatically generate XML documentation:
 


### PR DESCRIPTION
Clarify that a resource does not have to be another `.cs` source file, but can be any kind of file. Also, the identifier following the resource name is not needed since it defaults to the embedded resource filename.