### PR TITLE
style-guide: add backticks guide

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -78,7 +78,3 @@ Use backticks on the following:
 4. Commands, ex `ls`.
 5. Keyboard commands, ex. `CTRL+ALT+DEL`.
 6. Port numbers, ex. `8080`.
-
-
-
-

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -68,7 +68,6 @@ Keep the following guidelines in mind when choosing tokens:
 In general, tokens should make it as intuitive as possible
 to figure out how to use the command and fill it in with values.
 
-
 More technical wording on description lines should use the `backtick` syntax.
 Use backticks on the following:
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -74,4 +74,3 @@ Use backticks on the following:
 1. Paths, ex. `package.json`, `/etc/package.json`.
 2. Extensions, ex. `.dll`.
 3. Commands, ex. `ls`.
-4. Keyboard commands, ex. `CTRL+ALT+DEL`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -73,8 +73,8 @@ More technical wording on description lines should use the `backtick` syntax.
 Use backticks on the following:
 
 1. Filenames, ex. `package.json`.
-2. Directories, ex `/etc/ansible/hosts`.
-3. Extensions, ex `.dll`.
-4. Commands, ex `ls`.
+2. Directories, ex. `/etc/ansible/hosts`.
+3. Extensions, ex. `.dll`.
+4. Commands, ex. `ls`.
 5. Keyboard commands, ex. `CTRL+ALT+DEL`.
 6. Port numbers, ex. `8080`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -67,3 +67,18 @@ Keep the following guidelines in mind when choosing tokens:
 
 In general, tokens should make it as intuitive as possible
 to figure out how to use the command and fill it in with values.
+
+
+More technical wording on description lines should use the `backtick` syntax.
+Use backticks on the following:
+
+1. Filenames, ex. `package.json`.
+2. Directories, ex `/etc/ansible/hosts`.
+3. Extensions, ex `.dll`.
+4. Commands, ex `ls`.
+5. Keyboard commands, ex. `CTRL+ALT+DEL`.
+6. Port numbers, ex. `8080`.
+
+
+
+

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -75,4 +75,3 @@ Use backticks on the following:
 2. Extensions, ex. `.dll`.
 3. Commands, ex. `ls`.
 4. Keyboard commands, ex. `CTRL+ALT+DEL`.
-5. Port numbers, ex. `8080`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -71,9 +71,8 @@ to figure out how to use the command and fill it in with values.
 More technical wording on description lines should use the `backtick` syntax.
 Use backticks on the following:
 
-1. Filenames, ex. `package.json`.
-2. Directories, ex. `/etc/ansible/hosts`.
-3. Extensions, ex. `.dll`.
-4. Commands, ex. `ls`.
-5. Keyboard commands, ex. `CTRL+ALT+DEL`.
-6. Port numbers, ex. `8080`.
+1. Paths, ex. `package.json`, `/etc/package.json`.
+2. Extensions, ex. `.dll`.
+3. Commands, ex. `ls`.
+4. Keyboard commands, ex. `CTRL+ALT+DEL`.
+5. Port numbers, ex. `8080`.


### PR DESCRIPTION
This PR proposes a set of rules to use `backticks` in the command descriptions. Currently, it feels like there are no rules and there is no document to back us up in case we have any doubts on this. 

This goes along with #5119 as this sets the set of rules and #5119 implements them.
This is an only personal preference so I'm more than welcome to receive any feedback to add or remove anything from this set of rules.

I would especially like other's opinions about if we should or should not add two types of information to that list:

1. File types, ex. `JSON`
2. Addresses, ex. `localhost`, `123.456.789.1:3030`

What are your thoughts on this? 