### PR TITLE
scp: fix -P example

### DIFF
--- a/pages/common/scp.md
+++ b/pages/common/scp.md
@@ -10,7 +10,7 @@
 
 - Use a specific port when connecting to the remote host:
 
-`scp {{path/to/local_file}} -P {{port}} {{remote_host}}:{{path/to/remote_file}}`
+`scp -P {{port}} {{path/to/local_file}} {{remote_host}}:{{path/to/remote_file}}`
 
 - Copy a file from a remote host to a local directory:
 


### PR DESCRIPTION
So to use a specific port, the -P parameter comes first.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
