### PR TITLE
make: add --environment-overrides example

### DIFF
--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -2,6 +2,7 @@
 
 > Task runner for targets described in Makefile.
 > Mostly used to control the compilation of an executable from source code.
+> More information: <https://www.gnu.org/software/make/manual/make.html>.
 
 - Call the first target specified in the Makefile (usually named "all"):
 

--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -26,3 +26,7 @@
 - Force making of a target, even if source files are unchanged:
 
 `make --always-make {{target}}`
+
+- Override variables defined in the Makefile by the environment:
+
+`make --environment-overrides {{target}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

I find this option quite useful when I have to deal with poorly written Makefiles that do not define variables with `?=`.