### PR TITLE
CONTRIBUTING: Include homepage in example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ As a quick reference, the format of each page should match the following templat
 ```
 # command-name
 
-> Short, snappy description. Preferably one line; two are acceptable if necessary.
+> Short, snappy description.
+> Preferably one line; two are acceptable if necessary.
 > More information: <https://url-to-upstream.tld>.
 
 - Example description:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ As a quick reference, the format of each page should match the following templat
 ```
 # command-name
 
-> Short, snappy description.
-> Preferably one line; two are acceptable if necessary.
+> Short, snappy description. Preferably one line; two are acceptable if necessary.
+> More information: <https://url-to-upstream.tld>.
 
 - Example description:
 


### PR DESCRIPTION
The `> More information: <url>` seems to be used repository-wide so i think it's a good idea to be placed in contributing.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
	- Invalid
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
	- Invalid
- [X] The page has 8 or fewer examples.
	- Invalid
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
