### PR TITLE
pg_restore: add example for listing contents of a dump file

### DIFF
--- a/pages/common/pg_restore.md
+++ b/pages/common/pg_restore.md
@@ -15,6 +15,10 @@
 
 `pg_restore -h {{host}} -p {{port}} -d {{db_name}} {{archive_file.dump}}`
 
+- List database objects included in the archive:
+
+`pg_restore --list {{archive_file.dump}}`
+
 - Clean database objects before creating them:
 
 `pg_restore --clean -d {{db_name}} {{archive_file.dump}}`


### PR DESCRIPTION
This is a handy command for listings contents of a dump file before applying it.

Feedback is welcome,
Thanks

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
