### PR TITLE
bssh, bvnc, bshell: add pages

### DIFF
--- a/pages/common/bshell.md
+++ b/pages/common/bshell.md
@@ -1,0 +1,22 @@
+# bshell
+
+> A GUI tool for browsing for SSH/VNC servers on the local network.
+> See also: `bssh` and `bvnc`.
+> More information: <https://linux.extremeoverclocking.com/man/1/bssh>.
+
+- Browse for both SSH and VNC servers:
+
+`bshell`
+
+- Browse for SSH servers only:
+
+`bshell --ssh`
+
+- Browse for VNC servers only:
+
+`bshell --vnc`
+
+- Browse for both SSH and VNC servers in a specified domain:
+
+`bshell --domain={{domain}}`
+

--- a/pages/common/bshell.md
+++ b/pages/common/bshell.md
@@ -19,4 +19,3 @@
 - Browse for both SSH and VNC servers in a specified domain:
 
 `bshell --domain={{domain}}`
-

--- a/pages/common/bssh.md
+++ b/pages/common/bssh.md
@@ -1,0 +1,22 @@
+# bssh
+
+> A GUI tool for browsing for SSH/VNC servers on the local network.
+> See also: `bvnc` and `bshell`.
+> More information: <https://linux.extremeoverclocking.com/man/1/bssh>.
+
+- Browse for SSH servers:
+
+`bssh`
+
+- Browse for VNC servers:
+
+`bssh --vnc`
+
+- Browse for both SSH and VNC servers:
+
+`bssh --shell`
+
+- Browse for SSH servers in a specified domain:
+
+`bssh --domain={{domain}}`
+

--- a/pages/common/bssh.md
+++ b/pages/common/bssh.md
@@ -19,4 +19,3 @@
 - Browse for SSH servers in a specified domain:
 
 `bssh --domain={{domain}}`
-

--- a/pages/common/bvnc.md
+++ b/pages/common/bvnc.md
@@ -19,4 +19,3 @@
 - Browse for VNC servers in a specified domain:
 
 `bvnc --domain={{domain}}`
-

--- a/pages/common/bvnc.md
+++ b/pages/common/bvnc.md
@@ -1,0 +1,22 @@
+# bvnc
+
+> A GUI tool for browsing for SSH/VNC servers on the local network.
+> See also: `bssh` and `bshell`.
+> More information: <https://linux.extremeoverclocking.com/man/1/bssh>.
+
+- Browse for VNC servers:
+
+`bvnc`
+
+- Browse for SSH servers:
+
+`bvnc --ssh`
+
+- Browse for both VNC and SSH servers:
+
+`bvnc --shell`
+
+- Browse for VNC servers in a specified domain:
+
+`bvnc --domain={{domain}}`
+


### PR DESCRIPTION
This situation is actually a bit complicated. There is only one binary (`bssh`) and the other ones are just links to that one. The default behaviour of the command changes depending under which name it is called. Hower I couldn't just make two alias pages, since the arguments depend on the name it is called. I hope the way I did it is okay.