### PR TITLE
git-summary: add page

### DIFF
--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -1,6 +1,6 @@
 # git summary
 
-> Display data about a Git repository, gives the following information: repository name, repository age, days active, total amount of commits, total amount of files and committer information.
+> Display information about a Git repository.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-summary>.
 

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -10,7 +10,7 @@
 
 - Display data about a Git repository since a commit-ish:
 
-`git summary {{commit-ish}}`
+`git summary {{commit|branch_name|tag_name}}`
 
 - Display data about a Git repository, merging committers using different emails into 1 statistic:
 

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -8,7 +8,7 @@
 
 `git summary`
 
-- Display data about a Git repository since a commit-ish
+- Display data about a Git repository since a commit-ish:
 
 `git summary {{commit-ish}}`
 

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -12,6 +12,6 @@
 
 `git summary {{commit|branch_name|tag_name}}`
 
-- Display data about a Git repository, merging committers using different emails into 1 statistic:
+- Display data about a Git repository, merging committers using different emails into 1 statistic for each author:
 
 `git summary --dedup-by-email`

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -1,0 +1,17 @@
+# git summary
+
+> Display data about a Git repository, gives the following information: repository name, repository age, days active, total amount of commits, total amount of files and committer information.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-summary>.
+
+- Display data about a Git repository (see description for more information):
+
+`git summary`
+
+- Display data about a Git repository since a commit-ish
+
+`git summary {{commit-ish}}`
+
+- Display data about a Git repository, merging committers using different emails into 1 statistic:
+
+`git summary --dedup-by-email`

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -15,3 +15,7 @@
 - Display data about a Git repository, merging committers using different emails into 1 statistic for each author:
 
 `git summary --dedup-by-email`
+
+- Display data about a Git repository, showing the number of lines modified by each contributer:
+
+`git summary --line`

--- a/pages/common/git-summary.md
+++ b/pages/common/git-summary.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-summary>.
 
-- Display data about a Git repository (see description for more information):
+- Display data about a Git repository:
 
 `git summary`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 


## There is a missing option (--list) since it seems useles