### PR TITLE
Portuguese (Brazil) pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.pt_BR/common/git-add.md
+++ b/pages.pt_BR/common/git-add.md
@@ -1,6 +1,6 @@
 # git add
 
-> Adiciona arquivos modificados na área de preparação
+> Adiciona arquivos modificados na área de preparação.
 > Mais informações: <https://git-scm.com/docs/git-add>.
 
 - Adiciona um arquivo na área de preparação:

--- a/pages.pt_BR/common/git.md
+++ b/pages.pt_BR/common/git.md
@@ -1,6 +1,6 @@
 # git
 
-> Sistema de versionamento distribuído
+> Sistema de versionamento distribuído.
 > Mais informações: <https://git-scm.com>.
 
 - Verifique a versão do Git:

--- a/pages.pt_BR/common/kill.md
+++ b/pages.pt_BR/common/kill.md
@@ -1,6 +1,6 @@
 # kill
 
-> Envia um sinal para um processo, geralmente para finalizar o processo
+> Envia um sinal para um processo, geralmente para finalizar o processo.
 > Todos os sinais exceto pelo SIGKILL e SIGSTOP podem ser interceptados pelo processo para finalizar de forma limpa.
 
 - Finaliza um programa usando o sinal default SIGTERM (terminate):

--- a/pages.pt_BR/common/tar.md
+++ b/pages.pt_BR/common/tar.md
@@ -2,7 +2,7 @@
 
 > Ferramenta de compressão de arquivos.
 > Utilizado com metodos de compressão como o de gzip ou bzip2.
-> Mais informações: <https://www.gnu.org/software/tar>
+> Mais informações: <https://www.gnu.org/software/tar>.
 
 - Compactando arquivos em um arquivo tar:
 

--- a/pages.pt_BR/linux/apt-get.md
+++ b/pages.pt_BR/linux/apt-get.md
@@ -23,7 +23,7 @@
 
 `apt-get upgrade`
 
--  Limpar o repositório local — removendo os arquivos de pacotes (.deb) de downloads interrompidos que não podem mais ser baixados:
+- Limpar o repositório local — removendo os arquivos de pacotes (`.deb`) de downloads interrompidos que não podem mais ser baixados:
 
 `apt-get autoclean`
 


### PR DESCRIPTION
**(valid)** because `TLDR109`, which is only erroring on `eyeD3.md`, I would like to fix, along with other offenders of that rule, in a separate PR.
