### PR TITLE
history: add note for zsh

### DIFF
--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -7,7 +7,7 @@
 
 `history`
 
-- Display the last 20 commands:
+- Display the last 20 commands (in `zsh` it displays all commands starting from the 20th):
 
 `history {{20}}`
 


### PR DESCRIPTION
This page also has an `es` and `pt_PT` translation, which also should be updated now, since we'll probably never see if there's a difference in a command description.