### PR TITLE
Travis: separate building from deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ language: node_js
 node_js: stable
 cache: false
 
+git:
+  depth: 1
+
+script:
+  - npm test
+  - bash scripts/build.sh
+
 after_failure:
   - python scripts/send_to_bot.py < test_result
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script is executed by Travis CI for every successful push (on any branch, PR or not).
+set -ex
+
+function initialize {
+  if [ -z "$TLDRHOME" ]; then
+    export TLDRHOME=${TRAVIS_BUILD_DIR:-$(pwd)}
+  fi
+
+  export TLDR_ARCHIVE="tldr.zip"
+}
+
+function build_index {
+  npm run build-index
+  echo "Pages index succesfully built."
+}
+
+function build_archive {
+  rm -f "$TLDR_ARCHIVE"
+  cd "$TLDRHOME/"
+  zip -q -r "$TLDR_ARCHIVE" pages* LICENSE.md index.json
+  echo "Pages archive succesfully built."
+}
+
+###################################
+# MAIN
+###################################
+
+initialize
+build_index
+build_archive

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,9 +7,9 @@ function initialize {
   if [ -z "$TLDRHOME" ]; then
     export TLDRHOME=${TRAVIS_BUILD_DIR:-$(pwd)}
   fi
+
   export TLDR_ARCHIVE="tldr.zip"
   export SITE_HOME="$HOME/site"
-  export SITE_URL="github.com/tldr-pages/tldr-pages.github.io"
   export SITE_REPO_SLUG="tldr-pages/tldr-pages.github.io"
 
   # Configure git.
@@ -23,18 +23,6 @@ function initialize {
   openssl aes-256-cbc -K "$encrypted_973441be79af_key" -iv "$encrypted_973441be79af_iv" -in ./scripts/id_ed25519_tldr_asset_upload.enc -out id_ed25519 -d
   chmod 600 id_ed25519
   ssh-add id_ed25519
-}
-
-function rebuild_index {
-  npm run build-index
-  echo "Rebuilding index done."
-}
-
-function build_archive {
-  rm -f "$TLDR_ARCHIVE"
-  cd "$TLDRHOME/"
-  zip -r "$TLDR_ARCHIVE" pages*/ LICENSE.md index.json
-  echo "Pages archive created."
 }
 
 function upload_assets {
@@ -55,6 +43,4 @@ function upload_assets {
 ###################################
 
 initialize
-rebuild_index
-build_archive
 upload_assets


### PR DESCRIPTION
Fixes #3148.

I finally figured this out. After looking at the output of some failed builds, it seems that the build always crashes around ~1100 lines of output: for some reason Travis chokes on the very long output of `zip -r pages* ...`. The immediate fix for this was to add `-q` to make the `zip` command quiet. This also means there is no need to use `travis_retry` (or any sort of retry logic at all).

Other than this, as previously discussed in #3148 I also updated the build process to be more consistent. To summarize, the changes are the following:

 1. Added `-q` to the `zip` command to create the archive.
 2. Moved the actual building of the index and the archive from `deploy.sh` to a new `build.sh` script.
 3. Added a `script:` step to `.travis.yml` to run `build.sh` after `npm test`.
 4. Specified a clone depth of 1 in `.travis.yml` to make things faster since we don't need to do any git operation during the build.

---

NOTE: for obvious reasons, I could not actually test the deployment of the updated ZIP archive. The code that deploys stuff to `tldr-pages.github.io` in `deploy.sh` is basically left untouched, so it should all work. Just to be safe though, to anyone who merges this: please **keep an eye on the build when this is merged** and make sure everything works fine. 