### PR TITLE
bundle: add exec example

### DIFF
--- a/pages/common/bundle.md
+++ b/pages/common/bundle.md
@@ -7,6 +7,10 @@
 
 `bundle install`
 
+- Execute a command in the context of the current bundle:
+
+`bundle exec {{gemcommand}}`
+
 - Update all gems by the rules defined in the `Gemfile` and regenerate `Gemfile.lock`:
 
 `bundle update`

--- a/pages/common/bundle.md
+++ b/pages/common/bundle.md
@@ -9,7 +9,7 @@
 
 - Execute a command in the context of the current bundle:
 
-`bundle exec {{gemcommand}}`
+`bundle exec {{command}} {{arguments}}`
 
 - Update all gems by the rules defined in the `Gemfile` and regenerate `Gemfile.lock`:
 


### PR DESCRIPTION
I just added a very popular bundle command: `bundle exec`. Please check it!
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).