### PR TITLE
conan: add page

### DIFF
--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -1,0 +1,28 @@
+# conan
+
+> The open source, decentralized and multi-platform package manager to create and share all your native binaries.
+> More information: <https://conan.io/>.
+
+- Install packages based on conanfile.txt:
+
+`conan install {{.}}`
+
+- Install packages and create configuation files for a specific generator:
+
+`conan install -g {{generator}}`
+
+- Install packages, building from source:
+
+`conan install {{.}} --build`
+
+- Search for locally installed packages:
+
+`conan search {{package}}`
+
+- Search for remote packages:
+
+`conan search {{package}} -r {{remote}}`
+
+- List remotes:
+
+`conan remote --list`


### PR DESCRIPTION
Adds page for [conan](https://conan.io/).  Eventually I will add separate pages for conan subcommands.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
