### PR TITLE
README: link emacs client to melpa.org package

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ both for the command line and for other platforms:
   - [TLDR Elixir Client](https://github.com/edgurgel/tldr_elixir_client)
   (binaries not yet available)
 - [Emacs client](https://github.com/kuanyui/tldr.el), available on
-  [MELPA](https://github.com/melpa/melpa)
+  [MELPA](https://melpa.org/#/tldr)
 - Go clients:
   - [github.com/pranavraja/tldr](https://github.com/pranavraja/tldr):
     `go get github.com/pranavraja/tldr`


### PR DESCRIPTION
Earlier it pointed to melpa repo on github, which is not useful for someone trying to install the Emacs package.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

