### PR TITLE
hub: fix instructions for aliasing the command

### DIFF
--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -1,7 +1,7 @@
 # hub
 
 > A wrapper for git that adds commands for working with GitHub-based projects.
-> The commands can also be used using "git" instead of "hub".
+> If set up as instructed by `hub alias`, one can use `git` to run `hub` commands.
 > More information: <https://hub.github.com>.
 
 - Clone a repository you own, using just the repository name rather than the full URL:


### PR DESCRIPTION
The current instructions don't match the actual behavior of the tool, since it [does not set up the alias by default](https://github.com/github/hub/issues/1791); that has to be done manually by the user (and by the way, doing so can result in unexpected behavior: https://github.com/github/hub/issues/153, https://github.com/github/hub/issues/1721, https://github.com/github/hub/issues/1778).

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
