### PR TITLE
rename github to GitHub

### DIFF
--- a/pages.fr/common/git-pr.md
+++ b/pages.fr/common/git-pr.md
@@ -1,6 +1,6 @@
 # git pr
 
-> Récupére les pull-request github localement.
+> Récupére les pull-request GitHub localement.
 
 - Récupére une pull-request spécifique :
 

--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -8,15 +8,15 @@
 
 `hub clone {{repo_name}}`
 
-- Clone another user's repository, using their github username and the repository name:
+- Clone another user's repository, using their GitHub username and the repository name:
 
 `hub clone {{username}}/{{repo_name}}`
 
-- Create a fork of the current repository (cloned from another user) under your github profile:
+- Create a fork of the current repository (cloned from another user) under your GitHub profile:
 
 `hub fork`
 
-- Push the current local branch to github and create a PR for it in the original repository:
+- Push the current local branch to GitHub and create a PR for it in the original repository:
 
 `hub push {{remote_name}} && hub pull-request`
 
@@ -28,6 +28,6 @@
 
 `hub pr checkout {{pr_number}}`
 
-- Upload the current (local-only) repository to your github account:
+- Upload the current (local-only) repository to your GitHub account:
 
 `hub create`


### PR DESCRIPTION
this pr renames "github" to "GitHub" as it is the official name of the service. 