### PR TITLE
tar: simplify extraction examples

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -6,32 +6,28 @@
 
 - Create an archive from files:
 
-`tar -cf {{target.tar}} {{file1 file2 file3}}`
+`tar cf {{target.tar}} {{file1 file2 file3}}`
 
 - Create a gzipped archive:
 
-`tar -czf {{target.tar.gz}} {{file1 file2 file3}}`
+`tar czf {{target.tar.gz}} {{file1 file2 file3}}`
+
+- Extract a (compressed) archive in the current directory:
+
+`tar xf {{source.tar[.gz|.bz2|.xz]}}`
 
 - Extract an archive in a target directory:
 
-`tar -xf {{source.tar}} -C {{directory}}`
-
-- Extract a gzipped archive in the current directory:
-
-`tar -xzf {{source.tar.gz}}`
-
-- Extract a bzipped archive in the current directory:
-
-`tar -xjf {{source.tar.bz2}}`
+`tar xf {{source.tar}} -C {{directory}}`
 
 - Create a compressed archive, using archive suffix to determine the compression program:
 
-`tar -caf {{target.tar.xz}} {{file1 file2 file3}}`
+`tar caf {{target.tar.xz}} {{file1 file2 file3}}`
 
 - List the contents of a tar file:
 
-`tar -tvf {{source.tar}}`
+`tar tvf {{source.tar}}`
 
 - Extract files matching a pattern:
 
-`tar -xf {{source.tar}} --wildcards {{"*.html"}}`
+`tar xf {{source.tar}} --wildcards {{"*.html"}}`

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -12,11 +12,11 @@
 
 `tar czf {{target.tar.gz}} {{file1 file2 file3}}`
 
-- Extract a (compressed) archive in the current directory:
+- Extract a (compressed) archive into the current directory:
 
 `tar xf {{source.tar[.gz|.bz2|.xz]}}`
 
-- Extract an archive in a target directory:
+- Extract an archive into a target directory:
 
 `tar xf {{source.tar}} -C {{directory}}`
 


### PR DESCRIPTION
Dropped the examples for extraction of specific compressed archives, tar
has had autodetection of the compression for over two decades.

Removed the dashes. No versions of tar require them and all they do is
cost you POSIX compatibility. (POSIX tar did *not* allow for the
dashes.)

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
