### PR TITLE
module: add page

### DIFF
--- a/pages/linux/module.md
+++ b/pages/linux/module.md
@@ -1,0 +1,28 @@
+# module
+
+> Modify a users' environment using the module command.
+> More information: <https://modules.readthedocs.io/en/latest/module.html>.
+
+- Display available modules:
+
+`module avail`
+
+- Search for a module by name:
+
+`module spider {{module_name}}`
+
+- Load a module:
+
+`module load {{module_name}}`
+
+- Display loaded modules:
+
+`module list`
+
+- Unload a specific loaded module:
+
+`module {{module_name}}`
+
+- Unload all loaded modules:
+
+`module purge`

--- a/pages/linux/module.md
+++ b/pages/linux/module.md
@@ -1,7 +1,7 @@
 # module
 
 > Modify a users' environment using the module command.
-> More information: <https://modules.readthedocs.io/en/latest/module.html>.
+> More information: <https://lmod.readthedocs.io/en/latest/010_user.html>.
 
 - Display available modules:
 


### PR DESCRIPTION
- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

As a short summary, the module command allows for loading in different programs, or modules, into the user environment. This is useful in the case of HPC systems that may have numerous pieces of software that do not need to be loaded to run a job. 