### PR TITLE
cowsay: fix commands for zsh

### DIFF
--- a/pages.it/common/cowsay.md
+++ b/pages.it/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - Stampa una mucca ASCII che dice "Hello world!":
 
-`cowsay "Hello world!"`
+`cowsay "Hello world\!"`
 
 - Usa il testo da standard input per il fumetto:
 
-`echo "Ciao!" | cowsay`
+`echo "Ciao\!" | cowsay`
 
 - Elenca tutti i personaggi disponibili:
 
@@ -17,7 +17,7 @@
 
 - Stampa un drago ASCII che dice "Ciao!":
 
-`cowsay -f dragon "Ciao!"`
+`cowsay -f dragon "Ciao\!"`
 
 - Stampa una mucca ASCII sballata che pensa:
 

--- a/pages.it/common/cowsay.md
+++ b/pages.it/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - Stampa una mucca ASCII che dice "Hello world!":
 
-`cowsay "Hello world\!"`
+`cowsay 'Hello world!'`
 
 - Usa il testo da standard input per il fumetto:
 
-`echo "Ciao\!" | cowsay`
+`echo 'Ciao!' | cowsay`
 
 - Elenca tutti i personaggi disponibili:
 
@@ -17,7 +17,7 @@
 
 - Stampa un drago ASCII che dice "Ciao!":
 
-`cowsay -f dragon "Ciao\!"`
+`cowsay -f dragon 'Ciao!'`
 
 - Stampa una mucca ASCII sballata che pensa:
 

--- a/pages.it/common/cowsay.md
+++ b/pages.it/common/cowsay.md
@@ -3,21 +3,21 @@
 > Genera un personaggio ASCII (di default una mucca) che dice o pensa qualcosa.
 > Maggiori informazioni: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- Stampa una mucca ASCII che dice "Hello world!":
+- Stampa una mucca ASCII che dice "Hello world":
 
-`cowsay 'Hello world!'`
+`cowsay 'Hello world'`
 
 - Usa il testo da standard input per il fumetto:
 
-`echo 'Ciao!' | cowsay`
+`echo 'Ciao' | cowsay`
 
 - Elenca tutti i personaggi disponibili:
 
 `cowsay -l`
 
-- Stampa un drago ASCII che dice "Ciao!":
+- Stampa un drago ASCII che dice "Ciao":
 
-`cowsay -f dragon 'Ciao!'`
+`cowsay -f dragon 'Ciao'`
 
 - Stampa una mucca ASCII sballata che pensa:
 

--- a/pages.it/common/cowsay.md
+++ b/pages.it/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - Stampa una mucca ASCII che dice "Hello world":
 
-`cowsay 'Hello world'`
+`cowsay "Hello world"`
 
 - Usa il testo da standard input per il fumetto:
 
-`echo 'Ciao' | cowsay`
+`echo "Ciao" | cowsay`
 
 - Elenca tutti i personaggi disponibili:
 
@@ -17,7 +17,7 @@
 
 - Stampa un drago ASCII che dice "Ciao":
 
-`cowsay -f dragon 'Ciao'`
+`cowsay -f dragon "Ciao"`
 
 - Stampa una mucca ASCII sballata che pensa:
 

--- a/pages.ko/common/cowsay.md
+++ b/pages.ko/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - "Hello world"라고 말하는 ASCII cow 출력:
 
-`cowsay 'Hello world'`
+`cowsay "Hello world"`
 
 - 풍선에 표준 입력의 텍스트 사용:
 
-`echo 'Hello' | cowsay`
+`echo "Hello" | cowsay`
 
 - 사용 가능한 모든 문자 나열:
 
@@ -17,7 +17,7 @@
 
 - "Hello"라고 말하는 ASCII dragon 출력:
 
-`cowsay -f dragon 'Hello'`
+`cowsay -f dragon "Hello"`
 
 - 돌로 된 생각하는 ASCII cow 출력:
 

--- a/pages.ko/common/cowsay.md
+++ b/pages.ko/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - "Hello world!"라고 말하는 ASCII cow 출력:
 
-`cowsay "Hello world!"`
+`cowsay "Hello world\!"`
 
 - 풍선에 표준 입력의 텍스트 사용:
 
-`echo "Hello!" | cowsay`
+`echo "Hello\!" | cowsay`
 
 - 사용 가능한 모든 문자 나열:
 
@@ -17,8 +17,8 @@
 
 - "Hello!"라고 말하는 ASCII dragon 출력:
 
-`cowsay -f dragon "Hello!"`
+`cowsay -f dragon "Hello\!"`
 
 - 돌로 된 생각하는 ASCII cow 출력:
 
-`cowthink -s "I'm just a cow, not a great thinker ..."`
+`cowthink -s "I'm just a cow, not a great thinker..."`

--- a/pages.ko/common/cowsay.md
+++ b/pages.ko/common/cowsay.md
@@ -3,21 +3,21 @@
 > 무언가를 말하거나 생각하는 ASCII 문자(기본적으로 cow)를 생성.
 > 더 많은 정보: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- "Hello world!"라고 말하는 ASCII cow 출력:
+- "Hello world"라고 말하는 ASCII cow 출력:
 
-`cowsay 'Hello world!'`
+`cowsay 'Hello world'`
 
 - 풍선에 표준 입력의 텍스트 사용:
 
