### PR TITLE
git-show-tree: add page

### DIFF
--- a/pages/common/git-show-tree.md
+++ b/pages/common/git-show-tree.md
@@ -4,6 +4,6 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-show-tree>.
 
-- Show a decorated tree graph for all branches annotated with tags and branch names.
+- Show a decorated tree graph for all branches annotated with tags and branch names:
 
 `git show-tree`

--- a/pages/common/git-show-tree.md
+++ b/pages/common/git-show-tree.md
@@ -4,6 +4,6 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-show-tree>.
 
-- Show a decorated tree graph for each branch, showing commits other statistics:
+- Show a decorated tree graph for all branches annotated with tags and branch names.
 
 `git show-tree`

--- a/pages/common/git-show-tree.md
+++ b/pages/common/git-show-tree.md
@@ -1,6 +1,6 @@
 # git show-tree
 
-> Show a decorated tree graph for each branch, showing commits other statistics.
+> Show a decorated tree graph with all branches of a Git repository, showing annotations.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-show-tree>.
 

--- a/pages/common/git-show-tree.md
+++ b/pages/common/git-show-tree.md
@@ -1,0 +1,9 @@
+# git show-tree
+
+> Show a decorated tree graph for each branch, showing commits other statistics.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-show-tree>.
+
+- Show a decorated tree graph for each branch, showing commits other statistics:
+
+`git show-tree`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 