### PR TITLE
kubectl: add kubectl describe in header

### DIFF
--- a/pages/common/kubectl.md
+++ b/pages/common/kubectl.md
@@ -3,9 +3,13 @@
 > Command line interface for running commands against Kubernetes clusters.
 > More information: <https://kubernetes.io/docs/reference/kubectl/>.
 
-- List all information about a resource with more details:
+- List information about a resource with more details:
 
 `kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+
+- Describe information about a resource with all details:
+
+`kubectl describe {{pod|service|deployment|ingress|...}}`
 
 - Update specified pod with the label 'unhealthy' and the value 'true':
 

--- a/pages/common/kubectl.md
+++ b/pages/common/kubectl.md
@@ -1,15 +1,12 @@
 # kubectl
 
 > Command line interface for running commands against Kubernetes clusters.
+> See also `kubectl describe` and other pages for additional information.
 > More information: <https://kubernetes.io/docs/reference/kubectl/>.
 
 - List information about a resource with more details:
 
 `kubectl get {{pod|service|deployment|ingress|...}} -o wide`
-
-- Describe information about a resource with all details:
-
-`kubectl describe {{pod|service|deployment|ingress|...}}`
 
 - Update specified pod with the label 'unhealthy' and the value 'true':
 


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/pull/4494 added `kubectl describe` help, but the main page still doesn't mention it. Add a note about its usage.

~~This is an important command, but it exceeds the suggested limit of 8 examples (do subcommands count as "examples"?). We could instead replace the `kubectl get` example with `kubectl {{get|describe}}`, but I'm really not a fan of that, since they're two different subcommands.~~

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
