### PR TITLE
figlet: fix typo in example description

### DIFF
--- a/pages/common/figlet.md
+++ b/pages/common/figlet.md
@@ -12,7 +12,7 @@
 
 `figlet {{input_text}} -f {{path/to/font_file.flf}}`
 
-- Use a font from the default font directory (the extention can be omitted):
+- Use a font from the default font directory (the extension can be omitted):
 
 `figlet {{input_text}} -f {{font_filename}}`
 


### PR DESCRIPTION
extention -> extension

