### PR TITLE
pdftk: Avoid non-ascii characters

### DIFF
--- a/pages/common/pdftk.md
+++ b/pages/common/pdftk.md
@@ -9,7 +9,7 @@
 
 - Merge (concatenate) a list of PDF files and save the result as another one:
 
-`pdftk {{file1.pdf file2.pdf …}} cat output {{output.pdf}}`
+`pdftk {{file1.pdf file2.pdf ...}} cat output {{output.pdf}}`
 
 - Split each page of a PDF file into a separate file, with a given filename output pattern:
 


### PR DESCRIPTION
The ellipsis character (U+2026) generates an encoding error in the web client (tldr.ostera.io): the UTF-8 input is interpreted as Latin-1, resulting in garbled output.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
