### PR TITLE
coreutils*: use short more info links

### DIFF
--- a/pages.bs/common/false.md
+++ b/pages.bs/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > Vrati izlazni kod od 1.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/false>.
 
 - Vrati izlazni kod od 1:
 

--- a/pages.bs/common/logname.md
+++ b/pages.bs/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > Prikazuje ime prijevljenog korisnika.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/logname>.
 
 - Prikaži ime trenutno prijavljenog korisnika:
 

--- a/pages.bs/common/mkfifo.md
+++ b/pages.bs/common/mkfifo.md
@@ -1,7 +1,7 @@
 # mkfifo
 
 > Pravi FIFOs (imenovane cijevi).
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/mkfifo-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/mkfifo>.
 
 - Napravi imenovanu cijev na zadatoj putanji:
 

--- a/pages.bs/common/tty.md
+++ b/pages.bs/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > Vraća ime terminala.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/tty>.
 
 - Ispiši ime fajla ovog terminala:
 

--- a/pages.de/common/basename.md
+++ b/pages.de/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > Entfernt führende Verzeichniskomponenten in einem Pfad.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/basename>.
 
 - Ermittle den Dateinamen in einem Pfad:
 

--- a/pages.de/common/cat.md
+++ b/pages.de/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Verkette und gib einzelne oder mehrere Dateien aus.
-> Mehrere Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Mehrere Informationen: <https://www.gnu.org/software/coreutils/cat>.
 
 - Gib den Inhalt einer Datei aus:
 

--- a/pages.de/common/chmod.md
+++ b/pages.de/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Ändere die Zugriffsberechtigungen einer Datei oder eines Verzeichnisses.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Gib dem Besitzer einer Datei ([u]ser) das Recht, sie auszuführen (e[x]ecute):
 

--- a/pages.de/common/chown.md
+++ b/pages.de/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Ändere den Besitzer und die Besitzergruppe von Dateien und Verzeichnissen.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/chown>.
 
 - Ändere den Besitzer einer Datei/eines Verzeichnisses:
 

--- a/pages.de/common/chroot.md
+++ b/pages.de/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Führe einen Befehl oder eine interaktive Shell mit einem speziellen root-Verzeichnis aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Führe einen Befehl mit einem neuen root-Verzeichnis aus:
 

--- a/pages.de/common/cp.md
+++ b/pages.de/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Kopiere Dateien und Verzeichnisse.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/cp>.
 
 - Kopiere eine Datei an einen anderen Ort:
 

--- a/pages.de/common/cut.md
+++ b/pages.de/common/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > Schneide Felder von stdin oder einer Datei aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/cut-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/cut>.
 
 - Schneide die ersten 16 Zeichen jeder Zeile von stdin aus:
 

--- a/pages.de/common/dd.md
+++ b/pages.de/common/dd.md
@@ -1,7 +1,7 @@
 # dd
 
 > Konvertiere und kopiere eine Datei.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/dd-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/dd>.
 
 - Erstelle ein bootbares USB-Laufwerk von einer isohybriden Datei (wie `archlinux-xxxx.iso`) und zeige den Fortschritt an:
 

--- a/pages.de/common/echo.md
+++ b/pages.de/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > Gib angegebene Argumente aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/echo>.
 
 - Gib einen Text aus. (Hinweis: Anführungszeichen sind optional):
 

--- a/pages.de/common/ls.md
+++ b/pages.de/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Liste den Inhalt eines Verzeichnisses auf.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/ls>.
 
 - Liste den Inhalt in einer Datei pro Zeile auf:
 

--- a/pages.de/common/mv.md
+++ b/pages.de/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Verschiebe Dateien oder Verzeichnisse oder benenne diese um.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/mv>
 
 - Verschiebe eine Dateien an einen beliebigen Ort:
 

--- a/pages.de/common/whoami.md
+++ b/pages.de/common/whoami.md
@@ -1,7 +1,7 @@
 # whoami
 
 > Gib den Benutzernamen des aktuellen Benutzers aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/manual/html_node/whoami-invocation.html>.
+> Mehr Informationen: <https://www.gnu.org/software/coreutils/whoami>.
 
 - Gib den aktiven Benutzernamen aus:
 

--- a/pages.es/common/base64.md
+++ b/pages.es/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codifica o decodifica un archivo o la entrada estandar hacia/desde Base64, a la salida estandar.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/base64>.
 
 - Codifica un archivo:
 

--- a/pages.es/common/cat.md
+++ b/pages.es/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Imprime y concatena archivos.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/cat>.
 
 - Imprime el contenido de un archivo por la salida estándar:
 

--- a/pages.es/common/chmod.md
+++ b/pages.es/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Cambiar los permisos de acceso de un archivo o directorio.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Otorga al [u]suario que es propietario del archivo permiso para [x] ejecutarlo:
 

--- a/pages.es/common/chown.md
+++ b/pages.es/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Cambia la propiedad de usuario y grupo sobre archivos y directorios.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/chown>.
 
 - Cambia el usuario propietario de un archivo/directorio:
 

--- a/pages.es/common/cp.md
+++ b/pages.es/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Copia archivos y directorios.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/cp>.
 
 - Copia un archivo a otra ruta:
 

--- a/pages.es/common/ls.md
+++ b/pages.es/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Lista los contenidos de directorios.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/ls>.
 
 - Lista un archivo por línea:
 

--- a/pages.es/common/mkdir.md
+++ b/pages.es/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Crea un directorio.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - Crea un directorio en el directorio actual o en una ruta dada:
 

--- a/pages.es/common/mv.md
+++ b/pages.es/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Mueve o renombra archivos y directorios.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/mv>.
 
 - Mueve archivos en ubicaciones arbitrarias:
 

--- a/pages.es/common/rm.md
+++ b/pages.es/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Elimina archivos o directorios.
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/rm>.
 
 - Elimina archivos de ubicaciones arbitrarias:
 

--- a/pages.es/common/touch.md
+++ b/pages.es/common/touch.md
@@ -1,7 +1,7 @@
 # touch
 
 > Cambia el tiempo de accesso y modificación de un archivo (atime, mtime).
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/touch>.
 
 - Crea un archivo nuevo o cambia los tiempos de archivos existentes al tiempo actual:
 

--- a/pages.es/common/yes.md
+++ b/pages.es/common/yes.md
@@ -2,7 +2,7 @@
 
 > Retorna algo repetidamente.
 > Este comando es frecuentemente utilizado para aceptar todas las confirmaciones en comandos de instalación (como apt-get).
-> Más información: <https://www.gnu.org/software/coreutils/manual/html_node/yes-invocation.html>.
+> Más información: <https://www.gnu.org/software/coreutils/yes>.
 
 - Retornar repetidamente "mensaje":
 

--- a/pages.fa/common/cat.md
+++ b/pages.fa/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > چاپ و ترکیب کردن فایل ها.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/cat>.
 
 - چاپ محتویات فایل بر روی صفحه نمایش:
 

--- a/pages.fa/common/cp.md
+++ b/pages.fa/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > کپی فایل ها و دایرکتوری ها.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/cp>.
 
 - کپی فایل از مبدا به مقصد مشخص شده:
 

--- a/pages.fa/common/false.md
+++ b/pages.fa/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > برگرداندن 1 به عنوان کد خروجی.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/false>.
 
 - برگرداندن 1 به عنوان کد خروجی:
 

--- a/pages.fa/common/logname.md
+++ b/pages.fa/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > نمایش نام کاربر.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/logname>.
 
 - نمایش نام کاربر لاگین شده:
 

--- a/pages.fa/common/ls.md
+++ b/pages.fa/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > نمایش محتویات دایرکتوری.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/ls>.
 
 - نمایش فایل ها به صورت خطی:
 

--- a/pages.fa/common/nohup.md
+++ b/pages.fa/common/nohup.md
@@ -1,7 +1,7 @@
 # nohup
 
 > اجرای یک پردازش در پس زمینه حتی زمانی که ترمینال بسته شود.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/nohup-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/nohup>.
 
 - اجرای پردازش در پس زمینه فارغ از اجرا بودن ترمینال:
 

--- a/pages.fa/common/sleep.md
+++ b/pages.fa/common/sleep.md
@@ -1,7 +1,7 @@
 # sleep
 
 > ایجاد تاخیر بر اساس زمان.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/sleep>.
 
 - تاخیر به ثانیه:
 

--- a/pages.fa/common/tty.md
+++ b/pages.fa/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > نمایش نام ترمینال.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/tty>.
 
 - نمایش نام فایل ترمینال جاری:
 

--- a/pages.fa/common/uname.md
+++ b/pages.fa/common/uname.md
@@ -2,7 +2,7 @@
 
 > نمایش اطلاعاتی درباره سخت افزار و سیستم عامل.
 > نکته: برای دستیابی به اطلاعات اضافه در رابطه با سیستم عامل از دستور `lsb_release` استفاده کنید.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/uname>.
 
 - نمایش اطلاعات مربوط به سخت افزار و پردازنده سیستم:
 

--- a/pages.fa/common/users.md
+++ b/pages.fa/common/users.md
@@ -1,7 +1,7 @@
 # users
 
 > نمایش لیست کاربران لاگین شده.
->  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/manual/html_node/users-invocation.html>.
+>  اطلاعات بیشتر: <https://www.gnu.org/software/coreutils/users>.
 
 - نمایش لیست کاربران لاگین شده:
 

--- a/pages.fr/common/base32.md
+++ b/pages.fr/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > Encode ou décode un fichier ou l'entrée standard vers ou depuis la base 32, et retourne le résultat à la sortie standard.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/base32>.
 
 - Encode un fichier :
 

