### PR TITLE
pacman-files: fix typo

### DIFF
--- a/pages/linux/pacman-files.md
+++ b/pages/linux/pacman-files.md
@@ -21,7 +21,7 @@
 
 - List only the package names:
 
-`pacman --files --quite {{filename}}`
+`pacman --files --quiet {{filename}}`
 
 - List the files owned by a specific package:
 


### PR DESCRIPTION
Parameter --quite is almost certainly a typo. A correct form is --quiet.
This was tested before PR.
