### PR TITLE
multiple pages: normalize `regular expression` instead of `regex`, `regexp` or `pattern`

### DIFF
--- a/pages.fr/common/grep.md
+++ b/pages.fr/common/grep.md
@@ -18,7 +18,7 @@
 
 - Utilise des expressions rationnelles étendues (supporte `?`, `+`, `{}`, `()` et `|`) :
 
-`grep -E {{^regex$}} {{chemin/vers/fichier}}`
+`grep -E {{^expression_régulière$}} {{chemin/vers/fichier}}`
 
 - Affiche 3 lignes de [C]ontexte, avant ([B]efore), ou [A]près chaque concordance :
 

--- a/pages.fr/common/grep.md
+++ b/pages.fr/common/grep.md
@@ -18,7 +18,7 @@
 
 - Utilise des expressions rationnelles étendues (supporte `?`, `+`, `{}`, `()` et `|`) :
 
-`grep -E {{^expression_régulière$}} {{chemin/vers/fichier}}`
+`grep -E {{expression_régulière}} {{chemin/vers/fichier}}`
 
 - Affiche 3 lignes de [C]ontexte, avant ([B]efore), ou [A]près chaque concordance :
 

--- a/pages.fr/common/jest.md
+++ b/pages.fr/common/jest.md
@@ -7,9 +7,13 @@
 
 `jest`
 
-- Exécuter les suites de test des fichiers dont les chemins correspondent aux expressions régulières indiquées :
+- Exécuter les suites de test de fichiers donnés :
 
-`jest {{fichier_test1}} {{chemin/vers/fichier_test2.js}}`
+`jest {{chemin/vers/fichier1}} {{chemin/vers/fichier2}}`
+
+- Exécuter les suites de test pour des fichiers, dans le répertoire courant et ses sous-répertoires, dont le chemin correspond à l'expression régulière indiquée :
+
+`jest {{expression_régulière}} {{expression_régulière}}`
 
 - Exécuter les tests dont les noms correspondent aux expressions régulières indiquées :
 

--- a/pages.fr/common/z.md
+++ b/pages.fr/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Recherche les répertoires les plus utilisés et permet une navigation rapide à l'aide de chaine de caractères ou de regex.
+> Recherche les répertoires les plus utilisés et permet une navigation rapide à l'aide de chaine de caractères ou de expression régulière.
 > Plus d'informations : <https://github.com/rupa/z>.
 
 - Aller dans un répertoire qui contient "foo" dans son nom :

--- a/pages.fr/common/z.md
+++ b/pages.fr/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Recherche les répertoires les plus utilisés et permet une navigation rapide à l'aide de chaine de caractères ou de expression régulière.
+> Recherche les répertoires les plus utilisés et permet une navigation rapide à l'aide de chaine de caractères ou d'expressions régulières.
 > Plus d'informations : <https://github.com/rupa/z>.
 
 - Aller dans un répertoire qui contient "foo" dans son nom :

--- a/pages.id/common/nvim.md
+++ b/pages.id/common/nvim.md
@@ -26,7 +26,7 @@
 
 - Melakukan penggantian ekspresi reguler pada seluruh berkas:
 
-`<Esc>:%s/{{ekspresi reguler}}/{{pengganti}}/g<Enter>`
+`<Esc>:%s/{{ekspresi_reguler}}/{{pengganti}}/g<Enter>`
 
 - Menyimpan (write) berkas, dan keluar:
 

--- a/pages.id/common/nvim.md
+++ b/pages.id/common/nvim.md
@@ -26,7 +26,7 @@
 
 - Melakukan penggantian ekspresi reguler pada seluruh berkas:
 
-`<Esc>:%s/{{pattern}}/{{pengganti}}/g<Enter>`
+`<Esc>:%s/{{ekspresi reguler}}/{{pengganti}}/g<Enter>`
 
 - Menyimpan (write) berkas, dan keluar:
 

--- a/pages.id/common/nvim.md
+++ b/pages.id/common/nvim.md
@@ -24,7 +24,7 @@
 
 `<Esc>/{{pattern_pencarian}}<Enter>`
 
