### PR TITLE
gpgv: add page

### DIFF
--- a/pages/common/gpgv.md
+++ b/pages/common/gpgv.md
@@ -3,14 +3,14 @@
 > Verify OpenPGP signatures.
 > More information: <https://www.gnupg.org/documentation/manuals/gnupg/gpgv.html>.
 
-- Verify a signed file.
+- Verify a signed file:
 
 `gpgv doc.txt`
 
-- Verify a signed file using a detached signature.
+- Verify a signed file using a detached signature:
 
 `gpgv sigfile.asc doc.txt`
 
-- Add a file to the list of keyrings (a single exported key also accounts as a keyring).
+- Add a file to the list of keyrings (a single exported key also accounts as a keyring):
 
 `gpgv --keyring ./alice.keyring sigfile.asc doc.txt`

--- a/pages/common/gpgv.md
+++ b/pages/common/gpgv.md
@@ -1,0 +1,16 @@
+# gpgv
+
+> Verify OpenPGP signatures.
+> More information: <https://www.gnupg.org/documentation/manuals/gnupg/gpgv.html>.
+
+- Verify a signed file.
+
+`gpgv doc.txt`
+
+- Verify a signed file using a detached signature.
+
+`gpgv sigfile.asc doc.txt`
+
+- Add a file to the list of keyrings (a single exported key also accounts as a keyring).
+
+`gpgv --keyring ./alice.keyring sigfile.asc doc.txt`

--- a/pages/common/gpgv.md
+++ b/pages/common/gpgv.md
@@ -5,12 +5,12 @@
 
 - Verify a signed file:
 
-`gpgv doc.txt`
+`gpgv {{path/to/file}}`
 
 - Verify a signed file using a detached signature:
 
-`gpgv sigfile.asc doc.txt`
+`gpgv {{path/to/signature}} {{path/to/file}}`
 
 - Add a file to the list of keyrings (a single exported key also accounts as a keyring):
 
-`gpgv --keyring ./alice.keyring sigfile.asc doc.txt`
+`gpgv --keyring {{./alice.keyring}} {{path/to/file}} {{path/to/signature}}`


### PR DESCRIPTION
Hi,

Here's a PR adding an entry for the [gpgv](https://manpages.ubuntu.com/manpages/bionic/man1/gpgv.1.html) command.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
