### PR TITLE
stale GitHub action: re-wrap long message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -36,5 +36,5 @@ jobs:
         close-pr-message: |
           Hi everyone.
           This thread is being closed as there was no response to the previous prompt.
-          However, please leave a comment whenever you're ready to resume,
-          so the thread can be reopened. Thanks again!
+          However, please leave a comment whenever you're ready to resume, so the thread can be reopened.
+          Thanks again!


### PR DESCRIPTION
GitHub's markdown renderer does not wrap single line breaks, so the message the bot leaves when closing a thread ([example](https://github.com/tldr-pages/tldr-lint/pull/64#issuecomment-831610730)) would have an awkward line break. This commit re-wraps the message to avoid that.