### PR TITLE
mklost+found: add page

### DIFF
--- a/pages/linux/mklost+found.md
+++ b/pages/linux/mklost+found.md
@@ -3,6 +3,6 @@
 > Create a lost+found directory.
 > More information: <https://manned.org/mklost+found>.
 
-- Create a lost+found directory:
+- Create a `lost+found` directory in the current directory:
 
 `mklost+found`

--- a/pages/linux/mklost+found.md
+++ b/pages/linux/mklost+found.md
@@ -1,0 +1,8 @@
+# mklost+found
+
+> Create a lost+found directory:
+> More information: <https://manned.org/mklost+found.8>.
+
+- Create a lost+found directory:
+
+`mklost+found`

--- a/pages/linux/mklost+found.md
+++ b/pages/linux/mklost+found.md
@@ -1,7 +1,7 @@
 # mklost+found
 
 > Create a lost+found directory.
-> More information: <https://manned.org/mklost+found.8>.
+> More information: <https://manned.org/mklost+found>.
 
 - Create a lost+found directory:
 

--- a/pages/linux/mklost+found.md
+++ b/pages/linux/mklost+found.md
@@ -1,6 +1,6 @@
 # mklost+found
 
-> Create a lost+found directory:
+> Create a lost+found directory.
 > More information: <https://manned.org/mklost+found.8>.
 
 - Create a lost+found directory:


### PR DESCRIPTION

- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable)

Never seen or used the command, and it maybe could be an arch exclusive since I have never seen it on Debian based.

Unaware on how useful it really is since fsck will make one every boot anyway
