### PR TITLE
git-extras: add page

### DIFF
--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -1,6 +1,6 @@
 # git extras
 
-> Set of commands for `Git`.
+> Set of commands for Git.
 > More information: <https://github.com/tj/git-extras>.
 
 - Download and or upgrade `git-extras` commands:

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -3,7 +3,7 @@
 > Set of commands for Git.
 > More information: <https://github.com/tj/git-extras>.
 
-- Download and or upgrade `git-extras` commands:
+- Download and/or upgrade `git-extras` commands:
 
 `git extras update`
 

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -3,7 +3,7 @@
 > Git extension pack.
 > More information: <https://github.com/tj/git-extras>.
 
-- Download and/or upgrade `git-extras` commands:
+- Install or upgrade `git-extras` commands:
 
 `git extras update`
 

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -1,0 +1,16 @@
+# git extras
+
+> Set of commands for `Git`.
+> More information: <https://github.com/tj/git-extras>.
+
+- Download and or upgrade `git-extras` commands:
+
+`git extras update`
+
+- Display help and commands for `git-extras`:
+
+`git extras --help`
+
+- Print version of installed `git-extras`:
+
+`git extras --version`

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -1,6 +1,6 @@
 # git extras
 
-> Set of commands for Git.
+> Git extension pack.
 > More information: <https://github.com/tj/git-extras>.
 
 - Download and/or upgrade `git-extras` commands:

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -7,7 +7,7 @@
 
 `git extras update`
 
-- Display help and commands for `git-extras`:
+- Display help and subcommands:
 
 `git extras --help`
 

--- a/pages/common/git-extras.md
+++ b/pages/common/git-extras.md
@@ -11,6 +11,6 @@
 
 `git extras --help`
 
-- Print version of installed `git-extras`:
+- Print the version of installed `git-extras`:
 
 `git extras --version`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 