### PR TITLE
gcc: add long flag

### DIFF
--- a/pages.de/common/gcc.md
+++ b/pages.de/common/gcc.md
@@ -5,15 +5,15 @@
 
 - Kompiliere mehrere Quellcodedateien zu einer ausführbaren Datei:
 
-`gcc {{pfad/zu/datei1.c}} {{pfad/zu/datei2.c}} -o {{pfad/zu/binärdatei}}`
+`gcc {{pfad/zu/datei1.c}} {{pfad/zu/datei2.c}} --output {{pfad/zu/binärdatei}}`
 
 - Erlaube Warnungen und debug-Symbole in der Ausgabedatei:
 
-`gcc {{pfad/zu/datei.c}} -Wall -Og -o {{pfad/zu/binärdatei}}`
+`gcc {{pfad/zu/datei.c}} -Wall -Og --output {{pfad/zu/binärdatei}}`
 
 - Inkludiere Bibliotheken aus anderen Verzeichnissen:
 
-`gcc {{pfad/zu/datei.c}} -o {{pfad/zu/binärdatei}} -I{{pfad/zu/headerdatei}} -L{{pfad/zu/bibliothek1}} -l{{pfad/zu/bibliothek2}}`
+`gcc {{pfad/zu/datei.c}} --output {{pfad/zu/binärdatei}} -I{{pfad/zu/headerdatei}} -L{{pfad/zu/bibliothek1}} -l{{pfad/zu/bibliothek2}}`
 
 - Kompiliere Quellcodedateien zu Assemblerinstruktionen:
 

--- a/pages.pt_BR/common/gcc.md
+++ b/pages.pt_BR/common/gcc.md
@@ -5,15 +5,15 @@
 
 - Compilar múltiplos arquivos de código fonte, produzindo um arquivo executável:
 
-`gcc {{arquivo_fonte1.c}} {{arquivo_fonte2.c}} -o {{arquivo_executável}}`
+`gcc {{arquivo_fonte1.c}} {{arquivo_fonte2.c}} --output {{arquivo_executável}}`
 
 - Habilitar avisos durante a compilação:
 
-`gcc {{arquivo_fonte.c}} -Wall -Og -o {{arquivo_executável}}`
+`gcc {{arquivo_fonte.c}} -Wall -Og --output {{arquivo_executável}}`
 
 - Incluir bibliotecas de um local diferente:
 
-`gcc {{arquivo_fonte.c}} -o {{arquivo_executável}} -I{{caminho/para/header}} -L{{caminho/para/biblioteca}} -l{{nome_biblioteca}}`
+`gcc {{arquivo_fonte.c}} --output {{arquivo_executável}} -I{{caminho/para/header}} -L{{caminho/para/biblioteca}} -l{{nome_biblioteca}}`
 
 - Compilar o código fonte para instruções Assembler:
 

--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -5,15 +5,15 @@
 
 - Compile multiple source files into executable:
 
-`gcc {{source1.c}} {{source2.c}} -o {{executable}}`
+`gcc {{source1.c}} {{source2.c}} --output {{executable}}`
 
 - Allow warnings, debug symbols in output:
 
-`gcc {{source.c}} -Wall -Og -o {{executable}}`
+`gcc {{source.c}} -Wall -Og --output {{executable}}`
 
 - Include libraries from a different path:
 
-`gcc {{source.c}} -o {{executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`
+`gcc {{source.c}} --output {{executable}} -I{{header_path}} -L{{library_path}} -l{{library_name}}`
 
 - Compile source code into Assembler instructions:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

