### PR TITLE
cryfs, df, dfc, fls, ipfs, duperemove, edquote, lsattr, diskutil: consistently use "filesystem"

### DIFF
--- a/pages/common/cryfs.md
+++ b/pages/common/cryfs.md
@@ -3,11 +3,11 @@
 > A cryptographic filesystem for the cloud.
 > More information: <https://www.cryfs.org/>.
 
-- Mount an encrypted file system. The initialization wizard will be started on the first execution:
+- Mount an encrypted filesystem. The initialization wizard will be started on the first execution:
 
 `cryfs {{path/to/cipher_dir}} {{path/to/mount_point}}`
 
-- Unmount an encrypted file system:
+- Unmount an encrypted filesystem:
 
 `cryfs-unmount {{path/to/mount_point}}`
 

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -1,16 +1,16 @@
 # df
 
-> Gives an overview of the file system disk space usage.
+> Gives an overview of the filesystem disk space usage.
 
-- Display all file systems and their disk usage:
+- Display all filesystems and their disk usage:
 
 `df`
 
-- Display all file systems and their disk usage in human readable form:
+- Display all filesystems and their disk usage in human readable form:
 
 `df -h`
 
-- Display the file system and its disk usage containing the given file or directory:
+- Display the filesystem and its disk usage containing the given file or directory:
 
 `df {{path/to/file_or_directory}}`
 
@@ -18,6 +18,6 @@
 
 `df -i`
 
-- Display file systems but exclude the specified type:
+- Display filesystems but exclude the specified type:
 
 `df -x {{squashfs}} -x {{tmpfs}}`

--- a/pages/common/dfc.md
+++ b/pages/common/dfc.md
@@ -7,7 +7,7 @@
 
 `dfc`
 
-- Display all filesystems including pseudo, duplicate and inaccessible file systems:
+- Display all filesystems including pseudo, duplicate and inaccessible filesystems:
 
 `dfc -a`
 
@@ -15,6 +15,6 @@
 
 `dfc -c never`
 
-- Display filesystems containing "ext" in the file system type:
+- Display filesystems containing "ext" in the filesystem type:
 
 `dfc -t ext`

--- a/pages/common/fls.md
+++ b/pages/common/fls.md
@@ -7,7 +7,7 @@
 
 `fls -r -m {{C:}} {{/dev/loop1p1}}`
 
-- Analyse a single partition, providing the sector offset at which the file system starts in the image:
+- Analyse a single partition, providing the sector offset at which the filesystem starts in the image:
 
 `fls -r -m {{C:}} -o {{sector}} {{path/to/image_file}}`
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -4,11 +4,11 @@
 > A peer-to-peer hypermedia protocol. Aims to make the web more open.
 > More information: <https://ipfs.io>.
 
-- Add a file from local to the file system, pin it and print the relative hash:
+- Add a file from local to the filesystem, pin it and print the relative hash:
 
 `ipfs add {{filename}}`
 
-- Add a directory and its files recursively from local to the file system and print the relative hash:
+- Add a directory and its files recursively from local to the filesystem and print the relative hash:
 
 `ipfs add -r {{directory}}`
 

--- a/pages/linux/duperemove.md
+++ b/pages/linux/duperemove.md
@@ -1,15 +1,15 @@
 # duperemove
 
-> Finds duplicate file system extents and optionally schedule them for deduplication.
-> An extent is small part of a file inside the file system.
-> On some file systems one extent can be referenced multiple times, when parts of the content of the files are identical.
+> Finds duplicate filesystem extents and optionally schedule them for deduplication.
+> An extent is small part of a file inside the filesystem.
+> On some filesystems one extent can be referenced multiple times, when parts of the content of the files are identical.
 > More information: <https://markfasheh.github.io/duperemove/>.
 
 - Search for duplicate extents in a directory and show them:
 
 `duperemove -r {{path/to/directory}}`
 
-- Deduplicate duplicate extents on a Btrfs or XFS (experimental) file system:
+- Deduplicate duplicate extents on a Btrfs or XFS (experimental) filesystem:
 
 `duperemove -r -d {{path/to/directory}}`
 

--- a/pages/linux/edquota.md
+++ b/pages/linux/edquota.md
@@ -1,6 +1,6 @@
 # edquota
 
-> Edit quotas for a user or group. By default it operates on all file systems with quotas.
+> Edit quotas for a user or group. By default it operates on all filesystems with quotas.
 > Quota information is stored permanently in the `quota.user` and `quota.group` files in the root of the filesystem.
 
 - Edit quota of the current user:

--- a/pages/linux/lsattr.md
+++ b/pages/linux/lsattr.md
@@ -1,6 +1,6 @@
 # lsattr
 
-> List file attributes on a Linux file system.
+> List file attributes on a Linux filesystem.
 
 - Display the attributes of the files in the current directory:
 

--- a/pages/osx/diskutil.md
+++ b/pages/osx/diskutil.md
@@ -6,7 +6,7 @@
 
 `diskutil list`
 
-- Repair the file system data structures of a volume:
+- Repair the filesystem data structures of a volume:
 
 `diskutil repairVolume {{/dev/diskX}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The pages follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

In https://github.com/tldr-pages/tldr/pull/4379#discussion_r498534894 I mentioned making a PR to use "filesystem" consistently instead of "file system" in `df`. What I've done instead is do it for all occurrences I could find (which to my surprise also made me realise that I managed to miss 2 inside `dfc` after having said that I fixed it which is my bad).

I ran `grep -Hni "file system" */*` inside the pages directory to get a list of all files containing the words "file system" and those (with two exceptions) are the pages I've changed in this PR.

In [ipfs](https://github.com/tldr-pages/tldr/blame/master/pages/common/ipfs.md#L3) I left "Inter Planetary File System" as is as that's a name and is how its written in the [ipfs docs](https://docs.ipfs.io/).
And in [mount (windows)](https://github.com/tldr-pages/tldr/blame/master/pages/windows/mount.md#L3) I left "Network File System" as it is also a name.

