### PR TITLE
plattformio-home: add alias page

### DIFF
--- a/pages/common/platformio-home.md
+++ b/pages/common/platformio-home.md
@@ -1,6 +1,7 @@
 # platformio home
 
 > This command is an alias of `pio home`.
+
 - View documentation for the original command:
 
 `tldr pio-home`

--- a/pages/common/platformio-home.md
+++ b/pages/common/platformio-home.md
@@ -1,0 +1,6 @@
+# platformio home
+
+> This command is an alias of `pio home`.
+- View documentation for the original command:
+
+`tldr pio-home`


### PR DESCRIPTION
`platformio-home` is an alias of `pio-home` (#5406)