### PR TITLE
mutool: add outline example

### DIFF
--- a/pages/common/mutool.md
+++ b/pages/common/mutool.md
@@ -22,3 +22,7 @@
 - Extract all images, fonts and resources embedded in a PDF out into the current directory:
 
 `mutool extract {{input.pdf}}`
+
+- Print the outline (table of contents) of a PDF:
+
+`mutool outline {{input.pdf}}`

--- a/pages/common/mutool.md
+++ b/pages/common/mutool.md
@@ -25,4 +25,4 @@
 
 - Print the outline (table of contents) of a PDF:
 
-`mutool outline {{input.pdf}}`
+`mutool show {{input.pdf}} outline`


### PR DESCRIPTION
Add an example to print the table of contents in a PDF using the outline sub-command.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

