### PR TITLE
git-credential: add page

### DIFF
--- a/pages/common/git-credential.md
+++ b/pages/common/git-credential.md
@@ -3,7 +3,7 @@
 > Retrieve and store user credentials.
 > More information: <https://git-scm.com/docs/git-credential>.
 
-- Display credential information, retrieving the username/password from config files:
+- Display credential information, retrieving the username and password from configuration files:
 
 `echo "{{url=http://example.com}}" | git credential fill`
 

--- a/pages/common/git-credential.md
+++ b/pages/common/git-credential.md
@@ -5,12 +5,12 @@
 
 - Display credential information, retrieving the username/password from config files:
 
-`echo {{"url=http://example.com"}} | git credential fill`
+`echo "{{url=http://example.com}}" | git credential fill`
 
 - Send credential information to all configured credential helpers to store for later use:
 
-`echo {{"url=http://example.com"}} | git credential approve`
+`echo "{{url=http://example.com}}" | git credential approve`
 
 - Erase the specified credential information from all the configured credential helpers:
 
-`echo {{"url=http://example.com"}} | git credential reject`
+`echo "{{url=http://example.com}}" | git credential reject`

--- a/pages/common/git-credential.md
+++ b/pages/common/git-credential.md
@@ -7,10 +7,10 @@
 
 `echo {{"url=http://example.com"}} | git credential fill`
 
-- Send credential information to configured credential helpers to store for later use:
+- Send credential information to all configured credential helpers to store for later use:
 
 `echo {{"url=http://example.com"}} | git credential approve`
 
-- Send credential information to configured credential helpers to erase:
+- Erase the specified credential information from all the configured credential helpers:
 
 `echo {{"url=http://example.com"}} | git credential reject`

--- a/pages/common/git-credential.md
+++ b/pages/common/git-credential.md
@@ -1,0 +1,16 @@
+# git credential
+
+> Retrieve and store user credentials.
+> More information: <https://git-scm.com/docs/git-credential>.
+
+- Display credential information, retrieving the username/password from config files:
+
+`echo {{"url=http://example.com"}} | git credential fill`
+
+- Send credential information to configured credential helpers to store for later use:
+
+`echo {{"url=http://example.com"}} | git credential approve`
+
+- Send credential information to configured credential helpers to erase:
+
+`echo {{"url=http://example.com"}} | git credential reject`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953