### PR TITLE
circo, fdp, neato, osage, patchwork, sfdp, twopi: add page

### DIFF
--- a/pages/common/circo.md
+++ b/pages/common/circo.md
@@ -1,0 +1,25 @@
+# circo
+
+> Render an image of a `circular` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`circo -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`circo -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`circo -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | circo -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`circo -?`

--- a/pages/common/circo.md
+++ b/pages/common/circo.md
@@ -1,24 +1,24 @@
 # circo
 
 > Render an image of a `circular` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`circo -Tpng -O {{path/to/input.gv}}`
+`circo -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`circo -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`circo -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`circo -T{{format}} -O {{path/to/input.gv}}`
+`circo -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | circo -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | circo -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/circo.md
+++ b/pages/common/circo.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`circo -T png -O {{path/to/input.gv}}`
+`circo -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`circo -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`circo -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | circo -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | circo -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/circo.md
+++ b/pages/common/circo.md
@@ -16,7 +16,7 @@
 
 `circo -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | circo -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/circo.md
+++ b/pages/common/circo.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `circular` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `linear directed` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -16,7 +16,7 @@
 
 `dot -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -4,7 +4,7 @@
 > Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a 'png' image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format:
 
 `dot -Tpng -O {{path/to/input.gv}}`
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,6 +1,6 @@
 # dot
 
-> Render an image of a _linear directed_ network graph from a `graphviz` file.
+> Render an image of a `linear directed` network graph from a `graphviz` file.
 > Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,7 +1,7 @@
 # dot
 
 > Render an image of a _linear directed_ network graph from a `graphviz` file.
-> More information: http://graphviz.org/doc/info/command.html.
+> More information: <http://graphviz.org/doc/info/command.html>.
 
 - Render a 'png' image with a filename based on the input filename and output format:
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,6 +1,7 @@
 # dot
 
 > Render an image of a _linear directed_ network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
 - Render a 'png' image with a filename based on the input filename and output format:

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,12 +1,24 @@
 # dot
 
-> A command-line tool to produce layered drawings of directed graphs.
-> More information: <https://www.graphviz.org/pdf/dotguide.pdf>.
+> Render an image of a _linear directed_ network graph from a `graphviz` file.
+> More information: http://graphviz.org/doc/info/command.html.
 
-- Render an image file and determine output filename based on input filename and selected format:
+- Render a 'png' image with a filename based on the input filename and output format:
 
-`dot -Tpng -O {{path/to/file.dot}}`
+`dot -Tpng -O {{path/to/input.gv}}`
 
-- Create an SVG from DOT file:
+- Render a `svg` image with the specified output filename:
 
-`dot -Tsvg -o {{path/to/out_file.svg}} {{path/to/file.dot}}`
+`dot -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`dot -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | dot -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`dot -?`

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`dot -T png -O {{path/to/input.gv}}`
+`dot -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`dot -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`dot -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | dot -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/dot.md
+++ b/pages/common/dot.md
@@ -1,24 +1,24 @@
 # dot
 
 > Render an image of a `linear directed` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`dot -Tpng -O {{path/to/input.gv}}`
+`dot -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`dot -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`dot -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`dot -T{{format}} -O {{path/to/input.gv}}`
+`dot -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | dot -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | dot -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/fdp.md
+++ b/pages/common/fdp.md
@@ -1,0 +1,25 @@
+# fdp
+
+> Render an image of a `force-directed` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`fdp -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`fdp -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`fdp -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | fdp -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`fdp -?`

--- a/pages/common/fdp.md
+++ b/pages/common/fdp.md
@@ -1,24 +1,24 @@
 # fdp
 
 > Render an image of a `force-directed` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`fdp -Tpng -O {{path/to/input.gv}}`
+`fdp -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`fdp -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`fdp -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`fdp -T{{format}} -O {{path/to/input.gv}}`
+`fdp -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | fdp -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | fdp -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/fdp.md
+++ b/pages/common/fdp.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`fdp -T png -O {{path/to/input.gv}}`
+`fdp -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`fdp -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`fdp -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | fdp -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | fdp -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/fdp.md
+++ b/pages/common/fdp.md
@@ -16,7 +16,7 @@
 
 `fdp -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | fdp -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/fdp.md
