### PR TITLE
jq: fix jq syntax error

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -29,7 +29,7 @@
 
 - Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name` and `other_key_name`):
 
-`cat {{file.json}} | jq '{{{my_new_key}}: .{{key_name}}, {{my_other_key}}: {{other_key_name}}}'`
+`cat {{file.json}} | jq '{{{my_new_key}}: .{{key_name}}, {{my_other_key}}: .{{other_key_name}}}'`
 
 - Combine multiple filters:
 


### PR DESCRIPTION
The jq example was missing an important `.` character. If a user tried to follow the example, they would have received an error from jq.

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).