### PR TITLE
ansible: add German translation

### DIFF
--- a/pages.de/common/ansible.md
+++ b/pages.de/common/ansible.md
@@ -1,0 +1,29 @@
+# ansible
+
+> Verwalten von Computergruppen per Fernzugriff über SSH.
+> Verwenden Sie die Datei /etc/ansible/hosts, um neue Gruppen/Hosts hinzuzufügen.
+> Weitere Informationen: <https://www.ansible.com/>.
+
+- Hosts auflisten, die zu einer Gruppe gehören:
+
+`ansible {{Gruppe}} --list-hosts`
+
+- Pingen Sie eine Gruppe von Hosts an, indem Sie das Ping-Modul aufrufen:
+
+`mögliche {{Gruppe}} -m ping`
+
+- Zeigen Sie Fakten über eine Gruppe von Hosts an, indem Sie das Setup-Modul aufrufen:
+
+`mögliche {{Gruppe}} -m setup`
+
+- Führen Sie einen Befehl auf einer Gruppe von Hosts aus, indem Sie das Command-Modul mit Argumenten aufrufen:
+
+`mögliche {{Gruppe}} -m command -a '{{mein_command}}'`
+
+- Führen Sie einen Befehl mit administrativen Privilegien aus:
+
+`möglich {{Gruppe}} --become --ask-become-pass -m command -a '{{mein_command}}'`
+
+- Führen Sie einen Befehl mit einer benutzerdefinierten Inventardatei aus:
+
+`möglich {{Gruppe}} -i {{Inventardatei}} -m command -a '{{mein_command}}'`


### PR DESCRIPTION
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
 
Added German translation for Ansible.