### PR TITLE
bat: add french translation

### DIFF
--- a/pages.fr/common/bat.md
+++ b/pages.fr/common/bat.md
@@ -1,0 +1,29 @@
+# bat
+
+> Affiche et concatène le contenu d'un ou plusieurs fichiers.
+> Un clon de `cat` avec mise en valeur de la syntaxe et integration avec Git.
+> Plus d'informations : <https://github.com/sharkdp/bat>.
+
+- Affiche le contenu d'un fichier sur la sortie standard :
+
+`bat {{fichier}}`
+
+- Concatène le contenu de plusieurs fichiers vers le fichier de destination :
+
+`bat {{fichier1}} {{fichier2}} > {{fichier_de_destination}}`
+
+- Ajoute le contenu d'un ficher à la fin du fichier de destination :
+
+`bat {{fichier1}} {{fichier2}} >> {{fichier_de_destination}}`
+
+- Numérote toutes les lignes affichées :
+
+`bat -n {{fichier}}`
+
+- Affiche le contenu d'un fichier JSON sur la sortie standard avec mise en valeur de la syntaxe :
+
+`bat --language json {{fichier.json}}`
+
+- Affiche toutes les langages prises en charge :
+
+`bat --list-languages`


### PR DESCRIPTION
I have created a new page for the french language

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
