### PR TITLE
ssh*: Add German translation

### DIFF
--- a/pages.de/common/ssh-agent.md
+++ b/pages.de/common/ssh-agent.md
@@ -1,0 +1,13 @@
+# ssh-agent
+
+> Erstellt einen SSH Agenten-Prozess.
+> Ein SSH Agent behält die hinzugefügten SSH Schlüssel solange verschlüsselt im Arbeitsspeicher, bis diese entfernt werden oder der Agenten-Prozess beendet wird.
+> Hierfür wird im Folgenden das Programm `ssh-add` verwendet.
+
+- Starten eines SSH Agenten-Prozesses für die aktuelle Shell:
+
+`eval $(ssh-agent)`
+
+- Beenden eines aktuell laufenden SSH Agenten-Prozesses:
+
+`ssh-agent -k`

--- a/pages.de/common/ssh-copy-id.md
+++ b/pages.de/common/ssh-copy-id.md
@@ -1,0 +1,16 @@
+# ssh-copy-id
+
+> Installiert den öffentlichen Teil eines SSH Schlüssels in der `authorized_keys` Datei eines Benutzers von einem externen Server.
+> Ermöglicht darüber das zukünftige Einloggen unter diesem Benutzernamen bei diesem Server mit diesem Schlüssel.
+
+- Kopieren des eigenen öffentlichen SSH Schlüssels zu einem externen Server:
+
+`ssh-copy-id {{Benutzer@Externer_Server}}`
+
+- Kopieren des angegebenen öffentlichen SSH Schlüssels zu einem externen Server:
+
+`ssh-copy-id -i {{Pfad/zum/öffentlichen/Schlüssel}} {{Benutzer}}@{{Externer_Server}}`
+
+- Kopieren des angegeben öffentlichen SSH Schlüssels zu einem externen Server unter Angabe eines bestimmten SSH Ports:
+
+`ssh-copy-id -i {{Pfad/zum/öffentlichen/Schlüssel}} -p {{port}} {{Benutzer}}@{{Externer_Server}}`

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -1,0 +1,35 @@
+# ssh-keygen
+
+> Generiert ssh Schlüssel für Authentifizierung, Passwort-lose Logins und mehr.
+
+- Interaktives Erstellen eines SSH Schlüssel-Paars:
+
+`ssh-keygen`
+
+- Erstellen eines Schlüssel-Paars unter einem bestimmten Dateinamen:
+
+`ssh-keygen -f ~/.ssh/{{Dateiname}}`
+
+- Generieren eines ed25519 Schlüssel-Paars mit 100 Schlüssel Ableitungs-Iterationen:
+
+`ssh-keygen -t ed25519 -a 100`
+
+- Generieren eines 4096 Bit langen RSA Schlüssel-Paars mit der Email im Kommentarfeld:
+
+`ssh-keygen -t rsa -b 4096 -C "{{Email}}"`
+
+- Abrufen des Schlüssel Fingerabdrucks von einem Server (hilfreich um die Authentizität eines Servers beim ersten Verbinden zu überprüfen):
+
+`ssh-keygen -l -F {{Externer_Server}}`
+
+- Entfernen der Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
+
+`ssh-keygen -R {{Externer_Server}}`
+
+- Abrufen des Fingerabdrucks eines Schlüssels im MD5 Hex Format:
+
+`ssh-keygen -l -E md5 -f ~/.ssh/{{Dateiname}}`
+
+- Ändern des Passworts eines privaten Schlüssels:
+
+`ssh-keygen -p -f ~/.ssh/{{Dateiname}}`

--- a/pages.de/common/ssh-keyscan.md
+++ b/pages.de/common/ssh-keyscan.md
@@ -1,0 +1,19 @@
+# ssh-keyscan
+
+> Abruf von öffentlichen SSH Schlüssels eines externen Servers.
+
+- Abruf aller öffentlichen SSH Schlüssel:
+
+`ssh-keyscan {{Server}}`
+
+- Abruf aller öffentlichen SSH Schlüssel unter einem bestimmten Port:
+
+`ssh-keyscan -p {{Port}} {{Server}}`
+
+- Abruf bestimmter SSH Schüssel-Typen:
+
+`ssh-keyscan -t {{rsa,dsa,ecdsa,ed25519}} {{Server}}`
+
+- Manuelle Aktualisierung der `known_hosts` SSH Datei mit dem Fingerabdruck eines bestimmten Servers:
+
+`ssh-keyscan -H {{Server}} >> ~/.ssh/known_hosts`

