### PR TITLE
ssh-keygen: add key format conversion

### DIFF
--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -16,7 +16,7 @@
 
 - Generiere ein 4096 Bit langen RSA Schlüssel-Paar mit der Email im Kommentarfeld:
 
-`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{kommentar|email}}""`
+`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{kommentar|email}}"`
 
 - Entferne den Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
 

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -32,4 +32,4 @@
 
 - Ändern Sie den Typ des Schlüssel formats (z. B. vom OPENSSH-Format in PEM), die Datei wird an Ort und Stelle neu geschrieben:
 
-`ssh-keygen -p -N "" -m PEM -f ~/.ssh/{{datei}}`
+`ssh-keygen -p -N "" -m {{PEM}} -f ~/.ssh/{{datei}}`

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -33,3 +33,7 @@
 - Ändere das Passwort eines privaten Schlüssels:
 
 `ssh-keygen -p -f ~/.ssh/{{datei}}`
+
+- Ändern Sie den Typ des Schlüssel formats (z. B. vom OPENSSH-Format in PEM), die Datei wird an Ort und Stelle neu geschrieben:
+
+`ssh-keygen -p -N "" -m PEM -f ~/.ssh/{{datei}}`

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -8,15 +8,15 @@
 
 - Erstelle ein Schlüssel-Paar unter einem bestimmten Dateinamen:
 
-`ssh-keygen -f ~/.ssh/{{datei}}`
+`ssh-keygen -f {{~/.ssh/datei}}`
 
 - Generiere ein ed25519 Schlüssel-Paar mit 100 Schlüssel-Ableitungs-Iterationen:
 
-`ssh-keygen -t ed25519 -a 100`
+`ssh-keygen -t {{ed25519}} -a {{100}}`
 
 - Generiere ein 4096 Bit langen RSA Schlüssel-Paar mit der Email im Kommentarfeld:
 
-`ssh-keygen -t rsa -b 4096 -C "{{email}}"`
+`ssh-keygen -t {{rsa}} -b {{4096}} -C "{{email}}"`
 
 - Entferne den Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
 
@@ -24,11 +24,11 @@
 
 - Rufe den Fingerabdrucks eines Schlüssels im MD5 Hex Format ab:
 
-`ssh-keygen -l -E md5 -f ~/.ssh/{{datei}}`
+`ssh-keygen -l -E {{md5}} -f {{~/.ssh/datei}}`
 
 - Ändere das Passwort eines privaten Schlüssels:
 
-`ssh-keygen -p -f ~/.ssh/{{datei}}`
+`ssh-keygen -p -f {{~/.ssh/datei}}`
 
 - Ändern Sie den Typ des Schlüssel formats (z. B. vom OPENSSH-Format in PEM), die Datei wird an Ort und Stelle neu geschrieben:
 

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -18,10 +18,6 @@
 
 `ssh-keygen -t rsa -b 4096 -C "{{email}}"`
 
-- Rufe den Schlüssel-Fingerabdruck von einem Server ab (hilfreich um die Authentizität eines Servers beim ersten Verbinden zu überprüfen):
-
-`ssh-keygen -l -F {{externer_server}}`
-
 - Entferne den Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
 
 `ssh-keygen -R {{externer_server}}`

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -16,7 +16,7 @@
 
 - Generiere ein 4096 Bit langen RSA Schlüssel-Paar mit der Email im Kommentarfeld:
 
-`ssh-keygen -t {{rsa}} -b {{4096}} -C "{{email}}"`
+`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{kommentar|email}}""`
 
 - Entferne den Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -8,11 +8,11 @@
 
 - Specify file in which to save the key:
 
-`ssh-keygen -f ~/.ssh/{{filename}}`
+`ssh-keygen -f {{~/.ssh/filename}}`
 
 - Generate an ed25519 key with 100 key derivation function rounds:
 
-`ssh-keygen -t ed25519 -a 100`
+`ssh-keygen -t {{ed25519}} -a {{100}}`
 
 - Generate an RSA 4096 bit key with email as a comment:
 
@@ -24,7 +24,7 @@
 
 - Retrieve the fingerprint of a key in MD5 Hex:
 
-`ssh-keygen -l -E md5 -f ~/.ssh/{{filename}}`
+`ssh-keygen -l -E {{md5}} -f {{~/.ssh/filename}}`
 
 - Change the password of a key:
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -33,3 +33,7 @@
 - Change the password of a key:
 
 `ssh-keygen -p -f ~/.ssh/{{filename}}`
+
+- Change the type of the key format (for example from OPENSSH format to PEM), the file will be rewritten in-place:
+
+`ssh-keygen -p -N "" -m PEM -f ~/.ssh/{{filename}}`

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -18,10 +18,6 @@
 
 `ssh-keygen -t rsa -b 4096 -C "{{email}}"`
 
-- Retrieve the key fingerprint from a host (useful for confirming the authenticity of the host when first connecting to it via SSH):
-
-`ssh-keygen -l -F {{remote_host}}`
-
 - Remove the keys of a host from the known_hosts file (useful when a known host has a new key):
 
 `ssh-keygen -R {{remote_host}}`

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -28,7 +28,7 @@
 
 - Change the password of a key:
 
-`ssh-keygen -p -f ~/.ssh/{{filename}}`
+`ssh-keygen -p -f {{~/.ssh/filename}}`
 
 - Change the type of the key format (for example from OPENSSH format to PEM), the file will be rewritten in-place:
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -16,7 +16,7 @@
 
 - Generate an RSA 4096 bit key with email as a comment:
 
-`ssh-keygen -t rsa -b 4096 -C "{{email}}"`
+`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{comment|email}}"`
 
 - Remove the keys of a host from the known_hosts file (useful when a known host has a new key):
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -32,4 +32,4 @@
 
 - Change the type of the key format (for example from OPENSSH format to PEM), the file will be rewritten in-place:
 
-`ssh-keygen -p -N "" -m PEM -f ~/.ssh/{{filename}}`
+`ssh-keygen -p -N "" -m {{PEM}} -f {{~/.ssh/OpenSSH_private_key}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

Current versions of openssh generate keys in its own format while many CI/CD, hosted Git platforms do not accept this type of keys  
You can identify the openssh format private key by checking if it has the tags
-----BEGIN OPENSSH PRIVATE KEY-----
-----END OPENSSH PRIVATE KEY-----
