### PR TITLE
README: remove deprecated rust client

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,8 @@ You can access these pages on your computer using one of the following clients:
   `devtools::install_github('kirillseva/tldrrr')`
 - [Ruby client](https://github.com/YellowApple/tldrb):
   `gem install tldrb`
-- Rust clients:
-    - [rust-tldr](https://github.com/rilut/rust-tldr)
-      (thin client with online lookup):
-      `cargo install tldr`
-    - [tealdeer](https://github.com/dbrgn/tealdeer)
-      (fully featured client with offline cache):
-      `cargo install tealdeer`
+- [Rust client](https://github.com/dbrgn/tealdeer):
+  `cargo install tealdeer`
 - [Vim Client](https://github.com/wlemuel/vim-tldr)
 - [Visual Studio Code extension](https://github.com/bmuskalla/vscode-tldr) available on [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=bmuskalla.vscode-tldr)
 - Web clients:


### PR DESCRIPTION
I think this should probably be removed because it is no longer possible to install via `cargo install tldr` as the `tldr` crate has been [yanked from the crates.io package registry](https://crates.io/crates/tldr).

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
