### PR TITLE
ls: fix typo

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -33,4 +33,4 @@
 
 - Only list directories:
 
-`ls -d {{*/}}`
+`ls -d */`


### PR DESCRIPTION
"double curly braces" is an unknown syntax, nor by bash nor ksh or zsh even less by ls.
and currently, no need them to reach the aim.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repo.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).
