### PR TITLE
git lfs: add page

### DIFF
--- a/pages/common/git-lfs.md
+++ b/pages/common/git-lfs.md
@@ -22,3 +22,7 @@
 - List tracked files that have been commited:
 
 `git lfs ls-files`
+
+- Push all LFS objects to the remote server (useful if errors are encountered):
+
+`git lfs push --all {{remote_name}} {{branch_name}}`

--- a/pages/common/git-lfs.md
+++ b/pages/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Work with large files in Git repositories.
-> More information: <>.
+> More information: <https://git-lfs.github.com>.
 
 - Initialise Git LFS:
 

--- a/pages/common/git-lfs.md
+++ b/pages/common/git-lfs.md
@@ -1,0 +1,24 @@
+# git lfs
+
+> Work with large files in Git repositories.
+> More information: <>.
+
+- Initialise Git LFS:
+
+`git lfs install`
+
+- Track files that match a glob:
+
+`git lfs track '{{*.bin}}'`
+
+- Change the Git LFS endpoint URL (useful if the LFS server is separate from the Git server):
+
+`git config -f .lfsconfig lfs.url {{lfs_endpoint_url}}`
+
+- List tracked patterns:
+
+`git lfs track`
+
+- List tracked files that have been commited:
+
+`git lfs ls-files`


### PR DESCRIPTION
Just been setting up Git LFS, so I thought I'd contribute a page for it :-)

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
