### PR TITLE
gpg2: update page title to match file name

### DIFF
--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -1,6 +1,7 @@
 # gpg
 
 > GNU Privacy Guard.
+> See `gpg2` for GNU Privacy Guard 2.
 > More information: <https://gnupg.org>.
 
 - Sign doc.txt without encryption (writes output to doc.txt.asc):

--- a/pages/common/gpg2.md
+++ b/pages/common/gpg2.md
@@ -1,6 +1,7 @@
-# gpg
+# gpg2
 
 > GNU Privacy Guard 2.
+> See `gpg` for GNU Privacy Guard 1.
 > More information: <https://docs.releng.linuxfoundation.org/en/latest/gpg.html>.
 
 - List imported keys:


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Fixes the page title of `gpg2` to match its filename, per #5071. I have also appended this page (and `gpg`) to include a link to the other page per @owenvoke's [comment](https://github.com/tldr-pages/tldr/issues/5071#issuecomment-753867840) in that issue.