### PR TITLE
mimetype: add page

### DIFF
--- a/pages/linux/mimetype.md
+++ b/pages/linux/mimetype.md
@@ -1,0 +1,31 @@
+# mimetype
+
+> Automatically determine the MIME type of a file.
+
+- Print the MIME type of a given file:
+
+`mimetype {{path/to/file}}`
+
+- Display only the MIME type, and not the filename:
+
+`mimetype --brief {{path/to/file}}`
+
+- Display a description of the MIME type:
+
+`mimetype --describe {{path/to/file}}`
+
+- Determine the MIME type of stdin (does not check a filename):
+
+`{{some_command}} | mimetype --stdin`
+
+- Display debug information about how the MIME type was determined:
+
+`mimetype --debug {{path/to/file}}`
+
+- Display all the possible MIME types of a given file in confidence order:
+
+`mimetype --all {{path/to/file}}`
+
+- Explicitly specify the 2-letter language code of the output:
+
+`mimetype --language {{path/to/file}}`


### PR DESCRIPTION
Another day, another command from my tldr-missing-pages list. 1 down, 147 to go.....

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
