### PR TITLE
kdeconnect-cli: add share file/url; remove redundant pair; copyedit

### DIFF
--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -19,7 +19,7 @@
 
 `kdeconnect-cli --ring --name {{device_name}}`
 
-- Share a file or URL with a paired device, specifying its ID:
+- Share an URL or file with a paired device, specifying its ID:
 
 `kdeconnect-cli --share {{URL|path/to/file}} --device {{device_id}}`
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -16,13 +16,13 @@
 `kdeconnect-cli --pair --device {{device_id}}`
 
 - Request pairing with a specific device, specifying its name:
+- Ring a device, specifying its name:
 
 `kdeconnect-cli --pair --name {{device_name}}`
+`kdeconnect-cli --ring --name {{device_name}}`
 
-- Ring a specific device:
 - Share a file or URL to a paired device, specifying its ID: 
 
-`kdeconnect-cli --ring --name {{device_name}}`
 `kdeconnect-cli --share {{path/to/file|URL}} --device {{device_id}}`
 
 - Send an SMS with an optional attachment to a specific number:

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -11,7 +11,7 @@
 
 `kdeconnect-cli --list-available`
 
-- Request pairing to a device, specifying its ID:
+- Request pairing with a device, specifying its ID:
 
 `kdeconnect-cli --pair --device {{device_id}}`
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -19,7 +19,7 @@
 
 `kdeconnect-cli --ring --name {{device_name}}`
 
-- Share a file or URL to a paired device, specifying its ID:
+- Share a file or URL with a paired device, specifying its ID:
 
 `kdeconnect-cli --share {{path/to/file|URL}} --device {{device_id}}`
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -19,7 +19,7 @@
 
 `kdeconnect-cli --ring --name {{device_name}}`
 
-- Share a file or URL to a paired device, specifying its ID: 
+- Share a file or URL to a paired device, specifying its ID:
 
 `kdeconnect-cli --share {{path/to/file|URL}} --device {{device_id}}`
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -20,8 +20,10 @@
 `kdeconnect-cli --pair --name {{device_name}}`
 
 - Ring a specific device:
+- Share a file or URL to a paired device, specifying its ID: 
 
 `kdeconnect-cli --ring --name {{device_name}}`
+`kdeconnect-cli --share {{path/to/file|URL}} --device {{device_id}}`
 
 - Send an SMS with an optional attachment to a specific number:
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -15,10 +15,8 @@
 
 `kdeconnect-cli --pair --device {{device_id}}`
 
-- Request pairing with a specific device, specifying its name:
 - Ring a device, specifying its name:
 
-`kdeconnect-cli --pair --name {{device_name}}`
 `kdeconnect-cli --ring --name {{device_name}}`
 
 - Share a file or URL to a paired device, specifying its ID: 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -21,7 +21,7 @@
 
 - Share a file or URL with a paired device, specifying its ID:
 
-`kdeconnect-cli --share {{path/to/file|URL}} --device {{device_id}}`
+`kdeconnect-cli --share {{URL|path/to/file}} --device {{device_id}}`
 
 - Send an SMS with an optional attachment to a specific number:
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -11,7 +11,7 @@
 
 `kdeconnect-cli --list-available`
 
-- Request pairing with a device, specifying its ID:
+- Request pairing with a specific device, specifying its ID:
 
 `kdeconnect-cli --pair --device {{device_id}}`
 

--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -7,11 +7,11 @@
 
 `kdeconnect-cli --list-devices`
 
-- List all reachable devices:
+- List available (paired and reachable) devices:
 
 `kdeconnect-cli --list-available`
 
-- Request pairing with a specific device, specifying its ID:
+- Request pairing to a device, specifying its ID:
 
 `kdeconnect-cli --pair --device {{device_id}}`
 


### PR DESCRIPTION
- [ ] The page (if new), does not already exist in the repo.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
---
- add share file/url
- remove redundant pair
- copyedit