### PR TITLE
multiple italian pages: add homepages

### DIFF
--- a/pages.it/common/7z.md
+++ b/pages.it/common/7z.md
@@ -1,4 +1,5 @@
 # 7z
+> Homepage: <https://www.7-zip.org/>.
 
 > Archiviatore di file con alto fattore di compressione.
 

--- a/pages.it/common/7z.md
+++ b/pages.it/common/7z.md
@@ -1,7 +1,7 @@
 # 7z
-> Homepage: <https://www.7-zip.org/>.
 
 > Archiviatore di file con alto fattore di compressione.
+> Homepage: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/7za.md
+++ b/pages.it/common/7za.md
@@ -2,6 +2,7 @@
 
 > Archiviatore di file con alto fattore di compressione.
 > Versione standalone di `7z` con supporto a meno tipi di archivi.
+> Homepage: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/7zr.md
+++ b/pages.it/common/7zr.md
@@ -2,6 +2,7 @@
 
 > Archiviatore di file con alto fattore di compressione.
 > Versione standalone di `7z` che supporta solo file .7z.
+> Homepage: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/ab.md
+++ b/pages.it/common/ab.md
@@ -1,6 +1,7 @@
 # ab
 
 > Strumento di benchmarking di Apache. Il più semplice modo per eseguire un test sul carico del server.
+> Homepage: <https://httpd.apache.org/docs/2.4/programs/ab.html>
 
 - Esegui 100 richieste HTTP GET ad un dato URL:
 

--- a/pages.it/common/abduco.md
+++ b/pages.it/common/abduco.md
@@ -1,6 +1,7 @@
 # abduco
 
 > Gestore di sessioni di terminale.
+> Homepage: <http://www.brain-dump.org/projects/abduco/>.
 
 - List sessioni:
 

--- a/pages.it/common/ack.md
+++ b/pages.it/common/ack.md
@@ -1,6 +1,7 @@
 # ack
 
 > Un tool di ricerca simile a `grep`, ottimizzato per programmatori.
+> Homepage: <https://beyondgrep.com/documentation/>.
 
 - Trova file contenenti "foo":
 

--- a/pages.it/common/adb.md
+++ b/pages.it/common/adb.md
@@ -1,6 +1,7 @@
 # adb
 
 > Android Debug Bridge: comunica con un'instanza di un emulatore Android o con un dispositivo android connesso.
+> Homepage: <https://developer.android.com/studio/command-line/adb>.
 
 - Controlla se il processo server adb è attivo ed avvialo:
 

--- a/pages.it/common/ansible-galaxy.md
+++ b/pages.it/common/ansible-galaxy.md
@@ -1,6 +1,7 @@
 # ansible-galaxy
 
 > Crea e gestisci ruoli di Ansible.
+> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
 
 - Installa un ruolo:
 

--- a/pages.it/common/ansible-playbook.md
+++ b/pages.it/common/ansible-playbook.md
@@ -3,7 +3,6 @@
 > Esegui task definiti nel playbook di un computer remoto via SSH.
 > Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
 
-
 - Esegui tasks nel playbook:
 
 `ansible-playbook {{playbook}}`

--- a/pages.it/common/ansible-playbook.md
+++ b/pages.it/common/ansible-playbook.md
@@ -1,6 +1,8 @@
 # ansible-playbook
 
 > Esegui task definiti nel playbook di un computer remoto via SSH.
+> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+
 
 - Esegui tasks nel playbook:
 

--- a/pages.it/common/ansible.md
+++ b/pages.it/common/ansible.md
@@ -2,6 +2,7 @@
 
 > Gestisci gruppi di computer da remoto via SSH.
 > Usa il file /etc/ansible/hosts per aggiungere nuovi gruppi/host.
+> Homepage: <https://www.ansible.com/>.
 
 - Lista gli host appartenenti ad un gruppo:
 

--- a/pages.it/common/ansiweather.md
+++ b/pages.it/common/ansiweather.md
@@ -1,6 +1,7 @@
 # ansiweather
 
 > Uno script per mostrare le attuali condizioni meteo nel tuo terminale.