-- Melakukan penggantian regex pada seluruh berkas:
+- Melakukan penggantian ekspresi reguler pada seluruh berkas:
 
 `<Esc>:%s/{{pattern}}/{{pengganti}}/g<Enter>`
 

--- a/pages.it/common/ag.md
+++ b/pages.it/common/ag.md
@@ -25,7 +25,7 @@
 
 - Trova file il quale contenuto soddisfi una determinata espressione regolare:
 
-`ag '{{regexp}}'`
+`ag '{{espressione_regolare}}'`
 
 - Trova file il quale nome contiene "foo":
 

--- a/pages.it/common/csvgrep.md
+++ b/pages.it/common/csvgrep.md
@@ -8,9 +8,9 @@
 
 `csvgrep -c {{1}} -m {{stringa}} {{data.csv}}`
 
-- Trova righe per le quali le colonne 3 e 4 soddisfano una certa regex:
+- Trova righe per le quali le colonne 3 e 4 soddisfano una certa espressione regolare:
 
-`csvgrep -c {{3,4}} -r {{pattern_regex}} {{data.csv}}`
+`csvgrep -c {{3,4}} -r {{espressione_regolare}} {{data.csv}}`
 
 - Trova righe dove la colonna "nome" NON include la stringa "Mario Rossi":
 

--- a/pages.it/common/vim.md
+++ b/pages.it/common/vim.md
@@ -22,11 +22,11 @@
 
 - Cerca un pattern nel file (usa `n`/`N` per spostarti al risultato successivo/precedente):
 
-`<Esc>/{{espressione regolare}}<Invio>`
+`<Esc>/{{espressione_regolare}}<Invio>`
 
 - Effettua una sostituzione tramite espressione regolare nell'intero file:
 
-`<Esc>:%s/{{espressione regolare}}/{{sostituzione}}/g<Invio>`
+`<Esc>:%s/{{espressione_regolare}}/{{sostituzione}}/g<Invio>`
 
 - Salva modifiche al file ed esci:
 

--- a/pages.it/common/vim.md
+++ b/pages.it/common/vim.md
@@ -22,11 +22,11 @@
 
 - Cerca un pattern nel file (usa `n`/`N` per spostarti al risultato successivo/precedente):
 
-`<Esc>/{{pattern}}<Invio>`
+`<Esc>/{{espressione regolare}}<Invio>`
 
 - Effettua una sostituzione tramite espressione regolare nell'intero file:
 
-`<Esc>:%s/{{pattern}}/{{sostituzione}}/g<Invio>`
+`<Esc>:%s/{{espressione regolare}}/{{sostituzione}}/g<Invio>`
 
 - Salva modifiche al file ed esci:
 

--- a/pages.it/common/vim.md
+++ b/pages.it/common/vim.md
@@ -24,7 +24,7 @@
 
 `<Esc>/{{pattern}}<Invio>`
 
-- Effettua una sostituzione tramite regex nell'intero file:
+- Effettua una sostituzione tramite espressione regolare nell'intero file:
 
 `<Esc>:%s/{{pattern}}/{{sostituzione}}/g<Invio>`
 

--- a/pages.pl/common/ack.md
+++ b/pages.pl/common/ack.md
@@ -23,7 +23,7 @@
 
 `ack bar "{{foo bar}}" {{scieżka/do/pliku_lub_katalogu}}`
 
-- Przeszukaj plik pod kątem określonego wzorca regex:
+- Przeszukaj plik pod kątem określonego wzorca wyrażenia regularnego:
 
 `ack bar "{{[bB]ar \d+}}" {{scieżka/do/pliku_lub_katalogu}}`
 

--- a/pages.pt_BR/linux/csplit.md
+++ b/pages.pt_BR/linux/csplit.md
@@ -22,4 +22,4 @@
 
 - Dividir um arquivo na linha que atenda a expressão regular:
 
-`csplit {{arquivo}} /{{expressão_regular}}/`
+`csplit {{arquivo}} /{{expressao_regular}}/`

--- a/pages.pt_BR/linux/csplit.md
+++ b/pages.pt_BR/linux/csplit.md
@@ -22,4 +22,4 @@
 
 - Dividir um arquivo na linha que atenda a expressão regular:
 
-`csplit {{arquivo}} /{{regex}}/`
+`csplit {{arquivo}} /{{expressão_regular}}/`

