### PR TITLE
direnv: fix direnv edit example

### DIFF
--- a/pages/common/direnv.md
+++ b/pages/common/direnv.md
@@ -13,7 +13,7 @@
 
 - Edit the `.envrc` file in the default text editor and reload the environment on exit:
 
-`direnv allow`
+`direnv edit .`
 
 - Trigger a reload of the environment:
 


### PR DESCRIPTION
Second example for `direnv allow` should be `direnv edit` as per description

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

<!-- - [ ] The page (if new), does not already exist in the repo. -->
<!-- - [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.) -->
<!-- - [ ] The page has 8 or fewer examples. -->
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
<!-- - [ ] The page description includes a link to documentation or a homepage (if applicable). -->
