### PR TITLE
rsync: fix example description

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -11,7 +11,7 @@
 
 `rsync {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
 
-- Transfer file in [a]rchive (to preserve attributes) and compressed ([z]ipped) mode with [v]erbose and [h]uman-readable [p]rogress:
+- Transfer file in [a]rchive (to preserve attributes) and compressed ([z]ipped) mode with [v]erbose and [h]uman-readable [P]rogress:
 
 `rsync -azvhP {{path/to/local_file}} {{remote_host}}:{{path/to/remote_directory}}`
 


### PR DESCRIPTION
Hi 

To make more clear the documentation, I replaced [p](perms) with [P](progress).
Lowercase p and uppercase P have different meaning in rsync


