### PR TITLE
ln: convert paths to absolute and fix typo in Italian page

### DIFF
--- a/pages.fr/common/ln.md
+++ b/pages.fr/common/ln.md
@@ -5,12 +5,12 @@
 
 - Crée un lien symbolique vers un fichier ou un répertoire :
 
-`ln -s {{chemin/vers/fichier_ou_repertoire}} {{chemin/vers/lien_symbolique}}`
+`ln -s {{/chemin/vers/fichier_ou_repertoire}} {{chemin/vers/lien_symbolique}}`
 
 - Modifie la cible d'un lien symbolique existant :
 
-`ln -sf {{chemin/vers/nouveau_fichier}} {{chemin/vers/lien_symbolique}}`
+`ln -sf {{/chemin/vers/nouveau_fichier}} {{chemin/vers/lien_symbolique}}`
 
 - Crée un lien dur vers un fichier :
 
-`ln {{chemin/vers/fichier}} {{chemin/vers/lien_dur}}`
+`ln {{/chemin/vers/fichier}} {{chemin/vers/lien_dur}}`

--- a/pages.it/common/ln.md
+++ b/pages.it/common/ln.md
@@ -5,12 +5,12 @@
 
 - Crea un collegamento simbolico a un file (o directory):
 
-`ln -s {{percorso/al/file}} {{percorso/al/collegamento}}`
+`ln -s {{/percorso/al/file}} {{percorso/al/collegamento}}`
 
 - Sovrascrivi un collegamento esistente in modo che punti a un nuovo file:
 
-`ln -sg {{percorso/al/nuovo/file}} {{percorso/al/collegamento}}`
+`ln -sg {{/percorso/al/nuovo/file}} {{percorso/al/collegamento}}`
 
 - Crea un collegamento fisico a un file:
 
-`ln {{percorso/al/file}} {{percorso/al/collegamento}}`
+`ln {{/percorso/al/file}} {{percorso/al/collegamento}}`

--- a/pages.it/common/ln.md
+++ b/pages.it/common/ln.md
@@ -9,7 +9,7 @@
 
 - Sovrascrivi un collegamento esistente in modo che punti a un nuovo file:
 
-`ln -sg {{/percorso/al/nuovo/file}} {{percorso/al/collegamento}}`
+`ln -sf {{/percorso/al/nuovo/file}} {{percorso/al/collegamento}}`
 
 - Crea un collegamento fisico a un file:
 

--- a/pages/common/ln.md
+++ b/pages/common/ln.md
@@ -5,12 +5,12 @@
 
 - Create a symbolic link to a file or directory:
 
-`ln -s {{path/to/file_or_directory}} {{path/to/symlink}}`
+`ln -s {{/path/to/file_or_directory}} {{path/to/symlink}}`
 
 - Overwrite an existing symbolic link to point to a different file:
 
-`ln -sf {{path/to/new_file}} {{path/to/symlink}}`
+`ln -sf {{/path/to/new_file}} {{path/to/symlink}}`
 
 - Create a hard link to a file:
 
-`ln {{path/to/file}} {{path/to/hardlink}}`
+`ln {{/path/to/file}} {{path/to/hardlink}}`


### PR DESCRIPTION
When running `ln -s path1/file path2/symlink`, while in `path3` you'd expect it to create a symlink `path2/symlink`, which points to `path3/path1/file`. However the symlink points to `path2/path1/file`, so the base for the relative path of the file is actually the directory of the symlink and not the directory this was executed from. The easiest solution is to just specify an absolute path to the file.