### PR TITLE
tar: fix mnemonic for f

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -4,11 +4,11 @@
 > Often combined with a compression method, such as gzip or bzip2.
 > More information: <https://www.gnu.org/software/tar>.
 
-- [c]reate an archive from [f]iles:
+- [c]reate an archive and write it to a [f]ile:
 
 `tar cf {{target.tar}} {{file1}} {{file2}} {{file3}}`
 
-- [c]reate a g[z]ipped archive from [f]iles:
+- [c]reate a g[z]ipped archive and write it to a [f]ile:
 
 `tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
 
@@ -24,7 +24,7 @@
 
 `tar xf {{source.tar[.gz|.bz2|.xz]}} --directory={{directory}}`
 
-- [c]reate a compressed archive from [f]iles, using [a]rchive suffix to determine the compression program:
+- [c]reate a compressed archive and write it to a [f]ile, using [a]rchive suffix to determine the compression program:
 
 `tar caf {{target.tar.xz}} {{file1}} {{file2}} {{file3}}`
 
@@ -32,6 +32,6 @@
 
 `tar tvf {{source.tar}}`
 
-- E[x]tract [f]iles matching a pattern:
+- E[x]tract files matching a pattern from an archive [f]ile:
 
 `tar xf {{source.tar}} --wildcards "{{*.html}}"`


### PR DESCRIPTION
Before this patch the document suggested that the `f` allows the user to list some files to extract or insert to the archive.

This patch fixes that: the `f` allows an archive file to be specified. Without it the archive would be read from or written to stdout.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).