### PR TITLE
zip: add list files example and update first example

### DIFF
--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -2,9 +2,9 @@
 
 > Package and compress (archive) files into zip file.
 
-- Package and compress a directory and its contents, [r]ecursively:
+- Package and compress files and directories [r]ecursively:
 
-`zip -r {{compressed.zip}} {{path/to/directory}}`
+`zip -r {{compressed.zip}} {{path/to/file}} {{path/to/directory1}} {{path/to/directory2}}`
 
 - E[x]clude unwanted files from being added to the compressed archive:
 
@@ -13,10 +13,6 @@
 - Archive a directory and its contents with the highest level [9] of compression:
 
 `zip -r -{{9}} {{compressed.zip}} {{path/to/directory}}`
-
-- Package and compress multiple directories and files:
-
-`zip -r {{compressed.zip}} {{path/to/directory1}} {{path/to/directory2}} {{path/to/file}}`
 
 - Create an encrypted archive (user will be prompted for a password):
 

--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -30,6 +30,6 @@
 
 `zip -r -s {{3g}} {{compressed.zip}} {{path/to/directory}}`
 
-- Scan and show files within the archive (without processing them):
+- List files within a specified archive (without extracting them):
 
 `zip -sf {{compressed.zip}}`

--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -33,3 +33,7 @@
 - Archive a directory and its contents to a multi-part [s]plit zip file (e.g. 3GB parts):
 
 `zip -r -s {{3g}} {{compressed.zip}} {{path/to/directory}}`
+
+- Scan and show files within the archive (without processing them):
+
+`zip -sf {{compressed.zip}}`


### PR DESCRIPTION
From the `zip` man page: 
> The -sf show files option can be used to scan for files and get the list of files scanned without actually processing them.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

I noticed that `zip` already has 8 examples, so adding this PR does not adhere to the Guidelines.
I'm proposing this change as listing files within an archive is quite common for me and `-sf` is quite obscure and require me to check the `man` page almost every time. TLDR is very useful in this regard and I think such a basic option should be present too. I'm not sure how cases like this are handled, so I created a Draft PR. If you consider this change acceptable I'll move this in ready for review, otherwise feel free to close this.

Thank you!

