### PR TITLE
German pages: replace `Mehr Informationen` with `Weitere Informationen`

### DIFF
--- a/pages.de/common/7z.md
+++ b/pages.de/common/7z.md
@@ -1,7 +1,7 @@
 # 7z
 
 > Ein Dateiarchivierer mit hoher Komprimierungsrate.
-> Mehr Informationen: <https://www.7-zip.org/>.
+> Weitere Informationen: <https://www.7-zip.org/>.
 
 - Archiviere eine Datei oder ein Verzeichnis:
 

--- a/pages.de/common/7za.md
+++ b/pages.de/common/7za.md
@@ -2,7 +2,7 @@
 
 > Ein Dateiarchivierer mit hoher Kompressionsrate.
 > Eine alleinstehende Version von `7z` mit Unterstützung für neuere Archivtypen.
-> Mehr Informationen: <https://www.7-zip.org/>.
+> Weitere Informationen: <https://www.7-zip.org/>.
 
 - Archiviere eine Datei oder ein Verzeichnis:
 

--- a/pages.de/common/7zr.md
+++ b/pages.de/common/7zr.md
@@ -2,7 +2,7 @@
 
 > Ein Dateiarchivierer mit hoher Kompressionsrate.
 > Eine alleinstehende Version von `7z`, die nur .7z Dateien unterstützt.
-> Mehr Informationen: <https://www.7-zip.org/>.
+> Weitere Informationen: <https://www.7-zip.org/>.
 
 - Archiviere eine Datei oder ein Verzeichnis:
 

--- a/pages.de/common/aapt.md
+++ b/pages.de/common/aapt.md
@@ -2,7 +2,7 @@
 
 > Android Asset Packaging Tool.
 > Kompiliere und verpacke die Resourcen einer Android App.
-> Mehr Informationen: <https://elinux.org/Android_aapt>.
+> Weitere Informationen: <https://elinux.org/Android_aapt>.
 
 - Liste alle Dateien eines APK Archivs auf:
 

--- a/pages.de/common/ab.md
+++ b/pages.de/common/ab.md
@@ -1,7 +1,7 @@
 # ab
 
 > Apache HTTP server Benchmarking Tool.
-> Mehr Informationen: <https://httpd.apache.org/docs/current/programs/ab.html>.
+> Weitere Informationen: <https://httpd.apache.org/docs/current/programs/ab.html>.
 
 - Sende 100 HTTP GET Anfragen an eine URL:
 

--- a/pages.de/common/age.md
+++ b/pages.de/common/age.md
@@ -1,7 +1,7 @@
 # age
 
 > Ein einfaches, modernes und sicheres Dateiverschlüsselungswerkzeug.
-> Mehr Informationen: <https://age-encryption.org>.
+> Weitere Informationen: <https://age-encryption.org>.
 
 - Generiere eine verschlüsselte Datei, die mit einer Passphrase entschlüsselt werden kann:
 

--- a/pages.de/common/alacritty.md
+++ b/pages.de/common/alacritty.md
@@ -1,7 +1,7 @@
 # alacritty
 
 > Plattformübergreifender, GPU-beschleunigter Terminalemulator.
-> Mehr Informationen: <https://github.com/jwilm/alacritty>.
+> Weitere Informationen: <https://github.com/jwilm/alacritty>.
 
 - Öffne ein neues alacritty-Fenster:
 

--- a/pages.de/common/alias.md
+++ b/pages.de/common/alias.md
@@ -2,7 +2,7 @@
 
 > Erstellt Aliasse - Alterative Namen für Befehle.
 > Aliasse laufen mit der aktuellen Shell-Sitzung ab, es sei denn, sie werden in der Konfigurationsdatei der Shell definiert, z.B. `~/.bashrc`.
-> Mehr Informationen: <https://tldp.org/LDP/abs/html/aliases.html>.
+> Weitere Informationen: <https://tldp.org/LDP/abs/html/aliases.html>.
 
 - Listet alle Aliasse auf:
 

--- a/pages.de/common/ansible-galaxy.md
+++ b/pages.de/common/ansible-galaxy.md
@@ -1,7 +1,7 @@
 # ansible-galaxy
 
 > Mögliche Rollen erstellen und verwalten.
-> Mehr Informationen: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+> Weitere Informationen: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
 
 - Installiere eine Rolle:
 

--- a/pages.de/common/ansible-playbook.md
+++ b/pages.de/common/ansible-playbook.md
@@ -1,7 +1,7 @@
 # ansible-playbook
 
 > In Playbook definierte Aufgaben auf entfernten Rechnern über SSH ausführen.
-> Mehr Informationen: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+> Weitere Informationen: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
 
 - Führe Aufgaben im Playbook aus:
 

--- a/pages.de/common/ansible-vault.md
+++ b/pages.de/common/ansible-vault.md
@@ -1,7 +1,7 @@
 # ansible-vault
 
 > Verschlüsselt und entschlüsselt Werte, Datenstrukturen und Dateien innerhalb von Ansible-Projekten.
-> Mehr Informationen: <https://docs.ansible.com/ansible/latest/user_guide/vault.html>.
+> Weitere Informationen: <https://docs.ansible.com/ansible/latest/user_guide/vault.html>.
 
 - Erstelle eine neue verschlüsselte Vault-Datei mit einer Eingabeaufforderung für ein Passwort:
 

--- a/pages.de/common/ansible.md
+++ b/pages.de/common/ansible.md
@@ -2,7 +2,7 @@
 
 > Verwalte Computergruppen per Fernzugriff über SSH.
 > Verwende die Datei `/etc/ansible/hosts`, um neue Gruppen/Hosts hinzuzufügen.
-> Mehr Informationen: <https://www.ansible.com/>.
+> Weitere Informationen: <https://www.ansible.com/>.
 
 - Liste Hosts auf, die zu einer Gruppe gehören:
 

--- a/pages.de/common/atom.md
+++ b/pages.de/common/atom.md
@@ -2,7 +2,7 @@
 
 > Ein plattformübergreifender erweiterbarer Texteditor.
 > Erweiterungen werden durch `apm` verwaltet.
-> Mehr Informationen: <https://atom.io/>.
+> Weitere Informationen: <https://atom.io/>.
 
 - Öffne eine Datei oder ein Verzeichnis:
 

--- a/pages.de/common/avrdude.md
+++ b/pages.de/common/avrdude.md
@@ -1,7 +1,7 @@
 # avrdude
 
 > Treiberprogramm für Atmel AVR Mikrocontroller-Programmierung.
-> Mehr Informationen: <https://www.nongnu.org/avrdude/>.
+> Weitere Informationen: <https://www.nongnu.org/avrdude/>.
 
 - Schreibt den Speicherinhalt eines AVR-Mikrocontrollers in eine Datei:
 

--- a/pages.de/common/aws-ec2.md
+++ b/pages.de/common/aws-ec2.md
@@ -2,7 +2,7 @@
 
 > CLI für AWS EC2.
 > AWS EC2 stellt eine sichere und skalierbare Einheit in der AWS Cloud zur Verfügung um ein schnelleres Entwickeln und Ausrollen von Software zu ermöglichen.
-> Mehr Informationen: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
+> Weitere Informationen: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
 - Liste alle verfügbaren EC2 Befehle auf:
 

--- a/pages.de/common/aws-google-auth.md
+++ b/pages.de/common/aws-google-auth.md
@@ -1,7 +1,7 @@
 # aws-google-auth
 
 > CLI, um temporäre AWS credentials (STS) über Google Apps als Single Sign-On Dienstleister zu erhalten.
-> Mehr Informationen: <https://github.com/cevoaustralia/aws-google-auth>.
+> Weitere Informationen: <https://github.com/cevoaustralia/aws-google-auth>.
 
 - Einloggen mit Google SSO über IDP- und SP-Kennung für die Dauer einer Stunde:
 

