### PR TITLE
find: various improvements

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -22,7 +22,7 @@
 
 `find {{root_path}} -name '{{*.py}}' -not -path '{{*/site-packages/*}}'`
 
-- Find files of a certain size:
+- Find files matching a given size range:
 
 `find {{root_path}} -size {{+500k}} -size {{-10M}}`
 

--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -10,30 +10,26 @@
 
 `find {{root_path}} -name '{{*pattern_1*}}' -or -name '{{*pattern_2*}}'`
 
-- Find directories matching a given name:
+- Find directories matching a given name, in case-insensitive mode:
 
-`find {{root_path}} -type d -name {{*lib*}}`
+`find {{root_path}} -type d -iname {{*lib*}}`
 
-- Find files matching path pattern:
+- Find files matching a path pattern:
 
 `find {{root_path}} -path '{{**/lib/**/*.ext}}'`
 
-- Run a command for each file, use {} within the command to access the filename:
+- Find files matching a given pattern, excluding specific paths:
+
+`find {{root_path}} -name '{{*.py}}' -not -path '{{*/site-packages/*}}'`
+
+- Find files of a certain size:
+
+`find {{root_path}} -size {{+500k}} -size {{-10M}}`
+
+- Run a command for each file (use `{}` within the command to access the filename):
 
 `find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }}\;`
 
-- Find files modified in the last 24-hour period:
+- Find files modified in the last 7 days, and delete them:
 
-`find {{root_path}} -mtime {{-1}}`
-
-- Find files using case insensitive name matching, of a certain size:
-
-`find {{root_path}} -size {{+500k}} -size {{-10M}} -iname '{{*.TaR.gZ}}'`
-
-- Delete files by name, older than 180 days:
-
-`find {{root_path}} -name '{{*.ext}}' -mtime {{+180}} -delete`
-
-- Find files matching a given pattern, while excluding specific paths:
-
-`find {{root_path}} -name '{{*.py}}' -not -path '{{*/site-packages/*}}'`
+`find {{root_path}} -mtime {{-7}} -delete`


### PR DESCRIPTION
The information content of the page should be unchanged, but hopefully it's now easier to read
(and respects our length recommendations of 8 maximum examples).

The changes include:
- Make the `-mtime` example more intuitive, so it only needs to be shown once,
  and combine the `-delete` option with the first (now only) `-mtime` example
  (thus reducing the page size back to 8 examples)
- Fix a comma splice in the `-exec` example, and a missing "a" in the `-path` example
- Reorder the examples to provide a more consistent and intuitive sequence
  (e.g. by introducing `-iname` in an earlier example, and moving the `-exec` command down)

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
