### PR TITLE
netstat: remove inexistent option for MacOS

### DIFF
--- a/pages.zh/osx/netstat.md
+++ b/pages.zh/osx/netstat.md
@@ -18,10 +18,6 @@
 
 `netstat -p {{协议}}`
 
-- 连续列出信息（这条我电脑里 netstat 是不支持的。谁明白麻烦提交 pr!):
-
-`netstat -c`
-
 - 打印路由表:
 
 `netstat -nr`

--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -18,10 +18,6 @@
 
 `netstat -p {{protocol}}`
 
-- List information continuously:
-
-`netstat -c`
-
 - Print the routing table:
 
 `netstat -nr`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

`netstat -c` is supported in Linux, but not in macOS.

![image](https://user-images.githubusercontent.com/18191964/87503882-e4d8db80-c697-11ea-9696-e8cf14ec717e.png)
