### PR TITLE
readme: add ExTldr client

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ You can access these pages on your computer using one of the following clients:
   Open `Preferences` > `Downloads` > `User Contributed` and find `tldr pages` in the list
 - Docker images:
     - [tldr-docker](https://github.com/nutellinoit/tldr-docker)- Run the `tldr` command via a docker container: `alias tldr='docker run --rm -it -v ~/.tldr/:/root/.tldr/ nutellinoit/tldr'`
-- [TLDR Elixir Client](https://github.com/edgurgel/tldr_elixir_client)
+- Elixir clients:
+  - [ExTldr](https://github.com/ivanhercaz/extldr).
+  - [TLDR Elixir Client](https://github.com/edgurgel/tldr_elixir_client)
   (binaries not yet available)
 - [Emacs client](https://github.com/kuanyui/tldr.el), available on
   [MELPA](https://github.com/melpa/melpa)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can access these pages on your computer using one of the following clients:
   Open `Preferences` > `Downloads` > `User Contributed` and find `tldr pages` in the list
 - Docker images:
     - [tldr-docker](https://github.com/nutellinoit/tldr-docker)- Run the `tldr` command via a docker container: `alias tldr='docker run --rm -it -v ~/.tldr/:/root/.tldr/ nutellinoit/tldr'`
-- [Elixir client](https://github.com/edgurgel/tldr_elixir_client)
+- [TLDR Elixir Client](https://github.com/edgurgel/tldr_elixir_client)
   (binaries not yet available)
 - [Emacs client](https://github.com/kuanyui/tldr.el), available on
   [MELPA](https://github.com/melpa/melpa)


### PR DESCRIPTION
As I commented in #4032, I developed a new Elixir client for tldr-pages, although it is still in progress, it works fine at this moment and, as you can see in ivanhercaz/extldr#6, the main priority is to accomplish with the clients specification of tldr-pages. I am not going to extend much explaining the client and the aims, because there are already [open issues in the ExTldr repository](https://github.com/ivanhercaz/extldr/issues) and I explained practically everything in the issue mentioned at the beginning of this already long paragraph.

About this PR, three points about the changes I performed:

1. I rename the existing, but archived and apparently inactive, Elixir client.
2. I created a group of Elixir clients and then I added ExTldr.
3. I didn't specify instructions for ExTldr because to use it you just have to download the release and there isn't a package for any platform available.

As I said in the issue in which I introduced ExTldr to tldr-pages, I will be very thankfully of any feedback you give me :heart: