### PR TITLE
fail2ban-client: add page

### DIFF
--- a/pages/linux/fail2ban-client.md
+++ b/pages/linux/fail2ban-client.md
@@ -1,0 +1,16 @@
+# fail2ban-client
+
+> Configure and control fail2ban server
+> More information: <https://github.com/fail2ban/fail2ban/>
+
+- Gets the current status of the jail service:
+
+`fail2ban-client status {{jail}}`
+
+- Manually unban IP from the jail service:
+
+`fail2ban-client set {{jail}} unbanip {{ip}}`
+
+- Verify fail2ban server is alive:
+
+`fail2ban-client ping`

--- a/pages/linux/fail2ban-client.md
+++ b/pages/linux/fail2ban-client.md
@@ -1,7 +1,7 @@
 # fail2ban-client
 
 > Configure and control fail2ban server.
-> More information: <https://github.com/fail2ban/fail2ban/>.
+> More information: <https://github.com/fail2ban/fail2ban>.
 
 - Retrieve current status of the jail service:
 

--- a/pages/linux/fail2ban-client.md
+++ b/pages/linux/fail2ban-client.md
@@ -7,7 +7,7 @@
 
 `fail2ban-client status {{jail}}`
 
-- Manually unban IP from the jail service:
+- Remove the specified IP from the jail service's ban list:
 
 `fail2ban-client set {{jail}} unbanip {{ip}}`
 

--- a/pages/linux/fail2ban-client.md
+++ b/pages/linux/fail2ban-client.md
@@ -1,9 +1,9 @@
 # fail2ban-client
 
-> Configure and control fail2ban server
-> More information: <https://github.com/fail2ban/fail2ban/>
+> Configure and control fail2ban server.
+> More information: <https://github.com/fail2ban/fail2ban/>.
 
-- Gets the current status of the jail service:
+- Retrieve current status of the jail service:
 
 `fail2ban-client status {{jail}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Since I have only used `fail2ban-client` command in Linux systems, I have not placed in common. I have seen that `fail2ban-client` can be installed in Mac with [MacPorts](https://ports.macports.org/port/fail2ban/summary), but since Mac installation is not supported in [Wiki installation documentation page](https://github.com/fail2ban/fail2ban/wiki/How-to-install-or-upgrade-fail2ban-manually), I have just included it in `linux` directory.

Moreover, I have documented the main options I usually use, for example, to manage `nginx-http-auth` jail.

### References
* [fail2ban commands](https://www.fail2ban.org/wiki/index.php/Commands)
* [GitHub repository](https://github.com/fail2ban/fail2ban/)
* [fail2ban-client(1) - Linux man page](https://linux.die.net/man/1/fail2ban-client)