### PR TITLE
entr: simplify example

### DIFF
--- a/pages/common/entr.md
+++ b/pages/common/entr.md
@@ -4,7 +4,7 @@
 
 - Rebuild with `make` if any file in any subdirectory changes:
 
-`{{ag -l}} | entr {{make}}`
+`{{find}} | entr {{make}}`
 
 - Rebuild and test with `make` if any `.c` source files in the current directory change:
 


### PR DESCRIPTION
The first example of `entr` uses `ag -l` to list all files recursively. `find` does the same thing if launched without arguments.