### PR TITLE
snap: add example to update to another channel

### DIFF
--- a/pages/linux/snap.md
+++ b/pages/linux/snap.md
@@ -15,6 +15,10 @@
 
 `snap refresh {{package_name}}`
 
+- Update a package to another channel (track, risk-level, or branch):
+
+`snap refresh {{package_name}} --channel={{channel}}`
+
 - Update all packages:
 
 `snap refresh`

--- a/pages/linux/snap.md
+++ b/pages/linux/snap.md
@@ -15,7 +15,7 @@
 
 `snap refresh {{package_name}}`
 
-- Update a package to another channel (track, risk-level, or branch):
+- Update a package to another channel (track, risk, or branch):
 
 `snap refresh {{package_name}} --channel={{channel}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Sadly, tldr didn't tell me how to change an application I already had installed to another channel. :c
Figured since there is space for it, it'd be nice to add.

Referenced the snap docs:
https://snapcraft.io/docs/channels

This command allows a user to change the channel that an already installed package is on. For example, latest/stable → latest/beta or vice versa.