### PR TITLE
zramctl: improve module loading examples

### DIFF
--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -7,7 +7,11 @@
 
 `lsmod | grep -i zram`
 
-- Enable zram with 2 devices (use `zramctl` to configure the devices further):
+- Enable zram with a dynamic number of devices (use `zramctl` to configure devices further)
+
+`sudo modprobe zram`
+
+- Enable zram with exactly 2 devices:
 
 `sudo modprobe zram num_devices={{2}}`
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -7,7 +7,7 @@
 
 `lsmod | grep -i zram`
 
-- Enable zram with a dynamic number of devices (use `zramctl` to configure devices further)
+- Enable zram with a dynamic number of devices (use `zramctl` to configure devices further):
 
 `sudo modprobe zram`
 

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -1,7 +1,7 @@
 # zramctl
 
 > Setup and control zram devices.
-> Use `mke2fs` or `mkswap` to format zram devices to partitions.
+> Use `mkfs` or `mkswap` to format zram devices to partitions.
 
 - Check if zram is enabled:
 


### PR DESCRIPTION
I wrote this page a long time ago, and I discovered that you can have a dynamic number of devices when configuring _zram_ if you `modprobe` it differently. This PR updates the `modprobe` examples to show this.

Note that the zram kernel module is _not_ loaded by default - and as such you _need_ to `modprobe` it first.