### PR TITLE
CI: fix deployment branch check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: bash scripts/build.sh
 
     - name: Deploy
-      if: github.repository == 'tldr-pages/tldr' && github.ref == 'master'
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
       run: bash scripts/deploy.sh
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
Fix check for "deploy" step of GitHub Actions CI (see #4125).

**Note**: please do a "squash merge" when merging.