### PR TITLE
passwd: remove invalid example

### DIFF
--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -8,7 +8,7 @@
 
 - Change the password of the current user:
 
-`passwd {{new_password}}`
+`passwd {{username}}`
 
 - Get the current status of the user:
 

--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -10,10 +10,6 @@
 
 `passwd {{new_password}}`
 
-- Change the password of the specified user:
-
-`passwd {{username}} {{new_password}}`
-
 - Get the current status of the user:
 
 `passwd -S`

--- a/pages/common/passwd.md
+++ b/pages/common/passwd.md
@@ -6,7 +6,7 @@
 
 `passwd`
 
-- Change the password of the current user:
+- Change the password of a specific user:
 
 `passwd {{username}}`
 


### PR DESCRIPTION
passwd doesn't accept changing a password via specifying the password after the username in the command line, consider removing the example as it's misleading

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).