### PR TITLE
git-bugreport: add page

### DIFF
--- a/pages/common/git-bugreport.md
+++ b/pages/common/git-bugreport.md
@@ -1,6 +1,6 @@
 # git bugreport
 
-> Captures information about the user's machine, Git client, and repository state, as well as a form requesting information about the behavior the user observed, into a single text file which the user can then share, for example to the Git mailing list, in order to report an observed bug.
+> Captures information about the user's machine, Git client, and repository state, as well as a form requesting information about the behavior the user observed, into a single text file which the user can share in order to report an observed bug.
 
 - Create a new bugreport file in the current directory:
 

--- a/pages/common/git-bugreport.md
+++ b/pages/common/git-bugreport.md
@@ -1,0 +1,15 @@
+# git bugreport
+
+> Captures information about the user's machine, Git client, and repository state, as well as a form requesting information about the behavior the user observed, into a single text file which the user can then share, for example to the Git mailing list, in order to report an observed bug.
+
+- Create a new bugreport file in the current directory:
+
+`git bugreport`
+
+- Create a new bugreport file in the specified, creating the directory if it does not exist:
+
+`git bugreport --output-directory {{path/to/directory}}`
+
+- Create a new bugreport file with the filename suffix in the specified `strftime` format:
+
+`git bugreport --suffix {{%m%d%y}}`

--- a/pages/common/git-bugreport.md
+++ b/pages/common/git-bugreport.md
@@ -1,15 +1,15 @@
 # git bugreport
 
-> Captures information about the user's machine, Git client, and repository state, as well as a form requesting information about the behavior the user observed, into a single text file which the user can share in order to report an observed bug.
+> Captures debug information from the system and user, generating a text file to aid in the reporting of a bug in Git.
 
 - Create a new bugreport file in the current directory:
 
 `git bugreport`
 
-- Create a new bugreport file in the specified, creating the directory if it does not exist:
+- Create a new bugreport file in the specified directory, creating it if it does not exist:
 
 `git bugreport --output-directory {{path/to/directory}}`
 
-- Create a new bugreport file with the filename suffix in the specified `strftime` format:
+- Create a new bugreport file with the specified filename suffix in `strftime` format:
 
 `git bugreport --suffix {{%m%d%y}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953