### PR TITLE
git-show-branch: add page

### DIFF
--- a/pages/common/git-show-branch.md
+++ b/pages/common/git-show-branch.md
@@ -1,6 +1,6 @@
 # git show-branch
 
-> Show branches and their commits
+> Show branches and their commits.
 > More information: <https://git-scm.com/docs/git-show-branch>.
 
 - Show a summary of the latest commit on a branch:

--- a/pages/common/git-show-branch.md
+++ b/pages/common/git-show-branch.md
@@ -1,0 +1,36 @@
+# git show-branch
+
+> Show branches and their commits
+> More information: <https://git-scm.com/docs/git-show-branch>.
+
+- Show a summary of the latest commit on a branch:
+
+`git show-branch {{branch_name|ref|commit}}`
+
+- Compare commits in the history of multiple commits or branches:
+
+`git show-branch {{branch_name|ref|commit}}`
+
+- Compare all remote tracking branches:
+
+`git show-branch --remotes`
+
+- Compare both local and remote tracking branches:
+
+`git show-branch --all`
+
+- List the latest commits in all branches:
+
+`git show-branch --all --list`
+
+- Compare a given branch with the current branch:
+
+`git show-branch --current {{commit|branch_name|ref}}`
+
+- Display the commit name instead of the relative name:
+
+`git show-branch --sha1-name --current {{current|branch_name|ref}}`
+
+- Keep going a given number of commits past the common ancester:
+
+`git show-branch --more {{5}} {{commit|branch_name|ref}} {{commit|branch_name|ref}} {{...}}`


### PR DESCRIPTION
Part 1 of 4, for #3953.

This is a pretty interesting command actually. A bit on the obscure side, but still interesting and probably useful all the same.

It's also pretty complicated (but not as complex as some of the ones I plan to do later - those will be heaps of fun - check out the PR for `git help`.....) - so I'm splitting these 4 up into separate PRs.