### PR TITLE
openssl-dgst, openssl-genpkey: add page

### DIFF
--- a/pages/common/openssl-dgst.md
+++ b/pages/common/openssl-dgst.md
@@ -1,0 +1,24 @@
+# openssl dgst
+
+> OpenSSL command to generate digest values and perform signature operations.
+> More information: <https://www.openssl.org/docs/man1.0.2/man1/dgst.html>.
+
+- Generate a SHA256 hash value of a file:
+
+`openssl dgst -sha256 -binary -out {{output_file}} {{input_file}}`
+
+- Sign a file using and RSA key:
+
+`openssl dgst -sign {{private_key_file}} -sha256 -sigopt rsa_padding_mode:pss -out {{output_file}} {{input_file}}`
+
+- Verify an RSA signature:
+
+`openssl dgst -verify {{public_key_file}} -signature {{signature_file}} -sigopt rsa_padding_mode:pss {{signature_message_file}}`
+
+- Sign a file using and ECDSA key:
+
+`openssl dgst -sign {{private_key_file}} -sha256 -out {{output_file}} {{input_file}}`
+
+- Verify an ECDSA signature:
+
+`openssl dgst -verify {{public_key_file}} -signature {{signature_file}} {{signature_message_file}}`

--- a/pages/common/openssl-dgst.md
+++ b/pages/common/openssl-dgst.md
@@ -1,13 +1,13 @@
 # openssl dgst
 
 > OpenSSL command to generate digest values and perform signature operations.
-> More information: <https://www.openssl.org/docs/man1.0.2/man1/dgst.html>.
+> More information: <https://www.openssl.org/docs/manmaster/man1/dgst.html>.
 
 - Generate a SHA256 hash value of a file:
 
 `openssl dgst -sha256 -binary -out {{output_file}} {{input_file}}`
 
-- Sign a file using and RSA key:
+- Sign a file using an RSA key, saving the result to a specific file:
 
 `openssl dgst -sign {{private_key_file}} -sha256 -sigopt rsa_padding_mode:pss -out {{output_file}} {{input_file}}`
 

--- a/pages/common/openssl-dgst.md
+++ b/pages/common/openssl-dgst.md
@@ -1,9 +1,9 @@
 # openssl dgst
 
 > OpenSSL command to generate digest values and perform signature operations.
-> More information: <https://www.openssl.org/docs/manmaster/man1/dgst.html>.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-dgst.html>.
 
-- Generate a SHA256 hash value of a file:
+- Calculate the SHA256 digest for a file, saving the result to a specific file:
 
 `openssl dgst -sha256 -binary -out {{output_file}} {{input_file}}`
 

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -5,11 +5,11 @@
 
 - Generate an RSA private key of 2048 bits, saving it to a specific file:
 
-`openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:2048 -out {{filename.key}}`
+`openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:{{2048}} -out {{filename.key}}`
 
 - Generate an elliptic curve private key using the curve `prime256v1`, saving it to a specific file:
 
-`openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out {{filename.key}}`
+`openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:{{prime256v1}} -out {{filename.key}}`
 
 - Generate an `ED25519` elliptic curve private key, saving it to a specific file:
 

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -1,0 +1,16 @@
+# openssl genpkey
+
+> OpenSSL command to generate asymmetric key pairs.
+> More information: <https://www.openssl.org/docs/man1.0.2/man1/genpkey.html>.
+
+- Generate a 2048bit RSA private key and save it to a file:
+
+`openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:2048 -out {{filename.key}}`
+
+- Generate an elliptic curve private key using the curve *prime256v1* and save it to a file:
+
+`openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out {{filename.key}}`
+
+- Generate an ED25519 elliptic curve private key and save it to a file:
+
+`openssl genpkey -algorithm ED25519 -out {{filename.key}}`

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -1,7 +1,7 @@
 # openssl genpkey
 
 > OpenSSL command to generate asymmetric key pairs.
-> More information: <https://www.openssl.org/docs/manmaster/man1/genpkey.html>.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-genpkey.html>.
 
 - Generate an RSA private key of 2048 bits, saving it to a specific file:
 

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -13,4 +13,4 @@
 
 - Generate an `ED25519` elliptic curve private key, saving it to a specific file:
 
-`openssl genpkey -algorithm ED25519 -out {{filename.key}}`
+`openssl genpkey -algorithm {{ED25519}} -out {{filename.key}}`

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -1,16 +1,16 @@
 # openssl genpkey
 
 > OpenSSL command to generate asymmetric key pairs.
-> More information: <https://www.openssl.org/docs/man1.0.2/man1/genpkey.html>.
+> More information: <https://www.openssl.org/docs/manmaster/man1/genpkey.html>.
 
-- Generate a 2048bit RSA private key and save it to a file:
+- Generate an RSA private key of 2048 bits, saving it to a specific file:
 
 `openssl genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:2048 -out {{filename.key}}`
 
-- Generate an elliptic curve private key using the curve *prime256v1* and save it to a file:
+- Generate an elliptic curve private key using the curve `prime256v1`, saving it to a specific file:
 
 `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out {{filename.key}}`
 
-- Generate an ED25519 elliptic curve private key and save it to a file:
+- Generate an `ED25519` elliptic curve private key, saving it to a specific file:
 
 `openssl genpkey -algorithm ED25519 -out {{filename.key}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Add two pages for openssl subcommands related to digital signatures.

* One to generate asymmetric keypairs
* One how to generate and verify signatures