### PR TITLE
gml2gv, graphml2gv, gv2gml, gv2gxl, gxl2gv, mm2gv: add page

### DIFF
--- a/pages/common/gml2gv.md
+++ b/pages/common/gml2gv.md
@@ -1,16 +1,16 @@
 # gml2gv
 
-> Convert a graph from the `gml` format to the `gv` format.
+> Convert a graph from `gml` to `gv` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/gml2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/gml2gv.1.pdf>.
 
-- Convert a graph from the `gml` format to the `gv` format:
+- Convert a graph from `gml` to `gv` format:
 
-`gml2gv -o output.gv input.gml`
+`gml2gv -o {{output.gv}} {{input.gml}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.gml | gml2gv > output.gv`
+`cat {{input.gml}} | gml2gv > {{output.gv}}`
 
 - Display help:
 

--- a/pages/common/gml2gv.md
+++ b/pages/common/gml2gv.md
@@ -8,7 +8,7 @@
 
 `gml2gv -o output.gv input.gml`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.gml | gml2gv > output.gv`
 

--- a/pages/common/gml2gv.md
+++ b/pages/common/gml2gv.md
@@ -1,0 +1,17 @@
+# gml2gv
+
+> Convert a graph from the `gml` format to the `gv` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/gml2gv.1.pdf>.
+
+- Convert a graph from the `gml` format to the `gv` format:
+
+`gml2gv -o output.gv input.gml`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.gml | gml2gv > output.gv`
+
+- Display help:
+
+`gml2gv -?`

