### PR TITLE
wrong parameter in htop

### DIFF
--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -9,7 +9,7 @@
 
 - Start htop displaying processes owned by a specific user:
 
-`htop --username {{username}}`
+`htop --user {{username}}`
 
 - Sort processes by a specified `sort_item` (use `htop --sort help` for available options):
 


### PR DESCRIPTION
htop command uses `--user` instead of `--username`. 
Here is output from `htop --help` command:

  ```
htop 2.2.0 - (C) 2004-2019 Hisham Muhammad
  Released under the GNU GPL.
  
  -C --no-color               Use a monochrome color scheme
  -d --delay=DELAY            Set the delay between updates, in tenths of seconds
  -h --help                   Print this help screen
  -s --sort-key=COLUMN        Sort by COLUMN (try --sort-key=help for a list)
  -t --tree                   Show the tree view by default
  -u --user=USERNAME          Show only processes of a given user
  -p --pid=PID,[,PID,PID...]  Show only the given PIDs
  -v --version                Print version info
  
  Long options may be passed with a single dash.
  
  Press F1 inside htop for online help.
  See 'man htop' for more information.
```

