### PR TITLE
fstrim: add page

### DIFF
--- a/pages/linux/fstrim.md
+++ b/pages/linux/fstrim.md
@@ -1,0 +1,16 @@
+# fstrim
+
+> Discard unused blocks on a mounted filesystem.
+> Only supported by flash memory devices such as SSDs and microSD cards.
+
+- Trim unused blocks on all mounted partitions that support it:
+
+`sudo fstrim --all`
+
+- Trim unused blocks on a specified partition:
+
+`sudo fstrim {{/}}`
+
+- Display statistics after trimming:
+
+`sudo fstrim --verbose {{/}}`


### PR DESCRIPTION
While I suspect that *BSD variants support `fstrim` (does Solaris or macOS support too? I'm not sure), I'm unsure about other platforms.

This is `fstrim` that's part of `util-linux` on Ubuntu, but it appears to be common across most distributions with the same feature set.