--- a/pages.de/common/aws-iam.md
+++ b/pages.de/common/aws-iam.md
@@ -1,7 +1,7 @@
 # aws iam
 
 > CLI für AWS IAM.
-> Mehr Informationen: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/index.html>.
+> Weitere Informationen: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/index.html>.
 
 - Zeige die AWS IAM Hilfeseite (beinhaltet auch Hinweise für alle Unterbefehle):
 

--- a/pages.de/common/aws-kinesis.md
+++ b/pages.de/common/aws-kinesis.md
@@ -1,7 +1,7 @@
 # aws kinesis
 
 > Offizielles AWS CLI für die Amazon Kinesis-Streaming-Datenplattform.
-> Mehr Informationen: <https://docs.aws.amazon.com/cli/latest/reference/kinesis/index.html#cli-aws-kinesis>.
+> Weitere Informationen: <https://docs.aws.amazon.com/cli/latest/reference/kinesis/index.html#cli-aws-kinesis>.
 
 - Liste alle Streams auf:
 

--- a/pages.de/common/aws-quicksight.md
+++ b/pages.de/common/aws-quicksight.md
@@ -1,7 +1,7 @@
 # aws quicksight
 
 > CLI für AWS QuickSight.
-> Mehr Informationen: <https://docs.aws.amazon.com/cli/latest/reference/quicksight/>.
+> Weitere Informationen: <https://docs.aws.amazon.com/cli/latest/reference/quicksight/>.
 
 - Liste alle Datensätze auf:
 

--- a/pages.de/common/aws-s3.md
+++ b/pages.de/common/aws-s3.md
@@ -1,7 +1,7 @@
 # aws s3
 
 > CLI für AWS S3. AWS S3 stellt Speicherplatz in der Cloud zur Verfügung.
-> Mehr Informationen: <https://aws.amazon.com/cli>.
+> Weitere Informationen: <https://aws.amazon.com/cli>.
 
 - Liste alle Objekte in einem Bucket auf:
 

--- a/pages.de/common/aws-vault.md
+++ b/pages.de/common/aws-vault.md
@@ -1,7 +1,7 @@
 # aws-vault
 
 > Ein Tresor für Entwicklungsumgebungen um AWS Sicherheitsschlüssel sicher speichern und abrufen zu können.
-> Mehr Informationen: <https://github.com/99designs/aws-vault>.
+> Weitere Informationen: <https://github.com/99designs/aws-vault>.
 
 - Füge einen Sicherheitsschlüssel als Profil zu einem Tresor hinzu:
 

--- a/pages.de/common/aws.md
+++ b/pages.de/common/aws.md
@@ -2,7 +2,7 @@
 
 > Das offizielle CLI für Amazon Web Services.
 > Ausführungssassistent, SSO, Autovervollständigung von Ressourcen sowie YAML Optionen sind nur unter Version v2 verfügbar.
-> Mehr Informationen: <https://aws.amazon.com/cli>.
+> Weitere Informationen: <https://aws.amazon.com/cli>.
 
 - Konfiguriere die AWS Kommandozeile:
 

--- a/pages.de/common/awslogs.md
+++ b/pages.de/common/awslogs.md
@@ -1,7 +1,7 @@
 # awslogs
 
 > CLI um Log-Gruppen, Streams und Events von Amazon Cloudwatch Logs abzurufen.
-> Mehr Informationen: <https://github.com/jorgebastida/awslogs>.
+> Weitere Informationen: <https://github.com/jorgebastida/awslogs>.
 
 - Liste alle Log-Gruppen auf:
 

--- a/pages.de/common/basename.md
+++ b/pages.de/common/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 > Entfernt führende Verzeichniskomponenten in einem Pfad.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/basename>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/basename>.
 
 - Ermittle den Dateinamen in einem Pfad:
 

--- a/pages.de/common/bash.md
+++ b/pages.de/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell.
 > `sh`-kompatibler Kommandozeilen-Interpreter.
-> Mehr Informationen: <https://gnu.org/software/bash>.
+> Weitere Informationen: <https://gnu.org/software/bash>.
 
 - Interaktive Shell starten:
 

--- a/pages.de/common/borg.md
+++ b/pages.de/common/borg.md
@@ -2,7 +2,7 @@
 
 > Deduplizierendes Sicherungswerkzeug.
 > Erstellt lokale oder entfernte Sicherungen, die als Dateisysteme einhängbar sind.
-> Mehr Informationen: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
+> Weitere Informationen: <https://borgbackup.readthedocs.io/en/stable/usage/general.html>.
 
 - Initialisiere ein lokales Repository:
 

--- a/pages.de/common/cargo.md
+++ b/pages.de/common/cargo.md
@@ -2,7 +2,7 @@
 
 > Rust Paketmanager.
 > Verwalte Rust-Projekte und deren Abhängigkeiten (crates).
-> Mehr Informationen: <https://crates.io/>.
+> Weitere Informationen: <https://crates.io/>.
 
 - Suche nach Abhängigkeiten (crates):
 

--- a/pages.de/common/cd.md
+++ b/pages.de/common/cd.md
@@ -1,7 +1,7 @@
 # cd
 
 > Ändere das aktuelle Arbeitsverzeichnis.
-> Mehr Informationen: <https://man.archlinux.org/man/cd.n>.
+> Weitere Informationen: <https://man.archlinux.org/man/cd.n>.
 
 - Wechsle in das angegebene Verzeichnis:
 

--- a/pages.de/common/chmod.md
+++ b/pages.de/common/chmod.md
@@ -1,7 +1,7 @@
 # chmod
 
 > Ändere die Zugriffsberechtigungen einer Datei oder eines Verzeichnisses.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/chmod>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/chmod>.
 
 - Gib dem Besitzer einer Datei ([u]ser) das Recht, sie auszuführen (e[x]ecute):
 

--- a/pages.de/common/chown.md
+++ b/pages.de/common/chown.md
@@ -1,7 +1,7 @@
 # chown
 
 > Ändere den Besitzer und die Besitzergruppe von Dateien und Verzeichnissen.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/chown>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/chown>.
 
 - Ändere den Besitzer einer Datei/eines Verzeichnisses:
 

--- a/pages.de/common/chromium.md
+++ b/pages.de/common/chromium.md
@@ -1,7 +1,7 @@
 # chromium
 
 > Open-Source-Webbrowser von Google.
-> Mehr Informationen: <https://chromium.org>.
+> Weitere Informationen: <https://chromium.org>.
 
 - Öffne eine html-Datei:
 

--- a/pages.de/common/chroot.md
+++ b/pages.de/common/chroot.md
@@ -1,7 +1,7 @@
 # chroot
 
 > Führe einen Befehl oder eine interaktive Shell mit einem speziellen root-Verzeichnis aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/chroot>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/chroot>.
 
 - Führe einen Befehl mit einem neuen root-Verzeichnis aus:
 

--- a/pages.de/common/chsh.md
+++ b/pages.de/common/chsh.md
@@ -1,7 +1,7 @@
 # chsh
 
 > Ändere die Login-Shell eines Benutzers.
-> Mehr Informationen: <https://manned.org/chsh>.
+> Weitere Informationen: <https://manned.org/chsh>.
 
 - Ändere die Login-Shell eines Benutzers:
 

--- a/pages.de/common/clear.md
+++ b/pages.de/common/clear.md
@@ -1,7 +1,7 @@
 # clear
 
 > Leert den Bildschirm eines Terminals.
-> Mehr Informationen: <https://manned.org/clear>.
+> Weitere Informationen: <https://manned.org/clear>.
 
 - Leere den Bildschirm (äquivalent zu Strg+L in einer Bash Shell):
 

