### PR TITLE
inkscape: fix obsolete option, add -D example

### DIFF
--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -8,22 +8,26 @@
 
 `inkscape {{filename.svg}}`
 
-- Export an SVG file into a bitmap with the default format (PNG) and the default resolution (90 DPI):
+- Export an SVG file into a bitmap with the default format (PNG) and the default resolution (96 DPI):
 
-`inkscape {{filename.svg}} -e {{filename.png}}`
+`inkscape {{filename.svg}} -o {{filename.png}}`
 
 - Export an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):
 
-`inkscape {{filename.svg}} -e {{filename.png}} -w {{600}} -h {{400}}`
+`inkscape {{filename.svg}} -o {{filename.png}} -w {{600}} -h {{400}}`
+
+- Export the drawing (bounding box of all objects) of an SVG file into a bitmap:
+
+`inkscape {{filename.svg}} -o {{filename.png}} -D`
 
 - Export a single object, given its ID, into a bitmap:
 
-`inkscape {{filename.svg}} -i {{id}} -e {{object.png}}`
+`inkscape {{filename.svg}} -i {{id}} -o {{object.png}}`
 
 - Export an SVG document to PDF, converting all texts to paths:
 
-`inkscape {{filename.svg}} --export-pdf={{filename.pdf}} --export-text-to-path`
+`inkscape {{filename.svg}} -o {{filename.pdf}} --export-text-to-path`
 
 - Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
-`inkscape {{filename.svg}} --select=path123 --verb=EditDuplicate --verb=ObjectRotate90 --verb=FileSave --verb=FileQuit`
+`inkscape {{filename.svg}} --select=path123 --verb="EditDuplicate;ObjectRotate90;FileSave;FileQuit"`

--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -1,7 +1,7 @@
 # inkscape
 
 > An SVG (Scalable Vector Graphics) editing program.
-> Use -z to not open the GUI and only process files in the console.
+> For Inkscape versions up to 0.92.x, use -e instead of -o.
 > More information: <https://inkscape.org>.
 
 - Open an SVG file in the Inkscape GUI:


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


`-e` is obsolete option.

Added an example for output the drawing area `-D`, which should be very helpful to know.

`--verb` could receive more than one verbs.