### PR TITLE
qr: add page

### DIFF
--- a/pages/common/qr.md
+++ b/pages/common/qr.md
@@ -5,7 +5,7 @@
 
 - Generate a QR code:
 
-`echo "{{data}}" | qr
+`echo "{{data}}" | qr`
 
 - Specify the error correction level (defaults to M):
 

--- a/pages/common/qr.md
+++ b/pages/common/qr.md
@@ -1,0 +1,12 @@
+# qr
+
+> Generate QR codes in the terminal with ANSI VT-100 escape codes.
+> More information: <https://github.com/lincolnloop/python-qrcode/>.
+
+- Generate a QR code:
+
+`echo "{{data}}" | qr
+
+- Specify the error correction level (defaults to M):
+
+`echo "{{data}}" | qr --error-correction={{L|M|Q|H}}`


### PR DESCRIPTION
I was surprised to see that `qr` doesn't have a page yet! It's a great little utility for quickly generating temporary qr codes on the terminal.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
