### PR TITLE
trash: add trash-rm examples

### DIFF
--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -27,6 +27,6 @@
 
 `trash-rm foo`
 
-- Remove all files with exactly '/full/path' as original location:
+- Remove all files with '/full/path' as original location:
 
 `trash-rm /full/path`

--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -23,7 +23,7 @@
 
 `trash-empty {{10}}`
 
-- Remove all files named 'foo' from trash:
+- Remove all files named 'foo' from the trash:
 
 `trash-rm foo`
 

--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -22,3 +22,11 @@
 - Empty trash, keeping files trashed less than {{10}} days ago:
 
 `trash-empty {{10}}`
+
+- Remove all files matching name 'foo' from trash:
+
+`trash-rm foo`
+
+- Remove all files with exactly '/full/path' as original location:
+
+`trash-rm /full/path`

--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -27,6 +27,6 @@
 
 `trash-rm foo`
 
-- Remove all files with '/full/path' as original location:
+- Remove all files with a given original location:
 
 `trash-rm /full/path`

--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -23,7 +23,7 @@
 
 `trash-empty {{10}}`
 
-- Remove all files matching name 'foo' from trash:
+- Remove all files named 'foo' from trash:
 
 `trash-rm foo`
 


### PR DESCRIPTION

- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

#3909 

Does not include the more complex and powerful pattern-matching command ex. `trash-rm '*.o'` for simplicity. Let me know if this should be included. We have room for one more example. 