### PR TITLE
git-reset: add French translation

### DIFF
--- a/pages.fr/common/git-reset.md
+++ b/pages.fr/common/git-reset.md
@@ -1,36 +1,34 @@
 # git reset
 
-> Enlève des commits ou des changements en réinitialisant la tête git à l'état spécifié
-> Si un chemin est passé, git reset fonctionne comme «unstage»;
-> Si un hash de commit est passé, git reset annule les commits jusqu'à ce dernier.
+> Enlève des commits ou des changements en réinitialisant la tête git à l'état spécifié.
+> Si un chemin est passé en paramètre, git reset fonctionne comme «unstage».
+> Si un hash de commit est passé en paramètre, git reset annule les commits jusqu'à ce dernier.
 > Plus d'informations: <https://git-scm.com/docs/git-reset>.
 
-- Tout enlever de la *zone de stage*:
+- Tout enlever de la *zone de stage* :
 
 `git reset`
 
-- Enlever des fichiers spécifiques de la *zone de stage*:
+- Enlever des fichiers spécifiques de la *zone de stage* :
 
 `git reset {{path/to/file(s)}}`
 
-- Enlever une portion d'un fichier de la *zone de stage*:
+- Enlever une portion d'un fichier de la *zone de stage* :
 
 `git reset -p {{path/to/file}}`
 
-- Annuler le dernier *commit*, mais garder les chagements éffectués dans votre système de fichier:
+- Annuler le dernier *commit*, mais garder les chagements éffectués dans votre système de fichier :
 
 `git reset HEAD~`
 
-- Défaire les deux derniers *commits*, et ajouter leur changements à l'index adding their changes to the index (dans la zone de stage):
+- Défaire les deux derniers *commits*, et ajouter leur changements à l'index adding their changes to the index (dans la zone de stage) :
 
 `git reset --soft HEAD~2`
 
-- Enlever tout les changements qui n'ont pas été *commit*, qu'ils soient dans la *zone de stage* ou non
-  (pour enlever seulement les changements de la *zone de stage*, utiliser `git checkout`):
+- Enlever tout les changements qui n'ont pas été *commit*, qu'ils soient dans la *zone de stage* ou non (pour enlever seulement les changements de la *zone de stage*, utiliser `git checkout`) :
 
 `git reset --hard`
 
-- Réinitialiser le dépôt à un commit spécifique en retirant tout les changements
-  (ceci inclus les changements dans des commits entre la *tête* et le *commit* spécifié!)
+- Réinitialiser le dépôt à un commit spécifique en retirant tout les changements (ceci inclus les changements dans des commits entre la *tête* et le *commit* spécifié!) :
 
 `git reset --hard {{commit}}`

--- a/pages.fr/common/git-reset.md
+++ b/pages.fr/common/git-reset.md
@@ -1,0 +1,36 @@
+# git reset
+
+> Enlève des commits ou des changements en réinitialisant la tête git à l'état spécifié
+> Si un chemin est passé, git reset fonctionne comme «unstage»;
+> Si un hash de commit est passé, git reset annule les commits jusqu'à ce dernier.
+> Plus d'informations: <https://git-scm.com/docs/git-reset>.
+
+- Tout enlever de la *zone de stage*:
+
+`git reset`
+
+- Enlever des fichiers spécifiques de la *zone de stage*:
+
+`git reset {{path/to/file(s)}}`
+
+- Enlever une portion d'un fichier de la *zone de stage*:
+
+`git reset -p {{path/to/file}}`
+
+- Annuler le dernier *commit*, mais garder les chagements éffectués dans votre système de fichier:
+
+`git reset HEAD~`
+
+- Défaire les deux derniers *commits*, et ajouter leur changements à l'index adding their changes to the index (dans la zone de stage):
+
+`git reset --soft HEAD~2`
+
+- Enlever tout les changements qui n'ont pas été *commit*, qu'ils soient dans la *zone de stage* ou non
+  (pour enlever seulement les changements de la *zone de stage*, utiliser `git checkout`):
+
+`git reset --hard`
+
+- Réinitialiser le dépôt à un commit spécifique en retirant tout les changements
+  (ceci inclus les changements dans des commits entre la *tête* et le *commit* spécifié!)
+
+`git reset --hard {{commit}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

This PR adds a French translation of the `git reset` command.
