### PR TITLE
dexter: add page

### DIFF
--- a/pages/common/dexter.md
+++ b/pages/common/dexter.md
@@ -3,7 +3,7 @@
 > Tool for authenticating the kubectl users with OpenId Connect.
 > Homepage: <https://github.com/gini/dexter>.
 
-- Create and authenticate user with Google OIDC:
+- Create and authenticate a user with Google OIDC:
 
 `dexter auth -i {{client-id}} -s {{client-secret}}`
 

--- a/pages/common/dexter.md
+++ b/pages/common/dexter.md
@@ -1,0 +1,12 @@
+# dexter
+
+> Tool for authenticating the kubectl users with OpenId Connect.
+> Homepage: <https://github.com/gini/dexter>.
+
+- Create and authenticate user with Google OIDC:
+
+`dexter auth -i {{client-id}} -s {{client-secret}}`
+
+- Override the default kube config location:
+
+`dexter auth -i {{client-id}} -s {{client-secret}} --kube-config {{sample/config}}`


### PR DESCRIPTION
I have added [dexter](https://github.com/gini/dexter/) - a helper tool for authenticating kubectl users with OpenID Connect.