### PR TITLE
GetFileInfo: add page

### DIFF
--- a/pages/osx/GetFileInfo.md
+++ b/pages/osx/GetFileInfo.md
@@ -1,0 +1,19 @@
+# GetFileInfo
+
+> Get information about a file in an HFS+ directory.
+
+- See date and time of file creation:
+
+`GetFileInfo -d {{filename}}`
+
+- See date and time of latest file modification:
+
+`GetFileInfo -m {{filename}}`
+
+- See the creator of the file:
+
+`GetFileInfo -c {{filename}}`
+
+- See all infomation about the file:
+
+`GetFileInfo {{filename}}`

--- a/pages/osx/GetFileInfo.md
+++ b/pages/osx/GetFileInfo.md
@@ -2,18 +2,18 @@
 
 > Get information about a file in an HFS+ directory.
 
-- See date and time of file creation:
+- Display infomation about a given file:
 
-`GetFileInfo -d {{filename}}`
+`GetFileInfo {{path/to/filename}}`
 
-- See date and time of latest file modification:
+- Display the date and time a given file was created:
 
-`GetFileInfo -m {{filename}}`
+`GetFileInfo -d {{path/to/filename}}`
 
-- See the creator of the file:
+- Display the date and time a given file was last modified:
 
-`GetFileInfo -c {{filename}}`
+`GetFileInfo -m {{path/to/filename}}`
 
-- See all infomation about the file:
+- Display the creator of a given file:
 
-`GetFileInfo {{filename}}`
+`GetFileInfo -c {{path/to/filename}}`


### PR DESCRIPTION
Closes #3993.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
