### PR TITLE
unalias: add page

### DIFF
--- a/pages/common/unalias.md
+++ b/pages/common/unalias.md
@@ -1,0 +1,11 @@
+# unalias
+
+> Remove aliases.
+
+- Remove an alias:
+
+`unalias {{alias_name}}`
+
+- Remove all aliases:
+
+`unalias -a`


### PR DESCRIPTION
I created a page for `unalias`. It is cross-platform, so I included it in `common`.

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).