### PR TITLE
gh-secret-set: add page

### DIFF
--- a/pages/common/gh-secret-set.md
+++ b/pages/common/gh-secret-set.md
@@ -17,7 +17,7 @@
 
 - Set an organization secret for specific repositories:
 
-`gh secret set {{name}} --org {{organization}} --repos {{repository1,repository2}}`
+`gh secret set {{name}} --org {{organization}} --repos {{repository1,repository2,...}}`
 
 - Set an organization secret with a specific visibility:
 

--- a/pages/common/gh-secret-set.md
+++ b/pages/common/gh-secret-set.md
@@ -1,0 +1,24 @@
+# gh secret set
+
+> Create or update GitHub secrets from the command line.
+> More information: <https://cli.github.com/manual/gh_secret_set>.
+
+- Set a secret for the current repository (user will be prompted for the value):
+
+`gh secret set {{name}}`
+
+- Set a secret from a file for the current repository:
+
+`gh secret set {{name}} < {{path/to/file}}`
+
+- Set a secret for a specific repository:
+
+`gh secret set {{name}} --body {{value}} --repo {{owner}}/{{repository}}`
+
+- Set an organization secret for specific repositories:
+
+`gh secret set {{name}} --org {{organization}} --repos {{repository1,repository2}}`
+
+- Set an organization secret with a specific visibility:
+
+`gh secret set {{name}} --org {{organization}} --visibility {{all|private|selected}}`

--- a/pages/common/gh-secret-set.md
+++ b/pages/common/gh-secret-set.md
@@ -17,7 +17,7 @@
 
 - Set an organization secret for specific repositories:
 
-`gh secret set {{name}} --org {{organization}} --repos {{repository1,repository2,...}}`
+`gh secret set {{name}} --org {{organization}} --repos "{{repository1,repository2,...}}"`
 
 - Set an organization secret with a specific visibility:
 

--- a/pages/common/gh-secret.md
+++ b/pages/common/gh-secret.md
@@ -15,13 +15,13 @@
 
 `gh secret list --repo {{owner}}/{{repository}}`
 
+- Set a secret for the current repository (user will be prompted for the value):
+
+`gh secret set {{name}}`
+
 - Set a secret from a file for the current repository:
 
 `gh secret set {{name}} < {{path/to/file}}`
-
-- Set a secret for a specific repository:
-
-`gh secret set {{name}} --body {{value}} --repo {{owner}}/{{repository}}`
 
 - Set an organization secret for specific repositories:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

The `prompt` for the secret was added in the github-cli v1.10.0, I think the examples were invalid.
