### PR TITLE
git-setup: add page

### DIFF
--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -1,0 +1,13 @@
+# git setup
+
+> Setup a Git repository in a specific directory, add all files and make a commit with the added files.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-setup>.
+
+- Make a Git repository in the current directory, add all files and make a commit with the added files:
+
+`git setup`
+
+- Make a Git repository in a specific directory, add all files and make a commit with the added files:
+
+`git setup {{path/to/directory}}`

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-setup>.
 
-- Create a Git repository in the current directory, add all files and make a commit with the added files:
+- Create a Git repository in the current directory and commit all files:
 
 `git setup`
 

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -8,6 +8,6 @@
 
 `git setup`
 
-- Create a Git repository in a specific directory, add all files and make a commit with the added files:
+- Create a Git repository in a specific directory and commit all files:
 
 `git setup {{path/to/directory}}`

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -1,6 +1,6 @@
 # git setup
 
-> Setup a Git repository in a specific directory, add all files and make a commit with the added files.
+> Setup a Git repository in a specific directory and commit all files.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-setup>.
 

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -8,6 +8,6 @@
 
 `git setup`
 
-- Make a Git repository in a specific directory, add all files and make a commit with the added files:
+- Create a Git repository in a specific directory, add all files and make a commit with the added files:
 
 `git setup {{path/to/directory}}`

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-setup>.
 
-- Make a Git repository in the current directory, add all files and make a commit with the added files:
+- Create a Git repository in the current directory, add all files and make a commit with the added files:
 
 `git setup`
 

--- a/pages/common/git-setup.md
+++ b/pages/common/git-setup.md
@@ -1,6 +1,6 @@
 # git setup
 
-> Setup a Git repository in a specific directory and commit all files.
+> Create a Git repository in a specific directory and commit all files.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-setup>.
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 