### PR TITLE
aws-secretsmanager: add page

### DIFF
--- a/pages/common/aws-secretsmanager.md
+++ b/pages/common/aws-secretsmanager.md
@@ -9,7 +9,7 @@
 
 - Create a secret:
 
-`aws secretsmanager create-secret --name {{name}} --description "{{String describing secret}}" --secret-string {{secret}}`
+`aws secretsmanager create-secret --name {{name}} --description "{{secret_description}}" --secret-string {{secret}}`
 
 - Delete a secret:
 

--- a/pages/common/aws-secretsmanager.md
+++ b/pages/common/aws-secretsmanager.md
@@ -1,0 +1,32 @@
+# aws secretsmanager
+
+> Store, manage, and retrieve secrets.
+> More information: <https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/>.
+
+- Show secrets stored by the secrets manager in the current account:
+
+`aws secretsmanager list-secrets`
+
+- Create a secret:
+
+`aws secretsmanager create-secret --name {{name}} --description "{{String describing secret}}" --secret-string {{secret}}`
+
+- Delete a secret:
+
+`aws secretsmanager delete-secret --secret-id {{name_or_arn}}`
+
+- View details of a secret except for secret text:
+
+`aws secretsmanager describe-secret --secret-id {{name_or_arn}}`
+
+- Retrieve the value of a secret (to get the latest version of the secret omit `--version-stage`):
+
+`aws secretsmanager get-secret-value --secret-id {{name_or_arn}} --version-stage {{version_of_secret}}`
+
+- Rotate the secret immediately using a Lambda function:
+
+`aws secretsmanager rotate-secret --secret-id {{name_or_arn}} --rotation-lambda-arn {{arn_of_lambda_function}}`
+
+- Rotate the secret automatically every 30 days using a Lambda function:
+
+`aws secretsmanager rotate-secret --secret-id {{name_or_arn}} --rotation-lambda-arn {{arn_of_lambda_function}} --rotation-rules AutomaticallyAfterDays={{30}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5653