### PR TITLE
change `login`/`logout` to `log in`/`log out`

### DIFF
--- a/pages/common/aws-google-auth.md
+++ b/pages/common/aws-google-auth.md
@@ -3,11 +3,11 @@
 > Command line tool to acquire AWS temporary (STS) credentials using Google Apps as a federated (Single Sign-On) provider.
 > More information: <https://github.com/cevoaustralia/aws-google-auth>.
 
-- Login with Google SSO using the IDP and SP identifiers and set the credentials duration to one hour:
+- Log in with Google SSO using the IDP and SP identifiers and set the credentials duration to one hour:
 
 `aws-google-auth -u {{example@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}}`
 
-- Login [a]sking which role to use (in case of several available SAML roles):
+- Log in [a]sking which role to use (in case of several available SAML roles):
 
 `aws-google-auth -u {{example@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}} -a`
 

--- a/pages/common/balena.md
+++ b/pages/common/balena.md
@@ -3,7 +3,7 @@
 > Interact with the balenaCloud, openBalena and the balena API from the command line.
 > More information: <https://www.balena.io/docs/reference/cli/>.
 
-- Login to the balenaCloud account:
+- Log in to the balenaCloud account:
 
 `balena login`
 

--- a/pages/common/bosh.md
+++ b/pages/common/bosh.md
@@ -11,7 +11,7 @@
 
 `bosh environments`
 
-- Login to the director:
+- Log in to the director:
 
 `bosh login -e {{environment}} `
 

--- a/pages/common/firebase.md
+++ b/pages/common/firebase.md
@@ -3,7 +3,7 @@
 > Test, manage, and deploy Firebase projects from the command line.
 > More information: <https://github.com/firebase/firebase-tools>.
 
-- Login to <https://console.firebase.google.com>:
+- Log in to <https://console.firebase.google.com>:
 
 `firebase login`
 

--- a/pages/common/gcloud.md
+++ b/pages/common/gcloud.md
@@ -7,7 +7,7 @@
 
 `gcloud config list`
 
-- Login to Google account:
+- Log in to Google account:
 
 `gcloud auth login`
 

--- a/pages/common/gh-auth.md
+++ b/pages/common/gh-auth.md
@@ -3,11 +3,11 @@
 > Authenticate with a GitHub host from the command line.
 > More information: <https://cli.github.com/manual/gh_auth>.
 
-- Login with interactive prompt:
+- Log in with interactive prompt:
 
 `gh auth login`
 
