### PR TITLE
Refactor: update english and italian pages' links' description.

### DIFF
--- a/pages.it/common/7z.md
+++ b/pages.it/common/7z.md
@@ -1,7 +1,7 @@
 # 7z
 
 > Archiviatore di file con alto fattore di compressione.
-> Homepage: <https://www.7-zip.org/>.
+> Maggiori informazioni: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/7za.md
+++ b/pages.it/common/7za.md
@@ -2,7 +2,7 @@
 
 > Archiviatore di file con alto fattore di compressione.
 > Versione standalone di `7z` con supporto a meno tipi di archivi.
-> Homepage: <https://www.7-zip.org/>.
+> Maggiori informazioni: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/7zr.md
+++ b/pages.it/common/7zr.md
@@ -2,7 +2,7 @@
 
 > Archiviatore di file con alto fattore di compressione.
 > Versione standalone di `7z` che supporta solo file .7z.
-> Homepage: <https://www.7-zip.org/>.
+> Maggiori informazioni: <https://www.7-zip.org/>.
 
 - Archivia un file o una directory:
 

--- a/pages.it/common/ab.md
+++ b/pages.it/common/ab.md
@@ -1,7 +1,7 @@
 # ab
 
 > Strumento di benchmarking di Apache. Il più semplice modo per eseguire un test sul carico del server.
-> Homepage: <https://httpd.apache.org/docs/2.4/programs/ab.html>
+> Maggiori informazioni: <https://httpd.apache.org/docs/2.4/programs/ab.html>
 
 - Esegui 100 richieste HTTP GET ad un dato URL:
 

--- a/pages.it/common/abduco.md
+++ b/pages.it/common/abduco.md
@@ -1,7 +1,7 @@
 # abduco
 
 > Gestore di sessioni di terminale.
-> Homepage: <http://www.brain-dump.org/projects/abduco/>.
+> Maggiori informazioni: <http://www.brain-dump.org/projects/abduco/>.
 
 - List sessioni:
 

--- a/pages.it/common/ack.md
+++ b/pages.it/common/ack.md
@@ -1,7 +1,7 @@
 # ack
 
 > Un tool di ricerca simile a `grep`, ottimizzato per programmatori.
-> Homepage: <https://beyondgrep.com/documentation/>.
+> Maggiori informazioni: <https://beyondgrep.com/documentation/>.
 
 - Trova file contenenti "foo":
 

--- a/pages.it/common/adb.md
+++ b/pages.it/common/adb.md
@@ -1,7 +1,7 @@
 # adb
 
 > Android Debug Bridge: comunica con un'instanza di un emulatore Android o con un dispositivo android connesso.
-> Homepage: <https://developer.android.com/studio/command-line/adb>.
+> Maggiori informazioni: <https://developer.android.com/studio/command-line/adb>.
 
 - Controlla se il processo server adb è attivo ed avvialo:
 

--- a/pages.it/common/ansible-galaxy.md
+++ b/pages.it/common/ansible-galaxy.md
@@ -1,7 +1,7 @@
 # ansible-galaxy
 
 > Crea e gestisci ruoli di Ansible.
-> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+> Maggiori informazioni: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
 
 - Installa un ruolo:
 

--- a/pages.it/common/ansible-playbook.md
+++ b/pages.it/common/ansible-playbook.md
@@ -1,7 +1,7 @@
 # ansible-playbook
 
 > Esegui task definiti nel playbook di un computer remoto via SSH.
-> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+> Maggiori informazioni: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
 
 - Esegui tasks nel playbook:
 

--- a/pages.it/common/ansible.md
+++ b/pages.it/common/ansible.md
@@ -2,7 +2,7 @@
 
 > Gestisci gruppi di computer da remoto via SSH.
 > Usa il file /etc/ansible/hosts per aggiungere nuovi gruppi/host.
-> Homepage: <https://www.ansible.com/>.
+> Maggiori informazioni: <https://www.ansible.com/>.
 
 - Lista gli host appartenenti ad un gruppo:
 

--- a/pages.it/common/ansiweather.md
+++ b/pages.it/common/ansiweather.md
@@ -1,7 +1,7 @@
 # ansiweather
 
 > Uno script per mostrare le attuali condizioni meteo nel tuo terminale.
-> Homepage: <https://github.com/fcambus/ansiweather>.
+> Maggiori informazioni: <https://github.com/fcambus/ansiweather>.
 
 - Mostra una previsione usando unità SI per i prossimi cinque giorni in Rzeszow (Polonia):
 

--- a/pages.it/common/asar.md
+++ b/pages.it/common/asar.md
@@ -1,7 +1,7 @@
 # asar
 
 > Gestore di archivi per la piattaforma Electron.
-> Homepage: <https://github.com/electron/asar>.
+> Maggiori informazioni: <https://github.com/electron/asar>.
 
 - Archivia un file o una cartella:
 

--- a/pages.it/common/asciinema.md
+++ b/pages.it/common/asciinema.md
@@ -1,7 +1,7 @@
 # asciinema
 
 > Registra e riproduci sessioni di terminale, condividendole opzionalmente su asciiname.org.
-> Homepage: <https://asciinema.org/>.
+> Maggiori informazioni: <https://asciinema.org/>.
 
 - Associa l'installazione locale di `asciiname` ad un account di asciiname.org:
 

--- a/pages.it/common/assimp.md
+++ b/pages.it/common/assimp.md
@@ -2,7 +2,7 @@
 
 > Client da linea di comando per la Open Asset Import Library.
 > Supporta il caricamento di 40+ formati di file per modelli 3D, e l'espoerazione di diversi formati 3D popolari.
-> Homepage: <http://www.assimp.org/>.
+> Maggiori informazioni: <http://www.assimp.org/>.
 
 - Elenca tutti i formati supportati:
 

--- a/pages.it/common/astyle.md
+++ b/pages.it/common/astyle.md
@@ -2,7 +2,7 @@
 
 > Identificatore di codice sorgente, formattatore e beautifier per i linguaggi C, C++, C# e Java.
 > Quando eseguito, una copia del file originale è creata con l'estensione ".orig" aggiunta come suffisso.
-> Homepage: <http://astyle.sourceforge.net/>.
+> Maggiori informazioni: <http://astyle.sourceforge.net/>.
 
 - Applica lo stile di default di 4 spazi per livello di indentazione e nessun cambiamento alla formattazione:
 

--- a/pages.it/common/atom.md
+++ b/pages.it/common/atom.md
@@ -2,7 +2,7 @@
 
 > Un editor di testo cross-platform personalizzabile.
 > I plugin sono gestiti da `apm`.
-> Homepage: <https://atom.io/>.
+> Maggiori informazioni: <https://atom.io/>.
 
 - Apri un file o una cartella:
 

--- a/pages.it/common/autoflake.md
+++ b/pages.it/common/autoflake.md
@@ -1,7 +1,7 @@
 # autoflake
 
 > Uno strumento per rimuovere import e variabili inutilizzati da codice Python.
-> Homepage: <https://github.com/myint/autoflake>.
+> Maggiori informazioni: <https://github.com/myint/autoflake>.
 
 - Rimuovi le variabili inutilizzate da un file e mostra la differenza:
 

--- a/pages.it/common/autojump.md
+++ b/pages.it/common/autojump.md
@@ -2,7 +2,7 @@
 
 > Salta velocemente tra le directory che usi più spesso.
 > Alias come j o jc sono disponibili per una maggiore velocità di scrittura.
-> Homepage: <https://github.com/wting/autojump>.
+> Maggiori informazioni: <https://github.com/wting/autojump>.
 
 - Muoviti in una directory il cui nome contiene una parola chiave:
 

--- a/pages.it/common/avrdude.md
+++ b/pages.it/common/avrdude.md
@@ -1,7 +1,7 @@
 # avrdude
 
 > Driver per il programmatore di microcontrollori Atmel AVR.
-> Homepage: <https://www.nongnu.org/avrdude/>.
+> Maggiori informazioni: <https://www.nongnu.org/avrdude/>.
 
 - Leggi dal microcontrollore AVR:
 

--- a/pages.it/common/axel.md
+++ b/pages.it/common/axel.md
@@ -2,7 +2,7 @@
 
 > Downloader accelerato.
 > Supporta HTTP, HTTPS e FTP.
-> Homepage: <https://github.com/axel-download-accelerator/axel>.
+> Maggiori informazioni: <https://github.com/axel-download-accelerator/axel>.
 
 - Scarica un file da un URL:
 

--- a/pages.it/common/babel.md
+++ b/pages.it/common/babel.md
@@ -1,7 +1,7 @@
 # babel
 
 > Un transpiler che converte codice JavaScript da sintassi ES6/ES7 ad ES5.
-> Homepage: <https://babeljs.io/>.
+> Maggiori informazioni: <https://babeljs.io/>.
 
 - Transpila uno specifico file e stampa il risultato su stdout:
 

--- a/pages.it/common/beanstalkd.md
+++ b/pages.it/common/beanstalkd.md
@@ -1,7 +1,7 @@
 # beanstalkd
 
 > Un semplice e generico gestore di code di lavoro.
-> Homepage: <https://beanstalkd.github.io/>.
+> Maggiori informazioni: <https://beanstalkd.github.io/>.
 
 - Avvia beanstalkd, ascoltando sulla porta 11300:
 

--- a/pages.it/common/bedtools.md
+++ b/pages.it/common/bedtools.md
@@ -2,7 +2,7 @@
 
 > Un coltellino svizzero di strumenti per analisi genomica.
 > Usato per intersecare, raggruppare, convertire e contare dati in formato BAM, BED, GFF/GTF, VCF.
-> Homepage: <https://bedtools.readthedocs.io/en/latest/>.
+> Maggiori informazioni: <https://bedtools.readthedocs.io/en/latest/>.
 
 - Interseca i fili genetici delle sequenze contenute in due file diversi e salva il risultato:
 

--- a/pages.it/common/berks.md
+++ b/pages.it/common/berks.md
@@ -1,7 +1,7 @@
 # berks
 
 > Gestore di dipendenze per Chef cookbooks.
-> Homepage: <https://docs.chef.io/berkshelf.html>.
+> Maggiori informazioni: <https://docs.chef.io/berkshelf.html>.
 
 - Installa dipendenze cookbook in una repo locale:
 

--- a/pages.it/common/blender.md
+++ b/pages.it/common/blender.md
@@ -2,7 +2,7 @@
 
 > Interfaccia da linea di comando per il programma di grafica Blender 3D.
 > Gli argomenti sono eseguiti nell'ordine in cui sono dati.
-> Homepage: <https://docs.blender.org/manual/en/latest/render/workflows/command_line.html>.
+> Maggiori informazioni: <https://docs.blender.org/manual/en/latest/render/workflows/command_line.html>.
 
 - Renderizza tutti i frame di una animazione in background, senza caricare l'interfaccia grafica (l'output è salvato in `/tmp`):
 

--- a/pages.it/common/bmaptool.md
+++ b/pages.it/common/bmaptool.md
@@ -1,7 +1,7 @@
 # bmaptool
 
 > Crea o copia blockmap intelligentemente (e quindi più velocemente di `cp` o `dd`).
-> Homepage: <https://source.tizen.org/documentation/reference/bmaptool>.
+> Maggiori informazioni: <https://source.tizen.org/documentation/reference/bmaptool>.
 
 - Crea una blockmap da un file immagine:
 

--- a/pages.it/common/boot.md
+++ b/pages.it/common/boot.md
@@ -1,7 +1,7 @@
 # boot
 
 > Strumenti di build per il linguaggio di programmazione Clojure.
-> Homepage: <https://github.com/boot-clj/boot>.
+> Maggiori informazioni: <https://github.com/boot-clj/boot>.
 
 - Avvia una sessione REPL con il progetto o da sola:
 

--- a/pages.it/common/borg.md
+++ b/pages.it/common/borg.md
@@ -2,7 +2,7 @@
 
 > Strumento di backup con deduplicazione.
 > Crea backup locali o remoti che sono montabili come filesystem.
-> Homepage: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
+> Maggiori informazioni: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
 - Inizializza una repository (locale):
 

--- a/pages.it/common/bosh.md
+++ b/pages.it/common/bosh.md
@@ -1,7 +1,7 @@
 # bosh
 
 > Strumento da linea di comando per distribuire e gestire director BOSH.
-> Homepage: <https://bosh.io/docs/cli-v2/>.
+> Maggiori informazioni: <https://bosh.io/docs/cli-v2/>.
 
 - Crea un alias locale per un director:
 

--- a/pages.it/common/bower.md
+++ b/pages.it/common/bower.md
@@ -2,7 +2,7 @@
 
 > Un manager di pacchetti ottimizzato per sviluppo web front-end.
 > Un pacchetto può essere una abbreviazione utente/repo GitHub, un endpoint Git, un URL o un pacchetto registrato.
-> Homepage: <https://bower.io/>.
+> Maggiori informazioni: <https://bower.io/>.
 
 - Installa le dipendenze di un progetto, listate nel suo file bower.json:
 

--- a/pages.it/common/browser-sync.md
+++ b/pages.it/common/browser-sync.md
@@ -1,7 +1,7 @@
 # browser-sync
 
 > Avvia un web-server locale che si aggiorna al cambiamento dei file.
-> Homepage: <https://browsersync.io/docs/command-line>.
+> Maggiori informazioni: <https://browsersync.io/docs/command-line>.
 
 - Avvia un server da una specifica directory:
 

--- a/pages.it/common/bundle.md
+++ b/pages.it/common/bundle.md
@@ -1,7 +1,7 @@
 # bundle
 
 > Gestore di dipendenze per il linguaggio di programmazione Ruby.
-> Homepage: <https://bundler.io/man/bundle.1.html>.
+> Maggiori informazioni: <https://bundler.io/man/bundle.1.html>.
 
 - Installa tutte le gem definite nel gemfile della directory corrente:
 

--- a/pages.it/common/bup.md
+++ b/pages.it/common/bup.md
@@ -1,7 +1,7 @@
 # bup
 
 > Sistema di backup basato sul formato dei packfile git, fornendo salvataggi incrementali veloci e deduplicazione globale.
-> Homepage: <https://github.com/bup/bup>.
+> Maggiori informazioni: <https://github.com/bup/bup>.
 
 - Inizializza una repository di backup nella directory locale specificata:
 

