### PR TITLE
German translations for common commands

### DIFF
--- a/pages.de/common/cut.md
+++ b/pages.de/common/cut.md
@@ -1,0 +1,27 @@
+# cut
+
+> Entferne Felder von `stdin` oder einer Datei.
+
+- Entferne die ersten 16 Zeichen jeder Zeile von `stdin`:
+
+`cut -c {{1-16}}`
+
+- Entferne die ersten 16 Zeichen jeder Zeile der angegebenen Datei:
+
+`cut -c {{1-16}} {{datei}}`
+
+- Entferne alles ab dem dritten Zeichen bis zum Ende der Zeile:
+
+`cut -c {{3-}}`
+
+- Entferne das fünfte Feld jeder Zeile, nutze Doppelpunkt als Trennzeichen (Standart ist Tab):
+
+`cut -d'{{:}}' -f{{5}}`
+
+- Entferne das 2. und 10. Feld jeder Zeile, nutze Semikolon als Trennzeichen:
+
+`cut -d'{{;}}' -f{{2,10}}`
+
+- Entferne alles ab dem dritten Zeichen bis zum Ende der Zeile, nutze Leerzeichen als Trennzeichen:
+
+`cut -d'{{ }}' -f{{3-}}`

--- a/pages.de/common/ffmpeg.md
+++ b/pages.de/common/ffmpeg.md
@@ -1,0 +1,36 @@
+# ffmpeg
+
+> Programm zum konvertieren von Videos.
+> Mehr Informationen: <https://ffmpeg.org>.
+
+- Extrahiere den Ton eines Videos und speichere als MP3:
+
+`ffmpeg -i {{video.mp4}} -vn {{audio}}.mp3`
+
+- Konvertiere Frames eines Videos oder Gifs zu individuellen, numerierten Bildern:
+
+`ffmpeg -i {{video.mpg|video.gif}} {{frame_%d.png}}`
+
+- Kombiniere numerierte Bilder (frame_1.jpg, frame_2.jpg, etc) in ein Video oder Gif:
+
+`ffmpeg -i {{frame_%d.jpg}} -f bild2 {{video.mpg|video.gif}}`
+
+- Extrahiere einen einzelnen Frame von einem Video bei mm:ss and speichere als 128x128 Bild:
+
+`ffmpeg -ss {{mm:ss}} -i {{video.mp4}} -frames 1 -s {{128x128}} -f bild2 {{bild.png}}`
+
+- Trimme ein video von mm:ss bis mm2:ss2 (Ohne -to bis zum ende des Videos):
+
+`ffmpeg -ss {{mm:ss}} -to {{mm2:ss2}} -i {{video.mp4}} -codec copy {{output.mp4}}`
+
+- Konvertiere AVI Video zu MP4. AAC Audio @ 128kbit, h264 Video @ CRF 23:
+
+`ffmpeg -i {{input_video}}.avi -codec:audio aac -b:audio 128k -codec:video libx264 -crf 23 {{output_video}}.mp4`
+
+- Remuxe MKV Video zu MP4 ohne neu Audio oder Video streams neu zu Kodieren:
+
+`ffmpeg -i {{input_video}}.mkv -codec copy {{output_video}}.mp4`
+
+- Konvertiere MP4 video zu VP9. Für beste Qualität, nutze einen CRF Wert (Empfohlen 15-35) und -b:video MUSS 0 sein:
+
+`ffmpeg -i {{input_video}}.mp4 -codec:video libvpx-vp9 -crf {{30}} -b:video 0 -codec:audio libopus -vbr on -threads {{number_of_threads}} {{output_video}}.webm`

--- a/pages.de/common/fish.md
+++ b/pages.de/common/fish.md
@@ -1,0 +1,29 @@
+# fish
+
+> The Friendly Interactive SHell.
+> Eine benutzerfreundliche Eingabeaufforderung.
+> Mehr Informationen: <https://fishshell.com>.
+
+- Starte interaktive Eingabeaufforderung:
+
+`fish`
+
+- Führe einen Befehl aus:
+
+`fish -c "{{befehl}}"`
+
+- Führe Befehle von Datei aus:
+
+`fish {{datei.fish}}`
+
+- Überprüfe eine Datei auf Syntax Fehler:
+
+`fish --no-execute {{datei.fish}}`
+
+- Zeige Informationen über derzeitige Version und schließe:
+
+`fish --version`
+
+- Setze und exportiere Umgebungsvariabeln die nach einem Neustart weiter bestehen:
+
+`set -Ux {{variable_name}} {{variable_wert}}`

