### PR TITLE
reflex: add page

### DIFF
--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -1,6 +1,6 @@
 # reflex
 
-> Reflex is a small tool to watch a directory and rerun a command when certain files change.
+> Tool to watch a directory and rerun a command when certain files change.
 > More information: <https://github.com/cespare/reflex>.
 
 - Rebuild with `make` if any file changes:

--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -1,0 +1,24 @@
+# reflex
+
+> Reflex is a small tool to watch a directory and rerun a command when certain files change.
+> More information: <https://github.com/cespare/reflex>.
+
+- Rebuild with `make` if any file changes
+
+`reflex make`
+
+- Compile and run Go application if any .go file changes
+
+`reflex -r '\.go$' go run .`
+
+- Ignore a directory when wahtcing for changes
+
+`reflex -R '^node_modules/' yarn test`
+
+- Run command when reflex starts and restarts on file changes
+
+`reflex -s go test`
+
+- Substitude what file changes
+
+`reflex -- echo {}`

--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -19,6 +19,6 @@
 
 `reflex --start-service=true {{command}}`
 
-- Substitude what file changes:
+- Substitute the filename that changed in:
 
 `reflex -- echo {}`

--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -9,11 +9,11 @@
 
 - Compile and run Go application if any .go file changes:
 
-`reflex -r '{{\.go$}}' {{go run .}}`
+`reflex --regex='{{\.go$}}' {{go run .}}`
 
 - Ignore a directory when watching for changes:
 
-`reflex -R '{{^dir/}}' {{command}}`
+`reflex --inverse-regex='{{^dir/}}' {{command}}`
 
 - Run command when reflex starts and restarts on file changes:
 

--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -9,15 +9,15 @@
 
 - Compile and run Go application if any .go file changes:
 
-`reflex -r '\.go$' go run .`
+`reflex -r '{{\.go$}}' {{go run .}}`
 
-- Ignore a directory when wahtcing for changes:
+- Ignore a directory when watching for changes:
 
-`reflex -R '^node_modules/' yarn test`
+`reflex -R '{{^dir/}}' {{command}}`
 
 - Run command when reflex starts and restarts on file changes:
 
-`reflex -s go test`
+`reflex --start-service=true {{command}}`
 
 - Substitude what file changes:
 

--- a/pages/common/reflex.md
+++ b/pages/common/reflex.md
@@ -3,22 +3,22 @@
 > Reflex is a small tool to watch a directory and rerun a command when certain files change.
 > More information: <https://github.com/cespare/reflex>.
 
-- Rebuild with `make` if any file changes
+- Rebuild with `make` if any file changes:
 
 `reflex make`
 
-- Compile and run Go application if any .go file changes
+- Compile and run Go application if any .go file changes:
 
 `reflex -r '\.go$' go run .`
 
-- Ignore a directory when wahtcing for changes
+- Ignore a directory when wahtcing for changes:
 
 `reflex -R '^node_modules/' yarn test`
 
-- Run command when reflex starts and restarts on file changes
+- Run command when reflex starts and restarts on file changes:
 
 `reflex -s go test`
 
-- Substitude what file changes
+- Substitude what file changes:
 
 `reflex -- echo {}`


### PR DESCRIPTION
This pull request adds a page for [reflex](https://github.com/cespare/reflex), a populair tool to run arbitrary command when files change.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
