### PR TITLE
findstr: edit-page

### DIFF
--- a/pages/windows/findstr.md
+++ b/pages/windows/findstr.md
@@ -11,14 +11,6 @@
 
 `findstr /s "{{query}}" *`
 
-- Find strings using a case-insensitive search:
-
-`findstr /i "{{query}}" *"`
-
-- Find strings in all files using regular expressions:
-
-`findstr /r "{{expression}}" *`
-
 - Find a literal string (containing spaces) in all text files:
 
 `findstr /c:"{{query}}" *.txt`
@@ -27,9 +19,13 @@
 
 `findstr /x "{{query}}" *`
 
-- Display the line number before each matching line:
+- Find case [i]nsensitive, [r]egex string(s) in all files recur[s]ively, with line [n]umbered results:
 
-`findstr /n "{{query}}" *`
+`findstr /rins "{{query}}" *`
+
+- Find space-separated string(s) in a piped command's output:
+
+`{{dir}} | findstr "{{query}}"`
 
 - Display only the filenames that contain a match:
 

--- a/pages/windows/findstr.md
+++ b/pages/windows/findstr.md
@@ -11,21 +11,25 @@
 
 `findstr /s "{{query}}" *`
 
+- Find strings using a case-insensitive search:
+
+`findstr /i "{{query}}" *"`
+
+- Find strings in all files using regular expressions:
+
+`findstr /r "{{expression}}" *`
+
 - Find a literal string (containing spaces) in all text files:
 
 `findstr /c:"{{query}}" *.txt`
 
-- Find only lines that match the query e[x]actly:
-
-`findstr /x "{{query}}" *`
-
-- Find case [i]nsensitive, [r]egex string(s) in all files recur[s]ively, with line [n]umbered results:
-
-`findstr /rins "{{query}}" *`
-
 - Find space-separated string(s) in a piped command's output:
 
 `{{dir}} | findstr "{{query}}"`
+
+- Display the line number before each matching line:
+
+`findstr /n "{{query}}" *`
 
 - Display only the filenames that contain a match:
 

--- a/pages/windows/findstr.md
+++ b/pages/windows/findstr.md
@@ -7,6 +7,10 @@
 
 `findstr "{{query}}" *`
 
+- Find space-separated string(s) in a piped command's output:
+
+`{{dir}} | findstr "{{query}}"`
+
 - Find space-separated string(s) in all files recur[s]ively:
 
 `findstr /s "{{query}}" *`
@@ -22,10 +26,6 @@
 - Find a literal string (containing spaces) in all text files:
 
 `findstr /c:"{{query}}" *.txt`
-
-- Find space-separated string(s) in a piped command's output:
-
-`{{dir}} | findstr "{{query}}"`
 
 - Display the line number before each matching line:
 


### PR DESCRIPTION
added more useful examples and removed some old ones. fixes #3504

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
