### PR TITLE
pip3: fix argument spelling

### DIFF
--- a/pages.fr/common/pip3.md
+++ b/pages.fr/common/pip3.md
@@ -29,7 +29,7 @@
 
 - Installe des paquets à partir d'un fichier :
 
-`pip3 install --requirements {{requirements.txt}}`
+`pip3 install --requirement {{requirements.txt}}`
 
 - Affiche les informations d'un paquet installé :
 

--- a/pages.id/common/pip3.md
+++ b/pages.id/common/pip3.md
@@ -29,7 +29,7 @@
 
 - Memasang paket dari berkas:
 
-`pip3 install --requirements {{requirements.txt}}`
+`pip3 install --requirement {{requirements.txt}}`
 
 - Menampilkan informasi paket terinstal:
 

--- a/pages/common/pip3.md
+++ b/pages/common/pip3.md
@@ -29,7 +29,7 @@
 
 - Install packages from a file:
 
-`pip3 install --requirements {{requirements.txt}}`
+`pip3 install --requirement {{requirements.txt}}`
 
 - Show installed package info:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

```bash
Install Options:
  -r, --requirement <file>    Install from the given requirements file. This option can be used multiple times.
```

It's `--requirement`, not `--requirements`!