### PR TITLE
mat2: add page

### DIFF
--- a/pages/common/mat2.md
+++ b/pages/common/mat2.md
@@ -1,0 +1,23 @@
+# mat2
+
+> Anonymise various file formats by removing metadata. More information: <https://0xacab.org/jvoisin/mat2>
+
+- List supported file formats:
+
+`mat2 --list`
+
+- Remove metadata from a file:
+
+`mat2 {{file_path}}`
+
+- Remove metadata from a file and print detailed output to the console:
+
+`mat2 --verbose {{file_path}}`
+
+- Show metadata in a file without removing it:
+
+`mat2 --show {{file_path}}`
+
+- Partially remove metadata from a file:
+
+`mat2 --lightweight {{file_path}}`

--- a/pages/common/mat2.md
+++ b/pages/common/mat2.md
@@ -13,12 +13,12 @@
 
 - Remove metadata from a file and print detailed output to the console:
 
-`mat2 --verbose {{file_path}}`
+`mat2 --verbose {{path/to/file}}`
 
 - Show metadata in a file without removing it:
 
-`mat2 --show {{file_path}}`
+`mat2 --show {{path/to/file}}`
 
 - Partially remove metadata from a file:
 
-`mat2 --lightweight {{file_path}}`
+`mat2 --lightweight {{path/to/file}}`

--- a/pages/common/mat2.md
+++ b/pages/common/mat2.md
@@ -8,7 +8,7 @@
 
 - Remove metadata from a file:
 
-`mat2 {{file_path}}`
+`mat2 {{path/to/file}}`
 
 - Remove metadata from a file and print detailed output to the console:
 

--- a/pages/common/mat2.md
+++ b/pages/common/mat2.md
@@ -1,6 +1,7 @@
 # mat2
 
-> Anonymise various file formats by removing metadata. More information: <https://0xacab.org/jvoisin/mat2>.
+> Anonymise various file formats by removing metadata.
+> More information: <https://0xacab.org/jvoisin/mat2>.
 
 - List supported file formats:
 

--- a/pages/common/mat2.md
+++ b/pages/common/mat2.md
@@ -1,6 +1,6 @@
 # mat2
 
-> Anonymise various file formats by removing metadata. More information: <https://0xacab.org/jvoisin/mat2>
+> Anonymise various file formats by removing metadata. More information: <https://0xacab.org/jvoisin/mat2>.
 
 - List supported file formats:
 


### PR DESCRIPTION
I added a page for `mat2`. It is in `common` because it is available for GNU/Linux and OSX.

More information: <https://0xacab.org/jvoisin/mat2>

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
