### PR TITLE
svgo: add -o to second example

### DIFF
--- a/pages/common/svgo.md
+++ b/pages/common/svgo.md
@@ -10,7 +10,7 @@
 
 - Optimize a file and save the result to another file:
 
-`svgo {{test.svg}} {{test.min.svg}}`
+`svgo {{test.svg}} -o {{test.min.svg}}`
 
 - Optimize all SVG files within a directory (overwrites the original files):
 


### PR DESCRIPTION
I'm currently using svgo 1.3.2 which as of right now is the latest released version: https://github.com/svg/svgo/releases

The second command did not work and according to the help docs you need to specify `-o` to the output file, otherwise everything is treated as input files.

Without this change you will get an error like:
```
$ svgo email-03.svg email-03.min.svg
Error: Error: no such file or directory 'email-03.min.svg'.
```

Here's a link to the docs: https://github.com/svg/svgo#cli

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
