### PR TITLE
flutter: remove useless examples and add release APK

### DIFF
--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -19,6 +19,10 @@
 
 `flutter run -d all`
 
+- Download all packages specified in `pubspec.yaml`:
+
+`flutter pub get`
+
 - Run tests in a terminal from the root of the project:
 
 `flutter test {{test/example_test.dart}}`

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -26,3 +26,7 @@
 - Run tests in a terminal from the root of the project:
 
 `flutter test {{test/example_test.dart}}`
+
+- Build a release APK targeting most modern smartphones:
+
+`flutter build apk --target-platform {{android-arm}} {{android-arm64}}`

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -3,10 +3,6 @@
 > Google's free, open source, and cross-platform mobile app SDK.
 > More information: <https://github.com/flutter/flutter/wiki/The-flutter-tool>.
 
-- Check the Flutter version:
-
-`flutter --version`
-
 - Display help about a specific command:
 
 `flutter help {{command}}`

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -11,7 +11,7 @@
 
 `flutter help {{command}}`
 
-- Show information about the installed tooling:
+- Check if all external tools are correctly installed:
 
 `flutter doctor`
 

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -7,17 +7,9 @@
 
 `flutter --version`
 
-- Display general help:
-
-`flutter help`
-
 - Display help about a specific command:
 
 `flutter help {{command}}`
-
-- Execute a Flutter command:
-
-`flutter {{command}}`
 
 - Show information about the installed tooling:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

`flutter` page contained some examples that were pretty much useless and obvious, so I removed them, and added two other useful examples