--- a/pages.de/common/gpg.md
+++ b/pages.de/common/gpg.md
@@ -1,0 +1,32 @@
+# gpg
+
+> GNU Privacy Guard.
+> Mehr Informationen: <https://gnupg.org>.
+
+- Signiere doc.txt ohne Verschlüsselung (Ausabe nach doc.txt.asc):
+
+`gpg --clearsign {{doc.txt}}`
+
+- Verschlüssle doc.txt für alice@beispiel.de (Ausgabe nach doc.txt.gpg):
+
+`gpg --encrypt --recipient {{alice@beispiel.de}} {{doc.txt}}`
+
+- Verschlüssle doc.txt nur mit Passwort (Ausgabe nach doc.txt.gpg):
+
+`gpg --symmetric {{doc.txt}}`
+
+- Entschlüssle doc.txt.gpg (Ausgabe nach `stdout`):
+
+`gpg --decrypt {{doc.txt.gpg}}`
+
+- Importiere einen Öffentlichen Schlüssel:
+
+`gpg --import {{public.gpg}}`
+
+- Exportiere Öffentlichen Schlüssel von alice@beispiel.de (Ausgabe nach `stdout`):
+
+`gpg --export --armor {{alice@beispiel.de}}`
+
+- Exportiere Privaten Schlüssel von alice@beispiel.de (Ausgabe nach `stdout`):
+
+`gpg --export-secret-keys --armor {{alice@beispiel.de}}`

--- a/pages.de/common/less.md
+++ b/pages.de/common/less.md
@@ -1,0 +1,35 @@
+# less
+
+> Datei für interaktives lesen öffnen, erlaubt Scrollen und Suchen.
+
+- Datei öffnen:
+
+`less {{datei}}`
+
+- Seite runter / hoch:
+
+`<Space> (runter), b (hoch)`
+
+- Zum Ende / Anfang der Datei springen:
+
+`G (Ende), g (Anfang)`
+
+- Forwärtssuche nach eine Zeichenkette (n/N um zur nächsten/vorherigen Übereinstimmung zu springen):
+
+`/{{suche}}`
+
+- Rückwärtssuche nach eine Zeichenkette (n/N um zur nächsten/vorherigen Übereinstimmung zu springen):
+
+`?{{suche}}`
+
+- Ausgabe des geöffeten buffers folgen:
+
+`F`
+
+- Datei in einem Editor öffnen:
+
+`v`
+
+- Schließen:
+
+`q`

--- a/pages.de/common/lolcat.md
+++ b/pages.de/common/lolcat.md
@@ -1,0 +1,20 @@
+# lolcat
+
+> Ausgabe von Befehl in Regenbogenfarben einfärben.
+> Mehr Informationen: <https://github.com/busyloop/lolcat>.
+
+- Inhalt von Datei in Regenbogenfarben zur Konsole schreiben:
+
+`lolcat {{pfad/zur/datei}}`
+
+- Ausgabe von Befehl in Regenbogenfarben zur Konsole schreiben:
+
+`{{fortune}} | lolcat`
+
+- Inhalt von Datei in animierten Regenbogenfarben zur Konsole schreiben:
+
+`lolcat -a {{pfad/zur/datei}}`
+
+- Inhalt von Datei in 24-bit (truecolor) Regenbogenfarben zur Konsole schreiben:
+
+`lolcat -t {{pfad/zur/datei}`

