### PR TITLE
git-obliterate: add page

### DIFF
--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -8,6 +8,6 @@
 
 `git obliterate {{file_1 file_2 ...}}`
 
-- Remove existence of a file between 2 commits:
+- Erase the existence of a file between 2 commits:
 
 `git obliterate {{file_1 file_2 ...}} -- {{commit_hash1}}..{{commit_hash2}}`

--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -1,13 +1,13 @@
 # git obliterate
 
-> Delete a file and erase its history from a Git repository:
+> Delete specific files and erase their history from a Git repository.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-obliterate>.
 
-- Delete files and erase their history:
+- Erase the existence of specific files:
 
 `git obliterate {{file_1 file_2 ...}}`
 
-- Erase the existence of a file between 2 commits:
+- Erase the existence of specific files between 2 commits:
 
 `git obliterate {{file_1 file_2 ...}} -- {{commit_hash1}}..{{commit_hash2}}`

--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -1,0 +1,13 @@
+# git obliterate
+
+> Remove a file from all history in a Git repository.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-obliterate>.
+
+- Remove all existence of a file including history:
+
+`git obliterate {{file_1 file_2 ...}}`
+
+- Remove existence of a file between 2 commits:
+
+`git obliterate {{file_1 file_2 ...}} -- {{commit_hash1}}..{{commit_hash2}}`

--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-obliterate>.
 
-- Remove all existence of a file including history:
+- Delete files and erase their history:
 
 `git obliterate {{file_1 file_2 ...}}`
 

--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -10,4 +10,4 @@
 
 - Erase the existence of specific files between 2 commits:
 
-`git obliterate {{file_1 file_2 ...}} -- {{commit_hash1}}..{{commit_hash2}}`
+`git obliterate {{file_1 file_2 ...}} -- {{commit_hash_1}}..{{commit_hash_2}}`

--- a/pages/common/git-obliterate.md
+++ b/pages/common/git-obliterate.md
@@ -1,6 +1,6 @@
 # git obliterate
 
-> Remove a file from all history in a Git repository.
+> Delete a file and erase its history from a Git repository:
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-obliterate>.
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


I haven't tested this command so if anyone would like to double check, please do.
#5137 