### PR TITLE
git-show: add example for showing file contents

### DIFF
--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -23,6 +23,6 @@
 
 `git show --oneline -s {{commit}}`
 
-- Show the contents of a file as it was at a given branch, tag or commit:
+- Show the contents of a file as it was at a given revision (e.g. branch, tag or commit):
 
-`git show {{commit}}:{{path/to/file}}`
+`git show {{revision}}:{{path/to/file}}`

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -22,3 +22,7 @@
 - Show a commit's hash and message in a single line, suppressing the diff output:
 
 `git show --oneline -s {{commit}}`
+
+- Show the contents of a file as it was at a given branch, tag or commit:
+
+`git show {{commit}}:{{path/to/file}}`


### PR DESCRIPTION
This is a handy option which I have to look up how to do every now and then — most recently when seeking old versions of the Homebrew formula for cmake in the context of #3598.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
