### PR TITLE
cp: replace ambiguous text

### DIFF
--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -4,19 +4,19 @@
 
 - Copy a file to another location:
 
-`cp {{path/to/file.ext}} {{path/to/copy.ext}}`
+`cp {{path/to/source_file.ext}} {{path/to/target_file.ext}}`
 
 - Copy a file into another directory, keeping the filename:
 
-`cp {{path/to/file.ext}} {{path/to/target_parent_directory}}`
+`cp {{path/to/source_file.ext}} {{path/to/target_parent_directory}}`
 
 - Recursively copy a directory's contents to another location (if the destination exists, the directory is copied inside it):
 
-`cp -R {{path/to/directory}} {{path/to/copy}}`
+`cp -R {{path/to/source_directory}} {{path/to/target_directory}}`
 
 - Copy a directory recursively, in verbose mode (shows files as they are copied):
 
-`cp -vR {{path/to/directory}} {{path/to/copy}}`
+`cp -vR {{path/to/source_directory}} {{path/to/target_directory}}`
 
 - Copy text files to another location, in interactive mode (prompts user before overwriting):
 
@@ -24,4 +24,4 @@
 
 - Dereference symbolic links before copying:
 
-`cp -L {{link}} {{path/to/copy}}`
+`cp -L {{link}} {{path/to/target_directory}}`

--- a/pages/linux/cp.md
+++ b/pages/linux/cp.md
@@ -4,19 +4,19 @@
 
 - Copy a file to another location:
 
-`cp {{path/to/file.ext}} {{path/to/copy.ext}}`
+`cp {{path/to/source_file.ext}} {{path/to/target_file.ext}}`
 
 - Copy a file into another directory, keeping the filename:
 
-`cp {{path/to/file.ext}} {{path/to/target_parent_directory}}`
+`cp {{path/to/source_file.ext}} {{path/to/target_parent_directory}}`
 
 - Recursively copy a directory's contents to another location (if the destination exists, the directory is copied inside it):
 
-`cp -r {{path/to/directory}} {{path/to/copy}}`
+`cp -r {{path/to/source_directory}} {{path/to/target_directory}}`
 
 - Copy a directory recursively, in verbose mode (shows files as they are copied):
 
-`cp -vr {{path/to/directory}} {{path/to/copy}}`
+`cp -vr {{path/to/source_directory}} {{path/to/target_directory}}`
 
 - Copy text files to another location, in interactive mode (prompts user before overwriting):
 
@@ -24,8 +24,8 @@
 
 - Dereference symbolic links before copying:
 
-`cp -L {{link}} {{path/to/copy}}`
+`cp -L {{link}} {{path/to/target_directory}}`
 
 - Use the full path of source files, creating any missing intermediate directories when copying:
 
-`cp --parents {{source/path/to/file}} {{path/to/copy}}`
+`cp --parents {{source/path/to/file}} {{path/to/target_file}}`


### PR DESCRIPTION
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

I misunderstood `path/to/copy` as "the path of the file for this command to copy" instead of the correct meaning of "the path to place the new copy of the source file", so I thought making the text on this page more explicit could be helpful.