### PR TITLE
rg: improved fixed string suggestion

### DIFF
--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -34,4 +34,4 @@
 
 - Search a literal string pattern:
 
-`rg --fixed-strings {{string}}`
+`rg --fixed-strings -- {{string}}`


### PR DESCRIPTION
It's better to include a `--` prior to the search string so that strings starting with `--` (e.g. `--foo`) aren't processed as cli options.

https://github.com/BurntSushi/ripgrep/discussions/1560#discussioncomment-6346

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
