### PR TITLE
vault: add command

### DIFF
--- a/pages/common/vault.md
+++ b/pages/common/vault.md
@@ -23,6 +23,10 @@
 
 `vault read secret/{{hello}}`
 
+- Read a specific field from the value:
+
+`vault read -field={{field_name}} secret/{{hello}}`
+
 - Seal (lock) the Vault server, by removing the encryption key of the data store from memory:
 
 `vault seal`


### PR DESCRIPTION
Really important one that was missing. I thought it was better to use `field_name` instead of already used in previous commands `value`.