### PR TITLE
sqlmap: fix user token typo

### DIFF
--- a/pages/common/sqlmap.md
+++ b/pages/common/sqlmap.md
@@ -9,7 +9,7 @@
 
 - Send data in a POST request (`--data` implies POST request):
 
-`python sqlmap.py -u {{"http://www.target.com/vuln.php" --data={{"id=1"}}`
+`python sqlmap.py -u {{"http://www.target.com/vuln.php"}} --data={{"id=1"}}`
 
 - Change the parameter delimiter (& is the default):
 


### PR DESCRIPTION
Fixed broken `{{user_token}}` in second example missing closing brackets.