### PR TITLE
Change main license to CC-BY 4.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,18 +1,23 @@
-## The MIT License (MIT)
+Copyright © 2014—present the [TLDR team](https://github.com/orgs/tldr-pages/people) and [contributors](https://github.com/tldr-pages/tldr/graphs/contributors).
 
-Copyright (c) 2014 the [TLDR team](https://github.com/orgs/tldr-pages/people) and [contributors](https://github.com/tldr-pages/tldr/graphs/contributors)
+This work is licensed under a [**Creative Commons Attribution 4.0 International License**](http://creativecommons.org/licenses/by/4.0/).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
+The contents of the [scripts/](https://github.com/tldr-pages/tldr/tree/master/scripts) directory
+are licensed under the MIT license:
+
+> ## The MIT License
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
+>
+> The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER


### PR DESCRIPTION
This change has been a long time coming, but we can finally wrap up the long-running discussion at #1076!

This change is justified by the following:

1. The MIT license is appropriate for open source software, but the vast majority of content in this repository is open content prose;
2. The best-known licenses for open content text are the Creative Commons ones;
3. The Creative Commons license that most closely approximates the properties of the MIT license is CC-BY (Attribution) 4.0;
4. The community has voiced overall support for this change in #1076; 
5. The MIT license allows for relicensing content subject to it.

Note: The software part of this repository, i.e. the contents of the `scripts/` directory, remains under the MIT license.

Fixes #1076 (at long last! 🎉)