### PR TITLE
change quote type at git-branch page

### DIFF
--- a/pages/common/git-branch.md
+++ b/pages/common/git-branch.md
@@ -3,7 +3,7 @@
 > Main git command for working with branches.
 > More information: <https://git-scm.com/docs/git-branch>.
 
-- List local branches. The current branch is highlighted by `*`:
+- List local branches. The current branch is highlighted by '*':
 
 `git branch`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->
I found broken display at `git-branch` page.
It seems that the asterisk is surrounded by code blocks, but it is not well recognized and misunderstood as a chapter break.
Converted to single quotes, but more fundamental changes may be required

![Screenshot from 2019-10-19 15-56-41](https://user-images.githubusercontent.com/4703128/67139276-485ce680-f289-11e9-880d-adc9195289c9.png)

---
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
