### PR TITLE
yacas: add page

### DIFF
--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -17,7 +17,7 @@
 
 - Quit from the console session:
 
-`In> {{gquit}}`
+`In> {{quit}}`
 
 - Execute one or more yacas scripts, then exit:
 

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -7,17 +7,17 @@
 
 `yacas`
 
-- In the `yacas` session, execute a statement:
+- While in a `yacas` session, execute a statement:
 
-`In> {{Integrate(x)Cos(x);}}`
+`{{Integrate(x)Cos(x)}};`
 
-- In the `yacas` session, display an example:
+- While in a `yacas` session, display an example:
 
-`In> {{Example();}}`
+`{{Example()}};`
 
-- Quit from the `yacas` session:
+- Quit from a `yacas` session:
 
-`In> {{quit}}`
+`{{quit}}`
 
 - Execute one or more `yacas` scripts (without terminal or prompts), then exit:
 

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -9,15 +9,15 @@
 
 - In the console session, execute a statement:
 
-`In> {{Integrate(x)Cos(x)}};`
+`In> {{Integrate(x)Cos(x);}}`
 
 - In the console session, display an example:
 
-`In> Example();`
+`In> {{Example();}}`
 
 - Quit from the console session:
 
-`In> quit`
+`In> {{gquit}}`
 
 - Execute a yacas script, then exit:
 

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -10,7 +10,6 @@
 - In the console session, execute a statement:
 
 `In> {{Integrate(x)Cos(x)}};`
-`Out> {{Sin(x)}}`
 
 - In the console session, display an example:
 
@@ -19,7 +18,6 @@
 - Quit from the console session:
 
 `In> quit`
-`Quitting...`
 
 - Execute a yacas script, then exit:
 

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -3,23 +3,23 @@
 > Yet Another Computer Algebra System.
 > More information: <http://www.yacas.org>.
 
-- Start an interactive console session:
+- Start an interactive `yacas` session:
 
 `yacas`
 
-- In the console session, execute a statement:
+- In the `yacas` session, execute a statement:
 
 `In> {{Integrate(x)Cos(x);}}`
 
-- In the console session, display an example:
+- In the `yacas` session, display an example:
 
 `In> {{Example();}}`
 
-- Quit from the console session:
+- Quit from the `yacas` session:
 
 `In> {{quit}}`
 
-- Execute one or more yacas scripts (without terminal or prompts), then exit:
+- Execute one or more `yacas` scripts (without terminal or prompts), then exit:
 
 `yacas -p -c {{path/to/script1}} {{path/to/script2}}`
 

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -19,10 +19,10 @@
 
 `In> {{gquit}}`
 
-- Execute a yacas script, then exit:
+- Execute one or more yacas scripts, then exit:
 
-`yacas -pc {{path/to/script}}`
+`yacas -pc {{path/to/script1}} {{path/to/script2}}`
 
-- Execute and print the result of one statement:
+- Execute and print the result of one statement, then exit:
 
-`echo "Echo( {{Deriv(x)Cos(1/x)}} );" | yacas -pc /dev/stdin`
+`echo "{{Echo( Deriv(x)Cos(1/x) );}}" | yacas -pc /dev/stdin`

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -1,0 +1,30 @@
+# yacas
+
+> Yet Another Computer Algebra System.
+> More information: <http://www.yacas.org>.
+
+- Start an interactive console session:
+
+`yacas`
+
+- In the console session, execute a statement:
+
+`In> {{Integrate(x)Cos(x)}};`
+`Out> {{Sin(x)}}`
+
+- In the console session, display an example:
+
+`In> Example();`
+
+- Quit from the console session:
+
+`In> quit`
+`Quitting...`
+
+- Execute a yacas script, then exit:
+
+`yacas -pc {{path/to/script}}`
+
+- Execute and print the result of one statement:
+
+`echo "Echo( {{Deriv(x)Cos(1/x)}} );" | yacas -pc /dev/stdin`

--- a/pages/common/yacas.md
+++ b/pages/common/yacas.md
@@ -19,10 +19,10 @@
 
 `In> {{quit}}`
 
-- Execute one or more yacas scripts, then exit:
+- Execute one or more yacas scripts (without terminal or prompts), then exit:
 
-`yacas -pc {{path/to/script1}} {{path/to/script2}}`
+`yacas -p -c {{path/to/script1}} {{path/to/script2}}`
 
 - Execute and print the result of one statement, then exit:
 
-`echo "{{Echo( Deriv(x)Cos(1/x) );}}" | yacas -pc /dev/stdin`
+`echo "{{Echo( Deriv(x)Cos(1/x) );}}" | yacas -p -c /dev/stdin`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

The primary function of this command is to start a read-eval-print-loop console session to evaluate math statements.
I have taken a guess at a tldr format for the console session examples by saying "In the console session, ..." and by including the "In>" and "Out>" prompts. Please suggest something better.

The last sample is POSIX plumbing to evaluate a yacas statement at the command line and print the result to stdout. Yacas actually has both an --execute flag and a read-from-stdin flag, -f, but they don't work as advertised and this does.

I have not explained the -p and -c flags (dumb-term and no-prompts). Together as -pc, they are effectively --batch-mode, although one must also give an input file as a parameter to exit without starting the interactive repl.

`yacas --help` isn't a flag and `man yacas` came up dry on MacOS and the read-the-docs site omits command line flags, so the only documentation of the command line flags that I have found is on the abandoned sourceforge site at http://yacas.sourceforge.net/introchapter2.html

yacas --server {{port}}& works, but is perhaps beyond the tldr level?

-- Daniel Birket