### PR TITLE
tlp, tlp-stat: fix description

### DIFF
--- a/pages/linux/tlp-stat.md
+++ b/pages/linux/tlp-stat.md
@@ -2,7 +2,7 @@
 
 > A tool to generate TLP status reports.
 > See also `tlp`.
-> More information: <https://manned.org/tlp-stat>.
+> More information: <https://linrunner.de/tlp/usage/tlp-stat>.
 
 - Generate status report with configuration and all active settings:
 

--- a/pages/linux/tlp-stat.md
+++ b/pages/linux/tlp-stat.md
@@ -1,6 +1,8 @@
 # tlp-stat
 
-> A tool to generate TLP status reports. See also `tlp`.
+> A tool to generate TLP status reports.
+> See also `tlp`.
+> More information: <https://manned.org/tlp-stat>.
 
 - Generate status report with configuration and all active settings:
 

--- a/pages/linux/tlp.md
+++ b/pages/linux/tlp.md
@@ -2,7 +2,7 @@
 
 > Advanced power management for Linux.
 > See also `tlp-stat`.
-> More information: <https://manned.org/tlp>.
+> More information: <https://linrunner.de/tlp/>.
 
 - Apply settings (according to the actual power source):
 

--- a/pages/linux/tlp.md
+++ b/pages/linux/tlp.md
@@ -1,6 +1,8 @@
 # tlp
 
-> Advanced power management for Linux. See `tlp-stat` page for additional information.
+> Advanced power management for Linux.
+> See also `tlp-stat`.
+> More information: <https://manned.org/tlp>.
 
 - Apply settings (according to the actual power source):
 


### PR DESCRIPTION
- The See also was not on the new line.
- The More information was missing - included manned.org.

Found out while investigating details regarding https://github.com/tldr-pages/tldr/pull/5821#discussion_r619425974