### PR TITLE
MAINTAINERS.md: Remove leading whitespace in lists

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,20 +21,20 @@ as well as review and merge pull requests from other contributors.
 If you are an owner of the organization, you should be able to see an automated list
 [here](https://github.com/tldr-pages/tldr/settings/collaboration).
 
- - **Max Xu ([@jsonbruce](https://github.com/jsonbruce))**:
-   [13 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — present
- - **Jeef ([@jeeftor](https://github.com/jeeftor))**:
-   [12 March 2017](https://github.com/tldr-pages/tldr/issues/1209#issuecomment-285924778) — present
- - **Muhammad Falak R Wani ([@mfrw](https://github.com/mfrw))**:
-   [7 September 2018](https://github.com/tldr-pages/tldr/issues/2306) — present
- - **Lucas Schneider ([@schneiderl](https://github.com/schneiderl))**:
-   [11 April 2019](https://github.com/tldr-pages/tldr/issues/2898) — present
- - **Andrik Albuquerque ([@andrik](https://github.com/andrik))**:
-   [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) - present
- - **Ivan Aracki ([@Aracki](https://github.com/Aracki))**:
-   [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) - present
- - **Ein Verne ([@einverne](https://github.com/einverne))**:
-   [29 October 2019](https://github.com/tldr-pages/tldr/issues/3488) - present
+- **Max Xu ([@jsonbruce](https://github.com/jsonbruce))**:
+  [13 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — present
+- **Jeef ([@jeeftor](https://github.com/jeeftor))**:
+  [12 March 2017](https://github.com/tldr-pages/tldr/issues/1209#issuecomment-285924778) — present
+- **Muhammad Falak R Wani ([@mfrw](https://github.com/mfrw))**:
+  [7 September 2018](https://github.com/tldr-pages/tldr/issues/2306) — present
+- **Lucas Schneider ([@schneiderl](https://github.com/schneiderl))**:
+  [11 April 2019](https://github.com/tldr-pages/tldr/issues/2898) — present
+- **Andrik Albuquerque ([@andrik](https://github.com/andrik))**:
+  [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) - present
+- **Ivan Aracki ([@Aracki](https://github.com/Aracki))**:
+  [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) - present
+- **Ein Verne ([@einverne](https://github.com/einverne))**:
+  [29 October 2019](https://github.com/tldr-pages/tldr/issues/3488) - present
 
 
 ## Organization members
@@ -43,10 +43,10 @@ In addition everything that a repository collaborator can do,
 an organization member also has write access to all the repositories in the tldr-pages organization.
 An automated list can be found [here](https://github.com/orgs/tldr-pages/people).
 
- - **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:
-   [9 April 2019](https://github.com/tldr-pages/tldr/issues/2874) — present
- - Owen Voke ([@pxgamer](https://github.com/pxgamer))
-   [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258) — [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989)
+- **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:
+  [9 April 2019](https://github.com/tldr-pages/tldr/issues/2874) — present
+- Owen Voke ([@pxgamer](https://github.com/pxgamer))
+  [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258) — [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989)
 
 
 ## Organization owners


### PR DESCRIPTION
For some reason two of the lists in `MAINTAINERS.md` were indented by a single space.
This PR fixes them.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).