### PR TITLE
systemctl: fix example description caps

### DIFF
--- a/pages/linux/systemctl.md
+++ b/pages/linux/systemctl.md
@@ -19,7 +19,7 @@
 
 `systemctl {{enable|disable}} {{unit}}`
 
-- Mask/unmask a unit to prevent enablement and manual activation:
+- Mask/Unmask a unit to prevent enablement and manual activation:
 
 `systemctl {{mask|unmask}} {{unit}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Fix: https://github.com/tldr-pages/tldr/pull/5274#discussion_r579141281