### PR TITLE
git-diff: remove 9th example

### DIFF
--- a/pages.es/common/git-diff.md
+++ b/pages.es/common/git-diff.md
@@ -27,10 +27,6 @@
 
 `git diff --summary {{commit}}`
 
-- Crea un archivo parche:
-
-`git diff > {{archivo_objetivo}}.patch`
-
 - Compara un único archivo entre dos ramas o commits:
 
 `git diff {{rama_1}}..{{rama_2}} [--] {{ruta/del/archivo}}`

--- a/pages.it/common/git-diff.md
+++ b/pages.it/common/git-diff.md
@@ -27,10 +27,6 @@
 
 `git diff --summary {{commit}}`
 
-- Crea un file di patch:
-
-`git diff > {{nome_file_patch}}.patch`
-
 - Confronta le versioni di un dato file tra due rami o commit:
 
 `git diff {{ramo_1}}..{{ramo_2}} [--] {{percorso/al/file}}`

--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -27,10 +27,6 @@
 
 `git diff --summary {{commit}}`
 
-- Create a patch file:
-
-`git diff > {{target_file}}.patch`
-
 - Compare a single file between two branches or commits:
 
 `git diff {{branch_1}}..{{branch_2}} [--] {{path/to/file}}`


### PR DESCRIPTION
Closes #3753.

I removed the example I found the least useful. The last two are common use cases.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
