### PR TITLE
pgbench: fix typo in --client example

### DIFF
--- a/pages/common/pgbench.md
+++ b/pages/common/pgbench.md
@@ -9,4 +9,4 @@
 
 - Benchmark a database with 10 clients, 2 worker threads, and 10,000 transactions per client:
 
-`pgbench --clients={{10}} --jobs={{2}} --transactions={{10000}} {{database_name}}`
+`pgbench --client={{10}} --jobs={{2}} --transactions={{10000}} {{database_name}}`


### PR DESCRIPTION
According to pgbench 13.2, on my MacOS computer, the right parameter name is `client`.

>   -c, --client=NUM         number of concurrent database clients (default: 1)

According to https://www.postgresql.org/docs/10/pgbench.html ; the right parameter is `client` too.
