### PR TITLE
cmark: fix capitalization of "LaTeX"

### DIFF
--- a/pages.it/common/cmark.md
+++ b/pages.it/common/cmark.md
@@ -7,7 +7,7 @@
 
 `cmark --to html {{file.md}}`
 
-- Converti in latex da standard input:
+- Converti in LaTeX da standard input:
 
 `cmark --to latex`
 

--- a/pages/common/cmark.md
+++ b/pages/common/cmark.md
@@ -7,7 +7,7 @@
 
 `cmark --to html {{filename.md}}`
 
-- Convert data from standard input to latex:
+- Convert data from standard input to LaTeX:
 
 `cmark --to latex`
 


### PR DESCRIPTION
Inspired by [this discussion](https://github.com/tldr-pages/tldr/pull/5694#issuecomment-814006257) in #5694.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
