### PR TITLE
lvresize: add vg to positional arg and example extend

### DIFF
--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -9,7 +9,7 @@
 
 - Extend a logical volume's size by 120GB as well as the underlying filesystem:
 
-`lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
+`lvresize --size +{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
 
 - Extend a logical volume's size to 100% of the free physical volume space:
 

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -2,14 +2,18 @@
 
 > Change the size of a logical volume.
 
-- Change a volume's size to 120GB:
+- Change a logical volume's size to 120GB:
 
-`lvresize -L {{120G}} {{logical_volume}}`
+`lvresize --size {{120G}} {{volume_group}}/{{logical_volume}}`
 
-- Reduce a volume's size by 120GB as well as the underlying filesystem:
+- Extend a logical volume's size by 120GB as well as the underlying filesystem:
 
-`lvresize --size -{{120G}} -r {{logical_volume}}`
+`lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
 
-- Increase a volume's size to 100% of the free physical volume space:
+- Extend a logical volume's size to 100% of the free physical volume space:
 
-`lvresize --size {{100}}%FREE {{logical_volume}}`
+`lvresize --size {{100}}%FREE {{volume_group}}/{{logical_volume}}`
+
+- Reduce a logical volume's size by 120GB as well as the underlying filesystem:
+
+`lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -1,7 +1,7 @@
 # lvresize
 
 > Change the size of a logical volume.
-> More information: https://man7.org/linux/man-pages/man8/lvresize.8.html
+> More information: https://man7.org/linux/man-pages/man8/lvresize.8.html.
 
 - Change a logical volume's size to 120GB:
 

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -1,7 +1,7 @@
 # lvresize
 
 > Change the size of a logical volume.
-> More information: https://man7.org/linux/man-pages/man8/lvresize.8.html.
+> More information: <https://man7.org/linux/man-pages/man8/lvresize.8.html>.
 
 - Change a logical volume's size to 120GB:
 

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -1,6 +1,7 @@
 # lvresize
 
 > Change the size of a logical volume.
+> More information: https://man7.org/linux/man-pages/man8/lvresize.8.html
 
 - Change a logical volume's size to 120GB:
 

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -3,18 +3,18 @@
 > Change the size of a logical volume.
 > More information: <https://man7.org/linux/man-pages/man8/lvresize.8.html>.
 
-- Change a logical volume's size to 120GB:
+- Change the size of a logical volume to 120GB:
 
 `lvresize --size {{120G}} {{volume_group}}/{{logical_volume}}`
 
-- Extend a logical volume's size by 120GB as well as the underlying filesystem:
+- Extend the size of a logical volume by 120GB as well as the underlying filesystem:
 
 `lvresize --size +{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
 
-- Extend a logical volume's size to 100% of the free physical volume space:
+- Extend the size of a logical volume to 100% of the free physical volume space:
 
 `lvresize --size {{100}}%FREE {{volume_group}}/{{logical_volume}}`
 
-- Reduce a logical volume's size by 120GB as well as the underlying filesystem:
+- Reduce the size of a logical volume by 120GB as well as the underlying filesystem:
 
 `lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -15,6 +15,6 @@
 
 `lvresize --size {{100}}%FREE {{volume_group}}/{{logical_volume}}`
 
-- Reduce the size of a logical volume by 120GB as well as the underlying filesystem:
+- Reduce the size of a logical volume as well as the underlying filesystem by 120GB:
 
 `lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -7,7 +7,7 @@
 
 `lvresize --size {{120G}} {{volume_group}}/{{logical_volume}}`
 
-- Extend the size of a logical volume by 120GB as well as the underlying filesystem:
+- Extend the size of a logical volume as well as the underlying filesystem by 120GB:
 
 `lvresize --size +{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
 


### PR DESCRIPTION
- In the positional arg, it's needed to specify the VG and LV name as in `VG/LV`. As so, add `{{volume_group}}/`.
- Add example to extend LV with `--size +`
- normalize use of extended parameter names (e.g. `--resizefs` instead of `-r`).
- Move shrink example to below extend examples.
- clarify in description it's operating in a logical volume.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
