### PR TITLE
ansible: sync French translation with English page (list groups)

### DIFF
--- a/pages.fr/common/ansible.md
+++ b/pages.fr/common/ansible.md
@@ -20,10 +20,14 @@
 
 `ansible {{groupe}} -m command -a '{{ma_commande}}'`
 
-- Exécuter une commande avec des droits administreur :
+- Exécuter une commande avec des droits administrateur :
 
 `ansible {{groupe}} --become --ask-become-pass -m command -a '{{ma_commande}}'`
 
 - Exécuter une commande en utilisant un fichier d'inventaire personnalisé :
 
 `ansible {{groupe}} -i {{fichier_d'inventaire}} -m command -a '{{ma_commande}}'`
+
+- Lister les groupes d'un inventaire :
+
+`ansible localhost -m debug -a '{{var=groups.keys()}}'`


### PR DESCRIPTION
Should fix a `fr` warning from https://lukwebsforge.github.io/tldri18n/.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).