### PR TITLE
Indonesian pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.id/common/cd.md
+++ b/pages.id/common/cd.md
@@ -1,6 +1,6 @@
 # cd
 
-> Mengganti direktori yang dikunjungi saat ini
+> Mengganti direktori yang dikunjungi saat ini.
 
 - Menuju ke direktori yang telah ditentukan:
 


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the Indonesian pages, don't apply to any language but English.
