### PR TITLE
hub: add hub pr usage for checkout someone created pull-request

### DIFF
--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -24,7 +24,7 @@
 
 `hub pull-request --no-edit`
 
-- Create a new branch with the contents of the pull request and checkout it for review:
+- Create a new branch with the contents of a pull request and switch to it:
 
 `hub pr checkout {{pr_number}}`
 

--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -24,6 +24,10 @@
 
 `hub pull-request --no-edit`
 
+- Create a new branch with the contents of the pull request and checkout it for review:
+
+`hub pr checkout {{pr_number}}`
+
 - Upload the current (local-only) repository to your github account:
 
 `hub create`


### PR DESCRIPTION
Hi! Thanks for such a great project!

I add `hub pr` usege for checkout someone created pull-request.

Cited from `hub` official readme https://hub.github.com/#maintainer

best,

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).