+++ b/pages/common/fdp.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `force-directed` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/neato.md
+++ b/pages/common/neato.md
@@ -16,7 +16,7 @@
 
 `neato -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{graph {this -- that} }}" | neato -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/neato.md
+++ b/pages/common/neato.md
@@ -1,0 +1,25 @@
+# neato
+
+> Render an image of a `linear undirected` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`neato -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`neato -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`neato -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{graph {this -- that} }}" | neato -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`neato -?`

--- a/pages/common/neato.md
+++ b/pages/common/neato.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `linear undirected` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/neato.md
+++ b/pages/common/neato.md
@@ -1,24 +1,24 @@
 # neato
 
 > Render an image of a `linear undirected` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`neato -Tpng -O {{path/to/input.gv}}`
+`neato -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`neato -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`neato -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`neato -T{{format}} -O {{path/to/input.gv}}`
+`neato -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{graph {this -- that} }}" | neato -Tgif > {{path/to/image.gif}}`
+`echo "{{graph {this -- that} }}" | neato -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/neato.md
+++ b/pages/common/neato.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`neato -T png -O {{path/to/input.gv}}`
+`neato -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`neato -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`neato -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{graph {this -- that} }}" | neato -T gif > {{path/to/image.gif}}`
+`echo "{{graph {this -- that} }}" | neato -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/osage.md
+++ b/pages/common/osage.md
@@ -16,7 +16,7 @@
 
 `osage -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | osage -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/osage.md
+++ b/pages/common/osage.md
@@ -1,24 +1,24 @@
 # osage
 
 > Render an image of a `clustered` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`osage -Tpng -O {{path/to/input.gv}}`
+`osage -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`osage -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`osage -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`osage -T{{format}} -O {{path/to/input.gv}}`
+`osage -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | osage -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | osage -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/osage.md
+++ b/pages/common/osage.md
@@ -1,0 +1,25 @@
+# osage
+
+> Render an image of a `clustered` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`osage -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`osage -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`osage -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | osage -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`osage -?`

--- a/pages/common/osage.md
+++ b/pages/common/osage.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `clustered` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/osage.md
+++ b/pages/common/osage.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`osage -T png -O {{path/to/input.gv}}`
+`osage -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`osage -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`osage -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | osage -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | osage -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/patchwork.md
+++ b/pages/common/patchwork.md
@@ -16,7 +16,7 @@
 
 `patchwork -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | patchwork -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/patchwork.md
+++ b/pages/common/patchwork.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `squareified treemap` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/patchwork.md
+++ b/pages/common/patchwork.md
@@ -1,0 +1,25 @@
+# patchwork
+
+> Render an image of a `squareified treemap` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`patchwork -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`patchwork -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`patchwork -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | patchwork -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`patchwork -?`

--- a/pages/common/patchwork.md
+++ b/pages/common/patchwork.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`patchwork -T png -O {{path/to/input.gv}}`
+`patchwork -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`patchwork -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`patchwork -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | patchwork -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | patchwork -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/patchwork.md
+++ b/pages/common/patchwork.md
@@ -1,24 +1,24 @@
 # patchwork
 
 > Render an image of a `squareified treemap` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`patchwork -Tpng -O {{path/to/input.gv}}`
+`patchwork -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`patchwork -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`patchwork -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`patchwork -T{{format}} -O {{path/to/input.gv}}`
+`patchwork -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | patchwork -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | patchwork -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/sfdp.md
+++ b/pages/common/sfdp.md
@@ -1,24 +1,24 @@
 # sfdp
 
 > Render an image of a `scaled force-directed` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`sfdp -Tpng -O {{path/to/input.gv}}`
+`sfdp -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`sfdp -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`sfdp -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`sfdp -T{{format}} -O {{path/to/input.gv}}`
+`sfdp -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | sfdp -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | sfdp -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/sfdp.md
+++ b/pages/common/sfdp.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `scaled force-directed` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/sfdp.md
+++ b/pages/common/sfdp.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`sfdp -T png -O {{path/to/input.gv}}`
+`sfdp -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`sfdp -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`sfdp -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | sfdp -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | sfdp -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/sfdp.md
+++ b/pages/common/sfdp.md
@@ -1,0 +1,25 @@
+# sfdp
+
+> Render an image of a `scaled force-directed` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`sfdp -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`sfdp -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`sfdp -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | sfdp -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`sfdp -?`

--- a/pages/common/sfdp.md
+++ b/pages/common/sfdp.md
@@ -16,7 +16,7 @@
 
 `sfdp -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | sfdp -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/twopi.md
