### PR TITLE
curl: explain -d example

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -16,7 +16,7 @@
 
 `curl -O -L -C - {{http://example.com/filename}}`
 
-- Send form-encoded data (POST request of type `application/x-www-form-urlencoded`), try -d {{'@filename}} or -d {{'@-'}} to read from STDIN:
+- Send form-encoded data (POST request of type `application/x-www-form-urlencoded`). Use `-d @file_name` or `-d @'-'` to read from STDIN:
 
 `curl -d {{'name=bob'}} {{http://example.com/form}}`
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -16,7 +16,7 @@
 
 `curl -O -L -C - {{http://example.com/filename}}`
 
-- Send form-encoded data (POST request of type `application/x-www-form-urlencoded`):
+- Send form-encoded data (POST request of type `application/x-www-form-urlencoded`), try -d {{'@filename}} or -d {{'@-'}} to read from STDIN:
 
 `curl -d {{'name=bob'}} {{http://example.com/form}}`
 


### PR DESCRIPTION
Add curl -d {{'@filename'}} option. This is purely documented in curl man document but is very handy.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
