### PR TITLE
French punctuation and typos

### DIFF
--- a/pages.fr/common/awk.md
+++ b/pages.fr/common/awk.md
@@ -1,28 +1,28 @@
 # awk
 
 > Langage de programmation polyvalent pour travailler sur des fichiers.
-> Pour plus d'informations: <https://github.com/onetrueawk/awk>.
+> Pour plus d'informations : <https://github.com/onetrueawk/awk>.
 
-- Affiche la cinquième colonne (ou le champ) dans un fichier qui utilise des espaces comme séparateur:
+- Affiche la cinquième colonne (ou le champ) dans un fichier qui utilise des espaces comme séparateur :
 
 `awk '{print $5}' {{nom_de_fichier}}`
 
-- Affiche la deuxième colonne dans des lignes contenant "quelque-chose" dans un fichier qui utilise des espaces comme séparateur:
+- Affiche la deuxième colonne dans des lignes contenant "quelque-chose" dans un fichier qui utilise des espaces comme séparateur :
 
 `awk '/{{quelque-chose}}/ {print $2}' {{nom_de_fichier}}`
 
-- Affiche la dernière colonne de chaque ligne d'un fichier en utilisant une virgule (au lieu des espaces) comme séparateur:
+- Affiche la dernière colonne de chaque ligne d'un fichier en utilisant une virgule (au lieu des espaces) comme séparateur :
 
 `awk -F ',' '{print $NF}' {{nom_de_fichier}}`
 
-- Additionne les valeurs de la première colonne des lignes d'un fichier et affiche le total:
+- Additionne les valeurs de la première colonne des lignes d'un fichier et affiche le total :
 
 `awk '{s+=$1} END {print s}' {{nom_de_fichier}}`
 
-- Additionne les valeurs de la première colonne des lignes d'un fichier et affiche ces valeurs puis affiche le total:
+- Additionne les valeurs de la première colonne des lignes d'un fichier et affiche ces valeurs puis affiche le total :
 
 `awk '{s+=$1; print $1} END {print "--------"; print s}' {{nom_de_fichier}}`
 
-- Affiche une ligne sur trois en partant de la première ligne:
+- Affiche une ligne sur trois en partant de la première ligne :
 
 `awk 'NR%3==1' {{nom_de_fichier}}`

--- a/pages.fr/common/awk.md
+++ b/pages.fr/common/awk.md
@@ -1,7 +1,7 @@
 # awk
 
 > Langage de programmation polyvalent pour travailler sur des fichiers.
-> Pour plus d'informations : <https://github.com/onetrueawk/awk>.
+> Plus d'informations : <https://github.com/onetrueawk/awk>.
 
 - Affiche la cinquième colonne (ou le champ) dans un fichier qui utilise des espaces comme séparateur :
 

--- a/pages.fr/common/borg.md
+++ b/pages.fr/common/borg.md
@@ -2,7 +2,7 @@
 
 > Outil de sauvegarde avec déduplication.
 > Crée des sauvegardes distantes ou locales qui peuvent être montées comme un système de fichiers.
-> Pour plus d'informations : <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
+> Plus d'informations : <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
 - Initialise un dépôt local :
 

--- a/pages.fr/common/borg.md
+++ b/pages.fr/common/borg.md
@@ -2,32 +2,32 @@
 
 > Outil de sauvegarde avec déduplication.
 > Crée des sauvegardes distantes ou locales qui peuvent être montées comme un système de fichiers.
-> Pour plus d'informations: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
+> Pour plus d'informations : <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
-- Initialise un dépôt local:
+- Initialise un dépôt local :
 
 `borg init {{/chemin/vers/repertoire_du_depot}}`
 
-- Sauvegarde un répertoire dans le dépôt en créant une archive appelée "Lundi":
+- Sauvegarde un répertoire dans le dépôt en créant une archive appelée "Lundi" :
 
 `borg create --progress {{/chemin/vers/repertoire_du_depot}}::{{Lundi}} {{/chemin/vers/repertoire_source}}`
 
-- Liste toutes les archives d'un dépôt:
+- Liste toutes les archives d'un dépôt :
 
 `borg list {{/chemin/vers/repertoire_du_depot}}`
 
-- Extrait un répertoire donné de l'archive nommée "Lundi" à partir d'un dépôt distant tout en excluant tous les fichiers *.ext:
+- Extrait un répertoire donné de l'archive nommée "Lundi" à partir d'un dépôt distant tout en excluant tous les fichiers *.ext :
 
 `borg extract {{utilisateur}}@{{hote}}:{{/chemin/vers/repertoire_du_depot}}::{{Lundi}} {{chemin/vers/repertoire_destination}} --exclude '{{*.ext}}'`
 
-- Nettoie un dépôt en effaçant toutes les archives âgées de plus de 7 jours tout en affichant les changements:
+- Nettoie un dépôt en effaçant toutes les archives âgées de plus de 7 jours tout en affichant les changements :
 
 `borg prune --keep-within {{7d}} --list {{/chemin/vers/repertoire_du_depot}}`
 
