### PR TITLE
git-commit-tree: add page

### DIFF
--- a/pages/common/git-commit-tree.md
+++ b/pages/common/git-commit-tree.md
@@ -16,6 +16,6 @@
 
 `git commit-tree {{tree}} -m {{"message"}} -S`
 
-- Create a commit object with the specified parent:
+- Create a commit object with the specified parent commit object:
 
 `git commit-tree {{tree}} -m {{"message"}} -p {{parent_commit_sha}}`

--- a/pages/common/git-commit-tree.md
+++ b/pages/common/git-commit-tree.md
@@ -14,7 +14,7 @@
 
 - Create a GPG-signed commit object:
 
-`git commit-tree {{tree}} -m {{"message"}} --gpg-sign`
+`git commit-tree {{tree}} -m "{{message}}" --gpg-sign`
 
 - Create a commit object with the specified parent commit object:
 

--- a/pages/common/git-commit-tree.md
+++ b/pages/common/git-commit-tree.md
@@ -1,0 +1,21 @@
+# git commit-tree
+
+> Low level utility to create commit objects.
+> See also: `git commit`.
+> More information: <https://git-scm.com/docs/git-commit-tree>.
+
+- Create a commit object with the specified message:
+
+`git commit-tree {{tree}} -m {{"message"}}`
+
+- Create a commit object reading the message from a file (use `-` for `stdin`):
+
+`git commit-tree {{tree}} -F {{path/to/file}}`
+
+- Create a GPG-signed commit object:
+
+`git commit-tree {{tree}} -m {{"message"}} -S`
+
+- Create a commit object with the specified parent:
+
+`git commit-tree {{tree}} -m {{"message"}} -p {{parent_commit_sha}}`

--- a/pages/common/git-commit-tree.md
+++ b/pages/common/git-commit-tree.md
@@ -6,7 +6,7 @@
 
 - Create a commit object with the specified message:
 
-`git commit-tree {{tree}} -m {{"message"}}`
+`git commit-tree {{tree}} -m "{{message}}"`
 
 - Create a commit object reading the message from a file (use `-` for `stdin`):
 
@@ -14,8 +14,8 @@
 
 - Create a GPG-signed commit object:
 
-`git commit-tree {{tree}} -m {{"message"}} -S`
+`git commit-tree {{tree}} -m {{"message"}} --gpg-sign`
 
 - Create a commit object with the specified parent commit object:
 
-`git commit-tree {{tree}} -m {{"message"}} -p {{parent_commit_sha}}`
+`git commit-tree {{tree}} -m "{{message}}" -p {{parent_commit_sha}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953