### PR TITLE
gdb: disambiguate --args example

### DIFF
--- a/pages/common/gdb.md
+++ b/pages/common/gdb.md
@@ -19,6 +19,6 @@
 
 `gdb -ex "{{commands}}" {{executable}}`
 
-- Start gdb and pass arguments:
+- Start gdb and pass arguments to the executable:
 
 `gdb --args {{executable}} {{argument1}} {{argument2}}`


### PR DESCRIPTION
The current `--args` example is ambiguous, since it's not clear which program reads those given arguments, `gdb` itself or  `executable`. Fix that by adding a minor note.

---
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
