### PR TITLE
restic: replace -r by long argument --repo 

### DIFF
--- a/pages/common/restic.md
+++ b/pages/common/restic.md
@@ -5,23 +5,23 @@
 
 - Initialize a backup repository in the specified local directory:
 
-`restic init -r {{path/to/repository}}`
+`restic init --repo {{path/to/repository}}`
 
 - Backup a directory to the repository:
 
-`restic -r {{path/to/repository}} backup {{path/to/directory}}`
+`restic --repo {{path/to/repository}} backup {{path/to/directory}}`
 
 - Show backup snapshots currently stored in the repository:
 
-`restic -r {{path/to/repository}} snapshots`
+`restic --repo {{path/to/repository}} snapshots`
 
 - Restore a specific backup snapshot to a target directory:
 
-`restic -r {{path/to/repository}} restore {{snapshot_id}} {{path/to/target}}`
+`restic --repo {{path/to/repository}} restore {{snapshot_id}} {{path/to/target}}`
 
 - Restore a specific path from a specific backup to a target directory:
 
-`restic -r {{path/to/repository}} --include {{path/to/restore}} --target {{path/to/target}} restore {{snapshot_id}}`
+`restic --repo {{path/to/repository}} --include {{path/to/restore}} --target {{path/to/target}} restore {{snapshot_id}}`
 
 - Clean up the repository and keep only the most recent snapshot of each unique backup:
 


### PR DESCRIPTION
Using long arguments in examples increases verbosity. The `-r` argument
can mean multiple things, the most common being _recursive_, which is
not what it means under `restic init`.