### PR TITLE
deluged, deluge-console: clarify description

### DIFF
--- a/pages/common/deluge-console.md
+++ b/pages/common/deluge-console.md
@@ -1,6 +1,6 @@
 # deluge-console
 
-> An interactive BitTorrent client interface that uses curses.
+> An interactive interface for the Deluge BitTorrent client.
 > More information: <https://deluge-torrent.org>.
 
 - Start the interactive console interface:

--- a/pages/common/deluged.md
+++ b/pages/common/deluged.md
@@ -1,6 +1,6 @@
 # deluged
 
-> A BitTorrent client daemon process.
+> A daemon process for the Deluge BitTorrent client.
 > More information: <https://deluge-torrent.org>.
 
 - Start the Deluge daemon:


### PR DESCRIPTION
After reading these these two Deluge pages more carefully while translating them, I feel like the description is a bit unclear: it should be more clearly stated that these are specifically for the Deluge BitTorrent client, and not any other client.