### PR TITLE
wifi-password: add page

### DIFF
--- a/pages/osx/wifi-password.md
+++ b/pages/osx/wifi-password.md
@@ -1,0 +1,16 @@
+# wifi-password
+
+> Get the password of the wifi.
+> Homepage: <https://github.com/rauchg/wifi-password>.
+
+- Get the password for the wifi you are currently logged onto:
+
+`wifi-password`
+
+- Get the password for the wifi with a specific SSID:
+
+`wifi-password {{ssid}}`
+
+- Print only the password as output:
+
+`wifi-password -q`


### PR DESCRIPTION
I have added [wifi-password](https://github.com/rauchg/wifi-password) - osx tool for getting wifi password.