### PR TITLE
rankmirrors: add page

### DIFF
--- a/pages/linux/rankmirrors.md
+++ b/pages/linux/rankmirrors.md
@@ -2,6 +2,7 @@
 
 > Rank a list of Pacman mirrors by connection and opening speed.
 > Writes the new mirrorlist to stdout.
+> More information: <https://wiki.archlinux.org/index.php/mirrors>.
 
 - Rank a mirror list:
 

--- a/pages/linux/rankmirrors.md
+++ b/pages/linux/rankmirrors.md
@@ -1,0 +1,24 @@
+# rankmirrors
+
+> Rank a list of Pacman mirrors by connection and opening speed.
+> Writes the new mirrorlist to stdout.
+
+- Rank a mirror list:
+
+`rankmirrors {{/etc/pacman.d/mirrorlist}}`
+
+- Output only a given number of the top ranking servers:
+
+`rankmirrors -n {{number}} {{/etc/pacman.d/mirrorlist}}`
+
+- Be verbose when generating the mirrorlist:
+
+`rankmirrors -v {{/etc/pacman.d/mirrorlist}}`
+
+- Test only a specific URL:
+
+`rankmirrors --url {{url}}`
+
+- Output only the response times instead of a full mirrorlist:
+
+`rankmirrors --times {{/etc/pacman.d/mirrorlist}}`


### PR DESCRIPTION
Note that I've used a concrete example of a filepath here, because that's where the mirrorlist is actually located (so it saves some effort on the part of the reader in locating their mirrorlist file).

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

