### PR TITLE
gpgv: fix typo

### DIFF
--- a/pages/common/gpgv.md
+++ b/pages/common/gpgv.md
@@ -11,6 +11,6 @@
 
 `gpgv {{path/to/signature}} {{path/to/file}}`
 
-- Add a file to the list of keyrings (a single exported key also accounts as a keyring):
+- Add a file to the list of keyrings (a single exported key also counts as a keyring):
 
-`gpgv --keyring {{./alice.keyring}} {{path/to/file}} {{path/to/signature}}`
+`gpgv --keyring {{./alice.keyring}} {{path/to/signature}} {{path/to/file}}`


### PR DESCRIPTION
Hi, the arguments in the final example were the wrong way round.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

