### PR TITLE
stolonctl: change page title to filename

### DIFF
--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -1,6 +1,6 @@
 # stolonctl
 
-> Stolon is a cloud native PostgreSQL manager for PostgreSQL high availability.
+> CLI for Stolon, a cloud native PostgreSQL manager for PostgreSQL high availability.
 > More information: <https://github.com/sorintlab/stolon>.
 
 - Get cluster status:

--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -1,6 +1,6 @@
-# Stolon
+# stolonctl
 
-> A cloud native PostgreSQL manager for PostgreSQL high availability.
+> Stolon is a cloud native PostgreSQL manager for PostgreSQL high availability.
 > More information: <https://github.com/sorintlab/stolon>.
 
 - Get cluster status:


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Per discussion in #5071, this updates the `stolonctl` page to have its title match the file name. I have updated the description here to include the `Stolon` reference and that the description now matches the first sentence in the README as well.