### PR TITLE
atom, clear, convert, df: sync French translations with English pages

### DIFF
--- a/pages.fr/common/atom.md
+++ b/pages.fr/common/atom.md
@@ -24,6 +24,6 @@
 
 `atom --foreground`
 
-- Attendre la fermeture de la fenêtre avant de quitter (utile pour l'éditeur de commits Git) :
+- Attendre la fermeture de la fenêtre avant de quitter (utile pour l'éditeur de commits Git) :
 
 `atom --wait`

--- a/pages.fr/common/atom.md
+++ b/pages.fr/common/atom.md
@@ -16,10 +16,14 @@
 
 `atom --add {{chemin/vers/fichier_ou_dossier}}`
 
-- Ouvrir atom en mode sans-échec (les extensions ne seront pas chargées) :
+- Ouvrir en mode sans-échec (les extensions ne seront pas chargées) :
 
 `atom --safe`
 
-- Empêcher atom de se lancer en arrière-plan, en le forçant à s'attacher au terminal :
+- Empêcher Atom de se lancer en arrière-plan, en le forçant à s'attacher au terminal :
 
 `atom --foreground`
+
+- Attendre la fermeture de la fenêtre avant de quitter (utile pour l'éditeur de commits Git) :
+
+`atom --wait`

--- a/pages.fr/common/clear.md
+++ b/pages.fr/common/clear.md
@@ -5,3 +5,15 @@
 - Effacer l'écran (identique à la séquence Contrôle-L sur une interface bash) :
 
 `clear`
+
+- Effacer l'écran mais conserve le tampon de défilement du terminal :
+
+`clear -x`
+
+- Indiquer le type de terminal à effacer (utilise par défaut la variable d'environnement `TERM`) :
+
+`clear -T {{type_de_terminal}}`
+
+- Afficher la version de `ncurses` utilisée par `clear` :
+
+`clear -V`

--- a/pages.fr/common/clear.md
+++ b/pages.fr/common/clear.md
@@ -6,14 +6,14 @@
 
 `clear`
 
-- Effacer l'écran mais conserve le tampon de défilement du terminal :
+- Effacer l'écran mais conserve le tampon de défilement du terminal :
 
 `clear -x`
 
-- Indiquer le type de terminal à effacer (utilise par défaut la variable d'environnement `TERM`) :
+- Indiquer le type de terminal à effacer (utilise par défaut la variable d'environnement `TERM`) :
 
 `clear -T {{type_de_terminal}}`
 
-- Afficher la version de `ncurses` utilisée par `clear` :
+- Afficher la version de `ncurses` utilisée par `clear` :
 
 `clear -V`

--- a/pages.fr/common/convert.md
+++ b/pages.fr/common/convert.md
@@ -19,7 +19,7 @@
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} +append {{image123.png}}`
 
-- Coller plusieurs images verticalement :
+- Coller plusieurs images verticalement :
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} -append {{image123.png}}`
 

--- a/pages.fr/common/convert.md
+++ b/pages.fr/common/convert.md
@@ -19,6 +19,10 @@
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} +append {{image123.png}}`
 
+- Coller plusieurs images verticalement :
+
+`convert {{image1.png}} {{image2.png}} {{image3.png}} -append {{image123.png}}`
+
 - Créer un gif à partir d'une série d'images avec un délai de 100ms entre chaque :
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} -delay {{100}} {{animation.gif}}`

--- a/pages.fr/common/df.md
+++ b/pages.fr/common/df.md
@@ -18,3 +18,7 @@
 - Afficher des statistiques sur le nombre d'inodes disponibles :
 
 `df -i`
+
+- Afficher les systèmes de fichiers sauf ceux de types spécifiques :
+
+`df -x {{squashfs}} -x {{tmpfs}}`

--- a/pages.fr/common/df.md
+++ b/pages.fr/common/df.md
@@ -19,6 +19,6 @@
 
 `df -i`
 
-- Afficher les systèmes de fichiers sauf ceux de types spécifiques :
+- Afficher les systèmes de fichiers sauf ceux de types spécifiques :
 
 `df -x {{squashfs}} -x {{tmpfs}}`

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -19,6 +19,6 @@
 
 `df -i`
 
-- Display filesystems but exclude the specified type:
+- Display filesystems but exclude the specified types:
 
 `df -x {{squashfs}} -x {{tmpfs}}`


### PR DESCRIPTION
Fix a few `fr` warnings from https://lukwebsforge.github.io/tldri18n/.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
