### PR TITLE
gh: change command order and fix a mistake on pr/issue view command

### DIFF
--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -11,7 +11,7 @@
 
 `gh issue create`
 
-- View and filter repository’s open issues:
+- View and filter a repository’s open issues:
 
 `gh issue list`
 
@@ -31,6 +31,6 @@
 
 `gh pr checkout {{pr_number}}`
 
-- Check the status of your pull requests:
+- Check the status of a repository's pull requests:
 
 `gh pr status`

--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -3,22 +3,6 @@
 > Work seamlessly with GitHub from the command line.
 > More information: <https://cli.github.com/>.
 
-- Create a pull request:
-
-`gh pr create`
-
-- View a pull request in the browser:
-
-`gh pr view {{pr_number}}`
-
-- Check out pull requests locally:
-
-`gh pr checkout {{pr_number}}`
-
-- Check the status of your pull requests:
-
-`gh pr status`
-
 - Clone a repository locally:
 
 `gh repo clone {{owner}}/{{repository}}`
@@ -33,4 +17,20 @@
 
 - View an issue in the browser:
 
-`gh issue view {{issue_number}}`
+`gh issue view --web {{issue_number}}`
+
+- Create a pull request:
+
+`gh pr create`
+
+- View a pull request in the browser:
+
+`gh pr view --web {{pr_number}}`
+
+- Check out pull requests locally:
+
+`gh pr checkout {{pr_number}}`
+
+- Check the status of your pull requests:
+
+`gh pr status`


### PR DESCRIPTION
correct some errors about gh issue view and gh pr view, due to api
changes.
add new example to cover all github process:
repo creation -> issue management -> pr management -> release management

After discussions, this PR is only for some fixes and we will create sub-commands to add some details for each gh commands.
This PR will now resolve:

change command order to keep a logic on the examples from cloning a
repo, to issue/ticket creation to PR management.
fix a mistake on the pr/issue view commands, due to an api change on the
gh command.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
