### PR TITLE
French pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.fr/common/git-add.md
+++ b/pages.fr/common/git-add.md
@@ -20,6 +20,7 @@
 `git add -f`
 
 - Ajoute des parties de fichiers interactivement :
+
 `git add -p`
 
 - Ajoute interactivement les parties d un fichier specifié :

--- a/pages.fr/common/git-flow.md
+++ b/pages.fr/common/git-flow.md
@@ -1,6 +1,6 @@
 # git flow
 
-> Une colletion d'extentions Git pour procurer des opperation de registre supplementaires
+> Une colletion d'extentions Git pour procurer des opperation de registre supplementaires.
 > Plus d'informations : <https://github.com/nvie/gitflow>.
 
 - Initialiser dans un registre Git existant :

--- a/pages.fr/common/git-format-patch.md
+++ b/pages.fr/common/git-format-patch.md
@@ -4,7 +4,7 @@
 > Voir egalement `git am`, qui peut appliquer des fichiers de correctifs genérés.
 > Plus d'informations : <https://git-scm.com/docs/git-format-patch>.
 
--Créer un fichier de correctif `.patch` nommé automatiquement pour tout les commits non poussés :
+- Créer un fichier de correctif `.patch` nommé automatiquement pour tout les commits non poussés :
 
 `git format-patch {{origin}}`
 

--- a/pages.fr/common/git-show-ref.md
+++ b/pages.fr/common/git-show-ref.md
@@ -1,6 +1,6 @@
 # git show-ref
 
-> commande Git pour lister les références.
+> Commande Git pour lister les références.
 > Plus d'informations : <https://git-scm.com/docs/git-show-ref>.
 
 - Affiche toutes les références dans le dépot :

--- a/pages.fr/common/lua.md
+++ b/pages.fr/common/lua.md
@@ -1,7 +1,6 @@
 # lua
 
-> Un langage de programmation puissant, léger, et convenable aux
-systèmes embarqués.
+> Un langage de programmation puissant, léger, et convenable aux systèmes embarqués.
 > Plus d'informations : <https://www.lua.org>.
 
 - Démarre une session de commandes intéractive Lua :

--- a/pages.fr/common/mc.md
+++ b/pages.fr/common/mc.md
@@ -2,7 +2,7 @@
 
 > Midnight Commander, gestionnaire de fichiers à base de console.
 > La navigation dans les répertoires se fait à l'aide des touches directionnelles ou la souris, ou bien en tapant des commandes dans la console.
-> Plus d'informations : <https://midnight-commander.org>
+> Plus d'informations : <https://midnight-commander.org>.
 
 - Démarre `mc` :
 


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the French pages, don't apply to any language but English.
