### PR TITLE
losetup: added example for --read-only and --partscan

### DIFF
--- a/pages.ko/common/docker-logs.md
+++ b/pages.ko/common/docker-logs.md
@@ -1,0 +1,24 @@
+# docker logs
+
+> 컨테이너 로그들을 출력한다.
+> 더 많은 정보: <https://docs.docker.com/engine/reference/commandline/logs>.
+
+- 컨테이너로부터 로그들을 출력하기:
+
+`docker logs {{컨테이너_이름}}`
+
+- 로그들을 출력하고 추적하기:
+
+`docker logs -f {{컨테이너_이름}}`
+
+- 최근 5줄만 출력하기:
+
+`docker logs {{컨테이너_이름}} --tail {{5}}`
+
+- 로그들을 출력하고 타임스태프 추가하기:
+
+`docker logs -t {{컨테이너_이름}}`
+
+- 특정 시점의 컨테이너 실행 시점으로부터 로그 출력하기 (예시. 23m, 10s, 2013-01-02T13:23:37):
+
+`docker logs {{컨테이너_이름}} --until {{시간}}`

--- a/pages/linux/losetup.md
+++ b/pages/linux/losetup.md
@@ -18,7 +18,7 @@
 
 `sudo losetup -d /dev/{{loop}}`
 
-- Attach a file to the new free loop device. Scan the device for partitions:
+- Attach a file to a new free loop device and scan the device for partitions:
 
 `sudo losetup --show --partscan -f /{{path/to/file}}`
 


### PR DESCRIPTION
read-only losetup and partscan are commonly used options in digital forensics. It is benefitial to know about '--partscan' as it sometimes gives other results then losetup and partprobe/kpartx, e.g. with BSD-style partitions.

]x] The page has 8 or fewer examples.
]x] The PR title conforms to the recommended templates.
]x] The page follows the content guidelines.