### PR TITLE
git flow: add page

### DIFF
--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -9,7 +9,7 @@
 
 - Start developing a new feature. It creates a new branch based on develop:
 
-`git flow feature start <feature>`
+`git flow feature start {{feature}}`
 
 - Finish development of a feature, which will merge it into develop, remove the feature branch and switch to develop:
 

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -21,4 +21,4 @@
 
 - Get a feature published by another user:
 
-`git flow feature pull origin <feature>`
+`git flow feature pull origin {{feature}}`

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -13,7 +13,7 @@
 
 - Finish development of a feature, which will merge it into develop, remove the feature branch and switch to develop:
 
-`git flow feature finish <feature>`
+`git flow feature finish {{feature}}`
 
 - Publish a feature to the remote server so others can work on it too:
 

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -1,0 +1,24 @@
+# git flow
+
+> A collection of Git extensions to provide high-level repository operations for Vincent Driessen's branching model.
+> More information: <https://github.com/nvie/gitflow>.
+
+- Start using git-flow by initializing it inside an existing git repository:
+
+`git flow init`
+
+- Start developing a new feature. It creates a new branch based on develop:
+
+`git flow feature start <feature>`
+
+- Finish development of a feature, which will merge it into develop, remove the feature branch and switch to develop:
+
+`git flow feature finish <feature>`
+
+- Publish a feature to the remote server so others can work on it too:
+
+`git flow feature publish <feature>`
+
+- Get a feature published by another user:
+
+`git flow feature pull origin <feature>`

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -17,7 +17,7 @@
 
 - Publish a feature to the remote server so others can work on it too:
 
-`git flow feature publish <feature>`
+`git flow feature publish {{feature}}`
 
 - Get a feature published by another user:
 

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -11,7 +11,7 @@
 
 `git flow feature start {{feature}}`
 
-- Finish development of a feature, which will merge it into develop, remove the feature branch and switch to develop:
+- Finish development on a feature branch, merging it into the `develop` branch and deleting it:
 
 `git flow feature finish {{feature}}`
 

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -3,7 +3,7 @@
 > A collection of Git extensions to provide high-level repository operations for Vincent Driessen's branching model.
 > More information: <https://github.com/nvie/gitflow>.
 
-- Start using git-flow by initializing it inside an existing git repository:
+- Initialize it inside an existing git repository:
 
 `git flow init`
 

--- a/pages/common/git-flow.md
+++ b/pages/common/git-flow.md
@@ -1,13 +1,13 @@
 # git flow
 
-> A collection of Git extensions to provide high-level repository operations for Vincent Driessen's branching model.
+> A collection of Git extensions to provide high-level repository operations.
 > More information: <https://github.com/nvie/gitflow>.
 
 - Initialize it inside an existing git repository:
 
 `git flow init`
 
-- Start developing a new feature. It creates a new branch based on develop:
+- Start developing on a feature branch based on `develop`:
 
 `git flow feature start {{feature}}`
 
@@ -15,7 +15,7 @@
 
 `git flow feature finish {{feature}}`
 
-- Publish a feature to the remote server so others can work on it too:
+- Publish a feature to the remote server:
 
 `git flow feature publish {{feature}}`
 


### PR DESCRIPTION
Hello, I'm a [git flow](https://github.com/nvie/gitflow) user and saw that it there is no page for it yet. My biggest concern is that it would live next to other standard git commands under `/common/git-` even though git flow is an extension to git and therefore its own thing.  Nonetheless in practice it extends the standard git cli.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
