### PR TITLE
pip3: add search command, mention 'user' flag

### DIFF
--- a/pages/common/pip3.md
+++ b/pages/common/pip3.md
@@ -3,6 +3,10 @@
 > Python package manager.
 > More information: <https://pip.pypa.io>.
 
+- Find available packages:
+
+`pip3 search {{package_name}}`
+
 - Install a package:
 
 `pip3 install {{package_name}}`


### PR DESCRIPTION
I think `search` should definitely be there, as finding and confirming the correct package name (PyPI doesn't enforce naming conventions, so names are *wild*) is the first thing I do.

The `--user` flag also strikes me as important, as users won't want a system-wide installation in many cases. I don't know if my formatting fits the tldr style, not sure how to keep things brief and tidy looking. Feel free to edit it, in case you accept this PR.

Also, if the number of listed commands has become too high, I'd rather see something more niche go.