### PR TITLE
cat: add -v example

### DIFF
--- a/pages/common/cat.md
+++ b/pages/common/cat.md
@@ -17,3 +17,7 @@
 - Number all output lines:
 
 `cat -n {{file}}`
+
+- Display non-printable and whitespace characters (with `M-` prefix if non-ASCII):
+
+`cat -v -t -e {{file}}`


### PR DESCRIPTION
Inspired by [this UnixToolTip tweet](https://twitter.com/UnixToolTip/status/1145733858970742786), and further informed by [this commandlinefu example](https://www.commandlinefu.com/commands/view/1637/view-non-printing-characters-with-cat).

See also [this Unix.SX answer](https://unix.stackexchange.com/a/522300/30336) for further background.

- [ ] ~~The page (if new), does not already exist in the repo.~~
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
