### PR TITLE
README: add link to PDF version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This repository is just that: an ever-growing collection of examples
 for the most common UNIX, Linux, macOS, SunOS and Windows command-line tools.
 
 ## How do I use it?
-
-A popular and convenient way to access these pages on your computer
+If you just want to browse without installing anything, check out the [PDF version.](https://github.com/tldr-pages/tldr-pages.github.io/blob/master/assets/tldr-book.pdf)
+However, a popular and convenient way to access these pages on your computer
 is to install the [Node.js client](https://github.com/tldr-pages/tldr-node-client),
 which is supported by the tldr-pages project maintainers:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for the most common UNIX, Linux, macOS, SunOS and Windows command-line tools.
 
 ## How do I use it?
 
-If you just want to browse without installing anything, check out the [PDF version.](https://github.com/tldr-pages/tldr-pages.github.io/blob/master/assets/tldr-book.pdf)
+If you just want to browse without installing anything, check out the [PDF version](https://tldr.sh/assets/tldr-book.pdf).
 However, a popular and convenient way to access these pages on your computer
 is to install the [Node.js client](https://github.com/tldr-pages/tldr-node-client),
 which is supported by the tldr-pages project maintainers:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repository is just that: an ever-growing collection of examples
 for the most common UNIX, Linux, macOS, SunOS and Windows command-line tools.
 
 ## How do I use it?
+
 If you just want to browse without installing anything, check out the [PDF version.](https://github.com/tldr-pages/tldr-pages.github.io/blob/master/assets/tldr-book.pdf)
 However, a popular and convenient way to access these pages on your computer
 is to install the [Node.js client](https://github.com/tldr-pages/tldr-node-client),

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ for the most common UNIX, Linux, macOS, SunOS and Windows command-line tools.
 
 ## How do I use it?
 
-If you just want to browse without installing anything, check out the [PDF version](https://tldr.sh/assets/tldr-book.pdf).
-However, a popular and convenient way to access these pages on your computer
+A popular and convenient way to access these pages on your computer
 is to install the [Node.js client](https://github.com/tldr-pages/tldr-node-client),
 which is supported by the tldr-pages project maintainers:
 
@@ -56,6 +55,9 @@ which is supported by the tldr-pages project maintainers:
 
 That way you can write `tldr tar` in the terminal to show the tldr page for `tar`,
 just like you would write `man tar` to show its manpage.
+
+However, if you just want to browse without installing anything, check 
+out the [PDF version](https://tldr.sh/assets/tldr-book.pdf).
 
 There are also various other clients provided by the community,
 both for the command line and for other platforms:


### PR DESCRIPTION
Added a reference to the PDF version at the start of the "How do I use it" section

Fixes #4975 