### PR TITLE
spotify: add page

### DIFF
--- a/pages/osx/spotify.md
+++ b/pages/osx/spotify.md
@@ -7,6 +7,10 @@
 
 `spotify play {{song name}}`
 
+- Find a playlist by name and play it:
+
+`spotify play list {{playlist name}}`
+
 - Pause (or resume) playback:
 
 `spotify pause`

--- a/pages/osx/spotify.md
+++ b/pages/osx/spotify.md
@@ -1,0 +1,24 @@
+# shpotify
+
+> A command-line interface to Spotify.
+> More information: <https://github.com/hnarayanan/shpotify>.
+
+- Find a song by name and play it:
+
+`spotify play {{song name}}`
+
+- Pause (or resume) playback:
+
+`spotify pause`
+
+- Skip to the next song in a playlist:
+
+`spotify next`
+
+- Change volume:
+
+`spotify vol {{up|down|value}}`
+
+- Show the play status and song details:
+
+`spotify status`

--- a/pages/osx/spotify.md
+++ b/pages/osx/spotify.md
@@ -1,15 +1,15 @@
-# shpotify
+# spotify
 
 > A command-line interface to Spotify.
 > More information: <https://github.com/hnarayanan/shpotify>.
 
 - Find a song by name and play it:
 
-`spotify play {{song name}}`
+`spotify play {{song_name}}`
 
 - Find a playlist by name and play it:
 
-`spotify play list {{playlist name}}`
+`spotify play list {{playlist_name}}`
 
 - Pause (or resume) playback:
 
@@ -23,6 +23,6 @@
 
 `spotify vol {{up|down|value}}`
 
-- Show the play status and song details:
+- Show the playback status and song details:
 
 `spotify status`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

### Note

The name of the project is [**sh**potify](https://github.com/hnarayanan/shpotify), whereas the command is called `spotify` (without the **h**). I took a look at [another page](https://github.com/tldr-pages/tldr/blob/8b87e5f8285fd5b9d06fea143745d10abfb57ed9/pages/common/rg.md) where the repository name doesn't match the command name and following the same convention, I named the markdown file the same as the executable and set the page's title to the project name.
