### PR TITLE
age: replace `unencrypted` with `decrypted`

### DIFF
--- a/pages/common/age.md
+++ b/pages/common/age.md
@@ -5,19 +5,19 @@
 
 - Generate an encrypted file that can be decrypted with a passphrase:
 
-`age --passphrase --output {{path/to/encrypted_file}} {{path/to/unencrypted_file}}`
+`age --passphrase --output {{path/to/encrypted_file}} {{path/to/decrypted_file}}`
 
-- Generate a key pair, saving the private key to an unencrypted file and printing the public key to stdout:
+- Generate a key pair, saving the private key to an decrypted file and printing the public key to stdout:
 
 `age-keygen --output {{path/to/file}}`
 
 - Encrypt a file with one or more public keys that are entered as literals:
 
-`age --recipient {{public_key_1}} --recipient {{public_key_2}} {{path/to/unencrypted_file}} --output {{path/to/encrypted_file}}`
+`age --recipient {{public_key_1}} --recipient {{public_key_2}} {{path/to/decrypted_file}} --output {{path/to/encrypted_file}}`
 
 - Encrypt a file with one or more public keys that are specified in a recipients file:
 
-`age --recipients-file {{path/to/recipients_file}} {{path/to/unencrypted_file}} --output {{path/to/encrypted_file}}`
+`age --recipients-file {{path/to/recipients_file}} {{path/to/decrypted_file}} --output {{path/to/encrypted_file}}`
 
 - Decrypt a file with a passphrase:
 


### PR DESCRIPTION

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

Really small PR.
Feel free to close if it is incorrect