### PR TITLE
ocaml*: add ocamlopt and ocamlfind and improve existing ocaml* pages.

### DIFF
--- a/pages/common/ocaml.md
+++ b/pages/common/ocaml.md
@@ -2,6 +2,7 @@
 
 > The OCaml repl (read-evaluate-print-loop).
 > Interprets Ocaml commands.
+> More information: <https://ocaml.org>.
 
 - Read OCaml commands from the user and execute them:
 

--- a/pages/common/ocamlc.md
+++ b/pages/common/ocamlc.md
@@ -2,6 +2,7 @@
 
 > The OCaml bytecode compiler.
 > Produces executables runnable by the OCaml interpreter.
+> More information: <https://ocaml.org>.
 
 - Create a binary from a source file:
 
@@ -10,3 +11,7 @@
 - Create a named binary from a source file:
 
 `ocamlc -o {{path/to/binary}} {{path/to/source_file.ml}}`
+
+- Automatically generate a module signature (interface) file:
+
+`ocamlc -i {{path/to/source_file.ml}}`

--- a/pages/common/ocamlfind.md
+++ b/pages/common/ocamlfind.md
@@ -1,0 +1,17 @@
+# ocamlfind
+
+> The findlib package manager for OCaml.
+> Simplifies linking executables with external libraries.
+> More information: <http://projects.camlcity.org/projects/findlib.html>.
+
+- Compile a source file to a native binary and link with packages:
+
+`ocamlfind ocamlopt -package {{package1}},{{package2}} -linkpkg -o {{executable}} {{source_file.ml}}`
+
+- Compile a source file to a bytecode binary and link with packages:
+
+`ocamlfind ocamlc -package {{package1}},{{package2}} -linkpkg -o {{executable}} {{source_file.ml}}`
+
+- Cross-compile for a different platform:
+
+`ocamlfind -toolchain {{cross-toolchain}} ocamlopt -o {{executable}} {{source_file.ml}}`

--- a/pages/common/ocamlopt.md
+++ b/pages/common/ocamlopt.md
@@ -1,0 +1,13 @@
+# ocamlopt
+
+> The OCaml native code compiler.
+> Produces native executables, e.g. ELF on Linux.
+> More information: <https://ocaml.org>.
+
+- Compile a source file:
+
+`ocamlopt -o {{path/to/binary}} {{path/to/source_file.ml}}`
+
+- Compile with debugging enabled:
+
+`ocamlopt -g -o {{path/to/binary}} {{path/to/source_file.ml}}`


### PR DESCRIPTION
* New pages: ocamlopt (native code compiler), ocamlfind (library manager).
* New example for ocamlc: automatic module generation.
* Homepage links in all `ocaml*` pages.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
