### PR TITLE
docker-image: add page

### DIFF
--- a/pages/common/docker-image.md
+++ b/pages/common/docker-image.md
@@ -12,7 +12,7 @@
 
 `sudo docker image prune`
 
-- Delete all unused images, not just those without a tag:
+- Delete all unused images (not just those without a tag):
 
 `sudo docker image prune --all`
 

--- a/pages/common/docker-image.md
+++ b/pages/common/docker-image.md
@@ -6,7 +6,7 @@
 
 - List local Docker images:
 
-`sudo docker image ls`
+`docker image ls`
 
 - Delete unused local Docker images:
 

--- a/pages/common/docker-image.md
+++ b/pages/common/docker-image.md
@@ -10,12 +10,12 @@
 
 - Delete unused local Docker images:
 
-`sudo docker image prune`
+`docker image prune`
 
 - Delete all unused images (not just those without a tag):
 
-`sudo docker image prune --all`
+`docker image prune --all`
 
 - Show the history of a local Docker image:
 
-`sudo docker image history {{image}}`
+`docker image history {{image}}`

--- a/pages/common/docker-image.md
+++ b/pages/common/docker-image.md
@@ -1,0 +1,21 @@
+# docker image
+
+> Manage Docker images.
+> See also `docker build`, `docker import`, and `docker pull`.
+> More information: <https://docs.docker.com/engine/reference/commandline/image/>.
+
+- List local Docker images:
+
+`sudo docker image ls`
+
+- Delete unused local Docker images:
+
+`sudo docker image prune`
+
+- Delete all unused images, not just those without a tag:
+
+`sudo docker image prune --all`
+
+- Show the history of a local Docker image:
+
+`sudo docker image history {{image}}`


### PR DESCRIPTION
A few notes about this one:

 - `docker image` ≠ `docker images`
 - A number of subcommands of `docker image` have top-level counterparts (e.g. `docker image rm` has `docker rmi`), so I've focused on unique functionality of `docker image`