--- a/pages.de/common/pass.md
+++ b/pages.de/common/pass.md
@@ -1,0 +1,33 @@
+# pass
+
+> Programm zum speichern und lesen von Passwörtern und anderen empfindlichen Daten.
+> Die Daten sind mit GPG verschlüsselt und mit einem git repository verwaltet.
+> Mehr Informationen: <https://www.passwordstore.org>.
+
+- Neuen oder bestehenden Speicher mit einer oder mehreren GPG IDs initialisieren oder neu verschlüsseln:
+
+`pass init {{gpg_id_1}} {{gpg_id_2}}`
+
+- Passwort und zusätzliche Informationen speichern (Str + D auf neuer Zeile zum abschließen):
+
+`pass insert --multiline {{pfad/zu/daten}}`
+
+- Einen Eintrag bearbeiten:
+
+`pass edit {{pfad/zu/daten}}`
+
+- Passwort (Erste Zeile des Eintrags) in die Zwischenablage kopieren:
+
+`pass -c {{pfad/zu/daten}}`
+
+- Tree des Passwort stores anzeigen:
+
+`pass`
+
+- Neues, zufälliges Passwort mit Länge n generieren und in die Zwischenablage kopieren:
+
+`pass generate -c {{pfad/zu/daten}} {{n}}`
+
+- Neues Git Repository initialisieren (Alle durch pass durchgeführten änderungen werden automatisch committed):
+
+`pass git init`

--- a/pages.de/common/rev.md
+++ b/pages.de/common/rev.md
@@ -1,0 +1,11 @@
+# rev
+
+> Kehre die Reihenfolge von Text um.
+
+- Kehre die Reihenfolge des Textes "Hallo" um:
+
+`echo "Hallo" | rev`
+
+- Kehre die Reihenfolge einer Datei um:
+
+`rev {{file}}`

--- a/pages.de/common/rev.md
+++ b/pages.de/common/rev.md
@@ -8,4 +8,4 @@
 
 - Kehre die Reihenfolge einer Datei um:
 
-`rev {{file}}`
+`rev {{datei}}`

--- a/pages.de/common/tar.md
+++ b/pages.de/common/tar.md
@@ -1,0 +1,41 @@
+# tar
+
+> Werkzeug zur Archivierung.
+> Häufig kombiniert mit einer methode zur Komprimierung, wie gzip oder bzip.
+> Mehr Informationen: <https://www.gnu.org/software/tar>.
+
+- Erstelle ein Archiv von Datein:
+
+`tar cf {{ziel.tar}} {{datei1}} {{datei2}} {{datei3}}`
+
+- Erstelle ein mit gzip komprimiertes Archiv:
+
+`tar czf {{ziel.tar.gz}} {{datei1}} {{datei2}} {{datei3}}`
+
+- Erstelle ein mit gzip komprimiertes Archiv mit relativen Pfaden:
+
+`tar czf {{ziel.tar.gz}} -C {{pfad/zu/verzeichniss/}} .`
+
+- Extrahiere ein (komprimiertes) Archiv in das derzeitige Verzeichniss:
+
+`tar xf {{quelle.tar[.gz|.bz2|.xz]}}`
+
+- Extrahiere ein Archiv in ein Verzeichniss:
+
+`tar xf {{quelle.tar}} -C {{verzeichniss}}`
+
+- Erstelle ein komprimiertes Archiv; benutze den Archiv Suffix um die Kompressions Methode zu wählen:
+
+`tar caf {{ziel.tar.xz}} {{datei1}} {{datei2}} {{datei3}}`
+
+- Führe die Inhalte eines tar Archivs auf:
+
+`tar tvf {{quelle.tar}}`
+
+- Extrahiere Dateien die mit einem Muster übereinstimmen:
+
+`tar xf {{quelle.tar}} --wildcards {{"*.html"}}`
+
+- Extrahiere eine bestimmte Datei ohne die Verzeichniss Struktur beizubehalten:
+
+`tar xf {{quelle.tar}} {{quelle.tar/pfad/zum/extrahieren}} --strip-components={{tiefe_zu_entfernen}}`

--- a/pages.de/common/zsh.md
+++ b/pages.de/common/zsh.md
@@ -1,0 +1,21 @@
+# zsh
+
+> Z SHell.
+> Mit `bash` und `sh` kompatible Eingabeaufforderung.
+> Mehr Informationen: <https://www.zsh.org>.
+
+- Starte interaktive Eingabeaufforderung:
+
+`zsh`
+
+- Führe Parameter als Befehl aus:
+
+`zsh -c {{befehl}}`
+
+- Führe Befehle aus datei aus (Script):
+
+`zsh {{datei}}`
+
+- Führe Befehle aus Datei aus und schreibe die Befehle zur Konsole:
+
+`zsh -x {{datei}}`


### PR DESCRIPTION
Translated 10 of the common pages to German.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
