### PR TITLE
mmls: add page

### DIFF
--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -11,7 +11,7 @@
 
 `mmls -B -i {{path/to/image_file}}`
 
-- Display the partition table in a splitted EWF image:
+- Display the partition table in a split EWF image:
 
 `mmls -i ewf {{image.e01}} {{image.e02}}`
 

--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -5,11 +5,11 @@
 
 - Display the partition table stored in an image file:
 
-`mmls {{imagefile}}`
+`mmls {{/path/to/image_file}}`
 
 - Display the partition table with an additional column for the partition size:
 
-`mmls -B -i {{image}}`
+`mmls -B -i {{/path/to/image_file}}`
 
 - Display the partition table in a splitted EWF image:
 
@@ -17,4 +17,4 @@
 
 - Display nested partition tables:
 
-`mmls -t {{nested_table_type}} -o {{offset}} {{image}}`
+`mmls -t {{nested_table_type}} -o {{offset}} {{/path/to/image_file}}`

--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -17,4 +17,4 @@
 
 - Display nested partition tables:
 
-`mmls -t {{nested_table_type}} -o {{offset}} {{/path/to/image_file}}`
+`mmls -t {{nested_table_type}} -o {{offset}} {{path/to/image_file}}`

--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -1,0 +1,20 @@
+# mmls
+
+> Display the partition layout of a volume system.
+> More information: <https://wiki.sleuthkit.org/index.php?title=Mmls>.
+
+- Display the partition table stored in an image file:
+
+`mmls {{imagefile}}`
+
+- Display the partition table with an additional column for the partition size:
+
+`mmls -B -i {{image}}`
+
+- Display the partition table in a splitted EWF image:
+
+`mmls -i ewf {{image.e01}} {{image.e02}}`
+
+- Display nested partition tables:
+
+`mmls -t {{nested_table_type}} -o {{offset}} {{image}}`

--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -5,11 +5,11 @@
 
 - Display the partition table stored in an image file:
 
-`mmls {{/path/to/image_file}}`
+`mmls {{path/to/image_file}}`
 
 - Display the partition table with an additional column for the partition size:
 
-`mmls -B -i {{/path/to/image_file}}`
+`mmls -B -i {{path/to/image_file}}`
 
 - Display the partition table in a splitted EWF image:
 


### PR DESCRIPTION
Added explanation for mmls, a tool used in digital forensics to read partition tables of (mostly) image files.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
