### PR TITLE
atoum: fix homepage URL

### DIFF
--- a/pages/common/atoum.md
+++ b/pages/common/atoum.md
@@ -1,7 +1,7 @@
 # atoum
 
 > A simple, modern and intuitive unit testing framework for PHP.
-> Homepage: <https://atoum.org>.
+> Homepage: <http://atoum.org>.
 
 - Initialise a configuration file:
 


### PR DESCRIPTION
As noticed in #3024, the URL should be HTTP, not HTTPS.