### PR TITLE
tmux: add window management commands and small improvements

### DIFF
--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -19,18 +19,18 @@
 
 `tmux attach`
 
-- Attach to a named session:
-
-`tmux attach -t {{name}}`
-
 - Detach from the current session (with prefix Ctrl-B):
 
 `Ctrl-B d`
 
+- Create a new window (with prefix Ctrl-B):
+
+`Ctrl-B c`
+
+- Switch between sessions and windows (with prefix Ctrl-B):
+
+`Ctrl-B w`
+
 - Kill a session by name:
 
 `tmux kill-session -t {{name}}`
-
-- Kill the current session (with prefix Ctrl-B):
-
-`Ctrl-B :kill-session<Enter>`

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -19,15 +19,15 @@
 
 `tmux attach`
 
-- Detach from the current session (with prefix Ctrl-B):
+- Detach from the current session (inside a tmux session):
 
 `Ctrl-B d`
 
-- Create a new window (with prefix Ctrl-B):
+- Create a new window (inside a tmux session):
 
 `Ctrl-B c`
 
-- Switch between sessions and windows (with prefix Ctrl-B):
+- Switch between sessions and windows (inside a tmux session):
 
 `Ctrl-B w`
 

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -9,7 +9,7 @@
 
 - Start a new named session:
 
-`tmux new-session -s {{name}}`
+`tmux new -s {{name}}`
 
 - List existing sessions:
 
@@ -17,11 +17,11 @@
 
 - Attach to the most recently used session:
 
-`tmux attach-session`
+`tmux attach`
 
 - Attach to a named session:
 
-`tmux attach-session -t {{name}}`
+`tmux attach -t {{name}}`
 
 - Detach from the current session (with prefix Ctrl-B):
 


### PR DESCRIPTION
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

Window management commands are important to correctly work with tmux. I replaced two redundant commands with two window management commands.

Please note I reverted the full command names used by @ryanolsonx. This is a subjective choice, but I think the shorter command names are sufficient to understand what they do and preferable to a `tldr` (people can check more information on the `man` page anyway). I can revert this specific commit if you prefer.