### PR TITLE
Italian pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.it/common/nmap.md
+++ b/pages.it/common/nmap.md
@@ -32,10 +32,6 @@
 
 `nmap -sSU {{indirizzo_o_indirizzi}}`
 
-- Esegui una scansione di cifratori TLS verso un host per individuarne i cifratori supportati e i protocolli SSL/TLS:
-
-`nmap --script ssl-enum-ciphers {{indirizzo_o_indirizzi}} -p 443`
-
 - Determina vulnerabilità e informazioni di un host eseguendo una scansione di tutte le porte, servizi e versioni con tutti gli script di default NSE attivi:
 
 `nmap -sC -sV {{indirizzo_o_indirizzi}}`

--- a/pages.it/linux/apt-get.md
+++ b/pages.it/linux/apt-get.md
@@ -1,6 +1,6 @@
 # apt-get
 
-> Servizio di gestione dei pacchetti per Debian e Ubuntu
+> Servizio di gestione dei pacchetti per Debian e Ubuntu.
 > Cerca i pacchetti usando `apt-cache`.
 
 - Aggiorna la lista dei pacchetti e delle loro versioni disponibili (è consigliato eseguire questo comando prima di altri comandi `apt-get`):

--- a/pages.it/osx/brew.md
+++ b/pages.it/osx/brew.md
@@ -27,10 +27,6 @@
 
 `brew update`
 
-- Rimuovi le vecchie versioni di una specifica formula installata (se nessuna formula viene specificata, tutte le formule saranno processate):
-
-`brew cleanup {{formula}}`
-
 - Mostra le informazioni su una specifica formula (versione, percorso di installazione, dipendenze, ecc...):
 
 `brew info {{formula}}`


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the Italian pages, don't apply to any language but English.
