### PR TITLE
godot: update the `--export` example

### DIFF
--- a/pages/common/godot.md
+++ b/pages/common/godot.md
@@ -15,10 +15,10 @@
 
 `godot -p`
 
-- Export a project for a given target (the target must be defined in the project):
+- Export a project for a given export preset (the preset must be defined in the project):
 
-`godot --export {{target}}`
+`godot --export {{preset}} {{output_path}}`
 
-- Execute a standalone GDScript file:
+- Execute a standalone GDScript file (the script must inherit from `SceneTree` or `MainLoop`):
 
 `godot -s {{script.gd}}`


### PR DESCRIPTION
This also adds more information about the `-s` switch's requirements.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).