### PR TITLE
conda: fix examples

### DIFF
--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -5,7 +5,7 @@
 
 - Create a new environment, installing named packages into it:
 
-`conda create --name {{environment_name}} {{python=3.7 matplotlib}}`
+`conda create --name {{environment_name}} {{python=3.9 matplotlib}}`
 
 - List all environments:
 

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -5,7 +5,7 @@
 
 - Create a new environment, installing named packages into it:
 
-`conda create --name {{environment_name}} {{python=2.7 matplotlib}}`
+`conda create --name {{environment_name}} {{python=3.7 matplotlib}}`
 
 - List all environments:
 
@@ -13,7 +13,7 @@
 
 - Load or unload an environment:
 
-`conda {{activate|deactivate}} {{environment_name}}`
+`conda {{activate environment_name|deactivate}}`
 
 - Delete an environment (remove all packages):
 

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -11,17 +11,17 @@
 
 `conda info --envs`
 
-- Load or unload an environment:
+- Load an environment:
 
-`conda {{activate environment_name|deactivate}}`
+`conda {{activate environment_name}}`
+
+- Unload an environment:
+
+`conda {{deactivate}}`
 
 - Delete an environment (remove all packages):
 
 `conda remove --name {{environment_name}} --all`
-
-- Search conda channels for a package by name:
-
-`conda search {{package_name}}`
 
 - Install packages into the current environment:
 


### PR DESCRIPTION
Bumped the python version to remove the deprecated `2.7`.
`conda deactivate` does not accept arguments.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
