### PR TITLE
git-config: add example for editing in default editor

### DIFF
--- a/pages/common/git-config.md
+++ b/pages/common/git-config.md
@@ -28,10 +28,10 @@
 
 `git config --global --unset alias.unstage`
 
-- Edit the git configuration for the current repository in your default editor:
+- Edit the git configuration for the current repository in the default editor:
 
 `git config --edit`
 
-- Edit the global git configuration in your default editor:
+- Edit the global git configuration in the default editor:
 
 `git config --global --edit`

--- a/pages/common/git-config.md
+++ b/pages/common/git-config.md
@@ -27,3 +27,11 @@
 - Revert a global configuration entry to its default value:
 
 `git config --global --unset alias.unstage`
+
+- Edit the git configuration for the current repository in your default editor:
+
+`git config --edit`
+
+- Edit the global git configuration in your default editor:
+
+`git config --global --edit`


### PR DESCRIPTION
I've found this to be a pretty common thing to want to do, particularly if you want to edit multiple config values at once, or can't quite remember the name of the property you need to change.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
