### PR TITLE
git-info: add page

### DIFF
--- a/pages/common/git-info.md
+++ b/pages/common/git-info.md
@@ -1,0 +1,13 @@
+# git info
+
+> Display repository information.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-info>.
+
+- Display repository information about remote locations, remote and local branches, most recent commit data and `.git/config` settings:
+
+`git info`
+
+- Display repository information about remote locations, remote and local branches and most recent commit data:
+
+`git info --no-config`

--- a/pages/common/git-info.md
+++ b/pages/common/git-info.md
@@ -8,6 +8,6 @@
 
 `git info`
 
-- Display repository information about remote locations, remote and local branches and most recent commit data:
+- Display remote locations, remote and local branches and most recent commit data:
 
 `git info --no-config`

--- a/pages/common/git-info.md
+++ b/pages/common/git-info.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-info>.
 
-- Display repository information about remote locations, remote and local branches, most recent commit data and `.git/config` settings:
+- Display remote locations, remote and local branches, most recent commit data and `.git/config` settings:
 
 `git info`
 

--- a/pages/common/git-info.md
+++ b/pages/common/git-info.md
@@ -1,6 +1,6 @@
 # git info
 
-> Display repository information.
+> Display Git repository information.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-info>.
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 