### PR TITLE
git-verify-tag: add page

### DIFF
--- a/pages/common/git-verify-tag.md
+++ b/pages/common/git-verify-tag.md
@@ -1,0 +1,17 @@
+# git verify-tag
+
+> Check for GPG verification of tags.
+> If tag isn't signed with -s when made, you will get an error regardless of signing.
+> More information: <https://git-scm.com/docs/git-verify-tag>.
+
+- Check tags for a GPG signature:
+
+`git verify-tag {{tag1 optional_tag2 ...}}`
+
+- Check tags for a GPG signature and show details of each tag:
+
+`git verify-tag {{tag1 optional_tag2 ...}} --verbose`
+
+- Check tags for a GPG signature and print the raw details:
+
+`git verify-tag {{tag1 optional_tag2 ...}} --raw`

--- a/pages/common/git-verify-tag.md
+++ b/pages/common/git-verify-tag.md
@@ -8,7 +8,7 @@
 
 `git verify-tag {{tag1 optional_tag2 ...}}`
 
-- Check tags for a GPG signature and show details of each tag:
+- Check tags for a GPG signature and show details for each tag:
 
 `git verify-tag {{tag1 optional_tag2 ...}} --verbose`
 

--- a/pages/common/git-verify-tag.md
+++ b/pages/common/git-verify-tag.md
@@ -1,7 +1,7 @@
 # git verify-tag
 
 > Check for GPG verification of tags.
-> If a tag wasn't manually signed, an error will occur.
+> If a tag wasn't signed, an error will occur.
 > More information: <https://git-scm.com/docs/git-verify-tag>.
 
 - Check tags for a GPG signature:

--- a/pages/common/git-verify-tag.md
+++ b/pages/common/git-verify-tag.md
@@ -1,7 +1,7 @@
 # git verify-tag
 
 > Check for GPG verification of tags.
-> If tag isn't signed with -s when made, you will get an error regardless of signing.
+> If a tag wasn't manually signed, an error will occur.
 > More information: <https://git-scm.com/docs/git-verify-tag>.
 
 - Check tags for a GPG signature:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #3953