### PR TITLE
git-switch: add page

### DIFF
--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -18,8 +18,8 @@
 
 - Update all submodules to match the target branch:
 
-`git switch --recurse-submodules`
+`git switch --recurse-submodules {{branch_name}}`
 
-- Automatically merge the old branch and any uncommitted changes into the new branch:
+- Automatically merge the current branch and any uncommitted changes into the new branch:
 
 `git switch --merge {{branch_name}}`

--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -1,0 +1,26 @@
+# git switch
+
+> Switch between git branches. Requires git version 2.23+.
+> See also `git checkout`.
+> More information: <https://git-scm.com/docs/git-switch/>.
+
+- Switch to an existing branch:
+
+`git switch {{branch_name}}`
+
+- Create a new branch and switch to it:
+
+`git switch --create {{branch_name}}`
+
+- Create a new branch based on an existing commit:
+
+`git switch --create {{branch_name}} {{start_point}}`
+
+- Also update all submodules:
+
+`git switch --recurse-submodules`
+
+- Automatically merge the old branch and any uncommitted changes into the new branch:
+
+`git switch --merge {{branch_name}}`
+

--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -23,4 +23,3 @@
 - Automatically merge the old branch and any uncommitted changes into the new branch:
 
 `git switch --merge {{branch_name}}`
-

--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -14,9 +14,9 @@
 
 - Create a new branch based on an existing commit:
 
-`git switch --create {{branch_name}} {{start_point}}`
+`git switch --create {{branch_name}} {{commit}}`
 
-- Also update all submodules:
+- Update all submodules to match the target branch:
 
 `git switch --recurse-submodules`
 


### PR DESCRIPTION
Part 1 of several from GitHub's blog post about git v2.23!

Original source: https://github.blog/2019-08-16-highlights-from-git-2-23/?utm_campaign=1565911976&utm_medium=social&utm_source=twitter&utm_content=1565911976

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
