### PR TITLE
redis-cli: add URI connection example

### DIFF
--- a/pages/common/redis-cli.md
+++ b/pages/common/redis-cli.md
@@ -15,6 +15,10 @@
 
 `redis-cli -h {{host}} -p {{port}}`
 
+- Connect to a remote server specifying an URI:
+
+`redis-cli -u {{uri}}`
+
 - Specify a password:
 
 `redis-cli -a {{password}}`


### PR DESCRIPTION
Many Redis cloud services/hosting provider gives the connection info as a full URI, so an example on how to connect with that is nice to have

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