--- a/pages.de/common/cmake.md
+++ b/pages.de/common/cmake.md
@@ -1,7 +1,7 @@
 # cmake
 
 > Plattformübergreifndes Build-Automatisierungs-System, das Vorlagen für native Build-Systeme erzeugt.
-> Mehr Informationen: <https://cmake.org/cmake/help/latest/manual/cmake.1.html>.
+> Weitere Informationen: <https://cmake.org/cmake/help/latest/manual/cmake.1.html>.
 
 - Erzeuge eine Build-Vorlage im aktuellen Verzeichnis mit `CMakeLists.txt` eines Projektordners:
 

--- a/pages.de/common/code.md
+++ b/pages.de/common/code.md
@@ -1,7 +1,7 @@
 # code
 
 > Visual Studio Code.
-> Mehr Informationen: <https://github.com/microsoft/vscode>.
+> Weitere Informationen: <https://github.com/microsoft/vscode>.
 
 - Öffne VS Code:
 

--- a/pages.de/common/compare.md
+++ b/pages.de/common/compare.md
@@ -1,7 +1,7 @@
 # compare
 
 > Zeige Unterschiede von zwei Bildern.
-> Mehr Informationen: <https://imagemagick.org/script/compare.php>.
+> Weitere Informationen: <https://imagemagick.org/script/compare.php>.
 
 - Vergleiche 2 Bilder:
 

--- a/pages.de/common/convert.md
+++ b/pages.de/common/convert.md
@@ -1,7 +1,7 @@
 # convert
 
 > Imagemagick Bildkonvertierungswerkzeug.
-> Mehr Informationen: <https://imagemagick.org/script/convert.php>.
+> Weitere Informationen: <https://imagemagick.org/script/convert.php>.
 
 - Konvertiere ein Bild von JPG nach PNG:
 

--- a/pages.de/common/cp.md
+++ b/pages.de/common/cp.md
@@ -1,7 +1,7 @@
 # cp
 
 > Kopiere Dateien und Verzeichnisse.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/cp>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/cp>.
 
 - Kopiere eine Datei an einen anderen Ort:
 

--- a/pages.de/common/cradle-deploy.md
+++ b/pages.de/common/cradle-deploy.md
@@ -1,7 +1,7 @@
 # cradle deploy
 
 > Verwalte Cradle Implementierungen.
-> Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#deploy>.
+> Weitere Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#deploy>.
 
 - Implementiere Cradle auf einem Server:
 

--- a/pages.de/common/cradle-elastic.md
+++ b/pages.de/common/cradle-elastic.md
@@ -1,7 +1,7 @@
 # cradle elastic
 
 > Verwalte ElasticSearch Instanzen einer Cradle Instanz.
-> Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#elastic>.
+> Weitere Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#elastic>.
 
 - Entleere den ElasticSearch Index:
 

--- a/pages.de/common/cradle-install.md
+++ b/pages.de/common/cradle-install.md
@@ -1,7 +1,7 @@
 # cradle install
 
 > Installiere Cradle PHP Framework Komponenten.
-> Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#install>.
+> Weitere Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#install>.
 
 - Installiere Cradle Komponenten mithilfe eines Dialogs:
 

--- a/pages.de/common/cradle-package.md
+++ b/pages.de/common/cradle-package.md
@@ -1,7 +1,7 @@
 # cradle package
 
 > Verwalte Pakete für Cradle Instanzen.
-> Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#package>.
+> Weitere Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#package>.
 
 - Liste aller verfügbaren Pakete auf:
 

--- a/pages.de/common/cradle-sql.md
+++ b/pages.de/common/cradle-sql.md
@@ -1,7 +1,7 @@
 # cradle sql
 
 > Verwalte Cradle SQL Datenbanken.
-> Mehr Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#sql>.
+> Weitere Informationen: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#sql>.
 
 - Generiere ein neues Datenbank-Schema:
 

--- a/pages.de/common/cradle.md
+++ b/pages.de/common/cradle.md
@@ -2,7 +2,7 @@
 
 > Das Cradle PHP Framework.
 > Siehe `cradle-install`, `cradle-deploy`, etc. für zusätzliche Informationen.
-> Mehr Informationen: <https://cradlephp.github.io>.
+> Weitere Informationen: <https://cradlephp.github.io>.
 
 - Stelle eine Verbindung zu einem Server her:
 

--- a/pages.de/common/csvsql.md
+++ b/pages.de/common/csvsql.md
@@ -2,7 +2,7 @@
 
 > Generiere SQL-Anweisungen für eine CSV-Datei oder führe diese Anweisungen direkt in einer Datenbank aus.
 > Teil von csvkit.
-> Mehr Informationen: <https://csvkit.readthedocs.io/en/latest/scripts/csvsql.html>.
+> Weitere Informationen: <https://csvkit.readthedocs.io/en/latest/scripts/csvsql.html>.
 
 - Generiere eine `CREATE TABLE`-SQL-Anweisung für eine CSV-Datei:
 

--- a/pages.de/common/curl.md
+++ b/pages.de/common/curl.md
@@ -2,7 +2,7 @@
 
 > Überträgt Daten von oder zu einem Server.
 > Unterstützt die meisten Protokolle, inklusive HTTP, FTP und POP3.
-> Mehr Informationen: <https://curl.se>.
+> Weitere Informationen: <https://curl.se>.
 
 - Lade den Inhalt einer URL in eine Datei:
 

--- a/pages.de/common/cut.md
+++ b/pages.de/common/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > Schneide Felder von stdin oder einer Datei aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/cut>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/cut>.
 
 - Schneide die ersten 16 Zeichen jeder Zeile von stdin aus:
 

--- a/pages.de/common/dd.md
+++ b/pages.de/common/dd.md
@@ -1,7 +1,7 @@
 # dd
 
 > Konvertiere und kopiere eine Datei.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/dd>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/dd>.
 
 - Erstelle ein bootbares USB-Laufwerk von einer isohybriden Datei (wie `archlinux-xxxx.iso`) und zeige den Fortschritt an:
 

--- a/pages.de/common/diff.md
+++ b/pages.de/common/diff.md
@@ -1,7 +1,7 @@
 # diff
 
 > Vergleiche Dateien und Verzeichnisse.
-> Mehr Informationen: <https://man7.org/linux/man-pages/man1/diff.1.html>.
+> Weitere Informationen: <https://man7.org/linux/man-pages/man1/diff.1.html>.
 
 - Vergleiche Dateien (Listet jene Veränderungen auf, mit denen `datei1` zu `datei2` wird):
 

--- a/pages.de/common/docker.md
+++ b/pages.de/common/docker.md
@@ -1,7 +1,7 @@
 # docker
 
 > Verwalte Docker Container und Images.
-> Mehr Informationen: <https://docs.docker.com/engine/reference/commandline/cli/>.
+> Weitere Informationen: <https://docs.docker.com/engine/reference/commandline/cli/>.
 
 - Liste zur Zeit laufende Container auf:
 

--- a/pages.de/common/dotnet.md
+++ b/pages.de/common/dotnet.md
@@ -1,7 +1,7 @@
 # dotnet
 
 > Plattformübergreifende Kommandozeilenandwendungen für .NET Core.
-> Mehr Informationen: <https://docs.microsoft.com/dotnet/core/tools/>.
+> Weitere Informationen: <https://docs.microsoft.com/dotnet/core/tools/>.
 
 - Initialisiere ein neues .NET Projekt:
 

--- a/pages.de/common/echo.md
+++ b/pages.de/common/echo.md
@@ -1,7 +1,7 @@
 # echo
 
 > Gib angegebene Argumente aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/echo>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/echo>.
 
 - Gib einen Text aus. (Hinweis: Anführungszeichen sind optional):
 

--- a/pages.de/common/emacs.md
+++ b/pages.de/common/emacs.md
@@ -1,7 +1,7 @@
 # emacs
 
 > Der erweiterbare, veränderbare und selbst-dokumentierende Echtzeit Text Editor.