-- Monte un dépôt comme un système de fichiers FUSE:
+- Monte un dépôt comme un système de fichiers FUSE :
 
 `borg mount {{/chemin/vers/repertoire_du_depot}}::{{Lundi}} {{/chemin/vers/point_de_montage}}`
 
-- Affiche l'aide sur la création d'archives:
+- Affiche l'aide sur la création d'archives :
 
 `borg create --help`

--- a/pages.fr/common/cat.md
+++ b/pages.fr/common/cat.md
@@ -2,18 +2,18 @@
 
 > Affiche et concatène le contenu d'un ou plusieurs fichiers.
 
-- Affiche le contenu d'un fichier sur la sortie standard:
+- Affiche le contenu d'un fichier sur la sortie standard :
 
-`cat {{file}}`
+`cat {{fichier}}`
 
-- Concatène le contenu de plusieurs fichiers vers le fichier de destination:
+- Concatène le contenu de plusieurs fichiers vers le fichier de destination :
 
-`cat {{file1}} {{file2}} > {{target_file}}`
+`cat {{fichier1}} {{fichier2}} > {{fichier_de_destination}}`
 
-- Ajoute le contenu d'un ficher à la fin du fichier de destination:
+- Ajoute le contenu d'un ficher à la fin du fichier de destination :
 
-`cat {{file1}} {{file2}} >> {{target_file}}`
+`cat {{fichier1}} {{fichier2}} >> {{fichier_de_destination}}`
 
-- Numérote toutes les lignes affichées:
+- Numérote toutes les lignes affichées :
 
-`cat -n {{file}}`
+`cat -n {{fichier}}`

--- a/pages.fr/common/chmod.md
+++ b/pages.fr/common/chmod.md
@@ -2,26 +2,26 @@
 
 > Modifie les droits d'accès d'un fichier ou d'un répertoire.
 
-- Donne les droits d'e[x]écution à l'[u]tilisateur auquel le fichier appartient:
+- Donne les droits d'e[x]écution à l'[u]tilisateur auquel le fichier appartient :
 
 `chmod u+x {{fichier}}`
 
-- Donne à l'utilisateur les droits de lecture (r) et d'écriture (w) sur un fichier/répertoire:
+- Donne à l'utilisateur les droits de lecture (r) et d'écriture (w) sur un fichier/répertoire :
 
 `chmod u+rw {{fichier_ou_repertoire}}`
 
-- Enlève les droits d'exécution pour le [g]roupe:
+- Enlève les droits d'exécution pour le [g]roupe :
 
 `chmod g-x {{fichier}}`
 
-- Donne à tous (a) les utilisateurs les droits de lecture et d'exécution:
+- Donne à tous (a) les utilisateurs les droits de lecture et d'exécution :
 
 `chmod a+rx {{fichier}}`
 
-- Donne aux autres utilisateurs (qui sont dans un autre groupe) les mêmes droits que ceux du groupe propriétaire:
+- Donne aux autres utilisateurs (qui sont dans un autre groupe) les mêmes droits que ceux du groupe propriétaire :
 
 `chmod o=g {{fichier}}`
 
-- Modifie les permissions recursivement en donnant aux membres du groupe et aux autres utilisateurs le droit d'écriture:
+- Modifie les permissions recursivement en donnant aux membres du groupe et aux autres utilisateurs le droit d'écriture :
 
-`chmod -R g+w,o+w {{directory}}`
+`chmod -R g+w,o+w {{repertoire}}`

--- a/pages.fr/common/install.md
+++ b/pages.fr/common/install.md
@@ -3,22 +3,22 @@
 > Copie des fichiers et mets à jour leurs attributs.
 > Copie des fichiers (souvent des exécutables) dans un répertoire système comme `/usr/local/bin` et leur donne les permissions et propriétaires appropriés.
 
