### PR TITLE
git-contrib: add page

### DIFF
--- a/pages/common/git-contrib.md
+++ b/pages/common/git-contrib.md
@@ -6,4 +6,4 @@
 
 - Display all commit hashes and their corresponding commit messages from a specific author:
 
-`git contrib {{username}}`
+`git contrib {{author}}`

--- a/pages/common/git-contrib.md
+++ b/pages/common/git-contrib.md
@@ -4,6 +4,6 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-contrib>.
 
-- Display all commit hashes and corresponding commit messages from a specific author/username:
+- Display all commit hashes and corresponding commit messages from a specific author:
 
 `git contrib {{user_name}}`

--- a/pages/common/git-contrib.md
+++ b/pages/common/git-contrib.md
@@ -4,6 +4,6 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-contrib>.
 
-- Display all commit hashes and corresponding commit messages from a specific author:
+- Display all commit hashes and their corresponding commit messages from a specific author:
 
 `git contrib {{username}}`

--- a/pages/common/git-contrib.md
+++ b/pages/common/git-contrib.md
@@ -6,4 +6,4 @@
 
 - Display all commit hashes and corresponding commit messages from a specific author:
 
-`git contrib {{user_name}}`
+`git contrib {{username}}`

--- a/pages/common/git-contrib.md
+++ b/pages/common/git-contrib.md
@@ -1,0 +1,9 @@
+# git contrib
+
+> Display commits from a specific author.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-contrib>.
+
+- Display all commit hashes and corresponding commit messages from a specific author/username:
+
+`git contrib {{user_name}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 