### PR TITLE
grep: fix example description for stdin usage

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -27,7 +27,7 @@
 
 `grep -Hn {{search_pattern}} {{path/to/file}}`
 
-- Use the standard input instead of a file:
+- Use file instead of standard input
 
 `cat {{path/to/file}} | grep {{search_pattern}}`
 


### PR DESCRIPTION
seems like the original description was backwards in what it was trying to say
