### PR TITLE
cloc: add --by-file example

### DIFF
--- a/pages/common/cloc.md
+++ b/pages/common/cloc.md
@@ -18,3 +18,7 @@
 - Ignore files that are ignored by VCS, such as files specified in .gitignore:
 
 `cloc --vcs git {{path/to/directory}}`
+
+- Count all the lines of code in a directory, displaying the results for each file instead of each language
+
+`cloc --by-file {{path/to/directory}}`

--- a/pages/common/cloc.md
+++ b/pages/common/cloc.md
@@ -19,6 +19,6 @@
 
 `cloc --vcs git {{path/to/directory}}`
 
-- Count all the lines of code in a directory, displaying the results for each file instead of each language
+- Count all the lines of code in a directory, displaying the results for each file instead of each language:
 
 `cloc --by-file {{path/to/directory}}`


### PR DESCRIPTION
This might not be a very common option for large projects, but it's one I find myself looking for quite often when I want to get a feel for how large my source files are.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
