### PR TITLE
tar: update multiple file tokens

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -6,11 +6,11 @@
 
 - Create an archive from files:
 
-`tar cf {{target.tar}} {{file1 file2 file3}}`
+`tar cf {{target.tar}} {{file1}} {{file2}} {{file3}}`
 
 - Create a gzipped archive:
 
-`tar czf {{target.tar.gz}} {{file1 file2 file3}}`
+`tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
 
 - Extract a (compressed) archive into the current directory:
 
@@ -22,7 +22,7 @@
 
 - Create a compressed archive, using archive suffix to determine the compression program:
 
-`tar caf {{target.tar.xz}} {{file1 file2 file3}}`
+`tar caf {{target.tar.xz}} {{file1}} {{file2}} {{file3}}`
 
 - List the contents of a tar file:
 


### PR DESCRIPTION
As discussed in #3412 the tar page had mutliple file tokens written as `{{file1 file2 file3}}`, which would be more clear if it would be written as `{{file1}} {{file2}} {{file3}}`.
This pull request separates those file tokens.

I also checked all the other pages (on Windows I ran inside the `pages` folder: `findstr /d:common;linux;osx;sunos;windows /S "file1 file2 file3" *`. Looking for multiple file occurences) and only found that stow.md could be considered updating.

Output regarding stow.md:
``` 
stow.md:`stow --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
stow.md:`stow --delete --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
stow.md:`stow --simulate --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
stow.md:`stow --restow --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
stow.md:`stow --ignore={{regex}} --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}` 
```

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).