### PR TITLE
virsh: fix syntax of connect example

### DIFF
--- a/pages/common/virsh.md
+++ b/pages/common/virsh.md
@@ -6,7 +6,7 @@
 
 - Connect to a hypervisor session:
 
-`virsh connect {{qemu://system}}`
+`virsh connect {{qemu:///system}}`
 
 - List all domains:
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).

The current example throws the following error:
error: failed to connect to the hypervisor
error: internal error: invalid URI qemu://system (maybe you want qemu:///system)

