### PR TITLE
jq: add an example of skipping non-JSON lines

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -38,3 +38,7 @@
 - Output the value of a given key to a string (and disable JSON output):
 
 `cat {{file.json}} | jq --raw-output '"some text: \(.{{key_name}})"'`
+
+- Output the value of a given key from a JSON parsable lines, and skip if parsing is not successful:
+
+`cat {{file.json}} | jq --raw-input 'fromjson? | .{{key_name}}'`

--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -15,13 +15,9 @@
 
 `jq --slurp . {{file.json}}`
 
-- Output the first element in a JSON file:
+- Output a value under given path. The path can consist of array indices (wrapped with `[]`) and object keys:
 
-`jq '.[0]' {{file.json}}`
-
-- Output the value of a given key of the first element in a JSON text from `stdin`:
-
-`cat {{file.json}} | jq '.[0].{{key_name}}'`
+`jq '.{{key_name}}.[{{index}}].{{another_key}}' {{file.json}}`
 
 - Output the value of a given key of each element in a JSON text from `stdin`:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Hi 👋🏼

I add a new example that I find useful in my day-to-day work as it helps me to deal with reading JSON log streams with occasionally appearing non-JSON lines. For example, if you read a Node.js logger which produces JSON entries and from time to time you receive some non-JSON log entries from the Node.js itself.

Although the page has 9 examples already I decided to try it out anyway. I understand that the aim is to make the output as easy and beginner-friendly as possible, so I won't get hard feelings if the PR ends up closed. 🤗
