### PR TITLE
chore: remove locale from page urls

### DIFF
--- a/pages/common/dotnet-publish.md
+++ b/pages/common/dotnet-publish.md
@@ -1,7 +1,7 @@
 # dotnet publish
 
 > Publish a .NET application and its dependencies to a folder for deployment to a hosting system.
-> More information: <https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish>.
+> More information: <https://docs.microsoft.com/dotnet/core/tools/dotnet-publish>.
 
 - Compile a .NET project in release mode:
 

--- a/pages/windows/assoc.md
+++ b/pages/windows/assoc.md
@@ -1,7 +1,7 @@
 # assoc
 
 > Display or modify file extension associations.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/assoc>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/assoc>.
 
 - Display all associated filetypes:
 

--- a/pages/windows/attrib.md
+++ b/pages/windows/attrib.md
@@ -1,7 +1,7 @@
 # attrib
 
 > Displays or changes file and directory attributes.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/attrib>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/attrib>.
 
 - Display the attributes of the files in the current directory:
 

--- a/pages/windows/cd.md
+++ b/pages/windows/cd.md
@@ -1,7 +1,7 @@
 # cd
 
 > Displays the name of or changes the current working directory.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cd>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cd>.
 
 - Go to a directory in the same drive:
 

--- a/pages/windows/clip.md
+++ b/pages/windows/clip.md
@@ -1,7 +1,7 @@
 # clip
 
 > Copy input content to the Windows clipboard.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/clip>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/clip>.
 
 - Pipe command line output to the Windows clipboard:
 

--- a/pages/windows/cls.md
+++ b/pages/windows/cls.md
@@ -1,7 +1,7 @@
 # cls
 
 > Clears the screen.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cls>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cls>.
 
 - Clear the screen:
 

--- a/pages/windows/cmd.md
+++ b/pages/windows/cmd.md
@@ -1,7 +1,7 @@
 # cmd
 
 > The Windows command interpreter.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cmd>.
 
 - Start a new instance of the command interpreter:
 

--- a/pages/windows/cmstp.md
+++ b/pages/windows/cmstp.md
@@ -1,7 +1,7 @@
 # cmstp
 
 > A command line tool for managing connection service profiles.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmstp>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cmstp>.
 
 - Install a specific profile:
 

--- a/pages/windows/color.md
+++ b/pages/windows/color.md
@@ -1,7 +1,7 @@
 # color
 
 > Set the console foreground and background colors.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/color>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/color>.
 
 - Set the console colors to the default values:
 

--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -2,7 +2,7 @@
 
 > Compare the contents of two files or sets of files.
 > Use wildcards (*) to compare sets of files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/comp>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/comp>.
 
 - Compare files interactively:
 

--- a/pages/windows/del.md
+++ b/pages/windows/del.md
@@ -1,7 +1,7 @@
 # del
 
 > Delete one or more files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/del>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/del>.
 
 - Delete one or more space-separated files or patterns:
 

--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -1,7 +1,7 @@
 # dir
 
 > List directory contents.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/dir>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/dir>.
 
 - Show the contents of the current directory:
 

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -1,7 +1,7 @@
 # doskey
 
 > Manage macros, windows commands and command lines.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/doskey>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/doskey>.
 
 - List available macros:
 

--- a/pages/windows/driverquery.md
+++ b/pages/windows/driverquery.md
@@ -1,7 +1,7 @@
 # driverquery
 
 > Display information about installed device drivers.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/driverquery>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/driverquery>.
 
 - Display a list of all installed device drivers:
 

--- a/pages/windows/eventcreate.md
+++ b/pages/windows/eventcreate.md
@@ -2,7 +2,7 @@
 
 > Create custom entries in the event log.
 > Event IDs can be any number between 1 and 1000.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/eventcreate>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/eventcreate>.
 
 - Create a new event with a given id (1-1000) in the log:
 

--- a/pages/windows/exit.md
+++ b/pages/windows/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > Quit the current CMD instance or the current batch file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/exit>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/exit>.
 
 - Quit the current CMD instance:
 

--- a/pages/windows/expand.md
+++ b/pages/windows/expand.md
@@ -1,7 +1,7 @@
 # expand
 
 > Uncompress one or more Windows Cabinet files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/expand>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/expand>.
 
 - Uncompress a single-file Cabinet file to the specified directory:
 

--- a/pages/windows/fc.md
+++ b/pages/windows/fc.md
@@ -2,7 +2,7 @@
 
 > Compare the differences between two files or sets of files.
 > Use wildcards (*) to compare sets of files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fc>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/fc>.
 
 - Compare 2 specified files:
 

--- a/pages/windows/find.md
+++ b/pages/windows/find.md
@@ -1,7 +1,7 @@
 # find
 
 > Find a specified string in one or more files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/find>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/find>.
 
 - Find lines that contain a specified string:
 

