### PR TITLE
pamac: add note about AUR packages in the command description

### DIFF
--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,7 +1,8 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
-> If AUR is not enabled by default, add --aur (or -a) after a command.
+> If AUR is not enabled by default, add `--aur` after a command.
+> More information: <https://wiki.manjaro.org/index.php/Pamac>.
 
 - Install a new package:
 

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,7 +1,7 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
-> If AUR is not enabled by default, add `--aur` after a command.
+> If you can't see the AUR packages, enable it in the GUI version or in /etc/pamac.conf
 > More information: <https://wiki.manjaro.org/index.php/Pamac>.
 
 - Install a new package:

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,7 +1,7 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
-> If you can't see the AUR packages, enable it in the GUI version or in /etc/pamac.conf
+> If you can't see the AUR packages, enable it in /etc/pamac.conf or in the GUI version. 
 > More information: <https://wiki.manjaro.org/index.php/Pamac>.
 
 - Install a new package:

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,7 +1,7 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
-> If you can't see the AUR packages, enable it in /etc/pamac.conf or in the GUI version.
+> If you can't see the AUR packages, enable it in `/etc/pamac.conf` or in the GUI.
 > More information: <https://wiki.manjaro.org/index.php/Pamac>.
 
 - Install a new package:

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,7 +1,7 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
-> If you can't see the AUR packages, enable it in /etc/pamac.conf or in the GUI version. 
+> If you can't see the AUR packages, enable it in /etc/pamac.conf or in the GUI version.
 > More information: <https://wiki.manjaro.org/index.php/Pamac>.
 
 - Install a new package:

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -1,6 +1,7 @@
 # pamac
 
 > A command line utility for the GUI package manager pamac.
+> If AUR is not enabled by default, add --aur (or -a) after a command.
 
 - Install a new package:
 
@@ -21,3 +22,7 @@
 - Check for package updates:
 
 `pamac checkupdates`
+
+- Upgrade all packages:
+
+`pamac upgrade`

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -10,7 +10,7 @@
 
 - Remove a package and its no longer required dependencies (orphans):
 
-`pamac remove -o {{package_name}}`
+`pamac remove --orphans {{package_name}}`
 
 - Search the package database for a package:
 
@@ -18,7 +18,7 @@
 
 - List installed packages:
 
-`pamac list -i`
+`pamac list --installed`
 
 - Check for package updates:
 


### PR DESCRIPTION
- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


(partially) For #5510