### PR TITLE
platformio: add alias page

### DIFF
--- a/pages/common/platformio.md
+++ b/pages/common/platformio.md
@@ -1,0 +1,7 @@
+# platformio
+
+> This command is an alias of `pio`.
+
+- View documentation for the original command:
+
+`tldr pio`


### PR DESCRIPTION
`platformio` is an alias of `pio` (#5404)