### PR TITLE
README: tweak contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
-[contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
+[contributors-image]: https://img.shields.io/github/contributors-anon/tldr-pages/tldr.svg
 [license-url]: https://github.com/tldr-pages/tldr/blob/main/LICENSE.md
 [license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg
 </div>


### PR DESCRIPTION
The shields.io badge for displaying a count of contributors has two variants: `contributors` and `contributors-anon`, as shown in https://shields.io/category/activity (click the demo "contributors" badge there to see the configuration modal).

Apparently the former only counts contributions (i.e. commits) whose author emails can be mapped to GitHub users. Other contributions are considered "anonymous" by GitHub. They are usually the result of either a misconfigured git installation, emails that haven't been added to the user's GitHub profile, or accounts that have been deleted or that changed their email address.

Since the project has always existed on GitHub from its inception, the anonymous count is closer to the real number, since all contributions would have come from GitHub pull requests, which require a GitHub account to create.

There may be a slight overestimation in the contributors-anon count, e.g. from people who authored commits with different author emails; but that is nevertheless a closer estimate than the non-anon count, and besides, it matches what GitHub shows on their own interface.

See more details at <https://github.com/badges/shields/issues/5969>.