### PR TITLE
gh-pr: add page

### DIFF
--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -1,0 +1,24 @@
+# gh-pr
+
+> Work seamlessly with GitHub from the command line.
+> More information: <https://cli.github.com/>.
+
+- Create a pull request:
+
+`gh pr create`
+
+- Check out pull requests locally:
+
+`gh pr checkout {{pr_number}}`
+
+- View the changes made in the PR:
+
+`gh pr diff`
+
+- Approve the pull request of the current branch:
+
+`gh pr review --approve`
+
+- Merge a PR if you're on the branch, removes the branch on local and remote:
+
+`gh pr merge`

--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -1,13 +1,13 @@
 # gh-pr
 
-> Work seamlessly with GitHub from the command line.
-> More information: <https://cli.github.com/>.
+> Manage GitHub pull requests from the command line.
+> More information: <https://cli.github.com/manual/gh_pr>.
 
 - Create a pull request:
 
 `gh pr create`
 
-- Check out pull requests locally:
+- Check out a pull request locally:
 
 `gh pr checkout {{pr_number}}`
 
@@ -19,6 +19,6 @@
 
 `gh pr review --approve`
 
-- Merge a PR if you're on the branch, removes the branch on local and remote:
+- Merge the pull request associated with the current branch, removing the branch on both the local and the remote:
 
 `gh pr merge`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

https://github.com/tldr-pages/tldr/pull/4635 moved the main page to 8 examples, so I've created a new page for the subcommand pr by adding some commands that I use to manage PRs.

Ref: #4701 