### PR TITLE
package.json: update husky to v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "glob": "7.1.3",
     "markdownlint-cli": "0.1.0",
     "tldr-lint": "~0.0.7",
-    "husky": "1.3.1"
+    "husky": "^2.2.0"
   },
   "scripts": {
     "lint-markdown": "markdownlint pages/**/*.md",


### PR DESCRIPTION
As part of #2960, I bumped `husky` from `0.11.3` to `1.3.1`. I didn't want to bump 2 major versions as there was a breaking change. Version `2.0.0` removes support for `Node 6`, but I'm not sure if we still would support Node 6 at all?

This PR updates `husky` to `v2.2.0`. I've also used a hat (minor) version indicator as `husky` is now stable and follows semver. I can always hardcode it to `2.2.0` if needed though.