### PR TITLE
youtube-dl: add subtitle options

### DIFF
--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -34,3 +34,11 @@
 - From a playlist, download all "Let's Play" videos that aren't marked "NSFW" or age-restricted for 7 year-olds:
 
 `youtube-dl --match-title {{"let's play"}} --age-limit {{7}} --reject-title {{"nsfw"}} {{playlist_url}}`
+
+- List available subtitles
+
+`youtube-dl --list-subs {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
+
+- Download a particular language's subtitles
+
+`youtube-dl --sub-lang {{en}} {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -27,10 +27,10 @@
 
 `youtube-dl --format {{mp4}} -o {{"%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s"}} {{url}}`
 
-- List available subtitles
+- List available subtitles:
 
 `youtube-dl --list-subs {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
 
-- Download a particular language's subtitles
+- Download a particular language's subtitles:
 
 `youtube-dl --sub-lang {{en}} {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -31,6 +31,6 @@
 
 `youtube-dl --list-subs {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
 
-- Download a particular language's subtitles:
+- Download a particular language's subtitles along with the video:
 
-`youtube-dl --sub-lang {{en}} {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
+`youtube-dl --sub-lang {{en}} --write-sub {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -27,14 +27,6 @@
 
 `youtube-dl --format {{mp4}} -o {{"%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s"}} {{url}}`
 
-- Download a video and save its description, metadata, annotations, subtitles, and thumbnail:
-
-`youtube-dl --write-description --write-info-json --write-annotations --write-sub --write-thumbnail {{url}}`
-
-- From a playlist, download all "Let's Play" videos that aren't marked "NSFW" or age-restricted for 7 year-olds:
-
-`youtube-dl --match-title {{"let's play"}} --age-limit {{7}} --reject-title {{"nsfw"}} {{playlist_url}}`
-
 - List available subtitles
 
 `youtube-dl --list-subs {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`


### PR DESCRIPTION
This adds examples for getting the list of available subtitle languages and downloading subtitles in a chosen language.

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

The page already had the maximum eight examples, so I removed two that I thought were far less important. The addition and removal are in separate commits in case you think that it would be better to break the no more than 8 rule.