### PR TITLE
tar: add verbose argument to extract example

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -16,9 +16,9 @@
 
 `tar czf {{target.tar.gz}} --directory={{path/to/directory}} .`
 
-- E[x]tract a (compressed) archive [f]ile into the current directory:
+- E[x]tract a (compressed) archive [f]ile into the current directory [v]erbosely:
 
-`tar xf {{source.tar[.gz|.bz2|.xz]}}`
+`tar xvf {{source.tar[.gz|.bz2|.xz]}}`
 
 - E[x]tract a (compressed) archive [f]ile into the target directory:
 


### PR DESCRIPTION
Before this change, the `v` did not actually do anything since the `t` command already outputs the names of files in the archive.

It is more useful in a `c` or `x` command.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).