### PR TITLE
feat: update to use main branch as default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 - [ ] The page (if new), does not already exist in the repo.
 - [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
 - [ ] The page has 8 or fewer examples.
-- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
-- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
+- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
+- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
 - [ ] The page description includes a link to documentation or a homepage (if applicable).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,20 @@ jobs:
       run: bash scripts/build.sh
 
     - name: Setup Python for PDF generation
-      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
 
     - name: Build PDF
-      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       run: |
         cd scripts/pdf/
         pip3 install -r requirements.txt
         python3 render.py ../../pages -c solarized-light
 
     - name: Deploy
-      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/master'
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       run: bash scripts/deploy.sh
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,7 +2,7 @@ name: Main Mirror
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
 
 jobs:
   mirror:
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: zofrex/mirror-branch@v1
         with:
-          target-branch: main
+          target-branch: master

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -76,7 +76,7 @@ tldr --platform osx bash
 
 This section documents the directory structure that contains the pages themselves.
 
-The master version of every page is stored inside (but not directly) the `pages` directory. Inside this directory, there is a folder for each platform - for example `windows`, `linux`, and the special `common` platform:
+The main version of every page is stored inside (but not directly) the `pages` directory. Inside this directory, there is a folder for each platform - for example `windows`, `linux`, and the special `common` platform:
 
  - `pages/`
    - `common/`
@@ -98,7 +98,7 @@ Command name    | Mapped name     | Filename
 
 ### Translations
 
-Other directories sit alongside the main `pages` directory, and contain translations of the master versions of every page - though pages MAY NOT have a translation available for a given language yet. Furthermore, a given language MAY NOT have a folder yet either. The format of these directories is `pages.<locale>`, where `<locale>` is a [POSIX Locale Name](https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html#Locale-Names) in the form of `<language>_<country>`, where:
+Other directories sit alongside the main `pages` directory, and contain translations of the main versions of every page - though pages MAY NOT have a translation available for a given language yet. Furthermore, a given language MAY NOT have a folder yet either. The format of these directories is `pages.<locale>`, where `<locale>` is a [POSIX Locale Name](https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html#Locale-Names) in the form of `<language>_<country>`, where:
 
  - `<language>` is the shortest [ISO 639](https://en.wikipedia.org/wiki/ISO_639) language code for the chosen language (see [here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) for a complete list).
  - `<country>` is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) country code for the chosen region (see [here](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) for a complete list).
@@ -186,7 +186,7 @@ Examples:
  unset |`it:cz`    | `en`
  unset |unset      | `en`
 
-Regardless of the language determined through the environment, clients MUST always attempt to fallback to English if the page does not exist in the user preferred language. Clients MAY notify the user when a page in their preferred language cannot be found (optionally including a link to the [translations section of the contributing guide](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md#translations)).
+Regardless of the language determined through the environment, clients MUST always attempt to fallback to English if the page does not exist in the user preferred language. Clients MAY notify the user when a page in their preferred language cannot be found (optionally including a link to the [translations section of the contributing guide](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#translations)).
 
 It is also RECOMMENDED to make the language configurable, as to not only rely on the environment. Clients SHOULD offer options to configure or override the language using configuration files or even command line options (like `-L, --language` as suggested in the [arguments section](#arguments) above). If such a command-line option is specified, a client must strictly adhere to its value, and MUST NOT show pages in a different language, failing with an appropriate error message instead.
 

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -94,13 +94,13 @@ using one of the template messages below as a base.
    ```
    Hi, @username! You seem to be enjoying contributing to the tldr-pages project.
    You now have had five distinct pull requests merged (<!-- REPLACE THIS WITH LINKS TO THE RELEVANT PRs -->)!
-   That qualifies you to become a collaborator in this repository, as explained in our [community roles documentation](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md).
+   That qualifies you to become a collaborator in this repository, as explained in our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md).
 
    As a collaborator, you will have commit access to the repository.
    That means you can merge pull requests, label and close issues, and perform various other maintenance tasks that are needed here and there.
    Of course, all of this is voluntary — you're welcome to contribute to the project in whatever ways suit your liking.
 
-   If you do decide to start performing maintenance tasks, though, we only ask you to get familiar with the [maintainer's guide](https://github.com/tldr-pages/tldr/blob/master/contributing-guides/maintainers-guide.md).
+   If you do decide to start performing maintenance tasks, though, we only ask you to get familiar with the [maintainer's guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/maintainers-guide.md).
 
    So, what do you say? Can we add you as a collaborator?
 
@@ -123,13 +123,13 @@ using one of the template messages below as a base.
    ```
    Hi, @username! After joining as a collaborator in the repository, you have been regularly performing maintenance tasks (<!-- REPLACE THIS WITH LINKS TO THE RELEVANT ISSUES AND/OR PRs -->).
    Thank you for that!
-   According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md), you've now met the thresholds to be effectively considered an active maintainer of the project.
+   According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md), you've now met the thresholds to be effectively considered an active maintainer of the project.
    To publicly acknowledge that fact, we'd like to add you to the tldr-pages organization.
 
    If you accept the invitation, we ask you to make your membership public, and (in case you don't already) start hanging out in our Gitter chat room.
    Additionally, consider subscribing to the notifications from the various repositories under the [tldr-pages organization](https://github.com/tldr-pages).
    As one of the public faces of the tldr-pages project, it's also especially important that you follow and encourage the [project
-   governance principles](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md).
+   governance principles](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md).
 
    How does that sound? Are you up for it?
    ```
@@ -150,10 +150,10 @@ using one of the template messages below as a base.
    ```
    Hi, @username! You've been an active tldr-pages organization member for over 6 months.
    Thanks for sticking around this far and helping out!
-   According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md), you're now eligible for becoming an owner in the organization.
+   According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md), you're now eligible for becoming an owner in the organization.
 
    That means you will, from now on, be part of the team responsible for performing role changes (like this one!) in the community.
-   When performing such role transitions, make sure to follow the process described in the [COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md) document.
+   When performing such role transitions, make sure to follow the process described in the [COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md) document.
 
    Is that OK with you? Let us know!
 
@@ -174,7 +174,7 @@ using one of the template messages below as a base.
 1. Open an issue with the following message template (edit it as appropriate):
 
    ```
-   Hi, @username! As you know, our [community roles documentation](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md) defines processes for keeping the list of organization members in sync with the actual maintenance team.
+   Hi, @username! As you know, our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md) defines processes for keeping the list of organization members in sync with the actual maintenance team.
    Since you haven't been active in the project for a while now, we'll be relieving you from the maintainer responsibilities.
 
    In practice, not much will change on your side, since you'll remain a collaborator in the repos you have been active in.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 [contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
 [cla-assistant-url]: https://cla-assistant.io/tldr-pages/tldr
 [cla-assistant-image]: https://cla-assistant.io/readme/badge/tldr-pages/tldr
-[license-url]: https://github.com/tldr-pages/tldr/blob/master/LICENSE.md
+[license-url]: https://github.com/tldr-pages/tldr/blob/main/LICENSE.md
 [license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg
 
 Contributions to the tldr-pages project are [most welcome](GOVERNANCE.md)!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,7 +7,7 @@ and [contributors](https://github.com/tldr-pages/tldr/graphs/contributors).
 
 ----
 
-The contents of the [scripts/](https://github.com/tldr-pages/tldr/tree/master/scripts) directory
+The contents of the [scripts/](https://github.com/tldr-pages/tldr/tree/main/scripts) directory
 are licensed under the MIT license:
 
 > **The MIT License**

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ Note: only the people marked with **bold** are currently in the indicated role.
 The other entries are kept for historical record.
 
 There are three types of maintainers, as described in
-[COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/master/COMMUNITY-ROLES.md#when-to-change-roles):
+[COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md#when-to-change-roles):
 repository collaborators, organization members, and organization owners
 — each having specific roles in maintaining the project, as outlined below.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
 [contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
-[license-url]: https://github.com/tldr-pages/tldr/blob/master/LICENSE.md
+[license-url]: https://github.com/tldr-pages/tldr/blob/main/LICENSE.md
 [license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg
 </div>
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -32,7 +32,7 @@ tldrl -f {{page.md}}
 ```
 
 For other ways to use `tldrl`, such as linting an entire directory, check out (what else!)
-[`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/master/pages/common/tldrl.md)
+[`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldrl.md)
 
 If you're using the Node.js client of tldr-pages, you can preview a page locally using the `-f` flag (aka `--render`):
 

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -49,7 +49,7 @@ function check_diff {
   local line
   local entry
 
-  git_diff=$(git diff --name-status --find-copies-harder --diff-filter=AC --relative=pages/ remotes/origin/master)
+  git_diff=$(git diff --name-status --find-copies-harder --diff-filter=AC --relative=pages/ remotes/origin/main)
 
   if [ -n "$git_diff" ]; then
     echo -e "Check PR: git diff:\n$git_diff" >&2


### PR DESCRIPTION
I think the other things we need to do is basically switch the default branch in the settings, and add a branch protection rule for `main` instead of `master`. As far as I know, pull requests to `master` should be automatically changed to `main` (🤞🏻).

Closes https://github.com/tldr-pages/tldr/issues/5110