### PR TITLE
htop: add sorting option

### DIFF
--- a/pages/linux/htop.md
+++ b/pages/linux/htop.md
@@ -10,6 +10,10 @@
 
 `htop -u {{username}}`
 
+- Sort processes by a column (use `--sort-key help` for a column list)
+
+`htop -s {{column_name}}`
+
 - Get help about interactive commands:
 
 `?`

--- a/pages/linux/htop.md
+++ b/pages/linux/htop.md
@@ -10,7 +10,7 @@
 
 `htop -u {{username}}`
 
-- Sort processes by a column (use `--sort-key help` for a column list)
+- Sort processes by a column (use `--sort-key help` for a column list):
 
 `htop -s {{column_name}}`
 


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Added sorting option to htop command.

htop man: https://linux.die.net/man/1/htop

Issue: https://github.com/tldr-pages/tldr/issues/4133#issuecomment-651060960