### PR TITLE
binwalk: add Italian translation

### DIFF
--- a/pages.it/linux/binwalk.md
+++ b/pages.it/linux/binwalk.md
@@ -1,0 +1,28 @@
+# binwalk
+
+> Strumento per l'analisi di file binari.
+> Per ulteriori informazioni: <https://github.com/ReFirmLabs/binwalk>.
+
+- Scansiona un file binario:
+
+`binwalk {{percorso/a/file}}`
+
+- Estrae file da un binario, specificando la cartella di output:
+
+`binwalk --extract --directory {{cartella_di_output}} {{percorso/a/file}}`
+
+- Estrae file in maniera ricorsiva a partire da un binario, limitando la profondità di ricorsione a 2 livelli:
+
+`binwalk --extract --matryoshka --depth {{2}} {{percorso/a/file}}`
+
+- Estrae file da un binario utilizzando una particolare firma (ad esempio il MIME Type):
+
+`binwalk --dd '{{png image:png}}' {{percorso/a/file}}`
+
+- Analizza l'entropia di un binario e salva il grafico con lo stesso filename del binario, con l'estensione `.png` in fondo:
+
+`binwalk --entropy --save {{percorso/a/file}}`
+
+- Combina analisi di entropia, firme e opcode in un unico comando:
+
+`binwalk --entropy --signature --opcodes {{percorso/a/file}}`


### PR DESCRIPTION
Add italian translation for `binwalk` command. I've finally created the `linux` subfolder inside `pages.it`... hopefully this is just the start :)

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
