### PR TITLE
paci: add more information link

### DIFF
--- a/pages/common/paci.md
+++ b/pages/common/paci.md
@@ -1,7 +1,7 @@
 # paci
 
 > A package manager for bash scripts.
-> More information: https://github.com/tradebyte/paci.
+> More information: <https://github.com/tradebyte/paci>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `paci` commands):
 

--- a/pages/common/paci.md
+++ b/pages/common/paci.md
@@ -1,6 +1,7 @@
 # paci
 
 > A package manager for bash scripts.
+> More information: https://github.com/tradebyte/paci.
 
 - Update the list of available packages and versions (it's recommended to run this before other `paci` commands):
 


### PR DESCRIPTION
This is the homepage repository, the PyPi page is a copy of the readme and the github wiki is only one page long.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page description includes a link to documentation or a homepage (if applicable).

For #6062