### PR TITLE
jq: correct description of example

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -7,7 +7,7 @@
 
 `jq . {{file.json}}`
 
-- Output all elements from arrays (or all key-value pairs from objects) in a JSON file:
+- Output all elements from arrays (or all the values from objects) in a JSON file:
 
 `jq '.[]' {{file.json}}`
 


### PR DESCRIPTION
From the latest [jq manual](https://stedolan.github.io/jq/manual/#Basicfilters), it's said that when `use '.[]' on an object, and it will return all the values of the object`, but not all key-value pairs from objects

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
