### PR TITLE
hyperfine: fix typo

### DIFF
--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -25,4 +25,4 @@
 
 - Run a benchmark where a single parameter changes for each run:
 
-`hyperfine --prepare '{{make clean}}' --parameter-scan num_threads {{1}} {{10}} '{{make -j {num_threads}}}'`
+`hyperfine --prepare '{{make clean}}' --parameter-scan {{num_threads}} {{1}} {{10}} '{{make -j {num_threads}}}'`


### PR DESCRIPTION
Missing brackets around a user token.