### PR TITLE
Trim .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false
-
-[Makefile]
-indent_style = tab
-indent_size = 8


### PR DESCRIPTION
Changes (in `.editorconfig`):
- Makefile section removed
  - reason: Makefile not used
- `.md` trailing whitespace rule removed
  - reason: it leaves possibility for needless trailing whitespaces, while having no use (it's not used for `<br>`, since all lines have to be short)