### PR TITLE
cargo: Reword cargo build -j example

### DIFF
--- a/pages/common/cargo.md
+++ b/pages/common/cargo.md
@@ -28,6 +28,6 @@
 
 `cargo build`
 
-- Build with multiple parallel jobs:
+- Build using a specific number of threads (default is the number of CPU cores):
 
 `cargo build -j {{jobs}}`


### PR DESCRIPTION
It gives the false impression that cargo build doesnt compile with multiple jobs in parallel. By default it actually uses one job per cpu core:

https://github.com/rust-lang/cargo/blob/b03182a8ff0117ffa1c426119ae2b5a418776bbd/src/cargo/core/compiler/build_config.rs#L90

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