-- Login with a token from standard input (created in https://github.com/settings/tokens):
+- Log in with a token from standard input (created in https://github.com/settings/tokens):
 
 `echo {{your_token}} | gh auth login --with-token`
 
@@ -19,7 +19,7 @@
 
 `gh auth logout`
 
-- Login with a specific GitHub Enterprise Server:
+- Log in with a specific GitHub Enterprise Server:
 
 `gh auth login --hostname {{github.example.com}}`
 

--- a/pages/common/gist.md
+++ b/pages/common/gist.md
@@ -3,7 +3,7 @@
 > Upload code to https://gist.github.com.
 > More information: <https://github.com/defunkt/gist>.
 
-- Login in gist on this computer:
+- Log in in gist on this computer:
 
 `gist --login`
 

--- a/pages/common/heroku.md
+++ b/pages/common/heroku.md
@@ -3,7 +3,7 @@
 > Create and manage Heroku apps from the command line.
 > More information: <https://www.heroku.com/>.
 
-- Login to your heroku account:
+- Log in to your heroku account:
 
 `heroku login`
 

--- a/pages/common/k6.md
+++ b/pages/common/k6.md
@@ -27,7 +27,7 @@
 
 `k6 run --compatibility-mode=base {{script.js}}`
 
-- Login to cloud service using secret token:
+- Log in to cloud service using secret token:
 
 `k6 login cloud --token {{secret}}`
 

--- a/pages/common/lpass.md
+++ b/pages/common/lpass.md
@@ -3,7 +3,7 @@
 > Command line interface for the LastPass password manager.
 > More information: <https://github.com/lastpass/lastpass-cli>.
 
-- Login to your LastPass account, by entering your master password when prompted:
+- Log in to your LastPass account, by entering your master password when prompted:
 
 `lpass login {{username}}`
 

--- a/pages/common/molecule.md
+++ b/pages/common/molecule.md
@@ -19,6 +19,6 @@
 
 `molecule converge`
 
-- Login into the instance:
+- Log in into the instance:
 
 `molecule login`

--- a/pages/common/netlify.md
+++ b/pages/common/netlify.md
@@ -3,7 +3,7 @@
 > Deploy sites and configure continuous deployment to the Netlify platform.
 > More information: <https://www.netlify.com/docs/cli/>.
 
-- Login to the Netlify account:
+- Log in to the Netlify account:
 
 `netlify login`
 

--- a/pages/common/oc.md
+++ b/pages/common/oc.md
@@ -28,6 +28,6 @@
 
 `oc get pods`
 
-- Logout from the current session:
+- Log out from the current session:
 
 `oc logout`

--- a/pages/common/packtpub.md
+++ b/pages/common/packtpub.md
@@ -15,7 +15,7 @@
 
 `packtpub login`
 
-- Logout from packtpub.com:
+- Log out from packtpub.com:
 
 `packtpub logout`
 

--- a/pages/common/pio-account.md
+++ b/pages/common/pio-account.md
@@ -11,11 +11,11 @@
 
 `pio account destroy`
 
-- Login to your PlatformIO account:
+- Log in to your PlatformIO account:
 
 `pio account login --username {{username}} --password {{password}}`
 
-- Logout of your PlatformIO account:
+- Log out of your PlatformIO account:
 
 `pio account logout`
 

--- a/pages/common/rtv.md
+++ b/pages/common/rtv.md
@@ -20,7 +20,7 @@
 
 `o`
 
-- Login:
+- Log in:
 
 `u`
 

--- a/pages/common/snyk.md
+++ b/pages/common/snyk.md
@@ -3,7 +3,7 @@
 > Find vulnerabilities in your code and remediate risks.
 > More information: <https://snyk.io>.
 
-- Login to your Snyk account:
+- Log in to your Snyk account:
 
 `snyk auth`
 

--- a/pages/common/youtube-viewer.md
+++ b/pages/common/youtube-viewer.md
@@ -7,7 +7,7 @@
 
 `youtube-viewer {{search_term}}`
 
-- Login to your YouTube account:
+- Log in to your YouTube account:
 
 `youtube-viewer --login`
 

--- a/pages/linux/login.md
+++ b/pages/linux/login.md
@@ -2,18 +2,18 @@
 
 > Initiates a session for a user.
 
-- Login as a user:
+- Log in as a user:
 
 `login {{user}}`
 
-- Login as user without authentication if user is preauthenticated:
+- Log in as user without authentication if user is preauthenticated:
 
 `login -f {{user}}`
 
-- Login as user and preserve environment:
+- Log in as user and preserve environment:
 
 `login -p {{user}}`
 
-- Login as a user on a remote host:
+- Log in as a user on a remote host:
 
 `login -h {{host}} {{user}}`

--- a/pages/windows/azcopy.md
+++ b/pages/windows/azcopy.md
@@ -3,7 +3,7 @@
 > A file transfer tool for uploading to Azure Cloud Storage Accounts.
 > More information: <https://docs.microsoft.com/azure/storage/common/storage-use-azcopy-v10>.
 
-- Login to an Azure Tenant:
+- Log in to an Azure Tenant:
 
 `azopy login`
 


### PR DESCRIPTION
Login or logout, when used as a verb is incorrect (<https://grammarist.com/spelling/log-in-login/>).
