### PR TITLE
tree: ignore specific directories

### DIFF
--- a/pages/linux/tree.md
+++ b/pages/linux/tree.md
@@ -2,15 +2,15 @@
 
 > Show the contents of the current directory as a tree.
 
-- Show files and directories up to 'num' levels of depth (where 1 means the current directory):
+- Print files and directories up to 'num' levels of depth (where 1 means the current directory):
 
 `tree -L {{num}}`
 
-- Show directories only:
+- Print directories only:
 
 `tree -d`
 
-- Show hidden files too:
+- Print hidden files too:
 
 `tree -a`
 

--- a/pages/linux/tree.md
+++ b/pages/linux/tree.md
@@ -29,3 +29,7 @@
 - Ignore entries that match a wildcard (glob) pattern:
 
 `tree -I {{*.txt}}`
+
+- Print the tree with ignoring of specific directories:
+
+`tree -I 'vendor|.git|node_modules'`

--- a/pages/linux/tree.md
+++ b/pages/linux/tree.md
@@ -32,4 +32,4 @@
 
 - Print the tree ignoring the given directories:
 
-`tree -I 'vendor|.git|node_modules'`
+`tree -I '{{directory_name1|directory_name2}}'`

--- a/pages/linux/tree.md
+++ b/pages/linux/tree.md
@@ -30,6 +30,6 @@
 
 `tree -I {{*.txt}}`
 
-- Print the tree with ignoring of specific directories:
+- Print the tree ignoring the given directories:
 
 `tree -I 'vendor|.git|node_modules'`

--- a/pages/osx/tree.md
+++ b/pages/osx/tree.md
@@ -30,6 +30,6 @@
 
 `tree -P {{directory_name}} --matchdirs --prune`
 
-- Print the tree with ignoring of specific directories:
+- Print the tree ignoring the given directories:
 
 `tree -I 'vendor|.git|node_modules'`

--- a/pages/osx/tree.md
+++ b/pages/osx/tree.md
@@ -29,3 +29,7 @@
 - Find directories within the tree hierarchy, pruning out directories that aren't ancestors of the wanted one:
 
 `tree -P {{directory_name}} --matchdirs --prune`
+
+- Print the tree with ignoring of specific directories:
+
+`tree -I 'vendor|.git|node_modules'`

--- a/pages/osx/tree.md
+++ b/pages/osx/tree.md
@@ -2,15 +2,15 @@
 
 > Show the contents of the current directory as a tree.
 
-- Show files and directories up to 'num' levels of depth (where 1 means the current directory):
+- Print files and directories up to 'num' levels of depth (where 1 means the current directory):
 
 `tree -L {{num}}`
 
-- Show directories only:
+- Print directories only:
 
 `tree -d`
 
-- Show hidden files too:
+- Print hidden files too:
 
 `tree -a`
 
@@ -22,11 +22,11 @@
 
 `tree -s -h --du`
 
-- Find files within the tree hierarchy, using a wildcard (glob) pattern, and pruning out directories that don't contain matching files:
+- Print files within the tree hierarchy, using a wildcard (glob) pattern, and pruning out directories that don't contain matching files:
 
 `tree -P '{{*.txt}}' --prune`
 
-- Find directories within the tree hierarchy, pruning out directories that aren't ancestors of the wanted one:
+- Print directories within the tree hierarchy, using the wildcard (glob) pattern, and pruning out directories that aren't ancestors of the wanted one:
 
 `tree -P {{directory_name}} --matchdirs --prune`
 

--- a/pages/osx/tree.md
+++ b/pages/osx/tree.md
@@ -32,4 +32,4 @@
 
 - Print the tree ignoring the given directories:
 
-`tree -I 'vendor|.git|node_modules'`
+`tree -I '{{directory_name1|directory_name2}}'`


### PR DESCRIPTION
Ignoring of the specific directories is very important when you're going to print the tree of the repositories these days. 
I expected this information in `tldr` but didn't find it, so decided to add it. 

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
