### PR TITLE
Fix tldr-bot messages

### DIFF
--- a/scripts/send-to-bot.py
+++ b/scripts/send-to-bot.py
@@ -8,8 +8,7 @@ import urllib.request
 BOT_URL = 'https://tldr-bot.starbeamrainbowlabs.com'
 
 COMMENT_ERROR="""
-The [build](https://travis-ci.org/tldr-pages/tldr/builds/{build_id})
-for this PR failed with the following error(s):
+The [build](https://travis-ci.org/tldr-pages/tldr/builds/{build_id}) for this PR failed with the following error(s):
 
 ```
 {content}
@@ -23,8 +22,7 @@ Hello! I've noticed something unusual when checking this PR:
 
 {content}
 
-Is this intended? If so, just ignore this comment. Otherwise, please
-double-check the commits.
+Is this intended? If so, just ignore this comment. Otherwise, please double-check the commits.
 """
 
 ################################################################################


### PR DESCRIPTION
GitHub wraps text in comments even when a single newline is encountered. This caused @tldr-bot messages to be formatted like this:

> The [build](https://travis-ci.org/tldr-pages/tldr/builds/635578923)
> for this PR failed with the following error(s):
> ...

Which does not look good. They should instead be formatted like this:

> The [build](https://travis-ci.org/tldr-pages/tldr/builds/635578923) for this PR failed with the following error(s):
> ...

This PR removes the unneeded newlines in the script.