### PR TITLE
README: update clients' urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ both for the command line and for other platforms:
   - [tldr-flutter](https://github.com/Techno-Disaster/tldr-flutter), available on
     [Google Play](https://play.google.com/store/apps/details?id=wtf.technodisaster.tldr) or [F-Droid](https://f-droid.org/packages/wtf.technodisaster.tldr/)
 - Bash clients:
-  - [tldr](https://github.com/raylee/tldr)
+  - [tldr-sh-client](https://github.com/raylee/tldr-sh-client)
   - [tldr-bash-client](https://gitlab.com/pepa65/tldr-bash-client)
 - [C# client](https://github.com/principis/tldr-sharp)
 - [C client](https://github.com/tldr-pages/tldr-c-client):
@@ -100,7 +100,7 @@ both for the command line and for other platforms:
   - [github.com/pranavraja/tldr](https://github.com/pranavraja/tldr):
     `go get github.com/pranavraja/tldr`
     (or [platform binaries](https://github.com/pranavraja/tldr/releases))
-  - [4d63.com/tldr](https://4d63.com/tldr):
+  - [https://github.com/leighmcculloch/tldr](https://github.com/leighmcculloch/tldr):
     `go get 4d63.com/tldr` or `brew install 4d63/tldr/tldr`
     (or [platform binaries](https://github.com/leighmcculloch/tldr/releases))
   - [github.com/elecprog/tldr](https://github.com/elecprog/tldr):
@@ -124,7 +124,7 @@ both for the command line and for other platforms:
 - [Node.js client](https://github.com/tldr-pages/tldr-node-client):
   `npm install -g tldr`
 - [OCaml client](https://github.com/RosalesJ/tldr-ocaml): `opam install tldr`
-- [Perl5 client](https://github.com/shoichikaji/perl-tldr):
+- [Perl5 client](https://github.com/skaji/perl-tldr):
   `cpanm App::tldr`
 - [PHP client](https://github.com/BrainMaestro/tldr-php):
   `composer global require brainmaestro/tldr`

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ both for the command line and for other platforms:
 - Docker images:
     - [tldr-docker](https://github.com/nutellinoit/tldr-docker) - Run the `tldr` command via a docker container: `alias tldr='docker run --rm -it -v ~/.tldr/:/root/.tldr/ nutellinoit/tldr'`
 - Elixir clients:
-  - [ExTldr](https://github.com/ivanhercaz/extldr).
+  - [ExTldr](https://github.com/tldr-pages/extldr).
   - [TLDR Elixir Client](https://github.com/edgurgel/tldr_elixir_client)
   (binaries not yet available)
 - [Emacs client](https://github.com/kuanyui/tldr.el), available on


### PR DESCRIPTION
[Corresponding wiki update](https://github.com/tldr-pages/tldr/wiki/tldr-pages-clients/_compare/d45a8430c14897c810708049ea9c0d3aaa410ebd...da5004d61bf224226b84447421c8ae4a5e3991e9): https://github.com/tldr-pages/tldr/wiki/tldr-pages-clients/da5004d61bf224226b84447421c8ae4a5e3991e9

I'm compiling a list of clients' status based on the README list for #4044 (and #5240)