### PR TITLE
acme.sh-dns: add page; acme.sh: remove example

### DIFF
--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -1,0 +1,25 @@
+# acme.sh --dns
+
+> Use a DNS-01 challenge to issue a certificate.
+> DNS API mode documentation: <https://github.com/acmesh-official/acme.sh/wiki/dnsapi>
+> More information: <https://github.com/acmesh-official/acme.sh/wiki/DNS-manual-mode>.
+
+- Issue a certificate using an automatic DNS API mode:
+
+`acme.sh --issue --dns {{gnd_gd}} --domain {{example.com}}`
+
+- Issue a wildcard (\*) certificate using an automatic DNS API mode:
+
+`acme.sh --issue --dns {{dns_namesilo}} --domain {{*.example.com}}`
+
+- Issue a certificate using a DNS alias mode:
+
+`acme.sh --issue --dns {{dns_cf}} --domain {{example.com}} --challenge-alias {{alias-for-example-validation.com}}`
+
+- Issue a certificate while disabling an automatic Cloudflare or Google DNS polling after the DNS record is added by specifying a manual wait time:
+
+`acme.sh --issue --dns {{dns_namecheap}} --domain {{example.com}} --dnssleep 300`
+
+- Issue a certificate using a manual DNS mode:
+
+`acme.sh --issue --dns --domain {{example.com}} --yes-I-know-dns-manual-mode-enough-go-ahead-please`

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --dns {{dns_cf}} --domain {{example.com}} --challenge-alias {{alias-for-example-validation.com}}`
 
-- Issue a certificate while disabling an automatic Cloudflare or Google DNS polling after the DNS record is added by specifying a manual wait time:
+- Issue a certificate while disabling automatic Cloudflare / Google DNS polling after the DNS record is added by specifying a custom wait time in seconds:
 
 `acme.sh --issue --dns {{dns_namecheap}} --domain {{example.com}} --dnssleep {{300}}`
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -1,6 +1,6 @@
 # acme.sh --dns
 
-> Use a DNS-01 challenge to issue a certificate.
+> Use a DNS-01 challenge to issue a TLS certificate.
 > DNS API mode documentation: <https://github.com/acmesh-official/acme.sh/wiki/dnsapi>.
 > More information: <https://github.com/acmesh-official/acme.sh/wiki/DNS-manual-mode>.
 
@@ -18,7 +18,7 @@
 
 - Issue a certificate while disabling an automatic Cloudflare or Google DNS polling after the DNS record is added by specifying a manual wait time:
 
-`acme.sh --issue --dns {{dns_namecheap}} --domain {{example.com}} --dnssleep 300`
+`acme.sh --issue --dns {{dns_namecheap}} --domain {{example.com}} --dnssleep {{300}}`
 
 - Issue a certificate using a manual DNS mode:
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -8,7 +8,7 @@
 
 `acme.sh --issue --dns {{gnd_gd}} --domain {{example.com}}`
 
-- Issue a wildcard (\*) certificate using an automatic DNS API mode:
+- Issue a wildcard certificate (denoted by an asterisk) using an automatic DNS API mode:
 
 `acme.sh --issue --dns {{dns_namesilo}} --domain {{*.example.com}}`
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -10,7 +10,7 @@
 
 - Issue a wildcard certificate (denoted by an asterisk) using an automatic DNS API mode:
 
-`acme.sh --issue --dns {{dns_namesilo}} --domain {{*.example.com}}`
+`acme.sh --issue --dns {{dns_namesilo}} --domain  {{example.com}} --domain {{*.example.com}}`
 
 - Issue a certificate using a DNS alias mode:
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -1,8 +1,7 @@
 # acme.sh --dns
 
 > Use a DNS-01 challenge to issue a TLS certificate.
-> DNS API mode documentation: <https://github.com/acmesh-official/acme.sh/wiki/dnsapi>.
-> More information: <https://github.com/acmesh-official/acme.sh/wiki/DNS-manual-mode>.
+> More information: <https://github.com/acmesh-official/acme.sh/wiki>.
 
 - Issue a certificate using an automatic DNS API mode:
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -1,7 +1,7 @@
 # acme.sh --dns
 
 > Use a DNS-01 challenge to issue a certificate.
-> DNS API mode documentation: <https://github.com/acmesh-official/acme.sh/wiki/dnsapi>
+> DNS API mode documentation: <https://github.com/acmesh-official/acme.sh/wiki/dnsapi>.
 > More information: <https://github.com/acmesh-official/acme.sh/wiki/DNS-manual-mode>.
 
 - Issue a certificate using an automatic DNS API mode:

--- a/pages/common/acme.sh.md
+++ b/pages/common/acme.sh.md
@@ -1,6 +1,7 @@
 # acme.sh
 
 > Shell script implementing ACME client protocol, an alternative to certbot.
+> See also `acme.sh dns`.
 > More information: <https://github.com/acmesh-official/acme.sh>.
 
 - Issue a certificate using webroot mode:
@@ -23,13 +24,9 @@
 
 `acme.sh --issue --apache --domain {{example.com}}`
 
-- Issue a wildcard (\*) certificate using a manual DNS mode:
+- Issue a wildcard (\*) certificate using an automatic DNS API mode:
 
-`acme.sh --issue --dns --domain {{example.com}}`
-
-- Issue a certificate using an automatic DNS API mode:
-
-`acme.sh --issue --dns {{dns_cf}} --domain {{example.com}}`
+`acme.sh --issue --dns {{dns_cf}} --domain {{*.example.com}}`
 
 - Install certificate files into the specified locations (useful for automatic certificate renewal):
 

--- a/pages/common/acme.sh.md
+++ b/pages/common/acme.sh.md
@@ -8,9 +8,9 @@
 
 `acme.sh --issue --domain {{example.com}} --webroot {{/path/to/webroot}}`
 
-- Issue a certificate using standalone mode using port 80:
+- Issue a certificate for multiple domains using standalone mode using port 80:
 
-`acme.sh --issue --standalone --domain {{example.com}}`
+`acme.sh --issue --standalone --domain {{example.com}} --domain {{www.example.com}}`
 
 - Issue a certificate using standalone TLS mode using port 443:
 


### PR DESCRIPTION
The wildcard went completely missing somewhere before the merge. In the original design, wildcard certificate usage was about to be referenced with a manual mode example. Running a manual mode with the current example would not produce a wildcard certificate because of the missing \*. subdomain. Furthermore, it would not do anything because a manual DNS mode requires a sort of confirmation command, more info acmesh-official/acme.sh#1029. Because of the many quirks of the various DNS modes, a separate subcommand page `acme.sh dns` was created.

