### PR TITLE
cp: replace -r with -R

### DIFF
--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -12,11 +12,11 @@
 
 - Recursively copy a directory's contents to another location (if the destination exists, the directory is copied inside it):
 
-`cp -r {{path/to/directory}} {{path/to/copy}}`
+`cp -R {{path/to/directory}} {{path/to/copy}}`
 
 - Copy a directory recursively, in verbose mode (shows files as they are copied):
 
-`cp -vr {{path/to/directory}} {{path/to/copy}}`
+`cp -vR {{path/to/directory}} {{path/to/copy}}`
 
 - Copy text files to another location, in interactive mode (prompts user before overwriting):
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

## Why?

I paste the text directly from the official `cp` manpage:

```
Historic versions of the cp utility had a -r option. This implementation supports that option;
however, its use is strongly discouraged, as it does not correctly copy special files, symbolic
links, or fifo's.
```