### PR TITLE
git-release: add page

### DIFF
--- a/pages/common/git-release.md
+++ b/pages/common/git-release.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-release>.
 
-- Create a Git release, locally and remotely:
+- Create and push a Git release:
 
 `git release {{tag_name}}`
 

--- a/pages/common/git-release.md
+++ b/pages/common/git-release.md
@@ -8,7 +8,7 @@
 
 `git release {{tag_name}}`
 
-- Create a signed Git release, locally and remotely:
+- Create and push a signed Git release:
 
 `git release {{tag_name}} -s`
 

--- a/pages/common/git-release.md
+++ b/pages/common/git-release.md
@@ -12,6 +12,6 @@
 
 `git release {{tag_name}} -s`
 
-- Create a Git release with a message, locally and remotely:
+- Create and push a Git release with a message:
 
 `git release {{{tag_name}}} -m "{{message}}"`

--- a/pages/common/git-release.md
+++ b/pages/common/git-release.md
@@ -1,7 +1,7 @@
 # git release
 
 > Create a Git release tag.
-> Part of `git-extras`
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-release>.
 
 - Create a Git release, locally and remotely:

--- a/pages/common/git-release.md
+++ b/pages/common/git-release.md
@@ -1,0 +1,17 @@
+# git release
+
+> Create a Git release tag.
+> Part of `git-extras`
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-release>.
+
+- Create a Git release, locally and remotely:
+
+`git release {{tag_name}}`
+
+- Create a signed Git release, locally and remotely:
+
+`git release {{tag_name}} -s`
+
+- Create a Git release with a message, locally and remotely:
+
+`git release {{{tag_name}}} -m "{{message}}"`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 

This PR and command is cursed, it has coursed me nothing but trouble, I accidentally made a tag on tldr rather than my test repo. 
I had to rebase for the first time because of a commit between a good one and another good one 