### PR TITLE
cmake: remove cmake -i example

### DIFF
--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -11,7 +11,3 @@
 - Generate a Makefile and use it to compile a project in a separate "build" directory (out-of-source build):
 
 `cmake -H. -B{{build}} && make -C {{build}}`
-
-- Run cmake in interactive mode (it will ask for each variable, instead of using defaults):
-
-`cmake -i`


### PR DESCRIPTION
The "cmake -i" wizard mode is no longer supported.
Use the -D option to set cache values on the command line.
Use cmake-gui or ccmake for an interactive dialog.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

```
The "cmake -i" wizard mode is no longer supported.
Use the -D option to set cache values on the command line.
Use cmake-gui or ccmake for an interactive dialog.
```