### PR TITLE
ip address: add page

### DIFF
--- a/pages/linux/ip-address.md
+++ b/pages/linux/ip-address.md
@@ -1,0 +1,27 @@
+# ip address
+
+> IP Address management subcommand.
+
+- List network interfaces and their associated IP addresses:
+
+`ip address`
+
+- Filter to show only active network interfaces:
+
+`ip address show up`
+
+- Display information about a specific network interface:
+
+`ip address show dev {{network_interface}}`
+
+- Add an IP address to a network interface:
+
+`ip address add {{ip_address}} dev {{network_interface}}`
+
+- Remove an IP address from a network interface:
+
+`ip address delete {{ip_address}} dev {{network_interface}}`
+
+- Delete all IP addresses in a given scope from a network interface:
+
+`ip address flush dev {{network_interface}} scope {{global|host|link}}`


### PR DESCRIPTION
We've needed subpages for the `ip` command for ages in my opinion, so with the current IRL situation affecting the world I thought I'd use this as a welcome distraction.

As it happens the man page has some quite helpful examples at the bottom - this page is a curation and adjustment thereof.

By doing `man ip` you can see a list of all the subcommands if you're interested.

Edit: it's probably worth knowing that `ip address` is actually really powerful - it's just not possible to demonstrate all the crazy stuff it lets you do in a single tldr page :P