### PR TITLE
openssl: add certificate expiry checking


### DIFF
--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -18,6 +18,10 @@
 
 `openssl x509 -in {{filename.crt}} -noout -text`
 
+- Display certificate expiration date:
+
+`openssl x509 -enddate -noout -in {{filename.pem}}`
+
 - Display the start and expiry dates for a domain's certificate:
 
 `openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -18,7 +18,7 @@
 
 `openssl x509 -in {{filename.crt}} -noout -text`
 
-- Display certificate expiration date:
+- Display a certificate's expiration date:
 
 `openssl x509 -enddate -noout -in {{filename.pem}}`
 


### PR DESCRIPTION


Knowing expiry of a certificate can certainly be useful as a
oneliner, for scripting for example.