--- a/pages.fr/common/base64.md
+++ b/pages.fr/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Encoder ou décoder un fichier ou l'entrée standard en utilisant le codage Base64 à destination de la sortie standard.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/base64>.
 
 - Encoder un fichier :
 

--- a/pages.fr/common/basename.md
+++ b/pages.fr/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > Retourne la portion ne contenant pas de dossiers d'un chemin complet.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/basename>.
 
 - N'afficher que le nom du fichier depuis un chemin :
 

--- a/pages.fr/common/cat.md
+++ b/pages.fr/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Affiche et concatène le contenu d'un ou plusieurs fichiers.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/cat>.
 
 - Affiche le contenu d'un fichier sur la sortie standard :
 

--- a/pages.fr/common/chmod.md
+++ b/pages.fr/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Modifie les droits d'accès d'un fichier ou d'un répertoire.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/chmod>.
 
 - Donne les droits d'e[x]écution à l'[u]tilisateur auquel le fichier appartient :
 

--- a/pages.fr/common/chown.md
+++ b/pages.fr/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Modifie l'utilisateur et le groupe propriétaire des fichiers et dossiers.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/chown>.
 
 - Modifie le propriétaire d'un fichier/dossier :
 

--- a/pages.fr/common/cp.md
+++ b/pages.fr/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Copie des fichiers et des répertoires.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/cp>.
 
 - Copier un fichier vers un autre emplacement :
 

--- a/pages.fr/common/df.md
+++ b/pages.fr/common/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Montre un aperçu de l'utilisation de l'espace disque.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/df-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/df>.
 
 - Afficher tous les systèmes de fichiers et leur utilisation d'espace disque :
 

--- a/pages.fr/common/echo.md
+++ b/pages.fr/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > Affiche les paramètres donnés dans la console.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/echo>.
 
 - Affiche un message (les guillemets sont facultatifs) :
 

--- a/pages.fr/common/install.md
+++ b/pages.fr/common/install.md
@@ -2,7 +2,7 @@
 
 > Copie des fichiers et mets à jour leurs attributs.
 > Copie des fichiers (souvent des exécutables) dans un répertoire système comme `/usr/local/bin` et leur donne les permissions et propriétaires appropriés.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/install-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/install>.
 
 - Copie des fichiers vers une destination :
 

--- a/pages.fr/common/ln.md
+++ b/pages.fr/common/ln.md
@@ -1,7 +1,7 @@
 # ln
 
 > Crée des liens vers des fichiers et répertoires.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/ln-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/ln>.
 
 - Crée un lien symbolique vers un fichier ou un répertoire :
 

--- a/pages.fr/common/ls.md
+++ b/pages.fr/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Liste le contenu d'un répertoire.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/ls>.
 
 - Liste les fichiers, un par ligne :
 

--- a/pages.fr/common/mkdir.md
+++ b/pages.fr/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Crée un répertoire.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/mkdir>.
 
 - Crée un répertoire dans le répertoire actuel ou dans un chemin donné :
 

--- a/pages.fr/common/pwd.md
+++ b/pages.fr/common/pwd.md
@@ -1,7 +1,7 @@
 # pwd
 
 > Affiche le nom du répertoire actuel.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/pwd>.
 
 - Affiche le répertoire actuel :
 

--- a/pages.fr/common/wc.md
+++ b/pages.fr/common/wc.md
@@ -1,7 +1,7 @@
 # wc
 
 > Compte les lignes, les mots ou les octets.
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/wc-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/wc>.
 
 - Compte les lignes d'un fichier :
 

--- a/pages.fr/common/yes.md
+++ b/pages.fr/common/yes.md
@@ -2,7 +2,7 @@
 
 > Envoie un message à répétition en sortie console.
 > Cette commande est souvent utilisée pour éviter de devoir accepter des opérations successives (par exemple des installations via la commande `apt-get`).
-> Plus d'informations : <https://www.gnu.org/software/coreutils/manual/html_node/yes-invocation.html>.
+> Plus d'informations : <https://www.gnu.org/software/coreutils/yes>.
 
 - Envoyer « message » à répétition :
 

--- a/pages.hbs/common/head.md
+++ b/pages.hbs/common/head.md
@@ -1,7 +1,7 @@
 # head
 
 > Prikazuje prvi deo datoteka.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/head-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/head>.
 
 - Prikaži prvih nekoliko linija datoteke:
 

--- a/pages.hbs/common/sha1sum.md
+++ b/pages.hbs/common/sha1sum.md
@@ -1,7 +1,7 @@
 # sha1sum
 
 > Izračunava SHA1 kriptografske kontrolne brojeve.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/sha1sum-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/sha1sum>.
 
 - Izračunaj SHA1 kontrolni broj za datoteku:
 

--- a/pages.hbs/common/tail.md
+++ b/pages.hbs/common/tail.md
@@ -1,7 +1,7 @@
 # tail
 
 > Prikazuje krajnji deo datoteke.
-> Više informacija: <https://www.gnu.org/software/coreutils/manual/html_node/tail-invocation.html>.
+> Više informacija: <https://www.gnu.org/software/coreutils/tail>.
 
 - Prikaži poslednjih 'broj' linija u datoteci:
 

--- a/pages.hi/common/cat.md
+++ b/pages.hi/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > फ़ाइलों को प्रिंट और संक्षिप्त करें।
-> अधिक जानकारी: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> अधिक जानकारी: <https://www.gnu.org/software/coreutils/cat>.
 
 - मानक आउटपुट में फ़ाइल की सामग्री प्रिंट करें:
 

--- a/pages.hi/common/false.md
+++ b/pages.hi/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > 1 का एग्जिट कोड लौटाता है।
-> अधिक जानकारी: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> अधिक जानकारी: <https://www.gnu.org/software/coreutils/false>.
 
 - 1 का निकास कोड लौटाएँ:
 

--- a/pages.hi/common/ls.md
+++ b/pages.hi/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > निर्देशिका सामग्री को सूचीबद्ध करें।
-> अधिक जानकारी: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> अधिक जानकारी: <https://www.gnu.org/software/coreutils/ls>.
 
 - प्रति पंक्ति एक फ़ाइल की सूची बनाएं:
 

--- a/pages.hi/common/mkdir.md
+++ b/pages.hi/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > एक निर्देशिका बनाता है।
-> अधिक जानकारी: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> अधिक जानकारी: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - वर्तमान निर्देशिका या दिए गए पथ में एक निर्देशिका बनाएँ:
 

--- a/pages.hi/common/touch.md
+++ b/pages.hi/common/touch.md
@@ -1,7 +1,7 @@
 # touch
 
 > एक फ़ाइल का उपयोग और संशोधन समय (atime, mtime) बदलें।
-> अधिक जानकारी: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> अधिक जानकारी: <https://www.gnu.org/software/coreutils/touch>.
 
 - एक नई खाली फ़ाइल बनाएं (मौजूदा फ़ाइल के लिए समय बदल दें):
 

--- a/pages.id/common/cat.md
+++ b/pages.id/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Mencetak dan menggabungkan berkas.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/cat>.
 
 - Mencetak konten berkas ke keluaran standar:
 

--- a/pages.id/common/cp.md
+++ b/pages.id/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Membuat salinan file dan direktori.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/cp>.
 
 - Membuat salinan file ke lokasi lain:
 

--- a/pages.id/common/ls.md
+++ b/pages.id/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Menampilkan daftar konten pada direktori.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/ls>.
 
 - Menampilkan daftar berkas dengan satu item tiap baris:
 

--- a/pages.id/common/mkdir.md
+++ b/pages.id/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Membuat sebuah direktori.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - Membuat sebuah direktori di dalam direktori saat ini atau dalam jalan (path) yang diberikan:
 

--- a/pages.id/common/mv.md
+++ b/pages.id/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Memindah atau menamai-ulang file dan direktori.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/mv>.
 
 - Memindahkan file ke lokasi yang baru:
 

--- a/pages.id/common/pwd.md
+++ b/pages.id/common/pwd.md
@@ -1,7 +1,7 @@
 # pwd
 
 > Mencetak nama dari direktori saat ini/kerja.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/pwd>.
 
 - Mencetak direktori saat ini:
 

--- a/pages.id/common/rm.md
+++ b/pages.id/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Menghapus berkas atau direktori.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/rm>.
 
 - Menghapus berkas dari lokasi manapun:
 

--- a/pages.id/common/touch.md
+++ b/pages.id/common/touch.md
@@ -1,7 +1,7 @@
 # touch
 
 > Mengubah waktu akses (atime) dan waktu modifikasi (mtime) dari sebuah file.
-> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/touch>.
 
 - Membuat file baru yang kosong atau mengubah waktu file yang telahj ada ke waktu sekarang:
 

--- a/pages.it/common/arch.md
+++ b/pages.it/common/arch.md
@@ -2,7 +2,7 @@
 
 > Mostra il nome dell'architettura del sistema.
 > Vedi anche `uname`.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/arch>.
 
 - Mostra l'architettura del sistema:
 

--- a/pages.it/common/b2sum.md
+++ b/pages.it/common/b2sum.md
@@ -1,7 +1,7 @@
 # b2sum
 
 > Calcola checksum BLAKE2.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/b2sum-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/b2sum>.
 
 - Calcola il checksum BLAKE2 per un file:
 

--- a/pages.it/common/base32.md
+++ b/pages.it/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > Codifica o decodifica file o standard input in Base32 su standard output.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/base32>.
 
 - Codifica un file:
 

