### PR TITLE
qmv, qcp: add page

### DIFF
--- a/pages/common/qcp.md
+++ b/pages/common/qcp.md
@@ -1,0 +1,16 @@
+# qcp
+
+> Copy files with your favorite text editor.
+> More information: <https://www.nongnu.org/renameutils/>
+
+- Copy a single file (invoke an editor with source on the left, target on the right):
+
+`qcp {{source_file}}`
+
+- Copy multiple JPG files:
+
+`qcp {{*.jpg}}`
+
+- Copy files, but swap pattern in the editor -- target on the left and source on the right:
+
+`qcp --option swap {{IMG-*.jpg}}`

--- a/pages/common/qcp.md
+++ b/pages/common/qcp.md
@@ -1,7 +1,7 @@
 # qcp
 
 > Copy files with your favorite text editor.
-> More information: <https://www.nongnu.org/renameutils/>
+> More information: <https://www.nongnu.org/renameutils/>.
 
 - Copy a single file (invoke an editor with source on the left, target on the right):
 

--- a/pages/common/qcp.md
+++ b/pages/common/qcp.md
@@ -11,6 +11,6 @@
 
 `qcp {{*.jpg}}`
 
-- Copy files, but swap pattern in the editor -- target on the left and source on the right:
+- Copy files, but swap the positions of the source and the target in the editor:
 
 `qcp --option swap {{*.jpg}}`

--- a/pages/common/qcp.md
+++ b/pages/common/qcp.md
@@ -13,4 +13,4 @@
 
 - Copy files, but swap pattern in the editor -- target on the left and source on the right:
 
-`qcp --option swap {{IMG-*.jpg}}`
+`qcp --option swap {{*.jpg}}`

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -11,13 +11,13 @@
 
 `qmv {{*.jpg}}`
 
-- Move directories:
+- Move 3 directories:
 
-`qmv -d {{directory/}} {{another_directory/}} {{the_other_directory/}}`
+`qmv -d {{path/to/dir_1}} {{path/to/dir_2}} {{path/to/dir_3}}`
 
 - Move files/directories inside a directory:
 
-`qmv -R {{directory/}}`
+`qmv -R {{path/to/directory}}`
 
 - Move files, but swap pattern in the editor -- target on the left and source on the right:
 

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -13,11 +13,11 @@
 
 - Move directories:
 
-`qmv --directory {{my_directory/}} {{another_directory/}} {{the_other_directory/}}`
+`qmv -d {{directory/}} {{another_directory/}} {{the_other_directory/}}`
 
 - Move files/directories inside a directory:
 
-`qmv --recursive {{my_directory/}}`
+`qmv -R {{directory/}}`
 
 - Move files, but swap pattern in the editor -- target on the left and source on the right:
 

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -1,13 +1,13 @@
 # qmv
 
 > Move files and directories with your favorite text editor.
-> More information: <https://www.nongnu.org/renameutils/>
+> More information: <https://www.nongnu.org/renameutils/>.
 
 - Move a single file (invoke an editor with source on the left, target on the right):
 
 `qmv {{source_file}}`
 
-- Move multiple JPG files.
+- Move multiple JPG files:
 
 `qmv {{*.jpg}}`
 

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -1,0 +1,24 @@
+# qmv
+
+> Move files and directories with your favorite text editor.
+> More information: <https://www.nongnu.org/renameutils/>
+
+- Move a single file (invoke an editor with source on the left, target on the right):
+
+`qmv {{source_file}}`
+
+- Move multiple JPG files.
+
+`qmv {{*.jpg}}`
+
+- Move directories:
+
+`qmv --directory {{my_directory/}} {{another_directory/}} {{the_other_directory/}}`
+
+- Move files/directories inside a directory:
+
+`qmv --recursive {{my_directory/}}`
+
+- Move files, but swap pattern in the editor -- target on the left and source on the right:
+
+`qmv --option swap {{*.jpg}}`

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -19,6 +19,6 @@
 
 `qmv -R {{path/to/directory}}`
 
-- Move files, but swap pattern in the editor -- target on the left and source on the right:
+- Move files, but swap the positions of the source and the target in the editor:
 
 `qmv --option swap {{*.jpg}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


Personal note:
- I add 2 commands at once because the interface is quite the similar, and they comes with `renameutils` package.
- `qmv` has 5 examples, while `qcp` has only 3 since the ability to copy directories do not work now.
- What I'm not sure the most is do these 2 commands should go to `linux/` instead of `common/`? On my Ubuntu I can just run `apt install renameutils` and done, but I don't know about OS X or Windows (or others). I see that there is a source code but I don't have other platform to compile and try it.