### PR TITLE
nmcli: add password flag to command

### DIFF
--- a/pages/linux/nmcli.md
+++ b/pages/linux/nmcli.md
@@ -12,7 +12,7 @@
 
 - Connect to the Wi-Fi network with a specified name and password:
 
-`nmcli device wifi connect {{name}} {{password}}`
+`nmcli device wifi connect {{name}} password {{password}}`
 
 - Activate a connection by specifying an uuid:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

The way the command is shown in the tldr page currently will result in `Unknown parameter: {password}` because nmcli expects `{network name} password {password}` (with the literal word password in between).
