### PR TITLE
pdflatex: add -output-directory example

### DIFF
--- a/pages/common/pdflatex.md
+++ b/pages/common/pdflatex.md
@@ -8,7 +8,7 @@
 
 - Compile a pdf document specifying an output directory:
 
-`pdflatex -output-directory={{/tmp}} {{source.tex}}`
+`pdflatex -output-directory={{path/to/directory}} {{source.tex}}`
 
 - Compile a pdf document, halting on each error:
 

--- a/pages/common/pdflatex.md
+++ b/pages/common/pdflatex.md
@@ -6,6 +6,10 @@
 
 `pdflatex {{source.tex}}`
 
+- Compile a pdf document specifying an output directory:
+
+`pdflatex -output-directory={{/tmp}} {{source.tex}}`
+
 - Compile a pdf document, halting on each error:
 
 `pdflatex -halt-on-error {{source.tex}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
