### PR TITLE
git-ls-remote, git-switch, git-restore: fix "More information" links

### DIFF
--- a/pages.de/common/git-switch.md
+++ b/pages.de/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Wechsle zwischen Branches. Verfügbar ab Git Version 2.23+.
 > Betrachte auch `git checkout`.
-> Mehr Informationen: <https://git-scm.com/docs/git-switch/>.
+> Mehr Informationen: <https://git-scm.com/docs/git-switch>.
 
 - Wechsele zu einem existierenden Branch:
 

--- a/pages.es/common/git-restore.md
+++ b/pages.es/common/git-restore.md
@@ -2,7 +2,7 @@
 
 > Restura archivo del arbol de trabajo. Requiere la version 2.23 o superior de Git.
 > Véase también `git checkout`
-> Más información: <https://git-scm.com/docs/git-restore/>.
+> Más información: <https://git-scm.com/docs/git-restore>.
 
 - Restaura un archivo eliminado del contenido del commit actual (HEAD):
 

--- a/pages.es/common/git-switch.md
+++ b/pages.es/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Alterna entre ramas Git. Requiere una Git 2.23+.
 > Véase también `git-checkout`.
-> Más información: <https://git-scm.com/docs/git-switch/>.
+> Más información: <https://git-scm.com/docs/git-switch>.
 
 - Cambia a una rama existente:
 

--- a/pages.fr/common/git-ls-remote.md
+++ b/pages.fr/common/git-ls-remote.md
@@ -2,7 +2,7 @@
 
 > Commande Git pour répertorier les références dans un dépot distant en fonction du nom ou de l'URL.
 > Si aucun nom ou URL n'est donné, alors la branche amont configurée sera utilisée, ou l'origine distante si la première n'est pas configurée.
-> Plus d'informations: <https://git-scm.com/docs/git-ls-remote.html>.
+> Plus d'informations: <https://git-scm.com/docs/git-ls-remote>.
 
 - Afficher les références du dépot configuré par défaut :
 

--- a/pages.fr/common/git-restore.md
+++ b/pages.fr/common/git-restore.md
@@ -2,7 +2,7 @@
 
 > Restaurez les fichiers de l'arborescence de travail. Nécessite la version 2.23+ de Git.
 > Voir aussi `git checkout`.
-> Plus d'informations: <https://git-scm.com/docs/git-restore/>.
+> Plus d'informations: <https://git-scm.com/docs/git-restore>.
 
 - Restaurer un fichier supprimé à partir du contenu du commit actuel (HEAD) :
 

--- a/pages.fr/common/git-switch.md
+++ b/pages.fr/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Basculez entre les branches Git. Nécessite la version 2.23+ de Git.
 > Voir egalement `git checkout`.
-> Plus d'informations: <https://git-scm.com/docs/git-switch/>.
+> Plus d'informations: <https://git-scm.com/docs/git-switch>.
 
 - Baculer sur une branche existante :
 

--- a/pages.it/common/git-ls-remote.md
+++ b/pages.it/common/git-ls-remote.md
@@ -2,7 +2,7 @@
 
 > Elenca i riferimenti in un repository remoto dato un nome o un URL.
 > Qualora né nome né URL siano specificati, il ramo predefinito è upstream - se configurato - oppure origin.
-> Maggiori informazioni: <https://git-scm.com/docs/git-ls-remote.html>.
+> Maggiori informazioni: <https://git-scm.com/docs/git-ls-remote>.
 
 - Mostra tutti i riferimenti nel repository remoto predefinito:
 

--- a/pages.it/common/git-restore.md
+++ b/pages.it/common/git-restore.md
@@ -2,7 +2,7 @@
 
 > Ripristina i file dell'albero di lavoro. Richiede versioni di Git successive alla 2.23.
 > Vedi anche `git checkout`.
-> Maggiori informazioni: <https://git-scm.com/docs/git-restore/>.
+> Maggiori informazioni: <https://git-scm.com/docs/git-restore>.
 
 - Ripristina un file cancellato dal contenuto del commit corrente (HEAD):
 

--- a/pages.it/common/git-switch.md
+++ b/pages.it/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Passa ad altri rami. Richiede versioni di Git successive alla 2.23.
 > Vedi anche `git checkout`.
-> Maggiori informazioni: <https://git-scm.com/docs/git-switch/>.
+> Maggiori informazioni: <https://git-scm.com/docs/git-switch>.
 
 - Passa ad un altro ramo esistente:
 

--- a/pages/common/git-ls-remote.md
+++ b/pages/common/git-ls-remote.md
@@ -2,7 +2,7 @@
 
 > Git command for listing references in a remote repository based on name or URL.
 > If no name or URL are given, then the configured upstream branch will be used, or remote origin if the former is not configured.
-> More information: <https://git-scm.com/docs/git-ls-remote.html>.
+> More information: <https://git-scm.com/docs/git-ls-remote>.
 
 - Show all references in the default remote repository:
 

--- a/pages/common/git-restore.md
+++ b/pages/common/git-restore.md
@@ -2,7 +2,7 @@
 
 > Restore working tree files. Requires Git version 2.23+.
 > See also `git checkout` and `git reset`.
-> More information: <https://git-scm.com/docs/git-restore/>.
+> More information: <https://git-scm.com/docs/git-restore>.
 
 - Restore an unstaged file to the version of the current commit (HEAD):
 

--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Switch between Git branches. Requires Git version 2.23+.
 > See also `git checkout`.
-> More information: <https://git-scm.com/docs/git-switch/>.
+> More information: <https://git-scm.com/docs/git-switch>.
 
 - Switch to an existing branch:
 


### PR DESCRIPTION
`git-ls-remote` had an extra `.html`, and the others had a trailing `/` which git-scm.org [can't deal with 😄](https://git-scm.com/docs/git-restore/).

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
