### PR TITLE
README: add fast-tldr Haskell client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,12 @@ both for the command line and for other platforms:
     [App Store](https://appsto.re/sg/IQ0-_.i)
   - [tldr-pages](https://github.com/mflint/ios-tldr-viewer), available on
     [App Store](https://itunes.apple.com/us/app/tldt-pages/id1071725095?ls=1&mt=8)
-- [Haskell client](https://github.com/psibi/tldr-hs):
+- Haskell clients:
+  - [tldr-hs](https://github.com/psibi/tldr-hs):
   `stack install tldr`
   or `apt-get install tldr` on Debian-based distributions
+  - [fast-tldr](https://github.com/gutjuri/fast-tldr)
+  
 - [Node.js client](https://github.com/tldr-pages/tldr-node-client):
   `npm install -g tldr`
 - [OCaml client](https://github.com/RosalesJ/tldr-ocaml): `opam install tldr`


### PR DESCRIPTION
I modified an existing Haskell client heavily in order to have the fastest tldr-client. It does pretty good, it's a bit faster than the fastest other client I could find [Tealdeer](https://github.com/dbrgn/tealdeer). 

It follows the minimum requirements. It also follows large parts of the full requirements for tldr-clients, though I still have to assess to what extend.

I'd also appreciate if you'd add it to your [Wiki](https://github.com/tldr-pages/tldr/wiki/tldr-pages-clients) :)