--- a/pages.it/common/base64.md
+++ b/pages.it/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codifica o decodifica file o standard input in Base64 su standard output.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/base64>.
 
 - Codifica un file:
 

--- a/pages.it/common/basename.md
+++ b/pages.it/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > Restituisce la parte finale un percorso.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/basename>.
 
 - Mostra solo il nome del file da un percorso:
 

--- a/pages.it/common/cat.md
+++ b/pages.it/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Stampa e concatena file.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/cat>.
 
 - Stampa i contenuti di un file su standard output:
 

--- a/pages.it/common/chcon.md
+++ b/pages.it/common/chcon.md
@@ -1,7 +1,7 @@
 # chcon
 
 > Cambia contesto di sicurezza SELinux di file o directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/chcon-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/chcon>.
 
 - Mostra il contesto di sicurezza di un file:
 

--- a/pages.it/common/chgrp.md
+++ b/pages.it/common/chgrp.md
@@ -1,7 +1,7 @@
 # chgrp
 
 > Cambia il gruppo proprietario di file e directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/chgrp-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/chgrp>.
 
 - Cambia il gruppo proprietario di un file/directory:
 

--- a/pages.it/common/chmod.md
+++ b/pages.it/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Cambia i permessi di accesso di file o directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Dai il permesso di eseguire (x) un file al suo proprietario (u):
 

--- a/pages.it/common/chown.md
+++ b/pages.it/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Cambia utente e gruppo proprietario di file e directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/chown>.
 
 - Cambia l'utente proprietario di un file/directory:
 

--- a/pages.it/common/chroot.md
+++ b/pages.it/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Esegui un comando o una shell interattiva con una speciale root directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Esegui un comando con una diversa root directory:
 

--- a/pages.it/common/cksum.md
+++ b/pages.it/common/cksum.md
@@ -2,7 +2,7 @@
 
 > Calcola checksum CRC e conta i byte di un file.
 > Nota: in vecchi sistemi UNIX l'implementazione di CRC potrebbe essere diversa.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/cksum-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/cksum>.
 
 - Calcola e mostra un checksum di 32 bit, dimensione in byte e nome del file:
 

--- a/pages.it/common/comm.md
+++ b/pages.it/common/comm.md
@@ -1,7 +1,7 @@
 # comm
 
 > Seleziona o ignora linee comuni a due file. Entrambi i file devono essere ordinati.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/comm-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/comm>.
 
 - Produci tre colonne separate da tab: linee solo nel primo file, linee solo nel secondo file, e linee comuni ad entrambi:
 

--- a/pages.it/common/cp.md
+++ b/pages.it/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Copia file e directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/cp>.
 
 - Copia un file in un'altra posizione:
 

--- a/pages.it/common/cut.md
+++ b/pages.it/common/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > Taglia dividendo in campi stdin o file.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/cut-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/cut>.
 
 - Estrai i primi 16 caratteri di ogni riga da stdin:
 

--- a/pages.it/common/date.md
+++ b/pages.it/common/date.md
@@ -1,7 +1,7 @@
 # date
 
 > Imposta o mostra data e ora di sistema.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/date-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/date>.
 
 - Mostra la data corrente utilizzando il formato predefinito della locale corrente:
 

--- a/pages.it/common/dd.md
+++ b/pages.it/common/dd.md
@@ -1,7 +1,7 @@
 # dd
 
 > Converti e copia un file.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/dd-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/dd>.
 
 - Crea un disco USB avviabile da un file ISO e mostra il progresso:
 

--- a/pages.it/common/df.md
+++ b/pages.it/common/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Fornisce una panoramica dello spazio utilizzato dai file system sui dischi.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/df-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/df>.
 
 - Mostra tutti i file system ed il loro utilizzo del disco:
 

--- a/pages.it/common/dircolors.md
+++ b/pages.it/common/dircolors.md
@@ -1,7 +1,7 @@
 # dircolors
 
 > Stampa comandi necessari per settare la variabile d'ambiente LS_COLOR per stilizzare `ls`, `dir`, etc.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/dircolors-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/dircolors>.
 
 - Stampa i comandi per settare LS_COLOR con i colori predefiniti:
 

--- a/pages.it/common/dirname.md
+++ b/pages.it/common/dirname.md
@@ -1,7 +1,7 @@
 # dirname
 
 > Determina la directory genitore di un determinato file o percorso.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/dirname-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/dirname>.
 
 - Calcola la directory genitore di un dato percorso:
 

--- a/pages.it/common/du.md
+++ b/pages.it/common/du.md
@@ -1,7 +1,7 @@
 # du
 
 > Utilizzo del disco: stima e riassumi lo spazio utilizzato da file e directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/du-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/du>.
 
 - Elenca le dimensioni di una directory ed ogni sotto-directory, nell'unità specificata (B/KB/MB):
 

--- a/pages.it/common/echo.md
+++ b/pages.it/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > Stampa a schermo gli argomenti forniti.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/echo>.
 
 - Stampa un messaggio di testo. Nota: le virgolette sono opzionali:
 

--- a/pages.it/common/env.md
+++ b/pages.it/common/env.md
@@ -1,7 +1,7 @@
 # env
 
 > Mostra le variabili d'ambiente o esegui un programma in un ambiente modificato.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/env>.
 
 - Mostra le variabili d'ambiente:
 

--- a/pages.it/common/expand.md
+++ b/pages.it/common/expand.md
@@ -1,7 +1,7 @@
 # expand
 
 > Converti caratteri tab in spazi.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/expand-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/expand>.
 
 - Converti tab in un file in spazi, scrivendo su standard output:
 

--- a/pages.it/common/fmt.md
+++ b/pages.it/common/fmt.md
@@ -1,7 +1,7 @@
 # fmt
 
 > Riformatta i paragrafi di un file di testo unendoli e limitando la larghezza delle righe a un dato numero di caratteri (di default 75).
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/fmt-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/fmt>.
 
 - Riformatta un file:
 

--- a/pages.it/common/head.md
+++ b/pages.it/common/head.md
@@ -1,7 +1,7 @@
 # head
 
 > Stampa a schermo le prime linee di un file.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/head-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/head>.
 
 - Stampa a schermo le prime linee di un file:
 

--- a/pages.it/common/ln.md
+++ b/pages.it/common/ln.md
@@ -1,7 +1,7 @@
 # ln
 
 > Crea un collegamento a un file o a una directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/ln-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/ln>.
 
 - Crea un collegamento simbolico a un file (o directory):
 

--- a/pages.it/common/ls.md
+++ b/pages.it/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Elenca i contenuti di una directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/ls>.
 
 - Elenca i file nella directory corrente, uno per riga:
 

--- a/pages.it/common/mkdir.md
+++ b/pages.it/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Crea directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - Crea una directory nella directory corrente o in un dato percorso:
 

--- a/pages.it/common/mv.md
+++ b/pages.it/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Sposta o rinomina file e directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/mv>.
 
 - Sposta file:
 

--- a/pages.it/common/rm.md
+++ b/pages.it/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Rimuovi file o directory.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/rm>.
 
 - Rimuovi file:
 

--- a/pages.it/common/tac.md
+++ b/pages.it/common/tac.md
@@ -1,7 +1,7 @@
 # tac
 
 > Stampa e concatena file al contrario.
-> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/tac-invocation.html>.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/tac>.
 
 - Stampa il contenuto di *file1* al contrario su standard output:
 

--- a/pages.ja/common/arch.md
+++ b/pages.ja/common/arch.md
@@ -2,7 +2,7 @@
 
 > システムアーキテクチャ名前を示する.
 > 'uname' も参照してください.
-> 詳しくはこちら: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> 詳しくはこちら: <https://www.gnu.org/software/coreutils/arch>.
 
 - システムアーキテクチャを示する:
 

--- a/pages.ja/common/du.md
+++ b/pages.ja/common/du.md
@@ -1,7 +1,7 @@
 # du
 
 > ディスク使用状況: ファイルとディレクトリの使用量の概算を表示します。
-> 詳しくはこちら: <https://www.gnu.org/software/coreutils/manual/html_node/du-invocation.html>.
+> 詳しくはこちら: <https://www.gnu.org/software/coreutils/du>.
 
 - 指定した単位(B/KB/MB)でディレクトリおよびサブディレクトリのサイズを表示します。
 

--- a/pages.ko/common/arch.md
+++ b/pages.ko/common/arch.md
@@ -2,7 +2,7 @@
 
 > 시스템 구조의 이름을 보여줍니다.
 > `uname` 도 같이 보세요.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/arch>.
 
 - 시스템 구조 보여주기:
 

--- a/pages.ko/common/b2sum.md
+++ b/pages.ko/common/b2sum.md
@@ -1,7 +1,7 @@
 # b2sum
 
 > BLACK2 암호화 체크섬을 계산하십시오.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/b2sum-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/b2sum>.
 
 - 파일의 BLACKE2 체크섬 계산:
 

--- a/pages.ko/common/base32.md
+++ b/pages.ko/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > 파일 또는 표준 입력을 Base32와 표준 출력으로 인코딩하거나 디코딩함.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/base32>.
 
 - 파일 인코딩:
 

--- a/pages.ko/common/base64.md
+++ b/pages.ko/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > 파일 또는 표준 입력을 Base64와 표준 출력으로 인코딩하거나 디코딩함.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/base64>.
 
 - 파일 인코딩:
 

--- a/pages.ko/common/basename.md
+++ b/pages.ko/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > 경로명의 디렉토리가 아닌 부분을 반환.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/basename>.
 
 - 경로에서 파일 이름만 표시:
 

