### PR TITLE
diff: clarified and elaborated examples

### DIFF
--- a/pages/common/diff.md
+++ b/pages/common/diff.md
@@ -2,26 +2,26 @@
 
 > Compare files and directories.
 
-- Compare files:
+- Compare files (lists changes to turn `old_file` into `new_file`):
 
-`diff {{file1}} {{file2}}`
+`diff {{old_file}} {{new_file}}`
 
 - Compare files, ignoring white spaces:
 
-`diff -w {{file1}} {{file2}}`
+`diff -w {{old_file}} {{new_file}}`
 
 - Compare files, showing the differences side by side:
 
-`diff -y {{file1}} {{file2}}`
+`diff -y {{old_file}} {{new_file}}`
 
 - Compare files, showing the differences in unified format (as used by `git diff`):
 
-`diff -u {{file1}} {{file2}}`
+`diff -u {{old_file}} {{new_file}}`
 
-- Compare directories recursively:
+- Compare directories recursively (shows names for differing files/directories as well as changes made to files):
 
-`diff -r {{directory1}} {{directory2}}`
+`diff -r {{old_directory}} {{new_directory}}`
 
 - Compare directories, only showing the names of files that differ:
 
-`diff -rq {{directory1}} {{directory2}}`
+`diff -rq {{old_directory}} {{new_directory}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

The current version of the page doesn't do a great job of explaining how the order of the arguments affect the output, this PR tries to remedy that by changing all instances of `{{file1}}` to `{{old_file}}` and all instances of `{{file2}}` to `{{new_file}}` as well as elaborating on the explanations for `diff {{old_file}} {{new_file}}` and `diff -r {{directory1}} {{directory2}}`.

`{{directory1}}` and `{{directory2}}` retain their old names since diffs between directories is a little different. With just the `-r` option it does list differences in files similar to when called with no options but a lot of differences in file structure is just showed as is, for example with output such as "Only in directory2: file1".

The examples themselves are great and left unchanged.