### PR TITLE
sd: Remove option -i in favour of option -p

### DIFF
--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -1,6 +1,6 @@
 # sd
 
-> `sd` is an intuitive find & replace CLI.
+> Intuitive find & replace CLI.
 
 - Trim some whitespace using regex:
 

--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -10,10 +10,10 @@
 
 `{{echo 'cargo +nightly watch'}} | sd '(\w+)\s+\+(\w+)\s+(\w+)' 'cmd: $1, channel: $2, subcmd: $3'`
 
-- Find and replace in a file:
+- Find and replace in a file printing the result to stdout:
 
-`sd -i {{'window.fetch'}} {{'fetch'}} {{http.js}}`
+`sd -p {{'window.fetch'}} {{'fetch'}} {{http.js}}`
 
-- Find and replace across a project:
+- Find and replace across a project changing each file in place:
 
-`sd -i {{'from "react"'}} {{'from "preact"'}} $(find . -type f)`
+`sd {{'from "react"'}} {{'from "preact"'}} $(find . -type f)`


### PR DESCRIPTION
In version 0.6.4 `-i` has been deprecated and is the default now. The previous behavior can be forced with the `-p` option.
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
