### PR TITLE
convert: add -append example

### DIFF
--- a/pages/common/convert.md
+++ b/pages/common/convert.md
@@ -19,6 +19,10 @@
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} +append {{image123.png}}`
 
+- Vertically append images:
+
+`convert {{image1.png}} {{image2.png}} {{image3.png}} -append {{image123.png}}`
+
 - Create a gif from a series of images with 100ms delay between them:
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} -delay {{100}} {{animation.gif}}`


### PR DESCRIPTION
Summary:
The current description only has appending pictures horizontally. It's
very common to append pictures vertically too.

Test:
The command about +append is correct. I tested it with

```
convert 1.png 2.png 3.png -append vertical.png
```

, which successfully combine the three pictures into one.

I'm not sure how to test this in tldr locally. I installed tldr on my
local machine with `brew install tldr`. If anyone can let me know
about it, I'd be happy to do it.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
