### PR TITLE
pkgfile: fix example and update link

### DIFF
--- a/pages/linux/pkgfile.md
+++ b/pages/linux/pkgfile.md
@@ -2,7 +2,7 @@
 
 > Tool for searching files from packages in the official repositories on arch-based systems.
 > See also `pacman files`.
-> More information: <https://man.archlinux.org/man/extra/pkgfile/pkgfile.1.en>.
+> More information: <https://man.archlinux.org/man/extra/pkgfile/pkgfile.1>.
 
 - Synchronize the pkgfile database:
 

--- a/pages/linux/pkgfile.md
+++ b/pages/linux/pkgfile.md
@@ -24,6 +24,10 @@
 
 `pkgfile --ignorecase {{filename}}`
 
+- Search for a package that owns a specific file in the `bin` or `sbin` directory:
+
+`pkgfile --binaries {{filename}}`
+
 - Search for a package that owns a specific file, displaying the package version:
 
 `pkgfile --verbose {{filename}}`

--- a/pages/linux/pkgfile.md
+++ b/pages/linux/pkgfile.md
@@ -2,7 +2,7 @@
 
 > Tool for searching files from packages in the official repositories on arch-based systems.
 > See also `pacman files`.
-> More information: <https://wiki.archlinux.org/index.php/Pkgfile>.
+> More information: <https://man.archlinux.org/man/extra/pkgfile/pkgfile.1.en>.
 
 - Synchronize the pkgfile database:
 
@@ -16,17 +16,13 @@
 
 `pkgfile --list {{package_name}}`
 
-- List only files in the `bin` directory provided by a package:
+- List only files provided by a package located within the `bin` or `sbin` directory:
 
 `pkgfile --list --binaries {{package_name}}`
 
 - Search for a package that owns a specific file using case insensitive matching:
 
 `pkgfile --ignorecase {{filename}}`
-
-- Search for a package that owns a specific file in the `bin` directory:
-
-`pkgfile --binary {{filename}}`
 
 - Search for a package that owns a specific file, displaying the package version:
 

--- a/pages/linux/pkgfile.md
+++ b/pages/linux/pkgfile.md
@@ -1,7 +1,7 @@
 # pkgfile
 
 > Tool for searching files from packages in the official repositories on arch-based systems.
-> See also `pacman files`.
+> See also `pacman files`, describing the usage of `pacman --files`.
 > More information: <https://man.archlinux.org/man/extra/pkgfile/pkgfile.1>.
 
 - Synchronize the pkgfile database:


### PR DESCRIPTION
- Remove the invalid option as there is no  `--binary` option in the present version of pkgfile v21-2. 
- **EDIT:** add `--binaries` option instead
- Additionally, add `sbin` directory into the valid `--binaries` option to provide more precise description and reword that description slightly. 
- Change the More information link to the actual manual page.
- **EDIT:** include description in see also section.
- The change was tested before submitting.