### PR TITLE
espanso: fix "edit config" command

### DIFF
--- a/pages/common/espanso.md
+++ b/pages/common/espanso.md
@@ -9,7 +9,7 @@
 
 - Edit the configuration:
 
-`espanso config`
+`espanso edit config`
 
 - Install a package from the hub store (<https://hub.espanso.org/>):
 


### PR DESCRIPTION
My bad, I introduced the wrong command in commit 46ae3bf76a2170ddf12ac508e1f71ec5b5cdbf41 (#5662). 😇

Before:

```sh
$ espanso config
error: Found argument 'config' which wasn't expected, or isn't valid in this context

USAGE:
espanso [FLAGS] [SUBCOMMAND]

For more information try --help
```

Now:
```sh
$ espanso edit config

Editing file: "/Users/nicolas/Library/Preferences/espanso/user/config.yml"
No file has been created, avoiding reload
```

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
