### PR TITLE
qcp, qmv: small tweaks

### DIFF
--- a/pages/common/qcp.md
+++ b/pages/common/qcp.md
@@ -1,9 +1,9 @@
 # qcp
 
-> Copy files with your favorite text editor.
+> Copy files using the default text editor to define the filenames.
 > More information: <https://www.nongnu.org/renameutils/>.
 
-- Copy a single file (invoke an editor with source on the left, target on the right):
+- Copy a single file (open an editor with the source filename on the left and the target filename on the right):
 
 `qcp {{source_file}}`
 
@@ -11,6 +11,6 @@
 
 `qcp {{*.jpg}}`
 
-- Copy files, but swap the positions of the source and the target in the editor:
+- Copy files, but swap the positions of the source and the target filenames in the editor:
 
 `qcp --option swap {{*.jpg}}`

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -1,9 +1,9 @@
 # qmv
 
-> Move files and directories with your favorite text editor.
+> Move files and directories using the default text editor to define the filenames.
 > More information: <https://www.nongnu.org/renameutils/>.
 
-- Move a single file (invoke an editor with source on the left, target on the right):
+- Move a single file (open an editor with the source filename on the left and the target filename on the right):
 
 `qmv {{source_file}}`
 
@@ -11,14 +11,14 @@
 
 `qmv {{*.jpg}}`
 
-- Move 3 directories:
+- Move multiple directories:
 
-`qmv -d {{path/to/dir_1}} {{path/to/dir_2}} {{path/to/dir_3}}`
+`qmv -d {{path/to/directory1}} {{path/to/directory2}} {{path/to/directory3}}`
 
-- Move files/directories inside a directory:
+- Move all files and directories inside a directory:
 
-`qmv -R {{path/to/directory}}`
+`qmv --recursive {{path/to/directory}}`
 
-- Move files, but swap the positions of the source and the target in the editor:
+- Move files, but swap the positions of the source and the target filenames in the editor:
 
 `qmv --option swap {{*.jpg}}`


### PR DESCRIPTION
These changes are a follow-up to #3458. Besides the self-explanatory clarification changes, I also restored the fully-spelled `--recursive` option instead of `-R` (reverting the change discussed [here](https://github.com/tldr-pages/tldr/pull/3458#discussion_r337400925)), since the word "recursive" is not used in the example's description, so the single letter option's meaning isn't obvious (unlike the `-d` option which was changed from `--directory` following [this discussion](https://github.com/tldr-pages/tldr/pull/3458#discussion_r337399770)).

/cc @einverne and @neizod.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
