### PR TITLE
aria2: convert into page alias for aria2c

### DIFF
--- a/pages/common/aria2.md
+++ b/pages/common/aria2.md
@@ -1,33 +1,7 @@
 # aria2
 
-> A lightweight multi-protocol & multi-source command-line download utility.
-> Supports HTTP, HTTPS, FTP, SFTP, BitTorrent and Metalink.
-> More information: <https://aria2.github.io/>.
+> This command is an alias of `aria2c`.
 
-- Download a web resource:
+- View documentation for the original command:
 
-`aria2c {{http://example.org/myLinux.iso}}`
-
-- Download a resource from multiple sources:
-
-`aria2c {{http://mirror1.org/myLinux.iso}} {{http://mirror2.org/myLinux.iso}}`
-
-- Download using 2 connections per host:
-
-`aria2c -x{{2}} {{http://example.org/myLinux.iso}}`
-
-- Download from a Metalink URI:
-
-`aria2c {{http://example.org/myLinux.metalink}}`
-
-- Download from a BitTorrent URI:
-
-`aria2c {{http://example.org/myLinux.torrent}}`
-
-- Download from a BitTorrent Magnet URI:
-
-`aria2c {{'magnet:?xt=urn:btih:248D0A1CD08284299DE78D5C1ED359BB46717D8C'}}`
-
-- Download URIs from a file:
-
-`aria2c -i {{uris.txt}}`
+`tldr aria2c`

--- a/pages/common/aria2.md
+++ b/pages/common/aria2.md
@@ -2,6 +2,6 @@
 
 > This command is an alias of `aria2c`.
 
-- View documentation for the original command:
+- View documentation for the updated command:
 
 `tldr aria2c`


### PR DESCRIPTION
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

Hi, due to the following issue: #5978 I have reformed aria2 just to be a pointer for aria2c

closes #5978 