### PR TITLE
MAINTAINERS: Fix link to @zlatanvasovic's GH profile

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -43,7 +43,7 @@ If you are an owner of the organization, you should be able to see an automated 
   [11 April 2019](https://github.com/tldr-pages/tldr/issues/2898) — [17 January 2019](https://github.com/tldr-pages/tldr/issues/3764)
 - Ein Verne ([@einverne](https://github.com/einverne)):
   [29 October 2019](https://github.com/tldr-pages/tldr/issues/3488) — [12 January 2020](https://github.com/tldr-pages/tldr/issues/3738)
-- Zlatan Vasović ([@zdroid](https://github.com/zdroid)):
+- Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic)):
   [30 November 2019](https://github.com/tldr-pages/tldr/issues/3636) — [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663)
 - Iván Hernández Cazorla ([@ivanhercaz](https://github.com/ivanhercaz)):
   [24 December 2019](https://github.com/tldr-pages/tldr/issues/3690) — [5 January 2020](https://github.com/tldr-pages/tldr/issues/3736)
@@ -68,7 +68,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258) — [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989)
 - Marco Bonelli ([@mebeim](https://github.com/mebeim)):
   [9 April 2019](https://github.com/tldr-pages/tldr/issues/2874) — [21 December 2019](https://github.com/tldr-pages/tldr/issues/3672)
-- Zlatan Vasović ([@zdroid](https://github.com/zdroid)):
+- Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic)):
   [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663) — [19 June 2020](https://github.com/tldr-pages/tldr/issues/4113)
 
 
@@ -88,7 +88,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989) — present
 - **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:
   [21 December 2019](https://github.com/tldr-pages/tldr/issues/3672) — present
-- **Zlatan Vasović ([@zdroid](https://github.com/zdroid))**:
+- **Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic))**:
   [19 June 2020](https://github.com/tldr-pages/tldr/issues/4113) — present
 - Igor Shubovych ([@igorshubovych](https://github.com/igorshubovych)):
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

Fixes the link to Zlatan Vasović's profile from the old `@zdroid` that they used at some point in the past to their actual current profile @zlatanvasovic. The old name had been reclaimed by someone in December 2020.