### PR TITLE
yes: change verb 'uitvoeren' to 'printen' in Dutch translation

### DIFF
--- a/pages.nl/common/yes.md
+++ b/pages.nl/common/yes.md
@@ -1,12 +1,12 @@
 # yes
 
-> Voer herhaaldelijk iets uit.
+> Print herhaaldelijk iets op het scherm.
 > Meer informatie: <https://www.gnu.org/software/coreutils/yes>.
 
-- Voer herhaaldelijk "bericht" uit:
+- Print herhaaldelijk "bericht":
 
 `yes {{bericht}}`
 
-- Voor herhaaldelijk "y" uit:
+- Print herhaaldelijk "y":
 
 `yes`


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

The verb 'output' doesn't correctly translate to the Dutch verb 'uitvoeren'.
Uitvoeren means to execute something, which isn't what 'yes' does.

To avoid confusion about whether or not 'yes' prints the message to an actual
printer, or just the console, the description has also been altered slightly.
