### PR TITLE
env: add multi var set example

### DIFF
--- a/pages/common/env.md
+++ b/pages/common/env.md
@@ -21,3 +21,7 @@
 - Set a variable and run a program:
 
 `env {{variable}}={{value}} {{program}}`
+
+- Set multiple variables and run a program:
+
+`env {{variable1}}={{value}} {{variable2}}={{value}} {{variable3}}={{value}} {{program}}`


### PR DESCRIPTION
I had the question of whether or not I could set multiple variables before the command. I looked here first, but didn't' find it.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
