### PR TITLE
if: actually use if to test a command's success

### DIFF
--- a/pages/common/if.md
+++ b/pages/common/if.md
@@ -4,7 +4,7 @@
 
 - Echo a different thing depending on a command's success:
 
-`{{command}} && echo "success" || echo "failure"`
+`if {{command}}; then echo "success"; else echo "failure"; fi`
 
 - Full if syntax:
 


### PR DESCRIPTION
Using `{{command}} && {{command1}} || {{command2}}` does not actually work like if. The difference is that in the above expression, command2 gets executed if command1 fails, which does not happen in a real if as in `if {{command}}; then {{command1}}; else {{command2}}; fi`

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
