### PR TITLE
German pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.de/common/awslogs.md
+++ b/pages.de/common/awslogs.md
@@ -1,6 +1,6 @@
 # awslogs
 
-> Kommandozeilen Werkzeug um Log Gruppen, Streams und Events von Amazon Cloudwatch Logs abzurufen:
+> Kommandozeilen Werkzeug um Log Gruppen, Streams und Events von Amazon Cloudwatch Logs abzurufen.
 > Mehr Informationen: <https://github.com/jorgebastida/awslogs>.
 
 - Auflisten aller Log Gruppen:

--- a/pages.de/common/borg.md
+++ b/pages.de/common/borg.md
@@ -12,7 +12,7 @@
 
 `borg create --progress {{/pfad/zum/repo_verzeichnis}}::{{Montag}} {{/pfad/zum/quell_verzeichnis}}`
 
--  Alle Archive in einem Repository auflisten:
+- Alle Archive in einem Repository auflisten:
 
 `borg list {{/pfad/zum/repo_verzeichnis}}`
 

--- a/pages.de/common/convert.md
+++ b/pages.de/common/convert.md
@@ -1,7 +1,7 @@
 # convert
 
-> Imagemagick Bildkonvertierungswerkzeug
-> Mehr Informationen: <https://imagemagick.org/script/convert.php>
+> Imagemagick Bildkonvertierungswerkzeug.
+> Mehr Informationen: <https://imagemagick.org/script/convert.php>.
 
 - Konvertiert ein Bild von JPG nach PNG:
 

--- a/pages.de/common/cradle-install.md
+++ b/pages.de/common/cradle-install.md
@@ -1,6 +1,6 @@
 # cradle install
 
-> Installiert Cradle PHP Framework Komponenten
+> Installiert Cradle PHP Framework Komponenten.
 > Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#install>.
 
 - Installieren von Cradle Komponenten (öffnet erst einen Dialog):

--- a/pages.de/common/git-push.md
+++ b/pages.de/common/git-push.md
@@ -1,6 +1,6 @@
 # git push
 
-> Schiebe Commits zu einem Remote-Repository
+> Schiebe Commits zu einem Remote-Repository.
 > Mehr Informationen: <https://git-scm.com/docs/git-push>.
 
 - Sende lokale Änderungen des aktuellen Branches zu seinem entfernten Gegenstück (Remote Branch):

--- a/pages.de/common/tar.md
+++ b/pages.de/common/tar.md
@@ -35,7 +35,3 @@
 - Extrahiere Dateien die mit einem Muster übereinstimmen:
 
 `tar xf {{quelle.tar}} --wildcards "{{*.html}}"`
-
-- Extrahiere eine bestimmte Datei ohne die Verzeichniss Struktur beizubehalten:
-
-`tar xf {{quelle.tar}} {{quelle.tar/pfad/zum/extrahieren}} --strip-components={{tiefe_zu_entfernen}}`

--- a/pages.de/linux/cfdisk.md
+++ b/pages.de/linux/cfdisk.md
@@ -1,7 +1,7 @@
 # cfdisk
 
 > Ein Programm zur Verwaltung von Partitionstabellen mittels einer Curses-basierten UI.
-> Mehr Informationen: <https://linux.die.net/man/8/cfdisk>
+> Mehr Informationen: <https://linux.die.net/man/8/cfdisk>.
 
 - Das Partitionierungsinterface für eine bestimmte Festplatte öffnen:
 


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the German pages, don't apply to any language but English.
