### PR TITLE
transmission-remote: add page

### DIFF
--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -8,7 +8,7 @@
 
 - Change the default download directory:
 
-`transmission-remote {{hostname}} -w {{/path/to/download/to}}`
+`transmission-remote {{hostname}} -w {{path/to/download_directory}}`
 
 - List all torrents:
 

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -4,7 +4,7 @@
 
 - Add a torrent file or magnet link to Transmission and download to a specified directory:
 
-`transmission-remote {{hostname}} -a {{torrent|url}} -w {{/path/to/download/to}}`
+`transmission-remote {{hostname}} -a {{torrent|url}} -w {{path/to/download_directory}}`
 
 - Change the default download directory:
 

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -1,0 +1,31 @@
+# transmission-remote
+
+> Remote control utility for transmission-daemon and transmission.
+
+- Add a torrent file or magnet link to Transmission and download to a specified directory:
+
+`transmission-remote {{hostname}} -a {{torrent|url}} -w {{/path/to/download/to}}`
+
+- Change the default download directory:
+
+`transmission-remote {{hostname}} -w {{/path/to/download/to}}`
+
+- List all torrents:
+
+`transmission-remote {{hostname}} --list`
+
+- Start torrent 1 and 2, stop torrent 3:
+
+`transmission-remote {{hostname}} -t {{"1,2"}} --start -t {{3}} --stop`
+
+- Remove torrent 1 and 2, and also delete local data for torrent 2:
+
+`transmission-remote {{hostname}} -t {{1}} --remove -t {{2}} --remove-and-delete`
+
+- Stop all torrents:
+
+`transmission-remote {{hostname}} -t {{all}} --stop`
+
+- Move torrents 1-10 and 15-20 to a new folder (folder will be created if it does not exist):
+
+`transmission-remote {{hostname}} -t {{"1-10,15-20"}} --move {{/new/path}}`

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -28,4 +28,4 @@
 
 - Move torrents 1-10 and 15-20 to a new folder (folder will be created if it does not exist):
 
-`transmission-remote {{hostname}} -t {{"1-10,15-20"}} --move {{/new/path}}`
+`transmission-remote {{hostname}} -t {{"1-10,15-20"}} --move {{path/to/new_directory}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

Some thoughts on this PR:
- The trickiest thing to figure out with this command is how to select torrents. The option -t is quite flexible. I tried to illustrate different ways in which -t can be used to select individual torrents, ranges such as torrent 1-10, combinations of the two as well as the option "all".
- If `{{hostname}}` isn't specified it's assumed to be localhost. I'd like to illustrate this somehow since a lot of people will be connecting to a local daemon, but I'm not sure how best to illustrate it without it looking like a mistake in the page.
- The order of the arguments when dealing with `-t` and `-a` is very important. This is made clear with `-t` I think, but less so for `-a`. For example in the first example if -a and -w are flipped the default download directory is changed permanently, but in the example the download directory is only specified for the new torrent.