### PR TITLE
git-authors: add page

### DIFF
--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display log or list of committers of a Git repository.
+> Display log or list of committers of a Git repository. Sorted by amount of commits.
 > Part of `git-extras`.
 > Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -5,7 +5,7 @@
 > Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Print log of committers of a Git repository, reading from AUTHORS file, opened in your default editor:
+- Display log of committers of a Git repository, reading from AUTHORS file, opened in your default editor:
 
 `git authors`
 
@@ -13,6 +13,6 @@
 
 `git authors --list`
 
-- Print full list of committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
+- Display full log of committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -2,16 +2,17 @@
 
 > Display log of authors of a Git repository.
 > Part of `git-extras`.
+> Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display log of authors/committers of a Git repository:
+- Print log of authors/committers of a Git repository, reading from AUTHORS file, opened in your default editor:
 
 `git authors`
 
-- Print full list of authors/committers of a Git repository:
+- Print full list of authors/committers of a Git repository, reading from AUTHORS file:
 
 `git authors --list`
 
-- Print full list of authors/committers of a Git repository excluding emails:
+- Print full list of authors/committers of a Git repository excluding emails, reading from AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -8,7 +8,7 @@
 
 `git authors`
 
-- Print full list of committers of the current Git repository:
+- Print a full list of committers:
 
 `git authors --list`
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,18 +1,18 @@
 # git authors
 
-> Display log or list of authors of a Git repository.
+> Display log or list of committers of a Git repository.
 > Part of `git-extras`.
 > Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Print log of authors/committers of a Git repository, reading from AUTHORS file, opened in your default editor:
+- Print log of committers of a Git repository, reading from AUTHORS file, opened in your default editor:
 
 `git authors`
 
-- Print full list of authors/committers of a Git repository, reading from AUTHORS file:
+- Print full list of committers of a Git repository, reading from AUTHORS file:
 
 `git authors --list`
 
-- Print full list of authors/committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
+- Print full list of committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -12,6 +12,6 @@
 
 `git authors --list`
 
-- Display full log of committers of the current Git repository, excluding emails, reading from the AUTHORS file, opened in your default editor:
+- Display a log of committers, exluding emails, in the default editor, reading from the `AUTHORS` file:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -12,6 +12,6 @@
 
 `git authors --list`
 
-- Display a log of committers, excluding emails, in the default editor, reading from the `AUTHORS` file:
+- List committers, excluding emails, in the default editor, reading from the `AUTHORS` file:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display log or list of committers of a Git repository. Sorted by amount of commits.
+> Display log or list of committers of a Git repository. If you aren't using the list command, a new file called AUTHORS will be created. Sorted by amount of commits.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
@@ -8,7 +8,7 @@
 
 `git authors`
 
-- Print full list of committers of the current Git repository, reading from AUTHORS file:
+- Print full list of committers of the current Git repository:
 
 `git authors --list`
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display log of authors of a Git repository.
+> Display log or list of authors of a Git repository.
 > Part of `git-extras`.
 > Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display log or list of committers of a Git repository. Everything except `--list` will create a new file called `AUTHORS`.
+> Display a log or list of committers of a Git repository. Everything except `--list` will create a new file called `AUTHORS`.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -3,6 +3,7 @@
 > Display log of authors of a Git repository.
 > A part of git-extras.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+
 - Display log of authors/committers of a Git repository:
 
 `git authors`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display log of committers of the current Git repository, reading from AUTHORS the file, opened in your default editor:
+- Display log of committers of the current Git repository, reading from the AUTHORS file, opened in your default editor:
 
 `git authors`
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -5,14 +5,14 @@
 > Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display log of committers of a Git repository, reading from AUTHORS file, opened in your default editor:
+- Display log of committers of the current Git repository, reading from AUTHORS file, opened in your default editor:
 
 `git authors`
 
-- Print full list of committers of a Git repository, reading from AUTHORS file:
+- Print full list of committers of the current Git repository, reading from AUTHORS file:
 
 `git authors --list`
 
-- Display full log of committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
+- Display full log of committers of the current Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display log of committers of the current Git repository, reading from AUTHORS file, opened in your default editor:
+- Display log of committers of the current Git repository, reading from AUTHORS the file, opened in your default editor:
 
 `git authors`
 
@@ -12,6 +12,6 @@
 
 `git authors --list`
 
-- Display full log of committers of the current Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
+- Display full log of committers of the current Git repository, excluding emails, reading from the AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -12,6 +12,6 @@
 
 `git authors --list`
 
-- Display a log of committers, exluding emails, in the default editor, reading from the `AUTHORS` file:
+- Display a log of committers, excluding emails, in the default editor, reading from the `AUTHORS` file:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display log or list of committers of a Git repository. If you aren't using the list command, a new file called AUTHORS will be created. Sorted by amount of commits.
+> Display log or list of committers of a Git repository. Everything except `--list` will create a new file called `AUTHORS`.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display a log of committers in the default editor, reading from the `AUTHORS` file:
+- Create or replace the `AUTHORS` file with a list of committers and open it in the default editor:
 
 `git authors`
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Display log of committers of the current Git repository, reading from the AUTHORS file, opened in your default editor:
+- Display a log of committers in the default editor, reading from the `AUTHORS` file:
 
 `git authors`
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -2,7 +2,6 @@
 
 > Display log or list of committers of a Git repository. Sorted by amount of commits.
 > Part of `git-extras`.
-> Creates an AUTHORS file in the Git repository, this will be used for the command.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
 - Display log of committers of the current Git repository, reading from AUTHORS file, opened in your default editor:

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -13,6 +13,6 @@
 
 `git authors --list`
 
-- Print full list of authors/committers of a Git repository excluding emails, reading from AUTHORS file, opened in your default editor:
+- Print full list of authors/committers of a Git repository, excluding emails, reading from AUTHORS file, opened in your default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,0 +1,16 @@
+# git authors
+
+> Display log of authors of a Git repository.
+> A part of git-extras.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+- Display log of authors/committers of a Git repository:
+
+`git authors`
+
+- Print full list of authors/committers of a Git repository:
+
+`git authors --list`
+
+- Print full list of authors/committers of a Git repository excluding emails:
+
+`git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,7 +1,7 @@
 # git authors
 
 > Display log of authors of a Git repository.
-> A part of git-extras.
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
 - Display log of authors/committers of a Git repository:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137