### PR TITLE
Update example URL in youtube-viewer page

### DIFF
--- a/pages/common/youtube-viewer.md
+++ b/pages/common/youtube-viewer.md
@@ -13,7 +13,7 @@
 
 - Watch a video with a specific URL in VLC:
 
-`youtube-viewer --player={{vlc}} {{https://youtube.com/watch?v=1dastnond}}`
+`youtube-viewer --player={{vlc}} {{https://youtube.com/watch?v=dQw4w9WgXcQ}}`
 
 - Display a search prompt and play the selected video in 720p:
 


### PR DESCRIPTION
I have changed the example URL so instead of being a placeholder, it is in the correct format of a video ID (right amount of characters, right type of characters, etc.)

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->
 
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
