### PR TITLE
remove duplicate pages/index.json file

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,6 @@ function initialize {
 
 function build_index {
   npm run build-index
-  cp index.json pages/
   echo "Pages index succesfully built."
 }
 


### PR DESCRIPTION
Closes #2865.

Of the three clients listed that have not updated to use the new `index.json` location, two are essentially abandoned / dead, and I have opened a PR for [pepa65/tldr-bash-client](https://gitlab.com/pepa65/tldr-bash-client): https://gitlab.com/pepa65/tldr-bash-client/-/merge_requests/13

However, given that these clients have had a year and half to make this change, I think it's probably fair to make this change and remove the duplicate file.