### PR TITLE
mkfs.btrfs: add page

### DIFF
--- a/pages/linux/mkfs.btrfs.md
+++ b/pages/linux/mkfs.btrfs.md
@@ -1,0 +1,16 @@
+# mkfs.btrfs
+
+> Create a btrfs filesystem.
+> Defaults to `raid1`, which specifies 2 copies of a given data block spread across 2 different devices.
+
+- Create a btrfs filesystem on a single device:
+
+`sudo mkfs.btrfs --metadata single --data single {{/dev/sda}}`
+
+- Create a btrfs filesystem on multiple devices with raid1:
+
+`sudo mkfs.btrfs --metadata raid1 --data raid1 {{/dev/sda}} {{/dev/sdb}} {{/dev/sdN}}`
+
+- Set a label for the filesystem:
+
+`sudo mkfs.btrfs --label "{{label}}" {{/dev/sda}} [{{/dev/sdN}}]`

--- a/pages/linux/mkfs.btrfs.md
+++ b/pages/linux/mkfs.btrfs.md
@@ -2,6 +2,7 @@
 
 > Create a btrfs filesystem.
 > Defaults to `raid1`, which specifies 2 copies of a given data block spread across 2 different devices.
+> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/mkfs.btrfs>.
 
 - Create a btrfs filesystem on a single device:
 


### PR DESCRIPTION
You'll need this if you want to get started with btrfs - part of #5103.

Note that raid1 is actually misnomer in btrfs - it doesn't do whhat you think it does. In btrfs, you can have as many disks as you like (they don't even have to be the same size) in raid1 - all it means is that btrfs will keep 2 copies of every block of data on 2 different disks. Indeed, it's actually a smart idea to have 3 disks in raid1 - that way if 1 fails you don't end up with a degraded filesystem.

Note also that I'm not including raid5/6 examples here, because a bug in the current implementation causes data to be lost under obscure circumstances (it's not considered stable just yet).