### PR TITLE
fix missing space after arguments

### DIFF
--- a/pages/common/clang.md
+++ b/pages/common/clang.md
@@ -13,7 +13,7 @@
 
 - Include libraries located at a different path than the source file:
 
-`clang {{input_source.c}} -o {{output_executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`
+`clang {{input_source.c}} -o {{output_executable}} -I {{header_path}} -L {{library_path}} -l {{library_name}}`
 
 - Compile source code into LLVM Intermediate Representation (IR):
 


### PR DESCRIPTION
fixing missing space after arguments in clang page for readability

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
