### PR TITLE
git-show: add example for --stat option

### DIFF
--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -23,7 +23,7 @@
 
 `git show --oneline -s {{commit}}`
 
-- Show only a list of the files changed in a commit:
+- Show only the list of the files changed in a commit:
 
 `git show --stat {{commit}}`
 

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -3,7 +3,7 @@
 > Show various types of git objects (commits, tags, etc.).
 > More information: <https://git-scm.com/docs/git-show>.
 
-- Show information about the latest commit (message, changes, and other metadata):
+- Show information about the latest commit (hash, message, changes, and other metadata):
 
 `git show`
 
@@ -19,9 +19,13 @@
 
 `git show {{branch}}~{{3}}`
 
-- Show a commit's hash and message in a single line, suppressing the diff output:
+- Show a commit's message in a single line, suppressing the diff output:
 
 `git show --oneline -s {{commit}}`
+
+- Show only a list of the files changed in a commit:
+
+`git show --stat {{commit}}`
 
 - Show the contents of a file as it was at a given revision (e.g. branch, tag or commit):
 


### PR DESCRIPTION
As the title says :)

Also reword two descriptions to avoid misleading people regarding when the commit hash is shown.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
