### PR TITLE
COMMUNITY-ROLES: fix typo

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -191,7 +191,7 @@ using one of the template messages below as a base.
    go to https://github.com/orgs/tldr-pages/people, click the gear icon in their row,
    and select the "Convert to outside collaborator" menu entry.
 
-3. Open a PR moving their name to the "Past organization owners" section
+3. Open a PR moving their name to the "Past organization members" section
    in [MAINTAINERS.md](MAINTAINERS.md).
    Make sure to include `Closes #<issue number>` in the PR description.
    The issue will then be automatically closed once the PR is merged.


### PR DESCRIPTION
I fixed what I assume is a typo, since it doesn't really make sense otherwise.