### PR TITLE
qtchooser: add page

### DIFF
--- a/pages/linux/qtchooser.md
+++ b/pages/linux/qtchooser.md
@@ -1,0 +1,24 @@
+# qtchooser
+
+> A wrapper used to select between Qt development binary versions.
+> More information: <https://manned.org/qtchooser>.
+
+- Lists available Qt versions from the configuration files:
+
+`qtchooser --list-versions`
+
+- Prints environment information:
+
+`qtchooser --print-env`
+
+- Runs the specified tool using the specified Qt version:
+
+`qtchooser --run-tool={{tool}} -qt={{version_name}}`
+
+- Add a Qt version entry to be able to choose from:
+
+`qtchooser --install {{version_name}} {{path/to/qmake}}`
+
+- Output all available options:
+
+`qtchooser --help`

--- a/pages/linux/qtchooser.md
+++ b/pages/linux/qtchooser.md
@@ -3,15 +3,15 @@
 > A wrapper used to select between Qt development binary versions.
 > More information: <https://manned.org/qtchooser>.
 
-- Lists available Qt versions from the configuration files:
+- List available Qt versions from the configuration files:
 
 `qtchooser --list-versions`
 
-- Prints environment information:
+- Print environment information:
 
 `qtchooser --print-env`
 
-- Runs the specified tool using the specified Qt version:
+- Run the specified tool using the specified Qt version:
 
 `qtchooser --run-tool={{tool}} -qt={{version_name}}`
 

--- a/pages/linux/qtchooser.md
+++ b/pages/linux/qtchooser.md
@@ -13,12 +13,12 @@
 
 - Run the specified tool using the specified Qt version:
 
-`qtchooser --run-tool={{tool}} -qt={{version_name}}`
+`qtchooser --run-tool={{tool}} --qt={{version_name}}`
 
 - Add a Qt version entry to be able to choose from:
 
 `qtchooser --install {{version_name}} {{path/to/qmake}}`
 
-- Output all available options:
+- Display all available options:
 
 `qtchooser --help`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

This one was kind of annoying. 🤔 
The man pages and help document different commands, and have contradicting arguments.

* In the man pages it documents `qtchooser -print-env [-qt=version]`, but I don't think one can use the `-qt` argument with `-print-env`.
* The man pages doesn't document the `-install` argument, but it's available in help and works as well.

What's preferred, using the official source repository, or manned?
* https://github.com/qtproject/qtsdk-qtchooser
* https://manned.org/qtchooser