### PR TITLE
git-rename-remote: add page

### DIFF
--- a/pages/common/git-rename-remote.md
+++ b/pages/common/git-rename-remote.md
@@ -6,4 +6,4 @@
 
 - Change the upstream remote to origin:
 
-`git rename-remote upstream origin`
+`git rename-remote {{upstream}} {{origin}}`

--- a/pages/common/git-rename-remote.md
+++ b/pages/common/git-rename-remote.md
@@ -1,0 +1,9 @@
+# git rename-remote
+
+> Change remote for pulling and pushing.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-rename-remote>.
+
+- Change the upstream remote to origin:
+
+`git rename-remote upstream origin`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 

I couldn't find any more use cases for this command, if you can, please suggest them