### PR TITLE
git-commit-graph: add page

### DIFF
--- a/pages/common/git-commit-graph.md
+++ b/pages/common/git-commit-graph.md
@@ -1,0 +1,16 @@
+# git commit-graph
+
+> Write and verify Git commit-graph files.
+> More information: <https://git-scm.com/docs/git-commit-graph>.
+
+- Write a commit-graph file for the packed commits in the repository's local `.git` directory:
+
+`git commit-graph write`
+
+- Write a commit-graph file containing all reachable commits:
+
+`git show-ref --hash | git commit-graph write --stdin-commits`
+
+- Write a commit-graph file containing all commits in the current commit-graph file along with those reachable from `HEAD`:
+
+`git rev-parse {{HEAD}} | git commit-graph write --stdin-commits --append`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953