### PR TITLE
expand: clarify last command using a concrete example.

### DIFF
--- a/pages/common/expand.md
+++ b/pages/common/expand.md
@@ -18,6 +18,6 @@
 
 `expand -t={{number}} {{file}}`
 
-- Use comma separated list of explicit tab positions:
+- Use a comma separated list of explicit tab positions:
 
-`expand -t={{list}}`
+`expand -t={{1,4,6}}`


### PR DESCRIPTION
Thought the last command could be more useful with a concrete example instead of just `{{list}}`.