--- a/pages/common/graphml2gv.md
+++ b/pages/common/graphml2gv.md
@@ -1,0 +1,17 @@
+# graphml2gv
+
+> Convert a graph from the `graphml` format to the `gv` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/graphml2gv.1.pdf>.
+
+- Convert a graph from the `gml` format to the `gv` format:
+
+`graphml2gv -o output.gv input.gml`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.gml | graphml2gv > output.gv`
+
+- Display help:
+
+`graphml2gv -?`

--- a/pages/common/graphml2gv.md
+++ b/pages/common/graphml2gv.md
@@ -1,16 +1,16 @@
 # graphml2gv
 
-> Convert a graph from the `graphml` format to the `gv` format.
+> Convert a graph from `graphml` to `gv` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/graphml2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/graphml2gv.1.pdf>.
 
-- Convert a graph from the `gml` format to the `gv` format:
+- Convert a graph from `gml` to `gv` format:
 
-`graphml2gv -o output.gv input.gml`
+`graphml2gv -o {{output.gv}} {{input.gml}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.gml | graphml2gv > output.gv`
+`cat {{input.gml}} | graphml2gv > {{output.gv}}`
 
 - Display help:
 

--- a/pages/common/graphml2gv.md
+++ b/pages/common/graphml2gv.md
@@ -8,7 +8,7 @@
 
 `graphml2gv -o output.gv input.gml`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.gml | graphml2gv > output.gv`
 

--- a/pages/common/gv2gml.md
+++ b/pages/common/gv2gml.md
@@ -1,0 +1,17 @@
+# gv2gml
+
+> Convert a graph from the `gv` format to the `gml` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/gml2gv.1.pdf>.
+
+- Convert a graph from the `gv` format to the `gml` format:
+
+`gv2gml -o output.gml input.gv`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.gv | gv2gml > output.gml`
+
+- Display help:
+
+`gv2gml -?`

--- a/pages/common/gv2gml.md
+++ b/pages/common/gv2gml.md
@@ -8,7 +8,7 @@
 
 `gv2gml -o output.gml input.gv`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.gv | gv2gml > output.gml`
 

--- a/pages/common/gv2gml.md
+++ b/pages/common/gv2gml.md
@@ -1,16 +1,16 @@
 # gv2gml
 
-> Convert a graph from the `gv` format to the `gml` format.
+> Convert a graph from `gv` to `gml` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/gml2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/gml2gv.1.pdf>.
 
-- Convert a graph from the `gv` format to the `gml` format:
+- Convert a graph from `gv` to `gml` format:
 
-`gv2gml -o output.gml input.gv`
+`gv2gml -o {{output.gml}} {{input.gv}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.gv | gv2gml > output.gml`
+`cat {{input.gv}} | gv2gml > {{output.gml}}`
 
 - Display help:
 

--- a/pages/common/gv2gxl.md
+++ b/pages/common/gv2gxl.md
@@ -1,0 +1,17 @@
+# gv2gxl
+
+> Convert a graph from the `gv` format to the `gxl` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/gxl2gv.1.pdf>.
+
+- Convert a graph from the `gv` format to the `gxl` format:
+
+`gv2gxl -o output.gxl input.gv`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.gv | gv2gxl > output.gxl`
+
+- Display help:
+
+`gv2gxl -?`

--- a/pages/common/gv2gxl.md
+++ b/pages/common/gv2gxl.md
@@ -8,7 +8,7 @@
 
 `gv2gxl -o output.gxl input.gv`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.gv | gv2gxl > output.gxl`
 

--- a/pages/common/gv2gxl.md
+++ b/pages/common/gv2gxl.md
@@ -1,16 +1,16 @@
 # gv2gxl
 
-> Convert a graph from the `gv` format to the `gxl` format.
+> Convert a graph from `gv` to `gxl` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/gxl2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/gxl2gv.1.pdf>.
 
-- Convert a graph from the `gv` format to the `gxl` format:
+- Convert a graph from `gv` to `gxl` format:
 
-`gv2gxl -o output.gxl input.gv`
+`gv2gxl -o {{output.gxl}} {{input.gv}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.gv | gv2gxl > output.gxl`
+`cat {{input.gv}} | gv2gxl > {{output.gxl}}`
 
 - Display help:
 

--- a/pages/common/gxl2gv.md
+++ b/pages/common/gxl2gv.md
@@ -1,16 +1,16 @@
 # gxl2gv
 
-> Convert a graph from the `gxl` format to the `gv` format.
+> Convert a graph from `gxl` to `gv` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/gxl2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/gxl2gv.1.pdf>.
 
-- Convert a graph from the `gxl` format to the `gv` format:
+- Convert a graph from `gxl` to `gv` format:
 
-`gxl2gv -o output.gv input.gxl`
+`gxl2gv -o {{output.gv}} {{input.gxl}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.gxl | gxl2gv > output.gv`
+`cat {{input.gxl}} | gxl2gv > {{output.gv}}`
 
 - Display help:
 

--- a/pages/common/gxl2gv.md
+++ b/pages/common/gxl2gv.md
@@ -8,7 +8,7 @@
 
 `gxl2gv -o output.gv input.gxl`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.gxl | gxl2gv > output.gv`
 

--- a/pages/common/gxl2gv.md
+++ b/pages/common/gxl2gv.md
@@ -1,0 +1,17 @@
+# gxl2gv
+
+> Convert a graph from the `gxl` format to the `gv` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/gxl2gv.1.pdf>.
+
+- Convert a graph from the `gxl` format to the `gv` format:
+
+`gxl2gv -o output.gv input.gxl`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.gxl | gxl2gv > output.gv`
+
+- Display help:
+
+`gxl2gv -?`

--- a/pages/common/mm2gv.md
+++ b/pages/common/mm2gv.md
@@ -1,0 +1,17 @@
+# mm2gv
+
+> Convert a graph from the Matrix Market `mm` format to the `gv` format.
+> Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
+> More information: <http://graphviz.org/pdf/mm2gv.1.pdf>.
+
+- Convert a graph from the `mm` format to the `gv` format:
+
+`mm2gv -o output.gv input.mm`
+
+- Make same conversion using `stdin` and `stdout`:
+
+`cat input.mm | mm2gv > output.gv`
+
+- Display help:
+
+`mm2gv -?`

--- a/pages/common/mm2gv.md
+++ b/pages/common/mm2gv.md
@@ -8,7 +8,7 @@
 
 `mm2gv -o output.gv input.mm`
 
-- Make same conversion using `stdin` and `stdout`:
+- Convert a graph using stdin and stdout:
 
 `cat input.mm | mm2gv > output.gv`
 

--- a/pages/common/mm2gv.md
+++ b/pages/common/mm2gv.md
@@ -1,16 +1,16 @@
 # mm2gv
 
-> Convert a graph from the Matrix Market `mm` format to the `gv` format.
+> Convert a graph from Matrix Market `mm` format to `gv` format.
 > Converters: `gml2gv`, `gv2gml`, `gv2gxl`, `gxl2gv`, `graphml2gv` & `mm2gv`.
-> More information: <http://graphviz.org/pdf/mm2gv.1.pdf>.
+> More information: <https://graphviz.org/pdf/mm2gv.1.pdf>.
 
-- Convert a graph from the `mm` format to the `gv` format:
+- Convert a graph from `mm` to `gv` format:
 
-`mm2gv -o output.gv input.mm`
+`mm2gv -o {{output.gv}} {{input.mm}}`
 
 - Convert a graph using stdin and stdout:
 
-`cat input.mm | mm2gv > output.gv`
+`cat {{input.mm}} | mm2gv > {{output.gv}}`
 
 - Display help:
 


### PR DESCRIPTION
See #2580. These are the `xxx2yyy` graph converter commands from the
`graphviz` package. The commands have (mostly) the same syntax except
for the formats they convert between. These files are generated from
one template.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
