### PR TITLE
Remove bullet for gianasista/tldr-viewer, an outdated project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ You can access these pages on your computer using one of the following clients:
 
 - [Alfred Workflow](https://github.com/cs1707/tldr-alfred)
 - Android clients:
-  - [tldr-viewer](https://github.com/gianasista/tldr-viewer), available on
-    [Google Play](https://play.google.com/store/apps/details?id=de.gianasista.tldr_viewer)
   - [tldroid](https://github.com/hidroh/tldroid), available on
     [Google Play](https://play.google.com/store/apps/details?id=io.github.hidroh.tldroid) *(outdated)*
 - Bash clients:


### PR DESCRIPTION
The gianasista/tldr-viewer repo has not been updated in 4 years. The Google Play link does not resolve to a published app, so removing this bullet-point item.