### PR TITLE
uptime: add page

### DIFF
--- a/pages/osx/uptime.md
+++ b/pages/osx/uptime.md
@@ -1,0 +1,7 @@
+# uptime
+
+> Tell how long the system has been running and other information.
+
+- Print current time, uptime, number of logged-in users and other information:
+
+`uptime`


### PR DESCRIPTION
Added uptime.md to OSX platform since OSX doesn't support the arguments listed in common/uptime.md such as `--version`, `--pretty` and `--since`.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
