### PR TITLE
dconf, dconf-write: add page

### DIFF
--- a/pages/linux/dconf-write.md
+++ b/pages/linux/dconf-write.md
@@ -17,7 +17,7 @@
 
 - Write an array to a dconf path:
 
-`dconf write {{/example/dconf/path}} '[{{"My First Value", "My Second Value"}}]'`
+`dconf write {{/example/dconf/path}} "[{{'My First Value', 'My Second Value'}}]"`
 
 - Write an empty array to a dconf path:
 

--- a/pages/linux/dconf-write.md
+++ b/pages/linux/dconf-write.md
@@ -9,7 +9,7 @@
 
 - Write a boolean to a dconf path:
 
-`dconf write {{/example/dconf/path}} {{true}}`
+`dconf write {{/example/dconf/path}} {{true|false}}`
 
 - Write an integer to a dconf path:
 

--- a/pages/linux/dconf-write.md
+++ b/pages/linux/dconf-write.md
@@ -1,7 +1,7 @@
 # dconf write
 
 > Write a value to a dconf database path.
-> More information: <https://https://developer.gnome.org/dconf>.
+> More information: <https://developer.gnome.org/dconf>.
 
 - Write a string to a dconf path (note the nested quotes):
 

--- a/pages/linux/dconf-write.md
+++ b/pages/linux/dconf-write.md
@@ -1,0 +1,24 @@
+# dconf write
+
+> Write a value to a dconf database path.
+> More information: <https://https://developer.gnome.org/dconf>.
+
+- Write a string to a dconf path (note the nested quotes):
+
+`dconf write {{/example/dconf/path}} "'{{Example Value}}'"`
+
+- Write a boolean to a dconf path:
+
+`dconf write {{/example/dconf/path}} {{true}}`
+
+- Write an integer to a dconf path:
+
+`dconf write {{/example/dconf/path}} {{16}}`
+
+- Write an array to a dconf path:
+
+`dconf write {{/example/dconf/path}} '[{{"My First Value", "My Second Value"}}]'`
+
+- Write an empty array to a dconf path:
+
+`dconf write {{/example/dconf/path}} "@as []"`

--- a/pages/linux/dconf.md
+++ b/pages/linux/dconf.md
@@ -1,6 +1,7 @@
 # dconf
 
-> Simple tool for manipulating a dconf database.
+> Simple tool for manipulating dconf databases.
+> See also `dconf write`.
 > More information: <https://developer.gnome.org/dconf>.
 
 - Read the value of a dconf path:

--- a/pages/linux/dconf.md
+++ b/pages/linux/dconf.md
@@ -1,0 +1,16 @@
+# dconf
+
+> Simple tool for manipulating a dconf database.
+> More information: <https://https://developer.gnome.org/dconf>.
+
+- Read the value of a dconf path:
+
+`dconf read {{/example/dconf/path}}`
+
+- List contents of a dconf path:
+
+`dconf list {{/example/dconf/path}}`
+
+- Watch for dconf database changes in a path and subpaths:
+
+`dconf watch {{/example/dconf/path}}`

--- a/pages/linux/dconf.md
+++ b/pages/linux/dconf.md
@@ -4,7 +4,7 @@
 > See also `dconf write`.
 > More information: <https://developer.gnome.org/dconf>.
 
-- Read the value of a dconf path:
+- Print the value of a dconf path:
 
 `dconf read {{/example/dconf/path}}`
 

--- a/pages/linux/dconf.md
+++ b/pages/linux/dconf.md
@@ -1,7 +1,7 @@
 # dconf
 
 > Simple tool for manipulating a dconf database.
-> More information: <https://https://developer.gnome.org/dconf>.
+> More information: <https://developer.gnome.org/dconf>.
 
 - Read the value of a dconf path:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
