### PR TITLE
firewall-cmd: add zone change and arbitrary ports

### DIFF
--- a/pages/linux/firewall-cmd.md
+++ b/pages/linux/firewall-cmd.md
@@ -10,6 +10,10 @@
 
 `firewall-cmd --list-all`
 
+- Permanently move the interface into the block zone, effectively blocking all communication:
+
+`firewall-cmd --permanent --zone={{block}} --change-interface={{enp1s0}}`
+
 - Permanently open the port for a service in the specified zone (like port `443` when in the `public` zone):
 
 `firewall-cmd --permanent --zone={{public}} --add-service={{https}}`
@@ -17,6 +21,10 @@
 - Permanently close the port for a service in the specified zone (like port `80` when in the `public` zone):
 
 `firewall-cmd --permanent --zone={{public}} --remove-service={{http}}`
+
+- Permanently open two arbitrary ports in the specified zone:
+
+`firewall-cmd --permanent --zone={{public}} --add-port={{25565/tcp}} --add-port={{19132/udp}}`
 
 - Reload firewalld to force rule changes to take effect:
 


### PR DESCRIPTION
I do this a lot with my test servers - put an interface into trusted
zone. The syntax is a bit weird, therefore I always tend to dig in the
man page.

The patch also adds arbitrary port naming because the syntax is also a
bit weird and hard to remember. Cheers!

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).