### PR TITLE
conda: update delete an environment

### DIFF
--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -17,7 +17,7 @@
 
 - Delete an environment (remove all packages):
 
-`conda remove --name {{environment_name}} --all`
+`conda env remove -n {{environment_name}}`
 
 - Search conda channels for a package by name:
 


### PR DESCRIPTION
The original command `conda remove --name {{environment_name}} --all` does not work for me on Ubuntu (it works on windows).

I tested another command for it `conda env remove -n {{environment_name}}` and it works on both Ubuntu and Windows.
