### PR TITLE
git-help: add page

### DIFF
--- a/common/pages/git-help.md
+++ b/common/pages/git-help.md
@@ -1,6 +1,6 @@
 # git help
 
-> Display help information about Git
+> Display help information about git.
 > More information: <https://git-scm.com/docs/git-help>.
 
 - Display help about a specific git subcommand:

--- a/common/pages/git-help.md
+++ b/common/pages/git-help.md
@@ -1,0 +1,24 @@
+# git help
+
+> Display help information about Git
+> More information: <https://git-scm.com/docs/git-help>.
+
+- Display help about a specific git subcommand:
+
+`git help {{subcommand}}`
+
+- Display help about a specific git subcommand in a web browser: 
+
+`git help --web {{subcommand}}`
+
+- Display a list of all available git subcommands:
+
+`git help --all`
+
+- List the available guides:
+
+`git help --guide`
+
+- List all possible configuration variables:
+
+`git help --config`


### PR DESCRIPTION
Who knew that the `help` subcommand of `git` could be so useful?!

Of particular note is `git help --all`, which gives a complete list of all the subcommands built into git - include the most obscure ones available You can be sure that I'll be (eventually) making my way down that list!

Part 4 / 4 of this batch; for #3953