### PR TITLE
svgo: remove deprecated --enable=plugin_name example

### DIFF
--- a/pages/common/svgo.md
+++ b/pages/common/svgo.md
@@ -28,10 +28,6 @@
 
 `svgo {{test.svg}} -o -`
 
-- Optimize a file making sure a given plugin is enabled:
-
-`svgo --enable={{plugin_name}}`
-
 - Show available plugins:
 
 `svgo --show-plugins`


### PR DESCRIPTION
The `--enable` flag was removed in SVGO 2.0. For now, the only way to enable optional plugins is via config. Setting up a config file is out of scope for tldr so I'm just removing the deprecated flag in this PR.

See: https://github.com/svg/svgo/releases/tag/v2.0.0



- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