--- a/pages.it/common/bw.md
+++ b/pages.it/common/bw.md
@@ -1,7 +1,7 @@
 # bw
 
 > CLI per accedere e gestire vault Bitwarden.
-> Homepage: <https://help.bitwarden.com/article/cli/>.
+> Maggiori informazioni: <https://help.bitwarden.com/article/cli/>.
 
 - Esegui il login ad un account Bitwarden:
 

--- a/pages.it/common/cabal.md
+++ b/pages.it/common/cabal.md
@@ -2,7 +2,7 @@
 
 > Interfaccia da linea di comando per l'infrastruttura di compilazione di Haskell (Cabal).
 > Gestisce progetti Haskell e pacchetti Cabal dal repository di pacchetti Hackage.
-> Homepage: <https://cabal.readthedocs.io/en/latest/intro.html>.
+> Maggiori informazioni: <https://cabal.readthedocs.io/en/latest/intro.html>.
 
 - Cerca ed elenca pacchetti da Hackage:
 

--- a/pages.it/common/calibre-server.md
+++ b/pages.it/common/calibre-server.md
@@ -3,7 +3,7 @@
 > Un'applicazione server che può essere usata per distribuire ebook in una rete.
 > Gli ebook devono prima essere importati nella libreria usando la GUI o calibredb.
 > Parte del manager di ebook Calibre.
-> Homepage: <https://manual.calibre-ebook.com/generated/en/calibre-server.html>.
+> Maggiori informazioni: <https://manual.calibre-ebook.com/generated/en/calibre-server.html>.
 
 - Avvia un server per distribuire ebook. Accesso a http://localhost:8080:
 

--- a/pages.it/common/calibredb.md
+++ b/pages.it/common/calibredb.md
@@ -2,7 +2,7 @@
 
 > Strumentoi per gestire il tuo database di ebook.
 > Parte del manager di ebook Calibre.
-> Homepage: <https://manual.calibre-ebook.com/generated/en/calibredb.html>.
+> Maggiori informazioni: <https://manual.calibre-ebook.com/generated/en/calibredb.html>.
 
 - Elenca gli ebook nella libreria con informazioni aggiuntive:
 

--- a/pages.it/common/cargo.md
+++ b/pages.it/common/cargo.md
@@ -2,7 +2,7 @@
 
 > Gestore di pacchetti di Rust.
 > Gestisce progetti Rust ed i moduli dai quali sono dipendenti (detti crate).
-> Homepage: <https://crates.io/>.
+> Maggiori informazioni: <https://crates.io/>.
 
 - Cerca una crate:
 

--- a/pages.it/common/clockwork-cli.md
+++ b/pages.it/common/clockwork-cli.md
@@ -1,7 +1,7 @@
 # clockwork-cli
 
 > Una interfaccia da linea di comando per il framework PHP Clockwork.
-> Homepage: <https://github.com/ptrofimov/clockwork-cli>.
+> Maggiori informazioni: <https://github.com/ptrofimov/clockwork-cli>.
 
 - Monitora i log di Clockwork per il progetto corrente:
 

--- a/pages.it/common/cmake.md
+++ b/pages.it/common/cmake.md
@@ -2,7 +2,7 @@
 
 > Generatore di ambienti di compilazione multipiattaforma.
 > Genera Makefile, progetti Visual Studio o altro, in base al sistema operativo.
-> Homepage: <https://cmake.org/cmake/help/v3.2/manual/cmake.1.html>.
+> Maggiori informazioni: <https://cmake.org/cmake/help/v3.2/manual/cmake.1.html>.
 
 - Genera un Makefile ed usalo per compilare un progetto nella stessa directory dei sorgenti:
 

--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -1,7 +1,7 @@
 # 7z
 
 > A file archiver with high compression ratio.
-> Homepage: <https://www.7-zip.org/>.
+> More information: <https://www.7-zip.org/>.
 
 - Archive a file or directory:
 

--- a/pages/common/7za.md
+++ b/pages/common/7za.md
@@ -2,7 +2,7 @@
 
 > A file archiver with high compression ratio.
 > A standalone version of `7z` with support for fewer archive types.
-> Homepage: <https://www.7-zip.org/>.
+> More information: <https://www.7-zip.org/>.
 
 - Archive a file or directory:
 

--- a/pages/common/7zr.md
+++ b/pages/common/7zr.md
@@ -2,7 +2,7 @@
 
 > A file archiver with high compression ratio.
 > A standalone version of `7z` that only supports .7z files.
-> Homepage: <https://www.7-zip.org/>.
+> More information: <https://www.7-zip.org/>.
 
 - Archive a file or directory:
 

--- a/pages/common/ab.md
+++ b/pages/common/ab.md
@@ -1,7 +1,7 @@
 # ab
 
 > Apache Benchmarking tool. The simplest tool to perform a load testing.
-> Homepage: <https://httpd.apache.org/docs/2.4/programs/ab.html>.
+> More information: <https://httpd.apache.org/docs/2.4/programs/ab.html>.
 
 - Execute 100 HTTP GET requests to given URL:
 

--- a/pages/common/abduco.md
+++ b/pages/common/abduco.md
@@ -1,7 +1,7 @@
 # abduco
 
 > Terminal session manager.
-> Homepage: <http://www.brain-dump.org/projects/abduco/>.
+> More information: <http://www.brain-dump.org/projects/abduco/>.
 
 - List sessions:
 

--- a/pages/common/ack.md
+++ b/pages/common/ack.md
@@ -1,7 +1,7 @@
 # ack
 
 > A search tool like grep, optimized for programmers.
-> Homepage: <https://beyondgrep.com/documentation/>.
+> More information: <https://beyondgrep.com/documentation/>.
 
 - Find files containing "foo":
 

--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -1,7 +1,7 @@
 # adb
 
 > Android Debug Bridge: communicate with an Android emulator instance or connected Android devices.
-> Homepage: <https://developer.android.com/studio/command-line/adb>.
+> More information: <https://developer.android.com/studio/command-line/adb>.
 
 - Check whether the adb server process is running and start it:
 

--- a/pages/common/alex.md
+++ b/pages/common/alex.md
@@ -2,7 +2,7 @@
 
 > A tool that catches insensitive, inconsiderate writing.
 > It helps you find gender favouring, polarising, race related, religion inconsiderate, or other unequal phrasing in text.
-> Homepage: <https://github.com/get-alex/alex>.
+> More information: <https://github.com/get-alex/alex>.
 
 - Analyze text from `stdin`:
 

--- a/pages/common/ansible-galaxy.md
+++ b/pages/common/ansible-galaxy.md
@@ -1,7 +1,7 @@
 # ansible-galaxy
 
 > Create and manage Ansible roles.
-> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+> More information: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
 
 - Install a role:
 

--- a/pages/common/ansible-playbook.md
+++ b/pages/common/ansible-playbook.md
@@ -1,7 +1,7 @@
 # ansible-playbook
 
 > Execute tasks defined in playbook on remote machines over SSH.
-> Homepage: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+> More information: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
 
 - Run tasks in playbook:
 

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -2,7 +2,7 @@
 
 > Manage groups of computers remotely over SSH.
 > Use the /etc/ansible/hosts file to add new groups/hosts.
-> Homepage: <https://www.ansible.com/>.
+> More information: <https://www.ansible.com/>.
 
 - List hosts belonging to a group:
 

--- a/pages/common/ansiweather.md
+++ b/pages/common/ansiweather.md
@@ -1,7 +1,7 @@
 # ansiweather
 
 > A shell script for displaying the current weather conditions in your terminal.
-> Homepage: <https://github.com/fcambus/ansiweather>.
+> More information: <https://github.com/fcambus/ansiweather>.
 
 - Display a forecast using metric units for the next five days for Rzeszow, Poland:
 

--- a/pages/common/aria2.md
+++ b/pages/common/aria2.md
@@ -2,7 +2,7 @@
 
 > A lightweight multi-protocol & multi-source command-line download utility.
 > Supports HTTP, HTTPS, FTP, SFTP, BitTorrent and Metalink.
-> Homepage: <https://aria2.github.io/>.
+> More information: <https://aria2.github.io/>.
 
 - Download a web resource:
 

--- a/pages/common/asar.md
+++ b/pages/common/asar.md
@@ -1,7 +1,7 @@
 # asar
 
 > A file archiver for the Electron platform.
-> Homepage: <https://github.com/electron/asar>.
+> More information: <https://github.com/electron/asar>.
 
 - Archive a file or directory:
 

--- a/pages/common/asciinema.md
+++ b/pages/common/asciinema.md
@@ -1,7 +1,7 @@
 # asciinema
 
 > Record and replay terminal sessions, and optionally share them on asciinema.org.
-> Homepage: <https://asciinema.org/>.
+> More information: <https://asciinema.org/>.
 
 - Associate the local install of `asciinema` with an asciinema.org account:
 

--- a/pages/common/asdf.md
+++ b/pages/common/asdf.md
@@ -1,7 +1,7 @@
 # asdf
 
 > Command line interface for managing versions of different packages.
-> Homepage: <https://asdf-vm.com>.
+> More information: <https://asdf-vm.com>.
 
 - List all available plugins:
 

--- a/pages/common/assimp.md
+++ b/pages/common/assimp.md
@@ -2,7 +2,7 @@
 
 > Command-line client for the Open Asset Import Library.
 > Supports loading of 40+ 3D file formats, and exporting to several popular 3D formats.
-> Homepage: <http://www.assimp.org/>.
+> More information: <http://www.assimp.org/>.
 
 - List all supported import formats:
 

--- a/pages/common/astyle.md
+++ b/pages/common/astyle.md
@@ -2,7 +2,7 @@
 
 > Source code indenter, formatter, and beautifier for the C, C++, C# and Java programming languages.
 > Upon running, a copy of the original file is created with an ".orig" appended to the original file name.
-> Homepage: <http://astyle.sourceforge.net/>.
+> More information: <http://astyle.sourceforge.net/>.
 
 - Apply the default style of 4 spaces per indent and no formatting changes:
 

--- a/pages/common/atom.md
+++ b/pages/common/atom.md
@@ -2,7 +2,7 @@
 
 > A cross-platform pluggable text editor.
 > Plugins are managed by `apm`.
-> Homepage: <https://atom.io/>.
+> More information: <https://atom.io/>.
 
 - Open a file or directory:
 

--- a/pages/common/atoum.md
+++ b/pages/common/atoum.md
@@ -1,7 +1,7 @@
 # atoum
 
 > A simple, modern and intuitive unit testing framework for PHP.
-> Homepage: <http://atoum.org>.
+> More information: <http://atoum.org>.
 
 - Initialise a configuration file:
 

--- a/pages/common/autoflake.md
+++ b/pages/common/autoflake.md
@@ -1,7 +1,7 @@
 # autoflake
 
 > A tool to remove unused imports and variables from Python code.
-> Homepage: <https://github.com/myint/autoflake>.
+> More information: <https://github.com/myint/autoflake>.
 
 - Remove unused variables from a single file and display the diff:
 

--- a/pages/common/autojump.md
+++ b/pages/common/autojump.md
@@ -2,7 +2,7 @@
 
 > Quickly jump among the directories you visit the most.
 > Aliases like j or jc are provided for even less typing.
-> Homepage: <https://github.com/wting/autojump>.
+> More information: <https://github.com/wting/autojump>.
 
 - Jump to a directory that contains the given pattern:
 

--- a/pages/common/avrdude.md
+++ b/pages/common/avrdude.md
@@ -1,7 +1,7 @@
 # avrdude
 
 > Driver program for Atmel AVR microcontrollers programming.
-> Homepage: <https://www.nongnu.org/avrdude/>.
+> More information: <https://www.nongnu.org/avrdude/>.
 
 - Read AVR microcontroller:
 

--- a/pages/common/axel.md
+++ b/pages/common/axel.md
@@ -2,7 +2,7 @@
 
 > Download accelerator.
 > Supports HTTP, HTTPS, and FTP.
-> Homepage: <https://github.com/axel-download-accelerator/axel>.
+> More information: <https://github.com/axel-download-accelerator/axel>.
 
 - Download a URL to a file:
 

--- a/pages/common/babel.md
+++ b/pages/common/babel.md
@@ -1,7 +1,7 @@
 # babel
 
 > A transpiler which converts code from JavaScript ES6/ES7 syntax to ES5 syntax.
-> Homepage: <https://babeljs.io/>.
+> More information: <https://babeljs.io/>.
 
 - Transpile a specified input file and output to stdout:
 

--- a/pages/common/beanstalkd.md
+++ b/pages/common/beanstalkd.md
@@ -1,7 +1,7 @@
 # beanstalkd
 
 > A simple and generic work-queue server.
-> Homepage: <https://beanstalkd.github.io/>.
+> More information: <https://beanstalkd.github.io/>.
 
 - Start beanstalkd, listening on port 11300:
 

--- a/pages/common/bedtools.md
+++ b/pages/common/bedtools.md
@@ -2,7 +2,7 @@
 
 > A swiss-army knife of tools for genomic-analysis tasks.
 > Used to intersect, group, convert and count data in BAM, BED, GFF/GTF, VCF format.
-> Homepage: <https://bedtools.readthedocs.io/en/latest/>.
+> More information: <https://bedtools.readthedocs.io/en/latest/>.
 
 - Intersect two files with respect to the sequences' strand and save the result to {{path/to/output_file}}:
 

--- a/pages/common/berks.md
+++ b/pages/common/berks.md
@@ -1,7 +1,7 @@
 # berks
 
 > Chef cookbook dependency manager.
-> Homepage: <https://docs.chef.io/berkshelf.html>.
+> More information: <https://docs.chef.io/berkshelf.html>.
 
 - Install cookbook dependencies into a local repo:
 

--- a/pages/common/blackfire.md
+++ b/pages/common/blackfire.md
@@ -1,7 +1,7 @@
 # blackfire
 
 > A command line profiling tool for PHP.
-> Homepage: <https://blackfire.io>.
+> More information: <https://blackfire.io>.
 
 - Initialise and configure the Blackfire client:
 

--- a/pages/common/blender.md
+++ b/pages/common/blender.md
@@ -2,7 +2,7 @@
 
 > Command-line interface to the Blender 3D computer graphics application.
 > Arguments are executed in the order they are given.
