### PR TITLE
scoop: add cleanup example

### DIFF
--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -34,3 +34,7 @@
 - Add a bucket by its alias or a Git repository URL:
 
 `scoop bucket add {{bucket}}`
+
+- Remove old versions of all packages and clear the download cache:
+
+`scoop cleanup -k *`

--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -27,14 +27,6 @@
 
 `scoop search {{package}}`
 
-- List all known buckets (a bucket is an application repository):
-
-`scoop bucket known`
-
-- Add a bucket by its alias or a Git repository URL:
-
-`scoop bucket add {{bucket}}`
-
 - Remove old versions of all packages and clear the download cache:
 
 `scoop cleanup -k *`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples. 
_Please see below, I want to discuss which example should be removed or moved to it's own page._
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

Hello,

I've been using scoop for more than a year now and sometime I was beginning to wonder why my SSD, where `scoop` was installed, has been filling up so fast. At this time, I didn't know, that scoop doesn't automatically removes old versions of installed software. To do this you have to run the `scoop cleanup *` command manually. Just recently I discoverd, that by using the `-k` option, also the download cache of old software would be cleared. That's the reason why I think, it's worth adding this example. 

But there are now eight examples in this file. This is according to your guidelines not allowed. I would propose to move the two `bucket` commands into the separate file `scoop-bucket.md`, because both of them could be important for using this application. If you agree with my idea, please let me know and I'll implement it by creating an additional commit.
