### PR TITLE
Bump tldr-lint to 0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,17 +730,17 @@
       }
     },
     "tldr-lint": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/tldr-lint/-/tldr-lint-0.0.9.tgz",
-      "integrity": "sha512-Pc+ICLLZqRTNMEHQPOFH0MH2YW5hjK1RueRGVF3ZUe7MfRCJ+R0kfGMNKTHKG9hwH9WCsBrmpP1E1CgZiKGD9A==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/tldr-lint/-/tldr-lint-0.0.10.tgz",
+      "integrity": "sha512-wTjuVYwzZHk6tdIo+wBRyEMTticCKywelpiafgRio2mTjKOCAjpWax2XdMSowiIVlDm6ixTx3FSwP/hr02DXrQ==",
       "requires": {
-        "commander": "^6.1.0"
+        "commander": "^7.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "glob": "7.1.3",
     "husky": "^2.2.0",
     "markdownlint-cli": "0.19.0",
-    "tldr-lint": "~0.0.9"
+    "tldr-lint": "~0.0.10"
   },
   "scripts": {
     "lint-markdown": "markdownlint pages*/**/*.md",


### PR DESCRIPTION
Closes #5255
Closes #5071

Enables the following PRs to be merged:
#5205
#5088

---

This PR is waiting for the following pages to be corrected:
```
pages/common/R.md:0: TLDR109 File name should be lowercase
pages/common/theHarvester.md:0: TLDR109 File name should be lowercase
pages/linux/eyeD3.md:0: TLDR109 File name should be lowercase
pages/osx/GetFileInfo.md:0: TLDR109 File name should be lowercase
pages/osx/SafeEjectGPU.md:0: TLDR109 File name should be lowercase
pages/osx/csshX.md:0: TLDR109 File name should be lowercase
```

Checklist:

- [x] [`R.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/common/R.md) → #5379
- [x] [`theHarvester.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/common/theHarvester.md) → #5380
- [x] [`eyeD3.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/linux/eyeD3.md) → #5381
- [x] [`GetFileInfo.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/osx/GetFileInfo.md) → #5382
- [x] [`SafeEjectGPU.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/osx/SafeEjectGPU.md) → #5383
- [x] [`csshX.md`](https://github.com/tldr-pages/tldr/blob/6443e6a7254dd0d9c350be2db0ee9ad7cab2d032/pages/osx/csshX.md) → #5384
