### PR TITLE
tar: create bz2 archive

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -12,6 +12,10 @@
 
 `tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
 
+- Create a bzip2 archive:
+
+`tar cjf {{target.tar.bz2}} {{file1}} {{file2}} {{file3}}`
+
 - Create a gzipped archive from a directory using relative paths:
 
 `tar czf {{target.tar.gz}} -C {{path/to/directory}} .`


### PR DESCRIPTION
bz2 seems to be a common method, especially when smaller archive size needs to be obtained.
that is why i think it should be added as well.

note: there will be 10 examples, which exceeds recommended 8 per command.
note: other languages might need to be updated.
note: example image from tldr.sh might need to be updated.
