### PR TITLE
basename: change description and add directory example

### DIFF
--- a/pages/common/basename.md
+++ b/pages/common/basename.md
@@ -1,10 +1,14 @@
 # basename
 
-> Returns non-directory portion of a pathname.
+> Removes leading directory portions from a path.
 
 - Show only the file name from a path:
 
 `basename {{path/to/file}}`
+
+- Show only the rightmost directory name from a path:
+
+`basename {{path/to/directory/}}`
 
 - Show only the file name from a path, with a suffix removed:
 

--- a/pages/common/basename.md
+++ b/pages/common/basename.md
@@ -1,6 +1,6 @@
 # basename
 
-> Removes leading directory portions from a path.
+> Remove leading directory portions from a path.
 
 - Show only the file name from a path:
 


### PR DESCRIPTION
The previous description was wrong, because `basename {{path/to/directory/}}` does not return the non-directory portion of the specified path (which would be the empty string), but `directory`.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
