### PR TITLE
git*: add pt_BR translation

### DIFF
--- a/pages.pt_BR/common/git-add.md
+++ b/pages.pt_BR/common/git-add.md
@@ -1,9 +1,9 @@
 # git add
 
-> Adiciona arquivos modificados no index
+> Adiciona arquivos modificados na área de preparação
 > Mais informações: <https://git-scm.com/docs/git-add>.
 
-- Adiciona um arquivo no index:
+- Adiciona um arquivo na área de preparação:
 
 `git add {{caminho/do/arquivo}}`
 

--- a/pages.pt_BR/common/git-add.md
+++ b/pages.pt_BR/common/git-add.md
@@ -1,0 +1,32 @@
+# git add
+
+> Adiciona arquivos modificados no index
+> Mais informações: <https://git-scm.com/docs/git-add>.
+
+- Adiciona um arquivo no index:
+
+`git add {{caminho/do/arquivo}}`
+
+- Adiciona todos arquivos (rastreados ou não):
+
+`git add -A`
+
+- Adiciona apenas arquivos rastreados:
+
+`git add -u`
+
+- Adiciona arquivos ignorados:
+
+`git add -f`
+
+- Interativamente adiciona partes dos arquivo: 
+
+`git add -p`
+
+- Interativamente adiciona partes de um dado arquivo: 
+
+`git add -p {{caminho/para/arquivo}}`
+
+- Interativamente adiciona arquivos ou partes modificadas:
+
+`git add -i`

--- a/pages.pt_BR/common/git-mv.md
+++ b/pages.pt_BR/common/git-mv.md
@@ -1,0 +1,16 @@
+# git mv
+
+> Move ou renomeia arquivos e atualiza o index do git.
+> Mais informações: <https://git-scm.com/docs/git-mv>.
+
+- Move arquivos dentro de um repositório e adiciona no próximo commit:
+
+`git mv {{caminho/para/arquivo}} {{novo/caminho}}`
+
+- Renomeia um arquivo e adiciona a renomeação no próximo commit:
+
+`git mv {{nome_do_arquivo}} {{novo_nome}}`
+
+- Sobrescreve o arquivo no caminho alvo se ele já existir:
+
+`git mv --force {{arquivo}} {{alvo}}`

--- a/pages.pt_BR/common/git-remote.md
+++ b/pages.pt_BR/common/git-remote.md
@@ -1,0 +1,28 @@
+# git remote
+
+> Gerencia repositórios monitorados ("remotes").
+> Mais informações: <https://git-scm.com/docs/git-remote>.
+
+- Mostre uma lista de remotes existentes, seus nomes e URL:
+
+`git remote -v`
+
+- Mostra infomação de um remote específico:
+
+`git remote show {{nome_do_remote}}`
+
+- Adiciona um remote:
+
+`git remote add {{nome_do_remote}} {{url_do_remote}}`
+
+- Muda a URL de um remote (use `--add` para manter a URL existente):
+
+`git remote set-url {{nome_do_remote}} {{nova_url}}`
+
+- Remove um remote:
+
+`git remote remove {{nome_do_remote}}`
+
+- Renomeia um remote:
+
+`git remote rename {{nome_antigo}} {{novo_nome}}`

--- a/pages.pt_BR/common/git.md
+++ b/pages.pt_BR/common/git.md
@@ -1,0 +1,28 @@
+# git
+
+> Sistema de versionamento distruído
+> Mais informações: <https://git-scm.com>.
+
+- Verifique a versão do Git:
+
+`git --version`
+
+- Mostre ajuda geral:
+
+`git --help`
+
+- Mostre ajuda de um subcomando do Git (como `commit`, `log`, etc.):
+
+`git help {{subcomando}}`
+
+- Execute um subcomando Git:
+
+`git {{subcomando}}`
+
+- Execute um subcomando Git no caminho raíz de um repositório específico:
+
+`git -C {{caminho/para/o/repo}} {{subcomando}}`
+
+- Execute um subcomando Git com uma dada configuração:
+
+`git -c '{{config.chave}}={{valor}}' {{subcomando}}`

--- a/pages.pt_BR/common/git.md
+++ b/pages.pt_BR/common/git.md
@@ -1,6 +1,6 @@
 # git
 
-> Sistema de versionamento distruído
+> Sistema de versionamento distribuído
 > Mais informações: <https://git-scm.com>.
 
 - Verifique a versão do Git:


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

Hello there :)

This is a first PR to create some basic git translation to Brazilian Portuguese. However, I found this translation quirk since in Brazil is very common to use neologisms when talking about git (e.g. "Eu vou **commitar**", "Precisa dar um **push**", ...). I believe the translation should keep those terms in English when applicable. Feedbacks? 

Thanks!

(cc @schneiderl)

---

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
