### PR TITLE
gradle: Add spanish translation

### DIFF
--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -1,0 +1,24 @@
+# gradle
+
+> Gradle es un sistema de código abierto para automatizar la compilación de proyectos
+> Más información en: <https://gradle.org>.
+
+- Compilar un proyecto:
+
+`gradle build`
+
+- Excluit la tarea *test*:
+
+`gradle build -x {{test}}`
+
+- Ejecutar en modo offline para prevenir que gradle acceda a la red durante una compilación:
+
+`gradle build --offline`
+
+- Limpiar el directorio de compilación:
+
+`gradle clean`
+
+- Compilar y generar un paquete:
+
+`gradle assembleRelease`

--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -3,22 +3,22 @@
 > Gradle es un sistema de código abierto para automatizar la compilación de proyectos
 > Más información en: <https://gradle.org>.
 
-- Compilar un proyecto:
+- Compila un proyecto:
 
 `gradle build`
 
-- Excluit la tarea *test*:
+- Excluye la tarea *test*:
 
 `gradle build -x {{test}}`
 
-- Ejecutar en modo offline para prevenir que gradle acceda a la red durante una compilación:
+- Ejecuta en modo offline para prevenir que gradle acceda a la red durante una compilación:
 
 `gradle build --offline`
 
-- Limpiar el directorio de compilación:
+- Limpia el directorio de compilación:
 
 `gradle clean`
 
-- Compilar y generar un paquete:
+- Compila y genera un paquete:
 
 `gradle assembleRelease`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


Hello, I've added the translation in spanish for gralde page.

A note for spanish reviewers: Which is the rule that applies for spanish translation in verbs? I've readed some translations and some uses the "indicative" form and others "present simple". Some people comments in other pull requests and suggests to use the spanish present simple in every translation, but I could not found any rule