### PR TITLE
newman: add page

### DIFF
--- a/pages/common/newman.md
+++ b/pages/common/newman.md
@@ -1,0 +1,12 @@
+# newman
+
+> Newman is a command-line collection runner for Postman.
+> More information: <https://github.com/postmanlabs/newman>.
+
+- Run a collection (from a file):
+
+`newman run {{examples/sample-collection.json}}`
+
+- Run a collection (from a URL):
+
+`newman run {{https://www.getpostman.com/collections/631643-f695cab7-6878-eb55-7943-ad88e1ccfd65-JsLv}}`

--- a/pages/common/newman.md
+++ b/pages/common/newman.md
@@ -1,11 +1,11 @@
 # newman
 
-> Newman is a command-line collection runner for Postman.
+> Collection runner for Postman.
 > More information: <https://github.com/postmanlabs/newman>.
 
 - Run a collection (from a file):
 
-`newman run {{examples/sample-collection.json}}`
+`newman run {{path/to/collection.json}}`
 
 - Run a collection (from a URL):
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

---

The examples are taken directly from https://github.com/postmanlabs/newman/.

Fixes #4181.