### PR TITLE
README: Remove tldr.ooops.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ both for the command line and for other platforms:
     - [tldr.jsx](https://github.com/ostera/tldr.jsx): http://tldr.ostera.io
     - [tldr.finzzz.net](https://git.finzzz.net/tldr/): https://tldr.finzzz.net
     - [DistroWatch](https://distrowatch.com/dwres.php?resource=man-pages)
-    - [tldr.ooops.me](https://tldr.ooops.me): web client with multilingual support
     - [TLDR Persian](https://opoet7.github.io/tldr-persian/): Web Client in Persian
 
 There is also a comprehensive


### PR DESCRIPTION
https://tldr.ooops.me/ is broken, with an infinite redirect back to itself.