### PR TITLE
Checkout all branches in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up PR environment
       if: github.event.number != null

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -49,7 +49,7 @@ function check_diff {
   local line
   local entry
 
-  git_diff=$(git diff --name-status --find-copies-harder --diff-filter=AC --relative=pages/ master)
+  git_diff=$(git diff --name-status --find-copies-harder --diff-filter=AC --relative=pages/ remotes/origin/master)
 
   if [ -n "$git_diff" ]; then
     echo -e "Check PR: git diff:\n$git_diff" >&2


### PR DESCRIPTION
By default, `actions/checkout@v2` only checks out the latest commit of the current branch. Unfortunately, this causes the `git diff` check in `check-pr.sh` to fail, as `master` branch isn't available.

This change checks out all commits of all branches, which allows `git diff` to work correctly.

Ideally, I'd like to use the `ref` setting of `actions/checkout@v2`, but that only supports a single ref so it's not possible to check out the PR branch _and_ `master` branch at the same time.