### PR TITLE
mas: add page

### DIFF
--- a/pages/osx/mas.md
+++ b/pages/osx/mas.md
@@ -1,0 +1,24 @@
+# mas
+
+> Command line interface for the Mac App Store.
+> Homepage: <https://github.com/mas-cli/mas>.
+
+- Show all installed applications and their product identifiers:
+
+`mas list`
+
+- Search for an application with price included:
+
+`mas search {{application}} --price`
+
+- Install or update an application:
+
+`mas install {{product_identifier}}`
+
+- Install all pending updates:
+
+`mas upgrade`
+
+- Sign into the Mac App Store for the first time:
+
+`mas signin {{user@example.com}}`


### PR DESCRIPTION
I have added [mas](https://github.com/mas-cli/mas) - a CLI tool for the Mac App Store.