### PR TITLE
losetup: change order

### DIFF
--- a/pages/linux/losetup.md
+++ b/pages/linux/losetup.md
@@ -10,14 +10,6 @@
 
 `sudo losetup /dev/{{loop}} /{{path/to/file}}`
 
-- Detach all loop devices:
-
-`sudo losetup -D`
-
-- Detach a given loop device:
-
-`sudo losetup -d /dev/{{loop}}`
-
 - Attach a file to a new free loop device and scan the device for partitions:
 
 `sudo losetup --show --partscan -f /{{path/to/file}}`
@@ -25,3 +17,11 @@
 - Attach a file to a read-only loop device:
 
 `sudo losetup --read-only /dev/{{loop}} /{{path/to/file}}`
+
+- Detach all loop devices:
+
+`sudo losetup -D`
+
+- Detach a given loop device:
+
+`sudo losetup -d /dev/{{loop}}`


### PR DESCRIPTION
Changed order of examples.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