-> Homepage: <https://docs.blender.org/manual/en/latest/render/workflows/command_line.html>.
+> More information: <https://docs.blender.org/manual/en/latest/render/workflows/command_line.html>.
 
 - Render all frames of an animation in the background, without loading the UI (output is saved to `/tmp`):
 

--- a/pages/common/bmaptool.md
+++ b/pages/common/bmaptool.md
@@ -1,7 +1,7 @@
 # bmaptool
 
 > Create or Copy blockmaps intelligently (and therefore faster than `cp` or `dd`).
-> Homepage: <https://source.tizen.org/documentation/reference/bmaptool>.
+> More information: <https://source.tizen.org/documentation/reference/bmaptool>.
 
 - Create a blockmap from image file:
 

--- a/pages/common/boot.md
+++ b/pages/common/boot.md
@@ -1,7 +1,7 @@
 # boot
 
 > Build tooling for the Clojure programming language.
-> Homepage: <https://github.com/boot-clj/boot>.
+> More information: <https://github.com/boot-clj/boot>.
 
 - Start a REPL session either with the project or standalone:
 

--- a/pages/common/borg.md
+++ b/pages/common/borg.md
@@ -2,7 +2,7 @@
 
 > Deduplicating backup tool.
 > Creates local or remote backups that are mountable as filesystems.
-> Homepage: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
+> More information: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
 - Initialise a (local) repository:
 

--- a/pages/common/bosh.md
+++ b/pages/common/bosh.md
@@ -1,7 +1,7 @@
 # bosh
 
 > Command line tool to deploy and manage the bosh director.
-> Homepage: <https://bosh.io/docs/cli-v2/>.
+> More information: <https://bosh.io/docs/cli-v2/>.
 
 - Create local alias for director:
 

--- a/pages/common/bower.md
+++ b/pages/common/bower.md
@@ -2,7 +2,7 @@
 
 > A package manager optimized for front-end web development.
 > A package can be a GitHub user/repo shorthand, a Git endpoint, a URL or a registered package.
-> Homepage: <https://bower.io/>.
+> More information: <https://bower.io/>.
 
 - Install a project's dependencies, listed in its bower.json:
 

--- a/pages/common/browser-sync.md
+++ b/pages/common/browser-sync.md
@@ -1,7 +1,7 @@
 # browser-sync
 
 > Starts local web server that updates browser on file changes.
-> Homepage: <https://browsersync.io/docs/command-line>.
+> More information: <https://browsersync.io/docs/command-line>.
 
 - Start a server from a specific directory:
 

--- a/pages/common/bundle.md
+++ b/pages/common/bundle.md
@@ -1,7 +1,7 @@
 # bundle
 
 > Dependency manager for the Ruby programming language.
-> Homepage: <https://bundler.io/man/bundle.1.html>.
+> More information: <https://bundler.io/man/bundle.1.html>.
 
 - Install all gems defined in the `Gemfile` expected in the working directory:
 

--- a/pages/common/bup.md
+++ b/pages/common/bup.md
@@ -1,7 +1,7 @@
 # bup
 
 > Backup system based on the git packfile format, providing fast incremental saves and global deduplication.
-> Homepage: <https://github.com/bup/bup>.
+> More information: <https://github.com/bup/bup>.
 
 - Initialize a backup repository in the specified local directory:
 

--- a/pages/common/bw.md
+++ b/pages/common/bw.md
@@ -1,7 +1,7 @@
 # bw
 
 > A CLI to access and manage a Bitwarden vault.
-> Homepage: <https://help.bitwarden.com/article/cli/>.
+> More information: <https://help.bitwarden.com/article/cli/>.
 
 - Log in to a Bitwarden user account:
 

--- a/pages/common/cabal.md
+++ b/pages/common/cabal.md
@@ -2,7 +2,7 @@
 
 > Command line interface to the Haskell package infrastructure (Cabal).
 > Manage Haskell projects and Cabal packages from the Hackage package repository.
-> Homepage: <https://cabal.readthedocs.io/en/latest/intro.html>.
+> More information: <https://cabal.readthedocs.io/en/latest/intro.html>.
 
 - Search and list packages from Hackage:
 

--- a/pages/common/calibre-server.md
+++ b/pages/common/calibre-server.md
@@ -3,7 +3,7 @@
 > A server application that can be used to distribute ebooks over a network.
 > Ebooks must be imported into the library using the GUI or calibredb before.
 > Part of the Calibre ebook library.
-> Homepage: <https://manual.calibre-ebook.com/generated/en/calibre-server.html>.
+> More information: <https://manual.calibre-ebook.com/generated/en/calibre-server.html>.
 
 - Start a server to distribute ebooks. Access at http://localhost:8080:
 

--- a/pages/common/calibredb.md
+++ b/pages/common/calibredb.md
@@ -2,7 +2,7 @@
 
 > Tool to manipulate the your ebook database.
 > Part of the Calibre ebook library.
-> Homepage: <https://manual.calibre-ebook.com/generated/en/calibredb.html>.
+> More information: <https://manual.calibre-ebook.com/generated/en/calibredb.html>.
 
 - List ebooks in the library with additional information:
 

--- a/pages/common/cargo.md
+++ b/pages/common/cargo.md
@@ -2,7 +2,7 @@
 
 > Rust package manager.
 > Manage Rust projects and their module dependencies (crates).
-> Homepage: <https://crates.io/>.
+> More information: <https://crates.io/>.
 
 - Search for crates:
 

--- a/pages/common/clamscan.md
+++ b/pages/common/clamscan.md
@@ -1,7 +1,7 @@
 # clamscan
 
 > A command line virus scanner.
-> Homepage: <https://www.clamav.net>.
+> More information: <https://www.clamav.net>.
 
 - Scan a file for vulnerabilities:
 

--- a/pages/common/clang.md
+++ b/pages/common/clang.md
@@ -1,7 +1,7 @@
 # clang
 
 > Compiler for C, C++, and Objective-C source files. Can be used as a drop-in replacement for GCC.
-> Homepage: <https://clang.llvm.org/docs/ClangCommandLineReference.html>.
+> More information: <https://clang.llvm.org/docs/ClangCommandLineReference.html>.
 
 - Compile a source code file into an executable binary:
 

--- a/pages/common/clementine.md
+++ b/pages/common/clementine.md
@@ -1,7 +1,7 @@
 # clementine
 
 > A modern music player and library organizer.
-> Homepage: <https://www.clementine-player.org>.
+> More information: <https://www.clementine-player.org>.
 
 - Open Clementine:
 

--- a/pages/common/clockwork-cli.md
+++ b/pages/common/clockwork-cli.md
@@ -1,7 +1,7 @@
 # clockwork-cli
 
 > A command line interface for the Clockwork PHP debugging framework.
-> Homepage: <https://github.com/ptrofimov/clockwork-cli>.
+> More information: <https://github.com/ptrofimov/clockwork-cli>.
 
 - Monitor Clockwork logs for the current project:
 

--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -2,7 +2,7 @@
 
 > Cross-platform build system generator.
 > It generates Makefiles, Visual Studio projects or others, depending on the target system.
-> Homepage: <https://cmake.org/cmake/help/v3.2/manual/cmake.1.html>.
+> More information: <https://cmake.org/cmake/help/v3.2/manual/cmake.1.html>.
 
 - Generate a Makefile and use it to compile a project in the same directory as the source:
 

--- a/pages/common/code.md
+++ b/pages/common/code.md
@@ -1,7 +1,7 @@
 # code
 
 > Visual Studio Code.
-> Homepage: <https://github.com/microsoft/vscode>.
+> More information: <https://github.com/microsoft/vscode>.
 
 - Open VS Code:
 

--- a/pages/common/composer.md
+++ b/pages/common/composer.md
@@ -1,7 +1,7 @@
 # composer
 
 > A package-based dependency manager for PHP projects.
-> Homepage: <https://getcomposer.org/>.
+> More information: <https://getcomposer.org/>.
 
 - Add a package as a dependency for this project, adding it to `composer.json`:
 

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -1,7 +1,7 @@
 # conda
 
 > Package, dependency and environment management for any programming language.
-> Homepage: <https://github.com/conda/conda>.
+> More information: <https://github.com/conda/conda>.
 
 - Create a new environment, installing named packages into it:
 

--- a/pages/common/consul-kv.md
+++ b/pages/common/consul-kv.md
@@ -1,7 +1,7 @@
 # consul-kv
 
 > Distributed key-value store with health checking and service discovery.
-> Homepage: <https://learn.hashicorp.com/consul/getting-started/kv>.
+> More information: <https://learn.hashicorp.com/consul/getting-started/kv>.
 
 - Read a value from the key-value store:
 

--- a/pages/common/consul.md
+++ b/pages/common/consul.md
@@ -1,7 +1,7 @@
 # consul
 
 > Distributed key-value store with health checking and service discovery.
-> Homepage: <https://www.consul.io/docs/commands/index.html>.
+> More information: <https://www.consul.io/docs/commands/index.html>.
 
 - Check the Consul version:
 

--- a/pages/common/convert.md
+++ b/pages/common/convert.md
@@ -1,7 +1,7 @@
 # convert
 
 > Imagemagick image conversion tool.
-> Homepage: <https://imagemagick.org/script/convert.php>.
+> More information: <https://imagemagick.org/script/convert.php>.
 
 - Convert an image from JPG to PNG:
 

--- a/pages/common/convmv.md
+++ b/pages/common/convmv.md
@@ -1,7 +1,7 @@
 # convmv
 
 > Convert filenames (NOT file content) from one encoding to another.
