### PR TITLE
mosquitto: add page

### DIFF
--- a/pages/common/mosquitto.md
+++ b/pages/common/mosquitto.md
@@ -13,7 +13,7 @@
 
 - Listen on a specific port:
 
-`mosquitto --port {{1883}}`
+`mosquitto --port {{8883}}`
 
 - Daemonize by forking into the background:
 

--- a/pages/common/mosquitto.md
+++ b/pages/common/mosquitto.md
@@ -13,7 +13,7 @@
 
 - Listen on a specific port:
 
-`mosquitto --port {{port_number}}`
+`mosquitto --port {{1883}}`
 
 - Daemonize by forking into the background:
 

--- a/pages/common/mosquitto.md
+++ b/pages/common/mosquitto.md
@@ -1,0 +1,20 @@
+# mosquitto
+
+> An MQTT broker.
+> More information: <https://mosquitto.org/>.
+
+- Start mosquitto:
+
+`mosquitto`
+
+- Specify a configuration file to use:
+
+`mosquitto --config-file {{path/to/file.conf}}`
+
+- Listen on a specific port:
+
+`mosquitto --port {{port_number}}`
+
+- Daemonize by forking into the background:
+
+`mosquitto --daemon`


### PR DESCRIPTION
I'm setting one of these up, and I find having a tldr page to hand really helpful. Stay tuned for another PR adding `mosquitto_passwd`.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
