### PR TITLE
grep: refresh

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -30,7 +30,7 @@
 
 - Search for lines matching a pattern, printing [o]nly the matched text:
 
-`grep -o {{search_pattern}}`
+`grep -o {{search_pattern}} {{path/to/file}}`
 
 - Search for lines that do not match (in[v]ert) a pattern:
 

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -6,7 +6,7 @@
 
 - Search for a pattern within a file:
 
-`grep {{search_pattern}} {{path/to/file}}`
+`grep "{{search_pattern}}" {{path/to/file}}`
 
 - Search for an exact ([F]ixed) string:
 
@@ -14,24 +14,24 @@
 
 - Search for a pattern [R]ecursively in the current directory, showing matching line [n]umbers, [I]gnoring non-text files:
 
-`grep -RIn {{search_pattern}} {{.}}`
+`grep -RIn "{{search_pattern}}" {{.}}`
 
 - Use [E]xtended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`), in case-[i]nsensitive mode:
 
-`grep -Ei {{search_pattern}} {{path/to/file}}`
+`grep -Ei "{{search_pattern}}" {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`grep -{{C|B|A}} {{3}} {{search_pattern}} {{path/to/file}}`
+`grep -{{C|B|A}} {{3}} "{{search_pattern}}" {{path/to/file}}`
 
 - Print file name [H]eaders with the corresponding line [n]umber for each match:
 
-`grep -Hn {{search_pattern}} {{path/to/file}}`
+`grep -Hn "{{search_pattern}}" {{path/to/file}}`
 
 - Search for lines matching a pattern, printing [o]nly the matched text:
 
-`grep -o {{search_pattern}} {{path/to/file}}`
+`grep -o "{{search_pattern}}" {{path/to/file}}`
 
 - Search a file for lines that do not match (in[v]ert) a pattern:
 
-`cat {{path/to/file}} | grep -v {{search_pattern}}`
+`cat {{path/to/file}} | grep -v "{{search_pattern}}`"

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -10,7 +10,7 @@
 
 - Search for an exact ([F]ixed) string:
 
-`grep -F {{exact_string}} {{path/to/file}}`
+`grep -F "{{exact_string}}" {{path/to/file}}`
 
 - Search for a pattern [R]ecursively in the current directory, showing matching line [n]umbers, [I]gnoring non-text files:
 
@@ -34,4 +34,4 @@
 
 - Search a file for lines that do not match (in[v]ert) a pattern:
 
-`cat {{path/to/file}} | grep -v "{{search_pattern}}`"
+`cat {{path/to/file}} | grep -v "{{search_pattern}}"`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -2,35 +2,36 @@
 
 > Matches patterns in input text.
 > Supports simple patterns and regular expressions.
+> More information: <https://man7.org/linux/man-pages/man1/grep.1.html>.
 
 - Search for a pattern within a file:
 
 `grep {{search_pattern}} {{path/to/file}}`
 
-- Search for an exact string:
+- Search for an exact ([F]ixed) string:
 
 `grep -F {{exact_string}} {{path/to/file}}`
 
 - Search for a pattern [R]ecursively in the current directory, showing matching line [n]umbers, [I]gnoring non-text files:
 
-`grep -RIn {{search_pattern}} .`
+`grep -RIn {{search_pattern}} {{.}}`
 
-- Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`), in case-insensitive mode:
+- Use [E]xtended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`), in case-[i]nsensitive mode:
 
 `grep -Ei {{search_pattern}} {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`grep -{{C|B|A}} 3 {{search_pattern}} {{path/to/file}}`
+`grep -{{C|B|A}} {{3}} {{search_pattern}} {{path/to/file}}`
 
-- Print file name with the corresponding line number for each match:
+- Print file name [H]eaders with the corresponding line [n]umber for each match:
 
 `grep -Hn {{search_pattern}} {{path/to/file}}`
 
-- Use the standard input instead of a file:
+- Search for lines matching a pattern, printing [o]nly the matched text:
 
-`cat {{path/to/file}} | grep {{search_pattern}}`
+`grep -o {{search_pattern}}`
 
-- In[v]ert match for excluding specific strings:
+- Search for lines that do not match (in[v]ert) a pattern:
 
 `grep -v {{search_pattern}}`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -32,6 +32,6 @@
 
 `grep -o {{search_pattern}} {{path/to/file}}`
 
-- Search for lines that do not match (in[v]ert) a pattern:
+- Search a file for lines that do not match (in[v]ert) a pattern:
 
-`grep -v {{search_pattern}}`
+`cat {{path/to/file}} | grep -v {{search_pattern}}`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -1,37 +1,36 @@
 # grep
 
-> Matches patterns in input text.
-> Supports simple patterns and regular expressions.
+> Find patterns in files using regular expressions.
 > More information: <https://man7.org/linux/man-pages/man1/grep.1.html>.
 
 - Search for a pattern within a file:
 
 `grep "{{search_pattern}}" {{path/to/file}}`
 
-- Search for an exact ([F]ixed) string:
+- Search for an exact string (disables regular expressions):
 
-`grep -F "{{exact_string}}" {{path/to/file}}`
+`grep --fixed-strings "{{exact_string}}" {{path/to/file}}`
 
-- Search for a pattern [R]ecursively in the current directory, showing matching line [n]umbers, [I]gnoring non-text files:
+- Search for a pattern in all files recursively in a directory, showing line numbers of matches, ignoring binary files:
 
-`grep -RIn "{{search_pattern}}" {{.}}`
+`grep --recursive --line-number --binary-files={{without-match}} "{{search_pattern}}" {{path/to/directory}}`
 
-- Use [E]xtended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`), in case-[i]nsensitive mode:
+- Use extended regular expressions (supports `?`, `+`, `{}`, `()` and `|`), in case-insensitive mode:
 
-`grep -Ei "{{search_pattern}}" {{path/to/file}}`
+`grep --extended-regexp --ignore-case "{{search_pattern}}" {{path/to/file}}`
 
-- Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
+- Print 3 lines of context around, before, or after each match:
 
-`grep -{{C|B|A}} {{3}} "{{search_pattern}}" {{path/to/file}}`
+`grep --{{context|before-context|after-context}}={{3}} "{{search_pattern}}" {{path/to/file}}`
 
-- Print file name [H]eaders with the corresponding line [n]umber for each match:
+- Print file name and line number for each match:
 
-`grep -Hn "{{search_pattern}}" {{path/to/file}}`
+`grep --with-filename --line-number "{{search_pattern}}" {{path/to/file}}`
 
-- Search for lines matching a pattern, printing [o]nly the matched text:
+- Search for lines matching a pattern, printing only the matched text:
 
-`grep -o "{{search_pattern}}" {{path/to/file}}`
+`grep --only-matching "{{search_pattern}}" {{path/to/file}}`
 
-- Search a file for lines that do not match (in[v]ert) a pattern:
+- Search stdin for lines that do not match a pattern:
 
-`cat {{path/to/file}} | grep -v "{{search_pattern}}"`
+`cat {{path/to/file}} | grep --invert-match "{{search_pattern}}"`


### PR DESCRIPTION
Inspired by #5216

I removed the stdin example so I could add the `-o` example, which I personally find very useful but less obvious.

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
