### PR TITLE
Spanish pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.es/common/dotnet-restore.md
+++ b/pages.es/common/dotnet-restore.md
@@ -25,4 +25,4 @@
 
 - Restaura dependencias con un nivel específico de verbosidad:
 
-`dotnet restore --verbosity {{quiet|minimal|normal|detailed|diagnostic}}
+`dotnet restore --verbosity {{quiet|minimal|normal|detailed|diagnostic}}`

--- a/pages.es/common/git-restore.md
+++ b/pages.es/common/git-restore.md
@@ -1,7 +1,7 @@
 # git restore
 
 > Restura archivo del arbol de trabajo. Requiere la version 2.23 o superior de Git.
-> Véase también `git checkout`
+> Véase también `git checkout`.
 > Más información: <https://git-scm.com/docs/git-restore>.
 
 - Restaura un archivo eliminado del contenido del commit actual (HEAD):

--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -1,6 +1,6 @@
 # gradle
 
-> Gradle es un sistema de código abierto para automatizar la compilación de proyectos
+> Gradle es un sistema de código abierto para automatizar la compilación de proyectos.
 > Más información: <https://gradle.org>.
 
 - Compila un proyecto:

--- a/pages.es/common/mysql.md
+++ b/pages.es/common/mysql.md
@@ -1,6 +1,6 @@
 # mysql
 
-> Herramienta de línea de comandos para gestionar bases de datos MySQL
+> Herramienta de línea de comandos para gestionar bases de datos MySQL.
 > Más información: <https://www.mysql.com/>.
 
 - Conecta a una base de datos:

--- a/pages.es/linux/cal.md
+++ b/pages.es/linux/cal.md
@@ -21,4 +21,3 @@
 - Muestra el calendario para un año y mes concretos:
 
 `cal {{month}} {{year}}`
-

--- a/pages.es/linux/calc.md
+++ b/pages.es/linux/calc.md
@@ -9,4 +9,3 @@
 - Realizar un cálculo en modo no-interactivo:
 
 `calc -p '{{85 * (36 / 4)}}'`
-

--- a/pages.es/linux/conky.md
+++ b/pages.es/linux/conky.md
@@ -11,7 +11,7 @@
 
 `conky -C > ~/.conkyrc`
 
--Ejecuta conky con un archivo de configuración concreto:
+- Ejecuta conky con un archivo de configuración concreto:
 
 `conky -c {{ruta/a/la/configuración}}`
 

--- a/pages.es/linux/lsmod.md
+++ b/pages.es/linux/lsmod.md
@@ -1,7 +1,7 @@
 # lsmod
 
 > Muestra el estado de los módulos cargados en el kernel de linux.
-> Vease tambien `modprobe`, el cual carga módulos de kernel
+> Vease tambien `modprobe`, el cual carga módulos de kernel.
 
 - Lista todos los módulos de kernel cargados:
 

--- a/pages.es/osx/brew.md
+++ b/pages.es/osx/brew.md
@@ -27,10 +27,6 @@
 
 `brew update`
 
-- Elimina versiones antiguas de fórmulas instaladas (si no se indica el nombre, se busca en todas las fórmulas):
-
-`brew cleanup {{formula}}`
-
 - Muestra información acerca de una fórmula (versión, ruta de instalación, dependencias, etc.):
 
 `brew info {{formula}}`


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the Spanish pages, don't apply to any language but English.