### PR TITLE
multiple pages: standardize domain examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# tldr
 
 [![Build status][travis-image]][travis-url]
 [![Gitter chat][gitter-image]][gitter-url]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# tldr
 
 [![Build status][travis-image]][travis-url]
 [![Gitter chat][gitter-image]][gitter-url]

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -4,19 +4,19 @@
 
 - Lookup the IP(s) associated with a hostname (A records):
 
-`dig +short {{hostname.com}}`
+`dig +short {{example.com}}`
 
 - Lookup the mail server(s) associated with a given domain name (MX record):
 
-`dig +short {{hostname.com}} MX`
+`dig +short {{example.com}} MX`
 
 - Get all types of records for a given domain name:
 
-`dig {{hostname.com}} ANY`
+`dig {{example.com}} ANY`
 
 - Specify an alternate DNS server to query:
 
-`dig @{{8.8.8.8}} {{hostname.com}}`
+`dig @{{8.8.8.8}} {{example.com}}`
 
 - Perform a reverse DNS lookup on an IP address (PTR record):
 
@@ -24,8 +24,8 @@
 
 - Find authoritative name servers for the zone and display SOA records:
 
-`dig +nssearch {{hostname.com}}`
+`dig +nssearch {{example.com}}`
 
 - Perform iterative queries and display the entire trace path to resolve a domain name:
 
-`dig +trace {{hostname.com}}`
+`dig +trace {{example.com}}`

--- a/pages/common/drill.md
+++ b/pages/common/drill.md
@@ -4,19 +4,19 @@
 
 - Lookup the IP(s) associated with a hostname (A records):
 
-`drill {{hostname.com}}`
+`drill {{example.com}}`
 
 - Lookup the mail server(s) associated with a given domain name (MX record):
 
-`drill mx {{hostname.com}}`
+`drill mx {{example.com}}`
 
 - Get all types of records for a given domain name:
 
-`drill any {{hostname.com}}`
+`drill any {{example.com}}`
 
 - Specify an alternate DNS server to query:
 
-`drill {{hostname.com}} @{{8.8.8.8}}`
+`drill {{example.com}} @{{8.8.8.8}}`
 
 - Perform a reverse DNS lookup on an IP address (PTR record):
 
@@ -24,8 +24,8 @@
 
 - Perform DNSSEC trace from root servers down to a domain name:
 
-`drill -TD {{hostname.com}}`
+`drill -TD {{example.com}}`
 
 - Show DNSKEY record(s) for a domain name:
 
-`drill -s dnskey {{hostname.com}}`
+`drill -s dnskey {{example.com}}`

--- a/pages/common/irssi.md
+++ b/pages/common/irssi.md
@@ -4,7 +4,7 @@
 
 - Open irssi and connect to a server with a nickname:
 
-`irssi -n {{nickname}} -c {{server.example.com}}`
+`irssi -n {{nickname}} -c {{irc.example.com}}`
 
 - Open irssi and connect with a specific server on a given port:
 

--- a/pages/common/irssi.md
+++ b/pages/common/irssi.md
@@ -4,11 +4,11 @@
 
 - Open irssi and connect to a server with a nickname:
 
-`irssi -n {{nickname}} -c {{server.name.com}}`
+`irssi -n {{nickname}} -c {{server.example.com}}`
 
 - Open irssi and connect with a specific server on a given port:
 
-`irssi -c {{server.name.com}} -p {{port}}`
+`irssi -c {{server.example.com}} -p {{port}}`
 
 - View the help:
 

--- a/pages/common/irssi.md
+++ b/pages/common/irssi.md
@@ -8,7 +8,7 @@
 
 - Open irssi and connect with a specific server on a given port:
 
-`irssi -c {{server.example.com}} -p {{port}}`
+`irssi -c {{irc.example.com}} -p {{port}}`
 
 - View the help:
 

--- a/pages/common/salt.md
+++ b/pages/common/salt.md
@@ -12,7 +12,7 @@
 
 - Upgrade packages using the OS package manager (apt, yum, brew) on a subset of minions:
 
-`salt '*.domain.com' pkg.upgrade`
+`salt '*.example.com' pkg.upgrade`
 
 - Execute an arbitrary command on a particular minion:
 

--- a/pages/common/socat.md
+++ b/pages/common/socat.md
@@ -8,8 +8,8 @@
 
 - Create a connection to a host and port, transfer data in STDIO to connected host:
 
-`socat - TCP4:www.domain.com:80`
+`socat - TCP4:www.example.com:80`
 
 - Forward incoming data of a local port to another host and port:
 
-`socat TCP-LISTEN:80,fork TCP4:www.domain.com:80`
+`socat TCP-LISTEN:80,fork TCP4:www.example.com:80`


### PR DESCRIPTION
This PR proposes the standardization of domain examples in tldr-pages. 

As most pages already use example.com as example to domains I have decided to keep that and change only the pages that do not follow that. 