### PR TITLE
git-subtree: add page

### DIFF
--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -11,14 +11,14 @@
 
 `git subtree pull --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
 
-- Merge subtree repository:
+- Merge a subtree repository into master:
 
 `git subtree merge --prefix={{path/to/directory/}} --squash {{repository_url}} {{master}}`
 
-- Push commits to subtree repository:
+- Push commits to a subtree repository:
 
 `git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
 
-- Extract a new porject history from the history of subtree:
+- Extract a new project history from the history of subtree:
 
 `git subtree split --prefix={{path/to/directory/}} {{repository_url}} -b {{branch_name}}`

--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -1,6 +1,6 @@
 # git subtree
 
-> Tool to manage project dependencies as subprojects
+> Tool to manage project dependencies as subprojects.
 > More information: <https://manpages.debian.org/testing/git-man/git-subtree.1.en.html>.
 
 - Add a git repository as a subtree:

--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -1,6 +1,6 @@
 # git subtree
 
-> Merge subtrees together and split repository into subtrees.
+> Tool to manage project dependencies as subprojects
 > More information: <https://manpages.debian.org/testing/git-man/git-subtree.1.en.html>.
 
 - Add a git repository as a subtree:
@@ -19,6 +19,6 @@
 
 `git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
 
-- Extract a new project history from the history of subtree:
+- Extract a new project history from the history of a subtree:
 
 `git subtree split --prefix={{path/to/directory/}} {{repository_url}} -b {{branch_name}}`

--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -1,0 +1,24 @@
+# git subtree
+
+> Merge subtrees together and split repository into subtrees.
+> More information: <https://manpages.debian.org/testing/git-man/git-subtree.1.en.html>.
+
+- Add a git repository as a subtree:
+
+`git subtree add --prefix={{path/to/directory/}} --squash {{repository_url}} {{master}}`
+
+- Update subtree repository to its latest commit:
+
+`git subtree pull --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
+
+- Merge subtree repository:
+
+`git subtree merge --prefix={{path/to/directory/}} --squash {{repository_url}} {{master}}`
+
+- Push commits to subtree repository:
+
+`git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
+
+- Extract a new porject history from the history of subtree:
+
+`git subtree split --prefix={{path/to/directory/}} {{repository_url}} -b {{branch_name}}`


### PR DESCRIPTION
Try to add more git command.

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).