### PR TITLE
grep: regexp is used by default

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -3,34 +3,34 @@
 > Matches patterns in input text.
 > Supports simple patterns and regular expressions.
 
+- Search for a pattern within a file:
+
+`grep {{search_pattern}} {{path/to/file}}`
+
 - Search for an exact string:
 
-`grep {{search_string}} {{path/to/file}}`
+`grep -F {{exact_string}} {{path/to/file}}`
 
-- Search in case-insensitive mode:
+- Search for a pattern recursively in the current directory, ignoring non-text files:
 
-`grep -i {{search_string}} {{path/to/file}}`
+`grep -RI {{search_pattern}} .`
 
-- Search recursively (ignoring non-text files) in current directory for an exact string:
+- Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`), in case-insensitive mode:
 
-`grep -RI {{search_string}} .`
-
-- Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`):
-
-`grep -E {{^regex$}} {{path/to/file}}`
+`grep -Ei {{search_pattern}} {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`grep -{{C|B|A}} 3 {{search_string}} {{path/to/file}}`
+`grep -{{C|B|A}} 3 {{search_pattern}} {{path/to/file}}`
 
 - Print file name with the corresponding line number for each match:
 
-`grep -Hn {{search_string}} {{path/to/file}}`
+`grep -Hn {{search_pattern}} {{path/to/file}}`
 
 - Use the standard input instead of a file:
 
-`cat {{path/to/file}} | grep {{search_string}}`
+`cat {{path/to/file}} | grep {{search_pattern}}`
 
 - Invert match for excluding specific strings:
 
-`grep -v {{search_string}}`
+`grep -v {{search_pattern}}`


### PR DESCRIPTION
grep searches for regexp by default on Linux, and the '-F' switch is required for the exact string. 
Corrected by replacing `search_string` with `regexp`, or adding the mentioned switch.

Please review / confirm.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).