### PR TITLE
mosquitto_passwd: add page

### DIFF
--- a/pages/common/mosquitto_passwd.md
+++ b/pages/common/mosquitto_passwd.md
@@ -1,0 +1,21 @@
+# mosquitto_passwd
+
+> Manage password files for mosquitto.
+> See also `mosquitto`, the MQTT server that this manages.
+> More information: <https://mosquitto.org/man/mosquitto_passwd-1.html>.
+
+- Add a new user to a password file (will prompt to enter the password):
+
+`mosquitto_passwd {{path/to/password_file}} {{username}}`
+
+- Create the password file if it doesn't already exist:
+
+`mosquitto_passwd -c {{path/to/password_file}} {{username}}`
+
+- Delete the specified username instead:
+
+`mosquitto_passwd -D {{path/to/password_file}} {{username}}`
+
+- Upgrade an old plain-text password file to a hashed password file:
+
+`mosquitto_passwd -U {{path/to/password_file}}`


### PR DESCRIPTION
Sadly no long options here :-/

Part of #3231.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
