### PR TITLE
*: fix errors reported by languagetool

### DIFF
--- a/pages/android/am.md
+++ b/pages/android/am.md
@@ -15,6 +15,6 @@
 
 `am start -a {{android.intent.action.MAIN}} -c {{android.intent.category.HOME}}`
 
-- Convert an intent to an URI:
+- Convert an intent to a URI:
 
 `am to-uri -a {{android.intent.action.VIEW}} -d {{tel:123}}`

--- a/pages/android/getprop.md
+++ b/pages/android/getprop.md
@@ -27,6 +27,6 @@
 
 `getprop {{ro.oem_unlock_supported}}`
 
-- Display the MAC address of the Android's WiFi card:
+- Display the MAC address of the Android's Wi-Fi card:
 
 `getprop {{ro.boot.wifimacaddr}}`

--- a/pages/common/2to3.md
+++ b/pages/common/2to3.md
@@ -11,7 +11,7 @@
 
 `2to3 --write {{path/to/file.py}}`
 
-- Convert specific Python 2 language features to Python 3:
+- Convert a specific Python 2 language features to Python 3:
 
 `2to3 --write {{path/to/file.py}} --fix={{raw_input}} --fix={{print}}`
 

--- a/pages/common/2to3.md
+++ b/pages/common/2to3.md
@@ -11,7 +11,7 @@
 
 `2to3 --write {{path/to/file.py}}`
 
-- Convert a specific Python 2 language features to Python 3:
+- Convert specific Python 2 language features to Python 3:
 
 `2to3 --write {{path/to/file.py}} --fix={{raw_input}} --fix={{print}}`
 

--- a/pages/common/acme.sh-dns.md
+++ b/pages/common/acme.sh-dns.md
@@ -9,7 +9,7 @@
 
 - Issue a wildcard certificate (denoted by an asterisk) using an automatic DNS API mode:
 
-`acme.sh --issue --dns {{dns_namesilo}} --domain  {{example.com}} --domain {{*.example.com}}`
+`acme.sh --issue --dns {{dns_namesilo}} --domain {{example.com}} --domain {{*.example.com}}`
 
 - Issue a certificate using a DNS alias mode:
 

--- a/pages/common/ansible-playbook.md
+++ b/pages/common/ansible-playbook.md
@@ -15,7 +15,7 @@
 
 `ansible-playbook {{playbook}} -e "{{variable1}}={{value1}} {{variable2}}={{value2}}"`
 
-- Run tasks in playbook with extra variables defined in a json file:
+- Run tasks in playbook with extra variables defined in a JSON file:
 
 `ansible-playbook {{playbook}} -e "@{{variables.json}}"`
 

--- a/pages/common/apropos.md
+++ b/pages/common/apropos.md
@@ -11,6 +11,6 @@
 
 `apropos -l {{regular_expression}}`
 
-- Search for pages that contain all of the expressions given:
+- Search for pages that contain all the expressions given:
 
 `apropos {{regular_expression_1}} -a {{regular_expression_2}} -a {{regular_expression_3}}`

--- a/pages/common/aria2c.md
+++ b/pages/common/aria2c.md
@@ -16,7 +16,7 @@
 
 `aria2c --force-sequential {{url_1}} {{url_2}}`
 
-- Download from multiple sources, each URI pointing to the same file:
+- Download from multiple sources with each URI pointing to the same file:
 
 `aria2c {{url_1}} {{url_2}}`
 

--- a/pages/common/aria2c.md
+++ b/pages/common/aria2c.md
@@ -16,7 +16,7 @@
 
 `aria2c --force-sequential {{url_1}} {{url_2}}`
 
-- Download from multiple sources each URI pointing to the same file:
+- Download from multiple sources, each URI pointing to the same file:
 
 `aria2c {{url_1}} {{url_2}}`
 

--- a/pages/common/arping.md
+++ b/pages/common/arping.md
@@ -24,6 +24,6 @@
 
 `arping -U {{ip_to_broadcast}}`
 
-- Detect duplicated IP addresses in the network by sending ARP requests with a 3 seconds timeout:
+- Detect duplicated IP addresses in the network by sending ARP requests with a 3 second timeout:
 
 `arping -D -w {{3}} {{ip_to_check}}`

--- a/pages/common/atq.md
+++ b/pages/common/atq.md
@@ -11,6 +11,6 @@
 
 `atq -q {{a}}`
 
-- Show jobs of all users (run as super user):
+- Show jobs of all users (run as superuser):
 
 `sudo atq`

--- a/pages/common/aws.md
+++ b/pages/common/aws.md
@@ -20,7 +20,7 @@
 
 `aws sts get-caller-identity`
 
-- List AWS resources in a region and output in yaml:
+- List AWS resources in a region and output in YAML:
 
 `aws dynamodb list-tables --region {{us-east-1}} --output yaml`
 

--- a/pages/common/bastet.md
+++ b/pages/common/bastet.md
@@ -3,7 +3,7 @@
 > Clone of the game Tetris in the terminal.
 > More information: <https://fph.altervista.org/prog/bastet.html>.
 
-- Start a tetris game:
+- Start a Tetris game:
 
 `bastet`
 

--- a/pages/common/bat.md
+++ b/pages/common/bat.md
@@ -20,7 +20,7 @@
 
 `bat -n {{file}}`
 
-- Syntax highlight a json file:
+- Syntax highlight a JSON file:
 
 `bat --language json {{file.json}}`
 

--- a/pages/common/bedtools.md
+++ b/pages/common/bedtools.md
@@ -4,7 +4,7 @@
 > Used to intersect, group, convert and count data in BAM, BED, GFF/GTF, VCF format.
 > More information: <https://bedtools.readthedocs.io/en/latest/>.
 
-- Intersect two files with respect to the sequences' strand and save the result to {{`path/to/output_file`}}:
+- Intersect two files regarding the sequences' strand and save the result to {{`path/to/output_file`}}:
 
 `bedtools intersect -a {{path/to/file_1}} -b {{path/to/file_2}} -s > {{path/to/output_file}}`
 

--- a/pages/common/bedtools.md
+++ b/pages/common/bedtools.md
@@ -4,7 +4,7 @@
 > Used to intersect, group, convert and count data in BAM, BED, GFF/GTF, VCF format.
 > More information: <https://bedtools.readthedocs.io/en/latest/>.
 
-- Intersect two files regarding the sequences' strand and save the result to {{`path/to/output_file`}}:
+- Intersect two files regarding the sequences' strand and save the result to the specified file:
 
 `bedtools intersect -a {{path/to/file_1}} -b {{path/to/file_2}} -s > {{path/to/output_file}}`
 

--- a/pages/common/brotli.md
+++ b/pages/common/brotli.md
@@ -1,6 +1,6 @@
-# Brotli
+# brotli
 
-> Compress/uncompress files with brotli compression.
+> Compress/uncompress files with Brotli compression.
 > More information: <https://github.com/google/brotli>.
 
 - Compress a file, creating a compressed version next to the file:
@@ -15,7 +15,7 @@
 
 `brotli {{file.ext}} -o {{compressed_file.ext.br}}`
 
-- Decompress a brotli file specifying the output filename:
+- Decompress a Brotli file specifying the output filename:
 
 `brotli -d {{compressed_file.ext.br}} -o {{file.ext}}`
 

--- a/pages/common/browser-sync.md
+++ b/pages/common/browser-sync.md
@@ -7,7 +7,7 @@
 
 `browser-sync start --server {{path/to/directory}} --files {{path/to/directory}}`
 
-- Start a server from local directory, watching all css files in some directory:
+- Start a server from local directory, watching all CSS files in some directory:
 
 `browser-sync start --server --files '{{path/to/directory/*.css}}'`
 

--- a/pages/common/browser-sync.md
+++ b/pages/common/browser-sync.md
@@ -7,7 +7,7 @@
 
 `browser-sync start --server {{path/to/directory}} --files {{path/to/directory}}`
 
-- Start a server from local directory, watching all CSS files in some directory:
+- Start a server from local directory, watching all CSS files in a directory:
 
 `browser-sync start --server --files '{{path/to/directory/*.css}}'`
 

--- a/pages/common/btm.md
+++ b/pages/common/btm.md
@@ -4,7 +4,7 @@
 > Aims to be lightweight, cross-platform and more graphical than `top`.
 > More information: <https://github.com/ClementTsang/bottom>.
 
-- Show the default layout (cpu, memory, temperatures, disk, network, and processes):
+- Show the default layout (CPU, memory, temperatures, disk, network, and processes):
 
 `btm`
 

--- a/pages/common/cd.md
+++ b/pages/common/cd.md
@@ -7,7 +7,7 @@
 
 `cd {{path/to/directory}}`
 
-- Go to home directory of current user:
+- Go to the home directory of the current user:
 
 `cd`
 

--- a/pages/common/chroma.md
+++ b/pages/common/chroma.md
@@ -11,6 +11,6 @@
 
 `chroma --lexer="{{go}}" --formatter="{{html}}" {{source_file}} > {{html_file}}`
 
-- Highlight a source file with C++ lexer and output to an SVG image, using the Monokai style:
+- Highlight a source file with C++ lexer and output to an SVG, using the Monokai style:
 
 `chroma --lexer="{{c++}}" --formatter="{{svg}}" --syle="{{monokai}}" {{source_file}} > {{svg_file}}`

--- a/pages/common/chroma.md
+++ b/pages/common/chroma.md
@@ -7,7 +7,7 @@
 
 `chroma --lexer="{{python}}" {{source_file}}`
 
-- Highlight a source file with Go lexer and output to a HTML file:
+- Highlight a source file with Go lexer and output to an HTML file:
 
 `chroma --lexer="{{go}}" --formatter="{{html}}" {{source_file}} > {{html_file}}`
 

--- a/pages/common/chroma.md
+++ b/pages/common/chroma.md
@@ -7,10 +7,10 @@
 
 `chroma --lexer="{{python}}" {{source_file}}`
 
-- Highlight a source file with Go lexer and output to an HTML file:
+- Highlight a source file with the Go lexer and output to an HTML file:
 
 `chroma --lexer="{{go}}" --formatter="{{html}}" {{source_file}} > {{html_file}}`
 
-- Highlight a source file with C++ lexer and output to an SVG, using the Monokai style:
+- Highlight a source file with the C++ lexer and output to an SVG, using the Monokai style:
 
 `chroma --lexer="{{c++}}" --formatter="{{svg}}" --syle="{{monokai}}" {{source_file}} > {{svg_file}}`

--- a/pages/common/chromium.md
+++ b/pages/common/chromium.md
@@ -7,7 +7,7 @@
 
 `chromium {{path/to/file.html}}`
 
-- Open an URL:
+- Open a URL:
 
 `chromium {{example.com}}`
 

--- a/pages/common/cksum.md
+++ b/pages/common/cksum.md
@@ -4,6 +4,6 @@
 > Note, on old UNIX systems the CRC implementation may differ.
 > More information: <https://www.gnu.org/software/coreutils/cksum>.
 
-- Display a 32 bit checksum, size in bytes and filename:
+- Display a 32-bit checksum, size in bytes and filename:
 
 `cksum {{filename}}`

--- a/pages/common/code.md
+++ b/pages/common/code.md
@@ -23,6 +23,6 @@
 
 `code -d {{file1}} {{file2}}`
 
-- Open VS Code with super user (sudo) permissions:
+- Open VS Code with superuser (sudo) permissions:
 
 `sudo code {{path/to/file_or_directory}} --user-data-dir`

--- a/pages/common/column.md
+++ b/pages/common/column.md
@@ -12,7 +12,7 @@
 
 `printf "header1 header2\nbar foo\n" | column --table`
 
-- Specify the column delimiter character for the `--table` option (e.g. "," for csv) (defaults to whitespace):
+- Specify the column delimiter character for the `--table` option (e.g. "," for CSV) (defaults to whitespace):
 
 `printf "header1,header2\nbar,foo\n" | column --table --separator {{,}}`
 

--- a/pages/common/conda-create.md
+++ b/pages/common/conda-create.md
@@ -3,7 +3,7 @@
 > Create new conda environments.
 > More information: <https://docs.conda.io/projects/conda/en/latest/commands/create.html>.
 
-- Create a new environment named `py39`, and install Python 3.9 and numpy v1.11 or above in it:
+- Create a new environment named `py39`, and install Python 3.9 and NumPy v1.11 or above in it:
 
 `conda create --yes --name {{py39}} python={{3.9}} "{{numpy>=1.11}}"`
 

--- a/pages/common/convert.md
+++ b/pages/common/convert.md
@@ -23,7 +23,7 @@
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} -append {{image123.png}}`
 
-- Create a gif from a series of images with 100ms delay between them:
+- Create a GIF from a series of images with 100ms delay between them:
 
 `convert {{image1.png}} {{image2.png}} {{image3.png}} -delay {{10}} {{animation.gif}}`
 

--- a/pages/common/cordova.md
+++ b/pages/common/cordova.md
@@ -3,7 +3,7 @@
 > Mobile apps with HTML, CSS & JS.
 > More information: <https://cordova.apache.org/docs/en/latest/guide/cli/>.
 
-- Create a cordova project:
+- Create a Cordova project:
 
 `cordova create {{path}} {{package_name}} {{project_name}}`
 
@@ -11,18 +11,18 @@
 
 `cordova info`
 
-- Add a cordova platform:
+- Add a Cordova platform:
 
 `cordova platform add {{platform}}`
 
-- Remove a cordova platform:
+- Remove a Cordova platform:
 
 `cordova platform remove {{platform}}`
 
-- Add a cordova plugin:
+- Add a Cordova plugin:
 
 `cordova plugin add {{pluginid}}`
 
-- Remove a cordova plugin:
+- Remove a Cordova plugin:
 
 `cordova plugin remove {{pluginid}}`

--- a/pages/common/couchdb.md
+++ b/pages/common/couchdb.md
@@ -3,15 +3,15 @@
 > Command-line interface for Apache CouchDB database server.
 > More information: <https://couchdb.apache.org>.
 
-- Start couchdb:
+- Start CouchDB:
 
 `couchdb`
 
-- Start couchdb interactive shell:
+- Start CouchDB interactive shell:
 
 `couchdb -i`
 
-- Start couchdb as a background process:
+- Start CouchDB as a background process:
 
 `couchdb -b`
 

--- a/pages/common/cradle-elastic.md
+++ b/pages/common/cradle-elastic.md
@@ -1,28 +1,28 @@
 # cradle elastic
 
-> Manage the ElasticSearch instances for a Cradle instance.
+> Manage the Elasticsearch instances for a Cradle instance.
 > More information: <https://cradlephp.github.io/docs/3.B.-Reference-Command-Line-Tools.html#elastic>.
 
-- Truncate the ElasticSearch index:
+- Truncate the Elasticsearch index:
 
 `cradle elastic flush`
 
-- Truncate the ElasticSearch index for a specific package:
+- Truncate the Elasticsearch index for a specific package:
 
 `cradle elastic flush {{package_name}}`
 
-- Submit the ElasticSearch schema:
+- Submit the Elasticsearch schema:
 
 `cradle elastic map`
 
-- Submit the ElasticSearch schema for a specific package:
+- Submit the Elasticsearch schema for a specific package:
 
 `cradle elastic map {{package_name}}`
 
-- Populate the ElasticSearch indices for all packages:
+- Populate the Elasticsearch indices for all packages:
 
 `cradle elastic populate`
 
-- Populate the ElasticSearch indices for a specific package:
+- Populate the Elasticsearch indices for a specific package:
 
 `cradle elastic populate {{package_name}}`

--- a/pages/common/csslint.md
+++ b/pages/common/csslint.md
@@ -23,6 +23,6 @@
 
 `csslint --warnings={{box-sizing,selector-max,floats}} {{file.css}}`
 
-- Specify certain rules to completely ignore:
+- Specify certain rules to ignore:
 
 `csslint --ignore={{ids,rules-count,shorthand}} {{file.css}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -4,7 +4,7 @@
 > Supports most protocols, including HTTP, FTP, and POP3.
 > More information: <https://curl.se>.
 
-- Download the contents of an URL to a file:
+- Download the contents of a URL to a file:
 
 `curl {{http://example.com}} --output {{filename}}`
 
@@ -28,7 +28,7 @@
 
 `curl --data {{'{"name":"bob"}'}} --header {{'Content-Type: application/json'}} {{http://example.com/users/1234}}`
 
-- Pass a user name and password for server authentication:
+- Pass a username and password for server authentication:
 
 `curl --user myusername:mypassword {{http://example.com}}`
 

--- a/pages/common/dcfldd.md
+++ b/pages/common/dcfldd.md
@@ -7,6 +7,6 @@
 
 `dcfldd if=/dev/{{disk_device}} of={{file.img}} hash=sha256 hashlog={{file.hash}}`
 
-- Copy a disk to a raw image file, hashing each 1GB chunk:
+- Copy a disk to a raw image file, hashing each 1 GB chunk:
 
 `dcfldd if=/dev/{{disk_device}} of={{file.img}} hash={{sha512|sha384|sha256|sha1|md5}} hashlog={{file.hash}} hashwindow={{1G}}`

--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -3,7 +3,7 @@
 > Convert and copy a file.
 > More information: <https://www.gnu.org/software/coreutils/dd>.
 
-- Make a bootable usb drive from an isohybrid file (such like `archlinux-xxx.iso`) and show the progress:
+- Make a bootable USB drive from an isohybrid file (such like `archlinux-xxx.iso`) and show the progress:
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}} status=progress`
 

--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -7,7 +7,7 @@
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}} status=progress`
 
-- Clone a drive to another drive with 4MB block, ignore error and show progress:
+- Clone a drive to another drive with 4 MiB block, ignore error and show progress:
 
 `dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs=4M conv=noerror status=progress`
 

--- a/pages/common/detox.md
+++ b/pages/common/detox.md
@@ -8,7 +8,7 @@
 
 `detox {{file}}`
 
-- Show how detox would rename all of the files in a directory tree:
+- Show how detox would rename all the files in a directory tree:
 
 `detox --dry-run -r {{directory}}`
 

--- a/pages/common/df.md
+++ b/pages/common/df.md
@@ -7,7 +7,7 @@
 
 `df`
 
-- Display all filesystems and their disk usage in human readable form:
+- Display all filesystems and their disk usage in human-readable form:
 
 `df -h`
 

--- a/pages/common/dfc.md
+++ b/pages/common/dfc.md
@@ -3,7 +3,7 @@
 > Gives an overview of the filesystem disk space usage with colours and graphs.
 > More information: <https://projects.gw-computing.net/projects/dfc/wiki>.
 
-- Display filesystems and their disk usage in human readable form with colours and graphs:
+- Display filesystems and their disk usage in human-readable form with colours and graphs:
 
 `dfc`
 

--- a/pages/common/diffoscope.md
+++ b/pages/common/diffoscope.md
@@ -11,7 +11,7 @@
 
 `diffoscope --no-progress {{path/to/file1}} {{path/to/file2}}`
 