--- a/pages.ko/common/cat.md
+++ b/pages.ko/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > 파일 출력 및 연결.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/cat>.
 
 - 표준출력으로 파일 내용 출력:
 

--- a/pages.ko/common/chcon.md
+++ b/pages.ko/common/chcon.md
@@ -1,7 +1,7 @@
 # chcon
 
 > 파일 또는 파일/디렉토리의 SELinux 보안 내용 변경.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/chcon-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/chcon>.
 
 - 파일의 보안 내용 보기:
 

--- a/pages.ko/common/chgrp.md
+++ b/pages.ko/common/chgrp.md
@@ -1,7 +1,7 @@
 # chgrp
 
 > 파일 및 디렉토리의 그룹 소유권 변경.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/chgrp-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/chgrp>.
 
 - 파일/디렉토리의 소유 그룹 변경:
 

--- a/pages.ko/common/chmod.md
+++ b/pages.ko/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > 파일이나 디렉토리의 연결 권한 변경.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/chmod>.
 
 - 파일을 소유한 사용자[u]에게 실행[x] 권한 부여:
 

--- a/pages.ko/common/chown.md
+++ b/pages.ko/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > 파일과 디렉토리의 사용자 및 그룹 소유권을 변경.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/chown>.
 
 - 파일/디렉토리의 소유 사용자 변경:
 

--- a/pages.ko/common/chroot.md
+++ b/pages.ko/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > 특수 루트 디렉토리를 사용하여 명령 또는 대화형 쉘 실행.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/chroot>.
 
 - 새로운 루트 디렉토리로 명령어 실행:
 

--- a/pages.ko/common/cksum.md
+++ b/pages.ko/common/cksum.md
@@ -2,7 +2,7 @@
 
 > 파일의 바이트 개수나 CRC 무결성 검사를 계산합니다.
 > 알립니다, 오래된 UNIX 시스템은 CRC 검사가 다를 수 있습니다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/cksum-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/cksum>.
 
 - 바이트 단위의 사이즈와 파일이름의 32비트 무결성 검사를 보여줍니다:
 

--- a/pages.ko/common/comm.md
+++ b/pages.ko/common/comm.md
@@ -2,7 +2,7 @@
 
 > 두 파일의 공통되는 줄을 선택하거나 거절합니다.
 > 두 파일 모두 정렬되어 있어야합니다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/comm-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/comm>.
 
 - 세 개의 탭으로 구분된 열을 생성합니다: 첫 번째 파일에는 줄만, 두 번째 파일에서는 줄들과 공통 줄:
 

--- a/pages.ko/common/cp.md
+++ b/pages.ko/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > 파일 및 디렉토리 복사.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/cp>.
 
 - 파일을 다른 위치로 복사:
 

--- a/pages.ko/common/cut.md
+++ b/pages.ko/common/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > stdin 혹은 파일에서 출력 필드를 자른다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/cut-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/cut>.
 
 - stdin의 각 라인에 첫번째 16개의 문자를 자르기:
 

--- a/pages.ko/common/date.md
+++ b/pages.ko/common/date.md
@@ -1,7 +1,7 @@
 # date
 
 > 시스템 날짜 설정 및 표시.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/date-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/date>.
 
 - 기본 로컬 형식을 사용하여 현재 날짜 표시:
 

--- a/pages.ko/common/df.md
+++ b/pages.ko/common/df.md
@@ -1,7 +1,7 @@
 # df
 
 > 파일 시스템 디스크 공간 사용량에 대한 개요를 제공합니다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/df-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/df>.
 
 - 모든 파일 시스템들과 그들의 디스크 사용량 출력:
 

--- a/pages.ko/common/dircolors.md
+++ b/pages.ko/common/dircolors.md
@@ -1,7 +1,7 @@
 # dircolors
 
 > LS_COLOR 환경변수와 스타일 `ls`, `dir`, 등을 설정하기 위한 명령어들을 출력한다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/dircolors-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/dircolors>.
 
 - 기본 색상을 사용하여 LS_COLOR를 설정하는 명령어들 출력하기:
 

--- a/pages.ko/common/dirname.md
+++ b/pages.ko/common/dirname.md
@@ -1,7 +1,7 @@
 # dirname
 
 > 주어진 파일 혹은 디렉토리 경로의 부모 디렉토리를 계산한다.
-> 더 많은 정보: <https://www.gnu.org/software/coreutils/manual/html_node/dirname-invocation.html>.
+> 더 많은 정보: <https://www.gnu.org/software/coreutils/dirname>.
 
 - 주어진 경로의 부모 디렉토리 계산:
 

--- a/pages.nl/common/arch.md
+++ b/pages.nl/common/arch.md
@@ -2,7 +2,7 @@
 
 > Geef de naam van de systeemarchitectuur weer.
 > Zie ook `uname`.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/arch>.
 
 - Geef de architectuur van het systeem weer:
 

--- a/pages.nl/common/base64.md
+++ b/pages.nl/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codeer of decodeer bestand of standaardinvoer van/naar Base64 naar standaarduitvoer.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/base64>.
 
 - Codeer een bestand:
 

--- a/pages.nl/common/chgrp.md
+++ b/pages.nl/common/chgrp.md
@@ -1,7 +1,7 @@
 # chgrp
 
 > Verander beheerdersgroep van bestanden en mappen.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/chgrp-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/chgrp>.
 
 - Verander beheerdergroep van een bestand of map:
 

--- a/pages.nl/common/chmod.md
+++ b/pages.nl/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Verander de toegangstoestemmingen van een bestand of map.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Geef een gebruiker ([u]ser) die het bestand beheert het recht om deze uit te voeren (e[x]ecute):
 

--- a/pages.nl/common/chown.md
+++ b/pages.nl/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Verander gebruiker- en groepsbeheer van bestanden en mappen.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/chown>.
 
 - Verander gebruikkersbeheerder van een bestand/map:
 

--- a/pages.nl/common/chroot.md
+++ b/pages.nl/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Voer commando of interactieve shell uit met een speciale hoofdmap.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Voer commando uit met gegeven hoofdmap:
 

--- a/pages.nl/common/false.md
+++ b/pages.nl/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > Geeft een afsluitcode van 1 terug.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/false>.
 
 - Geeft een afsluitcode van 1 terug:
 

--- a/pages.nl/common/logname.md
+++ b/pages.nl/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > Toont de inlognaam van de gebruiker.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/logname>.
 
 - Geef de momenteel aangemelde gebruikersnaam weer:
 

--- a/pages.nl/common/tty.md
+++ b/pages.nl/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > Geeft de naam van de terminal terug.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/tty>.
 
 - Druk de bestandsnaam van deze terminal af:
 

--- a/pages.nl/common/yes.md
+++ b/pages.nl/common/yes.md
@@ -1,7 +1,7 @@
 # yes
 
 > Voer herhaaldelijk iets uit.
-> Meer informatie: <https://www.gnu.org/software/coreutils/manual/html_node/yes-invocation.html>.
+> Meer informatie: <https://www.gnu.org/software/coreutils/yes>.
 
 - Voer herhaaldelijk "bericht" uit:
 

--- a/pages.no/common/arch.md
+++ b/pages.no/common/arch.md
@@ -2,7 +2,7 @@
 
 > Vis navnet på systemarkitekturen.
 > Se også `uname`.
-> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/arch>.
 
 - Vis systemets arkitektur:
 

--- a/pages.no/common/false.md
+++ b/pages.no/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > Returner en utgangskode på 1.
-> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/false>.
 
 - Returner en utgangskode på 1:
 

--- a/pages.no/common/logname.md
+++ b/pages.no/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > Viser brukerens login navn.
-> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/logname>.
 
 - Vis brukerens nåværende innloggings navn:
 

--- a/pages.no/common/tty.md
+++ b/pages.no/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > Returner terminal navn.
-> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/tty>.
 
 - Print fil navnet fra denne terminalen:
 

--- a/pages.pl/common/base32.md
+++ b/pages.pl/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > Enkoduj lub dekoduj plik lub standardowe wejście do/z Base32, na standardowe wyjście.
-> Więcej informacji: <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> Więcej informacji: <https://www.gnu.org/software/coreutils/base32>.
 
 - Enkoduj plik:
 

--- a/pages.pl/common/base64.md
+++ b/pages.pl/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Enkoduj lub dekoduj plik lub standardowe wejście do/z Base64, na standardowe wyjście.
-> Więcej informacji: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Więcej informacji: <https://www.gnu.org/software/coreutils/base64>.
 
 - Enkoduj plik:
 

--- a/pages.pl/common/pathchk.md
+++ b/pages.pl/common/pathchk.md
@@ -1,7 +1,7 @@
 # pathchk
 
 > Sprawdź poprawność oraz przenośność jednej lub większej ilości ścieżek.
-> Więcej informacji: <https://www.gnu.org/software/coreutils/manual/html_node/pathchk-invocation.html>.
+> Więcej informacji: <https://www.gnu.org/software/coreutils/pathchk>.
 
 - Sprawdź ścieżki pod kątem poprawności w obecnym systemie:
 

--- a/pages.pl/common/rm.md
+++ b/pages.pl/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Usuwa pliki lub foldery.
-> Więcej informacji: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> Więcej informacji: <https://www.gnu.org/software/coreutils/rm>.
 
 - Usuń pliki z dowolnej lokalizacji:
 

