### PR TITLE
virt-install: add --name option to example

### DIFF
--- a/pages/common/virt-install.md
+++ b/pages/common/virt-install.md
@@ -5,4 +5,4 @@
 
 - Create a virtual machine with 1 GiB RAM and 12 GiB storage and start Debian installation:
 
-`virt-install --memory {{1024}} --disk path={{path/to/image.qcow2}},size={{12}} --cdrom {{path/to/debian.iso}}`
+`virt-install --name {{vm_name}} --memory {{1024}} --disk path={{path/to/image.qcow2}},size={{12}} --cdrom {{path/to/debian.iso}}`


### PR DESCRIPTION
Running the existing example (on Ubuntu 20.04) gives the error message:

ERROR    
--name is required

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