-> Mehr Informationen: <https://www.gnu.org/software/emacs>.
+> Weitere Informationen: <https://www.gnu.org/software/emacs>.
 
 - Starte Emacs in der Konsole (ohne X-Fenster):
 

--- a/pages.de/common/emacsclient.md
+++ b/pages.de/common/emacsclient.md
@@ -1,7 +1,7 @@
 # emacsclient
 
 > Öffnet Dateien in einem laufenden Emacs Server.
-> Mehr Informationen: <https://www.emacswiki.org/emacs/EmacsClient>.
+> Weitere Informationen: <https://www.emacswiki.org/emacs/EmacsClient>.
 
 - Öffne eine Datei (direkt in der GUI wenn möglich):
 

--- a/pages.de/common/exa.md
+++ b/pages.de/common/exa.md
@@ -1,7 +1,7 @@
 # exa
 
 > Ein moderner Ersatz für `ls` (Verzeichnisinhalte auflisten).
-> Mehr Informationen: <https://the.exa.website>.
+> Weitere Informationen: <https://the.exa.website>.
 
 - Liste eine Datei pro Zeile auf:
 

--- a/pages.de/common/fdroid.md
+++ b/pages.de/common/fdroid.md
@@ -2,7 +2,7 @@
 
 > F-Droid Build Tool.
 > F-Droid ist ein installierbarer Katalog mit FOSS (Freie Open Source Software) Apps für Android.
-> Mehr Informationen: <https://f-droid.org/>.
+> Weitere Informationen: <https://f-droid.org/>.
 
 - Kompiliere eine bestimmte App:
 

--- a/pages.de/common/fdroidcl.md
+++ b/pages.de/common/fdroidcl.md
@@ -1,7 +1,7 @@
 # fdroidcl
 
 > F-Droid CLI (Command Line Interface) Client.
-> Mehr Informationen: <https://github.com/mvdan/fdroidcl>.
+> Weitere Informationen: <https://github.com/mvdan/fdroidcl>.
 
 - Aktualisiere den Index:
 

--- a/pages.de/common/ffmpeg.md
+++ b/pages.de/common/ffmpeg.md
@@ -1,7 +1,7 @@
 # ffmpeg
 
 > Programm zum konvertieren von Videos.
-> Mehr Informationen: <https://ffmpeg.org>.
+> Weitere Informationen: <https://ffmpeg.org>.
 
 - Extrahiere den Ton eines Videos und speichere ihn als MP3:
 

--- a/pages.de/common/ffprobe.md
+++ b/pages.de/common/ffprobe.md
@@ -1,7 +1,7 @@
 # ffprobe
 
 > Multimedia Stream Analysierer.
-> Mehr Informationen: <https://ffmpeg.org/ffprobe.html>.
+> Weitere Informationen: <https://ffmpeg.org/ffprobe.html>.
 
 - Zeige alle verfügbaren Stream-Informationen einer Medien-Datei an:
 

--- a/pages.de/common/ffsend.md
+++ b/pages.de/common/ffsend.md
@@ -1,7 +1,7 @@
 # ffsend
 
 > Teile Dateien einfach und sicher in der Command Line.
-> Mehr Informationen: <https://gitlab.com/timvisee/ffsend>.
+> Weitere Informationen: <https://gitlab.com/timvisee/ffsend>.
 
 - Lade eine Datei hoch:
 

--- a/pages.de/common/fg.md
+++ b/pages.de/common/fg.md
@@ -1,7 +1,7 @@
 # fg
 
 > Bringt Prozesse in den Vordergrund.
-> Mehr Informationen: <https://manned.org/fg>.
+> Weitere Informationen: <https://manned.org/fg>.
 
 - Bringe zuletzt suspendierten Prozess in den Vordergrund:
 

--- a/pages.de/common/firefox.md
+++ b/pages.de/common/firefox.md
@@ -1,7 +1,7 @@
 # firefox
 
 > Ein gratis Open Source Internet Browser.
-> Mehr Informationen: <https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options>.
+> Weitere Informationen: <https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options>.
 
 - Starte Firefox und öffne eine Website:
 

--- a/pages.de/common/fish.md
+++ b/pages.de/common/fish.md
@@ -2,7 +2,7 @@
 
 > The Friendly Interactive SHell.
 > Eine benutzerfreundliche Eingabeaufforderung.
-> Mehr Informationen: <https://fishshell.com>.
+> Weitere Informationen: <https://fishshell.com>.
 
 - Starte fish:
 

--- a/pages.de/common/fortune.md
+++ b/pages.de/common/fortune.md
@@ -1,7 +1,7 @@
 # fortune
 
 > Gib ein zufälliges Glückskeks-Zitat aus.
-> Mehr Informationen: <https://man.archlinux.org/man/fortune.6>.
+> Weitere Informationen: <https://man.archlinux.org/man/fortune.6>.
 
 - Gib ein Zitat aus:
 

--- a/pages.de/common/fuck.md
+++ b/pages.de/common/fuck.md
@@ -1,7 +1,7 @@
 # fuck
 
 > Korrigiert den zuletzt ausgeführten Befehl.
-> Mehr Informationen: <https://github.com/nvbn/thefuck>.
+> Weitere Informationen: <https://github.com/nvbn/thefuck>.
 
 - Lege den `fuck` alias für `thefuck` fest:
 

--- a/pages.de/common/g++.md
+++ b/pages.de/common/g++.md
@@ -2,7 +2,7 @@
 
 > Kompiliere C++ Quelldateien.
 > Teil der GCC (GNU Compiler Collection).
-> Mehr Informationen: <https://gcc.gnu.org>.
+> Weitere Informationen: <https://gcc.gnu.org>.
 
 - Kompiliere eine Quelldatei in eine ausführbare Binärdatei:
 

--- a/pages.de/common/gcc.md
+++ b/pages.de/common/gcc.md
@@ -1,7 +1,7 @@
 # gcc
 
 > Präprozessiert und kompiliert C und C++ Quellcodedateien und linkt diese anschließend zusammen.
-> Mehr Informationen: <https://gcc.gnu.org>.
+> Weitere Informationen: <https://gcc.gnu.org>.
 
 - Kompiliere mehrere Quellcodedateien zu einer ausführbaren Datei:
 

--- a/pages.de/common/gdb.md
+++ b/pages.de/common/gdb.md
@@ -1,7 +1,7 @@
 # gdb
 
 > Der GNU Debugger.
-> Mehr Informationen: <https://www.gnu.org/software/gdb>.
+> Weitere Informationen: <https://www.gnu.org/software/gdb>.
 
 - Debugge eine ausführbare Datei:
 

--- a/pages.de/common/git-add.md
+++ b/pages.de/common/git-add.md
@@ -1,7 +1,7 @@
 # git add
 
 > Füge Dateien zum Index/Stage hinzu.
-> Mehr Informationen: <https://git-scm.com/docs/git-add>.
+> Weitere Informationen: <https://git-scm.com/docs/git-add>.
 
 - Füge eine bestimmte Datei zum Index/Stage hinzu:
 

--- a/pages.de/common/git-am.md
+++ b/pages.de/common/git-am.md
@@ -2,7 +2,7 @@
 
 > Patch-Dateien integrieren. Nützlich beim Empfang von Commits per E-Mail.
 > Siehe auch `git format-patch` zur Erzeugung von Patch-Dateien.
-> Mehr Informationen: <https://git-scm.com/docs/git-am>.
+> Weitere Informationen: <https://git-scm.com/docs/git-am>.
 
 - Integriere eine Patch-Datei:
 

--- a/pages.de/common/git-apply.md
+++ b/pages.de/common/git-apply.md
@@ -1,7 +1,7 @@
 # git apply
 
 > Integriere eine Patch-Datei und/oder füge sie zum Index/Stage hinzu.
