### PR TITLE
venv: add page

### DIFF
--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -1,0 +1,19 @@
+# venv
+
+> Create isolated "virtual" Python environements.
+
+- Create a new venv:
+
+`python3 -m venv <venv_path>`
+
+- Create a new venv in current directory
+
+`python3 -m venv .`
+
+- Activate the venv (Bash/zsh):
+
+`source <venv_path>/bin/activate`
+
+- Install dependencies:
+
+`pip3 install -r requirements.txt`


### PR DESCRIPTION
I keep having to look this up! Note that there are other similar commands for the `source bin/activate` on other platforms, but I don't have time to figure out how to do platform-specific tl;drs, sorry.

- [x] The page (if new), does not already exist in the repo.
- [mostly] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
