### PR TITLE
git-stash: replace deprecated git stash save

### DIFF
--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -5,7 +5,7 @@
 
 - Stash current changes, except new (untracked) files:
 
-`git stash [save {{optional_stash_message}}]`
+`git stash [push -m {{optional_stash_message}}]`
 
 - Stash current changes, including new (untracked) files:
 


### PR DESCRIPTION
This PR replaces the deprecated method of stashing changes with a message (`git stash save`) with the new way (`git stash push -m <message>`).

From the git docs:
> This option is deprecated in favour of git stash push. It differs from
> "stash push" in that it cannot take pathspecs, and any non-option
> arguments form the message.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
