### PR TITLE
git-commit: add gpg-sign example and sync German translation

### DIFF
--- a/pages.de/common/git-commit.md
+++ b/pages.de/common/git-commit.md
@@ -15,6 +15,10 @@
 
 `git commit -a -m "{{nachricht}}"`
 
+- Committe alle gestagten Dateien und [S]igniere sie mit dem in `~/.gitconfig` definierten GPG Schlüssel:
+
+`git commit -S -m "{{nachricht}}"`
+
 - Ersetze den letzten Commit mit den gerade auf dem Stage liegenden Änderungen:
 
 `git commit --amend`

--- a/pages.de/common/git-commit.md
+++ b/pages.de/common/git-commit.md
@@ -22,3 +22,7 @@
 - Comitte nur spezifische Dateien (die Dateien müssen schon auf dem Stage liegen):
 
 `git commit {{pfad/zu/datei1}} {{pfad/zu/datei2}}`
+
+- Erzeuge einen Commit, auch wenn keine Dateien auf dem Stage liegen:
+
+`git commit -m "{{nachricht}}" --allow-empty`

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -15,6 +15,10 @@
 
 `git commit -a -m "{{message}}"`
 
+- Commit staged files and [S]ign them with the GPG key defined in `~/.gitconfig`:
+
+`git commit -S -m "{{message}}"`
+
 - Update the last commit by adding the currently staged changes, changing the commit's hash:
 
 `git commit --amend`


### PR DESCRIPTION
If nothing changes, we probably should do a rebase for this one.