### PR TITLE
htpdate: add page

### DIFF
--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -6,7 +6,7 @@
 
 - Synchronize date and time:
 
-`htpdate {{host}}`
+`sudo htpdate {{host}}`
 
 - Perform simulation of syncronization, without any action:
 
@@ -14,8 +14,8 @@
 
 - Compensate the systematisch clock drift:
 
-`htpdate -x {{host}}`
+`sudo htpdate -x {{host}}`
 
 - Set time immediate after the syncronization:
 
-`htpdate -s {{host}}`
+`sudo htpdate -s {{host}}`

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -11,3 +11,11 @@
 - Perform simulation of syncronization, without any action:
 
 `htpdate -q {{host}}`
+
+- Compensate the systematisch clock drift:
+
+`htpdate -x {{host}}`
+
+- Set time immediate after the syncronization:
+
+`htpdate -s {{host}}`

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -6,8 +6,8 @@
 
 - Synchronize date and time:
 
-`sudo htpdate {{host}}`
+`htpdate {{host}}`
 
 - Perform simulation of syncronization, without any action:
 
-`sudo htpdate -q {{host}}`
+`htpdate -q {{host}}`

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -2,12 +2,12 @@
 
 > Synchronize local date and time via HTTP headers from web servers.
 > Requires administrator privileges.
-> More information: <http://www.rkeene.org/oss/htp/>
+> More information: <http://www.rkeene.org/oss/htp/>.
 
-- Synchronize date and time
+- Synchronize date and time:
 
 `sudo htpdate {{host}}`
 
-- Perform simulation of syncronization, without any action
+- Perform simulation of syncronization, without any action:
 
 `sudo htpdate -q {{host}}`

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -1,0 +1,13 @@
+# htpdate
+
+> Synchronize local date and time via HTTP headers from web servers.
+> Requires administrator privileges.
+> More information: <http://www.rkeene.org/oss/htp/>
+
+- Synchronize date and time
+
+`sudo htpdate {{host}}`
+
+- Perform simulation of syncronization, without any action
+
+`sudo htpdate -q {{host}}`

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -2,7 +2,7 @@
 
 > Synchronize local date and time via HTTP headers from web servers.
 > Requires administrator privileges.
-> More information: <http://www.rkeene.org/oss/htp/>.
+> More information: <http://www.vervest.org/htp/>.
 
 - Synchronize date and time:
 

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -1,7 +1,6 @@
 # htpdate
 
 > Synchronize local date and time via HTTP headers from web servers.
-> Requires administrator privileges.
 > More information: <http://www.vervest.org/htp/>.
 
 - Synchronize date and time:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Since I have only used `htpdate` command in Linux systems, I have not placed in common.

### References

* [htpdate(8) - Linux man page](https://linux.die.net/man/8/htpdate)
* [Keene Enterprises :: Open Source :: HTP](http://www.rkeene.org/oss/htp/)
* [ntpdate(8) - Linux man page](https://linux.die.net/man/8/ntpdate)
