### PR TITLE
Remove issue-stats badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [![Gitter chat][gitter-image]][gitter-url]
 [![Merged PRs][prs-merged-image]][prs-merged-url]
-[![Issue stats][issuestats-image]][issuestats-url]
 [![GitHub contributors][contributors-image]][contributors-url]
 [![CLA assistant][cla-assistant-image]][cla-assistant-url]
 [![license][license-image]][license-url]
@@ -11,8 +10,6 @@
 [gitter-image]: https://badges.gitter.im/tldr-pages/tldr.svg
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs
-[issuestats-url]: http://isitmaintained.com/project/tldr-pages/tldr
-[issuestats-image]: http://isitmaintained.com/badge/resolution/tldr-pages/tldr.svg
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
 [contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
 [cla-assistant-url]: https://cla-assistant.io/tldr-pages/tldr

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build status][travis-image]][travis-url]
 [![Gitter chat][gitter-image]][gitter-url]
 [![Merged PRs][prs-merged-image]][prs-merged-url]
-[![Issue stats][issuestats-image]][issuestats-url]
 [![GitHub contributors][contributors-image]][contributors-url]
 [![license][license-image]][license-url]
 
@@ -14,8 +13,6 @@
 [gitter-image]: https://badges.gitter.im/tldr-pages/tldr.svg
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs
-[issuestats-url]: https://isitmaintained.com/project/tldr-pages/tldr
-[issuestats-image]: https://isitmaintained.com/badge/resolution/tldr-pages/tldr.svg
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
 [contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
 [license-url]: https://github.com/tldr-pages/tldr/blob/master/LICENSE.md


### PR DESCRIPTION
The stats showcased by this badge (from the [IsItMaintained](https://isitmaintained.com/) project) don't accurately represent the responsiveness of the tldr-pages project.

See the discussion at https://github.com/tldr-pages/tldr/pull/4084#discussion_r433465926 for context.