### PR TITLE
git-diff: use English names for natural language dates in Spanish translation

### DIFF
--- a/pages.es/common/git-diff.md
+++ b/pages.es/common/git-diff.md
@@ -29,8 +29,8 @@
 
 - Compara un único archivo entre dos ramas o commits:
 
-`git diff {{rama_1}}..{{rama_2}} [--] {{ruta/del/archivo}}`
+`git diff {{rama_1}}..{{rama_2}} [--] {{ruta/al/archivo}}`
 
 - Compara diferentes archivos de la rama actual con otra rama:
 
-`git diff {{rama}}:{{ruta/del/archivo}} {{ruta/del/archivo2}}`
+`git diff {{rama}}:{{ruta/al/archivo}} {{ruta/al/archivo2}}`

--- a/pages.es/common/git-diff.md
+++ b/pages.es/common/git-diff.md
@@ -15,9 +15,9 @@
 
 `git diff --staged`
 
-- Muestra los cambios de todos los commits a partir de una fecha/tiempo específico (una expresión de fecha, por ej., "1 semana 2 días" o una fecha ISO):
+- Muestra los cambios de todos los commits a partir de una fecha/tiempo específico (una expresión de fecha, por ej., "1 week 2 days" o una fecha ISO):
 
-`git diff 'HEAD@{3 meses|semanas|días|horas|segundos}'`
+`git diff 'HEAD@{3 months|weeks|days|hours|seconds ago}`
 
 - Muestra solo los nombres de los archivos cambiados con un commit específico:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

They were translated into Spanish, which is great, but they don't actually work, which might be an unpleasant surprise to the user.