### PR TITLE
systemctl: improve mask/unmask example description

### DIFF
--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -31,6 +31,6 @@
 
 `systemctl is-active {{unit}}`
 
-- Check if a unit is enabled:
+- Check if a unit is enabled
 
 `systemctl is-enabled {{unit}}`

--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -19,7 +19,7 @@
 
 `systemctl enable/disable {{unit}}`
 
-- Mask/Unmask a unit to prohibit enablement and manual activation:
+- Mask/unmask a unit to prevent enablement and manual activation:
 
 `systemctl mask/unmask {{unit}}`
 

--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -19,7 +19,7 @@
 
 `systemctl enable/disable {{unit}}`
 
-- Mask/Unmask a unit, prevent it to be started on bootup:
+- Mask/Unmask a unit to prohibit enablement and manual activation:
 
 `systemctl mask/unmask {{unit}}`
 

--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -31,6 +31,6 @@
 
 `systemctl is-active {{unit}}`
 
-- Check if a unit is enabled
+- Check if a unit is enabled:
 
 `systemctl is-enabled {{unit}}`


### PR DESCRIPTION
Edit example description for Mask/Unmask to clarify meaning as per man page:

           This is a stronger version of disable, since it prohibits all
           kinds of activation of the unit, including enablement and manual
           activation.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

