### PR TITLE
openssl-prime: add page

### DIFF
--- a/pages/common/openssl-genrsa.md
+++ b/pages/common/openssl-genrsa.md
@@ -1,7 +1,7 @@
 # openssl genrsa
 
 > OpenSSL command to generate RSA private keys.
-> More information: <https://www.openssl.org/docs/man1.0.2/man1/genrsa.html>.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-genrsa.html>.
 
 - Generate an RSA private key of 2048 bits to stdout:
 

--- a/pages/common/openssl-prime.md
+++ b/pages/common/openssl-prime.md
@@ -3,10 +3,10 @@
 > OpenSSL command to compute prime numbers.
 > More information: <https://www.openssl.org/docs/manmaster/man1/openssl-prime.html>.
 
-- Generate a 2048bit prime number in hexadecimal format:
+- Generate a 2048bit prime number and display it in hexadecimal:
 
 `openssl prime -generate -bits 2048 -hex`
 
-- Check if given number is prime:
+- Check if a given number is prime:
 
 `openssl prime {{number}}`

--- a/pages/common/openssl-prime.md
+++ b/pages/common/openssl-prime.md
@@ -1,0 +1,10 @@
+# openssl prime
+
+> OpenSSL command to compute prime numbers.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-prime.html>.
+
+`openssl prime -generate -bits 2048 -hex`
+
+- Check if given number is prime:
+
+`openssl prime {{number}}`

--- a/pages/common/openssl-prime.md
+++ b/pages/common/openssl-prime.md
@@ -3,6 +3,8 @@
 > OpenSSL command to compute prime numbers.
 > More information: <https://www.openssl.org/docs/manmaster/man1/openssl-prime.html>.
 
+- Generate a 2048bit prime number in hexadecimal format:
+
 `openssl prime -generate -bits 2048 -hex`
 
 - Check if given number is prime:

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -34,11 +34,3 @@
 - Display the complete certificate chain of an HTTPS server:
 
 `openssl s_client -connect {{host}}:443 -showcerts </dev/null`
-
-- Generate a 2048bit prime number in hexadecimal format:
-
-`openssl prime -generate -bits 2048 -hex`
-
-- Check if given number is prime:
-
-`openssl prime {{number}}`

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -34,3 +34,11 @@
 - Display the complete certificate chain of an HTTPS server:
 
 `openssl s_client -connect {{host}}:443 -showcerts </dev/null`
+
+- Generate a 2048bit prime number in hexadecimal format:
+
+`openssl prime -generate -bits 2048 -hex`
+
+- Check if given number is prime:
+
+`openssl prime {{number}}`


### PR DESCRIPTION
Added two command for prime numbers. One generates a prime number, the other checks if given number is prime.

**Rational for exceeding 8 examples limit**:
I'm aware that this tldr page already has 8 examples, however all current examples are related to certificates. Direct generation of prime numbers using cryptographically secure methods is also a useful, even if it is just a niche function of openssl.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->
 
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).