### PR TITLE
dig: add more examples

### DIFF
--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -1,14 +1,19 @@
 # dig
 
 > DNS Lookup utility.
+> More information: <https://manpages.debian.org/buster/dnsutils/dig.1.en.html>.
 
 - Lookup the IP(s) associated with a hostname (A records):
 
 `dig +short {{example.com}}`
 
-- Lookup the mail server(s) associated with a given domain name (MX record):
+- Get a detailed answer for a given domain (A records):
 
-`dig +short {{example.com}} MX`
+`dig +noall +answer {{example.com}}`
+
+- Query a specific DNS record type associated with a given domain name:
+
+`dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
 - Get all types of records for a given domain name:
 


### PR DESCRIPTION
I originally made a [pull request ](https://github.com/tldr-pages/tldr/pull/5413) for adding a new `dig.md` page. However, I was recommended to take the good parts in my  `dig.md` file and merge them in the file already existing in the `common` directory. 

I have added what I think are the good changes to the existing `dig.md` file. In my original pull request, I wrote an acronym for dig "Domain Information Groper", upon further research, I learned that it was [removed in 2017](https://en.wikipedia.org/wiki/Dig_(command)#History).  A lot of sources online still use the acronym, so I was conflicted as I was editing new changes. I settled on removing it.  

Am looking forward to hearing your thoughts on the new changes. Thank you in advance.


- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
