### PR TITLE
xml*: add pages

### DIFF
--- a/pages/common/xml-canonic.md
+++ b/pages/common/xml-canonic.md
@@ -1,0 +1,8 @@
+# xml-canonic
+
+> XMLStarlet toolkit: Make XML documents canonical.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `canonic` subcommand:
+
+`xml canonic --help`

--- a/pages/common/xml-canonic.md
+++ b/pages/common/xml-canonic.md
@@ -3,15 +3,15 @@
 > Make XML documents canonical.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Make an XML document canonical, preserving comments (default behavior):
+- Make an XML document canonical, preserving comments:
 
-`xml canonic --with-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+`xml canonic {{path/to/input.xml|URI}} > {{path/to/output.xml}}`
 
 - Make an XML document canonical, removing comments:
 
-`xml canonic --without-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+`xml canonic --without-comments {{path/to/input.xml|URI}} > {{path/to/output.xml}}`
 
-- Exclusive XML canonicalization, using an XPATH from a file, preserving comments:
+- Make XML exclusively canonical, using an XPATH from a file, preserving comments:
 
 `xml canonic --exc-with-comments {{path/to/input.xml|URI}} {{path/to/c14n.xpath}}`
 

--- a/pages/common/xml-canonic.md
+++ b/pages/common/xml-canonic.md
@@ -1,7 +1,7 @@
 # xml-canonic
 
 > XMLStarlet toolkit: Make XML documents canonical.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `canonic` subcommand:
 

--- a/pages/common/xml-canonic.md
+++ b/pages/common/xml-canonic.md
@@ -1,20 +1,20 @@
-# xml-canonic
+# xml canonic
 
 > Make XML documents canonical.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Make an XML document canonical, including comments (default):
+- Make an XML document canonical, preserving comments (default behavior):
 
 `xml canonic --with-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
 
-- Make an XML document canonical, without comments:
+- Make an XML document canonical, removing comments:
 
 `xml canonic --without-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
 
-- Exclusive XML canonicalization, using an XPATH from a file:
+- Exclusive XML canonicalization, using an XPATH from a file, preserving comments:
 
 `xml canonic --exc-with-comments {{path/to/input.xml|URI}} {{path/to/c14n.xpath}}`
 
-- Display help for `canonic` subcommand:
+- Display help for the `canonic` subcommand:
 
 `xml canonic --help`

--- a/pages/common/xml-canonic.md
+++ b/pages/common/xml-canonic.md
@@ -1,7 +1,19 @@
 # xml-canonic
 
