### PR TITLE
etcdctl: add page

### DIFF
--- a/pages/common/etcdctl.md
+++ b/pages/common/etcdctl.md
@@ -1,0 +1,37 @@
+# etcdctl
+
+> CLI interface for interacting with etcd high performance key/value pair store.
+> Etcd stores keys in a filesystem-like format, e.g. /my/key.
+> More information: <https://etcd.io/docs/latest/dev-guide/interacting_v3/>.
+
+- Get a key:
+
+`etcdctl get {{/my/key}}`
+
+- Set a key:
+
+`etcdctl put {{/my/key}} {{my_value}}`
+
+- Delete a key:
+
+`etcdctl del {{/my/key}}`
+
+- Set a key, reading from a file:
+
+`etcdctl put {{/my/file}} < {{file.txt}}`
+
+- Save a snapshot of the etcd keystore:
+
+`etcdctl snapshot save {{snapshot.db}}`
+
+- Restore a snapshot of an etcd keystore (restart the etcd server afterwards):
+
+`etcdctl snapshot restore {{snapshot.db}}`
+
+- Add a user:
+
+`etcdctl user add {{my_user}}`
+
+- Watch a key for changes:
+
+`etcdctl watch {{/my/key}}`

--- a/pages/common/etcdctl.md
+++ b/pages/common/etcdctl.md
@@ -1,22 +1,22 @@
 # etcdctl
 
-> CLI interface for interacting with etcd high performance key/value pair store.
-> Etcd stores keys in a filesystem-like format, e.g. /my/key.
+> CLI interface for interacting with etcd high performance key-value pair store.
+> Etcd stores data in hierarchically organized directories, as in a standard filesystem.
 > More information: <https://etcd.io/docs/latest/dev-guide/interacting_v3/>.
 
-- Get a key:
+- Display the key-value pair:
 
 `etcdctl get {{my/key}}`
 
-- Set a key:
+- Store a key-value pair:
 
 `etcdctl put {{my/key}} {{my_value}}`
 
-- Delete a key:
+- Delete a key-value pair:
 
 `etcdctl del {{my/key}}`
 
-- Set a key, reading the value from a file:
+- Store a key-value pair, reading the value from a file:
 
 `etcdctl put {{my/file}} < {{path/to/file.txt}}`
 

--- a/pages/common/etcdctl.md
+++ b/pages/common/etcdctl.md
@@ -1,6 +1,6 @@
 # etcdctl
 
-> CLI interface for interacting with etcd high performance key-value pair store.
+> CLI interface for interacting with `etcd`, a highly-available key-value pair store.
 > Etcd stores data in hierarchically organized directories, as in a standard filesystem.
 > More information: <https://etcd.io/docs/latest/dev-guide/interacting_v3/>.
 

--- a/pages/common/etcdctl.md
+++ b/pages/common/etcdctl.md
@@ -4,7 +4,7 @@
 > Etcd stores data in hierarchically organized directories, as in a standard filesystem.
 > More information: <https://etcd.io/docs/latest/dev-guide/interacting_v3/>.
 
-- Display the key-value pair:
+- Display the value associated with a specified key:
 
 `etcdctl get {{my/key}}`
 

--- a/pages/common/etcdctl.md
+++ b/pages/common/etcdctl.md
@@ -6,27 +6,27 @@
 
 - Get a key:
 
-`etcdctl get {{/my/key}}`
+`etcdctl get {{my/key}}`
 
 - Set a key:
 
-`etcdctl put {{/my/key}} {{my_value}}`
+`etcdctl put {{my/key}} {{my_value}}`
 
 - Delete a key:
 
-`etcdctl del {{/my/key}}`
+`etcdctl del {{my/key}}`
 
-- Set a key, reading from a file:
+- Set a key, reading the value from a file:
 
-`etcdctl put {{/my/file}} < {{file.txt}}`
+`etcdctl put {{my/file}} < {{path/to/file.txt}}`
 
 - Save a snapshot of the etcd keystore:
 
-`etcdctl snapshot save {{snapshot.db}}`
+`etcdctl snapshot save {{path/to/snapshot.db}}`
 
 - Restore a snapshot of an etcd keystore (restart the etcd server afterwards):
 
-`etcdctl snapshot restore {{snapshot.db}}`
+`etcdctl snapshot restore {{path/to/snapshot.db}}`
 
 - Add a user:
 
@@ -34,4 +34,4 @@
 
 - Watch a key for changes:
 
-`etcdctl watch {{/my/key}}`
+`etcdctl watch {{my/key}}`


### PR DESCRIPTION
Adds page for [etcdctl](https://etcd.io/docs/v3.4.0/dev-guide/interacting_v3/), the CLI for [etcd](https://etcd.io/).  Page for `etcd` coming soon!

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
