### PR TITLE
mysqldump: move backup restore examples to the right page

### DIFF
--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -22,3 +22,11 @@
 - Execute SQL statements in a script file (batch file):
 
 `mysql -e "source {{filename.sql}}" {{database_name}}`
+
+- Restore a database from a backup (user will be prompted for a password):
+
+`mysql --user {{user}} --password {{database_name}} < {{path/to/backup.sql}}`
+
+- Restore all databases from a backup (user will be prompted for a password):
+
+`mysql --user {{user}} --password < {{path/to/backup.sql}}`

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -1,6 +1,7 @@
 # mysqldump
 
 > Backups MySQL databases.
+> See also `mysql` for restoring databases.
 > More information: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
 
 - Create a backup (user will be prompted for a password):

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -7,14 +7,6 @@
 
 `mysqldump --user {{user}} --password {{database_name}} -r {{path/to/file.sql}}`
 
-- Restore a backup (user will be prompted for a password):
-
-`mysqldump --user {{user}} --password {{database_name}} < {{path/to/file.sql}}`
-
 - Backup all databases redirecting the output to a file (user will be prompted for a password):
 
 `mysqldump --user {{user}} --password --all-databases > {{path/to/file.sql}}`
-
-- Restore all databases from a backup (user will be prompted for a password):
-
-`mysqldump --user {{user}} --password < {{path/to/file.sql}}`


### PR DESCRIPTION
Addressing [this comment thread](https://github.com/tldr-pages/tldr/pull/3835#pullrequestreview-371083122) in #3835.

This moves backup restore examples from `mysqldump` to `mysql` and also adds a reference to the latter in the description of the former.