### PR TITLE
gunzip: add command to keep original files

### DIFF
--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -11,7 +11,7 @@
 
 `gunzip -c {{archive.tar.gz}} > {{archive.tar}}`
 
-- Extract a file and keep input file:
+- Extract a file and keep the archive file:
 
 `gunzip --keep {{archive.tar.gz}}`
 

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -17,4 +17,4 @@
 
 - List the contents of a compressed file:
 
-`gunzip -l {{file.txt.gz}}`
+`gunzip --list {{file.txt.gz}}`

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -11,6 +11,10 @@
 
 `gunzip -c {{archive.tar.gz}} > {{archive.tar}}`
 
+- Extract a file and keep input file:
+
+`gunzip --keep {{archive.tar.gz}}`
+
 - List the contents of a compressed file:
 
 `gunzip -l {{file.txt.gz}}`

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -9,7 +9,7 @@
 
 - Extract a file to a target destination:
 
-`gunzip -c {{archive.tar.gz}} > {{archive.tar}}`
+`gunzip --stdout {{archive.tar.gz}} > {{archive.tar}}`
 
 - Extract a file and keep the archive file:
 


### PR DESCRIPTION
Add option to keep original files

Quicker than `gunzip -c {{archive.tar.gz}} > {{archive.tar}}`

- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
