### PR TITLE
ansible: add list groups in an inventory example

### DIFF
--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -30,4 +30,4 @@
 
 - List the groups in an inventory:
 
-`ansible localhost -m debug -a 'var=groups.keys()'`
+`ansible localhost -m debug -a '{{var=groups.keys()}}'`

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -27,3 +27,7 @@
 - Execute a command using a custom inventory file:
 
 `ansible {{group}} -i {{inventory_file}} -m command -a '{{my_command}}'`
+
+- List the groups in an inventory:
+
+`ansible localhost -m debug -a 'var=groups.keys()'`


### PR DESCRIPTION
Add example to list groups in an inventory.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

