### PR TITLE
Update the LICENSE information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 [cla-assistant-url]: https://cla-assistant.io/tldr-pages/tldr
 [cla-assistant-image]: https://cla-assistant.io/readme/badge/tldr-pages/tldr
 [license-url]: https://github.com/tldr-pages/tldr/blob/master/LICENSE.md
-[license-image]: https://img.shields.io/github/license/tldr-pages/tldr.svg
+[license-image]: https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey.svg
 
 Contributions to the tldr-pages project are [most welcome](GOVERNANCE.md)!
 All `tldr` pages are stored in Markdown right here on GitHub.
@@ -116,7 +116,7 @@ Examples:
 
 ## Licensing
 
-`tldr` is licensed under the [MIT license](https://github.com/tldr-pages/tldr/blob/master/LICENSE.md).
+`tldr` is licensed under a [Creative Commons Attribution 4.0 International License](LICENSE.md). The contents of the `scripts/` directory are licensed under the [MIT license](LICENSE.md).
 
 Any contributions to this project are governed by the
 [Contributor License Agreement](https://cla-assistant.io/tldr-pages/tldr).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
 [contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
 [license-url]: https://github.com/tldr-pages/tldr/blob/master/LICENSE.md
-[license-image]: https://img.shields.io/github/license/tldr-pages/tldr.svg
+[license-image]: https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey.svg
 
 A collection of simplified and community-driven man pages.
 


### PR DESCRIPTION
This PR does two things:

1. Updates the outdated licensing section in `CONTRIBUTING.md` to include both CC and MIT
2. Changes license badges to show CC-BY-4.0 instead of `license not identifiable`