### PR TITLE
git-check-mailmap: add page

### DIFF
--- a/pages/common/git-check-mailmap.md
+++ b/pages/common/git-check-mailmap.md
@@ -1,0 +1,8 @@
+# git check-mailmap
+
+> Show canonical names and email addresses of contacts.
+> More information: <https://git-scm.com/docs/git-check-mailmap>.
+
+- Look up the canonical name associated with an email address:
+
+`git check-mailmap "<{{email@example.com}}>"`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953