### PR TITLE
ssh-keyscan: add known_hosts example

### DIFF
--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -16,4 +16,4 @@
 
 - Manually update the ssh known_hosts file with the fingerprint of a given host:
 
-`ssh-keyscan -H {{host}} >> ~/.ssh/known_hosts
+`ssh-keyscan -H {{host}} >> ~/.ssh/known_hosts`

--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -13,3 +13,7 @@
 - Retrieve certain types of public ssh keys of a remote host:
 
 `ssh-keyscan -t {{rsa,dsa,ecdsa,ed25519}} {{host}}`
+
+- Manually update the ssh known_hosts file with the fingerprint of a given host:
+
+`ssh-keyscan -H {{host}} >> ~/.ssh/known_hosts

--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -2,18 +2,18 @@
 
 > Get the public ssh keys of remote hosts.
 
-- Retrieve all public ssh keys of a remote host:
+- Retrieve all public SSH keys of a remote host:
 
 `ssh-keyscan {{host}}`
 
-- Retrieve all public ssh keys of a remote host listening on a specific port:
+- Retrieve all public SSH keys of a remote host listening on a specific port:
 
 `ssh-keyscan -p {{port}} {{host}}`
 
-- Retrieve certain types of public ssh keys of a remote host:
+- Retrieve certain types of public SSH keys of a remote host:
 
 `ssh-keyscan -t {{rsa,dsa,ecdsa,ed25519}} {{host}}`
 
-- Manually update the ssh known_hosts file with the fingerprint of a given host:
+- Manually update the SSH known_hosts file with the fingerprint of a given host:
 
 `ssh-keyscan -H {{host}} >> ~/.ssh/known_hosts`

--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -2,18 +2,18 @@
 
 > Get the public ssh keys of remote hosts.
 
-- Retrieve all public SSH keys of a remote host:
+- Retrieve all public ssh keys of a remote host:
 
 `ssh-keyscan {{host}}`
 
-- Retrieve all public SSH keys of a remote host listening on a specific port:
+- Retrieve all public ssh keys of a remote host listening on a specific port:
 
 `ssh-keyscan -p {{port}} {{host}}`
 
-- Retrieve certain types of public SSH keys of a remote host:
+- Retrieve certain types of public ssh keys of a remote host:
 
 `ssh-keyscan -t {{rsa,dsa,ecdsa,ed25519}} {{host}}`
 
-- Manually update the SSH known_hosts file with the fingerprint of a given host:
+- Manually update the ssh known_hosts file with the fingerprint of a given host:
 
 `ssh-keyscan -H {{host}} >> ~/.ssh/known_hosts`


### PR DESCRIPTION
Just discovered this whilst configuring my cluster.

Ref https://www.techrepublic.com/article/how-to-easily-add-an-ssh-fingerprint-to-your-knownhosts-file-in-linux/