### PR TITLE
singularity: update file formats, replace shub with scloud

### DIFF
--- a/pages/common/singularity.md
+++ b/pages/common/singularity.md
@@ -2,26 +2,26 @@
 
 > Manage Singularity containers and images.
 
-- Download a remote image:
+- Download a remote image from Sylabs Cloud:
 
-`singularity pull --name {{container.simg}} {{shub://vsoch/hello-world}}`
+`singularity pull --name {{image.sif}} {{library://godlovedc/funny/lolcow:latest}}`
 
 - Rebuild a remote image using latest Singularity image format:
 
-`singularity build {{container.simg}} {{docker://godlovedc/lolcow}}`
+`singularity build {{image.sif}} {{docker://godlovedc/lolcow}}`
 
 - Start a container from an image and get a shell inside of it:
 
-`singularity shell {{container.simg}}`
+`singularity shell {{image.sif}}`
 
 - Start a container from an image and run a command:
 
-`singularity exec {{container.simg}} {{command}}`
+`singularity exec {{image.sif}} {{command}}`
 
 - Start a container from an image and execute the internal runscript:
 
-`singularity run {{container.simg}}`
+`singularity run {{image.sif}}`
 
 - Build a singularity image from a recipe file:
 
-`sudo singularity build {{container.simg}} {{recipe}}`
+`sudo singularity build {{image.sif}} {{recipe}}`


### PR DESCRIPTION
Updating the examples to reflect two recent(ish) changes to singularity:

* Singularity 3.0 introduced a new file format, with a new standard file extension: `.sif`
* The new [Sylabs Cloud](https://cloud.sylabs.io/) service has arguably overtaken [Singularity Hub](https://singularity-hub.org/) as the primary remote repository for singularity images

- [ ] ~The page (if new), does not already exist in the repo.~
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] ~The page description includes a link to documentation or a homepage (if applicable).~