+> Homepage: <https://github.com/fcambus/ansiweather>.
 
 - Mostra una previsione usando unità SI per i prossimi cinque giorni in Rzeszow (Polonia):
 

--- a/pages.it/common/asar.md
+++ b/pages.it/common/asar.md
@@ -1,6 +1,7 @@
 # asar
 
 > Gestore di archivi per la piattaforma Electron.
+> Homepage: <https://github.com/electron/asar>.
 
 - Archivia un file o una cartella:
 

--- a/pages.it/common/asciinema.md
+++ b/pages.it/common/asciinema.md
@@ -1,6 +1,7 @@
 # asciinema
 
 > Registra e riproduci sessioni di terminale, condividendole opzionalmente su asciiname.org.
+> Homepage: <https://asciinema.org/>.
 
 - Associa l'installazione locale di `asciiname` ad un account di asciiname.org:
 

--- a/pages.it/common/assimp.md
+++ b/pages.it/common/assimp.md
@@ -2,6 +2,7 @@
 
 > Client da linea di comando per la Open Asset Import Library.
 > Supporta il caricamento di 40+ formati di file per modelli 3D, e l'espoerazione di diversi formati 3D popolari.
+> Homepage: <http://www.assimp.org/>.
 
 - Elenca tutti i formati supportati:
 

--- a/pages.it/common/astyle.md
+++ b/pages.it/common/astyle.md
@@ -2,6 +2,7 @@
 
 > Identificatore di codice sorgente, formattatore e beautifier per i linguaggi C, C++, C# e Java.
 > Quando eseguito, una copia del file originale è creata con l'estensione ".orig" aggiunta come suffisso.
+> Homepage: <http://astyle.sourceforge.net/>.
 
 - Applica lo stile di default di 4 spazi per livello di indentazione e nessun cambiamento alla formattazione:
 

--- a/pages.it/common/atom.md
+++ b/pages.it/common/atom.md
@@ -2,6 +2,7 @@
 
 > Un editor di testo cross-platform personalizzabile.
 > I plugin sono gestiti da `apm`.
+> Homepage: <https://atom.io/>.
 
 - Apri un file o una cartella:
 

--- a/pages.it/common/autoflake.md
+++ b/pages.it/common/autoflake.md
@@ -1,6 +1,7 @@
 # autoflake
 
 > Uno strumento per rimuovere import e variabili inutilizzati da codice Python.
+> Homepage: <https://github.com/myint/autoflake>.
 
 - Rimuovi le variabili inutilizzate da un file e mostra la differenza:
 

--- a/pages.it/common/autojump.md
+++ b/pages.it/common/autojump.md
@@ -2,6 +2,7 @@
 
 > Salta velocemente tra le directory che usi più spesso.
 > Alias come j o jc sono disponibili per una maggiore velocità di scrittura.
+> Homepage: <https://github.com/wting/autojump>.
 
 - Muoviti in una directory il cui nome contiene una parola chiave:
 

--- a/pages.it/common/avrdude.md
+++ b/pages.it/common/avrdude.md
@@ -1,6 +1,7 @@
 # avrdude
 
 > Driver per il programmatore di microcontrollori Atmel AVR.
+> Homepage: <https://www.nongnu.org/avrdude/>.
 
 - Leggi dal microcontrollore AVR:
 

--- a/pages.it/common/axel.md
+++ b/pages.it/common/axel.md
@@ -2,6 +2,7 @@
 
 > Downloader accelerato.
 > Supporta HTTP, HTTPS e FTP.
+> Homepage: <https://github.com/axel-download-accelerator/axel>.
 
 - Scarica un file da un URL:
 

--- a/pages.it/common/babel.md
+++ b/pages.it/common/babel.md
@@ -1,6 +1,7 @@
 # babel
 
 > Un transpiler che converte codice JavaScript da sintassi ES6/ES7 ad ES5.
