### PR TITLE
valet: update more information link

### DIFF
--- a/pages/osx/valet.md
+++ b/pages/osx/valet.md
@@ -1,7 +1,7 @@
 # valet
 
 > A Laravel development environment that allows hosting sites via local tunnels on `http://<example>.test`.
-> More information: <https://laravel.com/docs/5.8/valet>.
+> More information: <https://laravel.com/docs/8.x/valet>.
 
 - Start the valet daemon:
 


### PR DESCRIPTION
Update the Laravel version in the link 5.8 → 8.x.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

This is good for users' impression of tldr-pages, as they will see 8.x the latest version and think we're very up-to-date! 😄 