### PR TITLE
syncthing: add -no-browser example

### DIFF
--- a/pages/common/syncthing.md
+++ b/pages/common/syncthing.md
@@ -7,6 +7,10 @@
 
 `syncthing`
 
+- Start syncthing without opening a browser:
+
+`syncthing -no-browser`
+
 - Print the device ID:
 
 `syncthing -device-id`

--- a/pages/common/syncthing.md
+++ b/pages/common/syncthing.md
@@ -7,7 +7,7 @@
 
 `syncthing`
 
-- Start syncthing without opening a browser:
+- Start syncthing without opening a web browser:
 
 `syncthing -no-browser`
 


### PR DESCRIPTION
I know this PR puts this page at 8 examples, but please consider adding it.  For those of us using Linux, this example can be set to auto-start upon login, removing the overhead of opening a web browser while other processes are starting up.  

Unfortunately, starting the daemon in the background is often not done by default in most distributions.

- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
