### PR TITLE
exec: correct and clarify example descriptions.

### DIFF
--- a/pages/common/exec.md
+++ b/pages/common/exec.md
@@ -6,14 +6,14 @@
 
 `exec {{command -with -flags}}`
 
-- Replace with the specified command using initialized environment variables:
+- Replace with the specified command clearing environment variables:
 
 `exec -c {{command -with -flags}}`
 
-- Replace with the specified command and login to the default shell:
+- Replace with the specified command and login using the default shell:
 
 `exec -l {{command -with -flags}}`
 
-- Replace with the specified command and rename the process name:
+- Replace with the specified command and change the process name:
 
 `exec -a {{process_name}} {{command -with -flags}}`

--- a/pages/common/exec.md
+++ b/pages/common/exec.md
@@ -6,7 +6,7 @@
 
 `exec {{command -with -flags}}`
 
-- Replace with the specified command clearing environment variables:
+- Replace with the specified command, clearing environment variables:
 
 `exec -c {{command -with -flags}}`
 


### PR DESCRIPTION
The `-c` example description was wrong, and two others were strangely worded.