### PR TITLE
Fixes #4552

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ Have a look at the [contributing guidelines](CONTRIBUTING.md), and go ahead!
 TL;DR stands for "Too Long; Didn't Read".
 It originates in Internet slang, where it is used to indicate that a long text
 (or parts of it) has been skipped as too lengthy.
-Read more in Wikipedia's [TL;DR article](https://en.wikipedia.org/wiki/TL;DR).
+Read more in Wikipedia's [TL;DR essay](https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn%27t_read).


### PR DESCRIPTION
This PR is to fix the dead link for the Wikipedia article mentioned in the issue #4552 

Link changed from https://en.wikipedia.org/wiki/TL;DR to https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn%27t_read

Signed-off-by: Karthikeyan Vaithilingam <seenukarthi@gmail.com>

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

Fixes #4552