### PR TITLE
feedreader: add page

### DIFF
--- a/pages/linux/feedreader.md
+++ b/pages/linux/feedreader.md
@@ -1,6 +1,6 @@
 # feedreader
 
-> A GUI desktop RSS client. More information: <https://jangernert.github.io/FeedReader/>
+> A GUI desktop RSS client. More information: <https://jangernert.github.io/FeedReader/>.
 
 - Print the count of unread articles:
 

--- a/pages/linux/feedreader.md
+++ b/pages/linux/feedreader.md
@@ -1,0 +1,23 @@
+# feedreader
+
+> A GUI desktop RSS client. More information: <https://jangernert.github.io/FeedReader/>
+
+- Print the count of unread articles:
+
+`feedreader --unreadCount`
+
+- Add a URL for a feed to follow:
+
+`feedreader --addFeed={{feed_url}}`
+
+- Grab a specific article using its URL:
+
+`feedreader --grabArticle={{article_url}}`
+
+- Download all images from a specific article:
+
+`feedreader --url={{feed_url}} --grabImages={{article_path}}`
+
+- Play media from a URL:
+
+`feedreader --playMedia={{article_url}}`


### PR DESCRIPTION
Feedreader is a GUI application for viewing RSS feeds.

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