+> Homepage: <https://babeljs.io/>.
 
 - Transpila uno specifico file e stampa il risultato su stdout:
 

--- a/pages.it/common/beanstalkd.md
+++ b/pages.it/common/beanstalkd.md
@@ -1,6 +1,7 @@
 # beanstalkd
 
 > Un semplice e generico gestore di code di lavoro.
+> Homepage: <https://beanstalkd.github.io/>.
 
 - Avvia beanstalkd, ascoltando sulla porta 11300:
 

--- a/pages.it/common/bedtools.md
+++ b/pages.it/common/bedtools.md
@@ -2,6 +2,7 @@
 
 > Un coltellino svizzero di strumenti per analisi genomica.
 > Usato per intersecare, raggruppare, convertire e contare dati in formato BAM, BED, GFF/GTF, VCF.
+> Homepage: <https://bedtools.readthedocs.io/en/latest/>.
 
 - Interseca i fili genetici delle sequenze contenute in due file diversi e salva il risultato:
 

--- a/pages.it/common/berks.md
+++ b/pages.it/common/berks.md
@@ -1,6 +1,7 @@
 # berks
 
 > Gestore di dipendenze per Chef cookbooks.
+> Homepage: <https://docs.chef.io/berkshelf.html>.
 
 - Installa dipendenze cookbook in una repo locale:
 

--- a/pages.it/common/blender.md
+++ b/pages.it/common/blender.md
@@ -2,6 +2,7 @@
 
 > Interfaccia da linea di comando per il programma di grafica Blender 3D.
 > Gli argomenti sono eseguiti nell'ordine in cui sono dati.
+> Homepage: <https://docs.blender.org/manual/en/latest/render/workflows/command_line.html>.
 
 - Renderizza tutti i frame di una animazione in background, senza caricare l'interfaccia grafica (l'output è salvato in `/tmp`):
 

--- a/pages.it/common/bmaptool.md
+++ b/pages.it/common/bmaptool.md
@@ -1,6 +1,7 @@
 # bmaptool
 
 > Crea o copia blockmap intelligentemente (e quindi più velocemente di `cp` o `dd`).
+> Homepage: <https://source.tizen.org/documentation/reference/bmaptool>.
 
 - Crea una blockmap da un file immagine:
 

--- a/pages.it/common/boot.md
+++ b/pages.it/common/boot.md
@@ -1,6 +1,7 @@
 # boot
 
 > Strumenti di build per il linguaggio di programmazione Clojure.
+> Homepage: <https://github.com/boot-clj/boot>.
 
 - Avvia una sessione REPL con il progetto o da sola:
 

--- a/pages.it/common/borg.md
+++ b/pages.it/common/borg.md
@@ -2,6 +2,7 @@
 
 > Strumento di backup con deduplicazione.
 > Crea backup locali o remoti che sono montabili come filesystem.
+> Homepage: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
 - Inizializza una repository (locale):
 

--- a/pages.it/common/bosh.md
+++ b/pages.it/common/bosh.md
@@ -1,6 +1,7 @@
 # bosh
 
 > Strumento da linea di comando per distribuire e gestire director BOSH.
+> Homepage: <https://bosh.io/docs/cli-v2/>.
 
 - Crea un alias locale per un director:
 

--- a/pages.it/common/bower.md
+++ b/pages.it/common/bower.md
@@ -2,6 +2,7 @@
 
 > Un manager di pacchetti ottimizzato per sviluppo web front-end.
 > Un pacchetto può essere una abbreviazione utente/repo GitHub, un endpoint Git, un URL o un pacchetto registrato.
+> Homepage: <https://bower.io/>.
 
 - Installa le dipendenze di un progetto, listate nel suo file bower.json:
 

--- a/pages.it/common/browser-sync.md
+++ b/pages.it/common/browser-sync.md
@@ -1,6 +1,7 @@
 # browser-sync
 
 > Avvia un web-server locale che si aggiorna al cambiamento dei file.
+> Homepage: <https://browsersync.io/docs/command-line>.
 
 - Avvia un server da una specifica directory:
 

