### PR TITLE
vmware-checkvm: add page

### DIFF
--- a/pages/linux/vmware-checkvm.md
+++ b/pages/linux/vmware-checkvm.md
@@ -1,0 +1,11 @@
+# vmware-checkvm
+
+> Checks to see if the current host is a VMWare VM or not.
+
+- Return the current VMWare software version (exit status determines whether the system is a VM or not):
+
+`vmware-checkvm`
+
+- Return the VMWare hardware version:
+
+`vmware-checkvm -h`


### PR DESCRIPTION
I've got a few VMWare virtual machines from my University, and I realised that they have the VMware guest tools installed, so I thought I'd play around with them a bit.

I even discovered a sweet hidden flag!

![image](https://user-images.githubusercontent.com/9929737/61302295-6e33a480-a7dd-11e9-81e6-519b7a5b99fe.png)


- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
