### PR TITLE
pip-install: add page

### DIFF
--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -15,6 +15,6 @@
 
 `pip install -r {{requirements.txt}}`
 
-- Install local package in develop (editable) mode:
+- Install the local package in the current directory in develop (editable) mode:
 
 `pip install -e .`

--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -11,7 +11,7 @@
 
 `pip install {{package_name}}=={{package_version}}`
 
-- Install packages from file:
+- Install packages listed in a file:
 
 `pip install -r {{requirements.txt}}`
 

--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -18,4 +18,3 @@
 - Install local package in develop (editable) mode:
 
 `pip install -e .`
-

--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -1,0 +1,17 @@
+# pip install
+
+> Install Python packages.
+> More information: <https://pip.pypa.io>.
+
+- Install a package:
+
+`pip install {{package_name}}`
+
+- Install a specific version of a package:
+
+`pip install {{package_name}}=={{package_version}}`
+
+- Install packages from file:
+
+`pip install -r {{requirements.txt}}`
+

--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -15,3 +15,7 @@
 
 `pip install -r {{requirements.txt}}`
 
+- Install local package in develop (editable) mode:
+
+`pip install -e .`
+

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -3,13 +3,9 @@
 > Python package manager.
 > More information: <https://pip.pypa.io>.
 
-- Install a package:
+- Install a package (see `tldr pip install` for more install commands):
 
 `pip install {{package_name}}`
-
-- Install a specific version of a package:
-
-`pip install {{package_name}}=={{package_version}}`
 
 - Upgrade a package:
 
@@ -22,10 +18,6 @@
 - Save installed packages to file:
 
 `pip freeze > {{requirements.txt}}`
-
-- Install packages from file:
-
-`pip install -r {{requirements.txt}}`
 
 - Show installed package info:
 

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -3,7 +3,7 @@
 > Python package manager.
 > More information: <https://pip.pypa.io>.
 
-- Install a package (see `tldr pip install` for more install commands):
+- Install a package (see `tldr pip install` for more install examples):
 
 `pip install {{package_name}}`
 

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -3,7 +3,7 @@
 > Python package manager.
 > More information: <https://pip.pypa.io>.
 
-- Install a package (see `tldr pip install` for more install examples):
+- Install a package (see `pip install` for more install examples):
 
 `pip install {{package_name}}`
 


### PR DESCRIPTION
The `pip` file has a lot of commands, and many of them are different kinds of installation. I broke them into a separate file to keep `pip.md` concise. Since `pip-install.md` now has some room, I also added the useful command for installing in editable mode.

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
