### PR TITLE
brew: use the term "formulae" for consistency

### DIFF
--- a/pages/osx/brew.md
+++ b/pages/osx/brew.md
@@ -3,7 +3,7 @@
 > Package manager for macOS.
 > More information: <https://brew.sh>.
 
-- Search for available formulas and casks:
+- Search for available formulae and casks:
 
 `brew search {{text}}`
 


### PR DESCRIPTION
Change "formulas" to "formulae" because that is what's used in the rest of the page.
Another thing - are you gonna be changing the name "osx" to "macos" or something because Big Sur will no longer officially be OS _X_ (No longer version 10)