### PR TITLE
ci: add tldr-pages/tldr before commit hash for auto gh linking

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,7 +37,7 @@ function upload_assets {
 
   cd "$SITE_HOME"
   git add -A
-  git commit -m "[GitHub Actions] uploaded assets after commit ${GITHUB_SHA}"
+  git commit -m "[GitHub Actions] uploaded assets after commit tldr-pages/tldr@${GITHUB_SHA}"
   git push -q
 
   echo "Assets (pages archive, index) deployed to static site."


### PR DESCRIPTION
This amends the commit message for the deploy from:

> `[GitHub Actions] uploaded assets after commit 0392bcf423708dca266ddd09e657c8b3950bbd99`

To: 

> `[GitHub Actions] uploaded assets after commit tldr-pages/tldr@0392bcf423708dca266ddd09e657c8b3950bbd99`

This allows the web UI to make use of GitHub's auto parsing of the text so that the second example would provide a hyperlink automatically back to the commit in question on GitHub's UI versus the first example which is always just plain text that the user then has to manually input into the URL bar (as well as getting the right prefix stem).

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
