### PR TITLE
MAINTAINERS: normalize dates, reorder entries

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,82 +12,84 @@ repository collaborators, organization members, and organization owners
 In general terms, all maintainers are expected to follow the
 [Maintainer's guide](contributing-guides/maintainers-guide.md).
 
-
 ## Repository collaborators
 
-Repository collaborators have write access to this repository,
-which allows them to label, edit and close issues,
+Repository collaborators have write access to the tldr repository,
+which allows them to label, edit and close issues/pull requests,
 as well as review and merge pull requests from other contributors.
-If you are an owner of the organization, you should be able to see an automated list
+If you are an owner of the organization, you can see an automated list
 [here](https://github.com/tldr-pages/tldr/settings/collaboration).
 
 - **Jeef ([@jeeftor](https://github.com/jeeftor))**:
   [12 March 2017](https://github.com/tldr-pages/tldr/issues/1209#issuecomment-285924778) — present
 - **Max Xu ([@jsonbruce](https://github.com/jsonbruce))**:
-  [13 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — present
+  [11 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — present
 - **Muhammad Falak R Wani ([@mfrw](https://github.com/mfrw))**:
-  [7 September 2018](https://github.com/tldr-pages/tldr/issues/2306) — present
+  [6 September 2018](https://github.com/tldr-pages/tldr/issues/2306) — present
 - **David Bialik ([@AnimiVulpis](https://github.com/AnimiVulpis))**:
   [5 November 2018](https://github.com/tldr-pages/tldr/issues/2556) — present
 - **Andrik Albuquerque ([@andrik](https://github.com/andrik))**:
-  [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) — present
+  [8 May 2019](https://github.com/tldr-pages/tldr/issues/2988) — present
 - **Ivan Aracki ([@Aracki](https://github.com/Aracki))**:
-  [9 May 2019](https://github.com/tldr-pages/tldr/issues/2988) — present
+  [8 May 2019](https://github.com/tldr-pages/tldr/issues/2988) — present
 - **Pierre Rudloff ([@Rudloff](https://github.com/Rudloff))**:
-  [19 November 2019](https://github.com/tldr-pages/tldr/issues/3580) — present
+  [16 November 2019](https://github.com/tldr-pages/tldr/issues/3580) — present
 - **Proscream ([@Proscream](https://github.com/Proscream))**:
-  [22 November 2019](https://github.com/tldr-pages/tldr/issues/3592) — present
+  [19 November 2019](https://github.com/tldr-pages/tldr/issues/3592) — present
 - **Guido Lena Cota ([@glenacota](https://github.com/glenacota))**:
   [19 October 2020](https://github.com/tldr-pages/tldr/issues/4763) — present
 - **Sahil Dhiman ([@sahilister](https://github.com/sahilister))**:
-  [05 December 2020](https://github.com/tldr-pages/tldr/issues/4994) - present
+  [27 November 2020](https://github.com/tldr-pages/tldr/issues/4994) - present
 - **Marcher Simon ([@marchersimon](https://github.com/marchersimon))**:
-  [09 March 2021](https://github.com/tldr-pages/tldr/issues/5390) — present
+  [9 March 2021](https://github.com/tldr-pages/tldr/issues/5390) — present
+- Owen Voke ([@owenvoke](https://github.com/owenvoke))
+  [11 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258)
+- Marco Bonelli ([@mebeim](https://github.com/mebeim)):
+  [28 January 2019](https://github.com/tldr-pages/tldr/issues/2735) — [8 April 2019](https://github.com/tldr-pages/tldr/issues/2874)
 - Lucas Schneider ([@schneiderl](https://github.com/schneiderl)):
   [11 April 2019](https://github.com/tldr-pages/tldr/issues/2898) — [17 January 2020](https://github.com/tldr-pages/tldr/issues/3764)
 - Ein Verne ([@einverne](https://github.com/einverne)):
-  [29 October 2019](https://github.com/tldr-pages/tldr/issues/3488) — [12 January 2020](https://github.com/tldr-pages/tldr/issues/3738)
+  [27 October 2019](https://github.com/tldr-pages/tldr/issues/3488) — [6 January 2020](https://github.com/tldr-pages/tldr/issues/3738)
 - Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic)):
-  [30 November 2019](https://github.com/tldr-pages/tldr/issues/3636) — [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663)
+  [28 November 2019](https://github.com/tldr-pages/tldr/issues/3636) — [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663)
 - Iván Hernández Cazorla ([@ivanhercaz](https://github.com/ivanhercaz)):
   [24 December 2019](https://github.com/tldr-pages/tldr/issues/3690) — [5 January 2020](https://github.com/tldr-pages/tldr/issues/3736)
 - Axel Navarro ([@navarroaxel](https://github.com/navarroaxel)):
-  [24 August 2020](https://github.com/tldr-pages/tldr/issues/4291) — [05 October 2020](https://github.com/tldr-pages/tldr/issues/4504)
+  [24 August 2020](https://github.com/tldr-pages/tldr/issues/4291) — [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504)
 - bl-ue ([@bl-ue](https://github.com/bl-ue)):
-  [01 January 2021](https://github.com/tldr-pages/tldr/issues/5056) — [02 February 2021](https://github.com/tldr-pages/tldr/issues/5219)
+  [30 December 2020](https://github.com/tldr-pages/tldr/issues/5056) — [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219)
 - Matthew Peveler ([@MasterOdin](https://github.com/MasterOdin)):
-  [09 January 2021](https://github.com/tldr-pages/tldr/issues/5122) — [01 April 2021](https://github.com/tldr-pages/tldr/issues/5473)
+  [9 January 2021](https://github.com/tldr-pages/tldr/issues/5122) — [18 March 2021](https://github.com/tldr-pages/tldr/issues/5473)
 - Tan Siret Akıncı ([@yutyo](https://github.com/yutyo)):
-  [03 March 2021](https://github.com/tldr-pages/tldr/issues/5345) — [07 April 2021](https://github.com/tldr-pages/tldr/issues/5702)
+  [3 March 2021](https://github.com/tldr-pages/tldr/issues/5345) — [7 April 2021](https://github.com/tldr-pages/tldr/issues/5702)
 
 ## Organization members
 
 In addition to everything that repository collaborators can do, organization members
 have write access to all the repositories in the tldr-pages organization,
-and [a few extra maintenance capabilities](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/permission-levels-for-an-organization).
+and [a few extra maintenance capabilities](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/permission-levels-for-an-organization).
 An automated list can be found [here](https://github.com/orgs/tldr-pages/people).
 
 - **Iván Hernández Cazorla ([@ivanhercaz](https://github.com/ivanhercaz))**:
   [5 January 2020](https://github.com/tldr-pages/tldr/issues/3736) — present
 - **Ein Verne ([@einverne](https://github.com/einverne))**:
-  [12 January 2020](https://github.com/tldr-pages/tldr/issues/3738) — present
+  [6 January 2020](https://github.com/tldr-pages/tldr/issues/3738) — present
 - **Axel Navarro ([@navarroaxel](https://github.com/navarroaxel))**:
-  [05 October 2020](https://github.com/tldr-pages/tldr/issues/4504) — present
+  [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504) — present
 - **bl-ue ([@bl-ue](https://github.com/bl-ue))**:
-  [02 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — present
+  [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — present
 - **Matthew Peveler ([@MasterOdin](https://github.com/MasterOdin))**:
-  [01 April 2021](https://github.com/tldr-pages/tldr/issues/5473) - present
+  [18 March 2021](https://github.com/tldr-pages/tldr/issues/5473) - present
 - **Tan Siret Akıncı ([@yutyo](https://github.com/yutyo))**:
-  [07 April 2021](https://github.com/tldr-pages/tldr/issues/5702) - present
-- Lucas Schneider ([@schneiderl](https://github.com/schneiderl)):
-  [17 January 2020](https://github.com/tldr-pages/tldr/issues/3764) — [3 February 2021](https://github.com/tldr-pages/tldr/issues/5224)
+  [7 April 2021](https://github.com/tldr-pages/tldr/issues/5702) - present
 - Owen Voke ([@owenvoke](https://github.com/owenvoke))
   [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258) — [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989)
 - Marco Bonelli ([@mebeim](https://github.com/mebeim)):
-  [9 April 2019](https://github.com/tldr-pages/tldr/issues/2874) — [21 December 2019](https://github.com/tldr-pages/tldr/issues/3672)
+  [8 April 2019](https://github.com/tldr-pages/tldr/issues/2874) — [20 December 2019](https://github.com/tldr-pages/tldr/issues/3672)
 - Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic)):
-  [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663) — [19 June 2020](https://github.com/tldr-pages/tldr/issues/4113)
-
+  [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663) — [18 June 2020](https://github.com/tldr-pages/tldr/issues/4113)
+- Lucas Schneider ([@schneiderl](https://github.com/schneiderl)):
+  [17 January 2020](https://github.com/tldr-pages/tldr/issues/3764) — [3 February 2021](https://github.com/tldr-pages/tldr/issues/5224)
 
 ## Organization owners
 
@@ -96,7 +98,7 @@ and are responsible for performing role changes in the community.
 An automated list can be found [here](https://github.com/orgs/tldr-pages/people).
 
 - **Romain Prieto ([@rprieto](https://github.com/rprieto))**:
-  created the project on [8 December 2013](https://github.com/tldr-pages/tldr/commit/11264d9)
+  created the project on [8 December 2013](https://github.com/tldr-pages/tldr/commit/11264d9b19000734a2d35ecbdbdebc0b0b45aed9)
 - **Agniva De Sarker ([@agnivade](https://github.com/agnivade))**:
   [27 September 2016](https://gitter.im/tldr-pages/tldr?at=57eaedefe4e41c6a4afc2f47) — present
 - **Starbeamrainbowlabs ([@sbrl](https://github.com/sbrl))**:
@@ -106,7 +108,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:
   [21 December 2019](https://github.com/tldr-pages/tldr/issues/3672) — present
 - **Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic))**:
-  [19 June 2020](https://github.com/tldr-pages/tldr/issues/4113) — present
+  [18 June 2020](https://github.com/tldr-pages/tldr/issues/4113) — present
 - **Lucas Schneider ([@schneiderl](https://github.com/schneiderl))**:
   [3 February 2021](https://github.com/tldr-pages/tldr/issues/5224) — present
 - Igor Shubovych ([@igorshubovych](https://github.com/igorshubovych)):


### PR DESCRIPTION
* Format all of the dates in the format '1 January 2021'
* Add @owenvoke and @mebeim to the collaborators section as emeritus
* Sort all entries by date
* Set all of the dates to the UTC date of the opening of the linked issue
* Minor wording adjustments