### PR TITLE
base64: clarify example descriptions that do not edit files inplace

### DIFF
--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -3,7 +3,7 @@
 > Encode or decode file or standard input to/from Base64, to standard output.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
 
-- Encode the contents of a file as base64 to stdout:
+- Encode the contents of a file as base64 and write the result to stdout:
 
 `base64 {{filename}}`
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -3,11 +3,11 @@
 > Encode or decode file or standard input to/from Base64, to standard output.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
 
-- Encode a file:
+- Print a plaintext file's contents encoded in base64:
 
 `base64 {{filename}}`
 
-- Decode a file:
+- Print a base64 encoded file's contents decoded to plaintext:
 
 `base64 --decode {{filename}}`
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -7,7 +7,7 @@
 
 `base64 {{filename}}`
 
-- Decode the base64 contents of a file to stdout:
+- Decode the base64 contents of a file and write the result to stdout:
 
 `base64 --decode {{filename}}`
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -3,7 +3,7 @@
 > Encode or decode file or standard input to/from Base64, to standard output.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
 
-- Print a plaintext file's contents encoded in base64:
+- Encode the contents of a file as base64 to stdout:
 
 `base64 {{filename}}`
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -7,7 +7,7 @@
 
 `base64 {{filename}}`
 
-- Print a base64 encoded file's contents decoded to plaintext:
+- Decode the base64 contents of a file to stdout:
 
 `base64 --decode {{filename}}`
 


### PR DESCRIPTION
Reading "Encode a file" made me worry that the command would edit the file inplace. Clarify that it prints the results instead.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