--- a/pages/windows/findstr.md
+++ b/pages/windows/findstr.md
@@ -1,7 +1,7 @@
 # findstr
 
 > Find specified text within one or more files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/findstr>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/findstr>.
 
 - Find space-separated string(s) in all files:
 

--- a/pages/windows/finger.md
+++ b/pages/windows/finger.md
@@ -2,7 +2,7 @@
 
 > Return information about one or more users on a specified system.
 > The remote system must be running the Finger service.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/finger>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/finger>.
 
 - Display information about a specific user:
 

--- a/pages/windows/fondue.md
+++ b/pages/windows/fondue.md
@@ -1,7 +1,7 @@
 # fondue
 
 > A command line installer for optional Windows features.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fondue>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/fondue>.
 
 - Enable a specific Windows feature:
 

--- a/pages/windows/forfiles.md
+++ b/pages/windows/forfiles.md
@@ -1,7 +1,7 @@
 # forfiles
 
 > Select one or more files to execute a specified command on.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/forfiles>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/forfiles>.
 
 - Search for files in the current directory:
 

--- a/pages/windows/ftype.md
+++ b/pages/windows/ftype.md
@@ -1,7 +1,7 @@
 # ftype
 
 > Display or modify file types used for file extension association.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ftype>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/ftype>.
 
 - Display a list of all file types:
 

--- a/pages/windows/getmac.md
+++ b/pages/windows/getmac.md
@@ -1,7 +1,7 @@
 # getmac
 
 > Display the MAC addresses of a system.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/getmac>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/getmac>.
 
 - Display the MAC addresses for the current system:
 

--- a/pages/windows/ipconfig.md
+++ b/pages/windows/ipconfig.md
@@ -1,7 +1,7 @@
 # ipconfig
 
 > Display and manage the network configuration of Windows.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ipconfig>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/ipconfig>.
 
 - Show a list of network adapters:
 

--- a/pages/windows/logoff.md
+++ b/pages/windows/logoff.md
@@ -1,7 +1,7 @@
 # logoff
 
 > Terminate a login session.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/logoff>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/logoff>.
 
 - Terminate the current session:
 

--- a/pages/windows/mkdir.md
+++ b/pages/windows/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Creates a directory.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mkdir>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/mkdir>.
 
 - Create a directory:
 

--- a/pages/windows/mklink.md
+++ b/pages/windows/mklink.md
@@ -1,7 +1,7 @@
 # mklink
 
 > Create symbolic links.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/mklink>.
 
 - Create a symbolic link to a file:
 

--- a/pages/windows/more.md
+++ b/pages/windows/more.md
@@ -1,7 +1,7 @@
 # more
 
 > Display paginated output from `stdin` or a file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/more>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/more>.
 
 - Display paginated output from `stdin`:
 

--- a/pages/windows/msg.md
+++ b/pages/windows/msg.md
@@ -1,7 +1,7 @@
 # msg
 
 > Send a message to a specific user or session.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/msg>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/msg>.
 
 - Send a message to a specified user or session:
 

--- a/pages/windows/path.md
+++ b/pages/windows/path.md
@@ -1,7 +1,7 @@
 # path
 
 > Display or set the search path for executable files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/path>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/path>.
 
 - Display the current path:
 

--- a/pages/windows/pathping.md
+++ b/pages/windows/pathping.md
@@ -1,7 +1,7 @@
 # pathping
 
 > A trace route tool combining features of `ping` and `tracert`.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/pathping>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/pathping>.
 
 - Ping and trace the route to a host:
 

--- a/pages/windows/popd.md
+++ b/pages/windows/popd.md
@@ -1,7 +1,7 @@
 # popd
 
 > Changes the current directory to the directory stored by the `pushd` command.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/popd>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/popd>.
 
 - Switch to directory at the top of the stack:
 

--- a/pages/windows/print.md
+++ b/pages/windows/print.md
@@ -1,7 +1,7 @@
 # print
 
 > Print a text file to a printer.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/print>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/print>.
 
 - Print a text file to the default printer:
 

--- a/pages/windows/pushd.md
+++ b/pages/windows/pushd.md
@@ -2,7 +2,7 @@
 
 > Place a directory on a stack so it can be accessed later.
 > See also `popd` to switch back to original directory.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/pushd>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/pushd>.
 
 - Switch to directory and push it on the stack:
 

--- a/pages/windows/pwlauncher.md
+++ b/pages/windows/pwlauncher.md
@@ -1,7 +1,7 @@
 # pwlauncher
 
 > A command line tool for managing the Windows To Go startup options.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/pwlauncher>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/pwlauncher>.
 
 - Display the current Windows To Go status:
 

