### PR TITLE
snapper: snapshot creation

### DIFF
--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -10,13 +10,13 @@
 
 `snapper -c {{config}} create-config {{path/to/directory}}`
 
+- Create snapshot and give description:
+
+`snapper -c {{config}} create -d {{"snapshot description"}}`
+
 - List snapshots for a config:
 
 `snapper -c {{config}} list`
-
-- Create a new snapshot:
-
-`snapper -c {{config}} snapshot`
 
 - Delete a snapshot:
 

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -13,7 +13,7 @@
 
 - Create snapshot with a description:
 
-`snapper -c {{config}} create -d {{"snapshot description"}}`
+`snapper -c {{config}} create -d {{"snapshot_description"}}`
 
 - List snapshots for a config:
 

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -26,4 +26,6 @@
 
 `snapper -c {{config}} delete {{snapshot_X}}-{{snapshot_Y}}`
 
-For a complete list of commands reference to http://snapper.io/manpages/snapper.html
+- For a complete list of commands reference to:
+
+`http://snapper.io/manpages/snapper.html`

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -26,4 +26,4 @@
 
 `snapper -c {{config}} delete {{snapshot_X}}-{{snapshot_Y}}`
 
-For a more complete list of commands reference to http://snapper.io/manpages/snapper.html
+For a complete list of commands reference to http://snapper.io/manpages/snapper.html

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -11,7 +11,7 @@
 
 `snapper -c {{config}} create-config {{path/to/directory}}`
 
-- Create snapshot with a description:
+- Create a snapshot with a description:
 
 `snapper -c {{config}} create -d {{"snapshot_description"}}`
 

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -10,7 +10,7 @@
 
 `snapper -c {{config}} create-config {{path/to/directory}}`
 
-- Create snapshot and give description:
+- Create snapshot with a description:
 
 `snapper -c {{config}} create -d {{"snapshot description"}}`
 
@@ -25,3 +25,5 @@
 - Delete a range of snapshots:
 
 `snapper -c {{config}} delete {{snapshot_X}}-{{snapshot_Y}}`
+
+For a more complete list of commands reference to http://snapper.io/manpages/snapper.html

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -1,6 +1,7 @@
 # snapper
 
 > Filesystem snapshot management tool.
+> More information: <http://snapper.io/manpages/snapper.html>.
 
 - List snapshot configs:
 
@@ -25,7 +26,3 @@
 - Delete a range of snapshots:
 
 `snapper -c {{config}} delete {{snapshot_X}}-{{snapshot_Y}}`
-
-- For a complete list of commands reference to:
-
-`http://snapper.io/manpages/snapper.html`


### PR DESCRIPTION
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

`-c config snapshot` doesn't work for me and can't find a reference... maybe the option changed.
`-c config create` does the job.

[openSUSE reference](https://en.opensuse.org/openSUSE:Snapper_Tutorial#Manually_Creating_A_Snapshot)

not sure about `-d` or `--description`

modified also the order of the things, this way it should be more straight forward, isn't it?