### PR TITLE
enca: clarify examples and fix tokens

### DIFF
--- a/pages/common/enca.md
+++ b/pages/common/enca.md
@@ -1,20 +1,20 @@
 # enca
 
-> Detect and convert encoding of text files.
+> Detect and convert the encoding of text files.
 > More information: <https://github.com/nijel/enca>.
 
-- Detect file(s) encoding according to your system's locale:
+- Detect file(s) encoding according to the system's locale:
 
-`enca {{file(s)}}`
+`enca {{file1 file2 ...}}`
 
-- Detect file(s) encoding; -L option tells enca the current language; language is in the POSIX/C locale format, e.g. zh_CN, en_US etc:
+- Detect file(s) encoding specifying a language the POSIX/C locale format (e.g. zh_CN, en_US):
 
-`enca -L {{language}} {{file(s)}}`
+`enca -L {{language}} {{file1 file2 ...}}`
 
-- Convert file(s) to specified encoding:
+- Convert file(s) to a specific encoding:
 
-`enca -L {{language}} -x {{to_encoding}} {{file(s)}}`
+`enca -L {{language}} -x {{to_encoding}} {{file1 file2 ...}}`
 
-- Save original_file as new_file and convert new_file to specified encoding:
+- Create a copy of an existing file using a different encoding:
 
 `enca -L {{language}} -x {{to_encoding}} < {{original_file}} > {{new_file}}`

--- a/pages/common/enca.md
+++ b/pages/common/enca.md
@@ -7,7 +7,7 @@
 
 `enca {{file1 file2 ...}}`
 
-- Detect file(s) encoding specifying a language the POSIX/C locale format (e.g. zh_CN, en_US):
+- Detect file(s) encoding specifying a language in the POSIX/C locale format (e.g. zh_CN, en_US):
 
 `enca -L {{language}} {{file1 file2 ...}}`
 


### PR DESCRIPTION
- Clarify and simplify examples' descriptions.
- Change the token `{{files(s)}}` to `{{file1 file2 ...}}` for consistency with other pages.
