### PR TITLE
ssh: remove -C and use SOCKS port

### DIFF
--- a/pages.de/common/ssh.md
+++ b/pages.de/common/ssh.md
@@ -19,9 +19,9 @@
 
 `ssh {{externer_server}} {{befehl}}`
 
-- SSH Tunneln: Leite Ports dynamische Port weiter (SOCKS proxy auf localhost:9999):
+- SSH Tunneln: Leite Ports dynamische Port weiter (SOCKS proxy auf localhost:1080):
 
-`ssh -D {{9999}} -C {{benutzer}}@{{externer_server}}`
+`ssh -D {{1080}} {{benutzer}}@{{externer_server}}`
 
 - SSH Tunneln: Leite einen spezifischen Ports (localhost:9999 zu example.org:80) weiter zusammen mit deaktivierter pseudy-tty Provisionierung für die Ausführung eines Befehls:
 

--- a/pages.fr/common/ssh.md
+++ b/pages.fr/common/ssh.md
@@ -19,9 +19,9 @@
 
 `ssh {{hote_distant}} {{commande -avec -options}}`
 
-- Tunnel SSH : Transfert par port dynamique (le SOCKS proxy se trouve sur localhost:9999) :
+- Tunnel SSH : Transfert par port dynamique (le SOCKS proxy se trouve sur localhost:1080) :
 
-`ssh -D {{9999}} -C {{utilisateur}}@{{hote_distant}}`
+`ssh -D {{1080}} {{utilisateur}}@{{hote_distant}}`
 
 - Tunnel SSH : Transfère un port spécifique (localhost:9999 vers example.org:80) en désactivant l'allocation de pseudo-[t]ty et l'exécution de commandes distantes :
 

--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -19,9 +19,9 @@
 
 `ssh {{remote_host}} {{command -with -flags}}`
 
-- SSH tunneling: Dynamic port forwarding (SOCKS proxy on localhost:9999):
+- SSH tunneling: Dynamic port forwarding (SOCKS proxy on localhost:1080):
 
-`ssh -D {{9999}} -C {{username}}@{{remote_host}}`
+`ssh -D {{1080}} {{username}}@{{remote_host}}`
 
 - SSH tunneling: Forward a specific port (localhost:9999 to example.org:80) along with disabling pseudo-[t]ty allocation and executio[n] of remote commands:
 


### PR DESCRIPTION
- Edit the [D]ynamic port forwarding example to not use [C]ompression, which is only recommended for slow connections and doesn't help the user perform the task as described.
- Change the port from 9999 to the standard SOCKS proxy port of 1080 to align with other examples.

---

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
