### PR TITLE
rbac-lookup: add page

### DIFF
--- a/pages/common/rbac-lookup.md
+++ b/pages/common/rbac-lookup.md
@@ -15,7 +15,7 @@
 
 `rbac-lookup -o wide`
 
-- View all RBAC bindings filtered by the kind of Subject:
+- View all RBAC bindings filtered by subject:
 
 `rbac-lookup -k {{user|group|serviceaccount}}`
 

--- a/pages/common/rbac-lookup.md
+++ b/pages/common/rbac-lookup.md
@@ -1,0 +1,25 @@
+# rbac-lookup
+
+> Find roles and cluster roles attached to any user, service account or group name in your Kubernetes cluster.
+> More information: <https://github.com/reactiveops/rbac-lookup>.
+
+- View all RBAC bindings:
+
+`rbac-lookup`
+
+- View RBAC bindings that matches a given expression:
+
+`rbac-lookup {{search_term}}`
+
+- View all RBAC bindings along with the source role binding:
+
+`rbac-lookup -o wide`
+
+- View all RBAC bindings filtered by the kind of Subject:
+
+`rbac-lookup -k {{user|group|serviceaccount}}`
+
+- View all RBAC bindings along with IAM roles (if you are using GKE):
+
+`rbac-lookup --gke`
+

--- a/pages/common/rbac-lookup.md
+++ b/pages/common/rbac-lookup.md
@@ -22,4 +22,3 @@
 - View all RBAC bindings along with IAM roles (if you are using GKE):
 
 `rbac-lookup --gke`
-

--- a/pages/common/rbac-lookup.md
+++ b/pages/common/rbac-lookup.md
@@ -7,7 +7,7 @@
 
 `rbac-lookup`
 
-- View RBAC bindings that matches a given expression:
+- View RBAC bindings that match a given expression:
 
 `rbac-lookup {{search_term}}`
 


### PR DESCRIPTION
I have added [rbac-lookup](https://github.com/reactiveops/rbac-lookup) - a util tool for K8s RBAC by ReactiveOps guys.