### PR TITLE
*: change folder to directory

### DIFF
--- a/pages/common/apktool.md
+++ b/pages/common/apktool.md
@@ -7,7 +7,7 @@
 
 `apktool d {{file.apk}}`
 
-- Build a folder into an APK file:
+- Build an APK file from a directory:
 
 `apktool b {{path/to/directory}}`
 

--- a/pages/common/croc.md
+++ b/pages/common/croc.md
@@ -3,21 +3,21 @@
 > Send and receive files easily and securely over any network.
 > More information: <https://github.com/schollz/croc>.
 
-- Send a file or folder:
+- Send a file or directory:
 
-`croc send {{path/to/file}}`
+`croc send {{path/to/file_or_directory}}`
 
-- Send a file or folder with a specific passphrase:
+- Send a file or directory with a specific passphrase:
 
-`croc send --code {{passphrase}} {{path/to/file}}`
+`croc send --code {{passphrase}} {{path/to/file_or_directory}}`
 
-- Receive a file or folder on receiving machine:
+- Receive a file or directory on receiving machine:
 
 `croc {{passphrase}}`
 
 - Send and connect over a custom relay:
 
-`croc --relay {{ip_to_relay}} send {{path/to/file}}`
+`croc --relay {{ip_to_relay}} send {{path/to/file_or_directory}}`
 
 - Receive and connect over a custom relay:
 

--- a/pages/common/dotnet-publish.md
+++ b/pages/common/dotnet-publish.md
@@ -1,6 +1,6 @@
 # dotnet publish
 
-> Publish a .NET application and its dependencies to a folder for deployment to a hosting system.
+> Publish a .NET application and its dependencies to a directory for deployment to a hosting system.
 > More information: <https://docs.microsoft.com/dotnet/core/tools/dotnet-publish>.
 
 - Compile a .NET project in release mode:

--- a/pages/common/evil-winrm.md
+++ b/pages/common/evil-winrm.md
@@ -12,7 +12,7 @@
 
 `evil-winrm --ip {{ip}} --user {{user}} --hash {{nt_hash}}`
 
-- Connect to a host, specifying folders for scripts and executables:
+- Connect to a host, specifying directories for scripts and executables:
 
 `evil-winrm --ip {{ip}} --user {{user}} --password {{password}} --scripts {{path/to/scripts}} --executables {{path/to/executables}}`
 
@@ -28,10 +28,10 @@
 
 `PS > menu`
 
-- Load a PowerShell script from the `--scripts` folder:
+- Load a PowerShell script from the `--scripts` directory:
 
 `PS > {{script.ps1}}`
 
-- Invoke a binary on the host from the `--executables` folder:
+- Invoke a binary on the host from the `--executables` directory:
 
 `PS > Invoke-Binary {{binary.exe}}`

--- a/pages/common/jekyll.md
+++ b/pages/common/jekyll.md
@@ -19,6 +19,6 @@
 
 `jekyll build`
 
-- Clean the site (removes site output and `cache` folder) without building:
+- Clean the site (removes site output and `cache` directory) without building:
 
 `jekyll clean`

--- a/pages/common/mpg321.md
+++ b/pages/common/mpg321.md
@@ -24,6 +24,6 @@
 
 `mpg321 -z {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
 
-- Play all files in the current folder and subfolders, randomly (until interrupted), with Basic Keys enabled:
+- Play all files in the current directory and subdirectories, randomly (until interrupted), with Basic Keys enabled:
 
 `mpg321 -B -Z -K .`

--- a/pages/common/security-checker.md
+++ b/pages/common/security-checker.md
@@ -3,7 +3,7 @@
 > Check if a PHP application uses dependencies with known security vulnerabilities.
 > More information: <https://github.com/sensiolabs/security-checker>.
 
-- Look for security issues in the project dependencies (based on the composer.lock file in the current folder):
+- Look for security issues in the project dependencies (based on the composer.lock file in the current directory):
 
 `security-checker security:check`
 

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -27,6 +27,6 @@
 
 `transmission-remote {{hostname}} -t {{all}} --stop`
 
-- Move torrents 1-10 and 15-20 to a new folder (folder will be created if it does not exist):
+- Move torrents 1-10 and 15-20 to a new directory (which will be created if it does not exist):
 
 `transmission-remote {{hostname}} -t "{{1-10,15-20}}" --move {{path/to/new_directory}}`

--- a/pages/windows/replace.md
+++ b/pages/windows/replace.md
@@ -24,7 +24,7 @@
 
 `replace {{path/to/file_or_directory}} {{path/to/destination}} /w`
 
-- Replace all files in subfolders of the destination:
+- Replace all files in subdirectories of the destination:
 
 `replace {{path/to/file_or_directory}} {{path/to/destination}} /s`
 


### PR DESCRIPTION
Changes "folder" to "directory" when appropriate.

The only ones I didn't change were:

- [`bw.md`](https://github.com/tldr-pages/tldr/blob/master/pages/common/bw.md)
- [`gdrive.md`](https://github.com/tldr-pages/tldr/blob/master/pages/common/gdrive.md)
- [`skicka.md`](https://github.com/tldr-pages/tldr/blob/master/pages/common/skicka.md)
- [`syncthing.md`](https://github.com/tldr-pages/tldr/blob/master/pages/common/syncthing.md)

...because "folder" seems more appropriate in those pages.

---

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
