### PR TITLE
efibootmgr: add page

### DIFF
--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -1,15 +1,15 @@
 # efibootmgr
 
 > Manipulate the UEFI Boot Manager (the Bootoptions).
-> 
-> More Information: https://linux.die.net/man/8/efibootmgr
+>
+> More Information: https://linux.die.net/man/8/efibootmgr .
 
 - List the current settings / bootnums:
 
 `efibootmgr`
 
 - List the Filepaths:
-  
+
 `efibootmgr -v`
 
 - Add UEFI Shell v2 as a boot option:

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -18,6 +18,6 @@
 
 `sudo efibootmgr -o {{0002,0008,0001,0005}}`
 
-- Delete Bootoption:
+- Delete a boot option:
 
 `sudo efibootmgr -b {{bootnum}} -B`

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -14,7 +14,7 @@
 
 `sudo efibootmgr -c -d /dev/sda1 -l \EFI\tools\Shell.efi -L "UEFI Shell"`
 
-- Change the current Bootorder (you can get the Bootnums from the first command):
+- Change the current boot order (you can get the Bootnums from the first command):
 
 `sudo efibootmgr -o {{0002,0008,0001,0005}}`
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -4,7 +4,7 @@
 
 - List the current settings:
 
-`efibootmgr `(`-v` for Filepaths)
+`efibootmgr -v for Filepaths`
 
 - Create new Bootoption:
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -1,0 +1,23 @@
+# efibootmgr
+
+> Manipulate the UEFI Boot Manager (the Bootoptions).
+
+- List the current settings:
+
+`efibootmgr `(`-v` for Filepaths)
+
+- Create new Bootoption:
+
+`sudo efibootmgr -c -d {{esp_blockdevice}} -l {{\path\to\file.efi}} -L "{{Label}}"`
+
+- > Specific Example: Adding UEFI Shell v2 as a Boot Options:
+
+`sudo efibootmgr -c -d /dev/sda1 -l \EFI\tools\Shell.efi -L "UEFI Shell"`
+
+- Change the current Bootorder (you can get the Bootnums from the first command):
+
+`sudo efibootmgr -o {{0002,0008,0001,0005}}`
+
+- Delete Bootoption:
+
+`sudo efibootmgr -b {{bootnum}} -B`

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -6,7 +6,7 @@
 
 `efibootmgr -v for Filepaths`
 
-- Create new Bootoption:
+- Create a new boot option:
 
 `sudo efibootmgr -c -d {{esp_blockdevice}} -l {{\path\to\file.efi}} -L "{{Label}}"`
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -10,7 +10,7 @@
 
 `sudo efibootmgr -c -d {{esp_blockdevice}} -l {{\path\to\file.efi}} -L "{{Label}}"`
 
-- > Specific Example: Adding UEFI Shell v2 as a Boot Options:
+- Add UEFI Shell v2 as a boot option:
 
 `sudo efibootmgr -c -d /dev/sda1 -l \EFI\tools\Shell.efi -L "UEFI Shell"`
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -1,23 +1,25 @@
 # efibootmgr
 
 > Manipulate the UEFI Boot Manager (the Bootoptions).
+> 
+> More Information: https://linux.die.net/man/8/efibootmgr
 
-- List the current settings:
+- List the current settings / bootnums:
 
-`efibootmgr -v for Filepaths`
+`efibootmgr`
 
-- Create a new boot option:
-
-`sudo efibootmgr -c -d {{esp_blockdevice}} -l {{\path\to\file.efi}} -L "{{Label}}"`
+- List the Filepaths
+  
+`efibootmgr -v`
 
 - Add UEFI Shell v2 as a boot option:
 
-`sudo efibootmgr -c -d /dev/sda1 -l \EFI\tools\Shell.efi -L "UEFI Shell"`
+`sudo efibootmgr -c -d {{/dev/sda1}} -l {{\EFI\tools\Shell.efi}} -L "{{UEFI Shell}}"`
 
-- Change the current boot order (you can get the Bootnums from the first command):
+- Change the current boot order:
 
 `sudo efibootmgr -o {{0002,0008,0001,0005}}`
 
 - Delete a boot option:
 
-`sudo efibootmgr -b {{bootnum}} -B`
+`sudo efibootmgr -b {{0008}} --delete-bootnum`

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -8,7 +8,7 @@
 
 `efibootmgr`
 
-- List the Filepaths
+- List the Filepaths:
   
 `efibootmgr -v`
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -7,7 +7,7 @@
 
 `efibootmgr`
 
-- List the Filepaths:
+- List the filepaths:
 
 `efibootmgr -v`
 

--- a/pages/linux/efibootbgr.md
+++ b/pages/linux/efibootbgr.md
@@ -1,8 +1,7 @@
 # efibootmgr
 
 > Manipulate the UEFI Boot Manager (the Bootoptions).
->
-> More Information: https://linux.die.net/man/8/efibootmgr .
+> More information: https://linux.die.net/man/8/efibootmgr.
 
 - List the current settings / bootnums:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

As you might have already seen, I included a specific example on creating a new boot option. I believe that in this case It is simpler to understand it with an extra example (because of the weird fat \ instead of / and it is possible that adding the UEFI Shell as a Bootoption.