### PR TITLE
lsblk: add custom output example

### DIFF
--- a/pages/linux/lsblk.md
+++ b/pages/linux/lsblk.md
@@ -29,3 +29,7 @@
 - Exclude the devices specified by the comma-separated list of major device numbers:
 
 `lsblk -e {{1,7}}`
+
+- Produce a customized summary:
+
+`lsblk --output NAME,SERIAL,MODEL,TRAN,TYPE,SIZE,FSTYPE,MOUNTPOINT`

--- a/pages/linux/lsblk.md
+++ b/pages/linux/lsblk.md
@@ -30,6 +30,6 @@
 
 `lsblk -e {{1,7}}`
 
-- Produce a customized summary:
+- Display a customized summary using a comma-separated list of columns:
 
-`lsblk --output NAME,SERIAL,MODEL,TRAN,TYPE,SIZE,FSTYPE,MOUNTPOINT`
+`lsblk --output {{NAME}},{{SERIAL}},{{MODEL}},{{TRAN}},{{TYPE}},{{SIZE}},{{FSTYPE}},{{MOUNTPOINT}}`


### PR DESCRIPTION
I generally find the output of lsblk presets to be lacking, and a customized output is very helpful, particularly as I've provided.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
