### PR TITLE
javadoc: add page

### DIFF
--- a/pages/common/javadoc.md
+++ b/pages/common/javadoc.md
@@ -1,0 +1,16 @@
+# javadoc
+
+> Generate Java API documentation in HTML format from source code.
+> More information: <https://docs.oracle.com/javase/9/javadoc/javadoc-command.htm>
+
+- Generate documentation for Java source code and save the result in the directory:
+
+`javadoc -d {{path/to/directory/}} {{path/to/java_source_code}}`
+
+- Generate documentation with specific encoding:
+
+`javadoc -docencoding {{encoding_name}} {{java_source_code}}`
+
+- Generate documentation exclude some packages:
+
+`javadoc -exclude {{package_list}} {{java_source_code}}`

--- a/pages/common/javadoc.md
+++ b/pages/common/javadoc.md
@@ -9,8 +9,8 @@
 
 - Generate documentation with a specific encoding:
 
-`javadoc -docencoding {{encoding_name}} {{java_source_code}}`
+`javadoc -docencoding {{UTF-8}} {{path/to/java_source_code}}`
 
 - Generate documentation excluding some packages:
 
-`javadoc -exclude {{package_list}} {{java_source_code}}`
+`javadoc -exclude {{package_list}} {{path/to/java_source_code}}`

--- a/pages/common/javadoc.md
+++ b/pages/common/javadoc.md
@@ -1,7 +1,7 @@
 # javadoc
 
 > Generate Java API documentation in HTML format from source code.
-> More information: <https://docs.oracle.com/javase/9/javadoc/javadoc-command.htm>
+> More information: <https://docs.oracle.com/javase/9/javadoc/javadoc-command.htm>.
 
 - Generate documentation for Java source code and save the result in the directory:
 

--- a/pages/common/javadoc.md
+++ b/pages/common/javadoc.md
@@ -3,14 +3,14 @@
 > Generate Java API documentation in HTML format from source code.
 > More information: <https://docs.oracle.com/javase/9/javadoc/javadoc-command.htm>.
 
-- Generate documentation for Java source code and save the result in the directory:
+- Generate documentation for Java source code and save the result in a directory:
 
 `javadoc -d {{path/to/directory/}} {{path/to/java_source_code}}`
 
-- Generate documentation with specific encoding:
+- Generate documentation with a specific encoding:
 
 `javadoc -docencoding {{encoding_name}} {{java_source_code}}`
 
-- Generate documentation exclude some packages:
+- Generate documentation excluding some packages:
 
 `javadoc -exclude {{package_list}} {{java_source_code}}`


### PR DESCRIPTION
- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).