### PR TITLE
cargo-doc: add page

### DIFF
--- a/pages/common/cargo-doc.md
+++ b/pages/common/cargo-doc.md
@@ -1,0 +1,20 @@
+# cargo doc
+
+> Build and view Rust package documentation offline.
+> More information: <https://doc.rust-lang.org/cargo/commands/cargo-doc.html>.
+
+- Build and view the default package documentation in your browser:
+
+`cargo doc --open`
+
+- Build documentation without accessing the network:
+
+`cargo doc --offline`
+
+- View a particular package's documentation:
+
+`cargo doc --open --package {{package}}`
+
+- View a particular package's documentation offline:
+
+`cargo doc --open --offline --package {{package}}`

--- a/pages/common/cargo-doc.md
+++ b/pages/common/cargo-doc.md
@@ -3,7 +3,7 @@
 > Build and view Rust package documentation offline.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-doc.html>.
 
-- Build and view the default package documentation in your browser:
+- Build and view the default package documentation in the browser:
 
 `cargo doc --open`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
