### PR TITLE
multiple pages: change user_name to username

### DIFF
--- a/pages.pt_BR/linux/top.md
+++ b/pages.pt_BR/linux/top.md
@@ -12,7 +12,7 @@
 
 - Exibir os processos de um usuário específico:
 
-`top -u {{user_name}}`
+`top -u {{username}}`
 
 - Exibir o(s) processo(s) de um ou mais PID específico(s), separado(s) por vírgula:
 

--- a/pages/common/gist.md
+++ b/pages/common/gist.md
@@ -25,7 +25,7 @@
 
 - List all gists for the currently logged in user:
 
-`gist -l {{user_name}}`
+`gist -l {{username}}`
 
 - Use the id from the gist URL to modify or include a file:
 

--- a/pages/common/htpasswd.md
+++ b/pages/common/htpasswd.md
@@ -5,24 +5,24 @@
 
 - Create/overwrite htpasswd file:
 
-`htpasswd -c {{path/to/file}} {{user_name}}`
+`htpasswd -c {{path/to/file}} {{username}}`
 
 - Add user to htpasswd file or update existing user:
 
-`htpasswd {{path/to/file}} {{user_name}}`
+`htpasswd {{path/to/file}} {{username}}`
 
 - Add user to htpasswd file in batch mode without an interactive password prompt (for script usage):
 
-`htpasswd -b {{path/to/file}} {{user_name}} {{password}}`
+`htpasswd -b {{path/to/file}} {{username}} {{password}}`
 
 - Delete user from htpasswd file:
 
-`htpasswd -D {{path/to/file}} {{user_name}}`
+`htpasswd -D {{path/to/file}} {{username}}`
 
 - Verify user password:
 
-`htpasswd -v {{path/to/file}} {{user_name}}`
+`htpasswd -v {{path/to/file}} {{username}}`
 
 - Display a string with username (plain text) and password (md5):
 
-`htpasswd -nbm {{user_name}} {{password}}`
+`htpasswd -nbm {{username}} {{password}}`

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -16,7 +16,7 @@
 
 - View all logins by a specific user and show the ip address instead of the hostname:
 
-`last {{user_name}} -i`
+`last {{username}} -i`
 
 - View all recorded reboots (i.e., the last logins of the pseudo user "reboot"):
 

--- a/pages/common/odps-auth.md
+++ b/pages/common/odps-auth.md
@@ -4,15 +4,15 @@
 
 - Add a user to the current project:
 
-`add user {{user_name}};`
+`add user {{username}};`
 
 - Grant a set of authorities to a user:
 
-`grant {{action_list}} on {{object_type}} {{object_name}} to user {{user_name}};`
+`grant {{action_list}} on {{object_type}} {{object_name}} to user {{username}};`
 
 - Show authorities of a user:
 
-`show grants for {{user_name}};`
+`show grants for {{username}};`
 
 - Create a user role:
 
@@ -28,4 +28,4 @@
 
 - Grant a role to a user:
 
-`grant {{role_name}} to {{user_name}};`
+`grant {{role_name}} to {{username}};`

--- a/pages/common/sendmail.md
+++ b/pages/common/sendmail.md
@@ -2,9 +2,9 @@
 
 > Send email from the command line.
 
-- Send a message with the content of message.txt to the mail directory of local user `user_name`:
+- Send a message with the content of message.txt to the mail directory of local user `username`:
 
-`sendmail {{user_name}} < {{message.txt}}`
+`sendmail {{username}} < {{message.txt}}`
 
 - Send an email from you@yourdomain.com (assuming the mail server is configured for this) to test@gmail.com containing the message in `message.txt`:
 

--- a/pages/linux/chage.md
+++ b/pages/linux/chage.md
@@ -4,15 +4,15 @@
 
 - List password information for the user:
 
-`chage -l {{user_name}}`
+`chage -l {{username}}`
 
 - Enable password expiration in 10 days:
 
-`sudo chage -M {{10}} {{user_name}}`
+`sudo chage -M {{10}} {{username}}`
 
 - Disable password expiration:
 
-`sudo chage -M -1 {{user_name}}`
+`sudo chage -M -1 {{username}}`
 
 - Set account expiration date:
 

--- a/pages/linux/htop.md
+++ b/pages/linux/htop.md
@@ -8,7 +8,7 @@
 
 - Start htop displaying only processes owned by given user:
 
-`htop -u {{user_name}}`
+`htop -u {{username}}`
 
 - Get help about interactive commands:
 

--- a/pages/linux/smbpasswd.md
+++ b/pages/linux/smbpasswd.md
@@ -9,12 +9,12 @@
 
 - Add a specified user to Samba and set password(user should already exist in system):
 
-`smbpasswd -a {{user_name}}`
+`smbpasswd -a {{username}}`
 
 - Modify an existing Samba user's password:
 
-`smbpasswd {{user_name}}`
+`smbpasswd {{username}}`
 
 - Delete a Samba user:
 
-`smbpasswd -x {{user_name}}`
+`smbpasswd -x {{username}}`

--- a/pages/linux/top.md
+++ b/pages/linux/top.md
@@ -12,7 +12,7 @@
 
 - Show only processes owned by given user:
 
-`top -u {{user_name}}`
+`top -u {{username}}`
 
 - Show the individual threads of a given process:
 


### PR DESCRIPTION
This PR changes the token `user_name` to `username` in multiple files. 

**Why?**
To me `user_name` is just weird to read.
Also: Most pages use the token `username` so just to have it concise between pages. 