### PR TITLE
openrc, rc-status, rc-service, rc-update: add pages

### DIFF
--- a/pages/linux/openrc.md
+++ b/pages/linux/openrc.md
@@ -1,0 +1,14 @@
+# openrc
+
+> The OpenRC service manager.
+> See also `rc-status`, `rc-update`, and `rc-service`.
+> More information: <https://wiki.gentoo.org/wiki/OpenRC>.
+
+- Change to a specific runlevel:
+
+`sudo openrc {{runlevel_name}}`
+
+- Change to a specific runlevel, but don't stop any existing services:
+
+`sudo openrc --no-stop {{runlevel_name}}`
+

--- a/pages/linux/openrc.md
+++ b/pages/linux/openrc.md
@@ -11,4 +11,3 @@
 - Change to a specific runlevel, but don't stop any existing services:
 
 `sudo openrc --no-stop {{runlevel_name}}`
-

--- a/pages/linux/rc-service.md
+++ b/pages/linux/rc-service.md
@@ -1,0 +1,33 @@
+# rc-service
+
+> Locate and run OpenRC services with arguments
+> See also `openrc`.
+
+- Show a service's status:
+
+`rc-service {{service_name}} status`
+
+- Start a service:
+
+`sudo rc-service {{service_name}} start`
+
+- Stop a service:
+
+`sudo rc-servie {{service_name}} stop`
+
+- Restart a service:
+
+`sudo rc-service {{service_name}} restart`
+
+- Simulate running a service's custom command:
+
+`sudo rc-service --dry-run {{service_name}} {{command_name}}`
+
+- Actually run a service's custom command:
+
+`sudo rc-service {{service_name}} {{command_name}}`
+
+- Resolve the location of a service definition on disk:
+
+`sudo rc-service --resolve {{service_name}}`
+

--- a/pages/linux/rc-service.md
+++ b/pages/linux/rc-service.md
@@ -1,6 +1,6 @@
 # rc-service
 
-> Locate and run OpenRC services with arguments
+> Locate and run OpenRC services with arguments.
 > See also `openrc`.
 
 - Show a service's status:
@@ -30,4 +30,3 @@
 - Resolve the location of a service definition on disk:
 
 `sudo rc-service --resolve {{service_name}}`
-

--- a/pages/linux/rc-status.md
+++ b/pages/linux/rc-status.md
@@ -1,0 +1,29 @@
+# rc-status
+
+> Show status info about runlevels
+> Part of OpenRC - see also `openrc`.
+
+- Show a summary of services and their status:
+
+`rc-status`
+
+- Include services in all runlevels in the summary:
+
+`rc-status --all`
+
+- List services that have crashed:
+
+`rc-status --crashed`
+
+- List manually started services:
+
+`rc-status --manual`
+
+- List supervised services:
+
+`rc-status --supervised`
+
+- Get the current runlevel:
+
+`rc-status --runlevel`
+

--- a/pages/linux/rc-status.md
+++ b/pages/linux/rc-status.md
@@ -27,3 +27,7 @@
 
 `rc-status --runlevel`
 
+- List all runlevels:
+
+`rc-status --list`
+

--- a/pages/linux/rc-status.md
+++ b/pages/linux/rc-status.md
@@ -1,7 +1,7 @@
 # rc-status
 
 > Show status info about runlevels.
-> Part of OpenRC - see also `openrc`.
+> See also `openrc`.
 
 - Show a summary of services and their status:
 

--- a/pages/linux/rc-status.md
+++ b/pages/linux/rc-status.md
@@ -1,6 +1,6 @@
 # rc-status
 
-> Show status info about runlevels
+> Show status info about runlevels.
 > Part of OpenRC - see also `openrc`.
 
 - Show a summary of services and their status:

--- a/pages/linux/rc-status.md
+++ b/pages/linux/rc-status.md
@@ -30,4 +30,3 @@
 - List all runlevels:
 
 `rc-status --list`
-

--- a/pages/linux/rc-update.md
+++ b/pages/linux/rc-update.md
@@ -1,7 +1,7 @@
 # rc-update
 
 > Add and remove OpenRC services to and from runlevels.
-> See also: `openrc`.
+> See also `openrc`.
 
 - List all services and the runlevels they are added to:
 

--- a/pages/linux/rc-update.md
+++ b/pages/linux/rc-update.md
@@ -1,0 +1,21 @@
+# rc-update
+
+> Add and remove OpenRC services to and from runlevels.
+> See also: `openrc`.
+
+- List all services and the runlevels they are added to:
+
+`rc-update show`
+
+- Add a service to a runlevel:
+
+`sudo rc-update add {{service_name}} {{runlevel}}`
+
+- Delete a service from a runlevel:
+
+`sudo rc-update delete {{service_name}} {{runlevel}}`
+
+- Delete a service from all runlevels:
+
+`sudo rc-update --all delete {{service_name}}`
+

--- a/pages/linux/rc-update.md
+++ b/pages/linux/rc-update.md
@@ -18,4 +18,3 @@
 - Delete a service from all runlevels:
 
 `sudo rc-update --all delete {{service_name}}`
-


### PR DESCRIPTION
I noticed that although we have pretty extensive pages for systemd and sysvinit, we don't yet have any have any pages for OpenRC.

This PR adds pages for the full suite of public-facing OpenRC commands.