### PR TITLE
rtcwake: fix command typo

### DIFF
--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -20,7 +20,7 @@
 
 - Disable a previously set alarm:
 
-`sudo rtc -m disable`
+`sudo rtcwake -m disable`
 
 - Perform a dry run to wakup the computer at a given time. (Press Ctrl + C to abort):
 


### PR DESCRIPTION
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