-> Mehr Informationen: <https://git-scm.com/docs/git-apply>.
+> Weitere Informationen: <https://git-scm.com/docs/git-apply>.
 
 - Gib Meldungen über eine gepatchten Datei aus:
 

--- a/pages.de/common/git-archive.md
+++ b/pages.de/common/git-archive.md
@@ -1,7 +1,7 @@
 # git archive
 
 > Erstelle ein Archiv von Dateien.
-> Mehr Informationen: <https://git-scm.com/docs/git-archive>.
+> Weitere Informationen: <https://git-scm.com/docs/git-archive>.
 
 - Erstelle ein tar-Archiv aus dem Inhalt des aktuellen HEAD und gib dieses aus:
 

--- a/pages.de/common/git-bisect.md
+++ b/pages.de/common/git-bisect.md
@@ -2,7 +2,7 @@
 
 > Benuzt binäre Suche um den commit ausfindig zu machen, welcher einen Fehler beinhaltet.
 > Git springt im Commit-Graph automatisch vor und zurück, um den fehlerhaften Commit schrittweise einzugrenzen zu können.
-> Mehr Informationen: <https://git-scm.com/docs/git-bisect>.
+> Weitere Informationen: <https://git-scm.com/docs/git-bisect>.
 
 - Starte eine Bisect-Session in einem Commit-Bereich, der durch einen bekannten fehlerhaften Commit und einen sauberen Commit begrenzt wird:
 

--- a/pages.de/common/git-blame.md
+++ b/pages.de/common/git-blame.md
@@ -1,7 +1,7 @@
 # git blame
 
 > Zeige den Commit-Hash und den letzten Autor jeder Zeile einer Datei.
-> Mehr Informationen: <https://git-scm.com/docs/git-blame>.
+> Weitere Informationen: <https://git-scm.com/docs/git-blame>.
 
 - Gib die Commit-Hashes und dem Autor jeder Zeile einer Datei aus:
 

--- a/pages.de/common/git-branch.md
+++ b/pages.de/common/git-branch.md
@@ -1,7 +1,7 @@
 # git branch
 
 > Verwalte und Arbeite mit Git Branches.
-> Mehr Informationen: <https://git-scm.com/docs/git-branch>.
+> Weitere Informationen: <https://git-scm.com/docs/git-branch>.
 
 - Liste alle lokalen Branches auf. Der momentan aktive (ausgecheckte) Branch wird mit `*` markiert:
 

--- a/pages.de/common/git-clone.md
+++ b/pages.de/common/git-clone.md
@@ -1,7 +1,7 @@
 # git clone
 
 > Klone ein existierendes Repository.
-> Mehr Informationen: <https://git-scm.com/docs/git-clone>.
+> Weitere Informationen: <https://git-scm.com/docs/git-clone>.
 
 - Klone ein existierendes Repository:
 

--- a/pages.de/common/git-commit.md
+++ b/pages.de/common/git-commit.md
@@ -1,7 +1,7 @@
 # git commit
 
 > Committe Dateien in ein Repository.
-> Mehr Informationen: <https://git-scm.com/docs/git-commit>.
+> Weitere Informationen: <https://git-scm.com/docs/git-commit>.
 
 - Committe gestagten Dateien zum Repository mit einer Nachricht:
 

--- a/pages.de/common/git-fetch.md
+++ b/pages.de/common/git-fetch.md
@@ -1,7 +1,7 @@
 # git fetch
 
 > Lade Objekte und Referenzen (refs) von einem entfernten Repository.
-> Mehr Informationen: <https://git-scm.com/docs/git-fetch>.
+> Weitere Informationen: <https://git-scm.com/docs/git-fetch>.
 
 - Hole die neusten Änderungen von dem standardmäßigen Repository im Upstream (wenn gesetzt):
 

--- a/pages.de/common/git-help.md
+++ b/pages.de/common/git-help.md
@@ -1,7 +1,7 @@
 # git help
 
 > Zeige Hilfe für Git an.
-> Mehr Informationen: <https://git-scm.com/docs/git-help>.
+> Weitere Informationen: <https://git-scm.com/docs/git-help>.
 
 - Zeige Hilfe für einen bestimmten Git-Unterbefehl an:
 

--- a/pages.de/common/git-ignore.md
+++ b/pages.de/common/git-ignore.md
@@ -1,7 +1,7 @@
 # git ignore
 
 > Erstelle `.gitignore` Dateien aus vorgefertigten Vorlagen.
-> Mehr Informationen: <https://docs.gitignore.io/install/command-line>.
+> Weitere Informationen: <https://docs.gitignore.io/install/command-line>.
 
 - Liste alle verfügbaren Vorlagen auf:
 

--- a/pages.de/common/git-init.md
+++ b/pages.de/common/git-init.md
@@ -1,7 +1,7 @@
 # git init
 
 > Erstelle eine neues lokales Git-Repository.
-> Mehr Informationen: <https://git-scm.com/docs/git-init>.
+> Weitere Informationen: <https://git-scm.com/docs/git-init>.
 
 - Erstelle eine neues lokales Repository:
 

--- a/pages.de/common/git-log.md
+++ b/pages.de/common/git-log.md
@@ -1,7 +1,7 @@
 # git log
 
 > Zeigt die Commit-Historie an.
-> Mehr Informationen: <https://git-scm.com/docs/git-log>.
+> Weitere Informationen: <https://git-scm.com/docs/git-log>.
 
 - Zeige die Sequenz der Commits des Git-Repository im aktuellen Verzeichnis, beginnend mit dem aktuellen, an.
 

--- a/pages.de/common/git-pull.md
+++ b/pages.de/common/git-pull.md
@@ -1,7 +1,7 @@
 # git pull
 
 > Hole Branches von einem entfernten Repository und binde sie in das lokale Repository ein.
-> Mehr Informationen: <https://git-scm.com/docs/git-pull>.
+> Weitere Informationen: <https://git-scm.com/docs/git-pull>.
 
 - Lade Änderungen vom Standard-Repository herunter und führe diese zusammen:
 

--- a/pages.de/common/git-push.md
+++ b/pages.de/common/git-push.md
@@ -1,7 +1,7 @@
 # git push
 
 > Lade Commits in ein Remote-Repository hoch.
-> Mehr Informationen: <https://git-scm.com/docs/git-push>.
+> Weitere Informationen: <https://git-scm.com/docs/git-push>.
 
 - Sende lokale Änderungen des aktuellen Branches zu seinem entfernten Repository (Remote Branch):
 

--- a/pages.de/common/git-remote.md
+++ b/pages.de/common/git-remote.md
@@ -1,7 +1,7 @@
 # git remote
 
 > Verwalte eine gewisse Anzahl an Repositories (remotes).
-> Mehr Informationen: <https://git-scm.com/docs/git-remote>.
+> Weitere Informationen: <https://git-scm.com/docs/git-remote>.
 
 - Liste alle existierenden Remotes, ihre Namen und ihre URLs auf:
 

--- a/pages.de/common/git-rm.md
+++ b/pages.de/common/git-rm.md
@@ -1,7 +1,7 @@
 # git rm
 
 > Entferne Dateien aus dem Index des Repositories und vom lokalen Dateisystem.
-> Mehr Informationen: <https://git-scm.com/docs/git-rm>.
+> Weitere Informationen: <https://git-scm.com/docs/git-rm>.
 
 - Entferne eine Datei aus dem Index und vom lokalen Dateisystem:
 

--- a/pages.de/common/git-status.md
+++ b/pages.de/common/git-status.md
@@ -1,7 +1,7 @@
 # git status
 
 > Zeige die Änderungen an Dateien in einem Git-Repository an.
-> Mehr Informationen: <https://git-scm.com/docs/git-status>.
+> Weitere Informationen: <https://git-scm.com/docs/git-status>.
 
 - Zeige veränderte Dateien an, die noch nicht für den Commit hinzugefügt wurden:
 

