### PR TITLE
mtr: Add package drop test

### DIFF
--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -22,3 +22,7 @@
 - Wait for a given time (in seconds) before sending another packet to the same hop:
 
 `mtr -i {{seconds}} {{host}}`
+
+- Perform a reliable package drop test that can be shown to the Internet Service Provider (ISP):
+
+`mtr --curses --no-dns --report-wide --report-cycles {{num}} "$(dig +short {{isp_website.tld}})"`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

---

I am using this to report package drops to my ISP which seems to show these very reliably including the hops that are causing the package drop.

Can be used as: 

`mtr --curses --no-dns --report-wide --report-cycles 60 "$(dig +short upc.cz)" | curl -F 'f:1=<-' ix.io`

To just sent an URL to the ISP since by default MTR is using TUI which makes it harder to get data from.

Report cycles `60` seems to be the most reliable in terms of speed and reliability.

Example output:

```console
kreyren@leonid:~$ mtr --curses --no-dns --report-wide --report-cycles 60 "$(dig +short upc.cz)"
Start: 2020-08-17T00:30:50+0200
HOST: leonid.rixotstudio.cz Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- ???                   100.0    60    0.0   0.0   0.0   0.0   0.0
  2.|-- 86.49.1.161            8.3%    60    7.6  26.5   6.6 147.2  38.4
  3.|-- 84.116.220.246        10.0%    60   30.5  43.3  29.4 143.8  29.2
  4.|-- 84.116.221.41          8.3%    60   30.5  42.8  29.5 208.8  34.5
  5.|-- 84.116.221.37          8.3%    60   30.5  43.2  29.8 197.6  34.2
  6.|-- 84.116.135.5           8.3%    60   37.3  50.8  35.5 204.0  36.7
  7.|-- 84.116.134.194         8.3%    60   35.9  41.5  29.8 154.1  26.4
  8.|-- 84.116.130.150         8.3%    60   30.1  41.2  29.1 206.2  31.3
  9.|-- 84.116.244.105         8.3%    60   38.3  48.4  35.6 161.1  29.7
 10.|-- 213.46.237.34         10.0%    60   35.9  47.9  35.7 145.4  26.7
 11.|-- 213.46.237.24         10.0%    60   35.2  36.3  34.4  77.9   5.9
```