### PR TITLE
find: add space to -exec example to avoid error

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -28,7 +28,7 @@
 
 - Run a command for each file (use `{}` within the command to access the filename):
 
-`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }}\;`
+`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }} \;`
 
 - Find files modified in the last 7 days, and delete them:
 


### PR DESCRIPTION
Add space before backslash in line 31. Without the space you would get the error message: missing argument to exec

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->


- [x ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
