### PR TITLE
cinst, cuninst, clist: add page

### DIFF
--- a/pages/windows/cinst.md
+++ b/pages/windows/cinst.md
@@ -1,0 +1,7 @@
+# cinst
+
+> This command is an alias of `choco install`.
+
+- View documentation for the original command:
+
+`tldr choco install`

--- a/pages/windows/clist.md
+++ b/pages/windows/clist.md
@@ -1,0 +1,7 @@
+# cinst
+
+> This command is an alias of `choco list`.
+
+- View documentation for the original command:
+
+`tldr choco list`

--- a/pages/windows/clist.md
+++ b/pages/windows/clist.md
@@ -1,4 +1,4 @@
-# cinst
+# clist
 
 > This command is an alias of `choco list`.
 

--- a/pages/windows/cuninst.md
+++ b/pages/windows/cuninst.md
@@ -1,4 +1,4 @@
-# cinst
+# cuninst
 
 > This command is an alias of `choco uninstall`.
 

--- a/pages/windows/cuninst.md
+++ b/pages/windows/cuninst.md
@@ -1,0 +1,7 @@
+# cinst
+
+> This command is an alias of `choco uninstall`.
+
+- View documentation for the original command:
+
+`tldr choco uninstall`


### PR DESCRIPTION
There's quite a few other aliases to `choco` subcommands, namely:

- `cpack` — CMake has a command called [`cpack`](https://cmake.org/cmake/help/v3.20/manual/cpack.1.html#manual:cpack(1))
- `cpush` — we don't have `choco push`
- `cup` — seems like there could easily be another command called `cup` and a page for this would override that for Windows users
- `cver` — we don't have `choco version`
