### PR TITLE
qpdf: fix merge documentation

### DIFF
--- a/pages/common/qpdf.md
+++ b/pages/common/qpdf.md
@@ -13,7 +13,7 @@
 
 - Merge (concatenate) given pages from a list of PDF files and save the result as a new PDF:
 
-`qpdf --empty --pages {{file1.pdf}} {{1,6-8}} --pages {{file2.pdf}} {{3,4,5}} -- {{output.pdf}}`
+`qpdf --empty --pages {{file1.pdf}} {{1,6-8}} {{file2.pdf}} {{3,4,5}} -- {{output.pdf}}`
 
 - Write each group of n pages to a separate output file with a given filename pattern:
 


### PR DESCRIPTION
## Checklist
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

## Rationale
Running this command locally with actual files results in this error: `open --pages: No such file or directory`. [QPDF's manual seems to support my change](http://qpdf.sourceforge.net/files/qpdf-manual.html#ref.page-selection) as their documented example looks like this:

```sh
qpdf --collate --empty --pages a.pdf 1-5 b.pdf 6-4 c.pdf r1 -- out.pdf
```

![](https://media.giphy.com/media/LPCb701JDUjbXunSVb/giphy.gif)