### PR TITLE
sort: add output file example

### DIFF
--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -19,9 +19,9 @@
 
 `sort -n {{path/to/file}}`
 
-- Sort the passwd file by the 3rd field, numerically:
+- Sort a file, printing the output to the specified output file (can be used to sort a file in-place):
 
-`sort -t: -k 3n /etc/passwd`
+`sort --output={{path/to/file}} {{path/to/file}}`
 
 - Sort a file preserving only unique lines:
 

--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -19,17 +19,17 @@
 
 `sort -n {{path/to/file}}`
 
-- Sort a file, printing the output to the specified output file (can be used to sort a file in-place):
+- Sort the passwd file by the 3rd field, numerically:
 
-`sort --output={{path/to/file}} {{path/to/file}}`
+`sort -t: -k 3n /etc/passwd`
 
 - Sort a file preserving only unique lines:
 
 `sort -u {{path/to/file}}`
 
-- Sort human-readable numbers (in this case the 5th field of `ls -lh`):
+- Sort a file, printing the output to the specified output file (can be used to sort a file in-place):
 
-`ls -lh | sort -h -k 5`
+`sort --output={{path/to/file}} {{path/to/file}}`
 
 - Sort numbers with exponents:
 


### PR DESCRIPTION
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

---

This PR aims to add an example for redirecting the sorted output to a file. I especially like the ability to use the `--output` flag to modify a file in-place, replacing the contents with the sorted lines.
Maybe even using the shorter version `sort -o path/to/file path/to/file`, since `-o` is a common flag, but the long version follows the guidelines and is probably easier to understand.

However, the sort page already has 8 examples. My commit suggestion removes an example that in my opinion refers to a more specific usecase. The possibility to sort by a field is also outlined in the 7th example.

But of course this is open for discussion and i'm interested to hear your feedback!