### PR TITLE
(chore) replace master/slave with inclusive language

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -85,7 +85,7 @@ tldr --platform osx bash
 
 This section documents the directory structure that contains the pages themselves.
 
-The master version of every page is stored inside (but not directly) the `pages` directory. Inside this directory, there is a folder for each platform - for example `windows`, `linux`, and the special `common` platform:
+The primary (English) version of every page is stored inside (but not directly in) the `pages` directory. Inside this directory, there is a folder for each platform - for example `windows`, `linux`, and the special `common` platform:
 
  - `pages/`
    - `common/`
@@ -107,7 +107,7 @@ Command name    | Mapped name     | Filename
 
 ### Translations
 
-Other directories sit alongside the main `pages` directory, and contain translations of the master versions of every page - though pages MAY NOT have a translation available for a given language yet. Furthermore, a given language MAY NOT have a folder yet either. The format of these directories is `pages.<locale>`, where `<locale>` is a [POSIX Locale Name](https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html#Locale-Names) in the form of `<language>_<country>`, where:
+Other directories sit alongside the main `pages` directory, and contain translations of the English versions of every page - though pages MAY NOT have a translation available for a given language yet. Furthermore, a given language MAY NOT have a folder yet either. The format of these directories is `pages.<locale>`, where `<locale>` is a [POSIX Locale Name](https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html#Locale-Names) in the form of `<language>_<country>`, where:
 
  - `<language>` is the shortest [ISO 639](https://en.wikipedia.org/wiki/ISO_639) language code for the chosen language (see [here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) for a complete list).
  - `<country>` is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) country code for the chosen region (see [here](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) for a complete list).

--- a/pages.es/common/git-rebase.md
+++ b/pages.es/common/git-rebase.md
@@ -4,9 +4,9 @@
 > Se utiliza comúnmente para "mover" una rama entera a otra base, ya que crea copias de los commits en una nueva ubicación.
 > Más información: <https://git-scm.com/docs/git-rebase>.
 
-- Rebasa la rama actual en lo más alto de la rama master:
+- Rebasa la rama actual en lo más alto de la rama main:
 
-`git rebase {{master}}`
+`git rebase {{main}}`
 
 - Inicia un rebase interactivo que permite reordenar los commits, omitirlos, combinarlos o modificarlos:
 
@@ -34,4 +34,4 @@
 
 - Resuelve automáticamente cualquier conflicto favoreciendo la versión de la rama en la que se esta trabajando (en este caso la palabra `theirs` tiene un significado invertido):
 
-`git rebase -X theirs {{master}}`
+`git rebase -X theirs {{main}}`

--- a/pages.es/common/git-rev-list.md
+++ b/pages.es/common/git-rev-list.md
@@ -9,7 +9,7 @@
 
 - Muestra los commits más reciente a partir de una fecha y una rama específica:
 
-`git rev-list --since={{'2019-12-01 00:00:00'}} {{master}}`
+`git rev-list --since={{'2019-12-01 00:00:00'}} {{main}}`
 
 - Muestra todos los commits fusionados en un commit específico:
 

--- a/pages.es/common/git-revert.md
+++ b/pages.es/common/git-revert.md
@@ -13,7 +13,7 @@
 
 - Revierte múltiples commits:
 
-`git revert {{master~5..master~2}}`
+`git revert {{main~5..main~2}}`
 
 - No crea nuevos commits, solo cambia el árbol de trabajo:
 

--- a/pages/common/git-rebase.md
+++ b/pages/common/git-rebase.md
@@ -4,9 +4,9 @@
 > Commonly used to "move" an entire branch to another base, creating copies of the commits in the new location.
 > More information: <https://git-scm.com/docs/git-rebase>.
 
-- Rebase the current branch on top of the master branch:
+- Rebase the current branch on top of the main branch:
 
-`git rebase {{master}}`
+`git rebase {{main}}`
 
 - Start an interactive rebase, which allows the commits to be reordered, omitted, combined or modified:
 
@@ -34,4 +34,4 @@
 
 - Auto-resolve any conflicts by favoring the working branch version (`theirs` keyword has reversed meaning in this case):
 
-`git rebase -X theirs {{master}}`
+`git rebase -X theirs {{main}}`

--- a/pages/common/git-request-pull.md
+++ b/pages/common/git-request-pull.md
@@ -3,10 +3,10 @@
 > Generate a request asking the upstream project to pull changes into its tree.
 > More information: <https://git-scm.com/docs/git-request-pull>.
 
-- Produce a request summarizing the changes between the v1.1 release and master:
+- Produce a request summarizing the changes between the v1.1 release and main:
 
-`git request-pull {{v1.1}} {{https://example.com/project}} {{master}}`
+`git request-pull {{v1.1}} {{https://example.com/project}} {{main}}`
 
-- Produce a request summarizing the changes between the v0.1 release on master branch and local foo branch:
+- Produce a request summarizing the changes between the v0.1 release on main branch and local foo branch:
 
-`git request-pull {{v0.1}} {{https://example.com/project}} {{master:foo}}`
+`git request-pull {{v0.1}} {{https://example.com/project}} {{main:foo}}`

--- a/pages/common/git-rev-list.md
+++ b/pages/common/git-rev-list.md
@@ -9,7 +9,7 @@
 
 - List commits more recent than a specific date, on a specific branch:
 
-`git rev-list --since={{'2019-12-01 00:00:00'}} {{master}}`
+`git rev-list --since={{'2019-12-01 00:00:00'}} {{main}}`
 
 - List all merge commits on a specific commit:
 

--- a/pages/common/git-revert.md
+++ b/pages/common/git-revert.md
@@ -13,7 +13,7 @@
 
 - Revert multiple commits:
 
-`git revert {{master~5..master~2}}`
+`git revert {{main~5..main~2}}`
 
 - Don't create new commits, just change the working tree:
 

--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -5,19 +5,19 @@
 
 - Add a git repository as a subtree:
 
-`git subtree add --prefix={{path/to/directory/}} --squash {{repository_url}} {{master}}`
+`git subtree add --prefix={{path/to/directory/}} --squash {{repository_url}} {{main}}`
 
 - Update subtree repository to its latest commit:
 
-`git subtree pull --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
+`git subtree pull --prefix={{path/to/directory/}} {{repository_url}} {{main}}`
 
-- Merge a subtree repository into master:
+- Merge a subtree repository into main:
 
-`git subtree merge --prefix={{path/to/directory/}} --squash {{repository_url}} {{master}}`
+`git subtree merge --prefix={{path/to/directory/}} --squash {{repository_url}} {{main}}`
 
 - Push commits to a subtree repository:
 
-`git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{master}}`
+`git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{main}}`
 
 - Extract a new project history from the history of a subtree:
 

--- a/pages/common/gocryptfs.md
+++ b/pages/common/gocryptfs.md
@@ -11,7 +11,7 @@
 
 `gocryptfs {{path/to/cipher_dir}} {{path/to/mount_point}}`
 
-- Mount with the explicit primary key instead of password:
+- Mount with the explicit master key instead of password:
 
 `gocryptfs --masterkey {{path/to/cipher_dir}} {{path/to/mount_point}}`
 

--- a/pages/common/gocryptfs.md
+++ b/pages/common/gocryptfs.md
@@ -11,7 +11,7 @@
 
 `gocryptfs {{path/to/cipher_dir}} {{path/to/mount_point}}`
 
-- Mount with the explicit master key instead of password:
+- Mount with the explicit primary key instead of password:
 
 `gocryptfs --masterkey {{path/to/cipher_dir}} {{path/to/mount_point}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

In an effort to promote more inclusive language, replacing the words master/slave where applicable (other than in the names of repository/branch links). [GitHub is changing the default branch name](https://github.com/github/renaming) from `master` to `main`, so these examples will be more accurate in the future with the new terminology.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
