### PR TITLE
drush: switch to Drupal 8 examples

### DIFF
--- a/pages/common/drush.md
+++ b/pages/common/drush.md
@@ -3,25 +3,17 @@
 > A command-line shell and scripting interface for Drupal.
 > More information: <https://www.drush.org>.
 
-- Download module "foo":
-
-`drush dl {{foo}}`
-
-- Download version 7.x-2.1-beta1 of module "foo":
-
-`drush dl {{foo}}-7.x-2.1-beta1`
-
 - Enable module "foo":
 
 `drush en {{foo}}`
 
-- Disable module "foo":
+- Uninstall module "foo":
 
-`drush dis {{foo}}`
+`drush pmu {{foo}}`
 
 - Clear all caches:
 
-`drush cc all`
+`drush cr`
 
 - Clear CSS and JavaScript caches:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

It seems the page was written for Drupal 7 and some of these examples don't apply to Drupal 8.
(`drush dl` has been replaced by `composer`. `dis` and `cc all` are deprecated.)