### PR TITLE
git-pr: add more information link

### DIFF
--- a/pages.es/common/git-pr.md
+++ b/pages.es/common/git-pr.md
@@ -1,6 +1,7 @@
 # git pr
 
 > Comprueba las solicitudes de extracción de cambios (*pull requests*) de GitHub localmente.
+> Más información: <https://github.com/tj/git-extras/blob/master/Commands.md#git-pr>.
 
 - Comprueba una pull request específica:
 

--- a/pages/common/git-pr.md
+++ b/pages/common/git-pr.md
@@ -1,6 +1,7 @@
 # git pr
 
 > Check out GitHub pull requests locally.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-pr>.
 
 - Check out a specific pull request:
 


### PR DESCRIPTION
See discussion in #4472

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page description includes a link to documentation or a homepage (if applicable).