+++ b/pages/common/twopi.md
@@ -16,7 +16,7 @@
 
 `twopi -T {{format}} -O {{path/to/input.gv}}`
 
-- Render a `gif` image using `stdin` and `stdout`:
+- Render a `gif` image using stdin and stdout:
 
 `echo "{{digraph {this -> that} }}" | twopi -T gif > {{path/to/image.gif}}`
 

--- a/pages/common/twopi.md
+++ b/pages/common/twopi.md
@@ -1,24 +1,24 @@
 # twopi
 
 > Render an image of a `radial` network graph from a `graphviz` file.
-> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
 > More information: <http://graphviz.org/doc/info/command.html>.
 
-- Render a `png` image with a filename based on the input filename and output format:
+- Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`twopi -Tpng -O {{path/to/input.gv}}`
+`twopi -T png -O {{path/to/input.gv}}`
 
-- Render a `svg` image with the specified output filename:
+- Render a `svg` image with the specified output filename (lowercase -o):
 
-`twopi -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`twopi -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
-`twopi -T{{format}} -O {{path/to/input.gv}}`
+`twopi -T {{format}} -O {{path/to/input.gv}}`
 
 - Render a `gif` image using `stdin` and `stdout`:
 
-`echo "{{digraph {this -> that} }}" | twopi -Tgif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | twopi -T gif > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/twopi.md
+++ b/pages/common/twopi.md
@@ -2,7 +2,7 @@
 
 > Render an image of a `radial` network graph from a `graphviz` file.
 > Layouts: `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
-> More information: <http://graphviz.org/doc/info/command.html>.
+> More information: <https://graphviz.org/doc/info/command.html>.
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 

--- a/pages/common/twopi.md
+++ b/pages/common/twopi.md
@@ -6,11 +6,11 @@
 
 - Render a `png` image with a filename based on the input filename and output format (uppercase -O):
 
-`twopi -T png -O {{path/to/input.gv}}`
+`twopi -T {{png}} -O {{path/to/input.gv}}`
 
 - Render a `svg` image with the specified output filename (lowercase -o):
 
-`twopi -T svg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+`twopi -T {{svg}} -o {{path/to/image.svg}} {{path/to/input.gv}}`
 
 - Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
 
@@ -18,7 +18,7 @@
 
 - Render a `gif` image using stdin and stdout:
 
-`echo "{{digraph {this -> that} }}" | twopi -T gif > {{path/to/image.gif}}`
+`echo "{{digraph {this -> that} }}" | twopi -T {{gif}} > {{path/to/image.gif}}`
 
 - Display help:
 

--- a/pages/common/twopi.md
+++ b/pages/common/twopi.md
@@ -1,0 +1,25 @@
+# twopi
+
+> Render an image of a `radial` network graph from a `graphviz` file.
+> Layouts are `dot`, `neato`, `twopi`, `circo`, `fdp`, `sfdp`, `osage` & `patchwork`.
+> More information: <http://graphviz.org/doc/info/command.html>.
+
+- Render a `png` image with a filename based on the input filename and output format:
+
+`twopi -Tpng -O {{path/to/input.gv}}`
+
+- Render a `svg` image with the specified output filename:
+
+`twopi -Tsvg -o {{path/to/image.svg}} {{path/to/input.gv}}`
+
+- Render the output in `ps`, `pdf`, `svg`, `fig`, `png`, `gif`, `jpg`, `json`, or `dot` format:
+
+`twopi -T{{format}} -O {{path/to/input.gv}}`
+
+- Render a `gif` image using `stdin` and `stdout`:
+
+`echo "{{digraph {this -> that} }}" | twopi -Tgif > {{path/to/image.gif}}`
+
+- Display help:
+
+`twopi -?`


### PR DESCRIPTION
See #6270, #2580.

This pull-request contains the other seven graphviz layout commands in
addition to `dot`, which is awaiting approval at #6270. These files
are generated from the same template as `dot.md` there. The eight
commands differ in the command name, description line and the content
of the `echo` command in one example. (If any more changes are
required, I will regenerate all the files together.)

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
