### PR TITLE
6 translations to Italian + fixing a typo

### DIFF
--- a/pages.it/common/ffmpeg.md
+++ b/pages.it/common/ffmpeg.md
@@ -1,0 +1,36 @@
+# ffmpeg
+
+> Tool per convertire audio e video.
+> Maggiori informazioni: <https://ffmpeg.org>.
+
+- Estrai l'audio da un video e salvalo come MP3:
+
+`ffmpeg -i {{video.mp4}} -vn {{audio}}.mp3`
+
+- Converti i fotogrammi di un video o una GIF in una serie di immagini numerate:
+
+`ffmpeg -i {{video.mpg|video.gif}} {{foto_%d.png}}`
+
+- Sequenzia immagini numerate (foto_1.jpg, foto_2.jpg, ecc) per creare un video o una GIF:
+
+`ffmpeg -i {{frame_%d.jpg}} -f image2 {{video.mpg|video.gif}}`
+
+- Estrai un singolo fotogramma da un video al timestamp mm:ss e salvalo come immagine di dimensioni 128x128
+
+`ffmpeg -ss {{mm:ss}} -i {{video.mp4}} -frames 1 -s {{128x128}} -f image2 {{image.png}}`
+
+- Taglia un video da un momento iniziale mm:ss a un momento finale mm:ss (rimuovi la flag -to per tagliare fino alla fine):
+
+`ffmpeg -ss {{mm:ss}} -to {{mm2:ss2}} -i {{video.mp4}} -codec copy {{output.mp4}}`
+
+- Converti un video AVI a MP4. Audio AAC a 128kbit, video h264 a CRF 23:
+
+`ffmpeg -i {{input_video}}.avi -codec:audio aac -b:audio 128k -codec:video libx264 -crf 23 {{output_video}}.mp4`
+
+- Effettua un remux di un video MKV a MP4 senza re-encodare gli stream audio o video:
+
+`ffmpeg -i {{input_video}}.mkv -codec copy {{output_video}}.mp4`
+
+- Converti un video MP4 a codec VP9. Per ottenere la migliore qualità possibile, usa un valore di CRF (consigliabile tra 15-35) e -b:video DEVE essere 0:
+
+`ffmpeg -i {{input_video}}.mp4 -codec:video libvpx-vp9 -crf {{30}} -b:video 0 -codec:audio libopus -vbr on -threads {{number_of_threads}} {{output_video}}.webm`

--- a/pages.it/common/man.md
+++ b/pages.it/common/man.md
@@ -1,0 +1,23 @@
+# man
+
+> Formatta e mostra pagine manuale.
+
+- Mostra la pagina di manuale di un comando:
+
+`man {{comando}}`
+
+- Mostra la pagina di manuale per un comando dalla sezione 7:
+
+`man {{comando}}.{{7}}`
+
+- Mostra il percorso in cui vengono cercate le pagine:
+
+`man --path`
+
+- Mostra la posizione di una pagina invece che la pagina stessa:
+
+`man -w {{comando}}`
+
+- Cerca pagine di manuale che contengano una certa stringa:
+
+`man -k {{ricerca}}` 

--- a/pages.it/common/mount.md
+++ b/pages.it/common/mount.md
@@ -1,0 +1,27 @@
+# mount
+
+> Fornisce accesso a un intero filesystem in una cartella specifica.
+
+- Mostra tutti i filesystem montati:
+
+`mount`
+
+- Monta un dispositivo in una cartella:
+
+`mount -t {{tipo_di_filesystem}} {{percorso/al/dispositivo}} {{percorso/alla/cartella_desiderata}}`
+
+- Monta un CD-ROM (con il filetypo ISO9660) a /cdrom (sola lettura):
+
+`mount -t {{iso9660}} -o ro {{/dev/cdrom}} {{/cdrom}}`
+
+- Monta tutti i filesystem definiti in /etc/fstab:
+
+`mount -a`
+
+- Monta un filesystem specifico descritto in /etc/fstab (ad esempio "dev/sda1 /my_drive ext2 defaults 0 2"):
+
+`mount {{/my_drive}}`
+
+- Monta una cartella in un'altra cartella:
+
+`mount --bind {{percorso/alla/vecchia_cartella}} {{percorso/alla/nuova_cartella}}`

--- a/pages.it/common/mpv.md
+++ b/pages.it/common/mpv.md
@@ -1,0 +1,28 @@
+# mpv
+
+> Un player audio/video basato su MPlayer.
+> Maggiori informazioni: <https://mpv.io>.
+
+- Riproduci un file video o audio:
+
+`mpv {{file}}`
+
+- Salta avanti/indietro di 5 secondi:
+
+`SINISTRA <oppure> DESTRA`
+
+- Salta indietro/avanti di 1 minuto:
+
+`GIÙ <oppure> SU`
+
+- Riduci o aumenta la velocità di riproduzione del 10%:
+
+`[ <oppure> ]`
+
+- Riproduci un file a una velocità specifica (da 0.01 a 100, normalmente 1):
+
+`mpv --speed {{velocità}} {{file}}`
+
+- Riproduci un file usando un profilo definito nel file `mpv.conf`:
+
+`mpv --profile {{nome_profilo}} {{file}}`

--- a/pages.it/common/sudo.md
+++ b/pages.it/common/sudo.md
@@ -1,0 +1,23 @@
+# sudo
+
+> Esegue un singolo comando come superuser o come un altro utente.
+
+- Esegui un comando come superuser:
+
+`sudo {{less /var/log/syslog}}`
+
+- Modifica un file come superuser con il tuo editor di default:
+
+`sudo -e {{/etc/fstab}}`
+
+- Esegui un comando come un altro utente e/o gruppo:
+
+`sudo -u {{utente}} -g {{gruppo}} {{id -a}}`
+
+- Ripeti l'ultimo comando prefissandolo con "sudo" (funziona solo in bash, zsh, ecc):
+
+`sudo !!`
+
+- Fai partire la shell di default con i privilegi da superuser:
+
+`sudo -i`

--- a/pages.it/common/vim.md
+++ b/pages.it/common/vim.md
@@ -1,6 +1,6 @@
 # vim
 
-> Vi IMproved, un editor di testo per programamtori che fornisce diverse modalità per modificare testo.
+> Vi IMproved, un editor di testo per programmatori che fornisce diverse modalità per modificare testo.
 > Premi `i` per entrare in insert mode e `<Esc>` per tornare in normal mode dove non puoi inserire testo normalmente.
 > Maggiori informazioni: <https://www.vim.org>.
 

--- a/pages.it/common/zsh.md
+++ b/pages.it/common/zsh.md
@@ -1,0 +1,21 @@
+# zsh
+
+> Z SHell.
+> Inteprete da linea di comando compatibile con `bash` e `sh`.
+> Maggiori informazioni: <https://www.zsh.org>.
+
+- Fai partire l'interprete interattivo da linea di comando:
+
+`zsh`
+
+- Esegui un comando passandolo come parametro:
+
+`zsh -c {{comando}}`
+
+- Esegui comandi da un file (script):
+
+`zsh {{file}}`
+
+- Esegui comandi da un file e stampali a schermo mentre vengono eseguiti:
+
+`zsh -x {{file}}`


### PR DESCRIPTION
Italian translations for `ffmpeg`, `man`, `mount`, `mpv`, `sudo`, `zsh`. Also fixed a small typo in italian tldr page for `vim`.