### PR TITLE
xclip: add PNG image copying example

### DIFF
--- a/pages/linux/xclip.md
+++ b/pages/linux/xclip.md
@@ -19,6 +19,10 @@
 
 `xclip -sel clip {{input_file.txt}}`
 
+- Copy the contents of a PNG image into the system clipboard (can be pasted in other programs correctly):
+
+`xclip -sel clip -t image/png {{input_file.png}}`
+
 - Paste the contents of the X11 primary selection area to the console:
 
 `xclip -o`


### PR DESCRIPTION
The `-t image/png` argument is required to paste the image correctly in software such as GIMP.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).