--- a/pages.de/common/git-switch.md
+++ b/pages.de/common/git-switch.md
@@ -2,7 +2,7 @@
 
 > Wechsle zwischen Branches. Verfügbar ab Git Version 2.23+.
 > Siehe auch `git checkout`.
-> Mehr Informationen: <https://git-scm.com/docs/git-switch>.
+> Weitere Informationen: <https://git-scm.com/docs/git-switch>.
 
 - Wechsle zu einem existierenden Branch:
 

--- a/pages.de/common/git-tag.md
+++ b/pages.de/common/git-tag.md
@@ -1,7 +1,7 @@
 # git tag
 
 > Erstelle, lösche, überprüfe und liste Tags auf.
-> Mehr Informationen: <https://git-scm.com/docs/git-tag>.
+> Weitere Informationen: <https://git-scm.com/docs/git-tag>.
 
 - Liste alle Tags auf:
 

--- a/pages.de/common/git.md
+++ b/pages.de/common/git.md
@@ -1,7 +1,7 @@
 # git
 
 > Verteiltes Versionskontrollsystem.
-> Mehr Informationen: <https://git-scm.com/>.
+> Weitere Informationen: <https://git-scm.com/>.
 
 - Gib die installierte Git Version aus:
 

--- a/pages.de/common/gpg.md
+++ b/pages.de/common/gpg.md
@@ -1,7 +1,7 @@
 # gpg
 
 > GNU Privacy Guard.
-> Mehr Informationen: <https://gnupg.org>.
+> Weitere Informationen: <https://gnupg.org>.
 
 - Signiere `doc.txt` ohne Verschlüsselung (Ausabe nach `doc.txt.asc`):
 

--- a/pages.de/common/gpg2.md
+++ b/pages.de/common/gpg2.md
@@ -2,7 +2,7 @@
 
 > GNU Privacy Guard 2.
 > Siehe `gpg` für GNU Privacy Guard 1.
-> Mehr Informationen: <https://docs.releng.linuxfoundation.org/en/latest/gpg.html>.
+> Weitere Informationen: <https://docs.releng.linuxfoundation.org/en/latest/gpg.html>.
 
 - Liste alle importierten Schlüssel auf:
 

--- a/pages.de/common/grep.md
+++ b/pages.de/common/grep.md
@@ -2,7 +2,7 @@
 
 > Findet Ausdrücke in einem Eingabetext.
 > Unterstützt einfache Muster und reguläre Ausdrücke.
-> Mehr Informationen: <https://www.gnu.org/software/grep/manual/grep.html>.
+> Weitere Informationen: <https://www.gnu.org/software/grep/manual/grep.html>.
 
 - Suche nach einem Ausdruck in einer Datei:
 

--- a/pages.de/common/latex.md
+++ b/pages.de/common/latex.md
@@ -1,7 +1,7 @@
 # latex
 
 > Kompiliere eine LaTeX Quelldatei in ein DVI Dokument.
-> Mehr Informationen: <https://www.latex-project.org>.
+> Weitere Informationen: <https://www.latex-project.org>.
 
 - Kompiliere ein DVI Dokument:
 

--- a/pages.de/common/lolcat.md
+++ b/pages.de/common/lolcat.md
@@ -1,7 +1,7 @@
 # lolcat
 
 > Färbe Text in Regenbogenfarben ein.
-> Mehr Informationen: <https://github.com/busyloop/lolcat>.
+> Weitere Informationen: <https://github.com/busyloop/lolcat>.
 
 - Gib den Inhalt einer Datei in Regenbogenfarben in der Konsole aus:
 

--- a/pages.de/common/ls.md
+++ b/pages.de/common/ls.md
@@ -1,7 +1,7 @@
 # ls
 
 > Liste den Inhalt eines Verzeichnisses auf.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/ls>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/ls>.
 
 - Liste den Inhalt in einer Datei pro Zeile auf:
 

--- a/pages.de/common/minisign.md
+++ b/pages.de/common/minisign.md
@@ -1,7 +1,7 @@
 # minisign
 
 > Ein denkbar einfaches Werkzeug um Dateien zu signieren und Signaturen zu verifizieren.
-> Mehr Informationen: <https://jedisct1.github.io/minisign/>.
+> Weitere Informationen: <https://jedisct1.github.io/minisign/>.
 
 - Generiere ein neues Schlüsselpaar im Standardpfad:
 

--- a/pages.de/common/mv.md
+++ b/pages.de/common/mv.md
@@ -1,7 +1,7 @@
 # mv
 
 > Verschiebe Dateien oder Verzeichnisse oder benenne diese um.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/mv>
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/mv>
 
 - Verschiebe eine Dateien an einen beliebigen Ort:
 

--- a/pages.de/common/nativefier.md
+++ b/pages.de/common/nativefier.md
@@ -1,7 +1,7 @@
 # nativefier
 
 > Befehlszeilen-Tool zum Erstellen einer Desktop-Anwendung für jede Website mit minimaler Konfiguration.
-> Mehr Informationen: <https://github.com/jiahaog/nativefier>.
+> Weitere Informationen: <https://github.com/jiahaog/nativefier>.
 
 - Erstelle einer Desktop-Anwendung für eine Website:
 

--- a/pages.de/common/npm.md
+++ b/pages.de/common/npm.md
@@ -1,7 +1,7 @@
 # npm
 
 > Ein Kommandozeilenwerkzeug für die Verwaltung von Javascript und Node.js Paketen (Packages).
-> Mehr Informationen: <https://www.npmjs.com>.
+> Weitere Informationen: <https://www.npmjs.com>.
 
 - Erstelle eine `package.json` Datei interaktiv:
 

--- a/pages.de/common/pass.md
+++ b/pages.de/common/pass.md
@@ -2,7 +2,7 @@
 
 > Programm zum Speichern und Lesen von Passwörtern und anderen sensiblen Daten.
 > Die Daten sind mit GPG verschlüsselt und werden mit einem Git repository verwaltet.
-> Mehr Informationen: <https://www.passwordstore.org>.
+> Weitere Informationen: <https://www.passwordstore.org>.
 
 - Initialisiere oder verschlüssle einen neuen oder bestehenden Speicher mit einer oder mehreren GPG IDs neu:
 

--- a/pages.de/common/pdflatex.md
+++ b/pages.de/common/pdflatex.md
@@ -1,7 +1,7 @@
 # pdflatex
 
 > Kompiliere eine LaTeX Quelldatei in ein PDF Dokument.
-> Mehr Informationen: <https://manned.org/pdflatex>.
+> Weitere Informationen: <https://manned.org/pdflatex>.
 
 - Kompiliere ein PDF Dokument:
 

--- a/pages.de/common/pdftex.md
+++ b/pages.de/common/pdftex.md
@@ -1,7 +1,7 @@
 # pdftex
 
 > Kompiliere eine TeX Quelldatei in ein PDF Dokument.
-> Mehr Informationen: <https://www.tug.org/applications/pdftex/>.
+> Weitere Informationen: <https://www.tug.org/applications/pdftex/>.
 
 - Kompiliere ein PDF Dokument:
 

--- a/pages.de/common/phpbu.md
+++ b/pages.de/common/phpbu.md
@@ -1,7 +1,7 @@
 # phpbu
 
 > Ein Backup framework für PHP.
-> Mehr Informationen: <https://phpbu.de>.
+> Weitere Informationen: <https://phpbu.de>.
 
 - Führe ein Backup mit der Standard `phpbu.xml` Konfigurationsdatei aus:
 

--- a/pages.de/common/plantuml.md
+++ b/pages.de/common/plantuml.md
@@ -1,7 +1,7 @@
 # plantuml
 
 > Erstelle UML-Diagramme aus einer reinen Textsprache und rendere sie in verschiedenen Formaten.
