### PR TITLE
7z: improve German translation

### DIFF
--- a/pages.de/common/7z.md
+++ b/pages.de/common/7z.md
@@ -19,7 +19,7 @@
 
 `7z x {{archiviert.7z}} -o{{Pfad/zu/ausgabe}}`
 
-- Entpacke ein Archiv nach stdout:
+- Entpacke ein Archiv nach `stdout`:
 
 `7z x {{archiviert.7z}} -so`
 

--- a/pages.de/common/7z.md
+++ b/pages.de/common/7z.md
@@ -3,34 +3,34 @@
 > Ein Dateiarchivierer mit hoher Komprimierungsrate.
 > Mehr Informationen: <https://www.7-zip.org/>.
 
-- Archiviert eine Datei oder ein Verzeichnis:
+- Archiviere eine Datei oder ein Verzeichnis:
 
 `7z a {{archiviert.7z}} {{Pfad/zur/Datei_oder_Verzeichnis}}`
 
-- Verschlüsseln Sie ein vorhandenes Archiv (einschließlich der Kopfzeilen):
+- Verschlüssle ein vorhandenes Archiv (einschließlich der Kopfzeilen):
 
 `7z a {{verschluesselt.7z}} -p{{Passwort}} -mhe=on {{archived.7z}}`
 
-- Extrahieren Sie eine vorhandene 7z-Datei mit der ursprünglichen Verzeichnisstruktur:
+- Extrahiere eine vorhandene 7z-Datei mit der ursprünglichen Verzeichnisstruktur:
 
 `7z x {{archiviert.7z}}`
 
-- Entpacken Sie ein Archiv mit benutzerdefiniertem Ausgabepfad:
+- Entpacke ein Archiv mit benutzerdefiniertem Ausgabepfad:
 
 `7z x {{archiviert.7z}} -o{{Pfad/zu/ausgabe}}`
 
-- Entpacken Sie ein Archiv in stdout:
+- Entpacke ein Archiv nach stdout:
 
 `7z x {{archiviert.7z}} -so`
 
-- Archivieren Sie mit einem bestimmten Archivtyp:
+- Archiviere mit einem bestimmten Archivtyp:
 
 `7z a -t{{zip|gzip|bzip2|tar}} {{archiviert.7z}} {{Pfad/zur/Datei_oder_Verzeichnis}}`
 
-- Führen Sie die verfügbaren Archivtypen auf:
+- Gib die verfügbaren Archivtypen aus:
 
 `7z i`
 
-- Den Inhalt einer Archivdatei auflisten:
+- Gib den Inhalt einer Archivdatei aus:
 
 `7z l {{archiviert.7z}}`


### PR DESCRIPTION
The grammar of the german translation of 7z was not consistent.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->
