### PR TITLE
rg: fix grammar

### DIFF
--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -24,7 +24,7 @@
 
 `rg {{pattern}} -g {{glob}}`
 
-- Only list matched files -- useful when piping to other commands:
+- Only list matched files (useful when piping to other commands):
 
 `rg --files-with-matches {{pattern}}`
 


### PR DESCRIPTION
Use parentheses around the second sentence instead of a double dash.