### PR TITLE
git commit: add example for committing specific files

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -1,7 +1,7 @@
 # git commit
 
 > Commit files to the repository.
-> Homepage: <https://git-scm.com/docs/git-commit>.
+> More information: <https://git-scm.com/docs/git-commit>.
 
 - Commit staged files to the repository with a message:
 
@@ -14,3 +14,7 @@
 - Replace the last commit with currently staged changes:
 
 `git commit --amend`
+
+- Commit only specific files or folders:
+
+`git commit -m {{message}} {{path/to/my/file.ext}}`

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -15,6 +15,6 @@
 
 `git commit --amend`
 
-- Commit only specific files or folders:
+- Commit only specific (already staged) files:
 
-`git commit -m {{message}} {{path/to/my/file}} {{path/to/my/second_file}}`
+`git commit {{path/to/my/file1}} {{path/to/my/file2}}`

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -17,4 +17,4 @@
 
 - Commit only specific files or folders:
 
-`git commit -m {{message}} {{path/to/my/file.ext}}`
+`git commit -m {{message}} {{path/to/my/file}} {{path/to/my/second_file}}`


### PR DESCRIPTION
This command was missing, but it's very important one.