--- a/pages.pt_BR/common/arch.md
+++ b/pages.pt_BR/common/arch.md
@@ -2,7 +2,7 @@
 
 > Exibir o nome da arquitetura do sistema.
 > Veja também `uname`.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/arch>.
 
 - Exibir a arquitetura do sistema:
 

--- a/pages.pt_BR/common/cat.md
+++ b/pages.pt_BR/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Exibe e concatena o conteúdo de arquivos.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/cat>.
 
 - Exibir o conteúdo de um arquivo no terminal:
 

--- a/pages.pt_BR/common/ls.md
+++ b/pages.pt_BR/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Listar o conteúdo de um diretório.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/ls>.
 
 - Listar todos os arquivos, apresentando um arquivo por linha:
 

--- a/pages.pt_BR/common/touch.md
+++ b/pages.pt_BR/common/touch.md
@@ -2,7 +2,7 @@
 
 > Atualizar as timestamps de um arquivo para a hora atual.
 > Se o arquivo não existir, cria um arquivo vazio, a menos que seja passado o parâmetro -c ou -h.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/touch>.
 
 - Criar um novo arquivo vazio, ou atualizar as timestamps para a hora atual:
 

--- a/pages.pt_BR/common/uname.md
+++ b/pages.pt_BR/common/uname.md
@@ -2,7 +2,7 @@
 
 > Apresenta detalhes sobre o hardware e sistema operacional do computador.
 > Nota: Para maiores detalhes sobre o sistema operacional, utilize o comando `lsb_release`.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/uname>.
 
 - Exibir informações relacionadas ao hardware: arquitetura e tipo de processador:
 

--- a/pages.pt_BR/common/yes.md
+++ b/pages.pt_BR/common/yes.md
@@ -1,7 +1,7 @@
 # yes
 
 > Exibe algo na tela repetidamente.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/yes-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/yes>.
 
 - Exibir na tela a palavra "mensagem" repetidamente:
 

--- a/pages.pt_BR/linux/csplit.md
+++ b/pages.pt_BR/linux/csplit.md
@@ -2,7 +2,7 @@
 
 > Divide um arquivo em várias partes.
 > O padrão de nomenclatura dos arquivos será "xx00", "xx01" e assim por diante.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/csplit-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/csplit>.
 
 - Dividir um arquivo nas linhas 5 e 23:
 

--- a/pages.pt_PT/common/chmod.md
+++ b/pages.pt_PT/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Alterar as permissões de acesso a um ficheiro ou diretório.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Dar a um [u]tilizador que possui um ficheiro o direito a e[x]ecutá-lo:
 

--- a/pages.pt_PT/common/touch.md
+++ b/pages.pt_PT/common/touch.md
@@ -2,7 +2,7 @@
 
 > Atualizar as timestamps de um ficheiro para a hora atual.
 > Se o ficheiro não existir, cria um ficheiro vazio, a menos que seja passado o parâmetro -c ou -h.
-> Mais informações: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> Mais informações: <https://www.gnu.org/software/coreutils/touch>.
 
 - Criar um novo ficheiro vazio, ou atualizar as timestamps para a hora atual:
 

--- a/pages.ru/common/cat.md
+++ b/pages.ru/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Выводит и объединяет файлы.
-> Больше информации: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> Больше информации: <https://www.gnu.org/software/coreutils/cat>.
 
 - Выводит содержимое файла:
 

--- a/pages.ru/common/chmod.md
+++ b/pages.ru/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Изменить права доступа файлу или папке.
-> Больше информации: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> Больше информации: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Дать [u]пользователю, который владеет файлом, права на его [x]исполнение:
 

--- a/pages.ru/common/ls.md
+++ b/pages.ru/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Выводит содержимого каталога.
-> Больше информации: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> Больше информации: <https://www.gnu.org/software/coreutils/ls>.
 
 - Список файлов по одному в строке:
 

--- a/pages.sv/common/arch.md
+++ b/pages.sv/common/arch.md
@@ -2,7 +2,7 @@
 
 > Visa namnet på systemarkitekturen:
 > Se även `uname`.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/arch>.
 
 - Visa systemarkitekturen:
 

--- a/pages.sv/common/false.md
+++ b/pages.sv/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > Returnerar en utgångskod på 1.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/false>.
 
 - Returnera en utgångskod på 1:
 

--- a/pages.sv/common/hostid.md
+++ b/pages.sv/common/hostid.md
@@ -1,7 +1,7 @@
 # hostid
 
 > Skriver ut den numeriska identifieraren för den aktuella värden (inte nödvändigtvis IP-adressen).
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/hostid-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/hostid>.
 
 - Visa den numeriska identifieraren för den aktuella värden i hexadecimal:
 

--- a/pages.sv/common/logname.md
+++ b/pages.sv/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > Visar användarens inloggningsnamn.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/logname>.
 
 - Visa den för tillfället inloggades användarnamn:
 

--- a/pages.sv/common/nohup.md
+++ b/pages.sv/common/nohup.md
@@ -1,7 +1,7 @@
 # nohup
 
 > Tillåter en process att leva när terminalen dödas.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/nohup-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/nohup>.
 
 - Kör process som kan leva bortom terminalen:
 

--- a/pages.sv/common/sleep.md
+++ b/pages.sv/common/sleep.md
@@ -1,7 +1,7 @@
 # sleep
 
 > Fördröjning under bestämd tid.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/sleep>.
 
 - Fördröj i sekunder:
 

--- a/pages.sv/common/true.md
+++ b/pages.sv/common/true.md
@@ -2,7 +2,7 @@
 
 > Returnerar en lyckad utgångsstatuskod på 0.
 > Använd detta med || operatör för att göra att ett kommando alltid stänger med 0.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/true-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/true>.
 
 - Returnera en lyckad utgångskod:
 

--- a/pages.sv/common/tty.md
+++ b/pages.sv/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > Returnerar terminalnamn.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/tty>.
 
 - Skriv ut filnamnet på denna terminal:
 

--- a/pages.sv/common/users.md
+++ b/pages.sv/common/users.md
@@ -1,7 +1,7 @@
 # users
 
 > Visa en lista över inloggade användare.
-> Mer information: <https://www.gnu.org/software/coreutils/manual/html_node/users-invocation.html>.
+> Mer information: <https://www.gnu.org/software/coreutils/users>.
 
 - Visa en lista över inloggade användare:
 

--- a/pages.ta/common/cp.md
+++ b/pages.ta/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > கோப்புகளையோ அடைவுகளையோ நகலெடு.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/cp>.
 
 - கோப்பை நகலெடு:
 

--- a/pages.ta/common/ls.md
+++ b/pages.ta/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > அடைவு உள்ளடக்கத்தைப் பட்டியலிடு.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/ls>.
 
 - கோப்புகளை வரிக்கொன்றாகப் பட்டியலிடு:
 

--- a/pages.ta/common/mkdir.md
+++ b/pages.ta/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > அடைவை உருவாக்கு.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - அடைவொன்றைத் தற்போதைய அடைவிலோக் குறிப்பிட்ட பாதையிலோ உருவாக்கு:
 

--- a/pages.ta/common/mv.md
+++ b/pages.ta/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > கோப்புகளையோ அடைவுகளையோ நகர்த்து அல்லது மறுபெயரிடு.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/mv>.
 
 - கோப்பை ஓரிடத்திலிருந்து இன்னோரிடத்திற்கு நகர்த்து:
 

--- a/pages.ta/common/rm.md
+++ b/pages.ta/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > கோப்புகளையோ அடைவுகளையோ அழி.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/rm>.
 
 - கோப்புகளை அழி:
 

--- a/pages.ta/common/rmdir.md
+++ b/pages.ta/common/rmdir.md
@@ -1,7 +1,7 @@
 # rmdir
 
 > அடைவை அழி.
-> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/manual/html_node/rmdir-invocation.html>.
+> மேலும் தகவல்: <https://www.gnu.org/software/coreutils/rmdir>.
 
 - அடைவு வெறுமையாகயிருந்தால் அதனை அழி. உள்ளடக்கமுடைய அடைவை நீக்க `rm` யைப் பயன்படுத்தவும்:
 

--- a/pages.tr/common/base32.md
+++ b/pages.tr/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > Bir dosya veya standart veriyi Base32 formatında şifrele veya yalın veri çıktısı olarak deşifre et.
-> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/base32>.
 
 - Bir dosyayı şifrele:
 

--- a/pages.tr/common/base64.md
+++ b/pages.tr/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Bir dosya veya standart veriyi Base64 formatında şifrele veya yalın veri çıktısı olarak deşifre et.
-> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/base64>.
 
 - Bir dosyayı şifrele:
 

--- a/pages.tr/common/chroot.md
+++ b/pages.tr/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Komut veya etkileşimli komut satırını özel kök diziniyle çalıştırır.
-> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Komutu yeni kök dizini olarak çalıştır:
 

--- a/pages.tr/common/dirname.md
+++ b/pages.tr/common/dirname.md
@@ -1,7 +1,7 @@
 # dirname
 
 > Belirtilen dosya veya yolun ana dizinini hesaplar.
-> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/manual/html_node/dirname-invocation.html>.
+> Daha fazla bilgi için: <https://www.gnu.org/software/coreutils/dirname>.
 
 - Belirtilen yolun ana dizinini hesapla:
 

--- a/pages.zh/common/arch.md
+++ b/pages.zh/common/arch.md
@@ -2,7 +2,7 @@
 
 > 展示系统架构的名称.
 > 另见`uname`.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/arch>.
 
 - 展示系统架构.
 

--- a/pages.zh/common/base32.md
+++ b/pages.zh/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > 将文件或标准输入编码到Base32或从Base32解码为标准输出。
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/base32>.
 
 - 编码一个文件:
 

