### PR TITLE
astyle: reword description

### DIFF
--- a/pages.it/common/astyle.md
+++ b/pages.it/common/astyle.md
@@ -1,6 +1,6 @@
 # astyle
 
-> Identificatore di codice sorgente, formattatore e beautifier per i linguaggi C, C++, C# e Java.
+> Indentatore, formattatore e beautifier di codice sorgente per i linguaggi C, C++, C# e Java.
 > Quando eseguito, una copia del file originale è creata con l'estensione ".orig" aggiunta come suffisso.
 > Maggiori informazioni: <http://astyle.sourceforge.net/>.
 


### PR DESCRIPTION
Just noticed that the short description for the astyle Italian page is incorrect and strangely worded. 