### PR TITLE
kdeconnect-cli: add page

### DIFF
--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -31,6 +31,6 @@
 
 `kdeconnect-cli --name {{device_name}} --unlock`
 
-- Send a key to a specific device:
+- Simulate a key press on a specific device:
 
 `kdeconnect-cli --name {{device_name}} --send-keys {{key}}`

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -1,6 +1,7 @@
 # kdeconnect-cli
 
 > KDE Connect CLI.
+> More information: <https://kdeconnect.kde.org>.
 
 - List all devices:
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -1,0 +1,35 @@
+# kdeconnect-cli
+
+> KDE Connect CLI.
+
+- List all devices:
+
+`kdeconnect-cli --list-devices`
+
+- List all reachable devices:
+
+`kdeconnect-cli --list-available`
+
+- Request pairing with a specific device, specifying its ID:
+
+`kdeconnect-cli --pair --device {{device_id}}`
+
+- Request pairing with a specific device, specifying its name:
+
+`kdeconnect-cli --pair --name {{device_name}}`
+
+- Ring a specific device:
+
+`kdeconnect-cli --ring --name {{device_name}}`
+
+- Send an SMS with an optional attachment to a specific number:
+
+`kdeconnect-cli --name {{device_name}} --send-sms {{message}} --destination {{phone_number}} --attachment {{path/to/file}}`
+
+- Unlock a specific device:
+
+`kdeconnect-cli --name {{device_name}} --unlock`
+
+- Send a key to a specific device:
+
+`kdeconnect-cli --name {{device_name}} --send-keys {{key}}`


### PR DESCRIPTION
For the link, we have <https://github.com/KDE/kdeconnect-kde/blob/master/cli/kdeconnect-cli.cpp> or <https://manned.org/kdeconnect-cli> and both are not ideal. (`manneg.org`, because it's completely outdated.)