### PR TITLE
youtube-dl: add download the best audio+video

### DIFF
--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -21,7 +21,7 @@
 
 - Download the best quality audio and video and merge them:
 
-`youtube-dl -f {{bestvideo+bestaudio}} {{url}}`
+`youtube-dl -f bestvideo+bestaudio {{url}}`
 
 - Download video(s) as MP4 files with custom filenames:
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -19,6 +19,10 @@
 
 `youtube-dl -x --audio-format {{mp3}} {{url}}`
 
+- Download the best quality audio and video and merge them:
+
+`youtube-dl -f {{bestvideo+bestaudio}} {{url}}`
+
 - Download video(s) as MP4 files with custom filenames:
 
 `youtube-dl --format {{mp4}} -o {{"%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s"}} {{url}}`


### PR DESCRIPTION
With this command the user can download the best audio and video separately. After it's done downloading, it will spawn ffmpeg to merge the two files together. Handy when downloading stuff from youtube as they host video and audio separate.

<!--

Thank you for sending a PR!
Please perform the following checks and mark all the boxes accordingly.
You can remove the checklist items that don't apply to your PR.

-->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
