### PR TITLE
pacman-mirrors: add page

### DIFF
--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -1,6 +1,6 @@
 # pacman-mirrors
 
-> Generate a pacman mirrorlist for Manjaro Linux
+> Generate a pacman mirrorlist for Manjaro Linux.
 > More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
 
 - Generate a mirrorlist, using the default settings:

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -5,19 +5,19 @@
 
 - Generate a mirrorlist, using the default settings:
 
-`sudo pacman-mirrors -f`
+`sudo pacman-mirrors --fasttrack`
 
 - Get the status of the current mirrors:
 
-`sudo pacman-mirrors --status`
+`pacman-mirrors --status`
 
-- Check, which branch you are on:
+- Display the current branch:
 
-`sudo pacman-mirrors --get-branch`
+`pacman-mirrors --get-branch`
 
 - Switch to a different branch:
 
-`sudo pacman-mirrors --api --setbranch {{stable|unstable|testing}}`
+`sudo pacman-mirrors --api --set-branch {{stable|unstable|testing}}`
 
 - Generate a mirrorlist, only using mirrors in your country:
 

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -1,6 +1,6 @@
 # pacman-mirrors
 
-> Generate pacman mirrorlist for Manjaro Linux
+> Generate a pacman mirrorlist for Manjaro Linux
 > More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
 
 - Generate a mirrorlist, using the default settings:

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -4,7 +4,7 @@
 > Every run of pacman-mirrors requires you to synchronize your database and update your system using `sudo pacman -Syyu`.
 > More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
 
-- Generate a mirrorlist, using the default settings:
+- Generate a mirrorlist using the default settings:
 
 `sudo pacman-mirrors --fasttrack`
 

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -1,6 +1,7 @@
 # pacman-mirrors
 
 > Generate a pacman mirrorlist for Manjaro Linux.
+> Every run of pacman-mirrors requires you to synchronize your database and update your system using `sudo pacman -Syyu`.
 > More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
 
 - Generate a mirrorlist, using the default settings:

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -1,0 +1,24 @@
+# pacman-mirrors
+
+> Generate pacman mirrorlist for Manjaro Linux
+> More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
+
+- Generate a mirrorlist, using the default settings:
+
+`sudo pacman-mirrors -f`
+
+- Get the status of the current mirrors:
+
+`sudo pacman-mirrors --status`
+
+- Check, which branch you are on:
+
+`sudo pacman-mirrors --get-branch`
+
+- Switch to a different branch:
+
+`sudo pacman-mirrors --api --setbranch {{stable|unstable|testing}}`
+
+- Generate a mirrorlist, only using mirrors in your country:
+
+`sudo pacman-mirrors --geoip`


### PR DESCRIPTION
The man page and the Manjaro wiki state that it's necessary to run `sudo pacman -Syyu` after every run of `pacman-mirrors`. However I'm not sure if and where I should add that to the tldr page.