### PR TITLE
ci: add 'master' to 'main' branch mirroring workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,14 @@
+name: Main Mirror
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: zofrex/mirror-branch@v1
+        with:
+          target-branch: main


### PR DESCRIPTION
Adds a commit mirror from `master` to `main`. This begins the transition from one branch to the other, testing to make sure this works, so that once `main` becomes the primary branch, we are confident that the reverse (`main` -> `master`) will work. Once this PR is merged and set-up, I will create a similar PR in tldr-pages/tldr.github.io.

Note: This probably requires the `main` branch to be created, though I am not positive.

This follow discussion in #5110 