### PR TITLE
brew: remove cleanup example

### DIFF
--- a/pages/osx/brew.md
+++ b/pages/osx/brew.md
@@ -27,10 +27,6 @@
 
 `brew update`
 
-- Remove old versions of installed formulae (if no formula name is given, all installed formulae are processed):
-
-`brew cleanup {{formula}}`
-
 - Display information about a formula (version, installation path, dependencies, etc.):
 
 `brew info {{formula}}`


### PR DESCRIPTION
This removes the cleanup example from the brew page. The [2.0 release](https://brew.sh/2019/02/02/homebrew-2.0.0/) back in Feb. 2019 made it so that cleanup is run automatically every 30 days, making manual usage of this command not really necessary for the casual user. Removing this example also brings this page to having only 8 examples as part of #5046.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).