### PR TITLE
jupyter: add nbconvert example

### DIFF
--- a/pages/common/jupyter.md
+++ b/pages/common/jupyter.md
@@ -12,6 +12,10 @@
 
 `jupyter notebook {{example.ipynb}}`
 
+- Export a specific Jupyter notebook into another format:
+
+`jupyter nbconvert --to {{html|markdown|pdf|script}} {{example.ipynb}}`
+
 - Start a server on a specific port:
 
 `jupyter notebook --port={{port}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

Hello,

I've added the command that allows to export `.ipynb` into `html`, `markdown`, `pdf` and plain `script`.
According to the guidelines it should have gone under `jupyter-nbconvert.md` but I saw the file already contained similar commands and, IMHO, for a basic usage (purpose of the project), it should be good enough as it is now.

Would you suggest to split the command `jupyter` into chunks?

Thanks for the nice project!


- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
