### PR TITLE
cmake: improve out-of-source build example

### DIFF
--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -10,7 +10,7 @@
 
 - Generate a Makefile and use it to compile a project in a separate "build" directory (out-of-source build):
 
-`cmake -H. -B{{build}} && make -C {{build}}`
+`cmake -B {{build}} && make -C $_`
 
 - Run cmake in interactive mode (it will ask for each variable, instead of using defaults):
 


### PR DESCRIPTION
This trick was first introduced in #1386. I can't find any discussion about why the `-H.` was needed; I do vaguely recall wondering about that back when I first came across this trick, and my impression was that the trick didn't work without it; but I just tested the command without the `-H` and it seems to work:

<details>

- Create a temporary folder and enter it:
  ```sh
  cd $(mktemp -d)
  ```

- Create the source file:
  ```sh
  echo '#include<iostream>
  
  int main(int argc, char *argv[]){
    std::cout << "Hello World!" << std::endl;
    return 0;
  }' > helloworld.cpp
  ```

- Create the project file:
  ```sh
  echo 'cmake_minimum_required(VERSION 2.8)
  project (hello)
  add_executable(hello helloworld.cpp)' > CMakeLists.txt
  ```

- Compile the project:
  ```
  cmake -B foobar && make -C $_
  ```
- Run the executable:
  ```
  ./foobar/hello #Hello World!
  ```
</details>

(Note that this was on a macOS machine; I will test under Linux later on.)

In any case, it does seem weird that the `-H` option would be needed for this command to work, because it's been an alias of the `--help` option for [at least a decade and a half](https://github.com/Kitware/CMake/commit/d54e7a68885e43c53a8929a57b50b34b2be03d2d#diff-c73e705212ebf865a952d011da13cd5dR567)!

Besides removing the need for the `-H` argument, the example can even be simplified further to avoid typing the folder name twice, by using the `$_` trick (that change was inspired by [this UnixToolTip tweet](https://twitter.com/UnixToolTip/status/1196483245778571266)).

The result is a much cleaner example! 🎉

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
