### PR TITLE
watson: add page

### DIFF
--- a/pages/common/watson.md
+++ b/pages/common/watson.md
@@ -1,0 +1,20 @@
+# watson
+
+> A wonderful CLI to track your time.
+> More information: <https://github.com/TailorDev/Watson>.
+
+- Start monitoring time in project:
+
+`watson start {{project}}`
+
+- Start monitoring time in project with tags:
+
+`watson start {{project}} +{{tag}}`
+
+- Stop monitoring time for the current project:
+
+`watson stop`
+
+- Display latest working sessions:
+
+`watson log`


### PR DESCRIPTION
Add [Watson](https://github.com/TailorDev/Watson) page.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md%23commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md%23guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
