### PR TITLE
archinstall: add page

### DIFF
--- a/pages/linux/archinstall.md
+++ b/pages/linux/archinstall.md
@@ -6,3 +6,7 @@
 - Start the interactive installer:
 
 `archinstall`
+
+- Start a preset installer:
+
+`archinstall {{minimal|unattended}}`

--- a/pages/linux/archinstall.md
+++ b/pages/linux/archinstall.md
@@ -1,0 +1,8 @@
+# archinstall
+
+> Guided Arch Linux installer with a twist.
+> More information: <https://archinstall.readthedocs.io>.
+
+- Start the interactive installer:
+
+`archinstall`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

I read the source code and I tested it in a VM but I couldn´t find any command line argument, only the guided/interactive mode.
I add this page because is a built-in command in the Arch Linux official ISO image <https://archlinux.org/news/installation-medium-with-installer/>.