### PR TITLE
brew: fix GitHub case in translations

### DIFF
--- a/pages.es/linux/brew.md
+++ b/pages.es/linux/brew.md
@@ -18,7 +18,7 @@
 
 `brew upgrade {{formula}}`
 
-- Actualiza a la última versión de Linuxbrew y de todas las fórmulas desde Github:
+- Actualiza a la última versión de Linuxbrew y de todas las fórmulas desde GitHub:
 
 `brew update`
 

--- a/pages.it/osx/brew.md
+++ b/pages.it/osx/brew.md
@@ -23,7 +23,7 @@
 
 `brew upgrade {{formula}}`
 
-- Trova la versione più aggiornata di Homebrew e di tutte le formule da Github: 
+- Trova la versione più aggiornata di Homebrew e di tutte le formule da GitHub: 
 
 `brew update`
 


### PR DESCRIPTION
Corrects `Github` to `GitHub` in Spanish and Italian `brew.md` translations.
