### PR TITLE
tcpdump: fixed negation example

### DIFF
--- a/pages/common/tcpdump.md
+++ b/pages/common/tcpdump.md
@@ -29,7 +29,7 @@
 
 - Capture all traffic except traffic over port 22 and save to a dump file:
 
-`tcpdump -w {{dumpfile.pcap}} not port {{22}}`
+`tcpdump -w {{dumpfile.pcap}} port not {{22}}`
 
 - Read from a given dump file:
 


### PR DESCRIPTION
I found this typo while trying to dump all non-SSH traffic and was hitting a syntax error.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
