### PR TITLE
envsubst: clarify examples and description

### DIFF
--- a/pages/common/envsubst.md
+++ b/pages/common/envsubst.md
@@ -1,20 +1,20 @@
 # envsubst
 
-> Substitutes shell format strings with environment variables in text.
-> Strings to be replaced should be in either `${var}` or `$var` format.
+> Substitutes environment variables with their value in shell format strings.
+> Variables to be replaced should be in either `${var}` or `$var` format.
 
-- Replace environment variables in stdin and output to `stdout`:
+- Replace environment variables in `stdin` and output to `stdout`:
 
 `echo '{{$HOME}}' | envsubst`
 
 - Replace environment variables in an input file and output to `stdout`:
 
-`envsubst < {{path/to/input}}`
+`envsubst < {{path/to/input_file}}`
 
 - Replace environment variables in an input file and output to a file:
 
-`envsubst < {{path/to/input}} > {{path/to/output}}`
+`envsubst < {{path/to/input_file}} > {{path/to/output_file}}`
 
-- Replace environment variables in input from a space-separated list:
+- Replace environment variables in an input file from a space-separated list:
 
-`envsubst {{variables}} < {{path/to/input}}`
+`envsubst '{{$USER $SHELL $HOME}}' < {{path/to/input_file}}`


### PR DESCRIPTION
Page description and last example were unclear. I also changed `output` to `output_file` and stdin to `stdin` for consistency with other pages.