### PR TITLE
docker-compose: add docker-compose ps

### DIFF
--- a/pages/common/docker-compose.md
+++ b/pages/common/docker-compose.md
@@ -26,3 +26,7 @@
 - Follow logs for all containers:
 
 `docker-compose logs --follow`
+
+- Lists all running containers:
+
+`docker-compose ps`


### PR DESCRIPTION
add "docker-compose ps command" list all running containers.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
