### PR TITLE
jq: Add example for constructing new JSON object

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -27,7 +27,7 @@
 
 `cat {{file.json}} | jq 'map(.{{key_name}})'`
 
-- Output the value of multiple keys as a new JSON object (assuming the input JSON has keys `key_name` and `other_key_name`):
+- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name` and `other_key_name`):
 
 `cat {{file.json}} | jq '{{{my_new_key}}: .{{key_name}}, {{my_other_key}}: {{other_key_name}}}'`
 

--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -27,6 +27,10 @@
 
 `cat {{file.json}} | jq 'map(.{{key_name}})'`
 
+- Output the value of multiple keys as a new JSON object (assuming the input JSON has keys `key_name` and `other_key_name`):
+
+`cat {{file.json}} | jq '{{{my_new_key}}: .{{key_name}}, {{my_other_key}}: {{other_key_name}}}'`
+
 - Combine multiple filters:
 
 `cat {{file.json}} | jq 'unique | sort | reverse'`


### PR DESCRIPTION
This example covers the functionality which `jq` provides to transform JSON input in to another JSON object. I've found this to be a common use case for `jq`.

This does bring the number of examples up to 9. In my experience this new example is a more common use case than the last two examples, so would propose that we remove one of those two.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
