### PR TITLE
git-abort: add page

### DIFF
--- a/pages/common/git-abort.md
+++ b/pages/common/git-abort.md
@@ -1,9 +1,9 @@
 # git abort
 
-> Abort a ongoing rebase, merge or cherry-pick.
+> Abort an ongoing rebase, merge, or cherry-pick.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
 
-- Abort a Git rebase, merge or cherry-pick:
+- Abort a Git rebase, merge, or cherry-pick:
 
 `git abort`

--- a/pages/common/git-abort.md
+++ b/pages/common/git-abort.md
@@ -1,7 +1,7 @@
 # git abort
 
-> Abort a current rebase, merge or cherry-pick.
-> Part of `git-extras`
+> Abort a ongoing rebase, merge or cherry-pick.
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
 
 - Abort a Git rebase, merge or cherry-pick:

--- a/pages/common/git-abort.md
+++ b/pages/common/git-abort.md
@@ -1,0 +1,8 @@
+# git abort
+
+> Abort a current rebase, merge or cherry-pick.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
+
+- Abort a Git rebase, merge or cherry-pick:
+
+`git abort`

--- a/pages/common/git-abort.md
+++ b/pages/common/git-abort.md
@@ -1,6 +1,7 @@
 # git abort
 
 > Abort a current rebase, merge or cherry-pick.
+> Part of `git-extras`
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
 
 - Abort a Git rebase, merge or cherry-pick:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #5137 