### PR TITLE
git-checkout-index: add page

### DIFF
--- a/pages/common/git-checkout-index.md
+++ b/pages/common/git-checkout-index.md
@@ -1,0 +1,20 @@
+# git checkout-index
+
+> Copy files from the index to the working tree.
+> More information: <https://git-scm.com/docs/git-checkout-index>.
+
+- Restore any files deleted since last commit:
+
+`git checkout-index --all`
+
+- Restore any files deleted or changed since last commit:
+
+`git checkout-index --all --force`
+
+- Restore any files changed since last commit (ignoring deleted files):
+
+`git checkout-index --all --force --no-create`
+
+- Create an export of the tree at the last commit in the specified directory (the trailing slash is important):
+
+`git checkout-index --all --force --prefix={{git-index-export/}}`

--- a/pages/common/git-checkout-index.md
+++ b/pages/common/git-checkout-index.md
@@ -15,6 +15,6 @@
 
 `git checkout-index --all --force --no-create`
 
-- Create an export of the tree at the last commit in the specified directory (the trailing slash is important):
+- Export a copy of the entire tree at the last commit in the specified directory (the trailing slash is important):
 
 `git checkout-index --all --force --prefix={{git-index-export/}}`

--- a/pages/common/git-checkout-index.md
+++ b/pages/common/git-checkout-index.md
@@ -3,18 +3,18 @@
 > Copy files from the index to the working tree.
 > More information: <https://git-scm.com/docs/git-checkout-index>.
 
-- Restore any files deleted since last commit:
+- Restore any files deleted since the last commit:
 
 `git checkout-index --all`
 
-- Restore any files deleted or changed since last commit:
+- Restore any files deleted or changed since the last commit:
 
 `git checkout-index --all --force`
 
-- Restore any files changed since last commit (ignoring deleted files):
+- Restore any files changed since the last commit, ignoring any files that were deleted:
 
 `git checkout-index --all --force --no-create`
 
-- Export a copy of the entire tree at the last commit in the specified directory (the trailing slash is important):
+- Export a copy of the entire tree at the last commit to the specified directory (the trailing slash is important):
 
-`git checkout-index --all --force --prefix={{git-index-export/}}`
+`git checkout-index --all --force --prefix={{path/to/export_directory/}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953