### PR TITLE
multiple pages: move away from die.net more information links

### DIFF
--- a/pages/common/iotop.md
+++ b/pages/common/iotop.md
@@ -1,7 +1,7 @@
 # iotop
 
 > Display a table of current I/O usage by processes or threads.
-> More information: <https://linux.die.net/man/1/iotop>.
+> More information: <https://man7.org/linux/man-pages/man8/iotop.8.html>.
 
 - Start top-like I/O monitor:
 

--- a/pages/common/sponge.md
+++ b/pages/common/sponge.md
@@ -1,7 +1,7 @@
 # sponge
 
 > Soak up the input before writing the output file.
-> More information: <https://linux.die.net/man/1/sponge>.
+> More information: <https://manpages.debian.org/moreutils/sponge.1.html>.
 
 - Append file content to the source file:
 


### PR DESCRIPTION
Replaces die.net "More information" links with man7.org when possible, otherwise the command's OS's specific man page.

Closes #5143