### PR TITLE
Update .gitattributes to force GH linguist to recognize pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 # be checked-out as CRLF, and re-converted to LF before check-in.
 # See https://git-scm.com/docs/gitattributes for more information.
 * text=auto
+
+# GitHub linguist ignores markdown files by default, but tldr-pages
+# is mostly markdown, so we explicitly make the pages detectable
+pages*/**/*.md linguist-detectable=true
+pages*/**/*.md linguist-documentation=false


### PR DESCRIPTION
tldr-pages is a mostly markdown repository, let's have GH detect markdown files as such.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
