### PR TITLE
nomad: add page

### DIFF
--- a/pages/common/nomad.md
+++ b/pages/common/nomad.md
@@ -1,0 +1,36 @@
+# nomad
+
+> Distributed, highly available, datacenter-aware scheduler
+> More information: <https://www.nomadproject.io/docs/commands/>.
+
+- Show the status of nodes in the cluster:
+
+`nomad node status`
+
+- Validate a job file:
+
+`nomad job validate {{path/to/file.nomad}}`
+
+- Plan a job for execution on the cluster:
+
+`nomad job plan {{path/to/file.nomad}}`
+
+- Run a job on the cluster:
+
+`nomad job run {{path/to/file.nomad}}`
+
+- Show the status of jobs currently running on the cluster:
+
+`nomad job status`
+
+- Show the detailed status information about a specific job:
+
+`nomad job status {{job_name}}`
+
+- Follow the logs of a specific allocation:
+
+`nomad alloc logs {{alloc_id}}`
+
+- Show the status of storage volumes:
+
+`nomad volume status`

--- a/pages/common/nomad.md
+++ b/pages/common/nomad.md
@@ -1,6 +1,6 @@
 # nomad
 
-> Distributed, highly available, datacenter-aware scheduler
+> Distributed, highly available, datacenter-aware scheduler.
 > More information: <https://www.nomadproject.io/docs/commands/>.
 
 - Show the status of nodes in the cluster:


### PR DESCRIPTION
I'm putting together a Raspberry Pi cluster with the Hashicorp stack and a page for Nomad would be very useful :P

Note that while the `agent` subcommand is commonly used, in a 'proper' setup you would generally have Nomad running as a system service, and so you would generally not use it day-to-day. Furthermore, the only time you'd use it is when you're learning it - and the official getting started guide contains plenty of guidance in that department.