### PR TITLE
plantuml: fix space was missing

### DIFF
--- a/pages/common/plantuml.md
+++ b/pages/common/plantuml.md
@@ -9,7 +9,7 @@
 
 - Render a diagram in given format (e.g. `png`, `pdf`, `svg`, `txt`):
 
-`plantuml -t{{format}} {{diagram.puml}}`
+`plantuml -t {{format}} {{diagram.puml}}`
 
 - Render all diagrams of a directory:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

There was a space missing. Command didn't work without that space.