### PR TITLE
scp: add -P example

### DIFF
--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -10,7 +10,7 @@
 
 - Use a specific port when connecting to the remote host:
 
-`scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}} -P {{port}}`
+`scp {{path/to/local_file}} -P {{port}} {{remote_host}}:{{path/to/remote_file}}`
 
 - Copy a file from a remote host to a local directory:
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -1,7 +1,8 @@
 # scp
 
-> Secure copy.
-> Copy files between hosts using Secure Copy Protocol over SSH.
+> Secure copy.  
+> Copy files between hosts using Secure Copy Protocol over SSH.  
+> More information: <https://man.openbsd.org/scp>.
 
 - Copy a local file to a remote host:
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -7,7 +7,7 @@
 
 `scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}}`
 
-- Specify which port to connect to the remote host on:
+- Use a specific port when connecting to the remote host:
 
 `scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}} -P {{port}}`
 

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -7,6 +7,10 @@
 
 `scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}}`
 
+- Specify which port to connect to the remote host on:
+
+`scp {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}} -P {{port}}`
+
 - Copy a file from a remote host to a local directory:
 
 `scp {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`

--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -1,7 +1,7 @@
 # scp
 
-> Secure copy.  
-> Copy files between hosts using Secure Copy Protocol over SSH.  
+> Secure copy.
+> Copy files between hosts using Secure Copy Protocol over SSH.
 > More information: <https://man.openbsd.org/scp>.
 
 - Copy a local file to a remote host:


### PR DESCRIPTION
The `ssh` example shows how to connect to the remote host using a specific port (`-p`), and in the past I've been caught-out that specifying a port with `scp` uses `-P` instead.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
