### PR TITLE
ci: add PDF generation to deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
     - name: Build
       run: bash scripts/build.sh
 
+    - name: Setup Python for PDF generation
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Build PDF
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
+      run: |
+        cd scripts/pdf/
+        pip3 install -r requirements.txt
+        python3 render.py ../../pages -c solarized-light
+
     - name: Deploy
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
       run: bash scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,11 @@ function upload_assets {
   mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
   cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
 
+  # Copy PDF to assets
+  if [[ -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" ]]; then
+    cp -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" "${SITE_HOME}/assets/tldr-book.pdf"
+  fi
+
   cd "$SITE_HOME"
   git add -A
   git commit -m "[GitHub Actions] uploaded assets after commit ${GITHUB_SHA}"


### PR DESCRIPTION
This adds PDF generation as a build step in the CI. It's currently only generating a Solarized Dark version, however we could upload a `tldr-book-dark.pdf` if we wanted to. 🤷🏻

You can view the  generated output on my test run here: https://github.com/owenvoke/tldr/runs/1462999918

And download the zipped build artifact containing the PDF here: https://github.com/owenvoke/tldr/suites/1570682479/artifacts/28298606

Personally I'm not sure a PDF is worth the wait time (3 minutes for that build step), which will only increase. But if people actually use it, then I guess this seems ok. The only other thing I'm not sure about is if multiple commits go to the master branch, which PDF would be uploaded last.

Closes #4969, and it would probably be good to wait until after #4993 is merged. 👍🏻