--- a/pages.pt_PT/common/history.md
+++ b/pages.pt_PT/common/history.md
@@ -16,4 +16,4 @@
 
 - Mostrar as entradas do histórico da linha de comandos que correspondem a uma expressão regular:
 
-`history | grep {{expressão_regular}}`
+`history | grep {{expressao_regular}}`

--- a/pages.pt_PT/common/history.md
+++ b/pages.pt_PT/common/history.md
@@ -16,4 +16,4 @@
 
 - Mostrar as entradas do histórico da linha de comandos que correspondem a uma expressão regular:
 
-`history | grep {{regex}}`
+`history | grep {{expressão_regular}}`

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -12,6 +12,6 @@
 
 `logcat -f {{path/to/file}}`
 
-- Display lines that match a regex:
+- Display lines that match a regular expression:
 
-`logcat --regex {{regex}}`
+`logcat --regex {{regular_expression}}`

--- a/pages/common/csvgrep.md
+++ b/pages/common/csvgrep.md
@@ -8,9 +8,9 @@
 
 `csvgrep -c {{1}} -m {{string_to_match}} {{data.csv}}`
 
-- Find rows in which columns 3 or 4 match a certain regex pattern:
+- Find rows in which columns 3 or 4 match a certain regular expression:
 
-`csvgrep -c {{3,4}} -r {{regex_pattern}} {{data.csv}}`
+`csvgrep -c {{3,4}} -r {{regular_expression}} {{data.csv}}`
 
 - Find rows in which the "name" column does NOT include the string "John Doe":
 

--- a/pages/common/fgrep.md
+++ b/pages/common/fgrep.md
@@ -22,8 +22,8 @@
 
 - Display all lines except those that contain the given regular expression:
 
-`fgrep -v {{^regular_expression$}} {{path/to/file}}`
+`fgrep -v {{regular_expression}} {{path/to/file}}`
 
 - Display filenames whose content matches the regular expression at least once:
 
