### PR TITLE
nmcli: add more server examples

### DIFF
--- a/pages/linux/nmcli-connection.md
+++ b/pages/linux/nmcli-connection.md
@@ -14,14 +14,14 @@
 
 `nmcli connection down uuid {{uuid}}`
 
-- Create a static IPv4-only connection:
+- Create an auto-configured dual stack connection:
 
-`nmcli connection add ifname {{interface_name}} type {{ethernet}} ip4 {{10.0.0.7/8}} gw4 {{10.0.0.1}} ipv4.dns {{10.0.0.1}} ipv6.method {{ignore}}`
+`nmcli connection add ifname {{interface_name}} type {{ethernet}} ipv4.method {{auto}} ipv6.method {{auto}}`
 
 - Create a static IPv6-only connection:
 
 `nmcli connection add ifname {{interface_name}} type {{ethernet}} ip6 {{2001:db8::2/64}} gw6 {{2001:db8::1}} ipv6.dns {{2001:db8::1}} ipv4.method {{ignore}}`
 
-- Create an auto-configured dual stack connection:
+- Create a static IPv4-only connection:
 
-`nmcli connection add ifname {{interface_name}} type {{ethernet}} ipv4.method {{auto}} ipv6.method {{auto}}`
+`nmcli connection add ifname {{interface_name}} type {{ethernet}} ip4 {{10.0.0.7/8}} gw4 {{10.0.0.1}} ipv4.dns {{10.0.0.1}} ipv6.method {{ignore}}`

--- a/pages/linux/nmcli-connection.md
+++ b/pages/linux/nmcli-connection.md
@@ -1,0 +1,27 @@
+# nmcli connection
+
+> Connection management with NetworkManager.
+
+- List all NetworkManager connections (shows name, uuid, type and device):
+
+`nmcli connection`
+
+- Activate a connection by specifying an uuid:
+
+`nmcli connection up uuid {{uuid}}`
+
+- Deactivate a connection:
+
+`nmcli connection down uuid {{uuid}}`
+
+- Create a static IPv4-only connection:
+
+`nmcli connection add ifname {{interface_name}} type {{ethernet}} ip4 {{10.0.0.7/8}} gw4 {{10.0.0.1}} ipv4.dns {{10.0.0.1}} ipv6.method {{ignore}}`
+
+- Create a static IPv6-only connection:
+
+`nmcli connection add ifname {{interface_name}} type {{ethernet}} ip6 {{2001:db8::2/64}} gw6 {{2001:db8::1}} ipv6.dns {{2001:db8::1}} ipv4.method {{ignore}}`
+
+- Create an auto-configured dual stack connection:
+
+`nmcli connection add ifname {{interface_name}} type {{ethernet}} ipv4.method {{auto}} ipv6.method {{auto}}`

--- a/pages/linux/nmcli-device.md
+++ b/pages/linux/nmcli-device.md
@@ -1,0 +1,15 @@
+# nmcli device
+
+> Hardware device management with NetworkManager.
+
+- Print statuses of network interfaces:
+
+`nmcli device status`
+
+- Print the available Wi-Fi access points:
+
+`nmcli device wifi`
+
+- Connect to the Wi-Fi network with a specified name and password:
+
+`nmcli device wifi connect {{name}} password {{password}}`

--- a/pages/linux/nmcli-device.md
+++ b/pages/linux/nmcli-device.md
@@ -2,7 +2,7 @@
 
 > Hardware device management with NetworkManager.
 
-- Print statuses of network interfaces:
+- Print the statuses of all network interfaces:
 
 `nmcli device status`
 
@@ -12,4 +12,4 @@
 
 - Connect to the Wi-Fi network with a specified name and password:
 
-`nmcli device wifi connect {{name}} password {{password}}`
+`nmcli device wifi connect {{ssid}} password {{password}}`

--- a/pages/linux/nmcli.md
+++ b/pages/linux/nmcli.md
@@ -2,26 +2,18 @@
 
 > A command line tool for controlling NetworkManager.
 
-- List all NetworkManager connections (shows name, uuid, type and device):
+- Check the nmcli version:
 
-`nmcli connection`
+`nmcli --version`
 
-- Print the available Wi-Fi access points:
+- Call general help:
 
-`nmcli device wifi`
+`nmcli --help`
 
-- Connect to the Wi-Fi network with a specified name and password:
+- Call help on a command:
 
-`nmcli device wifi connect {{name}} password {{password}}`
+`nmcli {{command}} --help`
 
-- Activate a connection by specifying an uuid:
+- Execute nmcli command:
 
-`nmcli connection up uuid {{uuid}}`
-
-- Deactivate a connection:
-
-`nmcli connection down uuid {{uuid}}`
-
-- Print statuses of network interfaces:
-
-`nmcli device status`
+`nmcli {{command}}`

--- a/pages/linux/nmcli.md
+++ b/pages/linux/nmcli.md
@@ -14,6 +14,6 @@
 
 `nmcli {{command}} --help`
 
-- Execute nmcli command:
+- Execute an `nmcli` command:
 
 `nmcli {{command}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

I know this expands the page up to maximum of 8 examples, but the
problem here is that NetworkManager is used both on clients (laptops,
PCs) mainly for WiFi connection management but also on servers to manage
ethernet, bond or VLAN connections.

It's one of the quite complex commands with lots of options, I
handpicked three new examples I struggle quite a lot: static IP
configurations for both IPv4 and IPv6. These options are inconsistent
(ip4 vs ipv4) and I always need to dig in the man page.

To hit the 8 examples limit, I propose to delete the last exapmle which
is IMHO rarely used (`ip` is preferred) and it renders the very similar
output as the very first example (the only difference is that it lists
unmanaged devices).

Cheers!