### PR TITLE
docker-build: add example with docker from stdin

### DIFF
--- a/pages/common/docker-build.md
+++ b/pages/common/docker-build.md
@@ -17,7 +17,7 @@
 
 - Build a docker image with no build context:
 
-`docker build --tag {{name:tag}} - < Dockerfile`
+`docker build --tag {{name:tag}} - < {{Dockerfile}}`
 
 - Do not use the cache when building the image:
 

--- a/pages/common/docker-build.md
+++ b/pages/common/docker-build.md
@@ -17,7 +17,7 @@
 
 - Build a docker image with no build context:
 
-`cat {{Dockerfile}} | docker build --tag {{name:tag}} -`
+`docker build --tag {{name:tag}} - < {{Dockerfile}}`
 
 - Do not use the cache when building the image:
 

--- a/pages/common/docker-build.md
+++ b/pages/common/docker-build.md
@@ -17,7 +17,7 @@
 
 - Build a docker image with no build context:
 
-`docker build --tag {{name:tag}} - < {{Dockerfile}}`
+`cat {{Dockerfile}} | docker build --tag {{name:tag}} -`
 
 - Do not use the cache when building the image:
 

--- a/pages/common/docker-build.md
+++ b/pages/common/docker-build.md
@@ -15,6 +15,10 @@
 
 `docker build --tag {{name:tag}} .`
 
+- Build a docker image with no build context:
+
+`docker build --tag {{name:tag}} - < Dockerfile`
+
 - Do not use the cache when building the image:
 
 `docker build --no-cache --tag {{name:tag}} .`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

More information: https://docs.docker.com/engine/reference/commandline/build/#text-files
This builds an image from stdin, which allows us to build an image with no build context. 