-`fgrep -l {{^regular_expression}} {{path/to/file1}} {{path/to/file2}}`
+`fgrep -l {{regular_expression}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/fgrep.md
+++ b/pages/common/fgrep.md
@@ -22,8 +22,8 @@
 
 - Display all lines except those that contain the given regular expression:
 
-`fgrep -v {{^regex$}} {{path/to/file}}`
+`fgrep -v {{^regular_expression$}} {{path/to/file}}`
 
 - Display filenames whose content matches the regular expression at least once:
 
-`fgrep -l {{^regex$}} {{path/to/file1}} {{path/to/file2}}`
+`fgrep -l {{^regular_expression}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/gem.md
+++ b/pages/common/gem.md
@@ -5,7 +5,7 @@
 
 - Search for remote gem(s) and show all available versions:
 
-`gem search {{regexp}} --all`
+`gem search {{regular_expression}} --all`
 
 - Install latest version of a gem:
 

--- a/pages/common/grex.md
+++ b/pages/common/grex.md
@@ -7,7 +7,7 @@
 
 ` grex {{space_separated_strings}}`
 
-- Generate a case-insensitive regex:
+- Generate a case-insensitive regular expression:
 
 `grex -i {{space_separated_strings}}`
 

--- a/pages/common/httpflow.md
+++ b/pages/common/httpflow.md
@@ -11,9 +11,9 @@
 
 `httpflow {{host httpbin.org or host baidu.com}}`
 
-- Use a regexp to filter requests by urls:
+- Use a regular expression to filter requests by urls:
 
-`httpflow -u '{{regex}}'`
+`httpflow -u '{{regular_expression}}'`
 
 - Read packets from pcap format binary file:
 

--- a/pages/common/jest.md
+++ b/pages/common/jest.md
@@ -13,7 +13,7 @@
 
 - Run the test suites from files within the current and subdirectories, whose paths match the given regular expression:
 
-`jest {{regular_expression}} {{regular_expression}}`
+`jest {{regular_expression1}} {{regular_expression2}}`
 
 - Run the tests whose names match the given regular expression:
 

--- a/pages/common/jest.md
+++ b/pages/common/jest.md
@@ -7,11 +7,11 @@
 
 `jest`
 
-- Run the test suites from files whose paths match the given regex patterns:
+- Run the test suites from files whose paths match the given regular expression:
 
 `jest {{test_file1}} {{path/to/test_file2.js}}`
 
-- Run the tests whose names match the given regex pattern:
+- Run the tests whose names match the given regular expression:
 
 `jest --testNamePattern {{spec_name}}`
 

--- a/pages/common/jest.md
+++ b/pages/common/jest.md
@@ -17,7 +17,7 @@
 
 - Run the tests whose names match the given regular expression:
 
-`jest --testNamePattern {{spec_name}}`
+`jest --testNamePattern {{regular_expression}}`
 
 - Run test suites related to a given source file:
 

--- a/pages/common/jest.md
+++ b/pages/common/jest.md
@@ -7,9 +7,13 @@
 
 `jest`
 
-- Run the test suites from files whose paths match the given regular expression:
+- Run the test suites from the given files:
 
-`jest {{test_file1}} {{path/to/test_file2.js}}`
+`jest {{path/to/file1}} {{path/to/file2}}`
+
+- Run the test suites from files within the current and subdirectories, whose paths match the given regular expression:
+
+`jest {{regular_expression}} {{regular_expression}}`
 
 - Run the tests whose names match the given regular expression:
 

--- a/pages/common/linkchecker.md
+++ b/pages/common/linkchecker.md
@@ -11,9 +11,9 @@
 
 `linkchecker --check-extern {{https://example.com/}}`
 
-- Ignore URLs that match a specific regex:
+- Ignore URLs that match a specific regular expression:
 
-`linkchecker --ignore-url {{regex}} {{https://example.com/}}`
+`linkchecker --ignore-url {{regular_expression}} {{https://example.com/}}`
 
 - Output results to a CSV file:
 

--- a/pages/common/mlr.md
+++ b/pages/common/mlr.md
@@ -29,4 +29,4 @@
 
 - Filter lines of a compressed CSV file treating numbers as strings:
 
-`mlr --prepipe 'gunzip' --csv filter -S '${{fieldName}} =~ "{{regexp}}"' {{example.csv.gz}}`
+`mlr --prepipe 'gunzip' --csv filter -S '${{fieldName}} =~ "{{regular_expression}}"' {{example.csv.gz}}`

--- a/pages/common/mocha.md
+++ b/pages/common/mocha.md
@@ -13,7 +13,7 @@
 
 - Run tests that match a specific grep pattern:
 
-`mocha --grep {{^regex$}}`
+`mocha --grep {{^regular_expression$}}`
 
 - Run tests on changes to JavaScript files in the current directory and once initially:
 

--- a/pages/common/mocha.md
+++ b/pages/common/mocha.md
@@ -13,7 +13,7 @@
 
 - Run tests that match a specific grep pattern:
 
-`mocha --grep {{^regular_expression$}}`
+`mocha --grep {{regular_expression}}`
 
 - Run tests on changes to JavaScript files in the current directory and once initially:
 

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -26,7 +26,7 @@
 
 - Perform a regular expression substitution in the whole file:
 
-`<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
+`<Esc>:%s/{{regular_expression}}/{{replacement}}/g<Enter>`
 
 - Save (write) the file, and quit:
 

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -24,7 +24,7 @@
 
 `<Esc>/{{search_pattern}}<Enter>`
 
-- Perform a regex substitution in the whole file:
+- Perform a regular expression substitution in the whole file:
 
 `<Esc>:%s/{{pattern}}/{{replacement}}/g<Enter>`
 

--- a/pages/common/recsel.md
+++ b/pages/common/recsel.md
@@ -9,8 +9,8 @@
 
 - Use "~" to match a string with a given regular expression:
 
-`recsel -e "{{field_name}} ~ '{{pattern_regex}}' {{data.rec}}"`
+`recsel -e "{{field_name}} ~ '{{regular_expression}}' {{data.rec}}"`
 
 - Use a predicate to match a name and a version:
 
-`recsel -e "name ~ '{{pattern_regex}}' && version ~ '{{pattern_regex}}'" {{data.rec}}`
+`recsel -e "name ~ '{{regular_expression}}' && version ~ '{{regular_expression}}'" {{data.rec}}`

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -6,31 +6,31 @@
 
 - Recursively search the current directory for a regular expression:
 
-`rg {{pattern}}`
+`rg {{regular_expression}}`
 
-- Search for pattern including all .gitignored and hidden files:
+- Search for regular expressions including all .gitignored and hidden files:
 
-`rg --no-ignore --hidden {{pattern}}`
+`rg --no-ignore --hidden {{regular_expression}}`
 
-- Search for a pattern only in a certain filetype (e.g., html, css, etc.):
+- Search for a regular expression only in a certain filetype (e.g., html, css, etc.):
 
-`rg --type {{filetype}} {{pattern}}`
+`rg --type {{filetype}} {{regular_expression}}`
 
-- Search for a pattern only in a subset of directories:
+- Search for a regular expression only in a subset of directories:
 
-`rg {{pattern}} {{set_of_subdirs}}`
+`rg {{regular_expression}} {{set_of_subdirs}}`
 
-- Search for a pattern in files matching a glob (e.g., `README.*`):
+- Search for a regular expression in files matching a glob (e.g., `README.*`):
 
-`rg {{pattern}} --glob {{glob}}`
+`rg {{regular_expression}} --glob {{glob}}`
 
 - Only list matched files (useful when piping to other commands):
 
-`rg --files-with-matches {{pattern}}`
+`rg --files-with-matches {{regular_expression}}`
 
-- Show lines that do not match the given pattern:
+- Show lines that do not match the given regular expression:
 
-`rg --invert-match {{pattern}}`
+`rg --invert-match {{regular_expression}}`
 
 - Search a literal string pattern:
 

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -4,7 +4,7 @@
 > Aims to be a faster alternative to `grep`.
 > More information: <https://github.com/BurntSushi/ripgrep>.
 
-- Recursively search the current directory for a regex pattern:
+- Recursively search the current directory for a regular expression:
 
 `rg {{pattern}}`
 

--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -2,7 +2,7 @@
 
 > Intuitive find & replace CLI.
 
-- Trim some whitespace using regex:
+- Trim some whitespace using a regular expression:
 
 `{{echo 'lorem ipsum 23   '}} | sd '\s+$' ''`
 

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -5,11 +5,11 @@
 
 - Replace the first occurrence of a regular expression in each line of a file, and print the result:
 
-`sed 's/{{regex}}/{{replace}}/' {{filename}}`
+`sed 's/{{regular_expression}}/{{replace}}/' {{filename}}`
 
 - Replace all occurrences of an extended regular expression in a file, and print the result:
 
-`sed -r 's/{{regex}}/{{replace}}/g' {{filename}}`
+`sed -r 's/{{regular_expression}}/{{replace}}/g' {{filename}}`
 
 - Replace all occurrences of a string in a file, overwriting the file (i.e. in-place):
 

--- a/pages/common/stow.md
+++ b/pages/common/stow.md
@@ -22,4 +22,4 @@
 
 - Exclude files matching a regular expression:
 
-`stow --ignore={{regex}} --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`
+`stow --ignore={{regular_expression}} --target={{path/to/target_directory}} {{file1 directory1 file2 directory2}}`

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -30,7 +30,7 @@
 
 - Perform a regular expression substitution in the whole file:
 
-`:%s/{{pattern}}/{{replacement}}/g<Enter>`
+`:%s/{{regular_expression}}/{{replacement}}/g<Enter>`
 
 - Display the line numbers:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -28,7 +28,7 @@
 
 `/{{search_pattern}}<Enter>`
 
-- Perform a regex substitution in the whole file:
+- Perform a regular expression substitution in the whole file:
 
 `:%s/{{pattern}}/{{replacement}}/g<Enter>`
 

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Tracks the most used (by frecency) directories and enables quickly navigating to them using string or regular expression.
+> Tracks the most used (by frecency) directories and enables quickly navigating to them using string patterns or regular expressions.
 > More information: <https://github.com/rupa/z>.
 
 - Go to a directory that contains "foo" in the name:

--- a/pages/common/z.md
+++ b/pages/common/z.md
@@ -1,6 +1,6 @@
 # z
 
-> Tracks the most used (by frecency) directories and enables quickly navigating to them using string or regex patterns.
+> Tracks the most used (by frecency) directories and enables quickly navigating to them using string or regular expression.
 > More information: <https://github.com/rupa/z>.
 
 - Go to a directory that contains "foo" in the name:

--- a/pages/common/zmv.md
+++ b/pages/common/zmv.md
@@ -4,7 +4,7 @@
 > See also `zcp` and `zln`.
 > More information: <http://zsh.sourceforge.net/Doc/Release/User-Contributions.html>.
 
-- Move files using a regex-like pattern:
+- Move files using a regular expression-like pattern:
 
 `zmv '{{(*).log}}' '{{$1.txt}}'`
 

--- a/pages/linux/apt-file.md
+++ b/pages/linux/apt-file.md
@@ -17,4 +17,4 @@
 
 - Search for packages that match the regular expresssion given in `pattern`:
 
-`apt-file {{search|find}} --regexp {{pattern}}`
+`apt-file {{search|find}} --regexp {{regular_expression}}`

--- a/pages/linux/auracle.md
+++ b/pages/linux/auracle.md
@@ -5,7 +5,7 @@
 
 - Display AUR packages that match a regular expression:
 
-`auracle search '{{regex}}'`
+`auracle search '{{regular_expression}}'`
 
 - Display package information for a space-separated list of AUR packages:
 

--- a/pages/linux/csplit.md
+++ b/pages/linux/csplit.md
@@ -22,4 +22,4 @@
 
 - Split a file at a line matching a regular expression:
 
-`csplit {{file}} /{{regex}}/`
+`csplit {{file}} /{{regular_expression}}/`

--- a/pages/linux/inotifywait.md
+++ b/pages/linux/inotifywait.md
@@ -16,7 +16,7 @@
 
 - Exclude files matching a regular expression:
 
-`while inotifywait --recursive {{path/to/directory}} --exlude '{{regex}}'; do {{command}}; done`
+`while inotifywait --recursive {{path/to/directory}} --exlude '{{regular_expression}}'; do {{command}}; done`
 
 - Wait at most 30 seconds:
 

--- a/pages/linux/pacman-files.md
+++ b/pages/linux/pacman-files.md
@@ -17,7 +17,7 @@
 
 - Find the package that owns a specific file, using a regular expression:
 
-`pacman --files --regex '{{search_pattern}}'`
+`pacman --files --regex '{{regular_expression}}'`
 
 - List only the package names:
 

--- a/pages/linux/zgrep.md
+++ b/pages/linux/zgrep.md
@@ -24,7 +24,7 @@
 
 - Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`):
 