-> Homepage: <https://www.j3e.de/linux/convmv/man/>.
+> More information: <https://www.j3e.de/linux/convmv/man/>.
 
 - Test filename encoding conversion (don't actually change the filename):
 

--- a/pages/common/cordova.md
+++ b/pages/common/cordova.md
@@ -1,7 +1,7 @@
 # cordova
 
 > Mobile apps with HTML, CSS & JS.
-> Homepage: <https://cordova.apache.org/docs/en/latest/guide/cli/>.
+> More information: <https://cordova.apache.org/docs/en/latest/guide/cli/>.
 
 - Create a cordova project:
 

--- a/pages/common/crystal.md
+++ b/pages/common/crystal.md
@@ -1,7 +1,7 @@
 # crystal
 
 > Tool for managing Crystal source code.
-> Homepage: <https://crystal-lang.org/reference/using_the_compiler>.
+> More information: <https://crystal-lang.org/reference/using_the_compiler>.
 
 - Run a Crystal file:
 

--- a/pages/common/dexter.md
+++ b/pages/common/dexter.md
@@ -1,7 +1,7 @@
 # dexter
 
 > Tool for authenticating the kubectl users with OpenId Connect.
-> Homepage: <https://github.com/gini/dexter>.
+> More information: <https://github.com/gini/dexter>.
 
 - Create and authenticate a user with Google OIDC:
 

--- a/pages/common/docker-compose.md
+++ b/pages/common/docker-compose.md
@@ -1,7 +1,7 @@
 # docker-compose
 
 > Run and manage multi container docker applications.
-> Homepage: <https://docs.docker.com/compose/reference/overview/>.
+> More information: <https://docs.docker.com/compose/reference/overview/>.
 
 - Create and start all containers in the background using a `docker-compose.yml` file from the current directory:
 

--- a/pages/common/docker-machine.md
+++ b/pages/common/docker-machine.md
@@ -1,7 +1,7 @@
 # docker-machine
 
 > Create and manage machines running Docker.
-> Homepage: <https://docs.docker.com/machine/reference/>.
+> More information: <https://docs.docker.com/machine/reference/>.
 
 - List currently running docker machines:
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -1,7 +1,7 @@
 # docker
 
 > Manage Docker containers and images.
-> Homepage: <https://docs.docker.com/engine/reference/commandline/cli/>.
+> More information: <https://docs.docker.com/engine/reference/commandline/cli/>.
 
 - List currently running docker containers:
 

--- a/pages/common/ect.md
+++ b/pages/common/ect.md
@@ -1,7 +1,7 @@
 # ect
 
 > Efficient Compression Tool (or ECT) is a C++ file optimizer. It supports PNG, JPEG, GZIP and ZIP files.
-> Homepage: <https://github.com/fhanau/Efficient-Compression-Tool>.
+> More information: <https://github.com/fhanau/Efficient-Compression-Tool>.
 
 - Compress a file:
 

--- a/pages/common/f3probe.md
+++ b/pages/common/f3probe.md
@@ -1,7 +1,7 @@
 # f3probe
 
 > Probe a block device (e.g. a flash drive or a microSD card) for counterfeit flash memory.
-> Homepage: <https://github.com/AltraMayor/f3>.
+> More information: <https://github.com/AltraMayor/f3>.
 
 - Probe a block device:
 

--- a/pages/common/fossa.md
+++ b/pages/common/fossa.md
@@ -1,7 +1,7 @@
 # fossa
 
 > CLI for the Fossa service - Generate realtime license audits, vulnerability scans and reports about dependencies licenses.
-> Homepage: <https://github.com/fossas/fossa-cli>.
+> More information: <https://github.com/fossas/fossa-cli>.
 
 - Initialize a `.fossa.yml` configuration file:
 

--- a/pages/common/git-add.md
+++ b/pages/common/git-add.md
@@ -1,7 +1,7 @@
 # git add
 
 > Adds changed files to the index.
-> Homepage: <https://git-scm.com/docs/git-add>.
+> More information: <https://git-scm.com/docs/git-add>.
 
 - Add a file to the index:
 

--- a/pages/common/git-am.md
+++ b/pages/common/git-am.md
@@ -2,7 +2,7 @@
 
 > Apply patch files. Useful when receiving commits via email.
 > See also `git format-patch`, which can generate patch files.
-> Homepage: <https://git-scm.com/docs/git-am>.
+> More information: <https://git-scm.com/docs/git-am>.
 
 - Apply a patch file:
 

--- a/pages/common/git-bisect.md
+++ b/pages/common/git-bisect.md
@@ -2,7 +2,7 @@
 
 > Use binary search to find the commit that introduced a bug.
 > Git automatically jumps back and forth in the commit graph to progressively narrow down the faulty commit.
-> Homepage: <https://git-scm.com/docs/git-bisect>.
+> More information: <https://git-scm.com/docs/git-bisect>.
 
 - Start a bisect session on a commit range bounded by a known buggy commit, and a known clean (typically older) one:
 

--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -1,7 +1,7 @@
 # git blame
 
 > Show commit hash and last author on each line of a file.
-> Homepage: <https://git-scm.com/docs/git-blame>.
+> More information: <https://git-scm.com/docs/git-blame>.
 
 - Print file with author name and commit hash on each line:
 

--- a/pages/common/git-branch.md
+++ b/pages/common/git-branch.md
@@ -1,7 +1,7 @@
 # git branch
 
 > Main git command for working with branches.
-> Homepage: <https://git-scm.com/docs/git-branch>.
+> More information: <https://git-scm.com/docs/git-branch>.
 
 - List local branches. The current branch is highlighted by `*`:
 

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -1,7 +1,7 @@
 # git checkout
 
 > Checkout a branch or paths to the working tree.
-> Homepage: <https://git-scm.com/docs/git-checkout>.
+> More information: <https://git-scm.com/docs/git-checkout>.
 
 - Create and switch to a new branch:
 

--- a/pages/common/git-cherry-pick.md
+++ b/pages/common/git-cherry-pick.md
@@ -2,7 +2,7 @@
 
 > Apply the changes introduced by existing commits to the current branch.
 > To apply changes to another branch, first use git-checkout to switch to the desired branch.
-> Homepage: <https://git-scm.com/docs/git-cherry-pick>.
+> More information: <https://git-scm.com/docs/git-cherry-pick>.
 
 - Apply a commit to the current branch:
 

--- a/pages/common/git-clean.md
+++ b/pages/common/git-clean.md
@@ -1,7 +1,7 @@
 # git clean
 
 > Remove untracked files from the working tree.
-> Homepage: <https://git-scm.com/docs/git-clean>.
+> More information: <https://git-scm.com/docs/git-clean>.
 
 - Delete files that are not tracked by git:
 

--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -1,7 +1,7 @@
 # git clone
 
 > Clone an existing repository.
-> Homepage: <https://git-scm.com/docs/git-clone>.
+> More information: <https://git-scm.com/docs/git-clone>.
 
 - Clone an existing repository:
 

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -1,7 +1,7 @@
 # git commit
 
 > Commit files to the repository.
-> Homepage: <https://git-scm.com/docs/git-commit>.
+> More information: <https://git-scm.com/docs/git-commit>.
 
 - Commit staged files to the repository with a message:
 

--- a/pages/common/git-config.md
+++ b/pages/common/git-config.md
@@ -2,7 +2,7 @@
 
 > Manage custom configuration options for git repositories.
 > These configurations can be local (for the current repository) or global (for the current user).
-> Homepage: <https://git-scm.com/docs/git-config>.
+> More information: <https://git-scm.com/docs/git-config>.
 
 - List only local configuration entries (stored in `.git/config` in the current repository):
 

--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -1,7 +1,7 @@
 # git diff
 
 > Show changes to tracked files.
-> Homepage: <https://git-scm.com/docs/git-diff>.
+> More information: <https://git-scm.com/docs/git-diff>.
 
 - Show unstaged, uncommitted changes:
 

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -1,7 +1,7 @@
 # git fetch
 
 > Download objects and refs from a remote repository.
-> Homepage: <https://git-scm.com/docs/git-fetch>.
+> More information: <https://git-scm.com/docs/git-fetch>.
 
 - Fetch the latest changes from the default remote upstream repository (if set):
 

--- a/pages/common/git-format-patch.md
+++ b/pages/common/git-format-patch.md
@@ -2,7 +2,7 @@
 
 > Prepare .patch files. Useful when emailing commits elsewhere.
 > See also `git am`, which can apply generated .patch files.
-> Homepage: <https://git-scm.com/docs/git-format-patch>.
+> More information: <https://git-scm.com/docs/git-format-patch>.
 
 - Create an auto-named .patch file for all the unpushed commits:
 

--- a/pages/common/git-gc.md
+++ b/pages/common/git-gc.md
@@ -1,7 +1,7 @@
 # git gc
 
 > Optimise the local repository by cleaning unnecessary files.
-> Homepage: <https://git-scm.com/docs/git-gc>.
+> More information: <https://git-scm.com/docs/git-gc>.
 
 - Optimise the repository:
 

--- a/pages/common/git-grep.md
+++ b/pages/common/git-grep.md
@@ -2,7 +2,7 @@
 
 > Find strings inside files anywhere in a repository's history.
 > Accepts a lot of the same flags as regular `grep`.
-> Documentation: <https://git-scm.com/docs/git-grep>.
+> More information: <https://git-scm.com/docs/git-grep>.
 
 - Search for a string in tracked files:
 

--- a/pages/common/git-imerge.md
+++ b/pages/common/git-imerge.md
@@ -2,7 +2,7 @@
 
 > Perform a merge or rebase between two git branches incrementally.
 > Conflicts between branches are tracked down to pairs of individual commits, to simplify conflict resolution.
-> Homepage: <https://github.com/mhagger/git-imerge>.
+> More information: <https://github.com/mhagger/git-imerge>.
 
 - Start imerge-based rebase (checkout the branch to be rebased, first):
 

--- a/pages/common/git-init.md
+++ b/pages/common/git-init.md
@@ -1,7 +1,7 @@
 # git init
 
 > Initializes a new local Git repository.
-> Homepage: <https://git-scm.com/docs/git-init>.
+> More information: <https://git-scm.com/docs/git-init>.
 
 - Initialize a new local repository:
 

--- a/pages/common/git-log.md
+++ b/pages/common/git-log.md
@@ -1,7 +1,7 @@
 # git log
 
 > Show a history of commits.
-> Homepage: <https://git-scm.com/docs/git-log>.
+> More information: <https://git-scm.com/docs/git-log>.
 
 - Show the sequence of commits starting from the current one, in reverse chronological order:
 

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -1,7 +1,7 @@
 # git merge
 
 > Merge branches.
-> Homepage: <https://git-scm.com/docs/git-merge>.
+> More information: <https://git-scm.com/docs/git-merge>.
 
 - Merge a branch with your current branch:
 

--- a/pages/common/git-mv.md
+++ b/pages/common/git-mv.md
@@ -1,7 +1,7 @@
 # git mv
 
 > Move or rename files and update the git index.
-> Homepage: <https://git-scm.com/docs/git-mv>.
+> More information: <https://git-scm.com/docs/git-mv>.
 
 - Move file inside the repo and add the movement to the next commit:
 

--- a/pages/common/git-pull.md
+++ b/pages/common/git-pull.md
@@ -1,7 +1,7 @@
 # git pull
 
 > Fetch branch from a remote repository and merge it to local repository.
-> Homepage: <https://git-scm.com/docs/git-pull>.
+> More information: <https://git-scm.com/docs/git-pull>.
 
 - Download changes from default remote repository and merge it:
 

--- a/pages/common/git-push.md
+++ b/pages/common/git-push.md
@@ -1,7 +1,7 @@
 # git push
 
 > Push commits to a remote repository.
-> Homepage: <https://git-scm.com/docs/git-push>.
+> More information: <https://git-scm.com/docs/git-push>.
 
 - Send local changes in the current branch to its remote counterpart:
 

--- a/pages/common/git-rebase.md
+++ b/pages/common/git-rebase.md
@@ -2,7 +2,7 @@
 
 > Reapply commits from one branch on top of another branch.
 > Commonly used to "move" an entire branch to another base, creating copies of the commits in the new location.
-> Homepage: <https://git-scm.com/docs/git-rebase>.
+> More information: <https://git-scm.com/docs/git-rebase>.
 
 - Rebase the current branch on top of the master branch:
 

--- a/pages/common/git-reflog.md
+++ b/pages/common/git-reflog.md
@@ -1,7 +1,7 @@
 # git reflog
 
 > Show when the reference logs were updated in local repository.
-> Homepage: <https://git-scm.com/docs/git-reflog>.
+> More information: <https://git-scm.com/docs/git-reflog>.
 
 - View reflog:
 

--- a/pages/common/git-remote.md
+++ b/pages/common/git-remote.md
@@ -1,7 +1,7 @@
 # git remote
 
 > Manage set of tracked repositories ("remotes").
-> Homepage: <https://git-scm.com/docs/git-remote>.
+> More information: <https://git-scm.com/docs/git-remote>.
 
 - Show a list of existing remotes, their names and URL:
 

--- a/pages/common/git-reset.md
+++ b/pages/common/git-reset.md
@@ -2,7 +2,7 @@
 
 > Undo commits or unstage changes, by resetting the current git HEAD to the specified state.
 > If a path is passed, it works as "unstage"; if a commit hash or branch is passed, it works as "uncommit".
-> Homepage: <https://git-scm.com/docs/git-reset>.
+> More information: <https://git-scm.com/docs/git-reset>.
 
 - Unstage everything:
 

--- a/pages/common/git-rm.md
+++ b/pages/common/git-rm.md
@@ -1,7 +1,7 @@
 # git rm
 
 > Remove files from repository index and local filesystem.
-> Homepage: <https://git-scm.com/docs/git-rm>.
+> More information: <https://git-scm.com/docs/git-rm>.
 
 - Remove file from repository index and filesystem:
 

--- a/pages/common/git-shortlog.md
+++ b/pages/common/git-shortlog.md
@@ -1,7 +1,7 @@
 # git shortlog
 
 > Summarizes the `git log` output.
-> Homepage: <https://git-scm.com/docs/git-shortlog>.
+> More information: <https://git-scm.com/docs/git-shortlog>.
 
 - View a summary of all the commits made, grouped alphabetically by author name:
 

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -1,7 +1,7 @@
 # git show
 
 > Show various types of git objects (commits, tags, etc.).
-> Homepage: <https://git-scm.com/docs/git-show>.
+> More information: <https://git-scm.com/docs/git-show>.
 
 - Show information about the latest commit (message, changes, and other metadata):
 

--- a/pages/common/git-sizer.md
+++ b/pages/common/git-sizer.md
@@ -1,7 +1,7 @@
 # git sizer
 
 > Computes various Git repository size metrics and alerts you to any that might cause problems or inconvenience.
-> Homepage: <https://github.com/github/git-sizer>.
+> More information: <https://github.com/github/git-sizer>.
 
 - Report only statistics that have a level of concern greater than 0:
 

--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -1,7 +1,7 @@
 # git stash
 
 > Stash local Git changes in a temporary area.
-> Homepage: <https://git-scm.com/docs/git-stash>.
+> More information: <https://git-scm.com/docs/git-stash>.
 
 - Stash current changes, except new (untracked) files:
 

--- a/pages/common/git-status.md
+++ b/pages/common/git-status.md
@@ -1,7 +1,7 @@
 # git status
 
 > Show the index (changed files).
-> Homepage: <https://git-scm.com/docs/git-status>.
+> More information: <https://git-scm.com/docs/git-status>.
 
 - Show changed files which are not yet added for commit:
 

--- a/pages/common/git-submodule.md
+++ b/pages/common/git-submodule.md
@@ -1,7 +1,7 @@
 # git submodule
 
 > Inspects, updates and manages submodules.
-> Homepage: <https://git-scm.com/docs/git-submodule>.
+> More information: <https://git-scm.com/docs/git-submodule>.
 
 - Install a repository's specified submodules:
 

--- a/pages/common/git-svn.md
+++ b/pages/common/git-svn.md
@@ -1,7 +1,7 @@
 # git svn
 
 > Bidirectional operation between a Subversion repository and Git.
-> Homepage: <https://git-scm.com/docs/git-svn>.
+> More information: <https://git-scm.com/docs/git-svn>.
 
 - Clone an SVN repository:
 

--- a/pages/common/git-tag.md
+++ b/pages/common/git-tag.md
@@ -2,7 +2,7 @@
 
 > Create, list, delete or verify tags.
 > A tag is a static reference to a specific commit.
-> Homepage: <https://git-scm.com/docs/git-tag>.
+> More information: <https://git-scm.com/docs/git-tag>.
 
 - List all tags:
 

--- a/pages/common/git-worktree.md
+++ b/pages/common/git-worktree.md
@@ -1,7 +1,7 @@
 # git worktree
 
 > Manage multiple working trees attached to the same repository.
-> Homepage: <https://git-scm.com/docs/git-worktree>.
+> More information: <https://git-scm.com/docs/git-worktree>.
 
 - Create a new directory with the specified branch checked out into it:
 

--- a/pages/common/git.md
+++ b/pages/common/git.md
@@ -1,7 +1,7 @@
 # git
 
 > Distributed version control system.
-> Homepage: <https://git-scm.com/>.
+> More information: <https://git-scm.com/>.
 
 - Check the Git version:
 

--- a/pages/common/github-label-sync.md
+++ b/pages/common/github-label-sync.md
@@ -1,7 +1,7 @@
 # github-label-sync
 
 > A command line interface for synchronising GitHub labels.
-> Homepage: <https://npmjs.com/package/github-label-sync>.
+> More information: <https://npmjs.com/package/github-label-sync>.
 
 - Synchronise labels using a local `labels.json` file:
 

--- a/pages/common/gitk.md
+++ b/pages/common/gitk.md
@@ -1,7 +1,7 @@
 # gitk
 
 > A graphical git repository browser.
-> Homepage: <https://git-scm.com/docs/gitk>.
+> More information: <https://git-scm.com/docs/gitk>.
 
 - Show the repository browser for the current git repository:
 

--- a/pages/common/gitsome.md
+++ b/pages/common/gitsome.md
@@ -2,7 +2,7 @@
 
 > A terminal-based interface for GitHub, accessed via the `gh` command.
 > It also provides menu-style autocomplete suggestions for `git` commands.
-> Homepage: <https://github.com/donnemartin/gitsome>.
+> More information: <https://github.com/donnemartin/gitsome>.
 
 - Enter the gitsome shell (optional), to enable autocompletion and interactive help for git (and gh) commands:
 

--- a/pages/common/glances.md
+++ b/pages/common/glances.md
@@ -1,7 +1,7 @@
 # glances
 
 > A cross-platform system monitoring tool.
-> Homepage: <https://nicolargo.github.io/glances/>.
+> More information: <https://nicolargo.github.io/glances/>.
 
 - Run in terminal:
 

--- a/pages/common/gnuplot.md
+++ b/pages/common/gnuplot.md
@@ -1,7 +1,7 @@
 # gnuplot
 
 > A graph plotter that outputs in several formats.
-> Homepage: <http://www.gnuplot.info/>.
+> More information: <http://www.gnuplot.info/>.
 
 - Start the interactive graph plotting shell:
 

--- a/pages/common/gocryptfs.md
+++ b/pages/common/gocryptfs.md
@@ -1,7 +1,7 @@
 # gocryptfs
 
 > Encrypted overlay filesystem written in Go.
-> Homepage: <https://github.com/rfjakob/gocryptfs>.
+> More information: <https://github.com/rfjakob/gocryptfs>.
 
 - Initialize an encrypted filesystem:
 

--- a/pages/common/godoc.md
+++ b/pages/common/godoc.md
@@ -1,7 +1,7 @@
 # godoc
 
 > Show documentation for go packages.
-> Homepage: <https://godoc.org/>.
+> More information: <https://godoc.org/>.
 
 - Display help for package "fmt":
 

--- a/pages/common/godot.md
+++ b/pages/common/godot.md
@@ -1,7 +1,7 @@
 # godot
 
 > An open source 2D and 3D game engine.
-> Homepage: <https://godotengine.org/>.
+> More information: <https://godotengine.org/>.
 
 - Run a project if the current directory contains a `project.godot` file, otherwise open the project manager:
 

--- a/pages/common/gofmt.md
+++ b/pages/common/gofmt.md
@@ -1,7 +1,7 @@
 # gofmt
 
 > Tool for formatting Go source code.
-> Homepage: <https://golang.org/cmd/gofmt/>.
+> More information: <https://golang.org/cmd/gofmt/>.
 
 - Format a file and display the result to the console:
 

--- a/pages/common/gops.md
+++ b/pages/common/gops.md
@@ -1,7 +1,7 @@
 # gops
 
 > CLI tool which lists and diagnoses Go processes currently running on your system.
-> Homepage: <https://github.com/google/gops>.
+> More information: <https://github.com/google/gops>.
 
 - Print all go processes running locally:
 

--- a/pages/common/grunt.md
+++ b/pages/common/grunt.md
@@ -1,7 +1,7 @@
 # grunt
 
 > A JavaScript task runner for automating processes.
-> Homepage: <https://github.com/gruntjs/grunt-cli>.
+> More information: <https://github.com/gruntjs/grunt-cli>.
 
 - Run the default task process:
 

--- a/pages/common/gtop.md
+++ b/pages/common/gtop.md
@@ -1,7 +1,7 @@
 # gtop
 
 > System monitoring dashboard for the terminal.
-> Homepage: <https://github.com/aksakalli/gtop>.
+> More information: <https://github.com/aksakalli/gtop>.
 
 - Show the system stats dashboard:
 

--- a/pages/common/guetzli.md
+++ b/pages/common/guetzli.md
@@ -1,7 +1,7 @@
 # guetzli
 
 > JPEG image compression utility.
-> Homepage: <https://github.com/google/guetzli>.
+> More information: <https://github.com/google/guetzli>.
 
 - Compress a JPEG image:
 

--- a/pages/common/gulp.md
+++ b/pages/common/gulp.md
@@ -2,7 +2,7 @@
 
 > JavaScript task runner and streaming build system.
 > Tasks are defined within gulpfile.js at the project root.
-> Homepage: <https://github.com/gulpjs/gulp-cli>.
+> More information: <https://github.com/gulpjs/gulp-cli>.
 
 - Run the default task:
 

--- a/pages/common/handbrakecli.md
+++ b/pages/common/handbrakecli.md
@@ -1,7 +1,7 @@
 # handbrakecli
 
 > Command-line interface to the HandBrake video conversion tool.
-> Homepage: <https://handbrake.fr/>.
+> More information: <https://handbrake.fr/>.
 
 - Convert a video file to MKV (AAC 160kbit audio and x264 CRF20 video):
 

--- a/pages/common/hangups.md
+++ b/pages/common/hangups.md
@@ -1,7 +1,7 @@
 # hangups
 
 > Third party command line client for Google Hangouts.
-> Homepage: <https://github.com/tdryer/hangups>.
+> More information: <https://github.com/tdryer/hangups>.
 
 - Start hangups:
 

--- a/pages/common/haxelib.md
+++ b/pages/common/haxelib.md
@@ -1,7 +1,7 @@
 # haxelib
 
 > Haxe Library Manager.
-> Homepage: <https://lib.haxe.org/>.
+> More information: <https://lib.haxe.org/>.
 
 - Search for a Haxe library:
 

--- a/pages/common/helm.md
+++ b/pages/common/helm.md
@@ -1,7 +1,7 @@
 # helm
 
 > Helm is a package manager for Kubernetes.
-> Homepage: <https://helm.sh/>.
+> More information: <https://helm.sh/>.
 
 - Create a helm chart:
 

--- a/pages/common/heroku.md
+++ b/pages/common/heroku.md
@@ -1,7 +1,7 @@
 # heroku
 
 > Create and manage Heroku apps from the command line.
-> Homepage: <https://www.heroku.com/>.
+> More information: <https://www.heroku.com/>.
 
 - Login to your heroku account:
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -1,7 +1,7 @@
 # hg add
 
 > Adds specified files to the staging area for the next commit in Mercurial.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#add>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#add>.
 
 - Add files or directories to the staging area:
 

--- a/pages/common/hg-branch.md
+++ b/pages/common/hg-branch.md
@@ -1,7 +1,7 @@
 # hg branch
 
 > Create or show a branch name.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#branch>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#branch>.
 
 - Show the name of the currently active branch:
 

--- a/pages/common/hg-clone.md
+++ b/pages/common/hg-clone.md
@@ -1,7 +1,7 @@
 # hg clone
 
 > Create a copy of an existing repository in a new directory.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#clone>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#clone>.
 
 - Clone a repository to a specified directory:
 

--- a/pages/common/hg-commit.md
+++ b/pages/common/hg-commit.md
@@ -1,7 +1,7 @@
 # hg commit
 
 > Commit all staged or specified files to the repository.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#commit>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#commit>.
 
 - Commit staged files to the repository:
 

--- a/pages/common/hg-init.md
+++ b/pages/common/hg-init.md
@@ -1,7 +1,7 @@
 # hg init
 
 > Create a new repository in the specified directory.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#init>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#init>.
 
 - Initialise a new repository in the current directory:
 

--- a/pages/common/hg-log.md
+++ b/pages/common/hg-log.md
@@ -1,7 +1,7 @@
 # hg log
 
 > Display the revision history of the repository.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#log>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#log>.
 
 - Display the entire revision history of the repository:
 

--- a/pages/common/hg-pull.md
+++ b/pages/common/hg-pull.md
@@ -1,7 +1,7 @@
 # hg pull
 
 > Pull changes from a specified repository to the local repository.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#pull>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#pull>.
 
 - Pull from the "default" source path:
 

--- a/pages/common/hg-push.md
+++ b/pages/common/hg-push.md
@@ -1,7 +1,7 @@
 # hg push
 
 > Push changes from the local repository to a specified destination.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#push>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#push>.
 
 - Push changes to the "default" remote path:
 

--- a/pages/common/hg-remove.md
+++ b/pages/common/hg-remove.md
@@ -1,7 +1,7 @@
 # hg remove
 
 > Remove specified files from the staging area.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#remove>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#remove>.
 
 - Remove files or directories from the staging area:
 

--- a/pages/common/hg-root.md
+++ b/pages/common/hg-root.md
@@ -1,7 +1,7 @@
 # hg root
 
 > Display the root location of a Hg repository.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#root>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#root>.
 
 - Display the root location of the current repository:
 

--- a/pages/common/hg-serve.md
+++ b/pages/common/hg-serve.md
@@ -1,7 +1,7 @@
 # hg serve
 
 > Start a standalone Mercurial web server for browsing repositories.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#serve>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#serve>.
 
 - Start a web server instance:
 

--- a/pages/common/hg-status.md
+++ b/pages/common/hg-status.md
@@ -1,7 +1,7 @@
 # hg status
 
 > Show files that have changed in the working directory.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#status>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#status>.
 
 - Display the status of changed files:
 

--- a/pages/common/hg-update.md
+++ b/pages/common/hg-update.md
@@ -1,7 +1,7 @@
 # hg update
 
 > Update the working directory to a specified changeset.
-> Homepage: <https://www.mercurial-scm.org/doc/hg.1.html#update>.
+> More information: <https://www.mercurial-scm.org/doc/hg.1.html#update>.
 
 - Update to the tip of the current branch:
 

--- a/pages/common/hg.md
+++ b/pages/common/hg.md
@@ -2,7 +2,7 @@
 
 > A command line interface for Mercurial, a distributed source control management system.
 > See `hg-add`, `hg-commit` and other pages for additional information.
-> Homepage: <https://www.mercurial-scm.org>.
+> More information: <https://www.mercurial-scm.org>.
 
 - Execute Mercurial command:
 

--- a/pages/common/hsd-cli.md
+++ b/pages/common/hsd-cli.md
@@ -1,7 +1,7 @@
 # hsd-cli
 
 > The command line REST tool for the Handshake blockchain.
-> Homepage: <https://handshake.org>.
+> More information: <https://handshake.org>.
 
 - Retrieve information about the current server:
 

--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -1,7 +1,7 @@
 # hyperfine
 
 > A command-line benchmarking tool.
-> Homepage: <https://github.com/sharkdp/hyperfine/>.
+> More information: <https://github.com/sharkdp/hyperfine/>.
 
 - Run a basic benchmark, performing at least 10 runs:
 

--- a/pages/common/is-up.md
+++ b/pages/common/is-up.md
@@ -1,7 +1,7 @@
 # is-up
 
 > Check whether a website is up or down.
-> Homepage: <https://github.com/sindresorhus/is-up-cli>.
+> More information: <https://github.com/sindresorhus/is-up-cli>.
 
 - Check the status of the specified website:
 

--- a/pages/common/kube-capacity.md
+++ b/pages/common/kube-capacity.md
@@ -2,7 +2,7 @@
 
 > A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster.
 > Combine the best parts of `kubectl top` and `kubectl describe` into a CLI focused on cluster resources.
-> Homepage: <https://github.com/robscott/kube-capacity>.
+> More information: <https://github.com/robscott/kube-capacity>.
 
 - Output a list of nodes with the total CPU and Memory resource requests and limits:
 

--- a/pages/common/mkcert.md
+++ b/pages/common/mkcert.md
@@ -1,7 +1,7 @@
 # mkcert
 
 > Tool for making locally-trusted development certificates.
-> Homepage: <https://github.com/FiloSottile/mkcert>.
+> More information: <https://github.com/FiloSottile/mkcert>.
 
 - Install the local CA in the system trust store:
 

--- a/pages/common/monodevelop.md
+++ b/pages/common/monodevelop.md
@@ -1,7 +1,7 @@
 # monodevelop
 
 > Cross platform IDE for C#, F# and more.
-> Homepage: <https://www.monodevelop.com/>.
+> More information: <https://www.monodevelop.com/>.
 
 - Start Monodevelop:
 

--- a/pages/common/monodis.md
+++ b/pages/common/monodis.md
@@ -1,7 +1,7 @@
 # monodis
 
 > The Mono Common Intermediate Language (CIL) disassembler.
-> Homepage: <https://www.mono-project.com/docs/tools+libraries/tools/monodis/>.
+> More information: <https://www.mono-project.com/docs/tools+libraries/tools/monodis/>.
 
 - Disassemble an assembly to textual CIL:
 

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -1,7 +1,7 @@
 # mysql
 
 > The MySQL command-line tool.
-> Homepage: <https://www.mysql.com/>.
+> More information: <https://www.mysql.com/>.
 
 - Connect to a database:
 

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -1,7 +1,7 @@
 # mysqldump
 
 > Backups MySQL databases.
-> Homepage: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+> More information: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
 
 - Create a backup, user will be prompted for a password:
 

--- a/pages/common/mytop.md
+++ b/pages/common/mytop.md
@@ -1,7 +1,7 @@
 # mytop
 
 > Display MySQL server performance info like `top`.
-> Homepage: <http://www.mysqlfanboy.com/mytop-3>.
+> More information: <http://www.mysqlfanboy.com/mytop-3>.
 
 - Start mytop:
 

--- a/pages/common/nginx.md
+++ b/pages/common/nginx.md
@@ -1,7 +1,7 @@
 # nginx
 
 > Nginx web server.
-> Homepage: <https://nginx.org/en/>.
+> More information: <https://nginx.org/en/>.
 
 - Start server with the default config file:
 

--- a/pages/common/ngrok.md
+++ b/pages/common/ngrok.md
@@ -1,7 +1,7 @@
 # ngrok
 
 > Reverse proxy that creates a secure tunnel from a public endpoint to a locally running web service.
-> Homepage: <https://ngrok.com>.
+> More information: <https://ngrok.com>.
 
 - Expose a local HTTP service on a given port:
 

--- a/pages/common/nmap.md
+++ b/pages/common/nmap.md
@@ -2,7 +2,7 @@
 
 > Network exploration tool and security / port scanner.
 > Some features only activate when Nmap is run with privileges.
-> Homepage: <https://nmap.org>.
+> More information: <https://nmap.org>.
 
 - Try to determine whether the specified hosts are up and what are their names:
 

--- a/pages/common/node.md
+++ b/pages/common/node.md
@@ -1,7 +1,7 @@
 # node
 
 > Server-side JavaScript platform (Node.js).
-> Homepage: <https://nodejs.org>.
+> More information: <https://nodejs.org>.
 
 - Run a JavaScript file:
 

--- a/pages/common/npm-check.md
+++ b/pages/common/npm-check.md
@@ -1,7 +1,7 @@
 # npm-check
 
 > Check for outdated, incorrect, and unused npm package dependencies.
-> Homepage: <https://www.npmjs.com/package/npm-check/>.
+> More information: <https://www.npmjs.com/package/npm-check/>.
 
 - Display a report of outdated, incorrect, and unused dependencies:
 

--- a/pages/common/npm-why.md
+++ b/pages/common/npm-why.md
@@ -1,7 +1,7 @@
 # npm-why
 
 > Identifies why an npm package is installed.
-> Homepage: <https://www.npmjs.com/package/npm-why>.
+> More information: <https://www.npmjs.com/package/npm-why>.
 
 - Show why an npm package is installed:
 

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -2,7 +2,7 @@
 
 > JavaScript and Node.js package manager.
 > Manage Node.js projects and their module dependencies.
-> Homepage: <https://www.npmjs.com/>.
+> More information: <https://www.npmjs.com/>.
 
 - Interactively create a package.json file:
 

--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -2,7 +2,7 @@
 
 > Install, uninstall or switch between Node.js versions.
 > Supports version numbers like "0.12" or "v4.2", and labels like "stable", "system", etc.
-> Homepage: <https://github.com/creationix/nvm>.
+> More information: <https://github.com/creationix/nvm>.
 
 - Install a specific version of Node.js:
 

--- a/pages/common/pamixer.md
+++ b/pages/common/pamixer.md
@@ -1,7 +1,7 @@
 # pamixer
 
 > A simple command-line mixer for PulseAudio.
-> Homepage: <https://github.com/cdemoulins/pamixer>.
+> More information: <https://github.com/cdemoulins/pamixer>.
 
 - List all sinks and sources with their corresponding IDs:
 

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -1,7 +1,7 @@
 # pip
 
 > Python package manager.
-> Homepage: <https://pip.pypa.io>.
+> More information: <https://pip.pypa.io>.
 
 - Install a package:
 

--- a/pages/common/pipenv.md
+++ b/pages/common/pipenv.md
@@ -2,7 +2,7 @@
 
 > Simple and unified Python development workflow.
 > Manages packages and the virtual environment for a project.
-> Homepage: <https://pypi.org/project/pipenv>.
+> More information: <https://pypi.org/project/pipenv>.
 
 - Create a new project:
 

--- a/pages/common/popeye.md
+++ b/pages/common/popeye.md
@@ -1,7 +1,7 @@
 # popeye
 
 > Utility that reports potential issues with Kubernetes deployment manifests.
-> Homepage: <https://github.com/derailed/popeye>.
+> More information: <https://github.com/derailed/popeye>.
 
 - Scan the current Kubernetes cluster:
 

--- a/pages/common/qemu.md
+++ b/pages/common/qemu.md
@@ -2,7 +2,7 @@
 
 > Generic machine emulator and virtualizer.
 > Supports a large variety of CPU architectures.
-> Homepage: <https://www.qemu.org>.
+> More information: <https://www.qemu.org>.
 
 - Boot from image emulating i386 architecture:
 

--- a/pages/common/rails.md
+++ b/pages/common/rails.md
@@ -1,7 +1,7 @@
 # rails
 
 > A server-side MVC framework written in Ruby.
-> Homepage: <https://guides.rubyonrails.org/command_line.html>.
+> More information: <https://guides.rubyonrails.org/command_line.html>.
 
 - Create a new rails project:
 

--- a/pages/common/ranger.md
+++ b/pages/common/ranger.md
@@ -1,7 +1,7 @@
 # ranger
 
 > Console file manager with VI key bindings.
-> Homepage: <https://github.com/ranger/ranger>.
+> More information: <https://github.com/ranger/ranger>.
 
 - Launch ranger:
 

--- a/pages/common/rbt.md
+++ b/pages/common/rbt.md
@@ -1,7 +1,7 @@
 # rbt
 
 > RBTools is a set of command line tools for working with Review Board and RBCommons.
-> Homepage: <https://www.reviewboard.org/docs/rbtools/dev/>.
+> More information: <https://www.reviewboard.org/docs/rbtools/dev/>.
 
 - Post changes to Review Board:
 

--- a/pages/common/repren.md
+++ b/pages/common/repren.md
@@ -1,7 +1,7 @@
 # repren
 
 > Multi-pattern string replacement and file renaming tool.
-> Homepage: <https://github.com/jlevy/repren>.
+> More information: <https://github.com/jlevy/repren>.
 
 - Do a dry-run renaming a directory of pngs with a literal string replacement:
 

--- a/pages/common/serverless.md
+++ b/pages/common/serverless.md
@@ -2,7 +2,7 @@
 
 > Toolkit for deploying and operating serverless architectures on AWS, Google Cloud, Azure and IBM OpenWhisk.
 > Commands can be run either using the `serverless` command or it's alias, `sls`.
-> Homepage: <https://serverless.com/>.
+> More information: <https://serverless.com/>.
 
 - Create a serverless project:
 

--- a/pages/common/shellcheck.md
+++ b/pages/common/shellcheck.md
@@ -1,7 +1,7 @@
 # shellcheck
 
 > Shell script static analysis tool.
-> Homepage: <https://www.shellcheck.net/>.
+> More information: <https://www.shellcheck.net/>.
 
 - Check a shell script:
 

--- a/pages/common/skaffold.md
+++ b/pages/common/skaffold.md
@@ -1,7 +1,7 @@
 # skaffold
 
 > A tool that facilitates continuous development for Kubernetes applications.
-> Homepage: <https://skaffold.dev>.
+> More information: <https://skaffold.dev>.
 
 - Build the artifacts:
 

--- a/pages/common/spark.md
+++ b/pages/common/spark.md
@@ -1,7 +1,7 @@
 # spark
 
 > The Laravel Spark command line tool.
-> Homepage: <https://spark.laravel.com>.
+> More information: <https://spark.laravel.com>.
 
 - Register your API token:
 

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -1,7 +1,7 @@
 # st-util
 
 > Run GDB (GNU Debugger) server to interact with STM32 ARM Cortex microcontoller.
-> Homepage: <https://github.com/texane/stlink>.
+> More information: <https://github.com/texane/stlink>.
 
 - Run GDB server on port 4500:
 

--- a/pages/common/subfinder.md
+++ b/pages/common/subfinder.md
@@ -2,7 +2,7 @@
 
 > A subdomain discovery tool that discovers valid subdomains for websites.
 > Designed as a passive framework to be useful for bug bounties and safe for penetration testing.
-> Homepage: <https://github.com/subfinder/subfinder>.
+> More information: <https://github.com/subfinder/subfinder>.
 
 - Find subdomains for a specific domain:
 

--- a/pages/common/subl.md
+++ b/pages/common/subl.md
@@ -1,7 +1,7 @@
 # subl
 
 > Sublime Text editor.
-> Homepage: <https://www.sublimetext.com>.
+> More information: <https://www.sublimetext.com>.
 
 - Open the current directory in Sublime Text:
 

--- a/pages/common/subliminal.md
+++ b/pages/common/subliminal.md
@@ -1,7 +1,7 @@
 # subliminal
 
 > Python-based subtitle downloader.
-> Homepage: <https://github.com/Diaoul/subliminal>.
+> More information: <https://github.com/Diaoul/subliminal>.
 
 - Download English subtitles for a video:
 

--- a/pages/common/supervisorctl.md
+++ b/pages/common/supervisorctl.md
@@ -2,7 +2,7 @@
 
 > Supervisor is a client/server system that allows its users to control a number of processes on UNIX-like operating systems.
 > Supervisorctl is the command-line client piece of the supervisor which provides a shell-like interface.
-> Homepage: <http://supervisord.org>.
+> More information: <http://supervisord.org>.
 
 - Start/stop/restart a process:
 

--- a/pages/common/supervisord.md
+++ b/pages/common/supervisord.md
@@ -2,7 +2,7 @@
 
 > Supervisor is a client/server system for controlling some processes on UNIX-like operating systems.
 > Supervisord is the server part of supervisor; it is primarily managed via a configuration file.
-> Homepage: <http://supervisord.org>.
+> More information: <http://supervisord.org>.
 
 - Start supervisord with specified configuration file:
 

--- a/pages/common/surge.md
+++ b/pages/common/surge.md
@@ -1,7 +1,7 @@
 # surge
 
 > Simple command line web publishing.
-> Homepage: <https://surge.sh>.
+> More information: <https://surge.sh>.
 
 - Upload a new site to surge.sh:
 

--- a/pages/common/svgcleaner.md
+++ b/pages/common/svgcleaner.md
@@ -1,7 +1,7 @@
 # svgcleaner
 
 > SVG image optimizing utility.
-> Homepage: <https://github.com/RazrFalcon/svgcleaner>.
+> More information: <https://github.com/RazrFalcon/svgcleaner>.
 
 - Optimize an SVG image:
 

--- a/pages/common/svgo.md
+++ b/pages/common/svgo.md
@@ -2,7 +2,7 @@
 
 > SVG Optimizer: a Node.js-based tool for optimizing Scalable Vector Graphics files.
 > It applies a series of transformation rules (plugins), which can be toggled individually.
-> Homepage: <https://github.com/svg/svgo>.
+> More information: <https://github.com/svg/svgo>.
 
 - Optimize a file using the default plugins (overwrites the original file):
 

--- a/pages/common/svn.md
+++ b/pages/common/svn.md
@@ -1,7 +1,7 @@
 # svn
 
 > Subversion command line client tool.
-> Homepage: <https://subversion.apache.org>.
+> More information: <https://subversion.apache.org>.
 
 - Check out a working copy from a repository:
 

--- a/pages/common/swagger-codegen.md
+++ b/pages/common/swagger-codegen.md
@@ -1,7 +1,7 @@
 # swagger-codegen
 
 > Generate code and documentation for your REST api from a OpenAPI/swagger definition.
-> Homepage: <https://github.com/swagger-api/swagger-codegen>.
+> More information: <https://github.com/swagger-api/swagger-codegen>.
 
 - Generate documentation and code from an OpenAPI/swagger file:
 

--- a/pages/common/swift.md
+++ b/pages/common/swift.md
@@ -1,7 +1,7 @@
 # swift
 
 > Create, run and build Swift projects.
-> Homepage: <https://swift.org>.
+> More information: <https://swift.org>.
 
 - Invoke the interactive interpreter (REPL):
 

--- a/pages/common/symfony.md
+++ b/pages/common/symfony.md
@@ -1,7 +1,7 @@
 # symfony
 
 > The console component for the Symfony framework.
-> Homepage: <https://symfony.com>.
+> More information: <https://symfony.com>.
 
 - Create a new Symfony project:
 

--- a/pages/common/tabula.md
+++ b/pages/common/tabula.md
@@ -1,7 +1,7 @@
 # tabula
 
 > Extract tables from PDF files.
-> Homepage: <https://tabula.technology>.
+> More information: <https://tabula.technology>.
 
 - Extract all tables from a PDF to a CSV file:
 

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -2,7 +2,7 @@
 
 > Archiving utility.
 > Often combined with a compression method, such as gzip or bzip.
-> Homepage: <https://www.gnu.org/software/tar>.
+> More information: <https://www.gnu.org/software/tar>.
 
 - Create an archive from files:
 

--- a/pages/common/tb.md
+++ b/pages/common/tb.md
@@ -1,7 +1,7 @@
 # tb
 
 > CLI for managing tasks and notes across multiple boards.
-> Homepage: <https://github.com/klaussinani/taskbook>.
+> More information: <https://github.com/klaussinani/taskbook>.
 
 - Add a new task to a board:
 

--- a/pages/common/tcpdump.md
+++ b/pages/common/tcpdump.md
@@ -1,7 +1,7 @@
 # tcpdump
 
 > Dump traffic on a network.
-> Homepage: <https://www.tcpdump.org>.
+> More information: <https://www.tcpdump.org>.
 
 - List available network interfaces:
 

--- a/pages/common/terminalizer.md
+++ b/pages/common/terminalizer.md
@@ -1,7 +1,7 @@
 # terminalizer
 
 > Utility program which records the terminal and generate animated gifs or share a video.
-> Homepage: <https://terminalizer.com>.
+> More information: <https://terminalizer.com>.
 
 - Create the global config directory:
 

--- a/pages/common/terraform.md
+++ b/pages/common/terraform.md
@@ -1,7 +1,7 @@
 # terraform
 
 > Create and deploy infrastructure as code to cloud providers.
-> Homepage: <https://www.terraform.io/>.
+> More information: <https://www.terraform.io/>.
 
 - Initialize a new or existing Terraform configuration:
 

--- a/pages/common/tesseract.md
+++ b/pages/common/tesseract.md
@@ -1,7 +1,7 @@
 # tesseract
 
 > OCR (Optical Character Recognition) engine.
-> Homepage: <https://github.com/tesseract-ocr/tesseract>.
+> More information: <https://github.com/tesseract-ocr/tesseract>.
 
 - Recognize text in an image and save it to `output.txt` (the '.txt' extension is added automatically):
 

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -1,7 +1,7 @@
 # tig
 
 > A text-mode interface for Git.
-> Homepage: <https://github.com/jonas/tig>.
+> More information: <https://github.com/jonas/tig>.
 
 - Show the sequence of commits starting from the current one in reverse chronological order:
 

--- a/pages/common/timew.md
+++ b/pages/common/timew.md
@@ -1,7 +1,7 @@
 # timew
 
 > A time tracking tool used to measure the duration of activities.
-> Homepage: <https://taskwarrior.org/docs/timewarrior>.
+> More information: <https://taskwarrior.org/docs/timewarrior>.
 
 - Start a new stopwatch, giving a tag name to the activity being tracked:
 

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -1,7 +1,7 @@
 # tldr
 
 > Simplified man pages.
-> Homepage: <https://tldr.sh>.
+> More information: <https://tldr.sh>.
 
 - Get typical usages of a command (hint: this is how you got here!):
 

--- a/pages/common/tldrl.md
+++ b/pages/common/tldrl.md
@@ -1,7 +1,7 @@
 # tldrl
 
 > Lint and format TLDR pages.
-> Homepage: <https://github.com/tldr-pages/tldr-lint>.
+> More information: <https://github.com/tldr-pages/tldr-lint>.
 
 - Lint all pages:
 

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -1,7 +1,7 @@
 # tmux
 
 > Multiplex several virtual consoles.
-> Homepage: <https://github.com/tmux/tmux>.
+> More information: <https://github.com/tmux/tmux>.
 
 - Start a new tmux session:
 

--- a/pages/common/tokei.md
+++ b/pages/common/tokei.md
@@ -1,7 +1,7 @@
 # tokei
 
 > A program that prints out statistics about code.
-> Homepage: <https://github.com/XAMPPRocky/tokei>.
+> More information: <https://github.com/XAMPPRocky/tokei>.
 
 - Get a report on the code in a directory and all subdirectories:
 

--- a/pages/common/tox.md
+++ b/pages/common/tox.md
@@ -2,7 +2,7 @@
 
 > Automate Python testing across multiple Python versions.
 > Use tox.ini to configure environments and test command.
-> Homepage: <https://github.com/tox-dev/tox>.
+> More information: <https://github.com/tox-dev/tox>.
 
 - Run tests on all test environments:
 

--- a/pages/common/tpp.md
+++ b/pages/common/tpp.md
@@ -1,7 +1,7 @@
 # tpp
 
 > Command-Line based presentation tool.
-> Homepage: <https://github.com/cbbrowne/tpp>.
+> More information: <https://github.com/cbbrowne/tpp>.
 
 - View a presentation:
 

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -1,7 +1,7 @@
 # traefik
 
 > A HTTP reverse proxy and load balancer.
-> Homepage: <https://traefik.io>.
+> More information: <https://traefik.io>.
 
 - Start server with default config:
 

--- a/pages/common/trans.md
+++ b/pages/common/trans.md
@@ -1,7 +1,7 @@
 # trans
 
 > Translate Shell is a command-line translator.
-> Homepage: <https://github.com/soimort/translate-shell>.
+> More information: <https://github.com/soimort/translate-shell>.
 
 - Translate a word (language is detected automatically):
 

--- a/pages/common/transmission-cli.md
+++ b/pages/common/transmission-cli.md
@@ -2,7 +2,7 @@
 
 > A lightweight, command-line BitTorrent client.
 > This tool has been deprecated, please see `transmission-remote`.
-> Homepage: <https://transmissionbt.com>.
+> More information: <https://transmissionbt.com>.
 
 - Download a specific torrent:
 

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -1,7 +1,7 @@
 # transmission-remote
 
 > Remote control utility for transmission-daemon and transmission.
-> Homepage: <https://transmissionbt.com>.
+> More information: <https://transmissionbt.com>.
 
 - Add a torrent file or magnet link to Transmission and download to a specified directory:
 

--- a/pages/common/trash-cli.md
+++ b/pages/common/trash-cli.md
@@ -1,7 +1,7 @@
 # trash-cli
 
 > A command line interface to the trashcan APIs.
-> Homepage: <https://github.com/andreafrancia/trash-cli>.
+> More information: <https://github.com/andreafrancia/trash-cli>.
 
 - Trash files and directories:
 

--- a/pages/common/trawl.md
+++ b/pages/common/trawl.md
@@ -1,7 +1,7 @@
 # trawl
 
 > Prints out network interface information to the console, much like ifconfig/ipconfig/ip/ifdata.
-> Homepage: <https://github.com/robphoenix/trawl>.
+> More information: <https://github.com/robphoenix/trawl>.
 
 - Show column names:
 

--- a/pages/common/tslint.md
+++ b/pages/common/tslint.md
@@ -1,7 +1,7 @@
 # tslint
 
 > A pluggable linting utility for TypeScript.
-> Homepage: <https://palantir.github.io/tslint>.
+> More information: <https://palantir.github.io/tslint>.
 
 - Create tslint config:
 

--- a/pages/common/upx.md
+++ b/pages/common/upx.md
@@ -1,7 +1,7 @@
 # upx
 
 > Compress or decompress executables.
-> Homepage: <https://upx.github.io>.
+> More information: <https://upx.github.io>.
 
 - Compress executable:
 

--- a/pages/common/vagrant.md
+++ b/pages/common/vagrant.md
@@ -1,7 +1,7 @@
 # vagrant
 
 > Manage lightweight, reproducible, and portable development environments.
-> Homepage: <https://www.vagrantup.com>.
+> More information: <https://www.vagrantup.com>.
 
 - Create Vagrantfile in current directory with the base Vagrant box:
 

--- a/pages/common/valgrind.md
+++ b/pages/common/valgrind.md
@@ -2,7 +2,7 @@
 
 > Wrapper for a set of expert tools for profiling, optimizing and debugging programs.
 > Commonly used tools include `memcheck`, `cachegrind`, `callgrind`, `massif`, `helgrind`, and `drd`.
-> Homepage: <http://www.valgrind.org>.
+> More information: <http://www.valgrind.org>.
 
 - Use the (default) Memcheck tool to show a diagnostic of memory usage by `program`:
 

--- a/pages/common/vault.md
+++ b/pages/common/vault.md
@@ -1,7 +1,7 @@
 # vault
 
 > A CLI to interact with HashiCorp Vault.
-> Homepage: <https://www.vaultproject.io/docs/commands>.
+> More information: <https://www.vaultproject.io/docs/commands>.
 
 - Connect to a Vault server and initialize a new encrypted data store:
 

--- a/pages/common/vcsh.md
+++ b/pages/common/vcsh.md
@@ -1,7 +1,7 @@
 # vcsh
 
 > Version Control System for the home directory using git repositories.
-> Homepage: <https://github.com/RichiH/vcsh>.
+> More information: <https://github.com/RichiH/vcsh>.
 
 - Initialize an (empty) repository:
 

--- a/pages/common/vegeta.md
+++ b/pages/common/vegeta.md
@@ -2,7 +2,7 @@
 
 > A command line utility and a library for HTTP load testing.
 > See also `ab`.
-> Homepage: <https://github.com/tsenart/vegeta>.
+> More information: <https://github.com/tsenart/vegeta>.
 
 - Launch an attack lasting 30 seconds:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -2,7 +2,7 @@
 
 > Vi IMproved, a programmer's text editor, provides several modes for different kinds of text manipulation.
 > Pressing `i` enters edit mode. `<Esc>` goes back to normal mode, which doesn't allow regular text insertion.
-> Homepage: <https://www.vim.org>.
+> More information: <https://www.vim.org>.
 
 - Open a file:
 

--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -1,7 +1,7 @@
 # virtualenv
 
 > Create virtual isolated Python environments.
-> Homepage: <https://virtualenv.pypa.io/>.
+> More information: <https://virtualenv.pypa.io/>.
 
 - Create a new environment:
 

--- a/pages/common/vsce.md
+++ b/pages/common/vsce.md
@@ -1,7 +1,7 @@
 # vsce
 
 > Extension manager for Visual Studio Code.
-> Homepage: <https://github.com/microsoft/vscode-vsce>.
+> More information: <https://github.com/microsoft/vscode-vsce>.
 
 - List all the extensions created by a publisher:
 

--- a/pages/common/vue.md
+++ b/pages/common/vue.md
@@ -2,7 +2,7 @@
 
 > Simple CLI for scaffolding Vue.js projects.
 > Official templates include: webpack, webpack-simple, browserify, browserify-simple, simple.
-> Homepage: <https://cli.vuejs.org>.
+> More information: <https://cli.vuejs.org>.
 
 - Create a new vue project:
 

--- a/pages/common/w3m.md
+++ b/pages/common/w3m.md
@@ -1,7 +1,7 @@
 # w3m
 
 > A text-based web browser.
-> Homepage: <http://w3m.sourceforge.net>.
+> More information: <http://w3m.sourceforge.net>.
 
 - Open an URL:
 

--- a/pages/common/wat2wasm.md
+++ b/pages/common/wat2wasm.md
@@ -1,7 +1,7 @@
 # wat2wasm
 
 > Convert a file from the WebAssembly text format to the binary format.
-> Homepage: <https://github.com/WebAssembly/wabt>.
+> More information: <https://github.com/WebAssembly/wabt>.
 
 - Parse and check a file for errors:
 

--- a/pages/common/weasyprint.md
+++ b/pages/common/weasyprint.md
@@ -1,7 +1,7 @@
 # weasyprint
 
 > Render HTML to PDF or PNG.
-> Homepage: <https://weasyprint.org/>.
+> More information: <https://weasyprint.org/>.
 
 - Render a HTML file to PDF:
 

--- a/pages/common/web-ext.md
+++ b/pages/common/web-ext.md
@@ -1,7 +1,7 @@
 # web-ext
 
 > A command line tool for managing web extension development.
-> Homepage: <https://www.npmjs.com/package/web-ext>.
+> More information: <https://www.npmjs.com/package/web-ext>.
 
 - Run the web extension in the current directory in Firefox:
 

--- a/pages/common/webpack.md
+++ b/pages/common/webpack.md
@@ -1,7 +1,7 @@
 # webpack
 
 > Bundle a web project's js files and other assets into a single output file.
-> Homepage: <https://webpack.js.org>.
+> More information: <https://webpack.js.org>.
 
 - Create a single output file from an entry point file:
 

--- a/pages/common/webtorrent.md
+++ b/pages/common/webtorrent.md
@@ -2,7 +2,7 @@
 
 > The command line interface for WebTorrent.
 > Supports magnets, urls, info hashes and .torrent files.
-> Homepage: <https://github.com/webtorrent/webtorrent-cli>.
+> More information: <https://github.com/webtorrent/webtorrent-cli>.
 
 - Download a torrent:
 

--- a/pages/common/wget.md
+++ b/pages/common/wget.md
@@ -2,7 +2,7 @@
 
 > Download files from the Web.
 > Supports HTTP, HTTPS, and FTP.
-> Homepage: <https://www.gnu.org/software/wget>.
+> More information: <https://www.gnu.org/software/wget>.
 
 - Download the contents of an URL to a file (named "foo" in this case):
 

--- a/pages/common/wordgrinder.md
+++ b/pages/common/wordgrinder.md
@@ -1,7 +1,7 @@
 # wordgrinder
 
 > Command-line word processor.
-> Homepage: <https://cowlark.com/wordgrinder>.
+> More information: <https://cowlark.com/wordgrinder>.
 
 - Start wordgrinder (loads a blank document by default):
 

--- a/pages/common/wrk.md
+++ b/pages/common/wrk.md
@@ -1,7 +1,7 @@
 # wrk
 
 > HTTP benchmarking tool.
-> Homepage: <https://github.com/wg/wrk>.
+> More information: <https://github.com/wg/wrk>.
 
 - Run a benchmark for `30` seconds, using `12` threads, and keeping `400` HTTP connections open:
 

--- a/pages/common/wuzz.md
+++ b/pages/common/wuzz.md
@@ -1,7 +1,7 @@
 # wuzz
 
 > Tool to interactively inspect HTTP requests and responses.
-> Homepage: <https://github.com/asciimoo/wuzz>.
+> More information: <https://github.com/asciimoo/wuzz>.
 
 - Start wuzz:
 

--- a/pages/common/x_x.md
+++ b/pages/common/x_x.md
@@ -1,7 +1,7 @@
 # x_x
 
 > View Excel and CSV files from the command-line.
-> Homepage: <https://github.com/kristianperkins/x_x>.
+> More information: <https://github.com/kristianperkins/x_x>.
 
 - View an XLSX or CSV file:
 

--- a/pages/common/xcv.md
+++ b/pages/common/xcv.md
@@ -1,7 +1,7 @@
 # xcv
 
 > Cut, copy, and paste in the command-line.
-> Homepage: <https://github.com/busterc/xcv>.
+> More information: <https://github.com/busterc/xcv>.
 
 - Cut a file:
 

--- a/pages/common/xo.md
+++ b/pages/common/xo.md
@@ -1,7 +1,7 @@
 # xo
 
 > A pluggable, zero-configuration linting utility for JavaScript.
-> Homepage: <https://github.com/xojs/xo>.
+> More information: <https://github.com/xojs/xo>.
 
 - Lint files in the "src" directory:
 

--- a/pages/common/xsv.md
+++ b/pages/common/xsv.md
@@ -1,7 +1,7 @@
 # xsv
 
 > A fast CSV command line toolkit written in Rust.
-> Homepage: <https://github.com/BurntSushi/xsv>.
+> More information: <https://github.com/BurntSushi/xsv>.
 
 - Inspect the headers of a file:
 

--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -1,7 +1,7 @@
 # xz
 
 > Compress or decompress .xz and .lzma files.
-> Homepage: <https://tukaani.org/xz/format.html>.
+> More information: <https://tukaani.org/xz/format.html>.
 
 - Compress a file to the xz file format:
 

--- a/pages/common/yarn-why.md
+++ b/pages/common/yarn-why.md
@@ -1,7 +1,7 @@
 # yarn-why
 
 > Identifies why a Yarn package has been installed.
-> Homepage: <https://www.npmjs.com/package/yarn-why>.
+> More information: <https://www.npmjs.com/package/yarn-why>.
 
 - Show why a Yarn package is installed:
 

--- a/pages/common/yarn.md
+++ b/pages/common/yarn.md
@@ -1,7 +1,7 @@
 # yarn
 
 > JavaScript and Node.js package manager alternative.
-> Homepage: <https://yarnpkg.com>.
+> More information: <https://yarnpkg.com>.
 
 - Install a module globally:
 

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -2,7 +2,7 @@
 
 > Helper tool for Yesod, a Haskell-based web framework.
 > All Yesod commands are invoked through the `stack` project manager.
-> Homepage: <https://github.com/yesodweb/yesod>.
+> More information: <https://github.com/yesodweb/yesod>.
 
 - Create a new scaffolded site, with sqlite as backend, in the "my-project" directory:
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -1,7 +1,7 @@
 # youtube-dl
 
 > Download videos from YouTube and other websites.
-> Homepage: <http://rg3.github.io/youtube-dl/>.
+> More information: <http://rg3.github.io/youtube-dl/>.
 
 - Download a video or playlist:
 

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -1,7 +1,7 @@
 # z
 
 > Tracks the most used directories and enables quickly navigating to them using string or regex patterns.
-> Homepage: <https://github.com/rupa/z>.
+> More information: <https://github.com/rupa/z>.
 
 - Go to a directory that contains "foo" in the name:
 

--- a/pages/common/zbarimg.md
+++ b/pages/common/zbarimg.md
@@ -1,7 +1,7 @@
 # zbarimg
 
 > Scan and decode bar codes from image file(s).
-> Homepage: <http://zbar.sourceforge.net>.
+> More information: <http://zbar.sourceforge.net>.
 
 - Process an image file:
 

--- a/pages/common/zopflipng.md
+++ b/pages/common/zopflipng.md
@@ -1,7 +1,7 @@
 # zopflipng
 
 > PNG image compression utility.
-> Homepage: <https://github.com/google/zopfli>.
+> More information: <https://github.com/google/zopfli>.
 
 - Optimize a PNG image:
 

--- a/pages/common/zsh.md
+++ b/pages/common/zsh.md
@@ -2,7 +2,7 @@
 
 > Z SHell.
 > `bash` and `sh`-compatible command line interpreter.
-> Homepage: <https://www.zsh.org>.
+> More information: <https://www.zsh.org>.
 
 - Start interactive command line interpreter:
 

--- a/pages/common/zstd.md
+++ b/pages/common/zstd.md
@@ -1,7 +1,7 @@
 # zstd
 
 > Compress or decompress files with Zstandard compression.
-> Homepage: <https://github.com/facebook/zstd>.
+> More information: <https://github.com/facebook/zstd>.
 
 - Compress a file into a new file with the .zst suffix:
 

--- a/pages/linux/calcurse.md
+++ b/pages/linux/calcurse.md
@@ -1,7 +1,7 @@
 # calcurse
 
 > A text-based calendar and scheduling application for the command line.
-> Homepage: <https://calcurse.org>.
+> More information: <https://calcurse.org>.
 
 - Start calcurse on interactive mode:
 

--- a/pages/linux/collectd.md
+++ b/pages/linux/collectd.md
@@ -1,7 +1,7 @@
 # collectd
 
 > System statistics collection daemon.
-> Homepage: <https://collectd.org/>.
+> More information: <https://collectd.org/>.
 
 - Show usage help, including the program version:
 

--- a/pages/linux/eyeD3.md
+++ b/pages/linux/eyeD3.md
@@ -1,7 +1,7 @@
 # eyeD3
 
 > Read and manipulate metadata of MP3 files.
-> Homepage: <https://eyed3.readthedocs.io/en/latest/>.
+> More information: <https://eyed3.readthedocs.io/en/latest/>.
 
 - View information about an MP3 file:
 

--- a/pages/linux/ffsend.md
+++ b/pages/linux/ffsend.md
@@ -1,7 +1,7 @@
 # ffsend
 
 > Easily and securely share files from command line.
-> Homepage: <https://gitlab.com/timvisee/ffsend>.
+> More information: <https://gitlab.com/timvisee/ffsend>.
 
 - Upload a file:
 

--- a/pages/linux/gopass.md
+++ b/pages/linux/gopass.md
@@ -1,7 +1,7 @@
 # gopass
 
 > Standard Unix Password Manager for Teams. Written in Go.
-> Homepage: <https://www.gopass.pw>.
+> More information: <https://www.gopass.pw>.
 
 - Initialise the configuration settings:
 

--- a/pages/linux/larasail.md
+++ b/pages/linux/larasail.md
@@ -1,7 +1,7 @@
 # larasail
 
 > A CLI tool for managing Laravel on Digital Ocean servers.
-> Homepage: <https://github.com/thedevdojo/larasail>.
+> More information: <https://github.com/thedevdojo/larasail>.
 
 - Set up the server with Laravel dependencies using the default PHP version:
 

--- a/pages/linux/lynis.md
+++ b/pages/linux/lynis.md
@@ -1,7 +1,7 @@
 # lynis
 
 > System and security auditing tool.
-> Documentation: <https://cisofy.com/documentation/lynis/>.
+> More information: <https://cisofy.com/documentation/lynis/>.
 
 - Check that Lynis is up-to-date:
 

--- a/pages/linux/nixos-rebuild.md
+++ b/pages/linux/nixos-rebuild.md
@@ -1,7 +1,7 @@
 # nixos-rebuild
 
 > Reconfigure a NixOS machine.
-> Documentation: <https://nixos.org/nixos/manual/#sec-changing-config>.
+> More information: <https://nixos.org/nixos/manual/#sec-changing-config>.
 
 - Build and switch to the new configuration, making it the boot default:
 

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -2,7 +2,7 @@
 
 > Run a new command in a running process' namespace.
 > Particularly useful for docker images or chroot jails.
-> Homepage: <https://github.com/jpetazzo/nsenter/>.
+> More information: <https://github.com/jpetazzo/nsenter/>.
 
 - Run command in existing processes network namespace:
 

--- a/pages/linux/pivpn.md
+++ b/pages/linux/pivpn.md
@@ -2,7 +2,7 @@
 
 > Easy security-hardened OpenVPN setup and manager.
 > Originally designed for the Raspberry Pi, but works on other Linux devices too.
-> Homepage: <http://www.pivpn.io/>.
+> More information: <http://www.pivpn.io/>.
 
 - Add a new client device:
 

--- a/pages/linux/sam.md
+++ b/pages/linux/sam.md
@@ -1,7 +1,7 @@
 # sam
 
 > AWS Serverless Application Model (SAM) CLI.
-> Homepage: <https://github.com/awslabs/aws-sam-cli>.
+> More information: <https://github.com/awslabs/aws-sam-cli>.
 
 - Initialize a serverless application:
 

--- a/pages/linux/silentcast.md
+++ b/pages/linux/silentcast.md
@@ -1,7 +1,7 @@
 # silentcast
 
 > Silent screencast creator. Saves in `.mkv` and animated gif formats.
-> Homepage: <https://github.com/colinkeenan/silentcast>.
+> More information: <https://github.com/colinkeenan/silentcast>.
 
 - Launch silentcast:
 

--- a/pages/linux/sm.md
+++ b/pages/linux/sm.md
@@ -1,7 +1,7 @@
 # sm
 
 > Displays a short message fullscreen.
-> Homepage: <https://github.com/nomeata/screen-message>.
+> More information: <https://github.com/nomeata/screen-message>.
 
 - Display a message in full-screen:
 

--- a/pages/osx/brew-cask.md
+++ b/pages/osx/brew-cask.md
@@ -1,7 +1,7 @@
 # brew cask
 
 > Package manager for macOS applications distributed as binaries.
-> Homepage: <https://github.com/Homebrew/homebrew-cask>.
+> More information: <https://github.com/Homebrew/homebrew-cask>.
 
 - Search for formulas and casks:
 

--- a/pages/osx/brew.md
+++ b/pages/osx/brew.md
@@ -1,7 +1,7 @@
 # brew
 
 > Package manager for macOS.
-> Homepage: <https://brew.sh>.
+> More information: <https://brew.sh>.
 
 - Search for available formulas and casks:
 

--- a/pages/osx/istats.md
+++ b/pages/osx/istats.md
@@ -1,7 +1,7 @@
 # istats
 
 > CLI tool that shows statistics such as CPU temperature, fan speeds and battery status.
-> Homepage: <https://github.com/Chris911/iStats>.
+> More information: <https://github.com/Chris911/iStats>.
 
 - Show all the stats:
 

--- a/pages/osx/mas.md
+++ b/pages/osx/mas.md
@@ -1,7 +1,7 @@
 # mas
 
 > Command line interface for the Mac App Store.
-> Homepage: <https://github.com/mas-cli/mas>.
+> More information: <https://github.com/mas-cli/mas>.
 
 - Sign into the Mac App Store for the first time:
 

--- a/pages/osx/sshuttle.md
+++ b/pages/osx/sshuttle.md
@@ -2,7 +2,7 @@
 
 > Transparent proxy server that tunnels traffic over an SSH connection.
 > Doesn't require admin, or any special setup on the remote SSH server.
-> Homepage: <https://github.com/sshuttle/sshuttle>.
+> More information: <https://github.com/sshuttle/sshuttle>.
 
 - Forward all IPv4 TCP traffic via a remote SSH server:
 

--- a/pages/osx/wacaw.md
+++ b/pages/osx/wacaw.md
@@ -1,7 +1,7 @@
 # wacaw
 
 > A little command-line tool for macOS that allows you to capture both still pictures and video from an attached camera.
-> Homepage: <http://webcam-tools.sourceforge.net>.
+> More information: <http://webcam-tools.sourceforge.net>.
 
 - Take a picture from webcam:
 

--- a/pages/osx/wifi-password.md
+++ b/pages/osx/wifi-password.md
@@ -1,7 +1,7 @@
 # wifi-password
 
 > Get the password of the wifi.
-> Homepage: <https://github.com/rauchg/wifi-password>.
+> More information: <https://github.com/rauchg/wifi-password>.
 
 - Get the password for the wifi you are currently logged onto:
 

--- a/pages/osx/xar.md
+++ b/pages/osx/xar.md
@@ -1,7 +1,7 @@
 # xar
 
 > Manage .xar archives.
-> Homepage: <https://linux.die.net/man/1/xar>.
+> More information: <https://linux.die.net/man/1/xar>.
 
 - Create a xar archive of all files in a given directory:
 

--- a/pages/osx/xctool.md
+++ b/pages/osx/xctool.md
@@ -1,7 +1,7 @@
 # xctool
 
 > Tool for building Xcode projects.
-> Homepage: <https://github.com/facebook/xctool>.
+> More information: <https://github.com/facebook/xctool>.
 
 - Build a single project without any workspace:
 

--- a/pages/windows/choco-apikey.md
+++ b/pages/windows/choco-apikey.md
@@ -1,7 +1,7 @@
 # choco-apikey
 
 > Manage API keys for Chocolatey sources.
-> Homepage: <https://chocolatey.org/docs/commands-apikey>.
+> More information: <https://chocolatey.org/docs/commands-apikey>.
 
 - Display a list of sources and their API keys:
 

--- a/pages/windows/choco-feature.md
+++ b/pages/windows/choco-feature.md
@@ -1,7 +1,7 @@
 # choco feature
 
 > Interact with features with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-feature>.
+> More information: <https://chocolatey.org/docs/commands-feature>.
 
 - Display a list of available features:
 

--- a/pages/windows/choco-info.md
+++ b/pages/windows/choco-info.md
@@ -1,7 +1,7 @@
 # choco info
 
 > Display detailed information about a package with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-info>.
+> More information: <https://chocolatey.org/docs/commands-info>.
 
 - Display information on a specific package:
 

--- a/pages/windows/choco-install.md
+++ b/pages/windows/choco-install.md
@@ -1,7 +1,7 @@
 # choco install
 
 > Install one or more packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-install>.
+> More information: <https://chocolatey.org/docs/commands-install>.
 
 - Install one or more space-separated packages:
 

--- a/pages/windows/choco-list.md
+++ b/pages/windows/choco-list.md
@@ -1,7 +1,7 @@
 # choco list
 
 > Display a list of packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-list>.
+> More information: <https://chocolatey.org/docs/commands-list>.
 
 - Display all available packages:
 

--- a/pages/windows/choco-new.md
+++ b/pages/windows/choco-new.md
@@ -1,7 +1,7 @@
 # choco new
 
 > Generate new package specification files with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-new>.
+> More information: <https://chocolatey.org/docs/commands-new>.
 
 - Create a new package skeleton:
 

--- a/pages/windows/choco-outdated.md
+++ b/pages/windows/choco-outdated.md
@@ -1,7 +1,7 @@
 # choco outdated
 
 > Check for outdated packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-outdated>.
+> More information: <https://chocolatey.org/docs/commands-outdated>.
 
 - Display a list of outdated packages in table format:
 

--- a/pages/windows/choco-pack.md
+++ b/pages/windows/choco-pack.md
@@ -1,7 +1,7 @@
 # choco pack
 
 > Package a NuGet specification into a nupkg file.
-> Homepage: <https://chocolatey.org/docs/commands-pack>.
+> More information: <https://chocolatey.org/docs/commands-pack>.
 
 - Package a NuGet specification to a nupkg file:
 

--- a/pages/windows/choco-pin.md
+++ b/pages/windows/choco-pin.md
@@ -2,7 +2,7 @@
 
 > Pin a package at a specific version with Chocolatey.
 > Pinned packages are skipped automatically when upgrading.
-> Homepage: <https://chocolatey.org/docs/commands-pin>.
+> More information: <https://chocolatey.org/docs/commands-pin>.
 
 - Display a list of pinned packages and their versions:
 

--- a/pages/windows/choco-search.md
+++ b/pages/windows/choco-search.md
@@ -1,7 +1,7 @@
 # choco search
 
 > Search for a local or remote package with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-search>.
+> More information: <https://chocolatey.org/docs/commands-search>.
 
 - Search for a package:
 

--- a/pages/windows/choco-source.md
+++ b/pages/windows/choco-source.md
@@ -1,7 +1,7 @@
 # choco source
 
 > Manage sources for packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-source>.
+> More information: <https://chocolatey.org/docs/commands-source>.
 
 - List currently available sources:
 

--- a/pages/windows/choco-uninstall.md
+++ b/pages/windows/choco-uninstall.md
@@ -1,7 +1,7 @@
 # choco uninstall
 
 > Uninstall one or more packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-uninstall>.
+> More information: <https://chocolatey.org/docs/commands-uninstall>.
 
 - Uninstall one or more space-separated packages:
 

--- a/pages/windows/choco-upgrade.md
+++ b/pages/windows/choco-upgrade.md
@@ -1,7 +1,7 @@
 # choco upgrade
 
 > Upgrade one or more packages with Chocolatey.
-> Homepage: <https://chocolatey.org/docs/commands-upgrade>.
+> More information: <https://chocolatey.org/docs/commands-upgrade>.
 
 - Upgrade one or more space-separated packages:
 

--- a/pages/windows/choco.md
+++ b/pages/windows/choco.md
@@ -2,7 +2,7 @@
 
 > A command line interface for the Chocolatey package manager.
 > See `choco install`, `choco upgrade` and other pages for additional information.
-> Homepage: <https://chocolatey.org>.
+> More information: <https://chocolatey.org>.
 
 - Execute Chocolatey command:
 

--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -1,7 +1,7 @@
 # scoop
 
 > A command-line installer for Windows.
-> Homepage: <https://scoop.sh>.
+> More information: <https://scoop.sh>.
 
 - Install a package:
 

--- a/pages/windows/virtualboxvm.md
+++ b/pages/windows/virtualboxvm.md
@@ -1,7 +1,7 @@
 # virtualboxvm
 
 > The VirtualBox virtual machine management CLI.
-> Homepage: <https://www.virtualbox.org>.
+> More information: <https://www.virtualbox.org>.
 
 - Start a virtual machine:
 


### PR DESCRIPTION
Followup on #3060.

This PR updates the wording of description links of all English and Italian pages to `More information: <...>` (italian `Maggiori informazioni: <...>`).

If anybody wants to take care of other languages, here's the script I used:

    sed -i 's/> .\+:.\+</> More information: </' pages/**/*

Pinging @schneiderl and @andrik in case one of you is interested.