### PR TITLE
docker-compose: add --rmi all --volumes

### DIFF
--- a/pages/common/docker-compose.md
+++ b/pages/common/docker-compose.md
@@ -21,7 +21,7 @@
 
 - Stop and remove all containers, networks, images, and volumes:
 
-`docker-compose down`
+`docker-compose down --rmi all --volumes`
 
 - Follow logs for all containers:
 


### PR DESCRIPTION
add "--rmi all --volumes" parameters to docker-compose down command, in order to match with description (by default, docker-compose didn't remove volumes).

- [/ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ /] The page has 8 or fewer examples.
- [ /] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ /] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ /] The page description includes a link to documentation or a homepage (if applicable).
