### PR TITLE
Fix syntax of "More information" links

### DIFF
--- a/pages/common/arc.md
+++ b/pages/common/arc.md
@@ -1,7 +1,7 @@
 # arc
 
 > Arcanist: A CLI for Phabricator.
-> More information <https://secure.phabricator.com/book/phabricator/article/arcanist/>.
+> More information: <https://secure.phabricator.com/book/phabricator/article/arcanist/>.
 
 - Send the changes to Differential for review:
 

--- a/pages/common/deemix.md
+++ b/pages/common/deemix.md
@@ -2,7 +2,7 @@
 
 > A barebone deezer downloader library built from the ashes of Deezloader Remix.
 > It can be used as a standalone CLI app or implemented in an UI using the API.
-> More Information: <https://deemix.app>.
+> More information: <https://deemix.app>.
 
 - Download a track or playlist:
 

--- a/pages/common/eva.md
+++ b/pages/common/eva.md
@@ -1,7 +1,7 @@
 # eva
 
 > Simple calculator REPL, similar to `bc`, with syntax highlighting and persistent history.
-> More information <https://github.com/NerdyPepper/eva>.
+> More information: <https://github.com/NerdyPepper/eva>.
 
 - Run the calculator in interactive mode:
 

--- a/pages/common/fnm.md
+++ b/pages/common/fnm.md
@@ -2,7 +2,7 @@
 
 > Fast Node.js version manager.
 > Install, uninstall or switch between Node.js versions.
-> More info: <https://github.com/Schniz/fnm>.
+> More information: <https://github.com/Schniz/fnm>.
 
 - Install a specific version of Node.js:
 

--- a/pages/common/glow.md
+++ b/pages/common/glow.md
@@ -1,7 +1,7 @@
 # glow
 
 > Render Markdown in the terminal.
-> More infomration: <https://github.com/charmbracelet/glow>.
+> More information: <https://github.com/charmbracelet/glow>.
 
 - Run glow and select a file to view:
 

--- a/pages/common/ipython.md
+++ b/pages/common/ipython.md
@@ -1,7 +1,7 @@
 # IPython
 
 > A Python shell with automatic history, dynamic object introspection, easier configuration, command completion, access to the system shell and more.
-> More information: https://ipython.org/documentation.html.
+> More information: <https://ipython.org/documentation.html>.
 
 - Start an interactive IPython session:
 

--- a/pages/common/kotlin.md
+++ b/pages/common/kotlin.md
@@ -1,7 +1,7 @@
 # kotlin
 
 > Kotlin Application Launcher.
-> More information <https://kotlinlang.org>.
+> More information: <https://kotlinlang.org>.
 
 - Run a jar file:
 

--- a/pages/common/nativefier.md
+++ b/pages/common/nativefier.md
@@ -1,7 +1,7 @@
 # nativefier
 
 > Command-line tool to create a desktop app for any web site with minimal configuration.
-> More information <https://github.com/jiahaog/nativefier>.
+> More information: <https://github.com/jiahaog/nativefier>.
 
 - Make a desktop app for a website:
 

--- a/pages/common/notmuch.md
+++ b/pages/common/notmuch.md
@@ -1,7 +1,7 @@
 # notmuch
 
 > Command-line based program for indexing, searching, reading, and tagging large collections of email messages.
-> More Information: <https://notmuchmail.org/manpages/>.
+> More information: <https://notmuchmail.org/manpages/>.
 
 - Configure for first use:
 

--- a/pages/common/virsh.md
+++ b/pages/common/virsh.md
@@ -1,8 +1,8 @@
 # virsh
 
 > Manage virsh guest domains.
-> More information: <https://libvirt.org/virshcmdref.html>.
 > NOTE: 'guest_id' can be the id, name or UUID of the guest.
+> More information: <https://libvirt.org/virshcmdref.html>.
 
 - Connect to a hypervisor session:
 

--- a/pages/linux/efibootmgr.md
+++ b/pages/linux/efibootmgr.md
@@ -1,7 +1,7 @@
 # efibootmgr
 
 > Manipulate the UEFI Boot Manager (the Bootoptions).
-> More information: https://linux.die.net/man/8/efibootmgr.
+> More information: <https://linux.die.net/man/8/efibootmgr>.
 
 - List the current settings / bootnums:
 

--- a/pages/linux/homeshick.md
+++ b/pages/linux/homeshick.md
@@ -1,7 +1,7 @@
-# Homeshick
+# homeshick
 
 > Synchronize Git dotfiles.
-> More information <https://github.com/andsens/homeshick/wiki>.
+> More information: <https://github.com/andsens/homeshick/wiki>.
 
 - Create a new castle:
 

--- a/pages/linux/netselect.md
+++ b/pages/linux/netselect.md
@@ -1,7 +1,7 @@
 # netselect
 
 > Speed test for choosing a fast network server.
-> More information: <https://github.com/apenwarr/netselect> .
+> More information: <https://github.com/apenwarr/netselect>.
 
 - Choose the server with the lowest latency:
 

--- a/pages/linux/rofi.md
+++ b/pages/linux/rofi.md
@@ -1,7 +1,7 @@
 # rofi
 
 > An application launcher and window switcher.
-> More Information: <https://github.com/davatorium/rofi>.
+> More information: <https://github.com/davatorium/rofi>.
 
 - Show the list of apps:
 

--- a/pages/linux/vgs.md
+++ b/pages/linux/vgs.md
@@ -1,7 +1,7 @@
 # vgs
 
 > Display information about LVM volume groups.
-> More information: https://man7.org/linux/man-pages/man8/vgs.8.html .
+> More information: <https://man7.org/linux/man-pages/man8/vgs.8.html>.
 
 - Display information about volume groups:
 

--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -2,7 +2,7 @@
 
 > Prompts the user to select one item from a list of single-character choices in a batch program, and then returns the index of the selected choice.
 > If used without parameters, choice displays the default choices Y and N.
-> More Information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/choice>.
+> More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/choice>.
 
 - A,B and C as list of choices to be used:
 


### PR DESCRIPTION
Changes split out from #5043. All credit to @owenvoke.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