--- a/pages.zh/common/base64.md
+++ b/pages.zh/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > 将文件或标准输入编码到Base64或从Base64解码为标准输出。
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/base64>.
 
 - 编码一个文件:
 

--- a/pages.zh/common/basename.md
+++ b/pages.zh/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > 移除一个路径的目录部分字符.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/basename>.
 
 - 仅显示文件名:
 

--- a/pages.zh/common/cat.md
+++ b/pages.zh/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > 打印和拼接文件的工具.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/cat>.
 
 - 以标准输出，打印文件内容:
 

--- a/pages.zh/common/echo.md
+++ b/pages.zh/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > 输出给定参数.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/echo>.
 
 - 输出文本信息. 注意: 引号是可选的:
 

--- a/pages.zh/common/md5sum.md
+++ b/pages.zh/common/md5sum.md
@@ -1,7 +1,7 @@
 # md5sum
 
 > 计算 MD5 加密校验和.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/md5sum-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/md5sum>.
 
 - 计算文件的 MD5 校验和:
 

--- a/pages.zh/common/stty.md
+++ b/pages.zh/common/stty.md
@@ -1,7 +1,7 @@
 # stty
 
 > 设置终端设备接口的选项.
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/stty-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/stty>.
 
 - 显示当前终端的所有设置:
 

--- a/pages.zh/common/uname.md
+++ b/pages.zh/common/uname.md
@@ -2,7 +2,7 @@
 
 > 输出关于当前机器和运行在该机器上的操作系统的详细信息。
 > 注意：如需了解操作系统的其他信息，请尝试使用 `lsb_release` 命令。
-> 更多信息： <https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html>.
+> 更多信息： <https://www.gnu.org/software/coreutils/uname>.
 
 - 打印硬件相关信息：机器和处理器：
 

--- a/pages.zh_TW/common/cat.md
+++ b/pages.zh_TW/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > 連接檔案並印出檔案的內容。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/cat>.
 
 - 將檔案的內容印在標準輸出：
 

--- a/pages.zh_TW/common/echo.md
+++ b/pages.zh_TW/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > 印出文字。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/echo>.
 
 - 印出一行文字（如果文字中沒有連續的空格，可以不加引號）：
 

--- a/pages.zh_TW/common/ls.md
+++ b/pages.zh_TW/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > 列出目錄內容。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/ls>.
 
 - 列出目錄中的檔案，其中每個檔案佔一行：
 

--- a/pages.zh_TW/common/mkdir.md
+++ b/pages.zh_TW/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > 建立目錄。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/mkdir>.
 
 - 在目前所在目錄或指定路徑中建立新目錄：
 

--- a/pages.zh_TW/common/pwd.md
+++ b/pages.zh_TW/common/pwd.md
@@ -1,7 +1,7 @@
 # pwd
 
 > 印出目前目錄的名稱。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/pwd>.
 
 - 印出目前所在的目錄名稱：
 

--- a/pages.zh_TW/common/rm.md
+++ b/pages.zh_TW/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > 移除檔案或目錄。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/rm>.
 
 - 移除位於指定路徑的檔案：
 

--- a/pages.zh_TW/common/rmdir.md
+++ b/pages.zh_TW/common/rmdir.md
@@ -1,7 +1,7 @@
 # rmdir
 
 > 移除目錄。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/rmdir-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/rmdir>.
 
 - 若為空目錄則移除目錄（如果目錄非空，可用 `rm -r` 移除目錄及其所包含的檔案）：
 

--- a/pages.zh_TW/common/touch.md
+++ b/pages.zh_TW/common/touch.md
@@ -1,7 +1,7 @@
 # touch
 
 > 改變檔案的存取與修改時間。
-> 更多資訊： <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> 更多資訊： <https://www.gnu.org/software/coreutils/touch>.
 
 - 建立新檔案，或更新現存檔案的存取與修改時間：
 

