### PR TITLE
package.json: Move husky install to prepare run-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint-tldr-pages": "tldr-lint ./pages",
     "test": "bash scripts/test.sh",
     "build-index": "node ./scripts/build-index.js > index.json",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "private": true
 }


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

The recommended way to use husky with npm is to put the `husky install` line in the `prepare` run-script, not `postinstall`. This is principally aimed at libraries where using `postinstall` would affect downstream consumers (unless you used pinst to prune the `postinstall` line), but might as well be consistent here.