### PR TITLE
Dutch pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.nl/windows/find.md
+++ b/pages.nl/windows/find.md
@@ -1,6 +1,6 @@
 # find
 
-> Vind een gespecificieerde string in een bestand
+> Vind een gespecificieerde string in een bestand.
 > Meer informatie: <https://docs.microsoft.com/windows-server/administration/windows-commands/find>.
 
 - Vind de lijnen dat een specifieke string bevatten:

--- a/pages.nl/windows/shutdown.md
+++ b/pages.nl/windows/shutdown.md
@@ -13,7 +13,7 @@
 
 - Herstart de huidige machine:
 
-`shutdown /r`
+`shutdown /r /t 0`
 
 - Zet de huidige machine in slaapstand:
 
@@ -26,10 +26,6 @@
 - Zet een timer in aantal seconden voor het afsluiten van de huidige machine:
 
 `shutdown /s /t {{seconden}}`
-
-- Specifieer een reden voor het afsluiten van de machine:
-
-`shutdown /s /c "{{reden}}"`
 
 - Breek een afsluit sequentie af vooraleer de timer was afgelopen:
 


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the Dutch pages, don't apply to any language but English.
