### PR TITLE
Correctly store language and platform mappings together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test_result
 # but it's been superseded by a static asset
 # hosted at https://tldr-pages.github.io/assets/index.json
 pages/index.json
+index.json

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -22,15 +22,20 @@ function buildPagesIndex(files) {
     let language = parseLanguage(file);
 
     if (index[page]) {
-      if (!index[page].platform.includes(os)) {
-        index[page].platform.push(os);
+      let targets = index[page].targets;
+      let needsPush = true;
+      for (const target of targets) {
+        if (target.platform === os && target.language === language) {
+          needsPush = false;
+          continue
+        }
       }
-
-      if (!index[page].language.includes(language)) {
-        index[page].language.push(language);
+      if (needsPush) {
+        targets.push({"os": os, "language": language})
+        index[page].targets = targets;
       }
     } else {
-      index[page] = {name: page, platform: [os], language: [language]};
+      index[page] = {name: page, targets: [{"os": os, "language": language}]};
     }
 
     return index;
@@ -43,8 +48,7 @@ function buildPagesIndex(files) {
       .map(function(page) {
         return {
           name: page,
-          platform: obj[page]["platform"],
-          language: obj[page]["language"]
+          targets: obj[page]["targets"]
         };
       });
 }

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -22,6 +22,12 @@ function buildPagesIndex(files) {
     let language = parseLanguage(file);
 
     if (index[page]) {
+      if (!index[page].platform.includes(os)) {
+        index[page].platform.push(os);
+      }
+      if (!index[page].language.includes(language)) {
+        index[page].language.push(language);
+      }
       let targets = index[page].targets;
       let needsPush = true;
       for (const target of targets) {
@@ -35,7 +41,11 @@ function buildPagesIndex(files) {
         index[page].targets = targets;
       }
     } else {
-      index[page] = {name: page, targets: [{"os": os, "language": language}]};
+      index[page] = {name: page,
+        platform: [os],
+        language: [language],
+        targets: [{"os": os, "language": language}]
+      };
     }
 
     return index;
@@ -48,6 +58,8 @@ function buildPagesIndex(files) {
       .map(function(page) {
         return {
           name: page,
+          platform: obj[page]["platform"],
+          language: obj[page]["language"],
           targets: obj[page]["targets"]
         };
       });

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -31,16 +31,16 @@ function buildPagesIndex(files) {
       }
 
       const targets = index[page].targets;
-      const exist = targets.some((t) => {return t.platform === os && t.language === language});
-      if (!exist) {
-        targets.push({"os": os, "language": language})
+      const exists = targets.some((t) => {return t.platform === os && t.language === language});
+      if (!exists) {
+        targets.push({os, language})
       }
     } else {
       index[page] = {
         name: page,
         platform: [os],
         language: [language],
-        targets: [{"os": os, "language": language}]
+        targets: [{os, language}]
       };
     }
 
@@ -54,9 +54,9 @@ function buildPagesIndex(files) {
       .map(function(page) {
         return {
           name: page,
-          platform: obj[page]["platform"],
-          language: obj[page]["language"],
-          targets: obj[page]["targets"]
+          platform: obj[page].platform,
+          language: obj[page].language,
+          targets: obj[page].targets
         };
       });
 }

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -25,23 +25,19 @@ function buildPagesIndex(files) {
       if (!index[page].platform.includes(os)) {
         index[page].platform.push(os);
       }
+
       if (!index[page].language.includes(language)) {
         index[page].language.push(language);
       }
-      let targets = index[page].targets;
-      let needsPush = true;
-      for (const target of targets) {
-        if (target.platform === os && target.language === language) {
-          needsPush = false;
-          continue
-        }
-      }
-      if (needsPush) {
+
+      const targets = index[page].targets;
+      const exist = targets.some((t) => {return t.platform === os && t.language === language});
+      if (!exist) {
         targets.push({"os": os, "language": language})
-        index[page].targets = targets;
       }
     } else {
-      index[page] = {name: page,
+      index[page] = {
+        name: page,
         platform: [os],
         language: [language],
         targets: [{"os": os, "language": language}]


### PR DESCRIPTION
Previously they were stored separately in their own arrays.
This made them disconnected, and impossible to know if a page
belonged to which platform and language combination.
