### PR TITLE
cp: sync French translations with English page (remove "--parents")

### DIFF
--- a/pages.fr/common/cp.md
+++ b/pages.fr/common/cp.md
@@ -26,7 +26,3 @@
 - Déréférencer les liens symboliques avant de copier :
 
 `cp -L {{link}} {{chemin/vers/répertoire_cible}}`
-
-- Copier en utilisant le chemin complet des fichiers source, en créant les répertoires intermédiaires manquants :
-
-`cp --parents {{source/chemin/vers/fichier}} {{chemin/vers/fichier_cible}}`


### PR DESCRIPTION
Should fix a `fr` warning from https://lukwebsforge.github.io/tldri18n/.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).