### PR TITLE
musescore: add page

### DIFF
--- a/pages/common/mscore.md
+++ b/pages/common/mscore.md
@@ -1,0 +1,7 @@
+# mscore
+
+> This command is an alias of `musescore`.
+
+- View documentation for the original command:
+
+`tldr musescore`

--- a/pages/common/musescore.md
+++ b/pages/common/musescore.md
@@ -19,7 +19,7 @@
 
 `musescore --experimental`
 
-- Export the given (or currently opened) file to the specified output file. The file type depends on the extension given:
+- Export the given file to the specified output file. The file type depends on the extension given:
 
 `musescore --export-to {{output_file}} {{input_file}}`
 

--- a/pages/common/musescore.md
+++ b/pages/common/musescore.md
@@ -19,14 +19,14 @@
 
 `musescore --experimental`
 
-- Export the given file to the specified output file. The file type depends on the extension given:
+- Export the given file to the specified output file. The file type depends on the given extension:
 
 `musescore --export-to {{output_file}} {{input_file}}`
 
 - Print a diff between the given scores:
 
-`musescore --diff {{file1}} {{file2}}`
+`musescore --diff {{path/to/file1}} {{path/to/file2}}`
 
 - Specify a MIDI import operations file:
 
-`musescore --midi-operations {{file}}`
+`musescore --midi-operations {{path/to/file}}`

--- a/pages/common/musescore.md
+++ b/pages/common/musescore.md
@@ -23,7 +23,7 @@
 
 `musescore --export-to {{output_file}} {{input_file}}`
 
-- Print a conditioned `diff` between the given scores:
+- Print a diff between the given scores:
 
 `musescore --diff {{file1}} {{file2}}`
 

--- a/pages/common/musescore.md
+++ b/pages/common/musescore.md
@@ -1,0 +1,32 @@
+# musescore
+
+> MuseScore 3 sheet music editor.
+> More information: <https://musescore.org/en/handbook/3/command-line-options>.
+
+- Use a specific audio driver:
+
+`musescore --audio-driver {{jack|alsa|portaudio|pulse}}`
+
+- Set the MP3 output bitrate in kbit/s:
+
+`musescore --bitrate {{bitrate}}`
+
+- Start MuseScore in debug mode:
+
+`musescore --debug`
+
+- Enable experimental features, such as layers:
+
+`musescore --experimental`
+
+- Export the given (or currently opened) file to the specified output file. The file type depends on the extension given:
+
+`musescore --export-to {{output_file}} {{input_file}}`
+
+- Print a conditioned `diff` between the given scores:
+
+`musescore --diff {{file1}} {{file2}}`
+
+- Specify a MIDI import operations file:
+
+`musescore --midi-operations {{file}}`


### PR DESCRIPTION
There's also `mscore`, which is identical to `musescore`. Is the alias system already in place or should I just add a new seperate page?