### PR TITLE
snap: add update package

### DIFF
--- a/pages/linux/snap.md
+++ b/pages/linux/snap.md
@@ -11,6 +11,10 @@
 
 `snap install {{package_name}}`
 
+- Update a package:
+
+`snap refresh {{package_name}}`
+
 - Update all packages:
 
 `snap refresh`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

I am surprised this isn't in here yet as it is one of the most important commands for a package manager. This is very different from updating all packages with `snap refresh`. You may be able to guess the syntax for updating one package if you know apt but the tldr pages are not about guessing. 