-- Compare two files and write a HTML-report to a file (use `-` for stdout):
+- Compare two files and write an HTML-report to a file (use `-` for stdout):
 
 `diffoscope --html {{path/to/outfile|-}} {{path/to/file1}} {{path/to/file2}}`
 

--- a/pages/common/django-admin.md
+++ b/pages/common/django-admin.md
@@ -3,7 +3,7 @@
 > Django’s utility for administrative tasks.
 > More information: <https://docs.djangoproject.com/en/3.0/ref/django-admin/>.
 
-- Create a new django project:
+- Create a new Django project:
 
 `django-admin startproject {{project_name}}`
 

--- a/pages/common/docker-exec.md
+++ b/pages/common/docker-exec.md
@@ -19,7 +19,7 @@
 
 `docker exec --interactive --detach {{container_name}} {{command}}`
 
-- Set an environment variable in a running bash session:
+- Set an environment variable in a running Bash session:
 
 `docker exec --interactive --tty --env {{variable_name}}={{value}} {{container_name}} {{/bin/bash}}`
 

--- a/pages/common/docker-network.md
+++ b/pages/common/docker-network.md
@@ -7,7 +7,7 @@
 
 `docker network ls`
 
-- Create a user defined network:
+- Create a user-defined network:
 
 `docker network create --driver {{driver_name}} {{network_name}}`
 

--- a/pages/common/docker-stats.md
+++ b/pages/common/docker-stats.md
@@ -11,7 +11,7 @@
 
 `docker stats {{container_name}}`
 
