### PR TITLE
Bugfix to correct linting error in french rsync tldr page

### DIFF
--- a/pages.fr/common/rsync.md
+++ b/pages.fr/common/rsync.md
@@ -15,7 +15,7 @@
 
 `rsync -azvhP {{chemin/vers/fichier_local}} {{hote_distant}}:{{chemin/vers/dossier_distant}}`
 
--Transférer un dossier et tous ses sous-dossiers d'un hôte distant vers l'hôte local:
+- Transférer un dossier et tous ses sous-dossiers d'un hôte distant vers l'hôte local:
 
 `rsync -r {{hote_distant}}:{{chemin/vers/dossier_distant}} {{chemin/vers/dossier_local}}`
 


### PR DESCRIPTION
The command "TLDR_LANG=FR tldr rsync " results in the following error: Page common/rsync.md not properly linted!  Line 18
 2nd character no space
This change solved this issue

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
