### PR TITLE
Translate git commands to Italian - part 2 

### DIFF
--- a/pages.it/common/git-am.md
+++ b/pages.it/common/git-am.md
@@ -1,6 +1,6 @@
 # git am
 
-> Applica file di patch. Utile quando si ricevono commits via email.
+> Applica file di patch. Utile quando si ricevono commit via email.
 > Vedi anche `git format-patch` per generare file di patch.
 > Maggiori informazioni: <https://git-scm.com/docs/git-am>.
 

--- a/pages.it/common/git-clone.md
+++ b/pages.it/common/git-clone.md
@@ -1,0 +1,24 @@
+# git clone
+
+> Clona un repository esistente.
+> Maggiori informazioni: <https://git-scm.com/docs/git-clone>.
+
+- Clona un repository remoto esistente:
+
+`git clone {{url_repository_remoto}}`
+
+- Clona un repository remoto insieme ai suoi sottomoduli:
+
+`git clone --recursive {{url_repository_remoto}}`
+
+- Clona un repository locale:
+
+`git clone -l`
+
+- Clona in modalità silenziosa:
+
+`git clone -q`
+
+- Clona un repository remoto troncando il numero di revisioni a un massimo di 10 per file, cosí da impiegare meno tempo:
+
+`git clone --depth {{10}} {{url_repository_remoto}}`

