### PR TITLE
git-verify-commit: add page

### DIFF
--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,7 +6,7 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit_SHA}}`
+`git verify-commit {{commit_SHA1}} {{commit_SHA2}}`
 
 - Check commits for a GPG signature and show details of each commit:
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -8,7 +8,7 @@
 
 `git verify-commit {{commit SHA hash}}`
 
-- Check git commits for a GPG signature and show details of specified commit:
+- Check commits for a GPG signature and show details of specified commit:
 
 `git verify-commit {{commit SHA hash}} --verbose`
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,12 +6,12 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}}`
+`git verify-commit {{commit_hash1 optional_commit_hash2 ...}}`
 
 - Check commits for a GPG signature and show details of each commit:
 
-`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --verbose`
+`git verify-commit {{commit_hash1 optional_commit_hash2 ...}} --verbose`
 
 - Check commits for a GPG signature and print the raw details:
 
-`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --raw`
+`git verify-commit {{commit_hash1 optional_commit_hash2 ...}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -2,7 +2,7 @@
 
 > Check for GPG verification of commits.
 > If GPG verification isn't present, nothing will be returned, even if extra options are chosen.
-> More information <https://git-scm.com/docs/git-verify-commit>.
+> More information: <https://git-scm.com/docs/git-verify-commit>.
 
 - Check git commits for a GPG signature:
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,12 +6,12 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit SHA hash}}`
+`git verify-commit {{commit_SHA}}`
 
 - Check commits for a GPG signature and show details of specified commit:
 
-`git verify-commit {{commit SHA hash}} --verbose`
+`git verify-commit {{commit_SHA}} --verbose`
 
 - Check commits for a GPG signature and give RAW details:
 
-`git verify-commit {{commit SHA hash}} --raw`
+`git verify-commit {{commit_SHA}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -12,6 +12,6 @@
 
 `git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --verbose`
 
-- Check commits for a GPG signature and print raw details:
+- Check commits for a GPG signature and print the raw details:
 
 `git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -4,7 +4,7 @@
 > If GPG verification isn't present, nothing will be returned, even if extra options are chosen.
 > More information: <https://git-scm.com/docs/git-verify-commit>.
 
-- Check git commits for a GPG signature:
+- Check commits for a GPG signature:
 
 `git verify-commit {{commit SHA hash}}`
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,12 +6,12 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit_hash}} {{commit_hash}}`
+`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}}`
 
 - Check commits for a GPG signature and show details of each commit:
 
-`git verify-commit {{commit_hash}} --verbose`
+`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --verbose`
 
 - Check commits for a GPG signature and print raw details:
 
-`git verify-commit {{commit_hash}} --raw`
+`git verify-commit {{commit_hash}} {{optional_commit_hash(s')}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -10,7 +10,7 @@
 
 - Check git commits for a GPG signature and show details of specified commit:
 
-`git verify-commit {{commit SHA hash}} -v`
+`git verify-commit {{commit SHA hash}} --verbose`
 
 - Check git commits for a GPG signature and give RAW details:
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,12 +6,12 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit_SHA}} {{commit_SHA}}`
+`git verify-commit {{commit_hash}} {{commit_hash}}`
 
 - Check commits for a GPG signature and show details of each commit:
 
-`git verify-commit {{commit_SHA}} --verbose`
+`git verify-commit {{commit_hash}} --verbose`
 
 - Check commits for a GPG signature and print raw details:
 
-`git verify-commit {{commit_SHA}} --raw`
+`git verify-commit {{commit_hash}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -12,6 +12,6 @@
 
 `git verify-commit {{commit_SHA}} --verbose`
 
-- Check commits for a GPG signature and give RAW details:
+- Check commits for a GPG signature and print raw details:
 
 `git verify-commit {{commit_SHA}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -8,7 +8,7 @@
 
 `git verify-commit {{commit_SHA}}`
 
-- Check commits for a GPG signature and show details of specified commit:
+- Check commits for a GPG signature and show details of each commit:
 
 `git verify-commit {{commit_SHA}} --verbose`
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -12,6 +12,6 @@
 
 `git verify-commit {{commit SHA hash}} --verbose`
 
-- Check git commits for a GPG signature and give RAW details:
+- Check commits for a GPG signature and give RAW details:
 
 `git verify-commit {{commit SHA hash}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -1,0 +1,17 @@
+# git verify-commit
+
+> Check for GPG verification of commits.
+> If GPG verification isn't present, nothing will be returned, even if extra options are chosen.
+> More information <https://git-scm.com/docs/git-verify-commit>.
+
+- Check git commits for a GPG signature:
+
+`git verify-commit {{commit SHA hash}}`
+
+- Check git commits for a GPG signature and show details of specified commit:
+
+`git verify-commit {{commit SHA hash}} -v`
+
+- Check git commits for a GPG signature and give RAW details:
+
+`git verify-commit {{commit SHA hash}} --raw`

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -6,7 +6,7 @@
 
 - Check commits for a GPG signature:
 
-`git verify-commit {{commit_SHA1}} {{commit_SHA2}}`
+`git verify-commit {{commit_SHA}} {{commit_SHA}}`
 
 - Check commits for a GPG signature and show details of each commit:
 

--- a/pages/common/git-verify-commit.md
+++ b/pages/common/git-verify-commit.md
@@ -1,7 +1,7 @@
 # git verify-commit
 
 > Check for GPG verification of commits.
-> If GPG verification isn't present, nothing will be returned, even if extra options are chosen.
+> If no commits are verified, nothing will be printed, regardless of options specified.
 > More information: <https://git-scm.com/docs/git-verify-commit>.
 
 - Check commits for a GPG signature:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953