### PR TITLE
mysqldump: harmonize the examples

### DIFF
--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -3,18 +3,18 @@
 > Backups MySQL databases.
 > More information: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
 
-- Create a backup, user will be prompted for a password:
+- Create a backup (user will be prompted for a password):
 
-`mysqldump -u {{user}} -p {{database_name}} -r {{filename.sql}}`
+`mysqldump --user {{user}} --password {{database_name}} -r {{filename.sql}}`
 
-- Restore a backup, user will be prompted for a password:
+- Restore a backup (user will be prompted for a password):
 
-`mysql -u {{user}} -p {{database_name}} < {{filename.sql}}`
+`mysqldump --user {{user}} --password {{database_name}} < {{path/to/file.sql}}`
 
 - Backup all databases redirecting the output to a file (user will be prompted for a password):
 
-`mysqldump -u {{user}} -p --all-databases > {{filename.sql}}`
+`mysqldump --user {{user}} --password --all-databases > {{filename.sql}}`
 
 - Restore all databases from a backup (user will be prompted for a password):
 
-`mysql -u {{user}} -p < {{filename.sql}}`
+`mysqldump --user {{user}} --password < {{filename.sql}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -5,7 +5,7 @@
 
 - Create a backup (user will be prompted for a password):
 
-`mysqldump --user {{user}} --password {{database_name}} -r {{filename.sql}}`
+`mysqldump --user {{user}} --password {{database_name}} -r {{path/to/file.sql}}`
 
 - Restore a backup (user will be prompted for a password):
 
@@ -13,8 +13,8 @@
 
 - Backup all databases redirecting the output to a file (user will be prompted for a password):
 
-`mysqldump --user {{user}} --password --all-databases > {{filename.sql}}`
+`mysqldump --user {{user}} --password --all-databases > {{path/to/file.sql}}`
 
 - Restore all databases from a backup (user will be prompted for a password):
 
-`mysqldump --user {{user}} --password < {{filename.sql}}`
+`mysqldump --user {{user}} --password < {{path/to/file.sql}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -5,11 +5,11 @@
 
 - Create a backup, user will be prompted for a password:
 
-`mysqldump -u {{user}} --password {{database_name}} -r {{filename.sql}}`
+`mysqldump -u {{user}} -p {{database_name}} -r {{filename.sql}}`
 
 - Restore a backup, user will be prompted for a password:
 
-`mysql -u {{user}} --password -e "source {{filename.sql}}" {{database_name}}`
+`mysql -u {{user}} -p {{database_name}} < {{filename.sql}}`
 
 - Backup all databases redirecting the output to a file (user will be prompted for a password):
 


### PR DESCRIPTION
- always use `-p` for password
- use short hand syntax for restoring a database (like the one used for restoring all databases)