### PR TITLE
Add script for finding undocumented pages more easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ scripts/pdf/tldr-pages.pdf
 # Python venv for testing the PDF script
 # Create it with: python3 -m venv scripts/pdf/venv/
 scripts/pdf/venv/
+
+# List of undocumented commands
+undocumented.txt
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Just open an issue or send a pull request and we'll incorporate it as soon as po
 To get started, please [sign](https://cla-assistant.io/tldr-pages/tldr) the
 [Contributor License Agreement](https://gist.github.com/waldyrious/e50feec13683e565769fbd58ce503d4e).
 
+A bash script for creating a list of all executables on your system, which don't yet have a tldr page can be found at `scripts/find-undocumented.sh`
+
 *Note*: when submitting a new command, don't forget to check if there's already a pull request in progress for it.
 
 ## Guidelines

--- a/scripts/find-undocumented.sh
+++ b/scripts/find-undocumented.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Check if the user is in tldr/scripts/
+directory=$(pwd | grep -o ".\{13\}$")
+if [ $directory != "/tldr/scripts" ]; then
+    echo "Please make sure your current working directory is tldr/scripts/"
+    exit 1
+fi
+
+# Print info message
+echo "Creating list of all executables on your system which don't yet have a tldr page."
+echo "For a list of missing translations, please refer to https://lukwebsforge.github.io/tldri18n/."
+
+# Create needed files
+mkdir /tmp/find-undocumented
+touch /tmp/find-undocumented/bin-files
+touch /tmp/find-undocumented/tldr-pages
+touch /tmp/find-undocumented/bin-files-sorted
+touch /tmp/find-undocumented/tldr-pages-sorted
+touch ../undocumented.txt
+
+# Create list of all binaries on the system
+for path in ${PATH//:/ }; do
+    ls $path >> /tmp/find-undocumented/bin-files
+done
+
+# Create a list of all tldr pages
+pagelist=( ../pages/common/ ../pages/linux/ ../pages/osx/ ../pages/sunos/ ../pages/windows/ )
+for path in ${pagelist[@]}; do
+    ls $path | cut -d "." -f 1 >> /tmp/find-undocumented/tldr-pages
+done
+
+# Sort both files and delete duplicate entries
+sort -u /tmp/find-undocumented/bin-files > /tmp/find-undocumented/bin-files-sorted
+sort -u /tmp/find-undocumented/tldr-pages > /tmp/find-undocumented/tldr-pages-sorted
+
+# Create a diff with all files which are in
+diff /tmp/find-undocumented/bin-files-sorted /tmp/find-undocumented/tldr-pages-sorted | grep "<" | cut -c 3- > ../undocumented.txt
+
+# Clean up
+rm /tmp/find-undocumented/bin-files
+rm /tmp/find-undocumented/tldr-pages
+rm /tmp/find-undocumented/bin-files-sorted
+rm /tmp/find-undocumented/tldr-pages-sorted
+rmdir /tmp/find-undocumented
+
+echo "List created successfully"
+echo "Output file is tldr/undocumented.txt"


### PR DESCRIPTION
I have made a little bash script, which creates a text file with every currently installed command (at least all in `$PATH`) which was not found in `pages/`. It's far from perfect, but at least (for me) it works. I thought about sorting the list by relevance by taking `.bashrc` into consideration, but I'm not sure how I'd do that.

I also added the output file to `.gitignore` and referenced to the script in `CONTRIBUTING.md`.