### PR TITLE
resize2fs: remove false statement

### DIFF
--- a/pages/linux/resize2fs.md
+++ b/pages/linux/resize2fs.md
@@ -1,7 +1,7 @@
 # resize2fs
 
 > Resize an ext2, ext3 or ext4 filesystem.
-> Does not resize the underlying partition, and the filesystem must be unmounted.
+> Does not resize the underlying partition.
 
 - Automatically resize a filesystem:
 

--- a/pages/linux/resize2fs.md
+++ b/pages/linux/resize2fs.md
@@ -1,7 +1,7 @@
 # resize2fs
 
 > Resize an ext2, ext3 or ext4 filesystem.
-> Does not resize the underlying partition.
+> Does not resize the underlying partition. The filesystem may have to be unmounted first, read the man page for more details.
 
 - Automatically resize a filesystem:
 


### PR DESCRIPTION
The statement `the filesystem must be unmounted` is not true: according to `man 8 resize2fs`:

>  It can be used to enlarge or shrink an unmounted file system located on device.
>  If the filesystem is mounted, it can be used to expand the size of the mounted
>  filesystem, assuming the  kernel and  the file system supports on-line
>  resizing.

Another option is to fix the statement to explain that the filesystem must be
unmounted only in some cases. However, the guideline states that `tldr` is not
meant as a substitute for `man`. Also, I find it difficult to express this
explanation more tersely than the man page, but I suppose the entire explanation
is too long to be included into a `tldr` page. So I suggest to just remove it completely.

If users assume that the filesystem can be mounted when it actually has to be
unmounted, nothing catastrophic is going to happen, they will just see a
warning:

> Filesystem at /dev/sdj1 is mounted on /mnt/usb; on-line resizing required
> resize2fs: On-line shrinking not supported

On the other hand, it's less than ideal if users falsely assume that the filesystem must be
unmounted. For example, they might temporarily shut down various services that
access the filesystem only to unmount it, resulting in a downtime even though
it's not necessary.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
