### PR TITLE
btrfs-filesystem: add page

### DIFF
--- a/pages/linux/btrfs-filesystem.md
+++ b/pages/linux/btrfs-filesystem.md
@@ -23,6 +23,6 @@
 
 `sudo btrfs filesystem sync {{path/to/btrfs_mount}}`
 
-- Summarise disk usage for the files in a directory recursively:
+- Summarize disk usage for the files in a directory recursively:
 
 `sudo btrfs filesystem du {{path/to/directory}}`

--- a/pages/linux/btrfs-filesystem.md
+++ b/pages/linux/btrfs-filesystem.md
@@ -1,0 +1,28 @@
+# btrfs filesystem
+
+> Manage btrfs filesystems.
+> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem>.
+
+- Show filesystem usage (optionally run as root to show detailed information):
+
+`btrfs filesystem usage {{path/to/btrfs_mount}}`
+
+- Show usage by individual devices:
+
+`btrfs filesystem show {{path/to/btrfs_mount}}`
+
+- Defragment a single file on a btrfs filesystem:
+
+`sudo btrfs filesystem defragment {{path/to/file}}`
+
+- Defragment a directory recursively (does not cross subvolume boundaries):
+
+`sudo btrfs filesystem defragment -r {{path/to/directory}}`
+
+- Force syncing unwritten data blocks to disk(s):
+
+`sudo btrfs filesystem sync {{path/to/btrfs_mount}}`
+
+- Summarise disk usage for the files in a directory recursively:
+
+`sudo btrfs filesystem du {{path/to/directory}}`


### PR DESCRIPTION
I'm setting up a new storage NAS, and I've decided to go with btrfs as the filesystem. To this end, I thought I'd contribute a series of tldr pages for btrfs, since it's rather like `docker` and `git` in that it's got a whole bunch of subcommands. I'm pretty familiar with them right now, so it's the best time to write those pages :P

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
