### PR TITLE
Add extra installation instructions to clients which OS packaged versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can access these pages on your computer using one of the following clients:
     [App Store](https://itunes.apple.com/us/app/tldt-pages/id1071725095?ls=1&mt=8)
 - [Haskell client](https://github.com/psibi/tldr-hs):
   `stack install tldr`
-  or `apt-get install tldr` on Debian
+  or `apt-get install tldr` on Debian and Ubuntu
 - [Node.js client](https://github.com/tldr-pages/tldr-node-client):
   `npm install -g tldr`
 - [OCaml client](https://github.com/RosalesJ/tldr-ocaml): `opam install tldr`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can access these pages on your computer using one of the following clients:
     [App Store](https://itunes.apple.com/us/app/tldt-pages/id1071725095?ls=1&mt=8)
 - [Haskell client](https://github.com/psibi/tldr-hs):
   `stack install tldr`
+  or `apt-get install tldr` on Debian
 - [Node.js client](https://github.com/tldr-pages/tldr-node-client):
   `npm install -g tldr`
 - [OCaml client](https://github.com/RosalesJ/tldr-ocaml): `opam install tldr`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can access these pages on your computer using one of the following clients:
   - [tldr-python-client](https://github.com/tldr-pages/tldr-python-client):
     `pip install tldr` or `pacman -S tldr` on Arch Linux
   - [tldr.py](https://github.com/lord63/tldr.py):
-    `pip install tldr.py`
+    `pip install tldr.py` or `apt-get install tldr-py` on Ubuntu
 - [R client](https://github.com/kirillseva/tldrrr):
   `devtools::install_github('kirillseva/tldrrr')`
 - [Ruby client](https://github.com/YellowApple/tldrb):

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can access these pages on your computer using one of the following clients:
   - [tldr-python-client](https://github.com/tldr-pages/tldr-python-client):
     `pip install tldr` or `pacman -S tldr` on Arch Linux
   - [tldr.py](https://github.com/lord63/tldr.py):
-    `pip install tldr.py` or `apt-get install tldr-py` on Ubuntu
+    `pip install tldr.py` or `apt-get install tldr-py` on Debian-based distributions
 - [R client](https://github.com/kirillseva/tldrrr):
   `devtools::install_github('kirillseva/tldrrr')`
 - [Ruby client](https://github.com/YellowApple/tldrb):

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can access these pages on your computer using one of the following clients:
     [App Store](https://itunes.apple.com/us/app/tldt-pages/id1071725095?ls=1&mt=8)
 - [Haskell client](https://github.com/psibi/tldr-hs):
   `stack install tldr`
-  or `apt-get install tldr` on Debian and Ubuntu
+  or `apt-get install tldr` on Debian-based distributions
 - [Node.js client](https://github.com/tldr-pages/tldr-node-client):
   `npm install -g tldr`
 - [OCaml client](https://github.com/RosalesJ/tldr-ocaml): `opam install tldr`


### PR DESCRIPTION
This tldr client written in Haskell is [available as a Debian package](https://packages.debian.org/sid/tldr) maintained by the Debian Haskell Group and Clint Adams, so it can be installed with the different commands Debian has to manage packages. The README already gives alternative installation instructions for some clients (one written in Go and one in Python).