### PR TITLE
PULL_REQUEST_TEMPLATE: add easy to copy links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 <!-- Thank you for sending a PR! -->
+<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
+<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
 <!-- Please perform the following checks and mark all the boxes accordingly. -->
 <!-- You can remove the checklist items that don't apply to your PR. -->
 


### PR DESCRIPTION
Due to the links being a little annoying to copy for the user, unless they read the link and find the page or they press `preview` they wont be able to easily use the links, meaning they are less likely to even give the effort, meaning more bug fixing.