-> XMLStarlet toolkit: Make XML documents canonical.
+> Make XML documents canonical.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Make an XML document canonical, including comments (default):
+
+`xml canonic --with-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+
+- Make an XML document canonical, without comments:
+
+`xml canonic --without-comments {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+
+- Exclusive XML canonicalization, using an XPATH from a file:
+
+`xml canonic --exc-with-comments {{path/to/input.xml|URI}} {{path/to/c14n.xpath}}`
 
 - Display help for `canonic` subcommand:
 

--- a/pages/common/xml-depyx.md
+++ b/pages/common/xml-depyx.md
@@ -5,11 +5,11 @@
 
 - Convert a PYX (ESIS - ISO 8879) document to XML format:
 
-`xml depyx {{path/to/input.pyx|URI}} >{{path/to/output.xml}}`
+`xml depyx {{path/to/input.pyx|URI}} > {{path/to/output.xml}}`
 
-- Convert a PYX document from the standard input to XML format:
+- Convert a PYX document from stdin to XML format:
 
-`cat {{path/to/input.pyx}} | xml depyx >{{path/to/output.xml}}`
+`cat {{path/to/input.pyx}} | xml depyx > {{path/to/output.xml}}`
 
 - Display help for the `depyx` subcommand:
 

--- a/pages/common/xml-depyx.md
+++ b/pages/common/xml-depyx.md
@@ -1,0 +1,8 @@
+# xml-depyx
+
+> XMLStarlet toolkit: Convert a PYX document to XML format. (ESIS - ISO 8879).
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Display help for `depyx` subcommand:
+
+`xml depyx --help`

--- a/pages/common/xml-depyx.md
+++ b/pages/common/xml-depyx.md
@@ -1,4 +1,4 @@
-# xml-depyx
+# xml depyx
 
 > Convert a PYX (ESIS - ISO 8879) document to XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
@@ -7,10 +7,10 @@
 
 `xml depyx {{path/to/input.pyx|URI}} >{{path/to/output.xml}}`
 
-- Convert a PYX document from standard input to XML format:
+- Convert a PYX document from the standard input to XML format:
 
 `cat {{path/to/input.pyx}} | xml depyx >{{path/to/output.xml}}`
 
-- Display help for `depyx` subcommand:
+- Display help for the `depyx` subcommand:
 
 `xml depyx --help`

--- a/pages/common/xml-depyx.md
+++ b/pages/common/xml-depyx.md
@@ -1,7 +1,15 @@
 # xml-depyx
 
-> XMLStarlet toolkit: Convert a PYX document to XML format. (ESIS - ISO 8879).
+> Convert a PYX (ESIS - ISO 8879) document to XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Convert a PYX (ESIS - ISO 8879) document to XML format:
+
+`xml depyx {{path/to/input.pyx|URI}} >{{path/to/output.xml}}`
+
+- Convert a PYX document from standard input to XML format:
+
+`cat {{path/to/input.pyx}} | xml depyx >{{path/to/output.xml}}`
 
 - Display help for `depyx` subcommand:
 

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -1,4 +1,4 @@
-# xml-edit
+# xml edit
 
 > Edit an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
@@ -23,6 +23,6 @@
 
 `xml edit`
 
-- Display help for `edit` subcommand:
+- Display help for the `edit` subcommand:
 
 `xml edit --help`

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -1,7 +1,27 @@
 # xml-edit
 
-> XMLStarlet toolkit: Edit an XML document.
+> Edit an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- TBD:
+
+`xml edit`
+
+- TBD:
+
+`xml edit`
+
+- TBD:
+
+`xml edit`
+
+- TBD:
+
+`xml edit`
+
+- TBD:
+
+`xml edit`
 
 - Display help for `edit` subcommand:
 

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -15,7 +15,7 @@
 
 `xml edit --rename "{{//*/@id}}" -v "{{ID}}" {{path/to/input.xml|URI}}`
 
-- Rename the XML elements of "table" named "rec" to "record":
+- Rename sub-elements of the element "table" that are named "rec" to "record":
 
 `xml edit --rename "{{/xml/table/rec}}" -v "{{record}}" {{path/to/input.xml|URI}}`
 

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -5,23 +5,23 @@
 
 - Delete elements matching an XPATH from an XML document:
 
-`xml edit --delete {{"XPATH1"}} {{path/to/input.xml|URI}}`
+`xml edit --delete "{{XPATH1}}" {{path/to/input.xml|URI}}`
 
 - Move an element node of an XML document from XPATH1 to XPATH2:
 
-`xml edit --move {{"XPATH1"}} {{"XPATH2"}} {{path/to/input.xml|URI}}`
+`xml edit --move "{{XPATH1}}" "{{XPATH2}}" {{path/to/input.xml|URI}}`
 
 - Rename all attributes named "id" to "ID":
 
-`xml edit --rename {{"//*/@id"}} -v {{"ID"}} {{path/to/input.xml|URI}}`
+`xml edit --rename "{{//*/@id}}" -v "{{ID}}" {{path/to/input.xml|URI}}`
 
-- Rename XML elements of "table" named "rec" to "record":
+- Rename the XML elements of "table" named "rec" to "record":
 
-`xml edit --rename {{"/xml/table/rec"}} -v {{"record"}} {{path/to/input.xml|URI}}`
+`xml edit --rename "{{/xml/table/rec}}" -v "{{record}}" {{path/to/input.xml|URI}}`
 
-- Update the value of XML table record ID=3 to 5:
+- Update the XML table record with "id=3" to the value "id=5":
 
-`xml edit --update {{"xml/table/rec[@id=3]/@id"}} -v {{5}} {{path/to/input.xml|URI}}`
+`xml edit --update "{{xml/table/rec[@id=3]/@id}}" -v {{5}} {{path/to/input.xml|URI}}`
 
 - Display help for the `edit` subcommand:
 

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -1,0 +1,8 @@
+# xml-edit
+
+> XMLStarlet toolkit: Edit an XML document.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `edit` subcommand:
+
+`xml edit --help`

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -3,25 +3,25 @@
 > Edit an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- TBD:
+- Delete elements matching an XPATH from an XML document:
 
-`xml edit`
+`xml edit --delete {{"XPATH1"}} {{path/to/input.xml|URI}}`
 
-- TBD:
+- Move an element node of an XML document from XPATH1 to XPATH2:
 
-`xml edit`
+`xml edit --move {{"XPATH1"}} {{"XPATH2"}} {{path/to/input.xml|URI}}`
 
-- TBD:
+- Rename all attributes named "id" to "ID":
 
-`xml edit`
+`xml edit --rename {{"//*/@id"}} -v {{"ID"}} {{path/to/input.xml|URI}}`
 
-- TBD:
+- Rename XML elements of "table" named "rec" to "record":
 
-`xml edit`
+`xml edit --rename {{"/xml/table/rec"}} -v {{"record"}} {{path/to/input.xml|URI}}`
 
-- TBD:
+- Update the value of XML table record ID=3 to 5:
 
-`xml edit`
+`xml edit --update {{"xml/table/rec[@id=3]/@id"}} -v {{5}} {{path/to/input.xml|URI}}`
 
 - Display help for the `edit` subcommand:
 

--- a/pages/common/xml-edit.md
+++ b/pages/common/xml-edit.md
@@ -1,7 +1,7 @@
 # xml-edit
 
 > XMLStarlet toolkit: Edit an XML document.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `edit` subcommand:
 

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -1,0 +1,8 @@
+# xml-elements
+
+> XMLStarlet toolkit: Diaplay element structure of an XML document.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `elements` subcommand:
+
+`xml elements --help`

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -1,7 +1,27 @@
 # xml-elements
 
-> XMLStarlet toolkit: Diaplay element structure of an XML document.
+> Extract elements and structure of an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Extract elements of an XML document (as XPATH expressions):
+
+`xml elements {{path/to/input.xml|URI}} >{{path/to/elements}}`
+
+- Extract elements and attributes of an XML document:
+
+`xml elements -a {{path/to/input.xml|URI}} >{{path/to/elements}}`
+
+- Extract elements, attributes, and their values:
+
+`xml elements -v {{path/to/input.xml|URI}} >{{path/to/elements}}`
+
+- Print sorted unique elements of an XML document (to see structure):
+
+`xml elements -u {{path/to/input.xml|URI}}`
+
+- Print sorted unique elements up to a depth of 3:
+
+`xml elements -d{{3}} {{path/to/input.xml|URI}}`
 
 - Display help for `elements` subcommand:
 

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -5,21 +5,21 @@
 
 - Extract elements from an XML document (producing XPATH expressions):
 
-`xml elements {{path/to/input.xml|URI}} >{{path/to/elements}}`
+`xml elements {{path/to/input.xml|URI}} > {{path/to/elements}}`
 
-- Extract elements and attributes from an XML document:
+- Extract elements and their attributes from an XML document:
 
-`xml elements -a {{path/to/input.xml|URI}} >{{path/to/elements}}`
+`xml elements -a {{path/to/input.xml|URI}} > {{path/to/elements}}`
 
-- Extract elements, attributes, and their values from an XML doc:
+- Extract elements and their attributes and values from an XML document:
 
-`xml elements -v {{path/to/input.xml|URI}} >{{path/to/elements}}`
+`xml elements -v {{path/to/input.xml|URI}} > {{path/to/elements}}`
 
-- Print sorted unique elements from an XML document (to see structure):
+- Print sorted unique elements from an XML document to see its structure:
 
 `xml elements -u {{path/to/input.xml|URI}}`
 
-- Print sorted unique elements up to a depth of 3:
+- Print sorted unique elements from an XML document up to a depth of 3:
 
 `xml elements -d{{3}} {{path/to/input.xml|URI}}`
 

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -1,7 +1,7 @@
 # xml-elements
 
 > XMLStarlet toolkit: Diaplay element structure of an XML document.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `elements` subcommand:
 

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -1,19 +1,19 @@
 # xml elements
 
-> Extract elements and display structure of an XML document.
+> Extract elements and display the structure of an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Extract elements from an XML document (producing XPATH expressions):
 
-`xml elements {{path/to/input.xml|URI}} > {{path/to/elements}}`
+`xml elements {{path/to/input.xml|URI}} > {{path/to/elements.xpath}}`
 
 - Extract elements and their attributes from an XML document:
 
-`xml elements -a {{path/to/input.xml|URI}} > {{path/to/elements}}`
+`xml elements -a {{path/to/input.xml|URI}} > {{path/to/elements.xpath}}`
 
 - Extract elements and their attributes and values from an XML document:
 
-`xml elements -v {{path/to/input.xml|URI}} > {{path/to/elements}}`
+`xml elements -v {{path/to/input.xml|URI}} > {{path/to/elements.xpath}}`
 
 - Print sorted unique elements from an XML document to see its structure:
 

--- a/pages/common/xml-elements.md
+++ b/pages/common/xml-elements.md
@@ -1,21 +1,21 @@
-# xml-elements
+# xml elements
 
-> Extract elements and structure of an XML document.
+> Extract elements and display structure of an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Extract elements of an XML document (as XPATH expressions):
+- Extract elements from an XML document (producing XPATH expressions):
 
 `xml elements {{path/to/input.xml|URI}} >{{path/to/elements}}`
 
-- Extract elements and attributes of an XML document:
+- Extract elements and attributes from an XML document:
 
 `xml elements -a {{path/to/input.xml|URI}} >{{path/to/elements}}`
 
-- Extract elements, attributes, and their values:
+- Extract elements, attributes, and their values from an XML doc:
 
 `xml elements -v {{path/to/input.xml|URI}} >{{path/to/elements}}`
 
-- Print sorted unique elements of an XML document (to see structure):
+- Print sorted unique elements from an XML document (to see structure):
 
 `xml elements -u {{path/to/input.xml|URI}}`
 
@@ -23,6 +23,6 @@
 
 `xml elements -d{{3}} {{path/to/input.xml|URI}}`
 
-- Display help for `elements` subcommand:
+- Display help for the `elements` subcommand:
 
 `xml elements --help`

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,0 +1,8 @@
+# xml-escape
+
+> XMLStarlet toolkit: Escape special XML characters.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `escape` subcommand:
+
+`xml escape --help`

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,16 +1,16 @@
-# xml-escape
+# xml escape
 
 > Escape special XML characters.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Escape special XML characters in a string:
 
-`xml escape {{"<a1>"}}`
+`xml escape "{{<a1>}}"`
 
-- Escape special XML characters in standard input:
+- Escape special XML characters from the standard input:
 
-`echo  {{"<a1>"}} | xml escape`
+`echo  "{{<a1>}}" | xml escape`
 
-- Display help for `escape` subcommand:
+- Display help for the `escape` subcommand:
 
 `xml escape --help`

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -3,6 +3,14 @@
 > XMLStarlet toolkit: Escape special XML characters.
 > More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
+- Escape special XML characters in a string:
+
+`xml escape {{"<a1>"}}`
+
+- Escape special XML characters in standard input:
+
+`echo  {{"<a1>"}} | xml escape`
+
 - Display help for `escape` subcommand:
 
 `xml escape --help`

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,13 +1,13 @@
 # xml escape
 
-> Escape special XML characters.
+> Escape special XML characters, e.g. `<a1>` -> `&lt;a1&gt;`.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Escape special XML characters in a string:
 
 `xml escape "{{<a1>}}"`
 
-- Escape special XML characters from the standard input:
+- Escape special XML characters from stdin:
 
 `echo  "{{<a1>}}" | xml escape`
 

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,6 +1,6 @@
 # xml escape
 
-> Escape special XML characters, e.g. `<a1>` -> `&lt;a1&gt;`.
+> Escape special XML characters, e.g. `<a1>` → `&lt;a1&gt;`.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Escape special XML characters in a string:

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,6 +1,6 @@
 # xml-escape
 
-> XMLStarlet toolkit: Escape special XML characters.
+> Escape special XML characters.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Escape special XML characters in a string:

--- a/pages/common/xml-escape.md
+++ b/pages/common/xml-escape.md
@@ -1,7 +1,7 @@
 # xml-escape
 
 > XMLStarlet toolkit: Escape special XML characters.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Escape special XML characters in a string:
 

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -1,7 +1,27 @@
 # xml-format
 
-> XMLStarlet toolkit: Format an XML document.
+> Format an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Format an XML document, indenting with tabs:
+
+`xml format --indent-tab {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+
+- Format an HTML document, indenting with 4 spaces:
+
+`xml format --html --indent-spaces {{4}} {{path/to/input.html|URI}} >{{path/to/output.html}}`
+
+- Recover parsable parts of a malformed XML document, without indenting:
+
+`xml format --recover --noindent {{path/to/malformed.xml|URI}} >{{path/to/recovered.xml}}`
+
+- Format an XML document from standard input, removing the DOCTYPE declaration:
+
+`cat {{path\to\input.xml}} | xml format --dropdtd >{{path/to/output.xml}}`
+
+- Format an XML document, omitting the XML declaration:
+
+`xml format --omit-decl {{path\to\input.xml|URI}} >{{path/to/output.xml}}`
 
 - Display help for `format` subcommand:
 

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -1,0 +1,8 @@
+# xml-format
+
+> XMLStarlet toolkit: Format an XML document.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `format` subcommand:
+
+`xml format --help`

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -1,4 +1,4 @@
-# xml-format
+# xml format
 
 > Format an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
@@ -15,7 +15,7 @@
 
 `xml format --recover --noindent {{path/to/malformed.xml|URI}} >{{path/to/recovered.xml}}`
 
-- Format an XML document from standard input, removing the DOCTYPE declaration:
+- Format an XML document from the standard input, removing the DOCTYPE declaration:
 
 `cat {{path\to\input.xml}} | xml format --dropdtd >{{path/to/output.xml}}`
 
@@ -23,6 +23,6 @@
 
 `xml format --omit-decl {{path\to\input.xml|URI}} >{{path/to/output.xml}}`
 
-- Display help for `format` subcommand:
+- Display help for the `format` subcommand:
 
 `xml format --help`

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -5,23 +5,23 @@
 
 - Format an XML document, indenting with tabs:
 
-`xml format --indent-tab {{path/to/input.xml|URI}} >{{path/to/output.xml}}`
+`xml format --indent-tab {{path/to/input.xml|URI}} > {{path/to/output.xml}}`
 
 - Format an HTML document, indenting with 4 spaces:
 
-`xml format --html --indent-spaces {{4}} {{path/to/input.html|URI}} >{{path/to/output.html}}`
+`xml format --html --indent-spaces {{4}} {{path/to/input.html|URI}} > {{path/to/output.html}}`
 
 - Recover parsable parts of a malformed XML document, without indenting:
 
-`xml format --recover --noindent {{path/to/malformed.xml|URI}} >{{path/to/recovered.xml}}`
+`xml format --recover --noindent {{path/to/malformed.xml|URI}} > {{path/to/recovered.xml}}`
 
-- Format an XML document from the standard input, removing the DOCTYPE declaration:
+- Format an XML document from stdin, removing the DOCTYPE declaration:
 
-`cat {{path\to\input.xml}} | xml format --dropdtd >{{path/to/output.xml}}`
+`cat {{path\to\input.xml}} | xml format --dropdtd > {{path/to/output.xml}}`
 
 - Format an XML document, omitting the XML declaration:
 
-`xml format --omit-decl {{path\to\input.xml|URI}} >{{path/to/output.xml}}`
+`xml format --omit-decl {{path\to\input.xml|URI}} > {{path/to/output.xml}}`
 
 - Display help for the `format` subcommand:
 

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -1,7 +1,7 @@
 # xml-format
 
 > XMLStarlet toolkit: Format an XML document.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `format` subcommand:
 

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -15,7 +15,7 @@
 
 `xml format --recover --noindent {{path/to/malformed.xml|URI}} > {{path/to/recovered.xml}}`
 
-- Format an XML document from stdin, removing the DOCTYPE declaration:
+- Format an XML document from stdin, removing the `DOCTYPE` declaration:
 
 `cat {{path\to\input.xml}} | xml format --dropdtd > {{path/to/output.xml}}`
 

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,15 +1,15 @@
 # xml list
 
-> List a directory's contents in XML format.
+> List a directory's contents (like 'ls') in XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - List the current directory's contents to an XML document:
 
-`xml list >{{path/to/dir_list.xml}}`
+`xml list > {{path/to/dir_list.xml}}`
 
 - List the specified directory's contents to an XML document:
 
-`xml list {{path/to/directory}} >{{path/to/dir_list.xml}}`
+`xml list {{path/to/directory}} > {{path/to/dir_list.xml}}`
 
 - Display help for the `list` subcommand:
 

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,13 +1,13 @@
 # xml list
 
-> List a directory's contents (like 'ls') in XML format.
+> Write a directory's listing (like 'ls') in XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- List the current directory's contents to an XML document:
+- Write the current directory's listing to an XML document:
 
 `xml list > {{path/to/dir_list.xml}}`
 
-- List the specified directory's contents to an XML document:
+- Write the specified directory's listing to an XML document:
 
 `xml list {{path/to/directory}} > {{path/to/dir_list.xml}}`
 

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,0 +1,8 @@
+# xml-list
+
+> XMLStarlet toolkit: List a directory as XML.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `list` subcommand:
+
+`xml list --help`

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,6 +1,6 @@
 # xml list
 
-> List a directory's contents (like 'ls') in XML format.
+> List a directory's contents (like `ls`) in XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Write the current directory's listing to an XML document:

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,7 +1,7 @@
 # xml-list
 
 > XMLStarlet toolkit: List a directory as XML.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `list` subcommand:
 

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,16 +1,16 @@
-# xml-list
+# xml list
 
-> List a directory as XML.
+> List a directory's contents in XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- List the current directory to an XML file:
+- List the current directory's contents to an XML document:
 
 `xml list >{{path/to/dir_list.xml}}`
 
-- List the specified directory to an XML file:
+- List the specified directory's contents to an XML document:
 
 `xml list {{path/to/directory}} >{{path/to/dir_list.xml}}`
 
-- Display help for `list` subcommand:
+- Display help for the `list` subcommand:
 
 `xml list --help`

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,7 +1,15 @@
 # xml-list
 
-> XMLStarlet toolkit: List a directory as XML.
+> List a directory as XML.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- List the current directory to an XML file:
+
+`xml list >{{path/to/dir_list.xml}}`
+
+- List the specified directory to an XML file:
+
+`xml list {{path/to/directory}} >{{path/to/dir_list.xml}}`
 
 - Display help for `list` subcommand:
 

--- a/pages/common/xml-list.md
+++ b/pages/common/xml-list.md
@@ -1,6 +1,6 @@
 # xml list
 
-> Write a directory's listing (like 'ls') in XML format.
+> List a directory's contents (like 'ls') in XML format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Write the current directory's listing to an XML document:

--- a/pages/common/xml-p2x.md
+++ b/pages/common/xml-p2x.md
@@ -1,0 +1,8 @@
+# xml-p2x
+
+> XMLStarlet toolkit: Convert a PYX document to XML format. (ESIS - ISO 8879).
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `p2x` subcommand:
+
+`xml p2x --help`

--- a/pages/common/xml-p2x.md
+++ b/pages/common/xml-p2x.md
@@ -1,8 +1,0 @@
-# xml-p2x
-
-> XMLStarlet toolkit: Convert a PYX document to XML format. (ESIS - ISO 8879).
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
-
-- Display help for `p2x` subcommand:
-
-`xml p2x --help`

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -1,4 +1,4 @@
-# xml-pyx
+# xml pyx
 
 > Convert an XML document to PYX (ESIS - ISO 8879) format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
@@ -7,10 +7,10 @@
 
 `xml pyx {{path/to/input.xml|URI}} >{{path/to/output.pyx}}`
 
-- Convert an XML document from standard input to PYX format:
+- Convert an XML document from the standard input to PYX format:
 
 `cat {{path/to/input.xml}} | xml pyx >{{path/to/output.pyx}}`
 
-- Display help for `pyx` subcommand:
+- Display help for the `pyx` subcommand:
 
 `xml pyx --help`

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -1,7 +1,15 @@
 # xml-pyx
 
-> XMLStarlet toolkit: Convert XML documents to PYX format. (ESIS - ISO 8879).
+> Convert an XML document to PYX (ESIS - ISO 8879) format.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Convert an XML document to PYX format:
+
+`xml pyx {{path/to/input.xml|URI}} >{{path/to/output.pyx}}`
+
+- Convert an XML document from standard input to PYX format:
+
+`cat {{path/to/input.xml}} | xml pyx >{{path/to/output.pyx}}`
 
 - Display help for `pyx` subcommand:
 

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -5,11 +5,11 @@
 
 - Convert an XML document to PYX format:
 
-`xml pyx {{path/to/input.xml|URI}} >{{path/to/output.pyx}}`
+`xml pyx {{path/to/input.xml|URI}} > {{path/to/output.pyx}}`
 
-- Convert an XML document from the standard input to PYX format:
+- Convert an XML document from stdin to PYX format:
 
-`cat {{path/to/input.xml}} | xml pyx >{{path/to/output.pyx}}`
+`cat {{path/to/input.xml}} | xml pyx > {{path/to/output.pyx}}`
 
 - Display help for the `pyx` subcommand:
 

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -1,0 +1,8 @@
+# xml-pyx
+
+> XMLStarlet toolkit: Convert XML documents to PYX format. (ESIS - ISO 8879).
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `pyx` subcommand:
+
+`xml pyx --help`

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -1,7 +1,7 @@
 # xml-pyx
 
 > XMLStarlet toolkit: Convert XML documents to PYX format. (ESIS - ISO 8879).
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `pyx` subcommand:
 

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -1,4 +1,4 @@
-# xml-select
+# xml select
 
 > Select from XML documents using XPATH.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdft>.
@@ -23,6 +23,6 @@
 
 `xml select`
 
-- Display help for `select` subcommand:
+- Display help for the `select` subcommand:
 
 `xml select --help`

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -6,17 +6,17 @@
 
 - Select all elements matching "XPATH1" and print the value of the element "XPATH2":
 
-`xml select --template --match {{"XPATH1"}} --value-of {{"XPATH2"}} {{path/to/input.xml|URI}}`
+`xml select --template --match "{{XPATH1}}" --value-of "{{XPATH2}}" {{path/to/input.xml|URI}}`
 
 - Match  "XPATH1" and print the value of "XPATH2" as text with new-lines:
 
-`xml select --text --template --match {{"XPATH1"}} --value-of {{"XPATH2"}} --nl {{path/to/input.xml|URI}}`
+`xml select --text --template --match "{{XPATH1}}" --value-of "{{XPATH2}}" --nl {{path/to/input.xml|URI}}`
 
 - Count the elements of "XPATH1":
 
 `xml select --template --value-of "count({{XPATH1}})" {{path/to/input.xml|URI}}`
 
-- Count all nodes in XML document(s):
+- Count all nodes in one or more XML documents:
 
 `xml select --text --template --inp-name --output " " --value-of "count(node())" --nl {{path/to/input1.xml|URI}} {{path/to/input2.xml|URI}}`
 

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -1,7 +1,7 @@
 # xml-select
 
 > XMLStarlet toolkit: Select from XML documents.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdft>.
 
 - Display help for `select` subcommand:
 

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -1,7 +1,27 @@
 # xml-select
 
-> XMLStarlet toolkit: Select from XML documents.
+> Select from XML documents using XPATH.
 > More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdft>.
+
+- TBD:
+
+`xml select`
+
+- TBD:
+
+`xml select`
+
+- TBD:
+
+`xml select`
+
+- TBD:
+
+`xml select`
+
+- TBD:
+
+`xml select`
 
 - Display help for `select` subcommand:
 

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -4,7 +4,7 @@
 > Tip: use `xml elements` to display the XPATHs of an XML document.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Select all elements matching "XPATH1" and print the value of the element "XPATH2":
+- Select all elements matching "XPATH1" and print the value of their sub-element "XPATH2":
 
 `xml select --template --match "{{XPATH1}}" --value-of "{{XPATH2}}" {{path/to/input.xml|URI}}`
 

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -1,0 +1,8 @@
+# xml-select
+
+> XMLStarlet toolkit: Select from XML documents.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `select` subcommand:
+
+`xml select --help`

--- a/pages/common/xml-select.md
+++ b/pages/common/xml-select.md
@@ -1,27 +1,24 @@
 # xml select
 
-> Select from XML documents using XPATH.
-> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdft>.
+> Select from XML documents using XPATHs.
+> Tip: use `xml elements` to display the XPATHs of an XML document.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- TBD:
+- Select all elements matching "XPATH1" and print the value of the element "XPATH2":
 
-`xml select`
+`xml select --template --match {{"XPATH1"}} --value-of {{"XPATH2"}} {{path/to/input.xml|URI}}`
 
-- TBD:
+- Match  "XPATH1" and print the value of "XPATH2" as text with new-lines:
 
-`xml select`
+`xml select --text --template --match {{"XPATH1"}} --value-of {{"XPATH2"}} --nl {{path/to/input.xml|URI}}`
 
-- TBD:
+- Count the elements of "XPATH1":
 
-`xml select`
+`xml select --template --value-of "count({{XPATH1}})" {{path/to/input.xml|URI}}`
 
-- TBD:
+- Count all nodes in XML document(s):
 
-`xml select`
-
-- TBD:
-
-`xml select`
+`xml select --text --template --inp-name --output " " --value-of "count(node())" --nl {{path/to/input1.xml|URI}} {{path/to/input2.xml|URI}}`
 
 - Display help for the `select` subcommand:
 

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -1,7 +1,27 @@
 # xml-transform
 
-> XMLStarlet toolkit: Transform XML documents using XSLT.
+> Transform XML documents using XSLT.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- TBD:
+
+`xml transform`
+
+- TBD:
+
+`xml transform`
+
+- TBD:
+
+`xml transform`
+
+- TBD:
+
+`xml transform`
+
+- TBD:
+
+`xml transform`
 
 - Display help for `transform` subcommand:
 

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -1,0 +1,8 @@
+# xml-transform
+
+> XMLStarlet toolkit: Transform XML documents using XSLT.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `transform` subcommand:
+
+`xml transform --help`

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -5,7 +5,7 @@
 
 - Transform an XML document using an XSL stylesheet, passing one XPATH parameter and one literal string parameter:
 
-`xml transform {{path/to/stylesheet.xsl}} -p {{"Count='count(/xml/table/rec)'"}} -s {{Text="Count="}} {{path/to/input.xml|URI}}`
+`xml transform {{path/to/stylesheet.xsl}} -p "{{Count='count(/xml/table/rec)'}}" -s {{Text="Count="}} {{path/to/input.xml|URI}}`
 
 - Display help for the `transform` subcommand:
 

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -1,4 +1,4 @@
-# xml-transform
+# xml transform
 
 > Transform XML documents using XSLT.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
@@ -23,6 +23,6 @@
 
 `xml transform`
 
-- Display help for `transform` subcommand:
+- Display help for the `transform` subcommand:
 
 `xml transform --help`

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -1,7 +1,7 @@
 # xml-transform
 
 > XMLStarlet toolkit: Transform XML documents using XSLT.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display help for `transform` subcommand:
 

--- a/pages/common/xml-transform.md
+++ b/pages/common/xml-transform.md
@@ -3,25 +3,9 @@
 > Transform XML documents using XSLT.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- TBD:
+- Transform an XML document using an XSL stylesheet, passing one XPATH parameter and one literal string parameter:
 
-`xml transform`
-
-- TBD:
-
-`xml transform`
-
-- TBD:
-
-`xml transform`
-
-- TBD:
-
-`xml transform`
-
-- TBD:
-
-`xml transform`
+`xml transform {{path/to/stylesheet.xsl}} -p {{"Count='count(/xml/table/rec)'"}} -s {{Text="Count="}} {{path/to/input.xml|URI}}`
 
 - Display help for the `transform` subcommand:
 

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,7 +1,7 @@
 # xml-edit
 
 > XMLStarlet toolkit: Un-escape special XML characters.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Unescape special XML characters from a string:
 

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,16 +1,16 @@
-# xml-unescape
+# xml unescape
 
-> Un-escape special XML characters.
+> Unescape special XML characters.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Unescape special XML characters from a string:
 
-`xml unescape {{"&lt;a1&gt;"}}`
+`xml unescape "{{&lt;a1&gt;}}"`
 
-- Unescape special XML characters from standard input:
+- Unescape special XML characters from the standard input:
 
-`echo  {{"&lt;a1&gt;"}} | xml unescape`
+`echo  "{{&lt;a1&gt;}}" | xml unescape`
 
-- Display help for `unescape` subcommand:
+- Display help for the `unescape` subcommand:
 
 `xml escape --help`

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,6 +1,6 @@
-# xml-edit
+# xml-unescape
 
-> XMLStarlet toolkit: Un-escape special XML characters.
+> Un-escape special XML characters.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Unescape special XML characters from a string:

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,13 +1,13 @@
 # xml unescape
 
-> Unescape special XML characters.
+> Unescape special XML characters, e.g. `&lt;a1&gt;` -> `<a1>`.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Unescape special XML characters from a string:
 
 `xml unescape "{{&lt;a1&gt;}}"`
 
-- Unescape special XML characters from the standard input:
+- Unescape special XML characters from stdin:
 
 `echo  "{{&lt;a1&gt;}}" | xml unescape`
 

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,6 +1,6 @@
 # xml unescape
 
-> Unescape special XML characters, e.g. `&lt;a1&gt;` -> `<a1>`.
+> Unescape special XML characters, e.g. `&lt;a1&gt;` → `<a1>`.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Unescape special XML characters from a string:

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -3,6 +3,14 @@
 > XMLStarlet toolkit: Un-escape special XML characters.
 > More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
+- Unescape special XML characters from a string:
+
+`xml unescape {{"&lt;a1&gt;"}}`
+
+- Unescape special XML characters from standard input:
+
+`echo  {{"&lt;a1&gt;"}} | xml unescape`
+
 - Display help for `unescape` subcommand:
 
 `xml escape --help`

--- a/pages/common/xml-unescape.md
+++ b/pages/common/xml-unescape.md
@@ -1,0 +1,8 @@
+# xml-edit
+
+> XMLStarlet toolkit: Un-escape special XML characters.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `unescape` subcommand:
+
+`xml escape --help`

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -1,6 +1,6 @@
 # xml-validate
 
-> XMLStarlet toolkit: Validate XML documents.
+> Validate XML documents.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Validate XML document for well-formedness only (default):

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -3,19 +3,19 @@
 > Validate XML documents.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Validate XML document(s) for well-formedness only:
+- Validate one or more XML documents for well-formedness only:
 
 `xml validate {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document(s) against a Document Type Definition (DTD):
+- Validate one or more XML documents against a Document Type Definition (DTD):
 
 `xml validate --dtd {{path/to/schema.dtd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document(s) against an XML Schema Definition (XSD):
+- Validate one or more XML documents against an XML Schema Definition (XSD):
 
 `xml validate --xsd {{path/to/schema.xsd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document(s) against a Relax NG schema (RNG):
+- Validate one or more XML documents against a Relax NG schema (RNG):
 
 `xml validate --relaxng {{path/to/schema.rng}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -1,0 +1,8 @@
+# xml-validate
+
+> XMLStarlet toolkit: Validate XML documents.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Display help for `validate` subcommand:
+
+`xml validate --help`

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -3,9 +3,9 @@
 > Validate XML documents.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Validate XML document(s) for well-formedness only (default behavior):
+- Validate XML document(s) for well-formedness only:
 
-`xml validate --well-formed {{path/to/input1.xml|URI}} {{input2.xml ...}}`
+`xml validate {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
 - Validate XML document(s) against a Document Type Definition (DTD):
 

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -1,7 +1,7 @@
 # xml-validate
 
 > XMLStarlet toolkit: Validate XML documents.
-> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Validate XML document for well-formedness only (default):
 

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -1,7 +1,23 @@
 # xml-validate
 
 > XMLStarlet toolkit: Validate XML documents.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Validate XML document for well-formedness only (default):
+
+`xml validate --well-formed {{path/to/input1.xml|URI}} {{input2.xml ...}}`
+
+- Validate XML document against Document Type Definition (DTD):
+
+`xml validate --dtd {{path/to/schema.dtd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
+
+- Validate XML document against XML Schema Definition (XSD):
+
+`xml validate --xsd {{path/to/schema.xsd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
+
+- Validate XML document against a Relax NG schema (RNG):
+
+`xml validate --relaxng {{path/to/schema.rng}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
 - Display help for `validate` subcommand:
 

--- a/pages/common/xml-validate.md
+++ b/pages/common/xml-validate.md
@@ -1,24 +1,24 @@
-# xml-validate
+# xml validate
 
 > Validate XML documents.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Validate XML document for well-formedness only (default):
+- Validate XML document(s) for well-formedness only (default behavior):
 
 `xml validate --well-formed {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document against Document Type Definition (DTD):
+- Validate XML document(s) against a Document Type Definition (DTD):
 
 `xml validate --dtd {{path/to/schema.dtd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document against XML Schema Definition (XSD):
+- Validate XML document(s) against an XML Schema Definition (XSD):
 
 `xml validate --xsd {{path/to/schema.xsd}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Validate XML document against a Relax NG schema (RNG):
+- Validate XML document(s) against a Relax NG schema (RNG):
 
 `xml validate --relaxng {{path/to/schema.rng}} {{path/to/input1.xml|URI}} {{input2.xml ...}}`
 
-- Display help for `validate` subcommand:
+- Display help for the `validate` subcommand:
 
 `xml validate --help`

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,20 +1,21 @@
 # xml
 
 > XMLStarlet Toolkit: Query, edit, check, convert and transform XML documents.
+> This command also has documentation about its subcommands, e.g. `xml validate`.
 > Subcommands: `canonic`, `edit`, `elements`, `escape`, `unescape`, `format`, `list`, `pyx`, `depyx`, `select`, `transform`, or `validate`.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
-- Execute a subcommand with input from a file or URI and using standard output:
+- Execute a subcommand with input from a file or URI, printing to stdout:
 
 `xml {{subcommand}} {{options}} {{path/to/input.xml|URI}}`
 
-- Execute a subcommand using the standard input and standard output:
+- Execute a subcommand using stdin and stdout:
 
 `xml {{subcommand}} {{options}}`
 
 - Execute a subcommand with input from a file or URI and output to a file:
 
-`xml {{subcommand}} {{options}} {{path/to/input.xml|URI}} >{{path/to/output}}`
+`xml {{subcommand}} {{options}} {{path/to/input.xml|URI}} > {{path/to/output}}`
 
 - Display help for a subcommand:
 
@@ -24,6 +25,6 @@
 
 `xml --help`
 
-- Display version:
+- Display the version of the XMLStarlet Toolkit:
 
 `xml --version`

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,7 +1,7 @@
 # xml
 
-> XMLStarlet toolkit: Query, edit, check, and transform XML documents.
-> Subcommands: `canonic`, `edit`, `elements`, `escape`, `format`, `list`, `pyx`, `p2x`, `select`, `transform`, `unescape`, or `validate`.
+> XMLStarlet Toolkit: Query, edit, check, convert and transform XML documents.
+> Subcommands: `canonic`, `edit`, `elements`, `escape`, `unescape`, `format`, `list`, `pyx`, `depyx`, `select`, `transform`, or `validate`.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Execute a subcommand with input from a file or URI and using standard output:

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -2,8 +2,11 @@
 
 > XMLStarlet Toolkit: Query, edit, check, convert and transform XML documents.
 > This command also has documentation about its subcommands, e.g. `xml validate`.
-> Subcommands: `canonic`, `edit`, `elements`, `escape`, `unescape`, `format`, `list`, `pyx`, `depyx`, `select`, `transform`, or `validate`.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
+
+- Display general help, including the list of subcommands:
+
+`xml --help`
 
 - Execute a subcommand with input from a file or URI, printing to stdout:
 
@@ -20,10 +23,6 @@
 - Display help for a subcommand:
 
 `xml {{subcommand}} --help`
-
-- Display general help:
-
-`xml --help`
 
 - Display the version of the XMLStarlet Toolkit:
 

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -2,11 +2,11 @@
 
 > XMLStarlet toolkit: Query, edit, check, and transform XML documents.
 > Subcommands: `canonic`, `edit`, `elements`, `escape`, `format`, `list`, `pyx`, `p2x`, `select`, `transform`, `unescape`, or `validate`.
-> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
 - Execute a subcommand with input from a file or URI and using standard output:
 
-`xml {{subcommand}} {{options}} {{xml_file_or_uri}}`
+`xml {{subcommand}} {{options}} {{path/to/input.xml|URI}}`
 
 - Execute a subcommand using standard input and standard output:
 
@@ -14,7 +14,7 @@
 
 - Execute a subcommand with input from a file or URI and output to a file:
 
-`xml {{subcommand}} {{options}} {{xml_file_or_uri}} >{{path/to/output}}`
+`xml {{subcommand}} {{options}} {{path/to/input.xml|URI}} >{{path/to/output}}`
 
 - Display help for a subcommand:
 

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,16 +1,20 @@
 # xml
 
 > XMLStarlet toolkit: Query / Edit / Check / Transform XML documents.
-> Subcommands: `edit`, `select`, `transform`, `validate`, `format`, `elements`, `canonic`, `list`, `escape`, `unescape`, `pyx`, or `p2x`.
+> Subcommands: `canonic`, `edit`, `elements`, `escape`, `format`, `list`, `pyx`, `p2x`, `select`, `transform`, `unescape`, or `validate`.
 > More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
-- Execute a subcommand:
+- Execute a subcommand with input from a file and using standard output:
 
-`xml {{subcommand}} {{options}} {{xml-file-or-uri}}`
+`xml {{subcommand}} {{options}} {{xml_file_or_uri}}`
 
-- Execute a subcommand, redirecting output to a file:
+- Execute a subcommand using standard input and standard output:
 
-`xml {{subcommand}} {{options}} {{xml-file-or-uri}} >{{path/to/output}}`
+`xml {{subcommand}} {{options}}`
+
+- Execute a subcommand with input from a file and output to a file:
+
+`xml {{subcommand}} {{options}} {{xml_file_or_uri}} >{{path/to/output}}`
 
 - Display help for a subcommand:
 

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,0 +1,25 @@
+# xml
+
+> XMLStarlet toolkit: Query / Edit / Check / Transform XML documents.
+> Subcommands: `edit`, `select`, `transform`, `validate`, `format`, `elements`, `canonic`, `list`, `escape`, `unescape`, `pyx`, or `p2x`.
+> More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+
+- Execute a subcommand:
+
+`xml {{subcommand}} {{options}} {{xml-file-or-uri}}`
+
+- Execute a subcommand, redirecting output to a file:
+
+`xml {{subcommand}} {{options}} {{xml-file-or-uri}} >{{path/to/output}}`
+
+- Display help for a subcommand:
+
+`xml {{subcommand}} --help`
+
+- Display general help:
+
+`xml --help`
+
+- Display version:
+
+`xml --version`

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -8,7 +8,7 @@
 
 `xml {{subcommand}} {{options}} {{path/to/input.xml|URI}}`
 
-- Execute a subcommand using standard input and standard output:
+- Execute a subcommand using the standard input and standard output:
 
 `xml {{subcommand}} {{options}}`
 

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -2,7 +2,7 @@
 
 > XMLStarlet toolkit: Query, edit, check, and transform XML documents.
 > Subcommands: `canonic`, `edit`, `elements`, `escape`, `format`, `list`, `pyx`, `p2x`, `select`, `transform`, `unescape`, or `validate`.
-> More information: <http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
+> More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Execute a subcommand with input from a file or URI and using standard output:
 

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,10 +1,10 @@
 # xml
 
-> XMLStarlet toolkit: Query / Edit / Check / Transform XML documents.
+> XMLStarlet toolkit: Query, edit, check, and transform XML documents.
 > Subcommands: `canonic`, `edit`, `elements`, `escape`, `format`, `list`, `pyx`, `p2x`, `select`, `transform`, `unescape`, or `validate`.
 > More information: <https://http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf>.
 
-- Execute a subcommand with input from a file and using standard output:
+- Execute a subcommand with input from a file or URI and using standard output:
 
 `xml {{subcommand}} {{options}} {{xml_file_or_uri}}`
 
@@ -12,7 +12,7 @@
 
 `xml {{subcommand}} {{options}}`
 
-- Execute a subcommand with input from a file and output to a file:
+- Execute a subcommand with input from a file or URI and output to a file:
 
 `xml {{subcommand}} {{options}} {{xml_file_or_uri}} >{{path/to/output}}`
 


### PR DESCRIPTION
Resolves issue #6368.

XML Starlet (`xml`) is a toolkit of commands that operate on XML documents. It has twelve subcommands.

PLEASE READ: This PR is _incomplete_. The three most complex commands, `select`, `edit`, and `transform`, have only "TBD" lines so far. I'm submitting the other nine subcommands now for your review while I work on the difficult three.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
