### PR TITLE
numlockx: add page

### DIFF
--- a/pages/linux/numlockx.md
+++ b/pages/linux/numlockx.md
@@ -1,0 +1,20 @@
+# numlockx
+
+> Control the number lock key status in X11 sessions.
+> More information: <http://www.mike-devlin.com/linux/README-numlockx.htm>.
+
+- Show the current number lock status:
+
+`numlockx status`
+
+- Turn the number lock on:
+
+`numlockx on`
+
+- Turn it off:
+
+`numlockx off`
+
+- Toggle the current state:
+
+`numlockx toggle`

--- a/pages/linux/numlockx.md
+++ b/pages/linux/numlockx.md
@@ -11,7 +11,7 @@
 
 `numlockx on`
 
-- Turn it off:
+- Turn the number lock off:
 
 `numlockx off`
 


### PR DESCRIPTION
To solve that really annoying problem where numlockx is always turned off when you boot Ubuntu (sorry wayland users, you'll have to keep looking).