-`zgrep -E {{^regular_expression$}} {{path/to/file}}`
+`zgrep -E {{regular_expression}} {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 

--- a/pages/linux/zgrep.md
+++ b/pages/linux/zgrep.md
@@ -24,7 +24,7 @@
 
 - Use extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`):
 
-`zgrep -E {{^regex$}} {{path/to/file}}`
+`zgrep -E {{^regular_expression$}} {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 

--- a/pages/osx/rename.md
+++ b/pages/osx/rename.md
@@ -1,6 +1,6 @@
 # rename
 
-> Rename a file or group of files with a regex.
+> Rename a file or group of files with a regular expression.
 
 - Replace `from` with `to` in the filenames of the specified files:
 

--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -9,7 +9,7 @@
 
 - Replace all occurrences of an extended regular expression in a file:
 
-`sed -E 's/{{regex}}/{{replace}}/g' {{filename}}`
+`sed -E 's/{{regular_expression}}/{{replace}}/g' {{filename}}`
 
 - Replace all occurrences of a string [i]n a file, overwriting the file (i.e. in-place):
 


### PR DESCRIPTION
Reference: https://github.com/tldr-pages/tldr/pull/5808#discussion_r619701289

I replaced `regex` and `regexp` with `regular expression` or `regular_expression` if part of a command.

For the translated pages, I looked what the other pages where using as translation, so that should be correct. Only for the Indonesian (`id`) page, I had to use a translator. 

For now I replaced all occurences of `regex` or `regexp` , but some pages used `{{^regex$}}`, which I for now replaced with `{{^regular_expression$}}`. However, I don't think this is ideal, since `_` can be part of a regular expression itself.