### PR TITLE
chore: fix use doublequotes and $(..) notation in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ set -ex
 
 function initialize {
   if [ -z "$TLDRHOME" ]; then
-    export TLDRHOME=${TRAVIS_BUILD_DIR:-`pwd`}
+    export TLDRHOME=${TRAVIS_BUILD_DIR:-$(pwd)}
   fi
   export TLDR_ARCHIVE="tldr.zip"
   export SITE_HOME="$HOME/site"
@@ -20,7 +20,7 @@ function initialize {
 
   # Decrypt and add deploy key.
   eval "$(ssh-agent -s)"
-  openssl aes-256-cbc -K $encrypted_973441be79af_key -iv $encrypted_973441be79af_iv -in ./scripts/id_ed25519_tldr_asset_upload.enc -out id_ed25519 -d
+  openssl aes-256-cbc -K "$encrypted_973441be79af_key" -iv "$encrypted_973441be79af_iv" -in ./scripts/id_ed25519_tldr_asset_upload.enc -out id_ed25519 -d
   chmod 600 id_ed25519
   ssh-add id_ed25519
 }
@@ -31,18 +31,18 @@ function rebuild_index {
 }
 
 function build_archive {
-  rm -f $TLDR_ARCHIVE
-  cd $TLDRHOME/
-  zip -r $TLDR_ARCHIVE pages*/ LICENSE.md index.json
+  rm -f "$TLDR_ARCHIVE"
+  cd "$TLDRHOME/"
+  zip -r "$TLDR_ARCHIVE" pages*/ LICENSE.md index.json
   echo "Pages archive created."
 }
 
 function upload_assets {
-  git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git $SITE_HOME
-  mv -f $TLDR_ARCHIVE $SITE_HOME/assets/
-  cp -f $TLDRHOME/index.json $SITE_HOME/assets/
+  git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git "$SITE_HOME"
+  mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
+  cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
 
-  cd $SITE_HOME
+  cd "$SITE_HOME"
   git add -A
   git commit -m "[TravisCI] uploaded assets after commits ${TRAVIS_COMMIT_RANGE}"
   git push -q


### PR DESCRIPTION
see: https://github.com/koalaman/shellcheck/wiki/SC2006 and https://github.com/koalaman/shellcheck/wiki/SC2086