### PR TITLE
dot: prepare to add all graphviz layout engines

### DIFF
--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `linear directed` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -16,7 +16,7 @@
 
 `dot -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -4,7 +4,7 @@
 > Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a 'png' image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format:
 
 `dot -Tpng -O {{path/to/input.gv}}`
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,6 +1,6 @@
 # dot
 
-> Render an image of a _linear directed_ network graph from a `graphviz` file.
+> Render an image of a `linear directed` network graph from a `graphviz` file.
 > Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,7 +1,7 @@
 # dot
 
 > Render an image of a _linear directed_ network graph from a `graphviz` file.
-> More information: http://graphviz.org/doc/info/command.html.
+> More information: <http://graphviz.org/doc/info/command.html>.
 
 - Render a 'png' image with a filename based on the input filename and output format:
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,6 +1,7 @@
 # dot
 
 > Render an image of a _linear directed_ network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
 - Render a 'png' image with a filename based on the input filename and output format:

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,12 +1,24 @@
 # dot
 
-> A command-line tool to produce layered drawings of directed graphs.
-> More information: <https://www.graphviz.org/pdf/dotguide.pdf>.
+> Render an image of a _linear directed_ network graph from a `graphviz` file.
+> More information: http://graphviz.org/doc/info/command.html.
 
-- Render an image file and determine output filename based on input filename and selected format:
+- Render a 'png' image with a filename based on the input filename and output format:
 
-`dot -Tpng -O {{path/to/file.dot}}`
+`dot -Tpng -O {{path/to/input.gv}}`
 
-- Create an SVG from DOT file:
+- Render a `svg` image with the specified output filename:
 
-`dot -Tsvg -o {{path/to/out_file.svg}} {{path/to/file.dot}}`
+`dot -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`dot -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | dot -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`dot -?`

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`dot -T png -O {{path/to/input.gv}}`
+`dot -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`dot -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`dot -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | dot -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,24 +1,24 @@
 # dot
 
 > Render an image of a `linear directed` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`dot -Tpng -O {{path/to/input.gv}}`
+`dot -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`dot -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`dot -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`dot -T{{format}} -O {{path/to/input.gv}}`
+`dot -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | dot -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
 
 - Display help:
 


### PR DESCRIPTION
See #2580, #6284.

These changes are in preparation for adding commands: `neato`,
`circo`, `twopi`, `pfd`, `spfd`, `osage` and `patchwork`, which use
the same command syntax. This one is to review before posting the
other seven, which are generated from the same template. (attached.)
[gv-layout.def.txt](https://github.com/tldr-pages/tldr/files/6900229/gv-layout.def.txt)
[gv-layout.tpl.md](https://github.com/tldr-pages/tldr/files/6900230/gv-layout.tpl.md)


Changes:

- use `gv` extension, not `dot`. Author uses `gv`.
- link to command usage guide page
- specify the type of layout in the description (varies)
- use `input` and `image` not `file` or `out_file`
- provide a list of available image formats
- show how to use the engine as a filter
- give the help command

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
