### PR TITLE
emacs: clarify examples

### DIFF
--- a/pages/common/emacs.md
+++ b/pages/common/emacs.md
@@ -3,7 +3,7 @@
 > The extensible, customizable, self-documenting, real-time display editor.
 > More information: <https://www.gnu.org/software/emacs>.
 
-- Open emacs in console mode (without X window):
+- Start emacs in console mode (without X window):
 
 `emacs -nw`
 
@@ -11,6 +11,6 @@
 
 `emacs {{filename}}`
 
-- Exit emacs:
+- Exit emacs (save buffers and terminate):
 
-`C-x C-c`
+`Ctrl + X, Ctrl + C`


### PR DESCRIPTION
- Use the word "start" instead of "open" when launching emacs.
- Clarify exit example and keyboard shortcuts.