-- Change the columns format to display container's cpu usage percentage:
+- Change the columns format to display container's CPU usage percentage:
 
 `docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -23,7 +23,7 @@
 
 `docker pull {{image}}`
 
-- Open a shell inside an already running container:
+- Open a shell inside a running container:
 
 `docker exec -it {{container_name}} {{sh}}`
 

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -23,7 +23,7 @@
 
 `docker pull {{image}}`
 
-- Open a shell inside of an already running container:
+- Open a shell inside an already running container:
 
 `docker exec -it {{container_name}} {{sh}}`
 

--- a/pages/common/dolt-config.md
+++ b/pages/common/dolt-config.md
@@ -11,11 +11,11 @@
 
 `dolt config --get {{name}}`
 
-- Modify the value of a local configuration variable, creating it if does not exist:
+- Modify the value of a local configuration variable, creating it if it doesn't exist:
 
 `dolt config --add {{name}} {{value}}`
 
-- Modify the value of a global configuration variable, creating it if does not exist:
+- Modify the value of a global configuration variable, creating it if it doesn't exist:
 
 `dolt config --global --add {{name}} {{value}}`
 

--- a/pages/common/dolt.md
+++ b/pages/common/dolt.md
@@ -1,6 +1,6 @@
 # dolt
 
-> Dolt is a SQL database that you can fork, clone, branch, merge, push and pull just like a Git repository.
+> Dolt is an SQL database that you can fork, clone, branch, merge, push and pull just like a Git repository.
 > More information: <https://github.com/dolthub/dolt>.
 
 - Execute a dolt subcommand:

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -7,7 +7,7 @@
 
 `dotnet new {{template_short_name}}`
 
-- Restore nuget packages:
+- Restore NuGet packages:
 
 `dotnet restore`
 

--- a/pages/common/du.md
+++ b/pages/common/du.md
@@ -11,7 +11,7 @@
 
 `du -h {{path/to/directory}}`
 
-- Show the size of a single directory, in human readable units:
+- Show the size of a single directory, in human-readable units:
 
 `du -sh {{path/to/directory}}`
 

--- a/pages/common/dvc-checkout.md
+++ b/pages/common/dvc-checkout.md
@@ -7,7 +7,7 @@
 
 `dvc checkout`
 
-- Checkout to latest version of a specified target:
+- Checkout the latest version of a specified target:
 
 `dvc checkout {{target}}`
 

--- a/pages/common/ebook-convert.md
+++ b/pages/common/ebook-convert.md
@@ -1,6 +1,6 @@
 # ebook-convert
 
-> Can be used to convert e-books between common formats, e.g., PDF, EPUB and MOBI.
+> Can be used to convert e-books between common formats, e.g. PDF, EPUB and MOBI.
 > Part of the Calibre e-book library tool.
 > More information: <https://manual.calibre-ebook.com/generated/en/ebook-convert.html>.
 

--- a/pages/common/ebook-convert.md
+++ b/pages/common/ebook-convert.md
@@ -1,6 +1,6 @@
 # ebook-convert
 
-> Can be used to convert e-books between common formats, e.g., pdf, epub and mobi.
+> Can be used to convert e-books between common formats, e.g., PDF, EPUB and MOBI.
 > Part of the Calibre e-book library tool.
 > More information: <https://manual.calibre-ebook.com/generated/en/ebook-convert.html>.
 

--- a/pages/common/envoy.md
+++ b/pages/common/envoy.md
@@ -19,7 +19,7 @@
 
 `envoy run --continue {{task_name}}`
 
-- Dump a task as a bash script for inspection:
+- Dump a task as a Bash script for inspection:
 
 `envoy run --pretend {{task_name}}`
 

--- a/pages/common/eslint.md
+++ b/pages/common/eslint.md
@@ -3,7 +3,7 @@
 > A pluggable linting utility for JavaScript and JSX.
 > More information: <https://eslint.org>.
 
-- Create eslint config:
+- Create ESLint config:
 
 `eslint --init`
 

--- a/pages/common/exrex.md
+++ b/pages/common/exrex.md
@@ -16,7 +16,7 @@
 
 `exrex --max-number {{100}} '{{regular_expression}}'`
 
-- Generate all possible strings that match a regular expression, joined together by a custom delimiter string:
+- Generate all possible strings that match a regular expression, joined by a custom delimiter string:
 
 `exrex --delimiter "{{, }}" '{{regular_expression}}'`
 

--- a/pages/common/figlet.md
+++ b/pages/common/figlet.md
@@ -16,6 +16,10 @@
 
 `figlet {{input_text}} -f {{font_filename}}`
 
-- Pipe command output through figlet:
+- Pipe command output through FIGlet:
 
 `{{command}} | figlet`
+
+- Show available FIGlet fonts:
+
+`showfigfonts {{optional_string_to_display}}`

--- a/pages/common/fisher.md
+++ b/pages/common/fisher.md
@@ -12,7 +12,7 @@
 
 `fisher {{gist_url}}`
 
-- Edit 'fishfile' by hand with your favorite editor and install multiple plugins:
+- Edit 'fishfile' manually with your favorite editor and install multiple plugins:
 
 `{{editor}} ~/.config/fish/fishfile; fisher`
 

--- a/pages/common/fkill.md
+++ b/pages/common/fkill.md
@@ -7,6 +7,6 @@
 
 `fkill`
 
-- Kill the process by pid, name or port:
+- Kill the process by PID, name or port:
 
 `fkill {{pid|name|:port}}`

--- a/pages/common/flac.md
+++ b/pages/common/flac.md
@@ -1,6 +1,6 @@
 # flac
 
-> Encodes, decodes and tests flac files.
+> Encodes, decodes and tests FLAC files.
 > More information: <https://xiph.org/flac>.
 
 - Encode a WAV file to FLAC (this will create a FLAC file in the same location as the WAV file):
@@ -15,6 +15,6 @@
 
 `flac -d -o {{path/to/output.wav}} {{path/to/file.flac}}`
 
-- Test a flac file for the correct encoding:
+- Test a FLAC file for the correct encoding:
 
 `flac -t {{path/to/file.flac}}`

--- a/pages/common/flac.md
+++ b/pages/common/flac.md
@@ -3,15 +3,15 @@
 > Encodes, decodes and tests flac files.
 > More information: <https://xiph.org/flac>.
 
-- Encode a wav file to flac (this will create a flac file in the same location as the wav file):
+- Encode a WAV file to FLAC (this will create a FLAC file in the same location as the WAV file):
 
 `flac {{path/to/file.wav}}`
 
-- Encode a wav file to flac, specifying the output file:
+- Encode a WAV file to FLAC, specifying the output file:
 
 `flac -o {{path/to/output.flac}} {{path/to/file.wav}}`
 
-- Decode a flac file to wav, specifying the output file:
+- Decode a FLAC file to WAV, specifying the output file:
 
 `flac -d -o {{path/to/output.wav}} {{path/to/file.flac}}`
 

--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -3,7 +3,7 @@
 > A cross-platform file change monitor.
 > More information: <https://emcrisostomo.github.io/fswatch>.
 
-- Run a bash command on file creation, update or deletion:
+- Run a Bash command on file creation, update or deletion:
 
 `fswatch {{path/to/file}} | xargs -n 1 {{bash_command}}`
 
@@ -15,6 +15,6 @@
 
 `fswatch {{path/to/directory}} | xargs -n 1 -I {} echo {}`
 
-- Filter by event type, eg. Updated, Deleted or Created:
+- Filter by event type, e.g. Updated, Deleted or Created:
 
 `fswatch --event {{Updated}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`

--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -15,6 +15,6 @@
 
 `fswatch {{path/to/directory}} | xargs -n 1 -I {} echo {}`
 
-- Filter by event type, e.g. Updated, Deleted or Created:
+- Filter by event type:
 
-`fswatch --event {{Updated}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`
+`fswatch --event {{Updated|Deleted|Created}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`

--- a/pages/common/gdalbuildvrt.md
+++ b/pages/common/gdalbuildvrt.md
@@ -11,7 +11,7 @@
 
 `gdalbuildvrt -input_file_list {{path/to/list.txt}} {{path/to/output.vrt}}`
 
-- Make a RGB virtual mosaic from 3 single-band input files:
+- Make an RGB virtual mosaic from 3 single-band input files:
 
 `gdalbuildvrt -separate {{path/to/rgb.vrt}} {{path/to/red.tif}} {{path/to/green.tif}} {{path/to/blue.tif}}`
 

--- a/pages/common/gdrive.md
+++ b/pages/common/gdrive.md
@@ -1,21 +1,21 @@
 # gdrive
 
 > Command-line tool to interact with Google Drive.
-> Folder/file id can be obtained from the Google Drive folder or id url.
+> Folder/file ID can be obtained from the Google Drive folder or ID URL.
 > More information: <https://github.com/gdrive-org/gdrive>.
 
-- Upload a local path to the parent folder with the specified id:
+- Upload a local path to the parent folder with the specified ID:
 
 `gdrive upload -p {{id}} {{path/to/file_or_folder}}`
 
-- Download file or directory by id to current directory:
+- Download file or directory by ID to current directory:
 
 `gdrive download {{id}}`
 
-- Download to a given local path by its id:
+- Download to a given local path by its ID:
 
 `gdrive download --path {{path/to/folder}} {{id}}`
 
-- Create a new revision of an id using a given file or folder:
+- Create a new revision of an ID using a given file or folder:
 
 `gdrive update {{id}} {{path/to/file_or_folder}}`

--- a/pages/common/gem.md
+++ b/pages/common/gem.md
@@ -7,7 +7,7 @@
 
 `gem search {{regular_expression}} --all`
 
-- Install latest version of a gem:
+- Install the latest version of a gem:
 
 `gem install {{gemname}}`
 

--- a/pages/common/gh-alias.md
+++ b/pages/common/gh-alias.md
@@ -7,7 +7,7 @@
 
 `gh alias`
 
-- List all of the aliases `gh` is configured to use:
+- List all the aliases `gh` is configured to use:
 
 `gh alias list`
 

--- a/pages/common/gist.md
+++ b/pages/common/gist.md
@@ -27,6 +27,6 @@
 
 `gist --list {{username}}`
 
-- Update a gist using the id from URL:
+- Update a gist using the ID from URL:
 
 `gist --update {{GIST_ID}} {{file.txt}}`

--- a/pages/common/git-authors.md
+++ b/pages/common/git-authors.md
@@ -8,10 +8,10 @@
 
 `git authors --list`
 
-- Append the list of committers to the the `AUTHORS` file and open it in the default editor:
+- Append the list of committers to the `AUTHORS` file and open it in the default editor:
 
 `git authors`
 
-- Append the list of committers, excluding emails, to the the `AUTHORS` file and open it in the default editor:
+- Append the list of committers, excluding emails, to the `AUTHORS` file and open it in the default editor:
 
 `git authors --no-email`

--- a/pages/common/git-bugreport.md
+++ b/pages/common/git-bugreport.md
@@ -3,14 +3,14 @@
 > Captures debug information from the system and user, generating a text file to aid in the reporting of a bug in Git.
 > More information: <https://git-scm.com/docs/git-bugreport>.
 
-- Create a new bugreport file in the current directory:
+- Create a new bug report file in the current directory:
 
 `git bugreport`
 
-- Create a new bugreport file in the specified directory, creating it if it does not exist:
+- Create a new bug report file in the specified directory, creating it if it does not exist:
 
 `git bugreport --output-directory {{path/to/directory}}`
 
-- Create a new bugreport file with the specified filename suffix in `strftime` format:
+- Create a new bug report file with the specified filename suffix in `strftime` format:
 
 `git bugreport --suffix {{%m%d%y}}`

--- a/pages/common/git-count-objects.md
+++ b/pages/common/git-count-objects.md
@@ -7,7 +7,7 @@
 
 `git count-objects`
 
-- Display a count of all objects and their total disk usage, displaying sizes in human readable units:
+- Display a count of all objects and their total disk usage, displaying sizes in human-readable units:
 
 `git count-objects --human-readable`
 
@@ -15,6 +15,6 @@
 
 `git count-objects --verbose`
 
-- Display more verbose information, displaying sizes in human readable units:
+- Display more verbose information, displaying sizes in human-readable units:
 
 `git count-objects --human-readable --verbose`

--- a/pages/common/git-delta.md
+++ b/pages/common/git-delta.md
@@ -8,6 +8,6 @@
 
 `git delta {{main}}`
 
-- List files from specific branch that differ from another specific branch:
+- List files from a specific branch that differ from another specific branch:
 
 `git delta {{branch_1}} {{branch_2}}`

--- a/pages/common/git-describe.md
+++ b/pages/common/git-describe.md
@@ -1,6 +1,6 @@
 # git describe
 
-> Give an object a human readable name based on an available ref.
+> Give an object a human-readable name based on an available ref.
 > More information: <https://git-scm.com/docs/git-describe>.
 
 - Create a unique name for the current commit (the name contains the most recent annotated tag, the number of additional commits, and the abbreviated commit hash):

--- a/pages/common/git-instaweb.md
+++ b/pages/common/git-instaweb.md
@@ -1,9 +1,9 @@
 # git instaweb
 
-> Helper to launch a gitweb server.
+> Helper to launch a GitWeb server.
 > More information: <https://git-scm.com/docs/git-instaweb>.
 
-- Launch a gitweb server for the current Git repository:
+- Launch a GitWeb server for the current Git repository:
 
 `git instaweb --start`
 
@@ -15,7 +15,7 @@
 
 `git instaweb --start --port {{1234}}`
 
-- Use a specified http daemon:
+- Use a specified HTTP daemon:
 
 `git instaweb --start --httpd {{lighttpd|apache2|mongoose|plackup|webrick}}`
 
@@ -23,10 +23,10 @@
 
 `git instaweb --start --browser`
 
-- Stop the currently running gitweb server:
+- Stop the currently running GitWeb server:
 
 `git instaweb --stop`
 
-- Restart the currently running gitweb server:
+- Restart the currently running GitWeb server:
 
 `git instaweb --restart`

--- a/pages/common/git-pull.md
+++ b/pages/common/git-pull.md
@@ -7,7 +7,7 @@
 
 `git pull`
 
-- Download changes from default remote repository and use fast forward:
+- Download changes from default remote repository and use fast-forward:
 
 `git pull --rebase`
 

--- a/pages/common/git-svn.md
+++ b/pages/common/git-svn.md
@@ -7,7 +7,7 @@
 
 `git svn clone {{https://example.com/subversion_repo}} {{local_dir}}`
 
-- Clone a SVN repository starting at a given revision number:
+- Clone an SVN repository starting at a given revision number:
 
 `git svn clone -r{{1234}}:HEAD {{https://svn.example.net/subversion/repo}} {{local_dir}}`
 

--- a/pages/common/go-list.md
+++ b/pages/common/go-list.md
@@ -11,7 +11,7 @@
 
 `go list std`
 
-- List packages in json format:
+- List packages in JSON format:
 
 `go list -json time net/http`
 

--- a/pages/common/gource.md
+++ b/pages/common/gource.md
@@ -12,7 +12,7 @@
 
 `gource -{{width}}x{{height}}`
 
-- Set a custom time scale for the animation:
+- Set a custom timescale for the animation:
 
 `gource -c {{time_scale_multiplier}}`
 

--- a/pages/common/guetzli.md
+++ b/pages/common/guetzli.md
@@ -7,10 +7,10 @@
 
 `guetzli {{input.jpg}} {{output.jpg}}`
 
-- Create compressed JPEG image from PNG image:
+- Create a compressed JPEG from a PNG:
 
 `guetzli {{input.png}} {{output.jpg}}`
 
-- Compress a JPEG image with desired visual quality (84-100):
+- Compress a JPEG with the desired visual quality (84-100):
 
 `guetzli --quality {{quality_value}} {{input.jpg}} {{output.jpg}}`

--- a/pages/common/heroku.md
+++ b/pages/common/heroku.md
@@ -3,11 +3,11 @@
 > Create and manage Heroku apps from the command-line.
 > More information: <https://www.heroku.com/>.
 
-- Log in to your heroku account:
+- Log in to your Heroku account:
 
 `heroku login`
 
-- Create a heroku app:
+- Create a Heroku app:
 
 `heroku create`
 

--- a/pages/common/hostess.md
+++ b/pages/common/hostess.md
@@ -3,7 +3,7 @@
 > An idempotent command-line utility for managing the `/etc/hosts` file.
 > More information: <https://github.com/cbednarski/hostess>.
 
-- List domains, target IPs and on/off status:
+- List domains, target IP addresses and on/off status:
 
 `hostess list`
 

--- a/pages/common/hostess.md
+++ b/pages/common/hostess.md
@@ -3,7 +3,7 @@
 > An idempotent command-line utility for managing the `/etc/hosts` file.
 > More information: <https://github.com/cbednarski/hostess>.
 
-- List domains, target ips and on/off status:
+- List domains, target IPs and on/off status:
 
 `hostess list`
 
@@ -15,6 +15,6 @@
 
 `hostess del {{local.example.com}}`
 
-- Disable a domain (but don't remove it completely):
+- Disable a domain (but don't remove it):
 
 `hostess off {{local.example.com}}`

--- a/pages/common/http.md
+++ b/pages/common/http.md
@@ -23,7 +23,7 @@
 
 `http {{example.org}} {{X-MyHeader:123}}`
 
-- Pass a user name and password for server authentication:
+- Pass a username and password for server authentication:
 
 `http --auth {{username:password}} {{example.org}}`
 

--- a/pages/common/id.md
+++ b/pages/common/id.md
@@ -3,7 +3,7 @@
 > Display current user and group identity.
 > More information: <https://www.gnu.org/software/coreutils/id>.
 
-- Display current user's id (UID), group id (GID) and groups to which they belong:
+- Display current user's ID (UID), group ID (GID) and groups to which they belong:
 
 `id`
 
@@ -15,6 +15,6 @@
 
 `id -g`
 
-- Display an arbitrary user's id (UID), group id (GID) and groups to which they belong:
+- Display an arbitrary user's ID (UID), group ID (GID) and groups to which they belong:
 
 `id {{username}}`

--- a/pages/common/identify.md
+++ b/pages/common/identify.md
@@ -3,6 +3,6 @@
 > Command-line utility of Image Magick project to describe the format and characteristics of one or more image files.
 > More information: <https://imagemagick.org/script/identify.php>.
 
-- Collect dimensions of all jpeg files under current directory:
+- Collect dimensions of all JPEG files under current directory:
 
 `identify -format "%f,%w,%h\n" *.{{jpg}} > {{filelist.csv}}`

--- a/pages/common/ifconfig.md
+++ b/pages/common/ifconfig.md
@@ -3,7 +3,7 @@
 > Network Interface Configurator.
 > More information: <https://net-tools.sourceforge.io/man/ifconfig.8.html>.
 
-- View network settings of an ethernet adapter:
+- View network settings of an Ethernet adapter:
 
 `ifconfig eth0`
 

--- a/pages/common/imapsync.md
+++ b/pages/common/imapsync.md
@@ -1,8 +1,8 @@
 # imapsync
 
-> Email IMAP tool for syncing, copying and migrating email mailboxes between two imap servers, one way, and without duplicates.
+> Email IMAP tool for syncing, copying and migrating email mailboxes between two IMAP servers, one way, and without duplicates.
 > More information: <https://imapsync.lamiral.info>.
 
-- Synchronize imap account between host1 and host2:
+- Synchronize IMAP account between host1 and host2:
 
 `imapsync --host1 {{host1}} --user1 {{user1}} --password1 {{secret1}} --host2 {{host2}} --user2 {{user2}} --password2 {{secret2}}`

--- a/pages/common/import.md
+++ b/pages/common/import.md
@@ -7,7 +7,7 @@
 
 `import -window root {{output.postscript}}`
 
-- Capture contents of a remote X server screen in the PNG image format:
+- Capture contents of a remote X server screen in the PNG format:
 
 `import -window root -display {{remote_host}}:{screen}.{display} {{output.png}}`
 

--- a/pages/common/import.md
+++ b/pages/common/import.md
@@ -9,7 +9,7 @@
 
 - Capture contents of a remote X server screen in the PNG format:
 
-`import -window root -display {{remote_host}}:{screen}.{display} {{output.png}}`
+`import -window root -display {{remote_host}}:{{screen}}.{{display}} {{output.png}}`
 
 - Capture a specific window, given its ID as displayed by `xwininfo`, into the JPEG format:
 

--- a/pages/common/infection.md
+++ b/pages/common/infection.md
@@ -19,7 +19,7 @@
 
 `infection --min-covered-msi {{percentage}}`
 
-- Use a specific test framework (defaults to phpunit):
+- Use a specific test framework (defaults to PHPUnit):
 
 `infection --test-framework {{phpunit|phpspec}}`
 

--- a/pages/common/install.md
+++ b/pages/common/install.md
@@ -4,22 +4,22 @@
 > Copy files (often executable) to a system location like `/usr/local/bin`, give them the appropriate permissions/ownership.
 > More information: <https://www.gnu.org/software/coreutils/install>.
 
-- Copy files to destination:
+- Copy files to the destination:
 
 `install {{path/to/source}} {{path/to/destination}}`
 
-- Copy files to destination, setting their ownership:
+- Copy files to the destination, setting their ownership:
 
 `install -o {{user}} {{path/to/source}} {{path/to/destination}}`
 
-- Copy files to destination, setting their group ownership:
+- Copy files to the destination, setting their group ownership:
 
 `install -g {{user}} {{path/to/source}} {{path/to/destination}}`
 
-- Copy files to destination, setting their `mode`:
+- Copy files to the destination, setting their `mode`:
 
 `install -m {{+x}} {{path/to/source}} {{path/to/destination}}`
 
-- Copy files and apply access/modification times of source to destination:
+- Copy files and apply access/modification times of source to the destination:
 
 `install -p {{path/to/source}} {{path/to/destination}}`

--- a/pages/common/ionic.md
+++ b/pages/common/ionic.md
@@ -23,6 +23,6 @@
 
 `ionic cordova run {{android|ios}} --device`
 
-- Check the health of a ionic app:
+- Check the health of an ionic app:
 
 `ionic doctor {{check}}`

--- a/pages/common/ionic.md
+++ b/pages/common/ionic.md
@@ -15,14 +15,14 @@
 
 `ionic g {{page}}`
 
-- Show versions of ionic, cordova, environment, etc.:
+- Show versions of Ionic, Cordova, environment, etc.:
 
 `ionic info`
 
-- Run app on an android/ios device:
+- Run app on an Android/iOS device:
 
 `ionic cordova run {{android|ios}} --device`
 
-- Check the health of an ionic app:
+- Check the health of an Ionic app:
 
 `ionic doctor {{check}}`

--- a/pages/common/ipcs.md
+++ b/pages/common/ipcs.md
@@ -2,7 +2,7 @@
 
 > Display information about resources used in IPC (Inter-process Communication).
 
-- Specific information about the Message Queue which has the id 32768:
+- Specific information about the Message Queue which has the ID 32768:
 
 `ipcs -qi 32768`
 

--- a/pages/common/irssi.md
+++ b/pages/common/irssi.md
@@ -3,11 +3,11 @@
 > Text based IRC client.
 > More information: <https://irssi.org>.
 
-- Open irssi and connect to a server with a nickname:
+- Open Irssi and connect to a server with a nickname:
 
 `irssi -n {{nickname}} -c {{irc.example.com}}`
 
-- Open irssi and connect with a specific server on a given port:
+- Open Irssi and connect with a specific server on a given port:
 
 `irssi -c {{irc.example.com}} -p {{port}}`
 

--- a/pages/common/jhat.md
+++ b/pages/common/jhat.md
@@ -11,6 +11,6 @@
 
 `jhat -p {{port}} {{dump_file.bin}}`
 
-- Analyze a dump letting jhat use up to 8GB RAM (2-4x dump size recommended):
+- Analyze a dump letting jhat use up to 8 GB RAM (2-4x dump size recommended):
 
 `jhat -J-mx8G {{dump_file.bin}}`

--- a/pages/common/jhat.md
+++ b/pages/common/jhat.md
@@ -3,7 +3,7 @@
 > Java Heap Analysis Tool.
 > More information: <https://docs.oracle.com/javase/8/docs/technotes/tools/unix/jhat.html>.
 
-- Analyze a heap dump (from jmap), view via http on port 7000:
+- Analyze a heap dump (from jmap), view via HTTP on port 7000:
 
 `jhat {{dump_file.bin}}`
 

--- a/pages/common/jhat.md
+++ b/pages/common/jhat.md
@@ -3,7 +3,7 @@
 > Java Heap Analysis Tool.
 > More information: <https://docs.oracle.com/javase/8/docs/technotes/tools/unix/jhat.html>.
 
-- Analyze a heap dump (from jmap), view via HTTP on port 7000:
+- Analyze a heap dump (from `jmap`), view via HTTP on port 7000:
 
 `jhat {{dump_file.bin}}`
 
@@ -11,6 +11,6 @@
 
 `jhat -p {{port}} {{dump_file.bin}}`
 
-- Analyze a dump letting jhat use up to 8 GB RAM (2-4x dump size recommended):
+- Analyze a dump letting `jhat` use up to 8 GB RAM (2-4x dump size recommended):
 
 `jhat -J-mx8G {{dump_file.bin}}`

--- a/pages/common/kak.md
+++ b/pages/common/kak.md
@@ -20,7 +20,7 @@
 
 `%s{{foo}}<Enter>c{{bar}}<Escape>`
 
-- Un-select all secondary selections, and keep only the main one:
+- Unselect all secondary selections, and keep only the main one:
 
 `<Space>`
 

--- a/pages/common/keepass2.md
+++ b/pages/common/keepass2.md
@@ -3,7 +3,7 @@
 > A light-weight password manager.
 > More information: <https://keepass.info>.
 
-- Start KeePass 2, opening the most recently-opened password database:
+- Start KeePass 2, opening the most recently opened password database:
 
 `keepass2`
 

--- a/pages/common/kops.md
+++ b/pages/common/kops.md
@@ -15,7 +15,7 @@
 
 `kops export kubecfg {{cluster_name}}`
 
-- Get the cluster configuration as yaml:
+- Get the cluster configuration as YAML:
 
 `kops get cluster {{cluster_name}} -o yaml`
 

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -14,7 +14,7 @@
 
 `last -F -a`
 
-- View all logins by a specific user and show the ip address instead of the hostname:
+- View all logins by a specific user and show the IP address instead of the hostname:
 
 `last {{username}} -i`
 

--- a/pages/common/latexmk.md
+++ b/pages/common/latexmk.md
@@ -20,10 +20,10 @@
 
 `latexmk -f {{source.tex}}`
 
-- Clean up temporary tex files created for a specific tex file:
+- Clean up temporary TEX files created for a specific TEX file:
 
 `latexmk -c {{source.tex}}`
 
-- Clean up all temporary tex files in the current directory:
+- Clean up all temporary TEX files in the current directory:
 
 `latexmk -c`

--- a/pages/common/latexmk.md
+++ b/pages/common/latexmk.md
@@ -12,7 +12,7 @@
 
 `latexmk {{source.tex}}`
 
-- Compile a pdf document:
+- Compile a PDF document:
 
 `latexmk -pdf {{source.tex}}`
 

--- a/pages/common/leave.md
+++ b/pages/common/leave.md
@@ -1,13 +1,13 @@
 # leave
 
-> Remind when it's time to leave.
+> Set a reminder for when it's time to leave.
 > To remove reminders use `kill $(pidof leave)`.
 
 - Set a reminder at a given time:
 
 `leave {{time_to_leave}}`
 
-- Remind to leave at noon:
+- Set a reminder to leave at noon:
 
 `leave {{1200}}`
 
@@ -15,6 +15,6 @@
 
 `leave +{{amount_of_time}}`
 
-- Remind to leave in 4 hours and 4 minutes:
+- Set a reminder to leave in 4 hours and 4 minutes:
 
 `leave +{{0404}}`

--- a/pages/common/live-server.md
+++ b/pages/common/live-server.md
@@ -1,6 +1,6 @@
 # live-server
 
-> A simple development http server with live reload capability.
+> A simple development HTTP server with live reload capability.
 > More information: <https://www.npmjs.com/package/live-server>.
 
 - Serve an `index.html` file and reload on changes:

--- a/pages/common/logstash.md
+++ b/pages/common/logstash.md
@@ -4,14 +4,14 @@
 > Commonly used to load data from various sources (such as databases and log files) into Elasticsearch.
 > More information: <https://www.elastic.co/products/logstash>.
 
-- Check validity of a logstash configuration:
+- Check validity of a Logstash configuration:
 
 `logstash --configtest --config {{logstash_config.conf}}`
 
-- Run logstash using configuration:
+- Run Logstash using configuration:
 
 `sudo logstash --config {{logstash_config.conf}}`
 
-- Run logstash with the most basic inline configuration string:
+- Run Logstash with the most basic inline configuration string:
 
 `sudo logstash -e 'input {} filter {} output {}'`

--- a/pages/common/lorem.md
+++ b/pages/common/lorem.md
@@ -14,6 +14,6 @@
 
 `lorem -s {{5}} --raven`
 
-- Print 40 random characters from Boccacio's Decameron:
+- Print 40 random characters from Boccaccio's Decameron:
 
 `lorem --randomize -c {{40}} --decamerone`

--- a/pages/common/lpr.md
+++ b/pages/common/lpr.md
@@ -20,7 +20,7 @@
 
 `lpr -o page-ranges={{2|2-16}} {{path/to/file}}`
 
-- Print double sided either in portrait (long) or in landscape (short):
+- Print double-sided either in portrait (long) or in landscape (short):
 
 `lpr -o sides={{two_sided_long_edge|two_sided_short_edge}} {{path/to/file}}`
 

--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -19,7 +19,7 @@
 
 `ls -la`
 
-- Long format list with size displayed using human readable units (KiB, MiB, GiB):
+- Long format list with size displayed using human-readable units (KiB, MiB, GiB):
 
 `ls -lh`
 

--- a/pages/common/meson.md
+++ b/pages/common/meson.md
@@ -3,7 +3,7 @@
 > SCons-like build system that uses python as a front-end language and Ninja as a building backend.
 > More information: <https://mesonbuild.com>.
 
-- Generate a c project with a given name and version:
+- Generate a C project with a given name and version:
 
 `meson init --language={{c}} --name={{myproject}} --version={{0.1}}`
 

--- a/pages/common/minetest.md
+++ b/pages/common/minetest.md
@@ -4,11 +4,11 @@
 > See also `minetestserver`, the server-only binary.
 > More information: <https://wiki.minetest.net/Minetest>.
 
-- Start minetest in client mode:
+- Start Minetest in client mode:
 
 `minetest`
 
-- Start minetest in server mode by hosting a specific world:
+- Start Minetest in server mode by hosting a specific world:
 
 `minetest --server --world {{name}}`
 

--- a/pages/common/mixxx.md
+++ b/pages/common/mixxx.md
@@ -15,7 +15,7 @@
 
 `mixxx --debugAssertBreak --developer --loglevel trace`
 
-- Start mixxx using the specified settings file:
+- Start Mixxx using the specified settings file:
 
 `mixxx --resourcePath {{mixxx/res/controllers}} --settingsPath {{path/to/settings-file}}`
 

--- a/pages/common/mogrify.md
+++ b/pages/common/mogrify.md
@@ -12,7 +12,7 @@
 
 `mogrify -resize {{800x600}} {{DSC*}}`
 
-- Convert all PNG images in the directory to JPEG:
+- Convert all PNGs in the directory to JPEG:
 
 `mogrify -format {{jpg}} {{*.png}}`
 

--- a/pages/common/mogrify.md
+++ b/pages/common/mogrify.md
@@ -16,7 +16,7 @@
 
 `mogrify -format {{jpg}} {{*.png}}`
 
-- Half the saturation of all image files in the current directory:
+- Halve the saturation of all image files in the current directory:
 
 `mogrify -modulate {{100,50}} {{*}}`
 

--- a/pages/common/mogrify.md
+++ b/pages/common/mogrify.md
@@ -16,7 +16,7 @@
 
 `mogrify -format {{jpg}} {{*.png}}`
 
-- Halve the saturation of all image files in the current directory:
+- Half the saturation of all image files in the current directory:
 
 `mogrify -modulate {{100,50}} {{*}}`
 

--- a/pages/common/molecule.md
+++ b/pages/common/molecule.md
@@ -1,9 +1,9 @@
 # molecule
 
-> Molecule helps testing ansible roles.
+> Molecule helps testing Ansible roles.
 > More information: <https://molecule.readthedocs.io>.
 
-- Create a new ansible role:
+- Create a new Ansible role:
 
 `molecule init role --role-name {{role_name}}`
 

--- a/pages/common/mongorestore.md
+++ b/pages/common/mongorestore.md
@@ -3,18 +3,18 @@
 > Utility to import a collection or database from a binary dump into a MongoDB instance.
 > More information: <https://docs.mongodb.com/database-tools/mongorestore/>.
 
-- Import a bson data dump from a directory to a MongoDB database:
+- Import a BSON data dump from a directory to a MongoDB database:
 
 `mongorestore --db {{database_name}} {{path/to/directory}}`
 
-- Import a bson data dump from a directory to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
+- Import a BSON data dump from a directory to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
 
 `mongorestore --host {{database_host:port}} --db {{database_name}} --username {{username}} {{path/to/directory}} --password`
 
-- Import a collection from a bson file to a MongoDB database:
+- Import a collection from a BSON file to a MongoDB database:
 
 `mongorestore --db {{database_name}} {{path/to/file}}`
 
-- Import a collection from a bson file to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
+- Import a collection from a BSON file to a given database in a MongoDB server host, running at a given port, with user authentication (user will be prompted for password):
 
 `mongorestore --host {{database_host:port}} --db {{database_name}} --username {{username}} {{path/to/file}} --password`

--- a/pages/common/montage.md
+++ b/pages/common/montage.md
@@ -20,6 +20,6 @@
 
 `montage {{image1.png}} {{image2.jpg}} {{imageN.png}} -geometry +0+0 -tile 2x3 montage_%d.jpg`
 
-- Resize and crop images to completely fill their grid cells before tiling:
+- Resize and crop images to fill their grid cells before tiling:
 
 `montage {{image1.png}} {{image2.jpg}} {{imageN.png}} -geometry +0+0 -resize 640x480^ -gravity center -crop 640x480+0+0 montage.jpg`

--- a/pages/common/mpv.md
+++ b/pages/common/mpv.md
@@ -7,7 +7,7 @@
 
 `mpv {{file}}`
 
-- Play a video or audio file from an URL:
+- Play a video or audio file from a URL:
 
 `mpv '{{https://www.youtube.com/watch?v=dQw4w9WgXcQ}}'`
 
@@ -19,7 +19,7 @@
 
 `DOWN <or> UP`
 
-- Decrease or increase playback speed by 10 %:
+- Decrease or increase playback speed by 10%:
 
 `[ <or> ]`
 

--- a/pages/common/mutool.md
+++ b/pages/common/mutool.md
@@ -3,7 +3,7 @@
 > Convert PDF files, query information and extract data.
 > More information: <https://mupdf.com/docs>.
 
-- Convert pages 1-10 into 10 PNG images:
+- Convert pages 1-10 into 10 PNGs:
 
 `mutool convert -o {{image%d.png}} {{file.pdf}} {{1-10}}`
 

--- a/pages/common/nkf.md
+++ b/pages/common/nkf.md
@@ -15,7 +15,7 @@
 
 `nkf -w --overwrite {{path/to/file.txt}}`
 
-- Set new line code to LF and overwrite (unix type):
+- Set new line code to LF and overwrite (UNIX type):
 
 `nkf -d --overwrite {{path/to/file.txt}}`
 

--- a/pages/common/nohup.md
+++ b/pages/common/nohup.md
@@ -3,6 +3,6 @@
 > Allows for a process to live when the terminal gets killed.
 > More information: <https://www.gnu.org/software/coreutils/nohup>.
 
-- Run process that can live beyond the terminal:
+- Run a process that can live beyond the terminal:
 
 `nohup {{command}} {{command_options}}`

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -28,7 +28,7 @@
 
 `npm uninstall {{module_name}}`
 
-- Print a tree of locally-installed dependencies:
+- Print a tree of locally installed dependencies:
 
 `npm list`
 

--- a/pages/common/optipng.md
+++ b/pages/common/optipng.md
@@ -1,17 +1,17 @@
 # optipng
 
-> PNG image file optimization utility.
+> PNG file optimization utility.
 > More information: <http://optipng.sourceforge.net>.
 
 - Compress a PNG with default settings:
 
 `optipng {{path/to/file.png}}`
 
-- Compress a PNG with best compression:
+- Compress a PNG with the best compression:
 
 `optipng -o{{7}} {{path/to/file.png}}`
 
-- Compress a PNG with fastest compression:
+- Compress a PNG with the fastest compression:
 
 `optipng -o{{0}} {{path/to/file.png}}`
 

--- a/pages/common/paci.md
+++ b/pages/common/paci.md
@@ -1,6 +1,6 @@
 # paci
 
-> A package manager for bash scripts.
+> A package manager for Bash scripts.
 > More information: <https://github.com/tradebyte/paci>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `paci` commands):

--- a/pages/common/pandoc.md
+++ b/pages/common/pandoc.md
@@ -3,7 +3,7 @@
 > Convert documents between various formats.
 > More information: <https://pandoc.org>.
 
-- Convert file to pdf (the output format is determined by file extension):
+- Convert file to PDF (the output format is determined by file extension):
 
 `pandoc {{input.md}} -o {{output.pdf}}`
 

--- a/pages/common/pathchk.md
+++ b/pages/common/pathchk.md
@@ -3,7 +3,7 @@
 > Check the validity and portability of one or more pathnames.
 > More information: <https://www.gnu.org/software/coreutils/pathchk>.
 
-- Check pathames for validity in the current system:
+- Check pathnames for validity in the current system:
 
 `pathchk {{path1 path2 …}}`
 

--- a/pages/common/pdfposter.md
+++ b/pages/common/pdfposter.md
@@ -1,6 +1,6 @@
 # pdfposter
 
-> Convert a large-sheeted pdf into multiple A4 pages for printing.
+> Convert a large-sheeted PDF into multiple A4 pages for printing.
 > More information: <https://pdfposter.readthedocs.io>.
 
 - Convert an A2 poster into 4 A4 pages:

--- a/pages/common/pdftocairo.md
+++ b/pages/common/pdftocairo.md
@@ -23,6 +23,6 @@
 
 `pdftocairo {{path/to/file.pdf}} -tiff -gray -paper A3`
 
-- Convert to PNG cropping x and y pixels from the top left corner:
+- Convert to PNG cropping x and y pixels from the top-left corner:
 
 `pdftocairo {{path/to/file.pdf}} -png -x {{x_pixels}} -y {{y_pixels}}`

--- a/pages/common/pg_dump.md
+++ b/pages/common/pg_dump.md
@@ -3,7 +3,7 @@
 > Extract a PostgreSQL database into a script file or other archive file.
 > More information: <https://www.postgresql.org/docs/current/app-pgdump.html>.
 
-- Dump database into a SQL-script file:
+- Dump database into an SQL-script file:
 
 `pg_dump {{db_name}} > {{output_file.sql}}`
 

--- a/pages/common/php.md
+++ b/pages/common/php.md
@@ -3,7 +3,7 @@
 > PHP command-line interface.
 > More information: <https://php.net>.
 
-- Parse and execute a php script:
+- Parse and execute a PHP script:
 
 `php {{file}}`
 

--- a/pages/common/pio-system.md
+++ b/pages/common/pio-system.md
@@ -3,7 +3,7 @@
 > Miscellaneous system commands for PlatformIO.
 > More information: <https://docs.platformio.org/en/latest/core/userguide/system/>.
 
-- Install shell completion for the current shell (supports Bash, fish, zsh and PowerShell):
+- Install shell completion for the current shell (supports Bash, Fish, Zsh and PowerShell):
 
 `pio system completion install`
 

--- a/pages/common/pio-system.md
+++ b/pages/common/pio-system.md
@@ -3,7 +3,7 @@
 > Miscellaneous system commands for PlatformIO.
 > More information: <https://docs.platformio.org/en/latest/core/userguide/system/>.
 
-- Install shell completion for the current shell (supports bash, fish, zsh and powershell):
+- Install shell completion for the current shell (supports Bash, fish, zsh and PowerShell):
 
 `pio system completion install`
 

--- a/pages/common/pngcrush.md
+++ b/pages/common/pngcrush.md
@@ -1,13 +1,13 @@
 # pngcrush
 
-> PNG image compression utility.
+> PNG compression utility.
 > More information: <https://pmt.sourceforge.io/pngcrush>.
 
 - Compress a PNG file:
 
 `pngcrush {{in.png}} {{out.png}}`
 
-- Compress all PNGs and output to directory:
+- Compress all PNGs and output them to the specified directory:
 
 `pngcrush -d {{path/to/output}} *.png`
 

--- a/pages/common/podman.md
+++ b/pages/common/podman.md
@@ -24,7 +24,7 @@
 
 `podman pull {{image_name}}:{{image_tag}}`
 
-- Open a shell inside of an already running container:
+- Open a shell inside an already running container:
 
 `podman exec --interactive --tty {{container_name}} {{sh}}`
 

--- a/pages/common/powerstat.md
+++ b/pages/common/powerstat.md
@@ -15,7 +15,7 @@
 
 `powerstat -R {{interval}} {{number_of_samples}}`
 
-- Show an histogram of the power measurements:
+- Show a histogram of the power measurements:
 
 `powerstat -H {{interval}} {{number_of_samples}}`
 

--- a/pages/common/pretty-bytes.md
+++ b/pages/common/pretty-bytes.md
@@ -1,13 +1,13 @@
 # pretty-bytes
 
-> Convert bytes to a human readable string.
+> Convert bytes to a human-readable string.
 > More information: <https://github.com/sindresorhus/pretty-bytes-cli>.
 
-- Convert numeric bytes value to a human readable string:
+- Convert numeric bytes value to a human-readable string:
 
 `pretty-bytes {{1337}}`
 
-- Convert numeric bytes value from stdin to a human readable string:
+- Convert numeric bytes value from stdin to a human-readable string:
 
 `echo {{1337}} | pretty-bytes`
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -22,7 +22,7 @@
 
 `ps --user $(id -u) f`
 
-- Get the parent pid of a process:
+- Get the parent PID of a process:
 
 `ps -o ppid= -p {{pid}}`
 

--- a/pages/common/psql.md
+++ b/pages/common/psql.md
@@ -3,15 +3,15 @@
 > PostgreSQL command-line client.
 > More information: <https://www.postgresql.org/docs/current/app-psql.html>.
 
-- Connect to database. It connects to localhost using default port 5432 with default user as currently logged in user:
+- Connect to the database. It connects to localhost using default port 5432 with default user as currently logged in user:
 
 `psql {{database}}`
 
-- Connect to database on given server host running on given port with given username, without a password prompt:
+- Connect to the database on given server host running on given port with given username, without a password prompt:
 
 `psql -h {{host}} -p {{port}} -U {{username}} {{database}}`
 
-- Connect to database; user will be prompted for password:
+- Connect to the database; user will be prompted for password:
 
 `psql -h {{host}} -p {{port}} -U {{username}} -W {{database}}`
 

--- a/pages/common/pueue-completions.md
+++ b/pages/common/pueue-completions.md
@@ -1,9 +1,9 @@
 # pueue completions
 
-> Generates shell completion files for bash, elvish, fish, powershell, and zsh.
+> Generates shell completion files for Bash, elvish, fish, PowerShell, and zsh.
 > More information: <https://github.com/Nukesor/pueue>.
 
-- Generate completions for bash:
+- Generate completions for Bash:
 
 `sudo pueue completions bash {{/usr/share/bash-completion/completions/pueue.bash}}`
 

--- a/pages/common/pueue-completions.md
+++ b/pages/common/pueue-completions.md
@@ -1,6 +1,6 @@
 # pueue completions
 
-> Generates shell completion files for Bash, elvish, fish, PowerShell, and zsh.
+> Generates shell completion files for Bash, Elvish, Fish, PowerShell, and Zsh.
 > More information: <https://github.com/Nukesor/pueue>.
 
 - Generate completions for Bash:

--- a/pages/common/qpdf.md
+++ b/pages/common/qpdf.md
@@ -19,7 +19,7 @@
 
 `qpdf --split-pages=n {{input.pdf}} {{out_%d.pdf}}`
 
-- Rotate certain pages of a pdf with a given angle:
+- Rotate certain pages of a PDF with a given angle:
 
 `qpdf --rotate={{90:2,4,6}} --rotate={{180:7-8}} {{input.pdf}} {{output.pdf}}`
 

--- a/pages/common/qpdf.md
+++ b/pages/common/qpdf.md
@@ -23,6 +23,6 @@
 
 `qpdf --rotate={{90:2,4,6}} --rotate={{180:7-8}} {{input.pdf}} {{output.pdf}}`
 
-- Remove the password from a password protected file:
+- Remove the password from a password-protected file:
 
 `qpdf --password={{password}} --decrypt {{input.pdf}} {{output.pdf}}`

--- a/pages/common/quota.md
+++ b/pages/common/quota.md
@@ -2,7 +2,7 @@
 
 > Display users' disk space usage and allocated limits.
 
-- Show disk quotas in human readable units for the current user:
+- Show disk quotas in human-readable units for the current user:
 
 `quota -s`
 

--- a/pages/common/rainbowstream.md
+++ b/pages/common/rainbowstream.md
@@ -4,7 +4,7 @@
 > Online help with `h`, up and down arrows for history, tab to auto-complete and 2-tab for suggestion.
 > More information: <https://github.com/orakaro/rainbowstream>.
 
-- Open rainbowstream:
+- Open RainbowStream:
 
 `rainbowstream`
 

--- a/pages/common/rainbowstream.md
+++ b/pages/common/rainbowstream.md
@@ -20,11 +20,11 @@
 
 `t {{message}}`
 
-- Retweet the tweet with given id (id is beside the time):
+- Retweet the tweet with given ID (ID is beside the time):
 
 `rt {{tweet_id}}`
 
-- Favorite the tweet with given id:
+- Favorite the tweet with given ID:
 
 `fav {{tweet_id}}`
 

--- a/pages/common/rclone.md
+++ b/pages/common/rclone.md
@@ -3,7 +3,7 @@
 > CLI program to copy/sync/move files and directories to and from many cloud services.
 > More information: <https://rclone.org>.
 
-- List contents of a directory on an rclone remote:
+- List contents of a directory on a rclone remote:
 
 `rclone lsf {{remote_name}}:{{path/to/directory}}`
 

--- a/pages/common/rclone.md
+++ b/pages/common/rclone.md
@@ -3,7 +3,7 @@
 > CLI program to copy/sync/move files and directories to and from many cloud services.
 > More information: <https://rclone.org>.
 
-- List contents of a directory on a rclone remote:
+- List contents of a directory on an rclone remote:
 
 `rclone lsf {{remote_name}}:{{path/to/directory}}`
 

--- a/pages/common/redis-cli.md
+++ b/pages/common/redis-cli.md
@@ -15,7 +15,7 @@
 
 `redis-cli -h {{host}} -p {{port}}`
 
-- Connect to a remote server specifying an URI:
+- Connect to a remote server specifying a URI:
 
 `redis-cli -u {{uri}}`
 

--- a/pages/common/redshift.md
+++ b/pages/common/redshift.md
@@ -7,7 +7,7 @@
 
 `redshift -t {{5700}}:{{3600}}`
 
-- Turn on Redshift with a manually-specified custom location:
+- Turn on Redshift with a manually specified custom location:
 
 `redshift -l {{latitude}}:{{longitude}}`
 

--- a/pages/common/repren.md
+++ b/pages/common/repren.md
@@ -3,15 +3,15 @@
 > Multi-pattern string replacement and file renaming tool.
 > More information: <https://github.com/jlevy/repren>.
 
-- Do a dry-run renaming a directory of pngs with a literal string replacement:
+- Do a dry-run renaming a directory of PNGs with a literal string replacement:
 
 `repren --dry-run --rename --literal --from '{{find_string}}' --to '{{replacement_string}}' {{*.png}}`
 
-- Do a dry-run renaming a directory of jpegs with a regular expression:
+- Do a dry-run renaming a directory of JPEGs with a regular expression:
 
 `repren --rename --dry-run --from '{{regular_expression}}' --to '{{replacement_string}}' {{*.jpg}} {{*.jpeg}}`
 
-- Do a find-and-replace on the contents of a directory of csv files:
+- Do a find-and-replace on the contents of a directory of CSV files:
 
 `repren --from '{{([0-9]+) example_string}}' --to '{{replacement_string \1}}' {{*.csv}}`
 

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -20,7 +20,7 @@
 
 `rg {{regular_expression}} {{set_of_subdirs}}`
 
-- Search for a regular expression in files matching a glob (e.g., `README.*`):
+- Search for a regular expression in files matching a glob (e.g. `README.*`):
 
 `rg {{regular_expression}} --glob {{glob}}`
 

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -12,7 +12,7 @@
 
 `rg --no-ignore --hidden {{regular_expression}}`
 
-- Search for a regular expression only in a certain filetype (e.g., html, css, etc.):
+- Search for a regular expression only in a certain filetype (e.g., HTML, CSS, etc.):
 
 `rg --type {{filetype}} {{regular_expression}}`
 

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -12,7 +12,7 @@
 
 `rg --no-ignore --hidden {{regular_expression}}`
 
-- Search for a regular expression only in a certain filetype (e.g., HTML, CSS, etc.):
+- Search for a regular expression only in a certain filetype (e.g. HTML, CSS, etc.):
 
 `rg --type {{filetype}} {{regular_expression}}`
 

--- a/pages/common/scrapy.md
+++ b/pages/common/scrapy.md
@@ -19,14 +19,14 @@
 
 `scrapy crawl {{spider_name}}`
 
-- Fetch a webpage as scrapy sees it and print source in stdout:
+- Fetch a webpage as Scrapy sees it and print source in stdout:
 
 `scrapy fetch {{url}}`
 
-- Open a webpage in the default browser as scrapy sees it (disable JavaScript for extra fidelity):
+- Open a webpage in the default browser as Scrapy sees it (disable JavaScript for extra fidelity):
 
 `scrapy view {{url}}`
 
-- Open scrapy shell for URL, which allows interaction with the page source in python shell (or ipython if available):
+- Open Scrapy shell for URL, which allows interaction with the page source in python shell (or ipython if available):
 
 `scrapy shell {{url}}`

--- a/pages/common/scrapy.md
+++ b/pages/common/scrapy.md
@@ -19,7 +19,7 @@
 
 `scrapy crawl {{spider_name}}`
 
-- Fetch a webpage as Scrapy sees it and print source in stdout:
+- Fetch a webpage as Scrapy sees it and print the source to stdout:
 
 `scrapy fetch {{url}}`
 
@@ -27,6 +27,6 @@
 
 `scrapy view {{url}}`
 
-- Open Scrapy shell for URL, which allows interaction with the page source in python shell (or ipython if available):
+- Open Scrapy shell for URL, which allows interaction with the page source in a Python shell (or IPython if available):
 
 `scrapy shell {{url}}`

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -31,6 +31,6 @@
 
 `sed -e 's/{{find}}/{{replace}}/' -e 's/{{find}}/{{replace}}/' {{filename}}`
 
-- Replace separator `/` by any other character not used in the find or replace patterns, e.g., `#`:
+- Replace separator `/` by any other character not used in the find or replace patterns, e.g. `#`:
 
 `sed 's#{{find}}#{{replace}}#' {{filename}}`

--- a/pages/common/serverless.md
+++ b/pages/common/serverless.md
@@ -1,7 +1,7 @@
 # serverless
 
 > Toolkit for deploying and operating serverless architectures on AWS, Google Cloud, Azure and IBM OpenWhisk.
-> Commands can be run either using the `serverless` command or it's alias, `sls`.
+> Commands can be run either using the `serverless` command or its alias, `sls`.
 > More information: <https://serverless.com/>.
 
 - Create a serverless project:

--- a/pages/common/singularity.md
+++ b/pages/common/singularity.md
@@ -6,11 +6,11 @@
 
 `singularity pull --name {{image.sif}} {{library://godlovedc/funny/lolcow:latest}}`
 
-- Rebuild a remote image using latest Singularity image format:
+- Rebuild a remote image using the latest Singularity image format:
 
 `singularity build {{image.sif}} {{docker://godlovedc/lolcow}}`
 
-- Start a container from an image and get a shell inside of it:
+- Start a container from an image and get a shell inside it:
 
 `singularity shell {{image.sif}}`
 

--- a/pages/common/solo.md
+++ b/pages/common/solo.md
@@ -11,7 +11,7 @@
 
 `solo key update`
 
-- Blink the led of a specific Solo:
+- Blink the LED of a specific Solo:
 
 `solo key wink --serial {{serial_number}}`
 

--- a/pages/common/spark.md
+++ b/pages/common/spark.md
@@ -19,6 +19,6 @@
 
 `spark new {{project_name}} --braintree`
 
-- Create a new Spark project with team based billing stubs:
+- Create a new Spark project with team-based billing stubs:
 
 `spark new {{project_name}} --team-billing`

--- a/pages/common/speedtest.md
+++ b/pages/common/speedtest.md
@@ -20,7 +20,7 @@
 
 `speedtest --precision={{precision}}`
 
-- Run a speed test and print it's progress (only available for output format `human-readable` and `json`):
+- Run a speed test and print its progress (only available for output format `human-readable` and `json`):
 
 `speedtest --progress={{yes|no}}`
 

--- a/pages/common/sqsc.md
+++ b/pages/common/sqsc.md
@@ -27,6 +27,6 @@
 
 `sqsc query "SELECT body FROM {{queue_name}} WHERE body LIKE '%user%'"`
 
-- Pull all messages from a queue into a local sqlite database in your present working directory:
+- Pull all messages from a queue into a local SQLite database in your present working directory:
 
 `sqsc pull {{queue_name}}`

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -14,7 +14,7 @@
 
 `ssh-keygen -t ed25519 -a 100`
 
-- Generate an RSA 4096 bit key with email as a comment:
+- Generate an RSA 4096-bit key with email as a comment:
 
 `ssh-keygen -t rsa -b 4096 -C "{{email}}"`
 

--- a/pages/common/st-info.md
+++ b/pages/common/st-info.md
@@ -7,7 +7,7 @@
 
 `st-info --flash`
 
-- Display amount of sram memory available:
+- Display amount of SRAM memory available:
 
 `st-info --sram`
 

--- a/pages/common/stolonctl.md
+++ b/pages/common/stolonctl.md
@@ -15,6 +15,6 @@
 
 `stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} spec`
 
-- Update cluster specification with a patch in json format:
+- Update cluster specification with a patch in JSON format:
 
 `stolonctl --cluster-name {{cluster_name}} --store-backend {{store_backend}} --store-endpoints {{store_endpoints}} update --patch '{{cluster_spec}}'`

--- a/pages/common/svgcleaner.md
+++ b/pages/common/svgcleaner.md
@@ -1,12 +1,12 @@
 # svgcleaner
 
-> SVG image optimizing utility.
+> SVG optimizing utility.
 > More information: <https://github.com/RazrFalcon/svgcleaner>.
 
-- Optimize an SVG image:
+- Optimize an SVG:
 
 `svgcleaner {{input.svg}} {{output.svg}}`
 
-- Optimize an SVG image multiple times:
+- Optimize an SVG multiple times:
 
 `svgcleaner --multipass {{input.svg}} {{output.svg}}`

--- a/pages/common/swig.md
+++ b/pages/common/swig.md
@@ -1,7 +1,7 @@
 # swig
 
 > Generate bindings between C / C++ code and various high level languages such as JavaScript, Python, C#, and more.
-> It uses special .i or .swg files to generate the bindings (C/C++ with SWIG directives, then outputs a C/C++ file that contains all of the wrapper code needed to build an extension module.
+> It uses special .i or .swg files to generate the bindings (C/C++ with SWIG directives, then outputs a C/C++ file that contains all the wrapper code needed to build an extension module.
 
 - Generate a binding between C++ and Python:
 

--- a/pages/common/syncthing.md
+++ b/pages/common/syncthing.md
@@ -3,11 +3,11 @@
 > Continuous bidirectional decentralised folder synchronisation tool.
 > More information: <https://docs.syncthing.net/>.
 
-- Start syncthing:
+- Start Syncthing:
 
 `syncthing`
 
-- Start syncthing without opening a web browser:
+- Start Syncthing without opening a web browser:
 
 `syncthing -no-browser`
 
@@ -27,10 +27,10 @@
 
 `syncthing -gui-address={{ip_address:port|path/to/socket.sock}}`
 
-- Show filepaths to the files used by syncthing:
+- Show filepaths to the files used by Syncthing:
 
 `syncthing -paths`
 
-- Disable the syncthing monitor process:
+- Disable the Syncthing monitor process:
 
 `syncthing -no-restart`

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -3,13 +3,13 @@
 > Read from standard input and write to standard output and files (or commands).
 > More information: <https://www.gnu.org/software/coreutils/tee>.
 
-- Copy standard input to each FILE, and also to standard output:
+- Copy standard input to each file, and also to standard output:
 
-`echo "example" | tee {{FILE}}`
+`echo "example" | tee {{path/to/file}}`
 
-- Append to the given FILEs, do not overwrite:
+- Append to the given files, do not overwrite:
 
-`echo "example" | tee -a {{FILE}}`
+`echo "example" | tee -a {{path/to/file}}`
 
 - Print standard input to the terminal, and also pipe it into another program for further processing:
 

--- a/pages/common/terminalizer.md
+++ b/pages/common/terminalizer.md
@@ -1,6 +1,6 @@
 # terminalizer
 
-> Utility program which records the terminal and generate animated gifs or share a video.
+> Utility program which records the terminal and generate animated GIFs or share a video.
 > More information: <https://terminalizer.com>.
 
 - Create the global config directory:
@@ -15,7 +15,7 @@
 
 `terminalizer play {{filename}}`
 
-- Render a recording file as an animated gif image:
+- Render a recording file as an animated GIF image:
 
 `terminalizer render {{filename}}`
 

--- a/pages/common/theharvester.md
+++ b/pages/common/theharvester.md
@@ -15,7 +15,7 @@
 
 `theHarvester --domain {{domain_name}} --source {{google}} --limit {{200}}`
 
-- Save the output to two files in xml and html format:
+- Save the output to two files in XML and HTML format:
 
 `theHarvester --domain {{domain_name}} --source {{google}} --file {{output_file_name}}`
 

--- a/pages/common/topydo.md
+++ b/pages/common/topydo.md
@@ -1,25 +1,25 @@
 # topydo
 
-> A todo list application that uses the todo.txt format.
+> A to-do list application that uses the todo.txt format.
 > More information: <https://github.com/topydo/topydo>.
 
-- Add a todo to a specific project with a given context:
+- Add a to-do to a specific project with a given context:
 
 `topydo add "{{todo_message}} +{{project_name}} @{{context_name}}"`
 
-- Add a todo with a due date of tomorrow with a priority of `A`:
+- Add a to-do with a due date of tomorrow with a priority of `A`:
 
 `topydo add "(A) {{todo _message}} due:{{1d}}"`
 
-- Add a todo with a due date of Friday:
+- Add a to-do with a due date of Friday:
 
 `topydo add "{{todo_message}} due:{{fri}}"`
 
-- Add a non-strict repeating todo (next due = now + rec):
+- Add a non-strict repeating to-do (next due = now + rec):
 
 `topydo add "water flowers due:{{mon}} rec:{{1w}}"`
 
-- Add a strict repeating todo (next due = currentdue + rec):
+- Add a strict repeating to-do (next due = current due + rec):
 
 `topydo add "{{todo_message}} due:{{2020-01-01}} rec:{{+1m}}"`
 

--- a/pages/common/topydo.md
+++ b/pages/common/topydo.md
@@ -11,7 +11,7 @@
 
 `topydo add "(A) {{todo _message}} due:{{1d}}"`
 
-- Add a todo with a due date of friday:
+- Add a todo with a due date of Friday:
 
 `topydo add "{{todo_message}} due:{{fri}}"`
 

--- a/pages/common/traefik.md
+++ b/pages/common/traefik.md
@@ -1,6 +1,6 @@
 # traefik
 
-> A HTTP reverse proxy and load balancer.
+> An HTTP reverse proxy and load balancer.
 > More information: <https://traefik.io>.
 
 - Start server with default config:

--- a/pages/common/transcode.md
+++ b/pages/common/transcode.md
@@ -6,10 +6,10 @@
 
 `transcode -J stabilize -i {{input_file}}`
 
-- Remove camera shakes after creating stabilisation file, transform video using xvid:
+- Remove camera shakes after creating stabilisation file, transform video using XviD:
 
 `transcode -J transform -i {{input_file}} -y xvid -o {{output_file}}`
 
-- Resize the video to 640x480 pixels and convert to MPEG4 codec using xvid:
+- Resize the video to 640x480 pixels and convert to MPEG4 codec using XviD:
 
 `transcode -Z 640x480 -i {{input_file}} -y xvid -o {{output_file}}`

--- a/pages/common/trawl.md
+++ b/pages/common/trawl.md
@@ -7,7 +7,7 @@
 
 `trawl -n`
 
-- Filter interface names using a case insensitive regular expression:
+- Filter interface names using a case-insensitive regular expression:
 
 `trawl -f wi`
 

--- a/pages/common/truncate.md
+++ b/pages/common/truncate.md
@@ -7,7 +7,7 @@
 
 `truncate --size {{10G}} {{filename}}`
 
-- Extend the file size by 50 M, fill with holes (which reads as zero bytes):
+- Extend the file size by 50 MiB, fill with holes (which reads as zero bytes):
 
 `truncate --size +{{50M}} {{filename}}`
 

--- a/pages/common/truncate.md
+++ b/pages/common/truncate.md
@@ -7,11 +7,11 @@
 
 `truncate --size {{10G}} {{filename}}`
 
-- Extend the file size by 50M, fill with holes (which reads as zero bytes):
+- Extend the file size by 50 M, fill with holes (which reads as zero bytes):
 
 `truncate --size +{{50M}} {{filename}}`
 
-- Shrink the file by 2GiB, by removing data from the end of file:
+- Shrink the file by 2 GiB, by removing data from the end of file:
 
 `truncate --size -{{2G}} {{filename}}`
 

--- a/pages/common/tslint.md
+++ b/pages/common/tslint.md
@@ -3,7 +3,7 @@
 > A pluggable linting utility for TypeScript.
 > More information: <https://palantir.github.io/tslint>.
 
-- Create tslint config:
+- Create TSLint config:
 
 `tslint --init`
 

--- a/pages/common/type.md
+++ b/pages/common/type.md
@@ -1,8 +1,8 @@
 # type
 
-> Display the kind of command the shell will execute.
+> Display the type of command the shell will execute.
 
-- Display the kind of a command:
+- Display the type of a command:
 
 `type {{command}}`
 

--- a/pages/common/ufraw-batch.md
+++ b/pages/common/ufraw-batch.md
@@ -2,11 +2,11 @@
 
 > Convert RAW files from cameras into standard image files.
 
-- Simply convert RAW files to jpg:
+- Simply convert RAW files to JPG:
 
 `ufraw-batch --out-type=jpg {{input_file(s)}}`
 
-- Simply convert RAW files to png:
+- Simply convert RAW files to PNG:
 
 `ufraw-batch --out-type=png {{input_file(s)}}`
 

--- a/pages/common/uuencode.md
+++ b/pages/common/uuencode.md
@@ -7,10 +7,10 @@
 
 `uuencode {{path/to/input_file}} {{output_file_name_after_decoding}}`
 
-- Encode a file and and write the result to a file:
+- Encode a file and write the result to a file:
 
 `uuencode -o {{path/to/output_file}} {{path/to/input_file}} {{output_file_name_after_decoding}}`
 
-- Encode a file using Base64 instead of the default uuencode encoding and and write the result to a file:
+- Encode a file using Base64 instead of the default uuencode encoding and write the result to a file:
 
 `uuencode -m -o {{path/to/output_file}} {{path/to/input_file}} {{output_file_name_after_decoding}}`

--- a/pages/common/vdir.md
+++ b/pages/common/vdir.md
@@ -8,7 +8,7 @@
 
 `vdir`
 
-- List with sizes displayed in human readable units (KB, MB, GB):
+- List with sizes displayed in human-readable units (KB, MB, GB):
 
 `vdir -h`
 

--- a/pages/common/vectorize-pixelart.md
+++ b/pages/common/vectorize-pixelart.md
@@ -3,6 +3,6 @@
 > Convert PNG pixel art graphics to SVG/EPS vector images.
 > More information: <https://github.com/und3f/vectorize-pixelart>.
 
-- Convert a PNG image to a vector image format:
+- Convert a PNG to a vector image format:
 
 `vectorize-pixelart {{path/to/input.png}} {{path/to/output.svg|.eps}}`

--- a/pages/common/vegeta.md
+++ b/pages/common/vegeta.md
@@ -8,7 +8,7 @@
 
 `echo "{{GET https://example.com}}" | vegeta attack -duration={{30s}}`
 
-- Launch an attack on a server with a self-signed https certificate:
+- Launch an attack on a server with a self-signed HTTPS certificate:
 
 `echo "{{GET https://example.com}}" | vegeta attack -insecure -duration={{30s}}`
 

--- a/pages/common/vue.md
+++ b/pages/common/vue.md
@@ -3,7 +3,7 @@
 > Multi-purpose CLI for Vue.js.
 > More information: <https://cli.vuejs.org>.
 
-- Create a new vue project interactively:
+- Create a new Vue project interactively:
 
 `vue create {{project_name}}`
 

--- a/pages/common/waitress-serve.md
+++ b/pages/common/waitress-serve.md
@@ -22,6 +22,6 @@
 
 `waitress-serve --call {{import.path.wsgi_factory}}`
 
-- Set the URL scheme to https:
+- Set the URL scheme to HTTPS:
 
 `waitress-serve --url-scheme={{https}} {{import.path:wsgi_func}}`

--- a/pages/common/wapm.md
+++ b/pages/common/wapm.md
@@ -23,7 +23,7 @@
 
 `wapm uninstall {{package_name}}`
 
-- Print a tree of locally-installed dependencies:
+- Print a tree of locally installed dependencies:
 
 `wapm list`
 

--- a/pages/common/watson.md
+++ b/pages/common/watson.md
@@ -15,7 +15,7 @@
 
 `watson stop`
 
-- Display latest working sessions:
+- Display the latest working sessions:
 
 `watson log`
 

--- a/pages/common/weasyprint.md
+++ b/pages/common/weasyprint.md
@@ -3,11 +3,11 @@
 > Render HTML to PDF or PNG.
 > More information: <https://weasyprint.org/>.
 
-- Render a HTML file to PDF:
+- Render an HTML file to PDF:
 
 `weasyprint {{path/to/input.html}} {{path/to/output}}.pdf`
 
-- Render a HTML file to PNG, including an additional user stylesheet:
+- Render an HTML file to PNG, including an additional user stylesheet:
 
 `weasyprint {{path/to/input.html}} {{path/to/output}}.png --stylesheet {{path/to/stylesheet.css}}`
 

--- a/pages/common/webpack.md
+++ b/pages/common/webpack.md
@@ -7,7 +7,7 @@
 
 `webpack {{app.js}} {{bundle.js}}`
 
-- Load CSS files too from the JS file (this uses the CSS loader for `.css` files):
+- Load CSS files too from the JavaScript file (this uses the CSS loader for `.css` files):
 
 `webpack {{app.js}} {{bundle.js}} --module-bind 'css=css'`
 

--- a/pages/common/webpack.md
+++ b/pages/common/webpack.md
@@ -7,7 +7,7 @@
 
 `webpack {{app.js}} {{bundle.js}}`
 
-- Load css files too from the js file (this uses the css loader for `.css` files):
+- Load CSS files too from the JS file (this uses the CSS loader for `.css` files):
 
 `webpack {{app.js}} {{bundle.js}} --module-bind 'css=css'`
 

--- a/pages/common/webpack.md
+++ b/pages/common/webpack.md
@@ -11,7 +11,7 @@
 
 `webpack {{app.js}} {{bundle.js}} --module-bind 'css=css'`
 
-- Pass a config file (with eg. the entry script and the output filename) and show compilation progress:
+- Pass a config file (with e.g. the entry script and the output filename) and show compilation progress:
 
 `webpack --config {{webpack.config.js}} --progress`
 

--- a/pages/common/webpack.md
+++ b/pages/common/webpack.md
@@ -9,7 +9,7 @@
 
 - Load CSS files too from the JavaScript file (this uses the CSS loader for `.css` files):
 
-`webpack {{app.js}} {{bundle.js}} --module-bind 'css=css'`
+`webpack {{app.js}} {{bundle.js}} --module-bind '{{css=css}}'`
 
 - Pass a config file (with e.g. the entry script and the output filename) and show compilation progress:
 

--- a/pages/common/webtorrent.md
+++ b/pages/common/webtorrent.md
@@ -1,7 +1,7 @@
 # webtorrent
 
 > The command-line interface for WebTorrent.
-> Supports magnets, urls, info hashes and .torrent files.
+> Supports magnets, URLs, info hashes and .torrent files.
 > More information: <https://github.com/webtorrent/webtorrent-cli>.
 
 - Download a torrent:

--- a/pages/common/webtorrent.md
+++ b/pages/common/webtorrent.md
@@ -1,7 +1,7 @@
 # webtorrent
 
 > The command-line interface for WebTorrent.
-> Supports magnets, URLs, info hashes and .torrent files.
+> Supports magnets, URLs, info hashes and `.torrent` files.
 > More information: <https://github.com/webtorrent/webtorrent-cli>.
 
 - Download a torrent:

--- a/pages/common/wget.md
+++ b/pages/common/wget.md
@@ -4,11 +4,11 @@
 > Supports HTTP, HTTPS, and FTP.
 > More information: <https://www.gnu.org/software/wget>.
 
-- Download the contents of an URL to a file (named "foo" in this case):
+- Download the contents of a URL to a file (named "foo" in this case):
 
 `wget {{https://example.com/foo}}`
 
-- Download the contents of an URL to a file (named "bar" in this case):
+- Download the contents of a URL to a file (named "bar" in this case):
 
 `wget --output-document {{bar}} {{https://example.com/foo}}`
 

--- a/pages/common/xmllint.md
+++ b/pages/common/xmllint.md
@@ -18,7 +18,7 @@
 
 `xmllint --format {{source_file.xml}}`
 
-- Check that a XML file meets the requirements of its DOCTYPE declaration:
+- Check that an XML file meets the requirements of its DOCTYPE declaration:
 
 `xmllint --valid {{source_file.xml}}`
 

--- a/pages/common/xmllint.md
+++ b/pages/common/xmllint.md
@@ -10,7 +10,7 @@
 
 `xmllint --xpath "string(//{{foo}})" {{source_file.xml}}`
 
-- Return the href attribute of the second anchor element in an html file:
+- Return the href attribute of the second anchor element in an HTML file:
 
 `xmllint --html --xpath "string(//a[2]/@href)" webpage.xhtml`
 

--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -13,11 +13,11 @@
 
 - Compress a file to the LZMA file format:
 
-`xz --format=lzma {{file}}`
+`xz --format={{lzma}} {{file}}`
 
 - Decompress an LZMA file:
 
-`xz -d --format=lzma {{file.lzma}}`
+`xz -d --format={{lzma}} {{file.lzma}}`
 
 - Decompress a file and write to stdout:
 

--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -11,11 +11,11 @@
 
 `xz -d {{file.xz}}`
 
-- Compress a file to the lzma file format:
+- Compress a file to the LZMA file format:
 
 `xz --format=lzma {{file}}`
 
-- Decompress an lzma file:
+- Decompress an LZMA file:
 
 `xz -d --format=lzma {{file.lzma}}`
 

--- a/pages/common/yesod.md
+++ b/pages/common/yesod.md
@@ -4,7 +4,7 @@
 > All Yesod commands are invoked through the `stack` project manager.
 > More information: <https://github.com/yesodweb/yesod>.
 
-- Create a new scaffolded site, with sqlite as backend, in the `my-project` directory:
+- Create a new scaffolded site, with SQLite as backend, in the `my-project` directory:
 
 `stack new {{my-project}} {{yesod-sqlite}}`
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -31,6 +31,6 @@
 
 `youtube-dl --sub-lang {{en}} --write-sub '{{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}'`
 
-- Download a playlist and extract mp3 from it:
+- Download a playlist and extract MP3s from it:
 
 `youtube-dl -f "bestaudio" --continue --no-overwrites --ignore-errors --extract-audio --audio-format mp3 -o "%(title)s.%(ext)s" {{url_to_playlist}}`

--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -26,7 +26,7 @@
 
 `zip -d {{compressed.zip}} "{{foo/*.tmp}}"`
 
-- Archive a directory and its contents to a multi-part [s]plit zip file (e.g. 3GB parts):
+- Archive a directory and its contents to a multi-part [s]plit zip file (e.g. 3 GB parts):
 
 `zip -r -s {{3g}} {{compressed.zip}} {{path/to/directory}}`
 

--- a/pages/common/zopflipng.md
+++ b/pages/common/zopflipng.md
@@ -1,12 +1,12 @@
 # zopflipng
 
-> PNG image compression utility.
+> PNG compression utility.
 > More information: <https://github.com/google/zopfli>.
 
-- Optimize a PNG image:
+- Optimize a PNG:
 
 `zopflipng {{input.png}} {{output.png}}`
 
-- Optimize several PNG images and save with given prefix:
+- Optimize several PNGs and save with given prefix:
 
 `zopflipng --prefix={{prefix}} {{image1.png}} {{image2.png}} {{image3.png}}`

--- a/pages/common/zsteg.md
+++ b/pages/common/zsteg.md
@@ -4,7 +4,7 @@
 > It detects LSB steganography, ZLIB-compressed data, OpenStego, Camouflage and LSB with the Eratosthenes set.
 > More information: <https://github.com/zed-0xff/zsteg>.
 
-- Detect embedded data in a PNG image:
+- Detect embedded data in a PNG:
 
 `zsteg {{path/to/image.png}}`
 
@@ -12,7 +12,7 @@
 
 `zsteg --all {{path/to/image.bmp}}`
 
-- Detect embedded data in a PNG image, iterating pixels vertically and using MSB first:
+- Detect embedded data in a PNG, iterating pixels vertically and using MSB first:
 
 `zsteg --msb --order yx {{path/to/image.png}}`
 
@@ -20,7 +20,7 @@
 
 `zsteg --bits {{1,2,3|1-3}} {{path/to/image.bmp}}`
 
-- Detect embedded data in a PNG image, extracting only prime pixels and inverting bits:
+- Detect embedded data in a PNG, extracting only prime pixels and inverting bits:
 
 `zsteg --prime --invert {{path/to/image.png}}`
 

--- a/pages/linux/aplay.md
+++ b/pages/linux/aplay.md
@@ -7,10 +7,10 @@
 
 `aplay {{path/to/file}}`
 
-- Play the first 10 seconds of a specific file at 2500Hz:
+- Play the first 10 seconds of a specific file at 2500 Hz:
 
 `aplay --duration={{10}} --rate={{2500}} {{path/to/file}}`
 
-- Play the raw file as a 22050Hz, mono, 8-bit, Mu-Law `.au` file:
+- Play the raw file as a 22050 Hz, mono, 8-bit, Mu-Law `.au` file:
 
 `aplay --channels={{1}} --file-type {{raw}} --rate={{22050}} --format={{mu_law}} {{path/to/file}}`

--- a/pages/linux/aptitude.md
+++ b/pages/linux/aptitude.md
@@ -23,7 +23,7 @@
 
 `aptitude remove {{package}}`
 
-- Upgrade installed packages to newest available versions:
+- Upgrade installed packages to the newest available versions:
 
 `aptitude upgrade`
 

--- a/pages/linux/arecord.md
+++ b/pages/linux/arecord.md
@@ -11,7 +11,7 @@
 
 `arecord -vv --format=cd --duration={{10}} {{path/to/file.wav}}`
 
-- Record a snippet and save it as mp3 (finish with Ctrl-C when done):
+- Record a snippet and save it as an MP3 (finish with Ctrl-C when done):
 
 `arecord -vv --format=cd --file-type raw | lame -r - {{path/to/file.mp3}}`
 

--- a/pages/linux/aspell.md
+++ b/pages/linux/aspell.md
@@ -15,7 +15,7 @@
 
 `aspell dicts`
 
-- Run aspell with different language (takes two letter ISO 639 language code):
+- Run aspell with different language (takes two-letter ISO 639 language code):
 
 `aspell --lang={{cs}}`
 

--- a/pages/linux/aspell.md
+++ b/pages/linux/aspell.md
@@ -15,7 +15,7 @@
 
 `aspell dicts`
 
-- Run aspell with different language (takes two-letter ISO 639 language code):
+- Run aspell with a different language (takes two-letter ISO 639 language code):
 
 `aspell --lang={{cs}}`
 

--- a/pages/linux/at.md
+++ b/pages/linux/at.md
@@ -7,7 +7,7 @@
 
 `at {{hh:mm}}`
 
-- Execute the commands and email the result using a local mailing program such as sendmail:
+- Execute the commands and email the result using a local mailing program such as Sendmail:
 
 `at {{hh:mm}} -m`
 

--- a/pages/linux/blkdiscard.md
+++ b/pages/linux/blkdiscard.md
@@ -11,6 +11,6 @@
 
 `blkdiscard --secure /dev/{{device}}`
 
-- Discard the first 100MB of a device:
+- Discard the first 100 MB of a device:
 
 `blkdiscard --length {{100MB}} /dev/{{device}}`

--- a/pages/linux/bluetoothctl.md
+++ b/pages/linux/bluetoothctl.md
@@ -1,6 +1,6 @@
 # bluetoothctl
 
-> Handling bluetooth devices from the shell.
+> Handling Bluetooth devices from the shell.
 > More information: <https://www.npmjs.com/package/bluetoothctl>.
 
 - Enter the bluetoothctl shell:

--- a/pages/linux/bluetoothctl.md
+++ b/pages/linux/bluetoothctl.md
@@ -1,6 +1,6 @@
 # bluetoothctl
 
-> Handling Bluetooth devices from the shell.
+> Manage Bluetooth devices from the command-line.
 > More information: <https://www.npmjs.com/package/bluetoothctl>.
 
 - Enter the bluetoothctl shell:

--- a/pages/linux/bpftrace.md
+++ b/pages/linux/bpftrace.md
@@ -11,7 +11,7 @@
 
 `sudo bpftrace -l`
 
-- Run a one-liner program (e.g syscall count by program):
+- Run a one-liner program (e.g. syscall count by program):
 
 `sudo bpftrace -e '{{tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }}}'`
 

--- a/pages/linux/brctl.md
+++ b/pages/linux/brctl.md
@@ -3,15 +3,15 @@
 > Ethernet bridge administration.
 > More information: <https://manned.org/brctl>.
 
-- Show a list with information about currently existing ethernet bridges:
+- Show a list with information about currently existing Ethernet bridges:
 
 `sudo brctl show`
 
-- Create a new ethernet bridge interface:
+- Create a new Ethernet bridge interface:
 
 `sudo brctl add {{bridge_name}}`
 
-- Delete an existing ethernet bridge interface:
+- Delete an existing Ethernet bridge interface:
 
 `sudo brctl del {{bridge_name}}`
 

--- a/pages/linux/cal.md
+++ b/pages/linux/cal.md
@@ -11,7 +11,7 @@
 
 `cal -3`
 
-- Use monday as the first day of the week:
+- Use Monday as the first day of the week:
 
 `cal --monday`
 

--- a/pages/linux/compgen.md
+++ b/pages/linux/compgen.md
@@ -1,6 +1,6 @@
 # compgen
 
-> A built-in command for auto-completion in bash, which is called on pressing TAB key twice.
+> A built-in command for auto-completion in Bash, which is called on pressing TAB key twice.
 > More information: <https://www.gnu.org/software/bash/manual/bash.html#index-compgen>.
 
 - List all commands that you could run:

--- a/pages/linux/compgen.md
+++ b/pages/linux/compgen.md
@@ -15,7 +15,7 @@
 
 `compgen -A function`
 
-- Show shell reserved key words:
+- Show shell reserved keywords:
 
 `compgen -k`
 

--- a/pages/linux/conky.md
+++ b/pages/linux/conky.md
@@ -11,7 +11,7 @@
 
 `conky -C > ~/.conkyrc`
 
-- Launch conky with a given config file:
+- Launch Conky with a given config file:
 
 `conky -c {{path/to/config}}`
 
@@ -19,7 +19,7 @@
 
 `conky -d`
 
-- Align conky on the desktop:
+- Align Conky on the desktop:
 
 `conky -a {{{top,bottom,middle}_{left,right,middle}}}`
 

--- a/pages/linux/cpufreq-aperf.md
+++ b/pages/linux/cpufreq-aperf.md
@@ -12,7 +12,7 @@
 
 `sudo cpufreq-aperf -c {{1}}`
 
-- Start calculating with a 3 seconds refresh interval for all CPU cores:
+- Start calculating with a 3 second refresh interval for all CPU cores:
 
 `sudo cpufreq-aperf -i {{3}}`
 

--- a/pages/linux/create_ap.md
+++ b/pages/linux/create_ap.md
@@ -23,10 +23,10 @@
 
 `create_ap -m bridge {{wlan0}} {{br0}} {{access_point_ssid}} {{passphrase}}`
 
-- Create an access port for Internet sharing from the same WiFi interface:
+- Create an access port for Internet sharing from the same Wi-Fi interface:
 
 `create_ap {{wlan0}} {{wlan0}} {{access_point_ssid}} {{passphrase}}`
 
-- Choose a different WiFi adapter driver:
+- Choose a different Wi-Fi adapter driver:
 
 `create_ap --driver {{wifi_adapter}} {{wlan0}} {{eth0}} {{access_point_ssid}} {{passphrase}}`

--- a/pages/linux/daemonize.md
+++ b/pages/linux/daemonize.md
@@ -7,7 +7,7 @@
 
 `daemonize {{command}} {{command_arguments}}`
 
-- Write the pid to the specified file:
+- Write the PID to the specified file:
 
 `daemonize -p {{path/to/pidfile}} {{command}} {{command_arguments}}`
 

--- a/pages/linux/dbus-daemon.md
+++ b/pages/linux/dbus-daemon.md
@@ -19,7 +19,7 @@
 
 `dbus-daemon --address {{address}}`
 
-- Output the process id to stdout:
+- Output the process ID to stdout:
 
 `dbus-daemon --print-pid`
 

--- a/pages/linux/dockerd.md
+++ b/pages/linux/dockerd.md
@@ -7,7 +7,7 @@
 
 `dockerd`
 
-- Run docker daemon and config it to listen to specific sockets (unix, tcp):
+- Run docker daemon and config it to listen to specific sockets (unix and tcp):
 
 `dockerd --host unix://{{path/to/tmp.sock}} --host tcp://{{ip}}`
 

--- a/pages/linux/dockerd.md
+++ b/pages/linux/dockerd.md
@@ -7,7 +7,7 @@
 
 `dockerd`
 
-- Run docker daemon and config it to listen to specific sockets(unix,tcp):
+- Run docker daemon and config it to listen to specific sockets (unix, tcp):
 
 `dockerd --host unix://{{path/to/tmp.sock}} --host tcp://{{ip}}`
 

--- a/pages/linux/dockerd.md
+++ b/pages/linux/dockerd.md
@@ -7,7 +7,7 @@
 
 `dockerd`
 
-- Run docker daemon and config it to listen to specific sockets (unix and tcp):
+- Run docker daemon and config it to listen to specific sockets (UNIX and TCP):
 
 `dockerd --host unix://{{path/to/tmp.sock}} --host tcp://{{ip}}`
 

--- a/pages/linux/faketime.md
+++ b/pages/linux/faketime.md
@@ -11,6 +11,6 @@
 
 `faketime '{{yesterday}}' {{bash}}`
 
-- Simulate how any program would act next friday night:
+- Simulate how any program would act next Friday night:
 
 `faketime '{{next Friday 1 am}}' {{path/to/any/program}}`

--- a/pages/linux/faketime.md
+++ b/pages/linux/faketime.md
@@ -11,6 +11,6 @@
 
 `faketime '{{yesterday}}' {{bash}}`
 
-- Simulate how any program would act next Friday night:
+- Simulate how a program would act next Friday night:
 
-`faketime '{{next Friday 1 am}}' {{path/to/any/program}}`
+`faketime '{{next Friday 1 am}}' {{path/to/program}}`

--- a/pages/linux/fallocate.md
+++ b/pages/linux/fallocate.md
@@ -4,14 +4,14 @@
 > The utility allocates space without zeroing.
 > More information: <https://manned.org/fallocate>.
 
-- Reserve a file taking up 700MB of disk space:
+- Reserve a file taking up 700 MiB of disk space:
 
 `fallocate --length {{700M}} {{path/to/file}}`
 
-- Shrink an already allocated file by 200MB:
+- Shrink an already allocated file by 200 MiB:
 
 `fallocate --collapse-range --length {{200M}} {{path/to/file}}`
 
-- Shrink 20MB of space after 100MB in a file:
+- Shrink 20 MB of space after 100 MiB in a file:
 
 `fallocate --collapse-range --offset {{100M}} --length {{20M}} {{path/to/file}}`

--- a/pages/linux/fc-cache.md
+++ b/pages/linux/fc-cache.md
@@ -1,6 +1,6 @@
 # fc-cache
 
-> Scan font directories in order to build font cache files.
+> Scan font directories to build font cache files.
 > More information: <https://manned.org/fc-cache>.
 
 - Generate font cache files:

--- a/pages/linux/flameshot.md
+++ b/pages/linux/flameshot.md
@@ -1,10 +1,10 @@
 # flameshot
 
-> Screenshot utility with a gui interface.
+> Screenshot utility with a GUI.
 > Supports basic image editing, such as text, shapes, colors, and imgur.
 > More information: <https://flameshot.js.org>.
 
-- Launch flameshot in gui mode:
+- Launch flameshot in GUI mode:
 
 `flameshot launcher`
 

--- a/pages/linux/flashrom.md
+++ b/pages/linux/flashrom.md
@@ -19,6 +19,6 @@
 
 `flashrom -p {{programmer}} --verify {{path/to/file}}`
 
-- Probe the chip using RaspberryPi:
+- Probe the chip using Raspberry Pi:
 
 `flashrom -p {{linux_spi:dev=/dev/spidev0.0}}`

--- a/pages/linux/free.md
+++ b/pages/linux/free.md
@@ -11,7 +11,7 @@
 
 `free -{{b|k|m|g}}`
 
-- Display memory in human readable units:
+- Display memory in human-readable units:
 
 `free -h`
 

--- a/pages/linux/genkernel.md
+++ b/pages/linux/genkernel.md
@@ -19,6 +19,6 @@
 
 `sudo genkernel --kernname={{custom_name}} all`
 
-- Use a kernel source outside of the default directory `/usr/src/linux`:
+- Use a kernel source outside the default directory `/usr/src/linux`:
 
 `sudo genkernel --kerneldir={{path/to/directory}} all`

--- a/pages/linux/hashcat.md
+++ b/pages/linux/hashcat.md
@@ -19,7 +19,7 @@
 
 `hashcat --hash-type {{hash_type_id}} --attack-mode {{0}} {{hash_value}} {{/usr/share/wordlists/rockyou.txt}}`
 
-- Perform a rule based dictionary attack (mode 0) using the RockYou wordlist mutated with common password variations:
+- Perform a rule-based dictionary attack (mode 0) using the RockYou wordlist mutated with common password variations:
 
 `hashcat --hash-type {{hash_type_id}} --attack-mode {{0}} --rules-file {{/usr/share/hashcat/rules/best64.rule}} {{hash_value}} {{/usr/share/wordlists/rockyou.txt}}`
 

--- a/pages/linux/http_load.md
+++ b/pages/linux/http_load.md
@@ -1,6 +1,6 @@
 # http_load
 
-> A HTTP benchmarking tool.
+> An HTTP benchmarking tool.
 > Runs multiple HTTP fetches in parallel to test the throughput of a web server.
 > More information: <http://www.acme.com/software/http_load/>.
 

--- a/pages/linux/httpie.md
+++ b/pages/linux/httpie.md
@@ -14,7 +14,7 @@
 
 `http {{https://example.com}} < {{file.json}}`
 
-- Send a PUT request with a given json body:
+- Send a PUT request with a given JSON body:
 
 `http PUT {{https://example.com/todos/7}} {{hello=world}}`
 

--- a/pages/linux/i3lock.md
+++ b/pages/linux/i3lock.md
@@ -15,7 +15,7 @@
 
 `i3lock -u`
 
-- Display mouse pointer instead of hiding it ('default' for default pointer, 'win' for a MS Windows pointer):
+- Display mouse pointer instead of hiding it ('default' for default pointer, 'win' for an MS Windows pointer):
 
 `i3lock -p {{default|win}}`
 

--- a/pages/linux/i7z.md
+++ b/pages/linux/i7z.md
@@ -2,6 +2,6 @@
 
 > An Intel CPU (only i3, i5 and i7) realtime reporting tool.
 
-- Start i7z (needs to be run in super user mode):
+- Start i7z (needs to be run in superuser mode):
 
 `sudo i7z`

--- a/pages/linux/imgp.md
+++ b/pages/linux/imgp.md
@@ -1,6 +1,6 @@
 # imgp
 
-> Command-line image resizer and rotator for JPEG and PNG images.
+> Command-line image resizer and rotator for JPEGs and PNGs.
 
 - Convert single images and/or whole directories containing valid image formats:
 

--- a/pages/linux/inxi.md
+++ b/pages/linux/inxi.md
@@ -2,7 +2,7 @@
 
 > Print a summary of system information and resources for debugging purposes.
 
-- Print a short summary of CPU, memory, hard drive and kernel information:
+- Print a summary of CPU, memory, hard drive and kernel information:
 
 `inxi`
 

--- a/pages/linux/ip.md
+++ b/pages/linux/ip.md
@@ -27,7 +27,7 @@
 
 `ip link set {{interface}} up/down`
 
-- Add/Delete an ip address to an interface:
+- Add/Delete an IP address to an interface:
 
 `ip addr add/del {{ip}}/{{mask}} dev {{interface}}`
 

--- a/pages/linux/iwconfig.md
+++ b/pages/linux/iwconfig.md
@@ -11,7 +11,7 @@
 
 `iwconfig {{interface}}`
 
-- Set the ESSID (network name) of the specified interface (e.g., eth0 or wlp2s0):
+- Set the ESSID (network name) of the specified interface (e.g. eth0 or wlp2s0):
 
 `iwconfig {{interface}} {{new_network_name}}`
 

--- a/pages/linux/iwctl.md
+++ b/pages/linux/iwctl.md
@@ -11,7 +11,7 @@
 
 `iwctl --help`
 
-- Display your wifi stations:
+- Display your Wi-Fi stations:
 
 `iwctl station list`
 

--- a/pages/linux/jobs.md
+++ b/pages/linux/jobs.md
@@ -6,7 +6,7 @@
 
 `jobs`
 
-- List jobs and their process ids:
+- List jobs and their process IDs:
 
 `jobs -l`
 
@@ -14,7 +14,7 @@
 
 `jobs -n`
 
-- Display process id of process group leader:
+- Display process ID of process group leader:
 
 `jobs -p`
 

--- a/pages/linux/jpegtran.md
+++ b/pages/linux/jpegtran.md
@@ -11,7 +11,7 @@
 
 `jpegtran -rotate {{90|180|270}} {{path/to/image.jpg}} > {{path/to/output.jpg}}`
 
-- Transpose the image across the upper left to lower right axis:
+- Transpose the image across the upper-left to lower right axis:
 
 `jpegtran -transpose {{path/to/image.jpg}} > {{path/to/output.jpg}}`
 
@@ -23,10 +23,10 @@
 
 `jpegtran -grayscale {{path/to/image.jpg}} > {{path/to/output.jpg}}`
 
-- Crop the image to a rectangular region of width `W` and height `H` from the upper left corner, saving the output to a specific file:
+- Crop the image to a rectangular region of width `W` and height `H` from the upper-left corner, saving the output to a specific file:
 
 `jpegtran -crop {{W}}x{{H}} -outfile {{path/to/output.jpg}} {{path/to/image.jpg}}`
 
-- Crop the image to a rectangular region of width `W` and height `H`, starting at point `X` and `Y` from the upper left corner:
+- Crop the image to a rectangular region of width `W` and height `H`, starting at point `X` and `Y` from the upper-left corner:
 
 `jpegtran -crop {{W}}x{{H}}+{{X}}+{{Y}} {{path/to/image.jpg}} > {{path/to/output.jpg}}`

--- a/pages/linux/kde-inhibit.md
+++ b/pages/linux/kde-inhibit.md
@@ -10,6 +10,6 @@
 
 `kde-inhibit --screenSaver {{command}} {{command_arguments}}`
 
-- Launch vlc, and inhibit colour correction (night mode) while it's running:
+- Launch VLC, and inhibit colour correction (night mode) while it's running:
 
 `kde-inhibit --colorCorrect {{vlc}}`

--- a/pages/linux/kde-inhibit.md
+++ b/pages/linux/kde-inhibit.md
@@ -10,6 +10,6 @@
 
 `kde-inhibit --screenSaver {{command}} {{command_arguments}}`
 
-- Launch VLC, and inhibit colour correction (night mode) while it's running:
+- Launch VLC, and inhibit color correction (night mode) while it's running:
 
 `kde-inhibit --colorCorrect {{vlc}}`

--- a/pages/linux/lastcomm.md
+++ b/pages/linux/lastcomm.md
@@ -3,7 +3,7 @@
 > Show last commands executed.
 > More information: <https://manpages.debian.org/stable/acct/lastcomm.1.en.html>.
 
-- Print information about all of the commands in the acct (record file):
+- Print information about all the commands in the acct (record file):
 
 `lastcomm`
 

--- a/pages/linux/lastlog.md
+++ b/pages/linux/lastlog.md
@@ -10,7 +10,7 @@
 
 `lastlog -u {{username}}`
 
-- Display records before than 7 days:
+- Display records before 7 days ago:
 
 `lastlog -b {{7}}`
 

--- a/pages/linux/libreoffice.md
+++ b/pages/linux/libreoffice.md
@@ -15,6 +15,6 @@
 
 `libreoffice --pt {{printer_name}} {{path/to/file1}} {{path/to/file2}}`
 
-- Convert all `.doc` files in current directory to pdf:
+- Convert all `.doc` files in current directory to PDF:
 
 `libreoffice --convert-to {{pdf}} {{*.doc}}`

--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -1,6 +1,6 @@
 # logwatch
 
-> Summarizes many different logs for common services (e.g., apache, pam_unix, sshd, etc.) in a single report.
+> Summarizes many different logs for common services (e.g. apache, pam_unix, sshd, etc.) in a single report.
 
 - Analyze logs for a range of dates at a certain level of detail:
 

--- a/pages/linux/logwatch.md
+++ b/pages/linux/logwatch.md
@@ -2,7 +2,7 @@
 
 > Summarizes many different logs for common services (e.g., apache, pam_unix, sshd, etc.) in a single report.
 
-- Analyze logs for a range of dates at certain level of detail:
+- Analyze logs for a range of dates at a certain level of detail:
 
 `logwatch --range {{yesterday|today|all|help}} --detail {{low|medium|others}}'`
 

--- a/pages/linux/lshw.md
+++ b/pages/linux/lshw.md
@@ -6,7 +6,7 @@
 
 `sudo lshw -X`
 
-- List all hardwares in tabular format:
+- List all hardware in tabular format:
 
 `sudo lshw -short`
 

--- a/pages/linux/lslocks.md
+++ b/pages/linux/lslocks.md
@@ -18,6 +18,6 @@
 
 `lslocks --pid {{PID}}`
 
-- List locks with json output to stdout:
+- List locks with JSON output to stdout:
 
 `lslocks --json`

--- a/pages/linux/lsmod.md
+++ b/pages/linux/lsmod.md
@@ -1,6 +1,6 @@
 # lsmod
 
-> Shows the status of linux kernel modules.
+> Shows the status of Linux kernel modules.
 > See also `modprobe`, which loads kernel modules.
 
 - List all currently loaded kernel modules:

--- a/pages/linux/lsscsi.md
+++ b/pages/linux/lsscsi.md
@@ -10,6 +10,6 @@
 
 `lsscsi -L`
 
-- List all SCSI devices with human readable disk capacity:
+- List all SCSI devices with human-readable disk capacity:
 
 `lsscsi -s`

--- a/pages/linux/lsusb.md
+++ b/pages/linux/lsusb.md
@@ -18,6 +18,6 @@
 
 `lsusb -D {{device}}`
 
-- List devices with a specified vendor and product id only:
+- List devices with a specified vendor and product ID only:
 
 `lsusb -d {{vendor}}:{{product}}`

--- a/pages/linux/lvcreate.md
+++ b/pages/linux/lvcreate.md
@@ -16,6 +16,6 @@
 
 `lvcreate -l {{60%VG}} -n {{mylv}} {{vg1}}`
 
-- Create a logical volume called mylv that uses all of the unallocated space in the volume group vg1:
+- Create a logical volume called mylv that uses all the unallocated space in the volume group vg1:
 
 `lvcreate -l {{100%FREE}} -n {{mylv}} {{vg1}}`

--- a/pages/linux/lvextend.md
+++ b/pages/linux/lvextend.md
@@ -4,11 +4,11 @@
 > See also: `lvm`.
 > More information: <https://man7.org/linux/man-pages/man8/lvextend.8.html>.
 
-- Increase a volume's size to 120GB:
+- Increase a volume's size to 120 GB:
 
 `lvextend --size {{120G}} {{logical_volume}}`
 
-- Increase a volume's size by 40GB as well as the underlying filesystem:
+- Increase a volume's size by 40 GB as well as the underlying filesystem:
 
 `lvextend --size +{{40G}} -r {{logical_volume}}`
 

--- a/pages/linux/lvreduce.md
+++ b/pages/linux/lvreduce.md
@@ -4,10 +4,10 @@
 > See also: `lvm`.
 > More information: <https://man7.org/linux/man-pages/man8/lvreduce.8.html>.
 
-- Reduce a volume's size to 120GB:
+- Reduce a volume's size to 120 GB:
 
 `lvreduce --size {{120G}} {{logical_volume}}`
 
-- Reduce a volume's size by 40GB as well as the underlying filesystem:
+- Reduce a volume's size by 40 GB as well as the underlying filesystem:
 
 `lvreduce --size -{{40G}} -r {{logical_volume}}`

--- a/pages/linux/lvresize.md
+++ b/pages/linux/lvresize.md
@@ -4,11 +4,11 @@
 > See also: `lvm`.
 > More information: <https://man7.org/linux/man-pages/man8/lvresize.8.html>.
 
-- Change the size of a logical volume to 120GB:
+- Change the size of a logical volume to 120 GB:
 
 `lvresize --size {{120G}} {{volume_group}}/{{logical_volume}}`
 
-- Extend the size of a logical volume as well as the underlying filesystem by 120GB:
+- Extend the size of a logical volume as well as the underlying filesystem by 120 GB:
 
 `lvresize --size +{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`
 
@@ -16,6 +16,6 @@
 
 `lvresize --size {{100}}%FREE {{volume_group}}/{{logical_volume}}`
 
-- Reduce the size of a logical volume as well as the underlying filesystem by 120GB:
+- Reduce the size of a logical volume as well as the underlying filesystem by 120 GB:
 
 `lvresize --size -{{120G}} --resizefs {{volume_group}}/{{logical_volume}}`

--- a/pages/linux/mcookie.md
+++ b/pages/linux/mcookie.md
@@ -1,6 +1,6 @@
 # mcookie
 
-> Generates random 128 bit hexadecimal numbers.
+> Generates random 128-bit hexadecimal numbers.
 
 - Generate a random number:
 

--- a/pages/linux/medusa.md
+++ b/pages/linux/medusa.md
@@ -6,7 +6,7 @@
 
 `medusa -M ftp -h host -U {{path/to/username_file}} -P {{path/to/password_file}}`
 
-- Execute a login attempt against a HTTP server using the username, password and user-agent specified:
+- Execute a login attempt against an HTTP server using the username, password and user-agent specified:
 
 `medusa -M HTTP -h host -u {{username}} -p {{password}} -m USER-AGENT:"{{Agent}}"`
 

--- a/pages/linux/nmcli-connection.md
+++ b/pages/linux/nmcli-connection.md
@@ -3,11 +3,11 @@
 > Connection management with NetworkManager.
 > More information: <https://man.archlinux.org/man/nmcli.1>.
 
-- List all NetworkManager connections (shows name, uuid, type and device):
+- List all NetworkManager connections (shows name, UUID, type and device):
 
 `nmcli connection`
 
-- Activate a connection by specifying an uuid:
+- Activate a connection by specifying a UUID:
 
 `nmcli connection up uuid {{uuid}}`
 

--- a/pages/linux/parted.md
+++ b/pages/linux/parted.md
@@ -24,7 +24,7 @@
 
 `select {{/dev/sdX}}`
 
-- Create a 16GB partition with the specified filesystem in interactive mode:
+- Create a 16 GB partition with the specified filesystem in interactive mode:
 
 `mkpart {{primary|logical|extended}} {{btrfs|ext2|ext3|ext4|fat16|fat32|hfs|hfs+|linux-swap|ntfs|reiserfs|udf|xfs}} {{0%}} {{16G}}`
 

--- a/pages/linux/pasuspender.md
+++ b/pages/linux/pasuspender.md
@@ -2,6 +2,6 @@
 
 > Temporarily suspends `pulseaudio` while another command is running to allow access to alsa.
 
-- Suspend pulseaudio while running `jackd`:
+- Suspend PulseAudio while running `jackd`:
 
 `pasuspender -- {{jackd -d alsa --device hw:0}}`

--- a/pages/linux/pdfgrep.md
+++ b/pages/linux/pdfgrep.md
@@ -10,7 +10,7 @@
 
 `pdfgrep --with-filename --page-number {{pattern}} {{file.pdf}}`
 
-- Do a case insensitive search for lines that begin with "foo" and return the first 3 matches:
+- Do a case-insensitive search for lines that begin with "foo" and return the first 3 matches:
 
 `pdfgrep --max-count {{3}} --ignore-case {{'^foo'}} {{file.pdf}}`
 

--- a/pages/linux/perf.md
+++ b/pages/linux/perf.md
@@ -1,6 +1,6 @@
 # perf
 
-> Framework for linux performance counter measurements.
+> Framework for Linux performance counter measurements.
 
 - Display basic performance counter stats for a command:
 

--- a/pages/linux/perf.md
+++ b/pages/linux/perf.md
@@ -6,7 +6,7 @@
 
 `perf stat {{gcc hello.c}}`
 
-- Display system-wide real time performance counter profile:
+- Display system-wide real-time performance counter profile:
 
 `sudo perf top`
 

--- a/pages/linux/phpdismod.md
+++ b/pages/linux/phpdismod.md
@@ -2,10 +2,10 @@
 
 > Disable PHP extensions on Debian-based OSes.
 
-- Disable the json extension for every SAPI of every PHP version:
+- Disable the JSON extension for every SAPI of every PHP version:
 
 `sudo phpdismod {{json}}`
 
-- Disable the json extension for PHP 7.3 with the cli SAPI:
+- Disable the JSON extension for PHP 7.3 with the cli SAPI:
 
 `sudo phpdismod -v {{7.3}} -s {{cli}} {{json}}`

--- a/pages/linux/phpenmod.md
+++ b/pages/linux/phpenmod.md
@@ -2,10 +2,10 @@
 
 > Enable PHP extensions on Debian-based OSes.
 
-- Enable the json extension for every SAPI of every PHP version:
+- Enable the JSON extension for every SAPI of every PHP version:
 
 `sudo phpenmod {{json}}`
 
-- Enable the json extension for PHP 7.3 with the cli SAPI:
+- Enable the JSON extension for PHP 7.3 with the cli SAPI:
 
 `sudo phpenmod -v {{7.3}} -s {{cli}} {{json}}`

--- a/pages/linux/phpquery.md
+++ b/pages/linux/phpquery.md
@@ -14,6 +14,6 @@
 
 `sudo phpquery -v {{7.3}} -s {{cli}} -M`
 
-- Check if the json extension is enabled for PHP 7.3 with the apache2 SAPI:
+- Check if the JSON extension is enabled for PHP 7.3 with the apache2 SAPI:
 
 `sudo phpquery -v {{7.3}} -s {{apache2}} -m {{json}}`

--- a/pages/linux/pkgfile.md
+++ b/pages/linux/pkgfile.md
@@ -20,7 +20,7 @@
 
 `pkgfile --list --binaries {{package_name}}`
 
-- Search for a package that owns a specific file using case insensitive matching:
+- Search for a package that owns a specific file using case-insensitive matching:
 
 `pkgfile --ignorecase {{filename}}`
 

--- a/pages/linux/protontricks.md
+++ b/pages/linux/protontricks.md
@@ -15,6 +15,6 @@
 
 `protontricks {{appid}} {{winetricks_args}}`
 
-- Run a command within a games installation directory:
+- Run a command within a game's installation directory:
 
 `protontricks -c {{command}} {{appid}}`

--- a/pages/linux/pulseaudio.md
+++ b/pages/linux/pulseaudio.md
@@ -1,17 +1,17 @@
 # pulseaudio
 
-> The pulseaudio sound system daemon and manager.
+> The PulseAudio sound system daemon and manager.
 > More information: <https://www.freedesktop.org/wiki/Software/PulseAudio/>.
 
-- Check if pulseaudio is running (a non-zero exit code means it is not running):
+- Check if PulseAudio is running (a non-zero exit code means it is not running):
 
 `pulseaudio --check`
 
-- Start the pulseaudio daemon in the background:
+- Start the PulseAudio daemon in the background:
 
 `pulseaudio --start`
 
-- Kill the running pulseaudio daemon:
+- Kill the running PulseAudio daemon:
 
 `pulseaudio --kill`
 

--- a/pages/linux/rdesktop.md
+++ b/pages/linux/rdesktop.md
@@ -23,6 +23,6 @@
 
 `rdesktop -u {{username}} -p {{password}} -d {{domainname}} {{host:port}}`
 
-- Use the 16 bit color (speed up):
+- Use the 16-bit color (speed up):
 
 `rdesktop -u {{username}} -p {{password}} -a 16 {{host:port}}`

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -6,7 +6,7 @@
 
 `sudo rtcwake -m show -v`
 
-- Suspend to ram and wakeup after 10 seconds:
+- Suspend to RAM and wakeup after 10 seconds:
 
 `sudo rtcwake -m mem -s {{10}}`
 
@@ -14,7 +14,7 @@
 
 `sudo rtcwake -m disk --date +{{15}}min`
 
-- Freeze the system (more efficient than suspend-to-ram but linux > 3.9 required) and wakeup at a given date and time:
+- Freeze the system (more efficient than suspend-to-RAM but linux > 3.9 required) and wakeup at a given date and time:
 
 `sudo rtcwake -m freeze --date {{YYYYMMDDhhmm}}`
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -14,7 +14,7 @@
 
 `sudo rtcwake -m disk --date +{{15}}min`
 
-- Freeze the system (more efficient than suspend-to-RAM but linux > 3.9 required) and wakeup at a given date and time:
+- Freeze the system (more efficient than suspend-to-RAM but Linux > 3.9 required) and wakeup at a given date and time:
 
 `sudo rtcwake -m freeze --date {{YYYYMMDDhhmm}}`
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -14,7 +14,7 @@
 
 `sudo rtcwake -m disk --date +{{15}}min`
 
-- Freeze the system (more efficient than suspend-to-RAM but Linux > 3.9 required) and wakeup at a given date and time:
+- Freeze the system (more efficient than suspend-to-RAM but Linux >3.9 required) and wakeup at a given date and time:
 
 `sudo rtcwake -m freeze --date {{YYYYMMDDhhmm}}`
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -14,7 +14,7 @@
 
 `sudo rtcwake -m disk --date +{{15}}min`
 
-- Freeze the system (more efficient than suspend-to-RAM but Linux kernel >3.9 required) and wakeup at a given date and time:
+- Freeze the system (more efficient than suspend-to-RAM but version 3.9 or newer of the Linux kernel is required) and wakeup at a given date and time:
 
 `sudo rtcwake -m freeze --date {{YYYYMMDDhhmm}}`
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -1,6 +1,6 @@
 # rtcwake
 
-> Enter a system sleep state until specified wakeup time relative to your bios clock.
+> Enter a system sleep state until specified wakeup time relative to your BIOS clock.
 
 - Show whether an alarm is set or not:
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -14,7 +14,7 @@
 
 `sudo rtcwake -m disk --date +{{15}}min`
 
-- Freeze the system (more efficient than suspend-to-RAM but Linux >3.9 required) and wakeup at a given date and time:
+- Freeze the system (more efficient than suspend-to-RAM but Linux kernel >3.9 required) and wakeup at a given date and time:
 
 `sudo rtcwake -m freeze --date {{YYYYMMDDhhmm}}`
 

--- a/pages/linux/schroot.md
+++ b/pages/linux/schroot.md
@@ -15,7 +15,7 @@
 
 `schroot --all {{command}}`
 
-- Start an interactive shell with in a specific chroot as a specific user:
+- Start an interactive shell within a specific chroot as a specific user:
 
 `schroot --chroot {{chroot}} --user {{user}}`
 

--- a/pages/linux/silentcast.md
+++ b/pages/linux/silentcast.md
@@ -1,6 +1,6 @@
 # silentcast
 
-> Silent screencast creator. Saves in `.mkv` and animated gif formats.
+> Silent screencast creator. Saves in `.mkv` and animated GIF formats.
 > More information: <https://github.com/colinkeenan/silentcast>.
 
 - Launch silentcast:

--- a/pages/linux/slapt-get.md
+++ b/pages/linux/slapt-get.md
@@ -19,7 +19,7 @@
 
 `slapt-get --upgrade`
 
-- Locate packages of interest by the package name, disk set, or version:
+- Locate packages by the package name, disk set, or version:
 
 `slapt-get --search {{package_name}}`
 

--- a/pages/linux/slapt-src.md
+++ b/pages/linux/slapt-src.md
@@ -16,7 +16,7 @@
 
 `slapt-src --install {{slackbuild_name}}`
 
-- Locate slackbuilds of interest by their name or description:
+- Locate slackbuilds by their name or description:
 
 `slapt-src --search {{search_term}}`
 

--- a/pages/linux/snmpwalk.md
+++ b/pages/linux/snmpwalk.md
@@ -7,18 +7,18 @@
 
 `snmpwalk -v1 -c {{community}} {{ip}}`
 
-- Query specific system information on a remote host by OID using SNMPv2 on a specified port:
+- Query system information on a remote host by OID using SNMPv2 on a specified port:
 
 `snmpwalk -v2c -c {{community}} {{ip}}:{{port}} {{oid}}`
 
-- Query specific system information on a remote host by OID using SNMPv3 and authentication without encryption:
+- Query system information on a remote host by OID using SNMPv3 and authentication without encryption:
 
 `snmpwalk -v3 -l {{authNoPriv}} -u {{username}} -a {{MD5|SHA}} -A {{passphrase}} {{ip}} {{oid}}`
 
-- Query specific system information on a remote host by OID using SNMPv3, authentication, and encryption:
+- Query system information on a remote host by OID using SNMPv3, authentication, and encryption:
 
 `snmpwalk -v3 -l {{authPriv}} -u {{username}} -a {{MD5|SHA}} -A {{auth_passphrase}} -x {{DES|AES}} -X {{enc_passphrase}} {{ip}} {{oid}}`
 
-- Query specific system information on a remote host by OID using SNMPv3 without authentication or encryption:
+- Query system information on a remote host by OID using SNMPv3 without authentication or encryption:
 
 `snmpwalk -v3 -l {{noAuthNoPriv}} -u {{username}} {{ip}} {{oid}}`

--- a/pages/linux/spectre-meltdown-checker.md
+++ b/pages/linux/spectre-meltdown-checker.md
@@ -7,7 +7,7 @@
 
 `sudo spectre-meltdown-checker`
 
-- Check the currently running kernel and show an explanation of the actions to take in order to mitigate a vulnerability:
+- Check the currently running kernel and show an explanation of the actions to take to mitigate a vulnerability:
 
 `sudo spectre-meltdown-checker --explain`
 

--- a/pages/linux/spi.md
+++ b/pages/linux/spi.md
@@ -15,7 +15,7 @@
 
 `spi --upgrade`
 
-- Locate packages or slackbuilds of interest by package name or description:
+- Locate packages or slackbuilds by package name or description:
 
 `spi {{search_terms}}`
 

--- a/pages/linux/sreport.md
+++ b/pages/linux/sreport.md
@@ -11,6 +11,6 @@
 
 `sreport job sizes printjobcount`
 
-- Show users with highest cpu time use:
+- Show users with the highest cpu time use:
 
 `sreport user topuser`

--- a/pages/linux/sreport.md
+++ b/pages/linux/sreport.md
@@ -11,6 +11,6 @@
 
 `sreport job sizes printjobcount`
 
-- Show users with the highest cpu time use:
+- Show users with the highest CPU time use:
 
 `sreport user topuser`

--- a/pages/linux/steghide.md
+++ b/pages/linux/steghide.md
@@ -3,7 +3,7 @@
 > Steganography tool for JPEG, BMP, WAV and AU file formats.
 > More information: <https://github.com/StefanoDeVuono/steghide>.
 
-- Embed data in a PNG image, prompting for a passphrase:
+- Embed data in a PNG, prompting for a passphrase:
 
 `steghide embed --coverfile {{path/to/image.png}} --embedfile {{path/to/data.txt}}`
 

--- a/pages/linux/swupd.md
+++ b/pages/linux/swupd.md
@@ -3,7 +3,7 @@
 > Package management utility for Clear Linux.
 > More information: <https://docs.01.org/clearlinux/latest/guides/clear/swupd.html>.
 
-- Update to latest version:
+- Update to the latest version:
 
 `sudo swupd update`
 

--- a/pages/linux/systemd-analyze.md
+++ b/pages/linux/systemd-analyze.md
@@ -6,7 +6,7 @@
 
 `systemd-analyze blame`
 
-- Print a tree of the time critical chain of units:
+- Print a tree of the time-critical chain of units:
 
 `systemd-analyze critical-chain`
 

--- a/pages/linux/tomb.md
+++ b/pages/linux/tomb.md
@@ -3,7 +3,7 @@
 > Manage encrypted storage directories that can be safely transported and hidden in a filesystem.
 > More information: <https://www.dyne.org/software/tomb/>.
 
-- Create a new tomb with an initial size of 100MB:
+- Create a new tomb with an initial size of 100 MB:
 
 `tomb dig -s {{100}} {{encrypted_directory.tomb}}`
 

--- a/pages/linux/xclip.md
+++ b/pages/linux/xclip.md
@@ -19,7 +19,7 @@
 
 `xclip -sel clip {{input_file.txt}}`
 
-- Copy the contents of a PNG image into the system clipboard (can be pasted in other programs correctly):
+- Copy the contents of a PNG into the system clipboard (can be pasted in other programs correctly):
 
 `xclip -sel clip -t image/png {{input_file.png}}`
 

--- a/pages/linux/xcursorgen.md
+++ b/pages/linux/xcursorgen.md
@@ -1,6 +1,6 @@
 # xcursorgen
 
-> Create an X cursor file from a collection of PNG images.
+> Create an X cursor file from a collection of PNGs.
 > If `--prefix` is omitted, the image files must be located in the current working directory.
 > More information: <https://manned.org/xcursorgen.1>.
 

--- a/pages/linux/xdg-mime.md
+++ b/pages/linux/xdg-mime.md
@@ -7,7 +7,7 @@
 
 `xdg-mime query filetype {{path/to/file}}`
 
-- Display the default application for opening PNG images:
+- Display the default application for opening PNGs:
 
 `xdg-mime query default {{image/png}}`
 

--- a/pages/linux/xdg-open.md
+++ b/pages/linux/xdg-open.md
@@ -7,7 +7,7 @@
 
 `xdg-open .`
 
-- Open an URL in the default browser:
+- Open a URL in the default browser:
 
 `xdg-open {{https://example.com}}`
 

--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -10,11 +10,11 @@
 
 `xdotool click {{3}}`
 
-- Get the id of the currently active window:
+- Get the ID of the currently active window:
 
 `xdotool getactivewindow`
 
-- Focus on the window with id of 12345:
+- Focus on the window with ID of 12345:
 
 `xdotool windowfocus --sync {{12345}}`
 

--- a/pages/linux/xsetwacom.md
+++ b/pages/linux/xsetwacom.md
@@ -2,7 +2,7 @@
 
 > Command-line tool to change settings for Wacom pen tablets at runtime.
 
-- List all the available wacom devices. The device name is in the first column:
+- List all the available Wacom devices. The device name is in the first column:
 
 `xsetwacom list`
 

--- a/pages/linux/yetris.md
+++ b/pages/linux/yetris.md
@@ -3,7 +3,7 @@
 > Clone of the game Tetris in the terminal.
 > More information: <https://github.com/alexdantas/yetris>.
 
-- Start a tetris game:
+- Start a Tetris game:
 
 `yetris`
 

--- a/pages/linux/yum.md
+++ b/pages/linux/yum.md
@@ -23,6 +23,6 @@
 
 `yum check-update`
 
-- Upgrade installed packages to newest available versions:
+- Upgrade installed packages to the newest available versions:
 
 `yum upgrade`

--- a/pages/linux/zramctl.md
+++ b/pages/linux/zramctl.md
@@ -15,7 +15,7 @@
 
 `sudo modprobe zram num_devices={{2}}`
 
-- Find and initialise the next free zram device to a 2GB virtual drive using LZ4 compression:
+- Find and initialise the next free zram device to a 2 GB virtual drive using LZ4 compression:
 
 `sudo zramctl --find --size {{2GB}} --algorithm {{lz4}}`
 

--- a/pages/linux/zypper.md
+++ b/pages/linux/zypper.md
@@ -15,7 +15,7 @@
 
 `zypper remove {{package}}`
 
-- Upgrade installed packages to newest available versions:
+- Upgrade installed packages to the newest available versions:
 
 `zypper update`
 

--- a/pages/osx/afinfo.md
+++ b/pages/osx/afinfo.md
@@ -15,7 +15,7 @@
 
 `afinfo -i {{path/to/file}}`
 
-- Print output in xml format:
+- Print output in XML format:
 
 `afinfo -x {{path/to/file}}`
 

--- a/pages/osx/caffeinate.md
+++ b/pages/osx/caffeinate.md
@@ -1,6 +1,6 @@
 # caffeinate
 
-> Prevent mac from sleeping.
+> Prevent macOS from sleeping.
 
 - Prevent from sleeping for 1 hour (3600 seconds):
 

--- a/pages/osx/compgen.md
+++ b/pages/osx/compgen.md
@@ -1,6 +1,6 @@
 # compgen
 
-> A built-in command for auto-completion in bash, which is called on pressing TAB key twice.
+> A built-in command for auto-completion in Bash, which is called on pressing TAB key twice.
 
 - List all commands that you could run:
 

--- a/pages/osx/compgen.md
+++ b/pages/osx/compgen.md
@@ -14,7 +14,7 @@
 
 `compgen -A function`
 
-- Show shell reserved key words:
+- Show shell reserved keywords:
 
 `compgen -k`
 

--- a/pages/osx/dd.md
+++ b/pages/osx/dd.md
@@ -6,7 +6,7 @@
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}}`
 
-- Clone a drive to another drive with 4MB block and ignore error:
+- Clone a drive to another drive with 4 MB block and ignore error:
 
 `dd if=/dev/{{source_drive}} of=/dev/{{dest_drive}} bs=4m conv=noerror`
 

--- a/pages/osx/dd.md
+++ b/pages/osx/dd.md
@@ -2,7 +2,7 @@
 
 > Convert and copy a file.
 
-- Make a bootable usb drive from an isohybrid file (such like `archlinux-xxx.iso`):
+- Make a bootable USB drive from an isohybrid file (such like `archlinux-xxx.iso`):
 
 `dd if={{file.iso}} of=/dev/{{usb_drive}}`
 

--- a/pages/osx/du.md
+++ b/pages/osx/du.md
@@ -10,7 +10,7 @@
 
 `du -h {{path/to/directory}}`
 
-- Show the size of a single directory, in human readable units:
+- Show the size of a single directory, in human-readable units:
 
 `du -sh {{path/to/directory}}`
 

--- a/pages/osx/m.md
+++ b/pages/osx/m.md
@@ -6,7 +6,7 @@
 
 `m battery status`
 
-- Turn off bluetooth:
+- Turn off Bluetooth:
 
 `m bluetooth off`
 

--- a/pages/osx/pdfgrep.md
+++ b/pages/osx/pdfgrep.md
@@ -10,7 +10,7 @@
 
 `pdfgrep --with-filename --page-number {{pattern}} {{file.pdf}}`
 
-- Do a case insensitive search for lines that begin with "foo" and return the first 3 matches:
+- Do a case-insensitive search for lines that begin with "foo" and return the first 3 matches:
 
 `pdfgrep --max-count {{3}} --ignore-case {{'^foo'}} {{file.pdf}}`
 

--- a/pages/osx/port.md
+++ b/pages/osx/port.md
@@ -14,7 +14,7 @@
 
 `port installed`
 
-- Update port and fetch latest list of available packages:
+- Update port and fetch the latest list of available packages:
 
 `sudo port selfupdate`
 

--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -27,7 +27,7 @@
 
 `sed -e 's/{{find}}/{{replace}}/' -e 's/{{find}}/{{replace}}/' {{filename}}`
 
-- Replace separator / by any other character not used in the find or replace patterns, e.g. #:
+- Replace separator `/` by any other character not used in the find or replace patterns, e.g. `#`:
 
 `sed 's#{{find}}#{{replace}}#' {{filename}}`
 

--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -27,7 +27,7 @@
 
 `sed -e 's/{{find}}/{{replace}}/' -e 's/{{find}}/{{replace}}/' {{filename}}`
 
-- Replace separator / by any other character not used in the find or replace patterns, e.g., #:
+- Replace separator / by any other character not used in the find or replace patterns, e.g. #:
 
 `sed 's#{{find}}#{{replace}}#' {{filename}}`
 

--- a/pages/osx/stat.md
+++ b/pages/osx/stat.md
@@ -6,7 +6,7 @@
 
 `stat {{file}}`
 
-- Same as above but verbose (more similar to linux's `stat`):
+- Same as above but verbose (more similar to Linux's `stat`):
 
 `stat -x {{file}}`
 

--- a/pages/osx/systemsetup.md
+++ b/pages/osx/systemsetup.md
@@ -6,7 +6,7 @@
 
 `systemsetup -setremotelogin on`
 
-- Specify TimeZone, NTP Server and enable network time:
+- Specify timezone, NTP Server and enable network time:
 
 `systemsetup -settimezone {{US/Pacific}} -setnetworktimeserver {{us.pool.ntp.org}} -setusingnetworktime on`
 

--- a/pages/osx/tmutil.md
+++ b/pages/osx/tmutil.md
@@ -3,11 +3,11 @@
 > Utility for managing Time Machine backups. Most verbs require root privileges.
 > More information: <https://ss64.com/osx/tmutil.html>.
 
-- Set a HFS+ drive as the backup destination:
+- Set an HFS+ drive as the backup destination:
 
 `sudo tmutil setdestination {{path/to/disk_mount_point}}`
 
-- Set a APF share or SMB share as the backup destination:
+- Set an APF share or SMB share as the backup destination:
 
 `sudo tmutil setdestination {{protocol://user[:password]@host/share}}`
 

--- a/pages/osx/wifi-password.md
+++ b/pages/osx/wifi-password.md
@@ -1,13 +1,13 @@
 # wifi-password
 
-> Get the password of the wifi.
+> Get the password of the Wi-Fi.
 > More information: <https://github.com/rauchg/wifi-password>.
 
-- Get the password for the wifi you are currently logged onto:
+- Get the password for the Wi-Fi you are currently logged onto:
 
 `wifi-password`
 
-- Get the password for the wifi with a specific SSID:
+- Get the password for the Wi-Fi with a specific SSID:
 
 `wifi-password {{ssid}}`
 

--- a/pages/osx/yaa.md
+++ b/pages/osx/yaa.md
@@ -22,6 +22,6 @@
 
 `yaa archive -a {{algorithm}} -d {{path/to/directory}} -o {{path/to/output.yaa}}`
 
-- Create an archive with an 8MB block size:
+- Create an archive with an 8 MB block size:
 
 `yaa archive -b {{8m}} -d {{path/to/directory}} -o {{path/to/output.yaa}}`

--- a/pages/sunos/prctl.md
+++ b/pages/sunos/prctl.md
@@ -8,7 +8,7 @@
 
 `prctl {{PID}}`
 
-- Examine process limits and permissions in machine parseable format:
+- Examine process limits and permissions in machine parsable format:
 
 `prctl -P {{PID}}`
 

--- a/pages/sunos/snoop.md
+++ b/pages/sunos/snoop.md
@@ -20,6 +20,6 @@
 
 `snoop to port {{port}} from host {{hostname}}`
 
-- Capture and show an hex-dump of network packets exchanged between two IP addresses:
+- Capture and show a hex-dump of network packets exchanged between two IP addresses:
 
 `snoop -x0 -p4 {{ip_address_1}} {{ip_address_2}}`

--- a/pages/windows/eventcreate.md
+++ b/pages/windows/eventcreate.md
@@ -4,7 +4,7 @@
 > Event IDs can be any number between 1 and 1000.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/eventcreate>.
 
-- Create a new event with a given id (1-1000) in the log:
+- Create a new event with a given ID (1-1000) in the log:
 
 `eventcreate /t {{success|error|warning|information}} /id {{id}} /d "{{message}}"`
 

--- a/pages/windows/pathping.md
+++ b/pages/windows/pathping.md
@@ -7,7 +7,7 @@
 
 `pathping {{hostname}}`
 
-- Do not perform reverse lookup of ip-address to hostname:
+- Do not perform reverse lookup of IP address to hostname:
 
 `pathping {{hostname}} -n`
 

--- a/pages/windows/robocopy.md
+++ b/pages/windows/robocopy.md
@@ -20,7 +20,7 @@
 
 `robocopy {{path/to/source}} {{path/to/destination}} /E /XO`
 
-- List all files 50 MBytes or larger in size instead of copying them:
+- List all files 50 MB or larger instead of copying them:
 
 `robocopy {{path/to/source}} {{path/to/destination}} /MIN:52428800 /L`
 

--- a/pages/windows/robocopy.md
+++ b/pages/windows/robocopy.md
@@ -22,7 +22,7 @@
 
 - List all files 50 MB or larger instead of copying them:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /MIN:52428800 /L`
+`robocopy {{path/to/source}} {{path/to/destination}} /MIN:{{52428800}} /L`
 
 - Allow resuming if network connection is lost and limit retries to 5 and wait time to 15 sec:
 

--- a/pages/windows/taskkill.md
+++ b/pages/windows/taskkill.md
@@ -1,9 +1,9 @@
 # taskkill
 
-> Terminate a process by its process id or name.
+> Terminate a process by its process ID or name.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/taskkill>.
 
-- Terminate a process by its id:
+- Terminate a process by its ID:
 
 `taskkill /pid {{process_id}}`
 

--- a/pages/windows/whoami.md
+++ b/pages/windows/whoami.md
@@ -19,6 +19,6 @@
 
 `whoami /upn`
 
-- Display the logon id of the current user:
+- Display the logon ID of the current user:
 
 `whoami /logonid`


### PR DESCRIPTION
Inspired by: https://github.com/tldr-pages/tldr/pull/5848

This only does the English files, LanguageTool does support other languages, but I can't manually review the suggestions.
I dumped only lines starting with `>` or `-` from the English files into a single file to save time.

The following is a non-exhaustive list of the changes made to the repository.

### Notable Changes
#### Hyphenated Words or Redundant Spaces
* human readable -> human-readable
* Un-select -> Unselect
* time scale -> timescale
* user name -> username

#### Fixed Nouns
* wifi / WiFi -> [Wi-Fi](https://en.wikipedia.org/wiki/Wi-Fi)
* tetris -> Tetris
* coachdb -> CoachDB
* heroku -> Heroku
* monday -> Monday
* friday -> Friday
* vue -> Vue

#### Fixed Acronyms
* url -> URL
* uri -> URI
* usb -> USB
* instances like pdf, png, jpg, xml, css, html, etc.
* instances like cpu, ram, etc

#### Typos
* pathames -> pathnames
* parseable -> parsable

### Misc Errors
* its vs it's
* an vs a
* singular vs plural
* double words (ie and and, or the the)
* inserting the word "the" ie "the largest", or "the highest", etc

#### Redundancies
These technically aren't incorrect, just longer than it needs to be.
* all of the -> all the
* short summary -> summary (short is inferred)
* in order to -> to

### Ignored
The following I ignored on purpose, feel free to drop opinions on them.

#### British vs American English
I also ignored locale-specific reports like British vs American English as discussed on Matrix. ([More Info](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$jECymhRKgh-Yf55UbktkX9U7Q2iz8Dt4HYs_9phXacs?via=gitter.im&via=matrix.org&via=matrix.coredump.ch))

### False Positives
It's common to refer to things like npm in lowercase even though it's technically an acronym. This makes LanguageTool mad since it thinks it's an actual word. ie `a npm package` vs `an npm package`. It thinks "a npm package" is correct, but because we _mean_ "a NPM package" it should be "an npm package".

---

I decided to be terrible and fixed another thing on the side in this PR.
There was a command that had extra spaces between arguments, so I also removed that. Nothing to do with LanguageTool.
* pages/common/acme.sh-dns.md