### PR TITLE
z:  add `-c` parameter to the command description

### DIFF
--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -26,3 +26,7 @@
 - Remove the current directory from `z`'s database:
 
 `z -x .`
+
+- Go to the directory that is a subdirectory of the current directory.
+
+`z -c {{foo}}`

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -27,6 +27,6 @@
 
 `z -x .`
 
-- Go to the directory that is a subdirectory of the current directory.
+- Go to the directory that is a subdirectory of the current directory (equivalent of `cd`):
 
 `z -c {{foo}}`

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Tracks the most used (_frecent_, read frequently recent) directories and enables quickly navigating to them using string or regex patterns.
+> Tracks the most used (by frecency) directories and enables quickly navigating to them using string or regex patterns.
 > More information: <https://github.com/rupa/z>.
 
 - Go to a directory that contains "foo" in the name:

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Tracks the most used directories and enables quickly navigating to them using string or regex patterns.
+> Tracks the most used (_frecent_, read frequently recent) directories and enables quickly navigating to them using string or regex patterns.
 > More information: <https://github.com/rupa/z>.
 
 - Go to a directory that contains "foo" in the name:
@@ -27,6 +27,6 @@
 
 `z -x .`
 
-- Go to the directory that is a subdirectory of the current directory (equivalent of `cd`):
+- Restrict matches to subdirectories of the current directory:
 
 `z -c {{foo}}`


### PR DESCRIPTION
Details:
---
* add the `-c` parameter to the [`z`](https://github.com/tldr-pages/tldr/blob/master/pages/common/z.md) command that enables user to go to a subdirectory of the current  directory

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
