### PR TITLE
Japanese pages: fix (valid) tldr-lint errors

### DIFF
--- a/pages.ja/common/tldr.md
+++ b/pages.ja/common/tldr.md
@@ -14,4 +14,3 @@
 - gitのサブコマンドについての情報を見る:
 
 `tldr {{git checkout}}`
-


### PR DESCRIPTION
**(valid)** because `TLDR015` and `TLDR104`, which are found a lot on the Japanese pages, don't apply to any language but English, and Japanese/Chinese use their own punctuation, which currently `TLDR004` and `TLDR005` don't account for.