### PR TITLE
elixir: add page

### DIFF
--- a/pages/common/elixir.md
+++ b/pages/common/elixir.md
@@ -1,0 +1,12 @@
+# elixir
+
+> Elixir programming language interpreter.
+> More information: <https://elixir-lang.org/>.
+
+- Run an Elixir file:
+
+`elixir {{path/to/file}}`
+
+- Evaluate Elixir by passing it in the command:
+
+`elixir -e "{{code}}"`

--- a/pages/common/elixir.md
+++ b/pages/common/elixir.md
@@ -1,7 +1,7 @@
 # elixir
 
 > Elixir programming language interpreter.
-> More information: <https://elixir-lang.org/>.
+> More information: <https://elixir-lang.org>.
 
 - Run an Elixir file:
 

--- a/pages/common/elixir.md
+++ b/pages/common/elixir.md
@@ -7,6 +7,6 @@
 
 `elixir {{path/to/file}}`
 
-- Evaluate Elixir by passing it in the command:
+- Evaluate Elixir code by passing it as an argument:
 
 `elixir -e "{{code}}"`


### PR DESCRIPTION
Though the `elixir` command has multiple uses and purposes, the included examples are the simplest of them. This addresses the second half of #2680, and likely closes it.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