-> Mehr Informationen: <https://plantuml.com/en/command-line>.
+> Weitere Informationen: <https://plantuml.com/en/command-line>.
 
 - Rendere Diagramme im Standardformat (PNG):
 

--- a/pages.de/common/sshfs.md
+++ b/pages.de/common/sshfs.md
@@ -1,7 +1,7 @@
 # sshfs
 
 > Dateisystem Client für SSH.
-> Mehr Informationen: <https://github.com/libfuse/sshfs>.
+> Weitere Informationen: <https://github.com/libfuse/sshfs>.
 
 - Hänge ein externes Verzeichnis ein:
 

--- a/pages.de/common/tar.md
+++ b/pages.de/common/tar.md
@@ -2,7 +2,7 @@
 
 > Archivierungs Tool.
 > Häufig kombiniert mit anderen Methoden zur Komprimierung, wie gzip oder bzip2.
-> Mehr Informationen: <https://www.gnu.org/software/tar>.
+> Weitere Informationen: <https://www.gnu.org/software/tar>.
 
 - Erstelle ein Archiv von Datein:
 

--- a/pages.de/common/tex.md
+++ b/pages.de/common/tex.md
@@ -1,7 +1,7 @@
 # tex
 
 > Kompiliere eine TeX Quelldatei in ein DVI Dokument.
-> Mehr Informationen: <https://www.tug.org/begin.html>.
+> Weitere Informationen: <https://www.tug.org/begin.html>.
 
 - Kompiliere ein DVI Dokument:
 

--- a/pages.de/common/texdoc.md
+++ b/pages.de/common/texdoc.md
@@ -1,7 +1,7 @@
 # texdoc
 
 > Suche nach passenden Dokumentationen für (La)TeX Befehle oder Packages.
-> Mehr Informationen: <https://texdoc.org/index.html>.
+> Weitere Informationen: <https://texdoc.org/index.html>.
 
 - Öffne das erste Suchergebnis im Standard-PDF-Viewer:
 

--- a/pages.de/common/texliveonfly.md
+++ b/pages.de/common/texliveonfly.md
@@ -1,7 +1,7 @@
 # texliveonfly
 
 > Lade fehlende TeX Live Packages während dem Kompilieren einer `.tex` Datei herunter.
-> Mehr Informationen: <https://ctan.org/pkg/texliveonfly>.
+> Weitere Informationen: <https://ctan.org/pkg/texliveonfly>.
 
 - Lade fehlende Packages während dem Kompilieren herunter:
 

--- a/pages.de/common/tlmgr.md
+++ b/pages.de/common/tlmgr.md
@@ -1,7 +1,7 @@
 # tlmgr
 
 > Verwalte Packages und Konfigurationen einer existierenden TeX Live Installation.
-> Mehr Informationen: <https://www.tug.org/texlive/tlmgr.html>.
+> Weitere Informationen: <https://www.tug.org/texlive/tlmgr.html>.
 
 - Installiere ein Package und seine Abhängigkeiten:
 

--- a/pages.de/common/whoami.md
+++ b/pages.de/common/whoami.md
@@ -1,7 +1,7 @@
 # whoami
 
 > Gib den Benutzernamen des aktuellen Benutzers aus.
-> Mehr Informationen: <https://www.gnu.org/software/coreutils/whoami>.
+> Weitere Informationen: <https://www.gnu.org/software/coreutils/whoami>.
 
 - Gib den aktiven Benutzernamen aus:
 

--- a/pages.de/common/zsh.md
+++ b/pages.de/common/zsh.md
@@ -2,7 +2,7 @@
 
 > Z SHell.
 > Mit `bash` und `sh` kompatible Eingabeaufforderung.
-> Mehr Informationen: <https://www.zsh.org>.
+> Weitere Informationen: <https://www.zsh.org>.
 
 - Starte eine interaktive Eingabeaufforderung:
 

--- a/pages.de/linux/apt-add-repository.md
+++ b/pages.de/linux/apt-add-repository.md
@@ -1,7 +1,7 @@
 # apt-add-repository
 
 > Editiere die Repository-Listen.
-> Mehr Informationen: <https://manpages.debian.org/latest/software-properties-common/apt-add-repository.1.html>.
+> Weitere Informationen: <https://manpages.debian.org/latest/software-properties-common/apt-add-repository.1.html>.
 
 - Füge ein neues Repository hinzu:
 

--- a/pages.de/linux/apt-get.md
+++ b/pages.de/linux/apt-get.md
@@ -2,7 +2,7 @@
 
 > Debian und Ubuntu Paket Management Tool.
 > Suche mit `apt-cache` nach Paketen.
-> Mehr Informationen: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
+> Weitere Informationen: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
 
 - Aktualisiere die Liste der Paketquellen (es wird empfohlen diesen Befehl zu Begin auszuführen):
 

--- a/pages.de/linux/apt.md
+++ b/pages.de/linux/apt.md
@@ -2,7 +2,7 @@
 
 > Debian und Ubuntu Paket Management Tool.
 > Empfohlene Alternative zu apt-get seit Ubuntu 16.04.
-> Mehr Informationen: <https://manpages.debian.org/latest/apt/apt.8.html>.
+> Weitere Informationen: <https://manpages.debian.org/latest/apt/apt.8.html>.
 
 - Aktualisiere die Liste der Paketquellen (es wird empfohlen diesen Befehl zu Begin auszuführen):
 

--- a/pages.de/linux/certbot.md
+++ b/pages.de/linux/certbot.md
@@ -2,7 +2,7 @@
 
 > The Let's Encrypt Agent zum automatischen Erhalten und Erneuern von TLS-Zertifikaten.
 > Nachfolger von `letsencrypt`.
-> Mehr Informationen: <https://certbot.eff.org/docs/using.html>.
+> Weitere Informationen: <https://certbot.eff.org/docs/using.html>.
 
 - Beziehe ein neues Zertifikat über die webroot-Autorisierung, aber ohne dieses automatisch zu installieren:
 

--- a/pages.de/linux/cfdisk.md
+++ b/pages.de/linux/cfdisk.md
@@ -1,7 +1,7 @@
 # cfdisk
 
 > Ein Programm zur Verwaltung von Partitionstabellen mittels einer Curses-basierten UI.
-> Mehr Informationen: <https://manned.org/cfdisk>.
+> Weitere Informationen: <https://manned.org/cfdisk>.
 
 - Öffne das Partitionierungsinterface für eine bestimmte Festplatte:
 

--- a/pages.de/linux/dnf.md
+++ b/pages.de/linux/dnf.md
@@ -1,7 +1,7 @@
 # dnf
 
 > Paketmanagement Tool für RHEL, Fedora, und CentOS (ersetzt yum).
-> Mehr Informationen: <https://dnf.readthedocs.io/>.
+> Weitere Informationen: <https://dnf.readthedocs.io/>.
 
 - Aktualisiere alle Pakete auf die neuste Version:
 

--- a/pages.de/osx/brew-bundle.md
+++ b/pages.de/osx/brew-bundle.md
@@ -1,7 +1,7 @@
 # brew bundle
 
 > Bundler für Homebrew, Homebrew Cask und den Mac App Store.
-> Mehr Informationen: <https://github.com/Homebrew/homebrew-bundle>.
+> Weitere Informationen: <https://github.com/Homebrew/homebrew-bundle>.
 
 - Installiere Pakete aus einer Brewfile im aktuellen Pfad:
 

--- a/pages.de/osx/tmutil.md
+++ b/pages.de/osx/tmutil.md
@@ -1,7 +1,7 @@
 # tmutil
 
 > Dienstprogramm zum Verwalten von Time Machine-Backups. Die meisten Befehle erfordern Root-Rechte.
