### PR TITLE
conda: fix deactivate example

### DIFF
--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -11,7 +11,7 @@
 
 `conda info --envs`
 
-- Load  an environment:
+- Load an environment:
 
 `conda activate {{environment_name}}`
 

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -11,9 +11,13 @@
 
 `conda info --envs`
 
-- Load or unload an environment:
+- Load  an environment:
 
-`conda {{activate|deactivate}} {{environment_name}}`
+`conda activate {{environment_name}}`
+
+- Unload an environment:
+
+`conda deactivate`
 
 - Delete an environment (remove all packages):
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

`conda deactivate environment` isn't a valid command. While calling deactivate without an environment based on the tldr example might seem obvious to experienced coders, it was the source of confusion in work today. I think the new change follows the guidelines for command examples:

> When in doubt, keep new command-line users in mind. Err on the side of clarity rather than terseness. For example, commands that require sudo should include it directly in the examples.