### PR TITLE
xkill: add page

### DIFF
--- a/pages/common/xkill.md
+++ b/pages/common/xkill.md
@@ -1,0 +1,8 @@
+# xkill
+
+> Kill a window interactively in a graphical session.
+> See also `kill` and `killall`.
+
+- Display a cursor to kill a window when pressing the left mouse button (press any other mouse button to cancel):
+
+`xkill`


### PR DESCRIPTION
There isn't much to write about it, but it may still be useful to document its "canceling" behavior :slightly_smiling_face:

PS: I added the page to the `common/` subdirectory, is this correct? Xorg can run on *BSDs after all.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).