### PR TITLE
firefox: expand & update syntax to version 60+

### DIFF
--- a/pages/common/firefox.md
+++ b/pages/common/firefox.md
@@ -23,7 +23,7 @@
 
 `firefox --safe-mode`
 
-- Headlessly take a screenshot of a web page:
+- Take a screenshot of a web page in headless mode:
 
 `firefox --headless --screenshot {{path/to/output_file.png}}  {{https://example.com/}}`
 

--- a/pages/common/firefox.md
+++ b/pages/common/firefox.md
@@ -9,16 +9,24 @@
 
 - Open it at a new window:
 
-`firefox -new-window {{https://www.duckduckgo.com}}`
+`firefox --new-window {{https://www.duckduckgo.com}}`
 
 - Open an incognito window:
 
-`firefox -private-window`
+`firefox --private-window`
 
 - Search 'wikipedia' on your default search engine:
 
-`firefox -search {{wikipedia}}`
+`firefox --search {{wikipedia}}`
 
 - Launch firefox without extensions:
 
-`firefox -safe-mode`
+`firefox --safe-mode`
+
+- Headlessly take a screenshot of a web page:
+
+`firefox --headless --screenshot {{path/to/output_file.png}}  {{https://example.com/}}`
+
+- Use a specific profile directory to allow multiple separate instances of Firefox to run at once:
+
+`firefox --new-instance --profile {{path/to/directory}} {{https://example.com/}}`


### PR DESCRIPTION
I noticed that we recently gained a page about firefox - which had been already merged by the time I got to it.

I also noticed that the syntax was out-of-date - recent versions of Firefox bring a much more powerful CLI that's even capable of taking headless screenshots!

This PR updates it to match the new syntax, and expands the page with some powerful new examples (which, when mixed together, mean you can take headless screenshots with Firefox whilst Firefox is already open :D)

I wanted to fit in setting the window width & height too, but was unsure how to do so.


- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