--- a/pages.it/common/bundle.md
+++ b/pages.it/common/bundle.md
@@ -1,6 +1,7 @@
 # bundle
 
 > Gestore di dipendenze per il linguaggio di programmazione Ruby.
+> Homepage: <https://bundler.io/man/bundle.1.html>.
 
 - Installa tutte le gem definite nel gemfile della directory corrente:
 

--- a/pages.it/common/bup.md
+++ b/pages.it/common/bup.md
@@ -1,6 +1,7 @@
 # bup
 
 > Sistema di backup basato sul formato dei packfile git, fornendo salvataggi incrementali veloci e deduplicazione globale.
+> Homepage: <https://github.com/bup/bup>.
 
 - Inizializza una repository di backup nella directory locale specificata:
 

--- a/pages.it/common/bw.md
+++ b/pages.it/common/bw.md
@@ -1,6 +1,7 @@
 # bw
 
 > CLI per accedere e gestire vault Bitwarden.
+> Homepage: <https://help.bitwarden.com/article/cli/>.
 
 - Esegui il login ad un account Bitwarden:
 

--- a/pages.it/common/cabal.md
+++ b/pages.it/common/cabal.md
@@ -2,6 +2,7 @@
 
 > Interfaccia da linea di comando per l'infrastruttura di compilazione di Haskell (Cabal).
 > Gestisce progetti Haskell e pacchetti Cabal dal repository di pacchetti Hackage.
+> Homepage: <https://cabal.readthedocs.io/en/latest/intro.html>.
 
 - Cerca ed elenca pacchetti da Hackage:
 

--- a/pages.it/common/calibre-server.md
+++ b/pages.it/common/calibre-server.md
@@ -3,6 +3,7 @@
 > Un'applicazione server che può essere usata per distribuire ebook in una rete.
 > Gli ebook devono prima essere importati nella libreria usando la GUI o calibredb.
 > Parte del manager di ebook Calibre.
+> Homepage: <https://manual.calibre-ebook.com/generated/en/calibre-server.html>.
 
 - Avvia un server per distribuire ebook. Accesso a http://localhost:8080:
 

--- a/pages.it/common/calibredb.md
+++ b/pages.it/common/calibredb.md
@@ -2,6 +2,7 @@
 
 > Strumentoi per gestire il tuo database di ebook.
 > Parte del manager di ebook Calibre.
+> Homepage: <https://manual.calibre-ebook.com/generated/en/calibredb.html>.
 
 - Elenca gli ebook nella libreria con informazioni aggiuntive:
 

--- a/pages.it/common/cargo.md
+++ b/pages.it/common/cargo.md
@@ -2,6 +2,7 @@
 
 > Gestore di pacchetti di Rust.
 > Gestisce progetti Rust ed i moduli dai quali sono dipendenti (detti crate).
+> Homepage: <https://crates.io/>.
 
 - Cerca una crate:
 

--- a/pages.it/common/clockwork-cli.md
+++ b/pages.it/common/clockwork-cli.md
@@ -1,6 +1,7 @@
 # clockwork-cli
 
 > Una interfaccia da linea di comando per il framework PHP Clockwork.
+> Homepage: <https://github.com/ptrofimov/clockwork-cli>.
 
 - Monitora i log di Clockwork per il progetto corrente:
 

--- a/pages.it/common/cmake.md
+++ b/pages.it/common/cmake.md
@@ -2,6 +2,7 @@
 
 > Generatore di ambienti di compilazione multipiattaforma.
 > Genera Makefile, progetti Visual Studio o altro, in base al sistema operativo.
+> Homepage: <https://cmake.org/cmake/help/v3.2/manual/cmake.1.html>.
 
 - Genera un Makefile ed usalo per compilare un progetto nella stessa directory dei sorgenti:
 


### PR DESCRIPTION
This PR proposes the copy of homepages from English pages to Italian translated pages. 
If this gets accepted I would be happy to do this for every other translated pages we have. 
(I would actually write a script for that instead of doing it by hand haha) 