--- a/pages.de/common/ssh.md
+++ b/pages.de/common/ssh.md
@@ -1,0 +1,36 @@
+# ssh
+
+> Secure Shell ist ein Protokoll für das sichere einloggen auf einem externen System.
+> Es kann dadurch eingesetzt werden um Kommandos auf externen Systemen auszuführen.
+
+- Verbindung zu einem externen Server:
+
+`ssh {{Benutzer}}@{{Externer_Server}}`
+
+- Verbindung zu einem externen Server mit spezifischer Identität (privatem SSH Schlüssel):
+
+`ssh -i {{path/to/key_file}} {{Benutzer}}@{{Externer_Server}}`
+
+- Verbindung zu einem externen Server unter einem spezifischen Port:
+
+`ssh {{Benutzer}}@{{Externer_Server}} -p {{2222}}`
+
+- Ausführen eines Kommandos auf einem externen Server:
+
+`ssh {{Externer_Server}} {{Kommando -mit -Optionen}}`
+
+- SSH Tunneln: Dynamische Port Weiterleitung (SOCKS proxy auf localhost:9999):
+
+`ssh -D {{9999}} -C {{Benutzer}}@{{Externer_Server}}`
+
+- SSH Tunneln: Weiterleitung eines spezifischen Ports (localhost:9999 zu example.org:80) zusammen mit deaktivierter pseudy-tty Provisionierung für die Ausführung eines Befehls:
+
+`ssh -L {{9999}}:{{example.org}}:{{80}} -N -T {{Benutzer}}@{{Externer_Server}}`
+
+- SSH Springen: Verbinden über einen Spring-Server zu einem externen Server (Es können auch mehrere Spring-Server über eine Komma-separierte Liste angegeben werden)
+
+`ssh -J {{Benutzer}}@{{Spring_Server}} {{Benutzer}}@{{Externer_Server}}`
+
+- Agenten Weiterleitung: Weiterleiten der eigenen Authentifizierungs-Information an den externen Server (siehe `man ssh_config` für mehr Optionen):
+
+`ssh -A {{Benutzer}}@{{Externer_Server}}`

--- a/pages.de/common/sshfs.md
+++ b/pages.de/common/sshfs.md
@@ -1,0 +1,23 @@
+# sshfs
+
+> Dateisystem Client für SSH.  Weitere Informationen: <https://github.com/libfuse/sshfs>.
+
+- Einhängen eines externen Ordners:
+
+`sshfs {{Benutzer}}@{{Externer_Server}}:{{Externer_Ordner}} {{Lokaler_Einhänguns_Ordner}}`
+
+- Aushängen eines externen Ordners:
+
+`umount {{Lokaler_Einhängungs_Ordner}}`
+
+- Einhängen eines externen Ordners unter einem bestimmten Port:
+
+`sshfs {{Benutzer}}@{{Externer_Server}}:{{Externer_Ordner}} -p {{2222}}`
+
+- Einsatz von Komprimierung:
+
+`sshfs {{Benutzer}}@{{Externer_Server}}:{{Externer_Ordner}} -C`
+
+- Beachtung symbolischer Verweise:
+
+`sshfs -o follow_symlinks {{Benutzer}}@{{Externer_Server}}:{{Externer_Ordner}} {{Lokaler_Einhängungs_Ordner}}`

--- a/pages.de/common/sshpass.md
+++ b/pages.de/common/sshpass.md
@@ -1,0 +1,16 @@
+# sshpass
+
+> Für die Bereitstellung von SSH Passwörtern.
+> Es funktioniert über die Übergabe des Passwortes and ein temporäres TTY und die Weiterleitung des `stdin` an die SSH Sitzung.
+
+- Verbindung zu einem externen Server über ein Passwort aus einem Datei-Objekt (in diesem Fall `stdin`):
+
+`sshpass -d {{0}} ssh {{Benutzer}}@{{Server}}`
+
+- Verbindung zu einem externen Server mit Hilfe eines Passworts bei automatischer Akzeptierung von unbekannten SSH Schlüsseln:
+
+`sshpass -p {{Passwort}} ssh -o StrictHostKeyChecking=no {{Benutzer}}@{{Server}}`
+
+- Verbindung zu einem externen Server mit Hilfe eines Passworts aus der ersten Zeile einer Datei bei automatischer Akzeptierung von unbekannten SSH Schlüsseln mit anschließender Ausführung eines Kommandos:
+
+`sshpass -f {{Datei}} ssh -o StrictHostKeyChecking=no {{Benutzer}}@{{Server}} "{{Kommando}}"`


### PR DESCRIPTION
- [X] The page (if new), does not already exist in the repo.
- [X]  The page is in the correct platform directory (common/, linux/, etc.)
- [X]  The page has 8 or fewer examples.
- [X]  The PR title conforms to the recommended templates.
- [X]  The page follows the content guidelines.
- [X]  The page description includes a link to documentation or a homepage (if applicable).

Hello again!

I translated all the ssh pages into German.