### PR TITLE
flameshot: remove trailing space in title line

### DIFF
--- a/pages/common/uvicorn.md
+++ b/pages/common/uvicorn.md
@@ -1,4 +1,4 @@
-# uvicorn 
+# uvicorn
 
 > Python ASGI HTTP Server, for asynchronous projects.
 > More information: <https://www.uvicorn.org/>.

--- a/pages/linux/flameshot.md
+++ b/pages/linux/flameshot.md
@@ -1,4 +1,4 @@
-# flameshot 
+# flameshot
 
 > Screenshot utility with a gui interface.
 > Supports basic image editing, such as text, shapes, colors, and imgur.


### PR DESCRIPTION
Fixes the title of this page so that it does not run afoul of the lint rule `TLDR014` which says to have no trailing spaces. This was caught in testing patch for tldr-lint (https://github.com/tldr-pages/tldr-lint/pull/31) to catch these sorts of lint errors.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