-- Copie des fichiers vers une destination:
+- Copie des fichiers vers une destination :
 
 `install {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
-- Copie des fichiers vers une destination en mettant à jour leur propriétaire:
+- Copie des fichiers vers une destination en mettant à jour leur propriétaire :
 
 `install -o {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
-- Copie des fichiers vers une destination en mettant à jour leur groupe d'appartenance:
+- Copie des fichiers vers une destination en mettant à jour leur groupe d'appartenance :
 
 `install -g {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
-- Copie des fichiers vers une destination en mettant à jour leur mode:
+- Copie des fichiers vers une destination en mettant à jour leur mode :
 
 `install -m {{+x}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
-- Copie des fichiers et met à jour leur date d'accès et de modification à partir de leur source respective:
+- Copie des fichiers en mettant à jour leur dates d'accès et de modification à partir de leurs sources respectives :
 
 `install -p {{chemin/fichier/source}} {{chemin/repertoire/destination}}`

--- a/pages.fr/common/ls.md
+++ b/pages.fr/common/ls.md
@@ -2,26 +2,26 @@
 
 > Liste le contenu d'un répertoire.
 
-- Liste les fichiers, un par ligne:
+- Liste les fichiers, un par ligne :
 
 `ls -1`
 
-- Liste tous les fichiers, ainsi que les fichiers cachés:
+- Liste tous les fichiers, ainsi que les fichiers cachés :
 
 `ls -a`
 
-- Liste tous les fichiers avec un format détaillé (permissions, propriétaire, taille et date de modification):
+- Liste tous les fichiers avec un format détaillé (permissions, propriétaire, taille et date de modification) :
 
 `ls -la`
 
-- Liste les fichiers avec un format détaillé en utilisant des prefixes d'unités (KB, MB, GB):
+- Liste les fichiers avec un format détaillé en utilisant des prefixes d'unités (ko, Mo, Go) :
 
 `ls -lh`
 
-- Liste les fichier avec un format détaillé en triant par taille décroissante:
+- Liste les fichier avec un format détaillé en triant par taille décroissante :
 
 `ls -lS`
 
-- Liste avec un format détaillé tous les fichiers en triant par date de modification (les plus anciennes en premier):
+- Liste avec un format détaillé tous les fichiers en triant par date de modification (les plus anciennes en premier) :
 
 `ls -ltr`

--- a/pages.fr/common/ssh.md
+++ b/pages.fr/common/ssh.md
@@ -1,37 +1,36 @@
 # ssh
 
-> Secure Shell est un protocole utilisé pour se connecter de façon sécure à des systèmes distants.
+> Secure Shell est un protocole utilisé pour se connecter de façon sécurisée à des systèmes distants.
 > On peut l'utiliser pour se connecter ou exécuter des commandes sur un serveur distant.
 
-- Se connecte à un serveur distant:
+- Se connecter à un serveur distant :
 
 `ssh {{utilisateur}}@{{hote_distant}}`
 
-- Se connecte à un serveur distant en utilisant une identité spécifique (clé privée):
+- Se connecter à un serveur distant en utilisant une identité spécifique (clé privée) :
 
 `ssh -i {{chemin/vers/fichier_clef}} {{utilisateur}}@{{hote_distant}}`
 
-- Se connecte à un serveur distant en utilisant un port spécifique:
+- Se connecter à un serveur distant en utilisant un port spécifique :
 
 `ssh {{utilisateur}}@{{hote_distant}} -p {{2222}}`
 
-- Exécute une commande sur un serveur distant:
+- Exécuter une commande sur un serveur distant :
 
 `ssh {{hote_distant}} {{commande -avec -options}}`
 
-- Tunnel SSH: Transfert par port dynamique (le SOCKS proxy se trouve sur localhost:9999):
+- Tunnel SSH : Transfert par port dynamique (le SOCKS proxy se trouve sur localhost:9999) :
 
 `ssh -D {{9999}} -C {{utilisateur}}@{{hote_distant}}`
 
-- Tunnel SSH: Transfère un port spécifique (localhost:9999 vers example.org:80) en désactivant l'allocation de pseudo-[t]ty et l'exécution de commandes distantes:
+- Tunnel SSH : Transfère un port spécifique (localhost:9999 vers example.org:80) en désactivant l'allocation de pseudo-[t]ty et l'exécution de commandes distantes :
 
 `ssh -L {{9999}}:{{exemple.org}}:{{80}} -N -T {{utilisateur}}@{{hote_distant}}`
 
-
-- Saut SSH: Se connecte sur un serveur distant à travers une machine de rebond (plusieurs machines de rebond peuvent être définies en les séparant par des virgules):
+- Saut SSH : Se connecter sur un serveur distant à travers une machine de rebond (plusieurs machines de rebond peuvent être définies en les séparant par des virgules) :
 
 `ssh -J {{utilisateur}}@{{hote_de_rebond}} {{utilisateur}}@{{hote_distant}}`
 
-- Transfert d'agent: Transfère les informations d'authentification vers la machine distante (voir `man ssh_config` pour les options disponibles):
+- Transfert d'agent : Transfère les informations d'authentification vers la machine distante (voir `man ssh_config` pour les options disponibles) :
 
 `ssh -A {{utilisateur}}@{{hote_distant}}`

--- a/pages.fr/common/wc.md
+++ b/pages.fr/common/wc.md
@@ -2,19 +2,19 @@
 
 > Compte les mots, les octets ou les lignes.
 
-- Compte les lignes d'un fichier:
+- Compte les lignes d'un fichier :
 
 `wc -l {{file}}`
 
-- Compte les motes d'un fichier:
+- Compte les mots d'un fichier :
 
 `wc -w {{file}}`
 
-- Compte les caractères (octets) d'un fichier:
+- Compte les caractères (octets) d'un fichier :
 
 `wc -c {{file}}`
 
-- Compte les caractères d'un fichier (en prenant en compte l'ensemble des caractèrs multi-octet):
+- Compte les caractères d'un fichier (en prenant en compte l'ensemble des caractères multi-octets) :
 
 `wc -m {{file}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Fixed usage of spaces before the ":" character in existing French pages (as discussed in #3446), and fixed a few typos.
