### PR TITLE
package.json: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "glob": "7.0.0",
     "markdownlint-cli": "0.1.0",
     "tldr-lint": "~0.0.7",
-    "husky": "0.11.3"
+    "husky": "1.3.1"
   },
   "scripts": {
     "precommit": "npm test",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,15 @@
     "husky": "1.3.1"
   },
   "scripts": {
-    "precommit": "npm test",
     "lint-markdown": "markdownlint pages/**/*.md",
     "lint-tldr": "tldr-lint ./pages",
     "test": "bash -c 'markdownlint pages/ && tldr-lint ./pages 2>&1 | tee test_result; test ${PIPESTATUS[0]} -eq 0'",
     "build-index": "node ./scripts/build-index.js | tee pages/index.json > index.json"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
   },
   "repository": "tldr-pages/tldr",
   "author": "Romain Prieto",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Simplified, community-driven man pages",
   "dependencies": {
-    "glob": "7.0.0",
+    "glob": "7.1.3",
     "markdownlint-cli": "0.1.0",
     "tldr-lint": "~0.0.7",
     "husky": "1.3.1"


### PR DESCRIPTION
Note, this can probably be rebased and merged rather than squashing. 👍

-----

Due to the issues mentioned in PRs #2867 and #2868, I've created this new PR with the appropriate changes committed by Dependabot.

I was planning on updating [`markdownlint-cli`](https://npm.im/markdownlint-cli) to `v0.15.0` which is the latest, but it now actually enforces the tests (see the [Travis build failure](https://travis-ci.com/pxgamer/tldr/builds/109987111)) so it may be better to implement this with a future PR.