### PR TITLE
mullvad: add page

### DIFF
--- a/pages/linux/mullvad.md
+++ b/pages/linux/mullvad.md
@@ -5,7 +5,7 @@
 
 - Link your mullvad account with specified account number:
 
-`mullvad account set {account number}`
+`mullvad account set {{account_number}}`
 
 - Enable LAN Access while VPN is on:
 

--- a/pages/linux/mullvad.md
+++ b/pages/linux/mullvad.md
@@ -3,18 +3,18 @@
 > CLI client for Mullvad VPN.
 > More information: <https://mullvad.net/>.
 
-- Link your mullvad account with {account number}
+- Link your mullvad account with {account number}:
 
 `mullvad account set {account number}`
 
-- Enable LAN Access while VPN is on
+- Enable LAN Access while VPN is on:
 
 `mullvad lan set allow`
 
-- Command the client to start establishing VPN tunnel
+- Command the client to start establishing VPN tunnel:
 
 `mullvad connect`
 
-- Check status of VPN tunnel
+- Check status of VPN tunnel:
 
 `mullvad status`

--- a/pages/linux/mullvad.md
+++ b/pages/linux/mullvad.md
@@ -3,11 +3,11 @@
 > CLI client for Mullvad VPN.
 > More information: <https://mullvad.net/>.
 
-- Link your mullvad account with specified account number:
+- Link your mullvad account with the specified account number:
 
 `mullvad account set {{account_number}}`
 
-- Enable LAN Access while VPN is on:
+- Enable LAN access while VPN is on:
 
 `mullvad lan set allow`
 

--- a/pages/linux/mullvad.md
+++ b/pages/linux/mullvad.md
@@ -3,7 +3,7 @@
 > CLI client for Mullvad VPN.
 > More information: <https://mullvad.net/>.
 
-- Link your mullvad account with {account number}:
+- Link your mullvad account with specified account number:
 
 `mullvad account set {account number}`
 

--- a/pages/linux/mullvad.md
+++ b/pages/linux/mullvad.md
@@ -1,0 +1,20 @@
+# mullvad
+
+> CLI client for Mullvad VPN.
+> More information: <https://mullvad.net/>.
+
+- Link your mullvad account with {account number}
+
+`mullvad account set {account number}`
+
+- Enable LAN Access while VPN is on
+
+`mullvad lan set allow`
+
+- Command the client to start establishing VPN tunnel
+
+`mullvad connect`
+
+- Check status of VPN tunnel
+
+`mullvad status`


### PR DESCRIPTION
Information on the mullvad command line utility.

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
