### PR TITLE
inotifywait: fix typo

### DIFF
--- a/pages/linux/inotifywait.md
+++ b/pages/linux/inotifywait.md
@@ -16,7 +16,7 @@
 
 - Exclude files matching a regular expression:
 
-`while inotifywait --recursive {{path/to/directory}} --exlude '{{regular_expression}}'; do {{command}}; done`
+`while inotifywait --recursive {{path/to/directory}} --exclude '{{regular_expression}}'; do {{command}}; done`
 
 - Wait at most 30 seconds:
 


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
