### PR TITLE
scrcpy: add --serial example

### DIFF
--- a/pages/common/scrcpy.md
+++ b/pages/common/scrcpy.md
@@ -7,7 +7,7 @@
 
 `scrcpy`
 
-- Display a mirror of a specific device based on its serial ID or IP address, as shown in the "adb devices" command:
+- Display a mirror of a specific device based on its ID or IP address. You can find it under the "adb devices" command:
 
 `scrcpy --serial {{0123456789abcdef|192.168.0.1:5555}}`
 

--- a/pages/common/scrcpy.md
+++ b/pages/common/scrcpy.md
@@ -7,6 +7,10 @@
 
 `scrcpy`
 
+- Display a mirror of a specific device based on its serial ID or IP address, as shown in the "adb devices" command:
+
+`scrcpy --serial {{0123456789abcdef|192.168.0.1:5555}}`
+
 - Start display in fullscreen mode:
 
 `scrcpy --fullscreen`

--- a/pages/common/scrcpy.md
+++ b/pages/common/scrcpy.md
@@ -7,7 +7,7 @@
 
 `scrcpy`
 
-- Display a mirror of a specific device based on its ID or IP address. You can find it under the "adb devices" command:
+- Display a mirror of a specific device based on its ID or IP address (find it under the `adb devices` command):
 
 `scrcpy --serial {{0123456789abcdef|192.168.0.1:5555}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

The `--serial` command is important to users who have more than one Android devices connected. Since each `scrcpy` command can only be able to mirror one device, they will need to specify the serial ID or the IP address of the connected device for mirroring.

The examples are taken straight from [scrcpy's README file](https://github.com/Genymobile/scrcpy#multi-devices), but you're welcome to replace `0123456789abcdef` to something more random, mimicking the actual device ID.