### PR TITLE
openssl: add subcommand pages

### DIFF
--- a/pages/common/openssl-req.md
+++ b/pages/common/openssl-req.md
@@ -1,0 +1,8 @@
+# openssl req
+
+> OpenSSL command to manage PKCS#10 Certificate Signing Requests.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-req.html>.
+
+- Generate a certificate signing request to be sent to a certificate authority:
+
+`openssl req -new -sha256 -key {{filename.key}} -out {{filename.csr}}`

--- a/pages/common/openssl-req.md
+++ b/pages/common/openssl-req.md
@@ -6,3 +6,7 @@
 - Generate a certificate signing request to be sent to a certificate authority:
 
 `openssl req -new -sha256 -key {{filename.key}} -out {{filename.csr}}`
+
+- Generate a selfsigned certificate and a corresponding keypair, storing both in a file:
+
+`openssl req -new -x509 -newkey {{rsa}}:{{4096}} -keyout {{filename.key}} -out {{filename.cert}} -subj "{{/C=XX/CN=foobar}}" -days {{365}}`

--- a/pages/common/openssl-s_client.md
+++ b/pages/common/openssl-s_client.md
@@ -1,0 +1,16 @@
+# openssl s_client
+
+> OpenSSL command to create TLS client connections.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-s_client.html>.
+
+- Display the start and expiry dates for a domain's certificate:
+
+`openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`
+
+- Display the certificate presented by an SSL/TLS server:
+
+`openssl s_client -connect {{host}}:{{port}} </dev/null`
+
+- Display the complete certificate chain of an HTTPS server:
+
+`openssl s_client -connect {{host}}:443 -showcerts </dev/null`

--- a/pages/common/openssl-x509.md
+++ b/pages/common/openssl-x509.md
@@ -1,0 +1,16 @@
+# openssl x509
+
+> OpenSSL command to manage X.509 certificates.
+> More information: <https://www.openssl.org/docs/manmaster/man1/openssl-x509.html>.
+
+- Generate a self-signed certificate from a certificate signing request valid for some number of days:
+
+`openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
+
+- Display certificate information:
+
+`openssl x509 -in {{filename.crt}} -noout -text`
+
+- Display a certificate's expiration date:
+
+`openssl x509 -enddate -noout -in {{filename.pem}}`

--- a/pages/common/openssl-x509.md
+++ b/pages/common/openssl-x509.md
@@ -3,10 +3,6 @@
 > OpenSSL command to manage X.509 certificates.
 > More information: <https://www.openssl.org/docs/manmaster/man1/openssl-x509.html>.
 
-- Generate a self-signed certificate from a certificate signing request valid for some number of days:
-
-`openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
-
 - Display certificate information:
 
 `openssl x509 -in {{filename.crt}} -noout -text`
@@ -14,3 +10,11 @@
 - Display a certificate's expiration date:
 
 `openssl x509 -enddate -noout -in {{filename.pem}}`
+
+- Convert a certificate between binary DER encoding and textual PEM encoding:
+
+`openssl x509 -inform {{der}} -outform {{pem}} -in {{original_certificate_file}} -out {{converted_certificate_file}}`
+
+- Store a certificate's public key in a file:
+
+`openssl x509 -in {{certificate_file}} -noout -pubkey -out {{output_file}}`

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -3,34 +3,14 @@
 > OpenSSL cryptographic toolkit.
 > More information: <https://www.openssl.org>.
 
-- Generate a 2048bit RSA private key and save it to a file:
+- Print a list of available subcommands:
 
-`openssl genrsa -out {{filename.key}} 2048`
+`openssl help`
 
-- Generate a certificate signing request to be sent to a certificate authority:
+- Print options for a specific subcommand:
 
-`openssl req -new -sha256 -key {{filename.key}} -out {{filename.csr}}`
+`openssl help {{x509}}`
 
-- Generate a self-signed certificate from a certificate signing request valid for some number of days:
+- Print the version of OpenSSL:
 
-`openssl x509 -req -days {{days}} -in {{filename.csr}} -signkey {{filename.key}} -out {{filename.crt}}`
-
-- Display certificate information:
-
-`openssl x509 -in {{filename.crt}} -noout -text`
-
-- Display a certificate's expiration date:
-
-`openssl x509 -enddate -noout -in {{filename.pem}}`
-
-- Display the start and expiry dates for a domain's certificate:
-
-`openssl s_client -connect {{host}}:{{port}} 2>/dev/null | openssl x509 -noout -dates`
-
-- Display the certificate presented by an SSL/TLS server:
-
-`openssl s_client -connect {{host}}:{{port}} </dev/null`
-
-- Display the complete certificate chain of an HTTPS server:
-
-`openssl s_client -connect {{host}}:443 -showcerts </dev/null`
+`openssl version`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

The old openssl page contained examples for various subcommands. This violates the contribution guide and prohibits adding more examples. This PR splits all available commands into appropriate subpages, adds the correct examples for the main command.
It also uses the new existing space to add a few more examples.
