### PR TITLE
paru: replace -P example by 2 --getpkgbuild examples

### DIFF
--- a/pages/linux/paru.md
+++ b/pages/linux/paru.md
@@ -23,6 +23,6 @@
 
 `paru --getpkgbuild  {{package_name}}`
 
-- Display the `PKGBUILD` of a package:
+- Display the `PKGBUILD` file of a package:
 
 `paru --getpkgbuild --print {{package_name}}`

--- a/pages/linux/paru.md
+++ b/pages/linux/paru.md
@@ -19,6 +19,6 @@
 
 `paru -Si {{package_name}}`
 
-- Show statistics for installed packages and system health:
+- Download PKGBUILDs from the AUR or ABS:
 
-`paru -P --stats`
+`paru -G {{package_name}}`

--- a/pages/linux/paru.md
+++ b/pages/linux/paru.md
@@ -19,6 +19,10 @@
 
 `paru -Si {{package_name}}`
 
-- Download PKGBUILDs from the AUR or ABS:
+- Download `PKGBUILD` and other package source files from the AUR or ABS:
 
-`paru -G {{package_name}}`
+`paru --getpkgbuild  {{package_name}}`
+
+- Display the `PKGBUILD` of a package:
+
+`paru --getpkgbuild --print {{package_name}}`

--- a/pages/linux/paru.md
+++ b/pages/linux/paru.md
@@ -1,7 +1,7 @@
 # paru
 
 > An AUR helper and pacman wrapper.
-> More information: <https://github.com/morganamilo/paru>.
+> More information: <https://github.com/Morganamilo/paru>.
 
 - Interactively search for and install a package:
 


### PR DESCRIPTION
Change "paru -P --stats", which no longer works, to a new, and also useful, example.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
