### PR TITLE
nc: improve grammar; bring under the 8 example limit

### DIFF
--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -15,19 +15,11 @@
 
 `nc -w {{timeout_in_seconds}} {{ipaddress}} {{port}}`
 
-- Serve a file:
-
-`nc -l {{port}} < {{file}}`
-
-- Receive a file:
-
-`nc {{ip_address}} {{port}} > {{file}}`
-
-- Server stay up after client detach:
+- Keep the server up after the client detaches:
 
 `nc -k -l {{port}}`
 
-- Client stay up after EOF:
+- Keep the client up even after EOF:
 
 `nc -q {{timeout}} {{ip_address}}`
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -7,7 +7,7 @@
 
 `nc -l {{port}}`
 
-- Connect to a certain port (you can then write to this port):
+- Connect to a certain port:
 
 `nc {{ip_address}} {{port}}`
 


### PR DESCRIPTION
This page edit is in its own PR, as I ended up making some more extensive modifications to it in addition to bringing it under the 8 example limit.

I argue that the send / receive a file examples a redundant, as it showcases existing shell functionality. The first 1 examples should cover these fine I think.

Part of #5046.