### PR TITLE
mv: add move multiple source paths to a directory example

### DIFF
--- a/pages/common/mv.md
+++ b/pages/common/mv.md
@@ -3,7 +3,7 @@
 > Move or rename files and directories.
 > More information: <https://www.gnu.org/software/coreutils/mv>.
 
-- Move file in arbitrary location:
+- Move a file to an arbitrary location:
 
 `mv {{source}} {{target}}`
 

--- a/pages/common/mv.md
+++ b/pages/common/mv.md
@@ -9,7 +9,7 @@
 
 - Move files into another directory, keeping the filenames:
 
-`mv {{source1}} {{source2}} {{source3}} {{directory}}`
+`mv {{source1}} {{source2}} {{source3}} {{target_directory}}`
 
 - Do not prompt for confirmation before overwriting existing files:
 

--- a/pages/common/mv.md
+++ b/pages/common/mv.md
@@ -3,9 +3,13 @@
 > Move or rename files and directories.
 > More information: <https://www.gnu.org/software/coreutils/mv>.
 
-- Move files in arbitrary locations:
+- Move file in arbitrary location:
 
 `mv {{source}} {{target}}`
+
+- Move files into another directory, keeping the filenames:
+
+`mv {{source1}} {{source2}} {{source3}} {{directory}}`
 
 - Do not prompt for confirmation before overwriting existing files:
 


### PR DESCRIPTION
I think this is an important feature of `mv` and it's not obvious from the examples that already existed on this page.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
