### PR TITLE
choco-install, choco-source, git: normalize 'caminho para' argument

### DIFF
--- a/pages.pt_BR/common/git.md
+++ b/pages.pt_BR/common/git.md
@@ -21,7 +21,7 @@
 
 - Execute um subcomando Git no caminho raíz de um repositório específico:
 
-`git -C {{caminho/para/o/repo}} {{subcomando}}`
+`git -C {{caminho/para/repo}} {{subcomando}}`
 
 - Execute um subcomando Git com uma dada configuração:
 

--- a/pages.pt_BR/windows/choco-install.md
+++ b/pages.pt_BR/windows/choco-install.md
@@ -9,11 +9,11 @@
 
 - Instalar pacotes a partir de um aquivo de configuração personalizado:
 
-`choco install {{caminho/para/os/pacotes.config}}`
+`choco install {{caminho/para/pacotes.config}}`
 
 - Instalar um arquivo específico `nuspec` ou `nupkg`:
 
-`choco install {{caminho/para/o/arquivo}}`
+`choco install {{caminho/para/arquivo}}`
 
 - Instalar uma versão específica de um pacote:
 

--- a/pages.pt_BR/windows/choco-source.md
+++ b/pages.pt_BR/windows/choco-source.md
@@ -17,7 +17,7 @@
 
 - Adicionar uma nova fonte de pacotes com certificado do cliente:
 
-`choco source add --name {{nome}} --source {{url_da_fonte}} --cert {{caminho/para/o/certificado}}`
+`choco source add --name {{nome}} --source {{url_da_fonte}} --cert {{caminho/para/certificado}}`
 
 - Habilitar uma fonte de pacotes:
 


### PR DESCRIPTION
Checking the repo we use `caminho/para` without `o/` or `os/`.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
