### PR TITLE
gh-config: add page

### DIFF
--- a/pages/common/gh-config.md
+++ b/pages/common/gh-config.md
@@ -22,3 +22,7 @@
 - Disable interactive prompts:
 
 `gh config set prompt {{disabled}}`
+
+- Set a specific configuration value:
+
+`gh config set {{key}} {{value}}`

--- a/pages/common/gh-config.md
+++ b/pages/common/gh-config.md
@@ -1,24 +1,24 @@
-# gh-config
+# gh config
 
 > Change configuration for GitHub cli.
 > More information: <https://cli.github.com/manual/gh_config>.
 
-- Check what git protocol you are using:
+- Display what Git protocol is being used:
 
 `gh config get git_protocol`
 
-- Change protocol to ssh:
+- Set protocol to SSH:
 
-`gh config set git_protocol ssh`
+`gh config set git_protocol {{ssh}}`
 
-- Change text editor to vim:
+- Set text editor to Vim:
 
-`gh config set editor vim`
+`gh config set editor {{vim}}`
 
-- Reset to default editor:
+- Reset to default text editor:
 
-`gh config set editor ""`
+`gh config set editor {{""}}`
 
 - Disable interactive prompts:
 
-`gh config set prompt disabled`
+`gh config set prompt {{disabled}}`

--- a/pages/common/gh-config.md
+++ b/pages/common/gh-config.md
@@ -1,0 +1,24 @@
+# gh-config
+
+> Change configuration for GitHub cli.
+> More information: <https://cli.github.com/manual/gh_config>.
+
+- Check what git protocol you are using:
+
+`gh config get git_protocol`
+
+- Change protocol to ssh:
+
+`gh config set git_protocol ssh`
+
+- Change text editor to vim:
+
+`gh config set editor vim`
+
+- Reset to default editor:
+
+`gh config set editor ""`
+
+- Disable interactive prompts:
+
+`gh config set prompt disabled`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Add a new page for `gh config`

I could not figure out what does `--host` option do - neither does it say anywhere in the official documentation. If someone ever knew, it would be nice to fill that

Ref: #4701