### PR TITLE
7z: fix spacing issues

### DIFF
--- a/pages/common/7z.md
+++ b/pages/common/7z.md
@@ -9,7 +9,7 @@
 
 - Encrypt an existing archive (including headers):
 
-`7z a {{encrypted.7z}} -p{{password}} -mhe=on {{archived.7z}}`
+`7z a {{encrypted.7z}} -p {{password}} -mhe=on {{archived.7z}}`
 
 - Extract an existing 7z file with original directory structure:
 
@@ -17,7 +17,7 @@
 
 - Extract an archive with user-defined output path:
 
-`7z x {{archived.7z}} -o{{path/to/output}}`
+`7z x {{archived.7z}} -o {{path/to/output}}`
 
 - Extract an archive to stdout:
 


### PR DESCRIPTION
fix a spacing issue on the 7z page

- [ X ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ X ] The page has 8 or fewer examples.
- [ X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

