### PR TITLE
bitcoin-cli: add page

### DIFF
--- a/pages/common/bitcoin-cli.md
+++ b/pages/common/bitcoin-cli.md
@@ -1,7 +1,7 @@
 # bitcoin-cli
 
 > Command-line client to interact with the Bitcoin daemon via RPC calls.
-> The client uses the configurations defined in the `bitcoin.conf` file.
+> Uses the configuration defined in `bitcoin.conf`.
 > More information: <https://en.bitcoin.it/wiki/Running_Bitcoin#Command-line_arguments>.
 
 - Send a transaction to a given address:

--- a/pages/common/bitcoin-cli.md
+++ b/pages/common/bitcoin-cli.md
@@ -1,0 +1,25 @@
+# bitcoin-cli
+
+> Command-line client to interact with the Bitcoin daemon via RPC calls.
+> The client uses the configurations defined in the `bitcoin.conf` file.
+> More information: <https://en.bitcoin.it/wiki/Running_Bitcoin#Command-line_arguments>.
+
+- Send a transaction to a given address:
+
+`bitcoin-cli sendtoaddress "{{address}}" {{amount}}`
+
+- Generate one or more blocks:
+
+`bitcoin-cli generate {{num_blocks}}`
+
+- Print high-level information about the wallet:
+
+`bitcoin-cli getwalletinfo`
+
+- List all outputs from previous transactions available to fund outgoing transactions:
+
+`bitcoin-cli listunspent`
+
+- Export the wallet information to a text file:
+
+`bitcoin-cli dumpwallet "{{path/to/file}}"`


### PR DESCRIPTION
First draft at a page for `bitcoin-cli`.

Further documentation:
- [Manpage source](https://github.com/bitcoin/bitcoin/blob/v0.18.0/doc/man/bitcoin-cli.1)
- [Rendered manpage from Debian](https://manpages.debian.org/experimental/bitcoind/bitcoin-cli.1.en.html)
- [Code that produces the help messages](https://github.com/bitcoin/bitcoin/blob/v0.18.0/src/bitcoin-cli.cpp#L43-L58)

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
