### PR TITLE
radeontop: add page

### DIFF
--- a/pages/linux/radeontop.md
+++ b/pages/linux/radeontop.md
@@ -1,6 +1,7 @@
 # radeontop
 
->  Show utilisation of AMD GPUs.
+> Show utilisation of AMD GPUs.
+> More information: <https://github.com/clbr/radeontop>.
 
 - Show the utilisation of the default AMD GPU:
 

--- a/pages/linux/radeontop.md
+++ b/pages/linux/radeontop.md
@@ -1,0 +1,19 @@
+# radeontop
+
+>  Show utilisation of AMD GPUs.
+
+- Show the utilisation of the default AMD GPU:
+
+`sudo radeontop`
+
+- Enable colourised output:
+
+`sudo radeontop --colour`
+
+- Select a specific GPU (the bus number is the first number in the output of `lspci`):
+
+`sudo radeontop --bus {{bus_number}}`
+
+- Specify the display refresh rate (higher means more GPU overhead):
+
+`sudo radeontop --ticks {{samples_per_second}}`


### PR DESCRIPTION
I was looking for an alternative to the Nvidia GPU top program (I can't remember what it's called now) for my AMD Radeon card in my laptop, and I found this. It's quite handy! It's available in most distro repos.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
