### PR TITLE
gradle: edit assembleRelease example to show Android Studio specificity

### DIFF
--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -11,7 +11,7 @@
 
 `gradle build -x {{test}}`
 
-- Ejecuta en modo offline para prevenir que gradle acceda a la red durante una compilación:
+- Ejecuta en modo offline para prevenir que Gradle acceda a la red durante una compilación:
 
 `gradle build --offline`
 
@@ -19,6 +19,6 @@
 
 `gradle clean`
 
-- Compila y genera un paquete:
+- Genera un `release` `Android Package Kit` paquete (específico para `Android Studio`):
 
 `gradle assembleRelease`

--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -19,6 +19,6 @@
 
 `gradle clean`
 
-- Genera un `release` `Android Package Kit` paquete (específico para `Android Studio`):
+- Genera una APK en modo lanzamiento:
 
 `gradle assembleRelease`

--- a/pages.es/common/gradle.md
+++ b/pages.es/common/gradle.md
@@ -19,6 +19,6 @@
 
 `gradle clean`
 
-- Genera una APK en modo lanzamiento:
+- Compila un paquete Android (APK) en modo lanzamiento:
 
 `gradle assembleRelease`

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -11,7 +11,7 @@
 
 `gradle build -x {{test}}`
 
-- Run in offline mode to prevent gradle from accessing the network during builds:
+- Run in offline mode to prevent Gradle from accessing the network during builds:
 
 `gradle build --offline`
 
@@ -19,7 +19,7 @@
 
 `gradle clean`
 
-- Compile and Release package:
+- Build a release `Android Package Kit` package (specific to `Android Studio):
 
 `gradle assembleRelease`
 

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -19,7 +19,7 @@
 
 `gradle clean`
 
-- Build a release `Android Package Kit` package (specific to `Android Studio):
+- Build an APK in release mode:
 
 `gradle assembleRelease`
 

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -19,7 +19,7 @@
 
 `gradle clean`
 
-- Build an APK in release mode:
+- Build an Android Package (APK) in release mode:
 
 `gradle assembleRelease`
 


### PR DESCRIPTION
`assembleDebug` and `assembleRelease` tasks are specific to Android Studio:
https://developer.android.com/studio/build/building-cmdline#ReleaseMode
https://stackoverflow.com/questions/44185165/what-are-the-differences-between-gradle-assemble-and-gradle-build-tasks

They are not common tasks like `build`, `assemble` and `check`:
https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_executing_tasks

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
