### PR TITLE
package.json: update markdownlint-cli to v0.15.0

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -2,7 +2,7 @@
   "default": true,
   "MD003": { "style": "atx" },
   "MD007": { "indent": 4 },
-  "MD013": { "line_length": 200 },
+  "MD013": { "line_length": 250 },
   "MD033": false,
   "MD034": false,
   "no-hard-tabs": false,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simplified, community-driven man pages",
   "dependencies": {
     "glob": "7.1.3",
-    "markdownlint-cli": "0.1.0",
+    "markdownlint-cli": "0.15.0",
     "tldr-lint": "~0.0.7",
     "husky": "1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "husky": "1.3.1"
   },
   "scripts": {
-    "lint-markdown": "markdownlint pages/**/*.md",
+    "lint-markdown": "markdownlint pages*/**/*.md",
     "lint-tldr": "tldr-lint ./pages",
-    "test": "bash -c 'markdownlint pages/ && tldr-lint ./pages 2>&1 | tee test_result; test ${PIPESTATUS[0]} -eq 0'",
+    "test": "bash -c 'markdownlint pages*/**/*.md && tldr-lint ./pages 2>&1 | tee test_result; test ${PIPESTATUS[0]} -eq 0'",
     "build-index": "node ./scripts/build-index.js | tee pages/index.json > index.json"
   },
   "husky": {


### PR DESCRIPTION
As mentioned in #2960, this updates [`markdownlint-cli`](https://npm.im/markdownlint-cli) to `v0.15.0`.

The package now actually enforces the tests. The issue that arises from this is that there is a page [`pages/linux/whiptail.md:27`](https://github.com/pxgamer/tldr/blob/da2344c7a5e289b92aa3d767363bfba4afb67e67/pages/linux/whiptail.md) that has a line with **233** characters. Whereas we restrict pages to a max of **200** characters in our linting config.

This is mentioned in previous builds, but it won't be enforced when linting (the exit code is `0`). In the new versions, the exit code is `1`, so Travis CI fails to build.

To resolve this, we could cut down or remove the `Display a multiple-choice menu` example in `whiptail` (@sbrl?), or increase/remove the line length limit?