### PR TITLE
renice: split description in two lines

### DIFF
--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -1,6 +1,7 @@
 # renice
 
-> Alters the scheduling priority/nicenesses of one or more running processes. Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
+> Alters the scheduling priority/nicenesses of one or more running processes.
+> Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 
 - Change priority of a running process:
 


### PR DESCRIPTION
This page has a very long description that would really read better splitted in two different lines.