### PR TITLE
find: always enclose the pattern in quotes

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -12,7 +12,7 @@
 
 - Find directories matching a given name, in case-insensitive mode:
 
-`find {{root_path}} -type d -iname {{*lib*}}`
+`find {{root_path}} -type d -iname '{{*lib*}}'`
 
 - Find files matching a path pattern:
 


### PR DESCRIPTION
As mentioned in man page, should always enclose the pattern in quotes in order to protect it from expansion by the shell.

