### PR TITLE
git-authors: fix example descriptions

### DIFF
--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,16 +1,16 @@
 # git authors
 
-> Display a list of committers of a Git repository. Everything except `--list` will append the list of commiters to the `AUTHORS` file.
+> Display a list of committers of a Git repository.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
-
-- Append the list of committers to the the `AUTHORS` file and open it in the default editor:
-
-`git authors`
 
 - Print a full list of committers to stdout instead of to the `AUTHORS` file:
 
 `git authors --list`
+
+- Append the list of committers to the the `AUTHORS` file and open it in the default editor:
+
+`git authors`
 
 - Append the list of committers, excluding emails, to the the `AUTHORS` file and open it in the default editor:
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,6 +1,6 @@
 # git authors
 
-> Display a list of committers of a Git repository.
+> Generate a list of committers of a Git repository.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -1,10 +1,10 @@
 # git authors
 
-> Display a log or list of committers of a Git repository. Everything except `--list` will create a new file called `AUTHORS`.
+> Display a list of committers of a Git repository. Everything except `--list` will append the list of commiters to the `AUTHORS` file.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
 
-- Create or replace the `AUTHORS` file with a list of committers and open it in the default editor:
+- Append the list of committers to the the `AUTHORS` file and open it in the default editor:
 
 `git authors`
 
@@ -12,6 +12,6 @@
 
 `git authors --list`
 
-- List committers, excluding emails, in the default editor, reading from the `AUTHORS` file:
+- Append the list of committers, excluding emails, to the the `AUTHORS` file and open it in the default editor:
 
 `git authors --no-email`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -8,7 +8,7 @@
 
 `git authors`
 
-- Print a full list of committers:
+- Print a full list of committers to stdout instead of to the `AUTHORS` file:
 
 `git authors --list`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

I re-check the command and don't `replace` the file, only append. Also, if you run the command twice, the authors appears twice.
