### PR TITLE
git-commit: clarify amend example

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -11,7 +11,7 @@
 
 `git commit -a -m {{message}}`
 
-- Update the last commit by adding the currently staged changes, changing commit's hash:
+- Update the last commit by adding the currently staged changes, changing the commit's hash:
 
 `git commit --amend`
 

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -11,7 +11,7 @@
 
 `git commit -a -m {{message}}`
 
-- Replace the last commit with currently staged changes:
+- Update the last commit by adding the currently staged changes, changing commit's hash:
 
 `git commit --amend`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

`git commit -a ` amends (or, in a more simple way, "adds") current staged changes on the last commit. The way is currently written gives the impression that changes on the last commit will be deleted and replaced by those new changes.

I understand why this was written in this way, since in `git commit --help` there is:

```
--amend

    Replace the tip of the current branch by creating a new commit. [...]
```   
But notice that "replace" here is referring to the commit, that will be replaced by a new commit that has the combination of changes of the old commit and the new added changes.

---

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
