### PR TITLE
postfix: add page

### DIFF
--- a/pages/linux/postfix.md
+++ b/pages/linux/postfix.md
@@ -1,0 +1,28 @@
+# postfix
+
+> Postfix mail transfer agent (MTA) control program.
+> More information: <http://postfix.org>
+
+- Check the configuration:
+
+`sudo postfix check`
+
+- Check the status of the Postfix daemon:
+
+`sudo postfix status`
+
+- Start Postfix:
+
+`sudo postfix start`
+
+- Gracefully stop Postfix:
+
+`sudo postfix stop`
+
+- Flush the mail queue:
+
+`sudo postfix flush`
+
+- Reload the configuration files:
+
+`sudo postfix reload`

--- a/pages/linux/postfix.md
+++ b/pages/linux/postfix.md
@@ -1,7 +1,8 @@
 # postfix
 
 > Postfix mail transfer agent (MTA) control program.
-> More information: <http://postfix.org>
+> See also `dovecot`, a mail delivery agent (MDA) that integrates with Postfix.
+> More information: <http://postfix.org>.
 
 - Check the configuration:
 


### PR DESCRIPTION
Postfix is an awesome and extremely lightweight MTA - just supremely complicated to configure :P

Note that there are a _ton_ of random extra commands that are post of the Postfix system:

```
SEE ALSO
       Commands:
       postalias(1), create/update/query alias database
       postcat(1), examine Postfix queue file
       postconf(1), Postfix configuration utility
       postfix(1), Postfix control program
       postfix-tls(1), Postfix TLS management
       postkick(1), trigger Postfix daemon
       postlock(1), Postfix-compatible locking
       postlog(1), Postfix-compatible logging
       postmap(1), Postfix lookup table manager
       postmulti(1), Postfix multi-instance manager
       postqueue(1), Postfix mail queue control
       postsuper(1), Postfix housekeeping
       mailq(1), Sendmail compatibility interface
       newaliases(1), Sendmail compatibility interface
       sendmail(1), Sendmail compatibility interface

       Postfix configuration:
       bounce(5), Postfix bounce message templates
       master(5), Postfix master.cf file syntax
       postconf(5), Postfix main.cf file syntax
       postfix-wrapper(5), Postfix multi-instance API
anvil(8), Postfix connection/rate limiting
       bounce(8), defer(8), trace(8), Delivery status reports
       cleanup(8), canonicalize and enqueue message
       discard(8), Postfix discard delivery agent
       dnsblog(8), DNS black/whitelist logger
       error(8), Postfix error delivery agent
       flush(8), Postfix fast ETRN service
       local(8), Postfix local delivery agent
       master(8), Postfix master daemon
       oqmgr(8), old Postfix queue manager
       pickup(8), Postfix local mail pickup
       pipe(8), deliver mail to non-Postfix command
       postlogd(8), Postfix internal logging service
       postscreen(8), Postfix zombie blocker
       proxymap(8), Postfix lookup table proxy server
       qmgr(8), Postfix queue manager
       qmqpd(8), Postfix QMQP server
       scache(8), Postfix connection cache manager
       showq(8), list Postfix mail queue
       smtp(8), lmtp(8), Postfix SMTP+LMTP client
       smtpd(8), Postfix SMTP server
       spawn(8), run non-Postfix server
       tlsmgr(8), Postfix TLS cache and randomness manager
       tlsproxy(8), Postfix TLS proxy server
       trivial-rewrite(8), Postfix address rewriting
       verify(8), Postfix address verification
       virtual(8), Postfix virtual delivery agent
```

_(Taken from the `postfix` man page)_

....Covering all of these will be quite a challenge - which I'm not going to tackle at the moment - so someone else is welcome to step up to the challenge :P

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
