### PR TITLE
stack: clarify command

### DIFF
--- a/pages/common/stack.md
+++ b/pages/common/stack.md
@@ -3,19 +3,15 @@
 > Tool for managing Haskell projects.
 > More information: <https://github.com/commercialhaskell/stack>.
 
-- Create a new project:
+- Create a new package:
 
-`stack new {{project_name}}`
+`stack new {{package_name}} {{template_name}}`
 
-- Install all packages needed by a project:
-
-`stack install`
-
-- Compile a project:
+- Compile a package:
 
 `stack build`
 
-- Run tests inside a project:
+- Run tests inside a package:
 
 `stack test`
 


### PR DESCRIPTION
Three changes:

* project -> package change as that's what it's referred to in the haskell ecosystem.
* Also include the template_name parameter
* Removing the `stack install` usage as it's just a synonym for `stack build --copy-bins`. Also it doesn't actually install all the packages needed by a project as documented here. Also, this command's inclusion was considered a mistake by the stack team. So, I'm removing it to discourage the use.


- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
