### PR TITLE
git-grep: add new command

### DIFF
--- a/pages/common/git-grep.md
+++ b/pages/common/git-grep.md
@@ -19,3 +19,7 @@
 - Search for a string at a specific point in history:
 
 `git grep {{search_string}} {{HEAD~2}}`
+
+- Search for a string across all branches:
+
+`git grep {{search_string}} $(git rev-list --all)`


### PR DESCRIPTION
I have added `git grep` missing command which is very useful. [Source](https://stackoverflow.com/questions/7151311/using-git-how-could-i-search-for-a-string-across-all-branches)