--- a/pages/windows/rdpsign.md
+++ b/pages/windows/rdpsign.md
@@ -1,7 +1,7 @@
 # rdpsign
 
 > A tool for signing Remote Desktop Protocol (RDP) files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/rdpsign>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/rdpsign>.
 
 - Sign an RDP file:
 

--- a/pages/windows/reg-add.md
+++ b/pages/windows/reg-add.md
@@ -1,7 +1,7 @@
 # reg add
 
 > Add new keys and their values to the registry.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-add>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-add>.
 
 - Add a new registry key:
 

--- a/pages/windows/reg-compare.md
+++ b/pages/windows/reg-compare.md
@@ -1,7 +1,7 @@
 # reg compare
 
 > Compare keys and their values in the registry.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-compare>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-compare>.
 
 - Compare all values under a specific key with a second key:
 

--- a/pages/windows/reg-copy.md
+++ b/pages/windows/reg-copy.md
@@ -1,7 +1,7 @@
 # reg copy
 
 > Copy keys and their values in the registry.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-copy>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-copy>.
 
 - Copy a registry key to a new registry location:
 

--- a/pages/windows/reg-delete.md
+++ b/pages/windows/reg-delete.md
@@ -1,7 +1,7 @@
 # reg delete
 
 > Delete keys or their values from the registry.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-delete>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-delete>.
 
 - Delete a specific registry key:
 

--- a/pages/windows/reg-export.md
+++ b/pages/windows/reg-export.md
@@ -1,7 +1,7 @@
 # reg export
 
 > Export the specified sub keys and values into a file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-export>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-export>.
 
 - Export all sub keys and values of a specific key:
 

--- a/pages/windows/reg-flags.md
+++ b/pages/windows/reg-flags.md
@@ -1,7 +1,7 @@
 # reg flags
 
 > Display or set flags on registry keys.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-flags>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-flags>.
 
 - Display current flags for a specific key:
 

--- a/pages/windows/reg-import.md
+++ b/pages/windows/reg-import.md
@@ -1,7 +1,7 @@
 # reg import
 
 > Import all available keys, subkeys, and values from a file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-import>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-import>.
 
 - Import all keys, subkeys and values from a file:
 

--- a/pages/windows/reg-load.md
+++ b/pages/windows/reg-load.md
@@ -2,7 +2,7 @@
 
 > Load saved sub keys into a different sub key in the registry.
 > This is intended for troubleshooting and temporary keys.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-load>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-load>.
 
 - Load a backup file into the specified key:
 

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -1,7 +1,7 @@
 # reg query
 
 > Display the values of keys and sub keys in the registry.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-query>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-query>.
 
 - Display all values of a key:
 

--- a/pages/windows/reg-restore.md
+++ b/pages/windows/reg-restore.md
@@ -2,7 +2,7 @@
 
 > Restore a key and its values from a backup file.
 > See `reg-save` for more information.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-restore>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-restore>.
 
 - Overwrite a specified key with data from a backup file:
 

--- a/pages/windows/reg-save.md
+++ b/pages/windows/reg-save.md
@@ -1,7 +1,7 @@
 # reg save
 
 > Save a registry key, its sub keys and values to a file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-save>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-save>.
 
 - Save a registry key, its sub keys and values to a specific file:
 

--- a/pages/windows/reg-unload.md
+++ b/pages/windows/reg-unload.md
@@ -1,7 +1,7 @@
 # reg unload
 
 > Remove data from the registry that was loaded using the `reg load` command.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg-unload>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg-unload>.
 
 - Remove data from the registry for a specified key:
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -2,7 +2,7 @@
 
 > A command line interface for managing keys and their values in the Windows registry.
 > See `reg-query`, `reg-add` and other pages for additional information.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/reg>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/reg>.
 
 - Execute registry commands:
 

--- a/pages/windows/repair-bde.md
+++ b/pages/windows/repair-bde.md
@@ -1,7 +1,7 @@
 # repair-bde
 
 > Attempt to repair or decrypt a damaged BitLocker-encrypted volume.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/repair-bde>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/repair-bde>.
 
 - Attempt to repair a specified volume:
 

--- a/pages/windows/rmdir.md
+++ b/pages/windows/rmdir.md
@@ -1,7 +1,7 @@
 # rmdir
 
 > Remove a directory and its contents.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/rmdir>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/rmdir>.
 
 - Remove an empty directory:
 

--- a/pages/windows/robocopy.md
+++ b/pages/windows/robocopy.md
@@ -2,7 +2,7 @@
 
 > Robust File and Folder Copy.
 > By default files will only be copied if the source and destination have different time stamps or different file sizes.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/robocopy>.
 
 - Copy all .jpg and .bmp files from one directory to another:
 

--- a/pages/windows/set.md
+++ b/pages/windows/set.md
@@ -1,7 +1,7 @@
 # set
 
 > Display or set environment variables for the current instance of CMD.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/set>.
 
 - List all current environment variables:
 