-> Mehr Informationen: <https://ss64.com/osx/tmutil.html>.
+> Weitere Informationen: <https://ss64.com/osx/tmutil.html>.
 
 - Setze ein HFS+ Laufwerk als Backupziel:
 

--- a/pages.de/windows/cd.md
+++ b/pages.de/windows/cd.md
@@ -1,7 +1,7 @@
 # cd
 
 > Zeige den Namen des aktuellen Arbeitsverzeichnisses an oder ändere dieses.
-> Mehr Informationen: <https://docs.microsoft.com/windows-server/administration/windows-commands/cd>.
+> Weitere Informationen: <https://docs.microsoft.com/windows-server/administration/windows-commands/cd>.
 
 - Wechsle zu einem Verzeichnis im selben Laufwerk:
 

--- a/pages.de/windows/choco-apikey.md
+++ b/pages.de/windows/choco-apikey.md
@@ -1,7 +1,7 @@
 # choco-apikey
 
 > Verwalte die API-Schlüssel für die Quellen von Chocolatey.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-apikey>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-apikey>.
 
 - Gib eine Liste von Quellen und ihren API-Schlüsseln aus:
 

--- a/pages.de/windows/choco-feature.md
+++ b/pages.de/windows/choco-feature.md
@@ -1,7 +1,7 @@
 # choco feature
 
 > Interagiere mit Funktionen, die das Verhalten von Chocolatey verändern.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-feature>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-feature>.
 
 - Gib eine Liste von verfügbaren Funktionen aus:
 

--- a/pages.de/windows/choco-info.md
+++ b/pages.de/windows/choco-info.md
@@ -1,7 +1,7 @@
 # choco info
 
 > Zeige ausführliche Informationen über ein Chocolatey-Paket an.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-info>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-info>.
 
 - Zeige Informationen über ein bestimmtes Paket an:
 

--- a/pages.de/windows/choco-install.md
+++ b/pages.de/windows/choco-install.md
@@ -1,7 +1,7 @@
 # choco install
 
 > Installiere ein oder mehrere Pakete mit Chocolatey.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-install>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-install>.
 
 - Installiere ein oder mehrere Pakete, deren Namen mit Leerzeichen getrennt sind:
 

--- a/pages.de/windows/choco-list.md
+++ b/pages.de/windows/choco-list.md
@@ -1,7 +1,7 @@
 # choco list
 
 > Zeige mit Chocolatey eine Liste von Paketen an.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-list>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-list>.
 
 - Zeige alle verfügbaren Pakete an:
 

--- a/pages.de/windows/choco-new.md
+++ b/pages.de/windows/choco-new.md
@@ -1,7 +1,7 @@
 # choco new
 
 > Erstelle neue Paket-Beschreibungs-Dateien mit Chocolatey.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-new>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-new>.
 
 - Erstelle ein neues Grundgerüst für ein Paket:
 

--- a/pages.de/windows/choco-outdated.md
+++ b/pages.de/windows/choco-outdated.md
@@ -1,7 +1,7 @@
 # choco outdated
 
 > Überprüfe mit Chocolatey, ob Pakete veraltet sind.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-outdated>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-outdated>.
 
 - Zeige eine Liste von veralteten Paketen im Tabellen-Format:
 

--- a/pages.de/windows/choco-pack.md
+++ b/pages.de/windows/choco-pack.md
@@ -1,7 +1,7 @@
 # choco pack
 
 > Verpacke eine NuGet-Spezifikation in eine nupkg-Datei.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-pack>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-pack>.
 
 - Verpacke eine NuGet-Spezifikation in eine nupkg-Datei:
 

--- a/pages.de/windows/choco-pin.md
+++ b/pages.de/windows/choco-pin.md
@@ -2,7 +2,7 @@
 
 > Hefte ein Chocolatey-Paket bei einer bestimmten Version an.
 > Angeheftete Pakete werden nicht weiter aktualisiert.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-pin>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-pin>.
 
 - Zeige eine Liste der angehefteten Pakete und ihrer Versionen an:
 

--- a/pages.de/windows/choco-search.md
+++ b/pages.de/windows/choco-search.md
@@ -1,7 +1,7 @@
 # choco search
 
 > Suche mit Chocolatey nach einem lokal oder im Internet verfügbaren Paket.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-search>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-search>.
 
 - Suche nach einem Paket:
 

--- a/pages.de/windows/choco-source.md
+++ b/pages.de/windows/choco-source.md
@@ -1,7 +1,7 @@
 # choco source
 
 > Verwalte die Paketquellen mit Chocolatey.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-source>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-source>.
 
 - Gib alle momentan verfügbaren Quellen aus:
 

--- a/pages.de/windows/choco-uninstall.md
+++ b/pages.de/windows/choco-uninstall.md
@@ -1,7 +1,7 @@
 # choco uninstall
 
 > Deinstalliere mit Chocolatey ein oder mehrere Pakete.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-uninstall>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-uninstall>.
 
 - Deinstalliere ein oder mehrere Pakete, deren Namen mit Leerzeichen getrennt sind:
 

--- a/pages.de/windows/choco-upgrade.md
+++ b/pages.de/windows/choco-upgrade.md
@@ -1,7 +1,7 @@
 # choco upgrade
 
 > Aktualisiere mit Chocolatey ein oder mehrere Pakete.
-> Mehr Informationen: <https://chocolatey.org/docs/commands-upgrade>.
+> Weitere Informationen: <https://chocolatey.org/docs/commands-upgrade>.
 
 - Aktualisiere ein oder mehrere Pakete, deren Namen mit Leerzeichen getrennt sind:
 

--- a/pages.de/windows/choco.md
+++ b/pages.de/windows/choco.md
@@ -2,7 +2,7 @@
 
 > Ein Kommandozeilenwerkzeug für die Chocolatey Paketverwaltung.
 > Schau dir `choco install`, `choco upgrade` und andere Seiten für weitergehende Informationen an.
-> Mehr Informationen: <https://chocolatey.org>.
+> Weitere Informationen: <https://chocolatey.org>.
 
 - Führe einen Chocolatey-Befehl aus:
 

--- a/pages.de/windows/scoop-bucket.md
+++ b/pages.de/windows/scoop-bucket.md
@@ -2,7 +2,7 @@
 
 > Verwalte "Eimer": Git-Repositories, welche Dateien enthalten, die beschreiben, wie Scoop Programme installiert werden.
 > Kennt Scoop nicht die URL eines Eimers, so muss diese angegeben werden.
-> Mehr Informationen: <https://github.com/lukesampson/scoop/wiki/Buckets>.
+> Weitere Informationen: <https://github.com/lukesampson/scoop/wiki/Buckets>.
 
 - Liste alle Eimer auf, die gerade aktiv sind:
 

--- a/pages.de/windows/scoop.md
+++ b/pages.de/windows/scoop.md
@@ -1,7 +1,7 @@
 # scoop
 
 > Ein Kommandozeilenwerkzeug, um Windows-Programme (hier bezeichnet als Pakete) zu installieren.
-> Mehr Informationen: <https://scoop.sh>.
+> Weitere Informationen: <https://scoop.sh>.
 
 - Installiere ein Paket:
 

--- a/scripts/set-more-info-link.py
+++ b/scripts/set-more-info-link.py
@@ -8,7 +8,7 @@ labels = {
     'en': 'More information:',
     'bs': 'Više informacija:',
     'da': 'Mere information:',
-    'de': 'Mehr Informationen:',
+    'de': 'Weitere Informationen:',
     'es': 'Más información:',
     'fa': 'اطلاعات بیشتر:',
     'fr': 'Plus d\'informations\xa0:',


### PR DESCRIPTION
This is something I wanted to do for quite a while. "Mehr Informationen" as a translation for "More information" is fine, but "Weitere Informationen" feels a bit more natural and professional.