### PR TITLE
lxc: change container creation command

### DIFF
--- a/pages/linux/lxc.md
+++ b/pages/linux/lxc.md
@@ -13,7 +13,7 @@
 
 - Create a new container from an image:
 
-`lxc launch [{{remote}}:]{{image}} {{container}}`
+`lxc init [{{remote}}:]{{image}} {{container}}`
 
 - Start a container:
 


### PR DESCRIPTION
`lxc init` does what the current description says, it creates a container. In contrast, `lxc launch` initializes and then immediately starts the container. Since the tldr guide follows with `lxc start` (which does not work on a "launched" container), I think it makes more sense to list `lxc init` here, especially since it's an under-documented, but desirable command.