--- a/pages/windows/sfc.md
+++ b/pages/windows/sfc.md
@@ -1,7 +1,7 @@
 # sfc
 
 > Scans the integrity of Windows system files.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sfc>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/sfc>.
 
 - Display information about the usage of the command:
 

--- a/pages/windows/shutdown.md
+++ b/pages/windows/shutdown.md
@@ -1,7 +1,7 @@
 # shutdown
 
 > A tool for shutting down, restarting or logging off a machine.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/shutdown>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/shutdown>.
 
 - Shutdown the current machine:
 

--- a/pages/windows/subst.md
+++ b/pages/windows/subst.md
@@ -1,7 +1,7 @@
 # subst
 
 > Associates a path with a virtual drive letter.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/subst>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/subst>.
 
 - List active associations:
 

--- a/pages/windows/systeminfo.md
+++ b/pages/windows/systeminfo.md
@@ -1,7 +1,7 @@
 # systeminfo
 
 > Display operating system configuration for a local or remote machine.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/systeminfo>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/systeminfo>.
 
 - Display system configuration for the local machine:
 

--- a/pages/windows/takeown.md
+++ b/pages/windows/takeown.md
@@ -1,7 +1,7 @@
 # takeown
 
 > Take ownership of a file or directory.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/takeown>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/takeown>.
 
 - Take ownership of the specified file:
 

--- a/pages/windows/taskkill.md
+++ b/pages/windows/taskkill.md
@@ -1,7 +1,7 @@
 # taskkill
 
 > Terminate a process by its process id or name.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/taskkill>.
 
 - Terminate a process by its id:
 

--- a/pages/windows/tasklist.md
+++ b/pages/windows/tasklist.md
@@ -1,7 +1,7 @@
 # tasklist
 
 > Display a list of currently running processes on a local or remote machine.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tasklist>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/tasklist>.
 
 - Display currently running processes:
 

--- a/pages/windows/title.md
+++ b/pages/windows/title.md
@@ -1,7 +1,7 @@
 # title
 
 > Set the title of the command prompt window.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/title>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/title>.
 
 - Set the title of the current command prompt window:
 

--- a/pages/windows/tree.md
+++ b/pages/windows/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Display a graphical tree of the directory structure for a path.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tree>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/tree>.
 
 - Display the tree for the current directory:
 

--- a/pages/windows/tskill.md
+++ b/pages/windows/tskill.md
@@ -1,7 +1,7 @@
 # tskill
 
 > Ends a process running in a session on a Remote Desktop Session Host.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tskill>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/tskill>.
 
 - Terminate a process by its process identifier:
 

--- a/pages/windows/type.md
+++ b/pages/windows/type.md
@@ -1,7 +1,7 @@
 # type
 
 > Display the contents of a file.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/type>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/type>.
 
 - Display the contents of a specific file:
 

--- a/pages/windows/tzutil.md
+++ b/pages/windows/tzutil.md
@@ -1,7 +1,7 @@
 # tzutil
 
 > A tool for displaying or configuring the system time zone.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tzutil>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/tzutil>.
 
 - Get the current time zone:
 

--- a/pages/windows/ver.md
+++ b/pages/windows/ver.md
@@ -1,7 +1,7 @@
 # ver
 
 > Display the current Windows or MS-DOS version number.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ver>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/ver>.
 
 - Display the current version number:
 

--- a/pages/windows/vol.md
+++ b/pages/windows/vol.md
@@ -1,7 +1,7 @@
 # vol
 
 > Display information about volumes.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/vol>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/vol>.
 
 - Display the label and serial number for the current drive:
 

--- a/pages/windows/where.md
+++ b/pages/windows/where.md
@@ -2,7 +2,7 @@
 
 > Display the location of files that match the search pattern.
 > Defaults to current work directory and paths in the PATH environment variable.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/where>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/where>.
 
 - Display the location of file pattern:
 

--- a/pages/windows/whoami.md
+++ b/pages/windows/whoami.md
@@ -1,7 +1,7 @@
 # whoami
 
 > Display details about the current user.
-> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/whoami>.
+> More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/whoami>.
 
 - Display the username of the current user:
 

--- a/pages/windows/wsl.md
+++ b/pages/windows/wsl.md
@@ -1,7 +1,7 @@
 # wsl
 
 > Manage the Windows Subsystem for Linux from the command line.
-> More information: <https://docs.microsoft.com/en-us/windows/wsl/reference>.
+> More information: <https://docs.microsoft.com/windows/wsl/reference>.
 
 - Start a Linux shell (in the default distribution):
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

This just updates all Microsoft docs links to not use `en-us`, meaning that they will redirect to the user's locale.

This applies to most of the Windows pages, although there was also one in `common`.