### PR TITLE
CLIENT-SPECIFICATION: add lowercasing of commands

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -59,7 +59,7 @@ tldr -l
 
 The first argument that does not start with a dash (`-`), MUST be considered the page name.
 
-In addition, page names MAY contain spaces (e.g. `git status`) - such page names MUST be transparently concatenated with dashes (`-`). For example, the page name:
+Page names MAY contain spaces (e.g. `git status`) - such page names MUST be transparently concatenated with dashes (`-`). For example, the page name:
 
 ```
 git checkout
@@ -69,6 +69,18 @@ becomes this:
 
 ```
 git-checkout
+```
+
+Page names MAY contain mix capitalization - such page names MUST be transparently lowercased. For example, the page name:
+
+```
+eyeD3
+```
+
+becomes this:
+
+```
+eyed3
 ```
 
 Here are some example invocations:
@@ -130,7 +142,7 @@ Although this specification is about the interface that clients must provide, it
 
 This section defines the algorithm by which a client can decide which page a user has requested.
 
-After transparently replacing spaces (` `) with dashes (`-`), clients have several decisions to make:
+After transparently replacing spaces (` `) with dashes (`-`) and lowercasing the name, clients have several decisions to make:
 
  - The language of a page to display to a client
  - The platform to display a page from

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -59,39 +59,16 @@ tldr -l
 
 The first argument that does not start with a dash (`-`), MUST be considered the page name.
 
-Page names MAY contain spaces (e.g. `git status`) - such page names MUST be transparently concatenated with dashes (`-`). For example, the page name:
-
-```
-git checkout
-```
-
-becomes this:
-
-```
-git-checkout
-```
-
-Page names MAY contain mixed capitalization - such page names MUST be transparently lowercased. For example, the page name:
-
-```
-eyeD3
-```
-
-becomes this:
-
-```
-eyed3
-```
+Page names MAY contain spaces (e.g. `git status`) - such page names MUST be transparently concatenated with dashes (`-`). For example, the page name `git checkout` becomes `git-checkout`. Page names MAY contain mixed capitalization - such page names MUST be transparently lowercased. For example, the page name `eyeD3` becomes `eyed3`.
 
 Here are some example invocations:
 
 ```bash
 tldr 7za
-tldr eyeD3
-tldr git checkout
+tldr eyeD3  # equivalent to tldr eyed3
+tldr git checkout  # equivalent to tldr git-checkout
 tldr --platform osx bash
 ```
-
 
 ## Directory structure
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -71,7 +71,7 @@ becomes this:
 git-checkout
 ```
 
-Page names MAY contain mix capitalization - such page names MUST be transparently lowercased. For example, the page name:
+Page names MAY contain mixed capitalization - such page names MUST be transparently lowercased. For example, the page name:
 
 ```
 eyeD3

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -59,7 +59,9 @@ tldr -l
 
 The first argument that does not start with a dash (`-`), MUST be considered the page name.
 
-Page names MAY contain spaces (e.g. `git status`), and such page names MUST be transparently concatenated with dashes (`-`). For example, the page name `git checkout` becomes `git-checkout`. Page names MAY contain mixed capitalization, and such page names MUST be transparently lowercased. For example, the page name `eyeD3` becomes `eyed3`.
+Page names MAY contain spaces (e.g. `git status`), and such page names MUST be transparently concatenated with dashes (`-`). For example, the page name `git checkout` becomes `git-checkout`.
+
+Page names MAY contain mixed capitalization, and such page names MUST be transparently lowercased. For example, the page name `eyeD3` becomes `eyed3`.
 
 Here are some example invocations:
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -59,7 +59,7 @@ tldr -l
 
 The first argument that does not start with a dash (`-`), MUST be considered the page name.
 
-Page names MAY contain spaces (e.g. `git status`) - such page names MUST be transparently concatenated with dashes (`-`). For example, the page name `git checkout` becomes `git-checkout`. Page names MAY contain mixed capitalization - such page names MUST be transparently lowercased. For example, the page name `eyeD3` becomes `eyed3`.
+Page names MAY contain spaces (e.g. `git status`), and such page names MUST be transparently concatenated with dashes (`-`). For example, the page name `git checkout` becomes `git-checkout`. Page names MAY contain mixed capitalization, and such page names MUST be transparently lowercased. For example, the page name `eyeD3` becomes `eyed3`.
 
 Here are some example invocations:
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

In preparation of landing tldr-lint@0.0.10 and resolving #5085 and #5255, I figured it would be good to add to the client specification about the lowercasing of file names as a transparent step to end users.