### PR TITLE
hcitool: add page

### DIFF
--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -7,7 +7,7 @@
 
 `hcitool scan`
 
-- Output the name of a device specifying its MAC address:
+- Output the name of a device, returning its MAC address:
 
 `hcitool name {{bdaddr}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -19,7 +19,7 @@
 
 `hcitool lq {{bdaddr}}`
 
-- Display transmit power level:
+- Display the transmit power level:
 
 `hcitool tpl {{bdaddr}} {{type}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -27,7 +27,7 @@
 
 `hcitool lp`
 
-- Request authentication:
+- Request authentication with a specific device:
 
 `hcitool auth {{bdaddr}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -19,9 +19,9 @@
 
 `hcitool lq {{bdaddr}}`
 
-- Display the transmit power level:
+- Modify the transmit power level:
 
-`hcitool tpl {{bdaddr}} {{type}}`
+`hcitool tpl {{bdaddr}} {{0|1}}`
 
 - Display the link policy:
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -11,7 +11,7 @@
 
 `hcitool name {{bdaddr}}`
 
-- Fetch info of a remote bluetooth device:
+- Fetch information about a remote Bluetooth device:
 
 `hcitool info {{bdaddr}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -23,7 +23,7 @@
 
 `hcitool tpl {{bdaddr}} {{type}}`
 
-- Check link policy:
+- Display the link policy:
 
 `hcitool lp`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -1,0 +1,36 @@
+# hcitool
+
+> Monitor & Configure Bluetooth connections.
+> Send special commands to Bluetooth devices.
+
+- Scan for remote devices:
+
+`hcitool scan`
+
+- Output name of the device with its mac address:
+
+`hcitool name {{bdaddr}}`
+
+- Fetch info of a remote bluetooth device:
+
+`hcitool info {{bdaddr}}`
+
+- Check link quality:
+
+`hcitool lq {{bdaddr}}`
+
+- Display transmit power level:
+
+`hcitool tpl {{bdaddr}} {{type}}`
+
+- Check link policy:
+
+`hcitool lp`
+
+- Request authentication:
+
+`hcitool auth {{bdaddr}}`
+
+- Display local devices:
+
+`hcitool dev`

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -3,7 +3,7 @@
 > Monitor & Configure Bluetooth connections.
 > Send special commands to Bluetooth devices.
 
-- Scan for remote devices:
+- Scan for Bluetooth devices:
 
 `hcitool scan`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -15,7 +15,7 @@
 
 `hcitool info {{bdaddr}}`
 
-- Check link quality:
+- Check the link quality to a Bluetooth device:
 
 `hcitool lq {{bdaddr}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -7,7 +7,7 @@
 
 `hcitool scan`
 
-- Output name of the device with its mac address:
+- Output the name of a device specifying its MAC address:
 
 `hcitool name {{bdaddr}}`
 

--- a/pages/linux/hcitool.md
+++ b/pages/linux/hcitool.md
@@ -1,7 +1,7 @@
 # hcitool
 
-> Monitor & Configure Bluetooth connections.
-> Send special commands to Bluetooth devices.
+> Monitor, configure connections, and send special commands to Bluetooth devices.
+> More information: <https://manned.org/hcitool>.
 
 - Scan for Bluetooth devices:
 


### PR DESCRIPTION
Page on a CLI-tool, which monitors and configures
bluetooth devices available within a threshold range.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repository.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

Close #6315