### PR TITLE
xinput: add disable and enable examples

### DIFF
--- a/pages/linux/xinput.md
+++ b/pages/linux/xinput.md
@@ -6,6 +6,14 @@
 
 `xinput list`
 
+- Disable an input:
+
+`xinput disable {{id}}`
+
+- Enable an input:
+
+`xinput enable {{id}}`
+
 - Disconnect an input from its master:
 
 `xinput float {{id}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
