### PR TITLE
git-describe: add page

### DIFF
--- a/pages/common/git-describe.md
+++ b/pages/common/git-describe.md
@@ -1,0 +1,24 @@
+# git describe
+
+> Give an object a human readable name based on an available ref.
+> More information: <https://git-scm.com/docs/git-describe>.
+
+- Create a unique name for the current commit (the name contains the most recent annotated tag, the number of additional commits, and the abbreviated commit hash):
+
+`git describe`
+
+- Create a name with 4 digits for the abbreviated commit hash:
+
+`git describe --abbrev={{4}}`
+
+- Generate a name with the tag reference path:
+
+`git describe --all`
+
+- Describe a git tag:
+
+`git describe {{v1.0.0}}`
+
+- Create a name for the last commit of a given branch:
+
+`git describe {{branch_name}}`


### PR DESCRIPTION
# Description

add a page for git describe command.
git describe is a command from the git scm software.

# Linked Issues:

* [Let's document git](https://github.com/tldr-pages/tldr/issues/3953)

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
