### PR TITLE
[, arduino-builder, arduino, bash, clear: add pt-BR translation

### DIFF
--- a/pages.pt_BR/common/[.md
+++ b/pages.pt_BR/common/[.md
@@ -14,11 +14,11 @@
 
 - Testa se um arquivo existe:
 
-`[ -f "{{caminho/para/o/arquivo}}" ]`
+`[ -f "{{caminho/para/arquivo}}" ]`
 
 - Testa se um diretório não existe:
 
-`[ ! -d "{{caminho/para/o/diretorio}}" ]`
+`[ ! -d "{{caminho/para/diretorio}}" ]`
 
 - Declaração de if-else:
 

--- a/pages.pt_BR/common/[.md
+++ b/pages.pt_BR/common/[.md
@@ -1,0 +1,25 @@
+# [
+
+> Avalia condição.
+> Retorna 0 se a condição for verdadeira, 1 se for falsa.
+> Mais informações: <https://www.gnu.org/software/coreutils/test>.
+
+- Testa se uma determinada variável é igual a uma determinada string:
+
+`[ "{{$VARIAVEL}}" == "{{/bin/zsh}}" ]`
+
+- Testa se uma determinada variável é vazia:
+
+`[ -z "{{$GIT_BRANCH}}" ]`
+
+- Testa se um arquivo existe:
+
+`[ -f "{{caminho/para/o/arquivo}}" ]`
+
+- Testa se um diretório não existe:
+
+`[ ! -d "{{caminho/para/o/diretorio}}" ]`
+
+- Declaração de if-else:
+
+`[ {{condicao}} ] && {{echo "true"}} || {{echo "false"}}`

--- a/pages.pt_BR/common/[.md
+++ b/pages.pt_BR/common/[.md
@@ -22,4 +22,4 @@
 
 - Declaração de if-else:
 
-`[ {{condicao}} ] && {{echo "true"}} || {{echo "false"}}`
+`[ {{condicao}} ] && {{echo "verdadeiro"}} || {{echo "falso"}}`

--- a/pages.pt_BR/common/arduino-builder.md
+++ b/pages.pt_BR/common/arduino-builder.md
@@ -6,7 +6,7 @@
 
 - Compilar um sketch:
 
-`arduino-builder -compile {{caminho/para/o/sketch.ino}}`
+`arduino-builder -compile {{caminho/para/sketch.ino}}`
 
 - Definir o nível de debug (1 a 10, o padrão é 5):
 
@@ -14,7 +14,7 @@
 
 - Definir um diretório de compilação customizado:
 
-`arduino-builder -build-path {{caminho/para/o/diretorio}}`
+`arduino-builder -build-path {{caminho/para/diretorio}}`
 
 - Usar um arquivo com as opções de compilação, em vez de especificar `--hardware`, `--tools`, etc. manualmente toda hora:
 

--- a/pages.pt_BR/common/arduino-builder.md
+++ b/pages.pt_BR/common/arduino-builder.md
@@ -2,7 +2,7 @@
 
 > Uma ferramenta de linha de comando para compilar sketches do arduino.
 > AVIDO DE OBSOLESCÊNCIA: Esta ferramenta está sendo descontinuada e substituida pelo `arduino`.
-> Saiba mais: <https://github.com/arduino/arduino-builder>.
+> Mais informações: <https://github.com/arduino/arduino-builder>.
 
 - Compilar um sketch:
 

--- a/pages.pt_BR/common/arduino-builder.md
+++ b/pages.pt_BR/common/arduino-builder.md
@@ -1,0 +1,25 @@
+# arduino-builder
+
+> Uma ferramenta de linha de comando para compilar sketches do arduino.
+> AVIDO DE OBSOLESCÊNCIA: Esta ferramenta está sendo descontinuada e substituida pelo `arduino`.
+> Saiba mais: <https://github.com/arduino/arduino-builder>.
+
+- Compilar um sketch:
+
+`arduino-builder -compile {{caminho/para/o/sketch.ino}}`
+
+- Definir o nível de debug (1 a 10, o padrão é 5):
+
+`arduino-builder -debug-level {{nivel}}`
+
+- Definir um diretório de compilação customizado:
+
+`arduino-builder -build-path {{caminho/para/o/diretorio}}`
+
+- Usar um arquivo com as opções de compilação, em vez de especificar `--hardware`, `--tools`, etc. manualmente toda hora:
+
+`arduino-builder -build-options-file {{caminho/para/build.options.json}}`
+
+- Habilitar o modo verboso:
+
+`arduino-builder -verbose {{true}}`

--- a/pages.pt_BR/common/arduino.md
+++ b/pages.pt_BR/common/arduino.md
@@ -5,15 +5,15 @@
 
 - Compilar um sketch:
 
-`arduino --verify {{caminho/para/o/arquivo.ino}}`
+`arduino --verify {{caminho/para/arquivo.ino}}`
 
 - Compilar e enviar sketch:
 
-`arduino --upload {{caminho/para/o/arquivo.ino}}`
+`arduino --upload {{caminho/para/arquivo.ino}}`
 
 - Compilar e enviar sketch para um Arduino Nano com uma CPU Atmega328p, conectada na porta `/dev/ttyACM0`:
 
-`arduino --board {{arduino:avr:nano:cpu=atmega328p}} --port {{/dev/ttyACM0}} --upload {{caminho/para/o/arquivo.ino}}`
+`arduino --board {{arduino:avr:nano:cpu=atmega328p}} --port {{/dev/ttyACM0}} --upload {{caminho/para/arquivo.ino}}`
 
 - Definir a preferência `nome` para um determinado `valor`:
 
@@ -21,7 +21,7 @@
 
 - Compilar um sketch, colocar o resultado da compilação no diretório de compilação, e reutilizar qualquer resultado pre-existente neste diretório:
 
-`arduino --pref build.path={{caminho/para/o/diretório}} --verify {{caminho/para/o/arquivo.ino}}`
+`arduino --pref build.path={{caminho/para/diretório}} --verify {{caminho/para/arquivo.ino}}`
 
 - Salvar todas as preferências (alteradas) para `preferences.txt`:
 

--- a/pages.pt_BR/common/arduino.md
+++ b/pages.pt_BR/common/arduino.md
@@ -1,7 +1,7 @@
 # arduino
 
 > Arduino Studio - Ambiente de Desenvolvimento Integrado para a plataforma Arduino.
-> Saiba mais: <https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc>.
+> Mais informações: <https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc>.
 
 - Compilar um sketch:
 

--- a/pages.pt_BR/common/arduino.md
+++ b/pages.pt_BR/common/arduino.md
@@ -1,0 +1,28 @@
+# arduino
+
+> Arduino Studio - Ambiente de Desenvolvimento Integrado para a plataforma Arduino.
+> Saiba mais: <https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc>.
+
+- Compilar um sketch:
+
+`arduino --verify {{caminho/para/o/arquivo.ino}}`
+
+- Compilar e enviar sketch:
+
+`arduino --upload {{caminho/para/o/arquivo.ino}}`
+
+- Compilar e enviar sketch para um Arduino Nano com uma CPU Atmega328p, conectada na porta `/dev/ttyACM0`:
+
+`arduino --board {{arduino:avr:nano:cpu=atmega328p}} --port {{/dev/ttyACM0}} --upload {{caminho/para/o/arquivo.ino}}`
+
+- Definir a preferência `nome` para um determinado `valor`:
+
+`arduino --pref {{nome}}={{valor}}`
+
+- Compilar um sketch, colocar o resultado da compilação no diretório de compilação, e reutilizar qualquer resultado pre-existente neste diretório:
+
+`arduino --pref build.path={{caminho/para/o/diretório}} --verify {{caminho/para/o/arquivo.ino}}`
+
+- Salvar todas as preferências (alteradas) para `preferences.txt`:
+
+`arduino --save-prefs`

--- a/pages.pt_BR/common/bash.md
+++ b/pages.pt_BR/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, um interpretador de linha de comando compatível com `sh`.
 > Veja também `histexpand` para a expansão do histórico.
-> Saiba mais: <https://gnu.org/software/bash/>.
+> Mais informações: <https://gnu.org/software/bash/>.
 
 - Iniciar uma seção interativa do shell:
 

--- a/pages.pt_BR/common/bash.md
+++ b/pages.pt_BR/common/bash.md
@@ -14,15 +14,15 @@
 
 - Executar um script:
 
-`bash {{caminho/para/o/script.sh}}`
+`bash {{caminho/para/script.sh}}`
 
 - Executar um script, exibindo cada comando antes de executá-lo:
 
-`bash -x {{caminho/para/o/script.sh}}`
+`bash -x {{caminho/para/script.sh}}`
 
 - Executar os comandos de um script, parando de executar no primeiro erro:
 
-`bash -e {{caminho/para/o/script.sh}}`
+`bash -e {{caminho/para/script.sh}}`
 
 - Ler e executar comandos do stdin (entrada padrão):
 

--- a/pages.pt_BR/common/bash.md
+++ b/pages.pt_BR/common/bash.md
@@ -1,0 +1,33 @@
+# bash
+
+> Bourne-Again SHell, um interpretador de linha de comando compatível com `sh`.
+> Veja também `histexpand` para a expansão do histórico.
+> Saiba mais: <https://gnu.org/software/bash/>.
+
+- Iniciar uma seção interativa do shell:
+
+`bash`
+
+- Executar um comando e sair:
+
+`bash -c "{{comando}}"`
+
+- Executar um script:
+
+`bash {{caminho/para/o/script.sh}}`
+
+- Executar um script, exibindo cada comando antes de executá-lo:
+
+`bash -x {{caminho/para/o/script.sh}}`
+
+- Executar os comandos de um script, parando de executar no primeiro erro:
+
+`bash -e {{caminho/para/o/script.sh}}`
+
+- Ler e executar comandos do stdin (entrada padrão):
+
+`bash -s`
+
+- Exibir a versão do Bash (`$BASH_VERSION` abrange apenas a versão sem informações da licença):
+
+`bash --version`

--- a/pages.pt_BR/common/clear.md
+++ b/pages.pt_BR/common/clear.md
@@ -1,7 +1,7 @@
 # clear
 
 > Limpa a tela do terminal.
-> Saiba mais: <https://manned.org/clear>.
+> Mais informações: <https://manned.org/clear>.
 
 - Limpar a tela (equivalente a apertar Control-L no terminal Bash):
 

--- a/pages.pt_BR/common/clear.md
+++ b/pages.pt_BR/common/clear.md
@@ -1,0 +1,20 @@
+# clear
+
+> Limpa a tela do terminal.
+> Saiba mais: <https://manned.org/clear>.
+
+- Limpar a tela (equivalente a apertar Control-L no terminal Bash):
+
+`clear`
+
+- Limpar a tela mantendo o buffer de rolagem do terminal:
+
+`clear -x`
+
+- Especificar o tipo de terminal a ser limpado (por padrão é o valor da variável de ambiente `TERM`):
+
+`clear -T {{tipo_do_terminal}}`
+
+- Mostra a versão do `ncurses` usado pelo `clear`:
+
+`clear -V`


### PR DESCRIPTION
## Commands translated:
- [
- arduino-builder
- arduino
- bash
- clear

---

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
