### PR TITLE
youtube-dl: add quotation marks

### DIFF
--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -17,15 +17,15 @@
 
 - Download the audio from a video and convert it to an MP3:
 
-`youtube-dl -x --audio-format {{mp3}} {{url}}`
+`youtube-dl -x --audio-format {{mp3}} '{{url}}'`
 
 - Download the best quality audio and video and merge them:
 
-`youtube-dl -f bestvideo+bestaudio {{url}}`
+`youtube-dl -f bestvideo+bestaudio '{{url}}'`
 
 - Download video(s) as MP4 files with custom filenames:
 
-`youtube-dl --format {{mp4}} -o "{{%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s}}" {{url}}`
+`youtube-dl --format {{mp4}} -o "{{%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s}}" '{{url}}'`
 
 - Download a particular language's subtitles along with the video:
 
@@ -33,4 +33,4 @@
 
 - Download a playlist and extract mp3 from it:
 
-`youtube-dl -i --extract-audio --audio-format mp3 -o "%(title)s.%(ext)s" {{url to playlist}}`
+`youtube-dl -i --extract-audio --audio-format mp3 -o "%(title)s.%(ext)s" '{{url to playlist}}'`

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -5,15 +5,15 @@
 
 - Download a video or playlist:
 
-`youtube-dl {{'https://www.youtube.com/watch?v=oHg5SJYRHA0'}}`
+`youtube-dl '{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}'`
 
 - List all formats that a video or playlist is available in:
 
-`youtube-dl --list-formats {{'https://www.youtube.com/watch?v=Mwa0_nE9H7A'}}`
+`youtube-dl --list-formats '{{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}'`
 
 - Download a video or playlist at a specific quality:
 
-`youtube-dl --format "{{best[height<=480]}}" {{'https://www.youtube.com/watch?v=oHg5SJYRHA0'}}`
+`youtube-dl --format "{{best[height<=480]}}" '{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}'`
 
 - Download the audio from a video and convert it to an MP3:
 
@@ -29,7 +29,7 @@
 
 - Download a particular language's subtitles along with the video:
 
-`youtube-dl --sub-lang {{en}} --write-sub {{'https://www.youtube.com/watch?v=Mwa0_nE9H7A'}}`
+`youtube-dl --sub-lang {{en}} --write-sub '{{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}'`
 
 - Download a playlist and extract mp3 from it:
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -5,15 +5,15 @@
 
 - Download a video or playlist:
 
-`youtube-dl {{https://www.youtube.com/watch?v=oHg5SJYRHA0}}`
+`youtube-dl {{'https://www.youtube.com/watch?v=oHg5SJYRHA0'}}`
 
 - List all formats that a video or playlist is available in:
 
-`youtube-dl --list-formats {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
+`youtube-dl --list-formats {{'https://www.youtube.com/watch?v=Mwa0_nE9H7A'}}`
 
 - Download a video or playlist at a specific quality:
 
-`youtube-dl --format "{{best[height<=480]}}" {{https://www.youtube.com/watch?v=oHg5SJYRHA0}}`
+`youtube-dl --format "{{best[height<=480]}}" {{'https://www.youtube.com/watch?v=oHg5SJYRHA0'}}`
 
 - Download the audio from a video and convert it to an MP3:
 
@@ -29,7 +29,7 @@
 
 - Download a particular language's subtitles along with the video:
 
-`youtube-dl --sub-lang {{en}} --write-sub {{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}`
+`youtube-dl --sub-lang {{en}} --write-sub {{'https://www.youtube.com/watch?v=Mwa0_nE9H7A'}}`
 
 - Download a playlist and extract mp3 from it:
 


### PR DESCRIPTION
Adding quotation marks when specifying a URL is necessary, since youtube URLs almost always contain a question mark (?), which is usually interpreted by the shell as globbing.

Signed-off-by: Atrate <Atrate@protonmail.com>

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
