### PR TITLE
nodenv: add page

### DIFF
--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -23,6 +23,6 @@
 
 `nodenv version`
 
-- Show the location of a NodeJS-installed command, e.g. `npm`:
+- Display the location of a Node.js installed command (e.g. `npm`):
 
 `nodenv which {{command}}`

--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -11,7 +11,7 @@
 
 `nodenv install --list`
 
-- Use a specific version of NodeJS across the whole system:
+- Use a specific version of Node.js across the whole system:
 
 `nodenv global {{version}}`
 

--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -3,7 +3,7 @@
 > A tool to manage NodeJS versions.
 > More information: <https://github.com/nodenv/nodenv>.
 
-- Install a version of NodeJS:
+- Install a specific version of Node.js:
 
 `nodenv install {{version}}`
 

--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -15,7 +15,7 @@
 
 `nodenv global {{version}}`
 
-- Use a specific version of NodeJS with a directory:
+- Use a specific version of Node.js with a directory:
 
 `nodenv local {{version}}`
 

--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -1,0 +1,28 @@
+# nodenv
+
+> A tool to manage NodeJS versions.
+> More information: <https://github.com/nodenv/nodenv>.
+
+- Install a version of NodeJS:
+
+`nodenv install {{version}}`
+
+- Display a list of available versions:
+
+`nodenv install --list`
+
+- Use a specific version of NodeJS across the whole system:
+
+`nodenv global {{version}}`
+
+- Use a specific version of NodeJS with a directory:
+
+`nodenv local {{version}}`
+
+- Show the NodeJS version for the current directory:
+
+`nodenv version`
+
+- Show the location of a NodeJS-installed command, e.g. `npm`:
+
+`nodenv which {{command}}`

--- a/pages/common/nodenv.md
+++ b/pages/common/nodenv.md
@@ -19,7 +19,7 @@
 
 `nodenv local {{version}}`
 
-- Show the NodeJS version for the current directory:
+- Display the Node.js version for the current directory:
 
 `nodenv version`
 


### PR DESCRIPTION
I didn't notice an issue requesting `nodenv`, but went looking for other commonly used but missing commands. There is a tldr page for `rbenv` and other variants, but `nodenv` was conspicuously missing.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).