### PR TITLE
scoop-bucket: add page

### DIFF
--- a/pages/windows/scoop-bucket.md
+++ b/pages/windows/scoop-bucket.md
@@ -1,7 +1,7 @@
 # scoop bucket
 
-> A bucket is a Git repository containing files which describe how scoop installs applications.
-> If Scoop doesn't know where the bucket is located we have to specify its repository location.
+> Manage buckets: Git repositories containing files which describe how scoop installs applications.
+> If Scoop doesn't know where the bucket is located its repository location must be specified.
 > More information: <https://github.com/lukesampson/scoop/wiki/Buckets>.
 
 - List all buckets currently in use:

--- a/pages/windows/scoop-bucket.md
+++ b/pages/windows/scoop-bucket.md
@@ -1,6 +1,6 @@
 # scoop bucket
 
-> A bucket is Git repository containing files which describe how scoop installs applications.
+> A bucket is a Git repository containing files which describe how scoop installs applications.
 > If Scoop doesn't know where the bucket is located we have to specify its repository location.
 > More information: <https://github.com/lukesampson/scoop/wiki/Buckets>.
 

--- a/pages/windows/scoop-bucket.md
+++ b/pages/windows/scoop-bucket.md
@@ -1,7 +1,7 @@
 # scoop bucket
 
-> A bucket is an application repository.
-> Some buckets are already known to scoop, so you don't have to provide an url.
+> A bucket is Git repository containing files which describe how scoop installs applications.
+> If Scoop doesn't know where the bucket is located we have to specify its repository location.
 > More information: <https://github.com/lukesampson/scoop/wiki/Buckets>.
 
 - List all buckets currently in use:
@@ -16,9 +16,9 @@
 
 `scoop bucket add {{name}}`
 
-- Add an unknown bucket by its name and Git repository url:
+- Add an unknown bucket by its name and Git repository URL:
 
-`scoop bucket add {{name}} {{repository}}`
+`scoop bucket add {{name}} {{https://example.com/repository.git}}`
 
 - Remove a bucket by its name:
 

--- a/pages/windows/scoop-bucket.md
+++ b/pages/windows/scoop-bucket.md
@@ -1,0 +1,25 @@
+# scoop bucket
+
+> A bucket is an application repository.
+> Some buckets are already known to scoop, so you don't have to provide an url.
+> More information: <https://github.com/lukesampson/scoop/wiki/Buckets>.
+
+- List all buckets currently in use:
+
+`scoop bucket list`
+
+- List all known buckets:
+
+`scoop bucket known`
+
+- Add a known bucket by its name:
+
+`scoop bucket add {{name}}`
+
+- Add an unknown bucket by its name and Git repository url:
+
+`scoop bucket add {{name}} {{repository}}`
+
+- Remove a bucket by its name:
+
+`scoop bucket rm {{name}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

Hello,

this is the follow-up pull request for #4531.
I'm creating a new `scoop-bucket.md` page to keep the eight example limit on the `scoop.md` page. 

If you compare the two old bucket examples on the `scoop.md` page to this page, you may see that I've added three options.
1. I guess it's useful to see, which buckets you are currently using: `scoop bucket list`
2. I've had to split up the `scoop bucket add` command, because the syntax has changed.
If you want to add an unknown bucket, you have to set a name and a repository url.
3. To complete the lifecycle of buckets, there's also an example how to remove them.