--- a/pages.it/common/git-commit.md
+++ b/pages.it/common/git-commit.md
@@ -1,0 +1,20 @@
+# git commit
+
+> Salva file nell'area di stage in una nuova istantanea del tuo repository.
+> Maggiori informazioni: <https://git-scm.com/docs/git-commit>.
+
+- Committa sul repository i file nell'area di stage, insieme a un messaggio:
+
+`git commit -m {{messaggio}}`
+
+- Aggiungi all'area di stage tutti i file modificati e committali con un messaggio:
+
+`git commit -a -m {{messaggio}}`
+
+- Sostituisci l'ultimo commit con le modifiche attualmente salvate nell'area di stage:
+
+`git commit --amend`
+
+- Committa solo i file specificati (tra quelli presenti nell'area di stage):
+
+`git commit {{percorso/al/file1}} {{percorso/al/file2}}`

--- a/pages.it/common/git-config.md
+++ b/pages.it/common/git-config.md
@@ -1,0 +1,29 @@
+# git config
+
+> Configura le impostazioni di uno o piu repository git.
+> Tali voci di configurazione possono essere sia locali (per il repository corrente) che globali (per l'utente corrente).
+> Maggiori informazioni: <https://git-scm.com/docs/git-config>.
+
+- Elenca solo le voci di configurazione locali (salvate in `.git/config` nel repository corrente):
+
+`git config --list --local`
+
+- Elenca solo le voci di configurazione globali (salvate in `~/.gitconfig`):
+
+`git config --list --global`
+
+- Elenca tutte le voci di configurazione impostate, sia locali che globali:
+
+`git config --list`
+
+- Mostra il valore di una data voce di configurazione:
+
+`git config alias.unstage`
+
+- Imposta il valore globale di una data voce di configurazione:
+
+`git config --global alias.unstage "reset HEAD --"`
+
+- Ripristina una voce di configurazione globale al suo valore di default:
+
+`git config --global --unset alias.unstage`

--- a/pages.it/common/git-diff.md
+++ b/pages.it/common/git-diff.md
@@ -1,0 +1,40 @@
+# git diff
+
+> Mostra le modifiche ai file tracciati.
+> Maggiori informazioni: <https://git-scm.com/docs/git-diff>.
+
+- Mostra le modifiche non ancora nell'area di stage:
+
+`git diff`
+
+- Mostra tutte le modifiche non ancora salvate in un commit (incluse quelle nell'area di stage):
+
+`git diff HEAD`
+
+- Mostra solo le modifiche nell'area di stage (aggiunte, ma non ancora committate):
+
+`git diff --staged`
+
+- Mostra le modifiche a tutti i commit a partire da una certa data/ora (un'espressione temporale come "1 week 2 days" o una data ISO):
+
+`git diff 'HEAD@{3 months|weeks|days|hours|seconds ago}'`
+
+- Mostra solo i nomi dei file modificati a partire da un dato commit:
+
+`git diff --name-only {{commit}}`
+
+- Stampa un riepilogo dei file creati, rinominati o la cui modalità è cambiata a partire da un dato commit:
+
+`git diff --summary {{commit}}`
+
+- Crea un file di patch:
+
+`git diff > {{nome_file_patch}}.patch`
+
+- Confronta le versioni di un dato file tra due rami o commit:
+
+`git diff {{ramo_1}}..{{ramo_2}} [--] {{percorso/al/file}}`
+
+- Confronta le versioni di più file tra il ramo corrente e un altro ramo:
+
+`git diff {{ramo}}:{{percorso/al/file2}} {{percorso/al/file}}`

--- a/pages.it/common/git-fetch.md
+++ b/pages.it/common/git-fetch.md
@@ -1,0 +1,24 @@
+# git fetch
+
+> Scarica oggetti e riferimenti da un repository remoto.
+> Maggiori informazioni: <https://git-scm.com/docs/git-fetch>.
+
+- Scarica le ultime modifiche dal repository remoto di origine (upstream) di default, se definito:
+
+`git fetch`
+
+- Scarica i nuovi rami da un dato repository remoto di origine:
+
+`git fetch {{nome_repository_remoto}}`
+
+- Scarica le ultime modifiche da tutti i repository remoti di origine:
+
+`git fetch --all`
+
+- Scarica anche i tag dal repository remoto di origine:
+
+`git fetch --tags`
+
+- Elimina i riferimenti locali ai rami remoti che sono stati eliminati upstream:
+
+`git fetch --prune`

--- a/pages.it/common/git-format-patch.md
+++ b/pages.it/common/git-format-patch.md
@@ -1,0 +1,17 @@
+# git format-patch
+
+> Prepara file .patch. Utile per l'invio di commit via email.
+> Vedi anche `git am`, che permette di applicare file .patch.
+> Maggiori informazioni: <https://git-scm.com/docs/git-format-patch>.
+
+- Crea un file .patch (il nome è assegnato automaticamente) con i commit non ancora inviati al repository remoto:
+
+`git format-patch {{origin}}`
+
+- Scrivi su `stdout` un file .patch con l'intervallo di commit definito dai due commit dati:
+
+`git format-patch --stdout {{commit_1}}..{{commit_2}}`
+
+- Scrivi un file .patch con gli ultimi 3 commit:
+
+`git format-patch -{{3}}`

--- a/pages.it/common/git-gc.md
+++ b/pages.it/common/git-gc.md
@@ -1,0 +1,24 @@
+# git gc
+
+> Ottimizza il repository locale ripulendolo dai file non necessari.
+> Maggiori informazioni: <https://git-scm.com/docs/git-gc>.
+
+- Ottimizza il repository:
+
+`git gc`
+
+- Ottimizza il repository in modo più aggressivo, impiegando più tempo:
+
+`git gc --aggressive`
+
+- Non eliminare gli oggetti non tracciati (sono eliminati di default):
+
+`git gc --no-prune`
+
+- Non mostrare alcun output:
+
+`git gc --quiet`
+
+- Mostra utilizzo completo:
+
+`git gc --help`

--- a/pages.it/common/git-grep.md
+++ b/pages.it/common/git-grep.md
@@ -1,0 +1,25 @@
+# git-grep
+
+> Cerca stringhe nello storico dei file tracciati nel repository.
+> Supporta molti degli stessi flag accettati dal `grep` tradizionale.
+> Maggiori informazioni: <https://git-scm.com/docs/git-grep>.
+
+- Cerca una stringa nei file tracciati:
+
+`git grep {{stringa_ricercata}}`
+
+- Cerca una stringa nei file tracciati che soddisfano un dato pattern:
+
+`git grep {{stringa_ricercata}} -- {{file_pattern}}`
+
+- Cerca una stringa nei file tracciati, sottomoduli inclusi:
+
+`git grep --recurse-submodules {{stringa_ricercata}}`
+
+- Cerca una stringa in uno dato momento della cronologia del repository:
+
+`git grep {{stringa_ricercata}} {{HEAD~2}}`
+
+- Cerca una stringa in tutti i rami:
+
+`git grep {{stringa_ricercata}} $(git rev-list --all)`

--- a/pages.it/common/git-imerge.md
+++ b/pages.it/common/git-imerge.md
@@ -1,0 +1,29 @@
+# git-imerge
+
+> Esegui un'unione (merge) o rebase tra due rami git in modo incrementale.
+> Eventuali conflitti tra i due rami sono tracciati in coppie di commit distinti, per semplificarne la risoluzione.
+> Maggiori informazioni: <https://github.com/mhagger/git-imerge>.
+
+- Avvia un rebase usando imerge (dopo aver fatto il checkout del ramo di lavoro):
+
+`git imerge rebase {{ramo_su_cui_eseguire_il_rebase}}`
+
+- Avvia un'unione usando imerge (dopo aver fatto il checkout dal ramo di lavoro):
+
+`git imerge merge {{ramo_su_cui_eseguire_l_unione}}`
+
+- Mostra con un diagramma ASCII lo stato di esecuzione dell'unione o rebase:
+
+`git imerge diagram`
+
+- Continua con l'operazione di imerge dopo aver risolto i conflitti (ricorda di aggiungere i file in conflitto con `git add`):
+
+`git imerge continue --no-edit`
+
+- Concludi l'operazione di imerge dopo aver risolto tutti i conflitti:
+
+`git imerge finish`
+
+- Interrompi l'operazione di imerge e ritorna al ramo precedente:
+
+`git-imerge remove && git checkout {{ramo_precedente}}`

--- a/pages.it/common/git-init.md
+++ b/pages.it/common/git-init.md
@@ -1,0 +1,12 @@
+# git init
+
+> Inizializza un nuovo repository git locale.
+> Maggiori informazioni: <https://git-scm.com/docs/git-init>.
+
+- Inizializza un nuovo repository locale:
+
+`git init`
+
+- Inizializza un repository di soli dati, adatto per essere usato come server remoto accessibile via ssh:
+
+`git init --bare`


### PR DESCRIPTION
Ten more Italian translations to git commands. 🇮🇹 
Related issue: #3317

- [x] The pages are new
- [x] The pages are in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The pages has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

