### PR TITLE
wc (fr): remove additional trailing whitespace

### DIFF
--- a/pages.fr/common/wc.md
+++ b/pages.fr/common/wc.md
@@ -17,4 +17,3 @@
 - Compte les caractères d'un fichier (en prenant en compte l'ensemble des caractères multi-octets) :
 
 `wc -m {{file}}`
-


### PR DESCRIPTION
Just a typo, the page ends with `\n\n` instead of just `\n`.