-`echo 'Hello!' | cowsay`
+`echo 'Hello' | cowsay`
 
 - 사용 가능한 모든 문자 나열:
 
 `cowsay -l`
 
-- "Hello!"라고 말하는 ASCII dragon 출력:
+- "Hello"라고 말하는 ASCII dragon 출력:
 
-`cowsay -f dragon 'Hello!'`
+`cowsay -f dragon 'Hello'`
 
 - 돌로 된 생각하는 ASCII cow 출력:
 

--- a/pages.ko/common/cowsay.md
+++ b/pages.ko/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - "Hello world!"라고 말하는 ASCII cow 출력:
 
-`cowsay "Hello world\!"`
+`cowsay 'Hello world!'`
 
 - 풍선에 표준 입력의 텍스트 사용:
 
-`echo "Hello\!" | cowsay`
+`echo 'Hello!' | cowsay`
 
 - 사용 가능한 모든 문자 나열:
 
@@ -17,7 +17,7 @@
 
 - "Hello!"라고 말하는 ASCII dragon 출력:
 
-`cowsay -f dragon "Hello\!"`
+`cowsay -f dragon 'Hello!'`
 
 - 돌로 된 생각하는 ASCII cow 출력:
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -3,7 +3,7 @@
 > Generate an ASCII character (by default a cow) saying or thinking something.
 > More information: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- Print an ASCII cow saying "Hello world\!":
+- Print an ASCII cow saying `Hello world!`:
 
 `cowsay 'Hello world!'`
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -7,7 +7,7 @@
 
 `cowsay 'Hello world!'`
 
-- Use text from standard input for the balloon:
+- Read text from stdin for the balloon:
 
 `echo 'Hello!' | cowsay`
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -3,13 +3,13 @@
 > Generate an ASCII character (by default a cow) saying or thinking something.
 > More information: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- Print an ASCII cow saying `Hello world`:
+- Print an ASCII cow saying "Hello world":
 
-`cowsay 'Hello world'`
+`cowsay "Hello world"`
 
 - Read text from stdin for the balloon:
 
-`echo 'Hello' | cowsay`
+`echo "Hello" | cowsay`
 
 - List all available characters:
 
@@ -17,7 +17,7 @@
 
 - Print an ASCII dragon saying "Hello":
 
-`cowsay -f dragon 'Hello'`
+`cowsay -f dragon "Hello"`
 
 - Print a stoned thinking ASCII cow:
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -3,21 +3,21 @@
 > Generate an ASCII character (by default a cow) saying or thinking something.
 > More information: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- Print an ASCII cow saying `Hello world!`:
+- Print an ASCII cow saying `Hello world`:
 
-`cowsay 'Hello world!'`
+`cowsay 'Hello world'`
 
 - Read text from stdin for the balloon:
 
-`echo 'Hello!' | cowsay`
+`echo 'Hello' | cowsay`
 
 - List all available characters:
 
 `cowsay -l`
 
-- Print an ASCII dragon saying "Hello!":
+- Print an ASCII dragon saying "Hello":
 
-`cowsay -f dragon 'Hello!'`
+`cowsay -f dragon 'Hello'`
 
 - Print a stoned thinking ASCII cow:
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -5,11 +5,11 @@
 
 - Print an ASCII cow saying "Hello world\!":
 
-`cowsay "Hello world\!"`
+`cowsay 'Hello world!'`
 
 - Use text from standard input for the balloon:
 
-`echo "Hello\!" | cowsay`
+`echo 'Hello!' | cowsay`
 
 - List all available characters:
 
@@ -17,7 +17,7 @@
 
 - Print an ASCII dragon saying "Hello!":
 
-`cowsay -f dragon "Hello\!"`
+`cowsay -f dragon 'Hello!'`
 
 - Print a stoned thinking ASCII cow:
 

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -3,13 +3,13 @@
 > Generate an ASCII character (by default a cow) saying or thinking something.
 > More information: <https://github.com/tnalpgge/rank-amateur-cowsay>.
 
-- Print an ASCII cow saying "Hello world!":
+- Print an ASCII cow saying "Hello world\!":
 
-`cowsay "Hello world!"`
+`cowsay "Hello world\!"`
 
 - Use text from standard input for the balloon:
 
-`echo "Hello!" | cowsay`
+`echo "Hello\!" | cowsay`
 
 - List all available characters:
 
@@ -17,8 +17,8 @@
 
 - Print an ASCII dragon saying "Hello!":
 
-`cowsay -f dragon "Hello!"`
+`cowsay -f dragon "Hello\!"`
 
 - Print a stoned thinking ASCII cow:
 
-`cowthink -s "I'm just a cow, not a great thinker ..."`
+`cowthink -s "I'm just a cow, not a great thinker..."`


### PR DESCRIPTION
Fix commands that fail with `zsh` due to missing escaping for the exclamation mark:

	$ cowsay -f dragon "Hello!"
	dquote>

	$ uname -a
	Darwin **** 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64 x86_64

	$ echo $SHELL
	/bin/zsh

	$ cowsay -h
	cow{say,think} version 3.03, (c) 1999 Tony Monroe
	Usage: cowsay [-bdgpstwy] [-h] [-e eyes] [-f cowfile]
          [-l] [-n] [-T tongue] [-W wrapcolumn] [message]

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
