### PR TITLE
git-check-attr: add page

### DIFF
--- a/pages/common/git-check-attr.md
+++ b/pages/common/git-check-attr.md
@@ -5,7 +5,7 @@
 
 - Check the values of all attributes on a file:
 
-`git check-attr -a {{path/to/file}}`
+`git check-attr --all {{path/to/file}}`
 
 - Check the value of a specific attribute on a file:
 
@@ -13,7 +13,7 @@
 
 - Check the value of a specific attribute on files:
 
-`git check-attr -a {{path/to/file1}} {{path/to/file2}}`
+`git check-attr --all {{path/to/file1}} {{path/to/file2}}`
 
 - Check the value of a specific attribute on one or more files:
 

--- a/pages/common/git-check-attr.md
+++ b/pages/common/git-check-attr.md
@@ -1,0 +1,20 @@
+# git check-attr
+
+> For every pathname, list if each attribute is unspecified, set, or unset as a gitattribute on that pathname.
+> More information: <https://git-scm.com/docs/git-check-attr>.
+
+- Check the values of all attributes on a file:
+
+`git check-attr -a {{path/to/file}}`
+
+- Check the value of a specific attribute on a file:
+
+`git check-attr {{attribute}} {{path/to/file}}`
+
+- Check the value of a specific attribute on files:
+
+`git check-attr -a {{path/to/file1}} {{path/to/file2}}`
+
+- Check the value of a specific attribute on a file:
+
+`git check-attr {{attribute}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/git-check-attr.md
+++ b/pages/common/git-check-attr.md
@@ -15,6 +15,6 @@
 
 `git check-attr -a {{path/to/file1}} {{path/to/file2}}`
 
-- Check the value of a specific attribute on a file:
+- Check the value of a specific attribute on one or more files:
 
 `git check-attr {{attribute}} {{path/to/file1}} {{path/to/file2}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953