--- a/pages/common/[.md
+++ b/pages/common/[.md
@@ -2,7 +2,7 @@
 
 > Evaluate condition.
 > Returns 0 if the condition evaluates to true, 1 if it evaluates to false.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/test-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/test>.
 
 - Test if a given variable is equal to a given string:
 

--- a/pages/common/arch.md
+++ b/pages/common/arch.md
@@ -2,7 +2,7 @@
 
 > Display the name of the system architecture.
 > See also `uname`.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/arch>.
 
 - Display the system's architecture:
 

--- a/pages/common/b2sum.md
+++ b/pages/common/b2sum.md
@@ -1,7 +1,7 @@
 # b2sum
 
 > Calculate BLAKE2 cryptographic checksums.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/b2sum-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/b2sum>.
 
 - Calculate the BLAKE2 checksum for a file:
 

--- a/pages/common/base32.md
+++ b/pages/common/base32.md
@@ -1,7 +1,7 @@
 # base32
 
 > Encode or decode file or standard input to/from Base32, to standard output.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/base32-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/base32>.
 
 - Encode a file:
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Encode or decode file or standard input to/from Base64, to standard output.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/base64>.
 
 - Encode a file:
 

--- a/pages/common/basename.md
+++ b/pages/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > Remove leading directory portions from a path.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/basename-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/basename>.
 
 - Show only the file name from a path:
 

--- a/pages/common/cat.md
+++ b/pages/common/cat.md
@@ -1,7 +1,7 @@
 # cat
 
 > Print and concatenate files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/cat>.
 
 - Print the contents of a file to the standard output:
 

--- a/pages/common/chcon.md
+++ b/pages/common/chcon.md
@@ -1,7 +1,7 @@
 # chcon
 
 > Change SELinux security context of a file or files/directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/chcon-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/chcon>.
 
 - View security context of a file:
 

--- a/pages/common/chgrp.md
+++ b/pages/common/chgrp.md
@@ -1,7 +1,7 @@
 # chgrp
 
 > Change group ownership of files and directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/chgrp-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/chgrp>.
 
 - Change the owner group of a file/directory:
 

--- a/pages/common/chmod.md
+++ b/pages/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Change the access permissions of a file or directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Give the [u]ser who owns a file the right to e[x]ecute it:
 

--- a/pages/common/chown.md
+++ b/pages/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Change user and group ownership of files and directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/chown>.
 
 - Change the owner user of a file/directory:
 

--- a/pages/common/chroot.md
+++ b/pages/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Run command or interactive shell with special root directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/chroot-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Run command as new root directory:
 

--- a/pages/common/cksum.md
+++ b/pages/common/cksum.md
@@ -2,7 +2,7 @@
 
 > Calculates CRC checksums and byte counts of a file.
 > Note, on old UNIX systems the CRC implementation may differ.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/cksum-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/cksum>.
 
 - Display a 32 bit checksum, size in bytes and filename:
 

--- a/pages/common/comm.md
+++ b/pages/common/comm.md
@@ -1,7 +1,7 @@
 # comm
 
 > Select or reject lines common to two files. Both files must be sorted.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/comm-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/comm>.
 
 - Produce three tab-separated columns: lines only in first file, lines only in second file and common lines:
 

--- a/pages/common/cp.md
+++ b/pages/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Copy files and directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/cp>.
 
 - Copy a file to another location:
 

--- a/pages/common/cut.md
+++ b/pages/common/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > Cut out fields from stdin or files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/cut-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/cut>.
 
 - Cut out the first sixteen characters of each line of stdin:
 

--- a/pages/common/date.md
+++ b/pages/common/date.md
@@ -1,7 +1,7 @@
 # date
 
 > Set or display the system date.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/date-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/date>.
 
 - Display the current date using the default locale's format:
 

--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -1,7 +1,7 @@
 # dd
 
 > Convert and copy a file.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/dd-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/dd>.
 
 - Make a bootable usb drive from an isohybrid file (such like `archlinux-xxx.iso`) and show the progress:
 

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Gives an overview of the filesystem disk space usage.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/df-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/df>.
 
 - Display all filesystems and their disk usage:
 

--- a/pages/common/dircolors.md
+++ b/pages/common/dircolors.md
@@ -1,7 +1,7 @@
 # dircolors
 
 > Output commands to set the LS_COLOR environment variable and style `ls`, `dir`, etc.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/dircolors-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/dircolors>.
 
 - Output commands to set LS_COLOR using default colors:
 

--- a/pages/common/dirname.md
+++ b/pages/common/dirname.md
@@ -1,7 +1,7 @@
 # dirname
 
 > Calculates the parent directory of a given file or directory path.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/dirname-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/dirname>.
 
 - Calculate the parent directory of a given path:
 

--- a/pages/common/du.md
+++ b/pages/common/du.md
@@ -1,7 +1,7 @@
 # du
 
 > Disk usage: estimate and summarize file and directory space usage.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/du-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/du>.
 
 - List the sizes of a directory and any subdirectories, in the given unit (B/KB/MB):
 

--- a/pages/common/echo.md
+++ b/pages/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > Print given arguments.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/echo>.
 
 - Print a text message. Note: quotes are optional:
 

--- a/pages/common/env.md
+++ b/pages/common/env.md
@@ -1,7 +1,7 @@
 # env
 
 > Show the environment or run a program in a modified environment.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/env>.
 
 - Show the environment:
 

--- a/pages/common/expand.md
+++ b/pages/common/expand.md
@@ -1,7 +1,7 @@
 # expand
 
 > Convert tabs to spaces.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/expand-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/expand>.
 
 - Convert tabs in each file to spaces, writing to standard output:
 

--- a/pages/common/expr.md
+++ b/pages/common/expr.md
@@ -1,7 +1,7 @@
 # expr
 
 > Evaluate expressions and manipulate strings.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/expr-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/expr>.
 
 - Get string length:
 

--- a/pages/common/factor.md
+++ b/pages/common/factor.md
@@ -1,7 +1,7 @@
 # factor
 
 > Prints the prime factorization of a number.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/factor-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/factor>.
 
 - Display the prime-factorization of a number:
 

--- a/pages/common/false.md
+++ b/pages/common/false.md
@@ -1,7 +1,7 @@
 # false
 
 > Returns an exit code of 1.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/false-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/false>.
 
 - Return an exit code of 1:
 

--- a/pages/common/fmt.md
+++ b/pages/common/fmt.md
@@ -1,7 +1,7 @@
 # fmt
 
 > Reformat a text file by joining its paragraphs and limiting the line width to given number of characters (75 by default).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/fmt-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/fmt>.
 
 - Reformat a file:
 

--- a/pages/common/fold.md
+++ b/pages/common/fold.md
@@ -1,7 +1,7 @@
 # fold
 
 > Wraps each line in an input file to fit a specified width and prints it to the standard output.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/fold-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/fold>.
 
 - Wrap each line to default width (80 characters):
 

--- a/pages/common/groups.md
+++ b/pages/common/groups.md
@@ -1,7 +1,7 @@
 # groups
 
 > Print group memberships for a user.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/groups-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/groups>.
 
 - Print group memberships for the current user:
 

--- a/pages/common/head.md
+++ b/pages/common/head.md
@@ -1,7 +1,7 @@
 # head
 
 > Output the first part of files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/head-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/head>.
 
 - Output the first few lines of a file:
 

--- a/pages/common/hostid.md
+++ b/pages/common/hostid.md
@@ -1,7 +1,7 @@
 # hostid
 
 > Prints the numeric identifier for the current host (not necessarily the IP address).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/hostid-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/hostid>.
 
 - Display the numeric identifier for the current host in hexadecimal:
 

--- a/pages/common/id.md
+++ b/pages/common/id.md
@@ -1,7 +1,7 @@
 # id
 
 > Display current user and group identity.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/id-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/id>.
 
 - Display current user's id (UID), group id (GID) and groups to which they belong:
 

--- a/pages/common/install.md
+++ b/pages/common/install.md
@@ -2,7 +2,7 @@
 
 > Copy files and set attributes.
 > Copy files (often executable) to a system location like `/usr/local/bin`, give them the appropriate permissions/ownership.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/install-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/install>.
 
 - Copy files to destination:
 

--- a/pages/common/join.md
+++ b/pages/common/join.md
@@ -1,7 +1,7 @@
 # join
 
 > Join lines of two sorted files on a common field.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/join-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/join>.
 
 - Join two files on the first (default) field:
 

--- a/pages/common/link.md
+++ b/pages/common/link.md
@@ -2,7 +2,7 @@
 
 > Create a hard link to an existing file.
 > For more options, see the `ln` command.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/link-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/link>.
 
 - Create a hard link from a new file to an existing file:
 

--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -1,7 +1,7 @@
 # ln
 
 > Creates links to files and directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/ln-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/ln>.
 
 - Create a symbolic link to a file or directory:
 

--- a/pages/common/logname.md
+++ b/pages/common/logname.md
@@ -1,7 +1,7 @@
 # logname
 
 > Shows the user's login name.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/logname-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/logname>.
 
 - Display the currently logged in user's name:
 

--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > List directory contents.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/ls>.
 
 - List files one per line:
 

--- a/pages/common/md5sum.md
+++ b/pages/common/md5sum.md
@@ -1,7 +1,7 @@
 # md5sum
 
 > Calculate MD5 cryptographic checksums.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/md5sum-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/md5sum>.
 
 - Calculate the MD5 checksum for a file:
 

--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -1,7 +1,7 @@
 # mkdir
 
 > Creates a directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/mkdir>.
 
 - Create a directory in current directory or given path:
 

--- a/pages/common/mkfifo.md
+++ b/pages/common/mkfifo.md
@@ -1,7 +1,7 @@
 # mkfifo
 
 > Makes FIFOs (named pipes).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/mkfifo-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/mkfifo>.
 
 - Create a named pipe at a given path:
 

--- a/pages/common/mv.md
+++ b/pages/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Move or rename files and directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/mv>.
 
 - Move files in arbitrary locations:
 

--- a/pages/common/nice.md
+++ b/pages/common/nice.md
@@ -2,7 +2,7 @@
 
 > Execute a program with a custom scheduling priority (niceness).
 > Niceness values range from -20 (the highest priority) to 19 (the lowest).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/nice-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/nice>.
 
 - Launch a program with altered priority:
 

--- a/pages/common/nl.md
+++ b/pages/common/nl.md
@@ -1,7 +1,7 @@
 # nl
 
 > A utility for numbering lines, either from a file, or from standard input.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/nl-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/nl>.
 
 - Number non-blank lines in a file:
 

--- a/pages/common/nohup.md
+++ b/pages/common/nohup.md
@@ -1,7 +1,7 @@
 # nohup
 
 > Allows for a process to live when the terminal gets killed.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/nohup-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/nohup>.
 
 - Run process that can live beyond the terminal:
 

--- a/pages/common/nproc.md
+++ b/pages/common/nproc.md
@@ -1,7 +1,7 @@
 # nproc
 
 > Print the number of processing units (normally CPUs) available.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/nproc-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/nproc>.
 
 - Display the number of available processing units:
 

--- a/pages/common/numfmt.md
+++ b/pages/common/numfmt.md
@@ -1,7 +1,7 @@
 # numfmt
 
 > Convert numbers to and from human-readable strings.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/numfmt-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/numfmt>.
 
 - Convert 1.5K (SI Units) to 1500:
 

--- a/pages/common/od.md
+++ b/pages/common/od.md
@@ -2,7 +2,7 @@
 
 > Display file contents in octal, decimal or hexadecimal format.
 > Optionally display the byte offsets and/or printable representation for each line.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/od-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/od>.
 
 - Display file using default settings: octal format, 8 bytes per line, byte offsets in octal, and duplicate lines replaced with `*`:
 

--- a/pages/common/paste.md
+++ b/pages/common/paste.md
@@ -1,7 +1,7 @@
 # paste
 
 > Merge lines of files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/paste-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/paste>.
 
 - Join all the lines into a single line, using TAB as delimiter:
 

--- a/pages/common/pathchk.md
+++ b/pages/common/pathchk.md
@@ -1,7 +1,7 @@
 # pathchk
 
 > Check the validity and portability of one or more pathnames.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/pathchk-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/pathchk>.
 
 - Check pathames for validity in the current system:
 

--- a/pages/common/pr.md
+++ b/pages/common/pr.md
@@ -1,7 +1,7 @@
 # pr
 
 > Paginate or columnate files for printing.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/pr-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/pr>.
 
 - Print multiple files with a default header and footer:
 

--- a/pages/common/printenv.md
+++ b/pages/common/printenv.md
@@ -1,7 +1,7 @@
 # printenv
 
 > Print values of all or specific environment variables.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/printenv-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/printenv>.
 
 - Display key-value pairs of all environment variables:
 

--- a/pages/common/printf.md
+++ b/pages/common/printf.md
@@ -1,7 +1,7 @@
 # printf
 
 > Format and print text.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/printf-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/printf>.
 
 - Print a text message:
 

--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -1,7 +1,7 @@
 # pwd
 
 > Print name of current/working directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/pwd>.
 
 - Print the current directory:
 

--- a/pages/common/readlink.md
+++ b/pages/common/readlink.md
@@ -1,7 +1,7 @@
 # readlink
 
 > Follow symlinks and get symlink information.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/readlink-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/readlink>.
 
 - Get the actual file to which the symlink points:
 

--- a/pages/common/realpath.md
+++ b/pages/common/realpath.md
@@ -1,7 +1,7 @@
 # realpath
 
 > Display the resolved absolute path for a file or directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/realpath-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/realpath>.
 
 - Display the absolute path for a file or directory:
 

--- a/pages/common/rm.md
+++ b/pages/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Remove files or directories.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/rm>.
 
 - Remove files from arbitrary locations:
 

--- a/pages/common/rmdir.md
+++ b/pages/common/rmdir.md
@@ -1,7 +1,7 @@
 # rmdir
 
 > Removes a directory.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/rmdir-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/rmdir>.
 
 - Remove directory, provided it is empty. Use `rm -r` to remove non-empty directories:
 

--- a/pages/common/seq.md
+++ b/pages/common/seq.md
@@ -1,7 +1,7 @@
 # seq
 
 > Output a sequence of numbers to stdout.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/seq-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/seq>.
 
 - Sequence from 1 to 10:
 

--- a/pages/common/sha1sum.md
+++ b/pages/common/sha1sum.md
@@ -1,7 +1,7 @@
 # sha1sum
 
 > Calculate SHA1 cryptographic checksums.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/sha1sum-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/sha1sum>.
 
 - Calculate the SHA1 checksum for a file:
 

--- a/pages/common/shred.md
+++ b/pages/common/shred.md
@@ -1,7 +1,7 @@
 # shred
 
 > Overwrite files to securely delete data.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/shred>.
 
 - Overwrite a file:
 

--- a/pages/common/shuf.md
+++ b/pages/common/shuf.md
@@ -1,7 +1,7 @@
 # shuf
 
 > Generate random permutations.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/shuf-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/shuf>.
 
 - Randomize the order of lines in a file and output the result:
 

--- a/pages/common/sleep.md
+++ b/pages/common/sleep.md
@@ -1,7 +1,7 @@
 # sleep
 
 > Delay for a specified amount of time.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/sleep>.
 
 - Delay in seconds:
 

--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -1,7 +1,7 @@
 # sort
 
 > Sort lines of text files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/sort>.
 
 - Sort a file in ascending order:
 

--- a/pages/common/split.md
+++ b/pages/common/split.md
@@ -1,7 +1,7 @@
 # split
 
 > Split a file into pieces.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/split-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/split>.
 
 - Split a file, each split having 10 lines (except the last split):
 

--- a/pages/common/stdbuf.md
+++ b/pages/common/stdbuf.md
@@ -1,7 +1,7 @@
 # stdbuf
 
 > Run a command with modified buffering operations for its standard streams.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/stdbuf-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/stdbuf>.
 
 - Change the standard input buffer size to 512 KiB:
 

--- a/pages/common/stty.md
+++ b/pages/common/stty.md
@@ -1,7 +1,7 @@
 # stty
 
 > Set options for a terminal device interface.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/stty-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/stty>.
 
 - Display all settings for the current terminal:
 

--- a/pages/common/sum.md
+++ b/pages/common/sum.md
@@ -2,7 +2,7 @@
 
 > Compute checksums and the number of blocks for a file.
 > A predecessor to the more modern `cksum`.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/sum-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/sum>.
 
 - Compute a checksum with BSD-compatible algorithm and 1024-byte blocks:
 

--- a/pages/common/sync.md
+++ b/pages/common/sync.md
@@ -1,7 +1,7 @@
 # sync
 
 > Flushes all pending write operations to the appropriate disks.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/sync-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/sync>.
 
 - Flush all pending write operations on all disks:
 

--- a/pages/common/tac.md
+++ b/pages/common/tac.md
@@ -1,7 +1,7 @@
 # tac
 
 > Print and concatenate files in reverse (last line first).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tac-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tac>.
 
 - Print the contents of *file1* reversed to the standard output:
 

--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -1,7 +1,7 @@
 # tail
 
 > Display the last part of a file.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tail-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tail>.
 
 - Show last 'num' lines in file:
 

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -1,7 +1,7 @@
 # tee
 
 > Read from standard input and write to standard output and files (or commands).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tee-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tee>.
 
 - Copy standard input to each FILE, and also to standard output:
 

--- a/pages/common/test.md
+++ b/pages/common/test.md
@@ -2,7 +2,7 @@
 
 > Evaluate condition.
 > Returns 0 if the condition evaluates to true, 1 if it evaluates to false.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/test-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/test>.
 
 - Test if a given variable is equal to a given string:
 

--- a/pages/common/timeout.md
+++ b/pages/common/timeout.md
@@ -1,7 +1,7 @@
 # timeout
 
 > Run a command with a time limit.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/timeout>.
 
 - Run `sleep 10` and terminate it, if it runs for more than 3 seconds:
 

--- a/pages/common/touch.md
+++ b/pages/common/touch.md
@@ -1,7 +1,7 @@
 # touch
 
 > Change a file access and modification times (atime, mtime).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/touch-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/touch>.
 
 - Create a new empty file(s) or change the times for existing file(s) to current time:
 

--- a/pages/common/tr.md
+++ b/pages/common/tr.md
@@ -1,7 +1,7 @@
 # tr
 
 > Translate characters: run replacements based on single characters and character sets.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tr-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tr>.
 
 - Replace all occurrences of a character in a file, and print the result:
 

--- a/pages/common/true.md
+++ b/pages/common/true.md
@@ -2,7 +2,7 @@
 
 > Returns a successful exit status code of 0.
 > Use this with the || operator to make a command always exit with 0.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/true-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/true>.
 
 - Return a successful exit code:
 

--- a/pages/common/truncate.md
+++ b/pages/common/truncate.md
@@ -1,7 +1,7 @@
 # truncate
 
 > Shrink or extend the size of a file to the specified size.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/truncate-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/truncate>.
 
 - Set a size of 10 GB to an exsting file, or create a new file with the specified size:
 

--- a/pages/common/tsort.md
+++ b/pages/common/tsort.md
@@ -2,7 +2,7 @@
 
 > Perform a topological sort.
 > A common use is to show the dependency order of nodes in a directed acyclic graph.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tsort-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tsort>.
 
 - Perform a topological sort consistent with a partial sort per line of input separated by blanks:
 

--- a/pages/common/tty.md
+++ b/pages/common/tty.md
@@ -1,7 +1,7 @@
 # tty
 
 > Returns terminal name.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/tty-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/tty>.
 
 - Print the file name of this terminal:
 

--- a/pages/common/uname.md
+++ b/pages/common/uname.md
@@ -2,7 +2,7 @@
 
 > Print details about the current machine and the operating system running on it.
 > Note: for additional information about the operating system, try the `lsb_release` command.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/uname>.
 
 - Print hardware-related information: machine and processor:
 

--- a/pages/common/unexpand.md
+++ b/pages/common/unexpand.md
@@ -1,7 +1,7 @@
 # unexpand
 
 > Convert spaces to tabs.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/unexpand-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/unexpand>.
 
 - Convert blanks in each file to tabs, writing to standard output:
 

--- a/pages/common/uniq.md
+++ b/pages/common/uniq.md
@@ -2,7 +2,7 @@
 
 > Output the unique lines from the given input or file.
 > Since it does not detect repeated lines unless they are adjacent, we need to sort them first.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/uniq-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/uniq>.
 
 - Display each line once:
 

--- a/pages/common/unlink.md
+++ b/pages/common/unlink.md
@@ -2,7 +2,7 @@
 
 > Remove a link to a file from the filesystem.
 > The file contents is lost if the link is the last one to the file.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/unlink-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/unlink>.
 
 - Remove the specified file if it is the last link:
 

--- a/pages/common/uptime.md
+++ b/pages/common/uptime.md
@@ -1,7 +1,7 @@
 # uptime
 
 > Tell how long the system has been running and other information.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/uptime-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/uptime>.
 
 - Print current time, uptime, number of logged-in users and other information:
 

--- a/pages/common/users.md
+++ b/pages/common/users.md
@@ -1,7 +1,7 @@
 # users
 
 > Display a list of logged in users.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/users-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/users>.
 
 - Display a list of logged in users:
 

--- a/pages/common/vdir.md
+++ b/pages/common/vdir.md
@@ -2,7 +2,7 @@
 
 > List directory contents.
 > Drop-in replacement for `ls -l`.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/vdir-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/vdir>.
 
 - List files and directories in the current directory, one per line, with details:
 

--- a/pages/common/wc.md
+++ b/pages/common/wc.md
@@ -1,7 +1,7 @@
 # wc
 
 > Count lines, words, or bytes.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/wc-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/wc>.
 
 - Count lines in file:
 

--- a/pages/common/who.md
+++ b/pages/common/who.md
@@ -1,7 +1,7 @@
 # who
 
 > Display who is logged in and related data (processes, boot time).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/who-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/who>.
 
 - Display the username, line, and time of all currently logged-in sessions:
 

--- a/pages/common/whoami.md
+++ b/pages/common/whoami.md
@@ -1,7 +1,7 @@
 # whoami
 
 > Print the username associated with the current effective user ID.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/whoami-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/whoami>.
 
 - Display currently logged username:
 

--- a/pages/common/yes.md
+++ b/pages/common/yes.md
@@ -2,7 +2,7 @@
 
 > Output something repeatedly.
 > This command is commonly used to answer yes to every prompt by install commands (such as apt-get).
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/yes-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/yes>.
 
 - Repeatedly output "message":
 

--- a/pages/linux/csplit.md
+++ b/pages/linux/csplit.md
@@ -2,7 +2,7 @@
 
 > Split a file into pieces.
 > This generates files named "xx00", "xx01", and so on.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/csplit-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/csplit>.
 
 - Split a file at lines 5 and 23:
 

--- a/pages/linux/mknod.md
+++ b/pages/linux/mknod.md
@@ -1,7 +1,7 @@
 # mknod
 
 > Create block or character device special files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/mknod-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/mknod>.
 
 - Create a block device:
 

--- a/pages/linux/ptx.md
+++ b/pages/linux/ptx.md
@@ -1,7 +1,7 @@
 # ptx
 
 > Generate a permuted index of words from one or more text files.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/ptx-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/ptx>.
 
 - Generate a permuted index where the first field of each line is an index reference:
 

--- a/pages/linux/runcon.md
+++ b/pages/linux/runcon.md
@@ -2,7 +2,7 @@
 
 > Run a program in a different SELinux security context.
 > With neither context nor command, print the current security context.
-> More information: <https://www.gnu.org/software/coreutils/manual/html_node/runcon-invocation.html>.
+> More information: <https://www.gnu.org/software/coreutils/runcon>.
 
 - Determine the current domain:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

GNU online documentation provides user-friendly URLs - for example, https://www.gnu.org/software/coreutils/ls which redirects to https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html#ls-invocation. Those short forms are advertised through `coreutils` manpages (for example, [`ls`](https://manned.org/ls.1#head7)) so I've updated all accompanying `coreutils` tldr pages to follow the suit.

This is done using following script:
```sh
rg -l 'gnu.org/software/coreutils/manual/html_node/(.*?)-invocation.html' |
    xargs sed -i -E 's|(gnu.org/software/coreutils)/manual/html_node/(.*?)-invocation.html|\1/\2|g'
```