### PR TITLE
magick: Fix title & add better description

### DIFF
--- a/pages/common/magick.md
+++ b/pages/common/magick.md
@@ -1,6 +1,7 @@
-# ImageMagick
+# magick
 
 > Create, edit, compose, or convert bitmap images.
+> ImageMagick version 7+. See `convert` for versions 6 and below.
 > More information: <https://imagemagick.org/>.
 
 - Convert file type:


### PR DESCRIPTION
Ref #3653.

I've also updated the description, since I didn't get a chance to comment on it. `magick` is actually only available in ImageMagick v7+, which isn't yet available on Ubuntu (why? it's been out long enough).