### PR TITLE
lsblk df: add exclude example

### DIFF
--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -17,3 +17,7 @@
 - Display statistics on the number of free inodes:
 
 `df -i`
+
+- Display file systems but exclude the specified type:
+
+`df -x {{squashfs}} -x {{tmpfs}}`

--- a/pages/linux/lsblk.md
+++ b/pages/linux/lsblk.md
@@ -25,3 +25,7 @@
 - Output info about block-device topology:
 
 `lsblk -t`
+
+- Exclude the devices specified by the comma-separated list of major device numbers:
+
+`lsblk -e {{1, 7}}`

--- a/pages/linux/lsblk.md
+++ b/pages/linux/lsblk.md
@@ -28,4 +28,4 @@
 
 - Exclude the devices specified by the comma-separated list of major device numbers:
 
-`lsblk -e {{1, 7}}`
+`lsblk -e {{1,7}}`


### PR DESCRIPTION
closes #4080

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).