### PR TITLE
lynis: add page

### DIFF
--- a/pages/linux/lynis.md
+++ b/pages/linux/lynis.md
@@ -1,0 +1,16 @@
+# lynis
+
+> System and security auditing tool.
+> Homepage: <https://cisofy.com/lynis/>.
+
+- Check that Lynis is up-to-date:
+
+`sudo lynis update info`
+
+- Run a security audit of the system:
+
+`sudo lynis audit system`
+
+- Run a security audit of a Dockerfile:
+
+`sudo lynis audit dockerfile {{path/to/dockerfile}}`

--- a/pages/linux/lynis.md
+++ b/pages/linux/lynis.md
@@ -1,7 +1,7 @@
 # lynis
 
 > System and security auditing tool.
-> Homepage: <https://cisofy.com/documentation/lynis/>.
+> Documentation: <https://cisofy.com/documentation/lynis/>.
 
 - Check that Lynis is up-to-date:
 

--- a/pages/linux/lynis.md
+++ b/pages/linux/lynis.md
@@ -1,7 +1,7 @@
 # lynis
 
 > System and security auditing tool.
-> Homepage: <https://cisofy.com/lynis/>.
+> Homepage: <https://cisofy.com/documentation/lynis/>.
 
 - Check that Lynis is up-to-date:
 


### PR DESCRIPTION
Lynis is a brilliant security auditing tool that cacn give you tips on hardening your Linux installation.

Personally I don't think much to the suggestions for SSH (as it doesn't give reasons for some of it's claims, I've found [this](https://sshcheck.com/) to be useful for ssh, as is [this](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server)), but it's great everywhere else.