### PR TITLE
restic: fix restore example

### DIFF
--- a/pages/common/restic.md
+++ b/pages/common/restic.md
@@ -21,7 +21,7 @@
 
 - Restore a specific path from a specific backup to a target directory:
 
-`restic --repo {{path/to/repository}} --include {{path/to/restore}} --target {{path/to/target}} restore {{snapshot_id}}`
+`restic --repo {{path/to/repository}} restore {{snapshot_id}} --target {{path/to/target}} --include {{path/to/restore}}`
 
 - Clean up the repository and keep only the most recent snapshot of each unique backup:
 

--- a/pages/common/restic.md
+++ b/pages/common/restic.md
@@ -17,7 +17,7 @@
 
 - Restore a specific backup snapshot to a target directory:
 
-`restic --repo {{path/to/repository}} restore {{snapshot_id}} {{path/to/target}}`
+`restic --repo {{path/to/repository}} restore {{latest|snapshot_id}} --target {{path/to/target}}`
 
 - Restore a specific path from a specific backup to a target directory:
 


### PR DESCRIPTION
The restore command, at least as of the current stable version v0.12.0
requires --target to specify where the restored data should go. With the
urrent command here, meaning without the --target, there is this error:

> Fatal: more than one snapshot ID specified

I have also included a latest word that automatically picks the latest
tag without needing the actual snapshot ID.
