### PR TITLE
apt-add-repository: add page

### DIFF
--- a/pages/linux/apt-add-repository.md
+++ b/pages/linux/apt-add-repository.md
@@ -17,4 +17,3 @@
 - Enable source packages:
 
 `apt-add-repository --enable-source {{repository_spec}}`
-

--- a/pages/linux/apt-add-repository.md
+++ b/pages/linux/apt-add-repository.md
@@ -1,0 +1,20 @@
+# apt-add-repository
+
+> Manages apt repository definitions.
+
+- Add a new apt repository:
+
+`apt-add-repository {{repository_spec}}`
+
+- Remove an apt repository:
+
+`apt-add-repository --remove {{repository_spec}}`
+
+- Update the package cache after adding a repository:
+
+`apt-add-repository --update {{repository_spec}}`
+
+- Enable source packages:
+
+`apt-add-repository --enable-source {{repository_spec}}`
+


### PR DESCRIPTION
We have `add-apt-repository`, and now we have `apt-add-repository`.