### PR TITLE
gpg: add --full-generate-key example

### DIFF
--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -4,7 +4,7 @@
 > See `gpg2` for GNU Privacy Guard 2.
 > More information: <https://gnupg.org>.
 
-- Create a GPG public and private key with a interactive creator:
+- Create a GPG public and private key with an interactive creator:
 
 `gpg --full-generate-key`
 

--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -4,7 +4,7 @@
 > See `gpg2` for GNU Privacy Guard 2.
 > More information: <https://gnupg.org>.
 
-- Create a GPG public and private key with an interactive creator:
+- Create a GPG public and private key interactively:
 
 `gpg --full-generate-key`
 

--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -4,6 +4,10 @@
 > See `gpg2` for GNU Privacy Guard 2.
 > More information: <https://gnupg.org>.
 
+- Create a GPG public and private key with a interactive creator:
+
+`gpg --full-generate-key`
+
 - Sign `doc.txt` without encryption (writes output to `doc.txt.asc`):
 
 `gpg --clearsign {{doc.txt}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

## This command deserves to be at the top, since it would be the first thing a user would do when starting with gpg