### PR TITLE
acyclic, bcomps, ccomps, edgepaint, gvcolor, gvpack, mingle, nop, sccmap, unflatten: add page

### DIFF
--- a/pages/common/acyclic.md
+++ b/pages/common/acyclic.md
@@ -1,0 +1,17 @@
+# acyclic
+
+> Make a directed graph acyclic by reversing some edges.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/acyclic.1.pdf>.
+
+- Make a directed graph acyclic by reversing some edges:
+
+`acyclic {{path/to/input.gv}} > {{path/to/output.gv}}`
+
+- Print if a graph is acyclic, has a cycle, or is undirected, producing no output graph:
+
+`acyclic -v -n {{path/to/input.gv}}`
+
+- Display help:
+
+`acyclic -?`

--- a/pages/common/acyclic.md
+++ b/pages/common/acyclic.md
@@ -12,6 +12,6 @@
 
 `acyclic -v -n {{path/to/input.gv}}`
 
-- Display help:
+- Display help for `acyclic`:
 
 `acyclic -?`

--- a/pages/common/bcomps.md
+++ b/pages/common/bcomps.md
@@ -8,7 +8,7 @@
 
 `bcomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Print the number of blocks and cutvertice in one or more graphs:
+- Print the number of blocks and cutvertices in one or more graphs:
 
 `bcomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 

--- a/pages/common/bcomps.md
+++ b/pages/common/bcomps.md
@@ -1,21 +1,21 @@
 # bcomps
 
-> Discompose graphs into their biconnected components.
+> Decompose graphs into their biconnected components.
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/bcomps.1.pdf>.
 
-- Discompose graphs into their biconnected components:
+- Decompose graphs into their biconnected components:
 
-`bcomps {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`bcomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Print the number of blocks and cutvertice, producing no output graph:
+- Print the number of blocks and cutvertice in one or more graphs:
 
-`bcomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+`bcomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
-- Write each block and block-cutvertex tree to numbered filenames based on `output.gv`:
+- Write each block and block-cutvertex tree to multiple numbered filenames based on `output.gv`:
 
-`bcomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv}}`
+`bcomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
-- Display help:
+- Display help for `bcomps`:
 
 `bcomps -?`

--- a/pages/common/bcomps.md
+++ b/pages/common/bcomps.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/bcomps.1.pdf>.
 
-- Decompose graphs into their biconnected components:
+- Decompose one or more graphs into their biconnected components:
 
 `bcomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/bcomps.md
+++ b/pages/common/bcomps.md
@@ -1,0 +1,21 @@
+# bcomps
+
+> Discompose graphs into their biconnected components.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/bcomps.1.pdf>.
+
+- Discompose graphs into their biconnected components:
+
+`bcomps {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Print the number of blocks and cutvertice, producing no output graph:
+
+`bcomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+
+- Write each block and block-cutvertex tree to numbered filenames based on `output.gv`:
+
+`bcomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv}}`
+
+- Display help:
+
+`bcomps -?`

--- a/pages/common/ccomps.md
+++ b/pages/common/ccomps.md
@@ -1,21 +1,22 @@
 # ccomps
 
-> Discompose graphs into their connected components.
+> Decompose graphs into their connected components.
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/ccomps.1.pdf>.
 
-- Discompose graphs into their connected components:
+- Decompose graphs into their connected components:
 
-`ccomps {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`ccomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Print counts of nodes, edges, and connected components, producing no output graph:
+- Print the number of nodes, edges, and connected components in one or
+  more graphs:
 
-`ccomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+`ccomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
 - Write each connected component to numbered filenames based on `output.gv`:
 
-`ccomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv}}`
+`ccomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
-- Display help:
+- Display help for `ccomps`:
 
 `ccomps -?`

--- a/pages/common/ccomps.md
+++ b/pages/common/ccomps.md
@@ -8,8 +8,7 @@
 
 `ccomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Print the number of nodes, edges, and connected components in one or
-  more graphs:
+- Print the number of nodes, edges, and connected components in one or more graphs:
 
 `ccomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 

--- a/pages/common/ccomps.md
+++ b/pages/common/ccomps.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/ccomps.1.pdf>.
 
-- Decompose graphs into their connected components:
+- Decompose one or more graphs into their connected components:
 
 `ccomps {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/ccomps.md
+++ b/pages/common/ccomps.md
@@ -1,0 +1,21 @@
+# ccomps
+
+> Discompose graphs into their connected components.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/ccomps.1.pdf>.
+
+- Discompose graphs into their connected components:
+
+`ccomps {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Print counts of nodes, edges, and connected components, producing no output graph:
+
+`ccomps -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+
+- Write each connected component to numbered filenames based on `output.gv`:
+
+`ccomps -x -o {{path/to/output.gv}} {{path/to/input1.gv}} {{path/to/input2.gv}}`
+
+- Display help:
+
+`ccomps -?`

--- a/pages/common/edgepaint.md
+++ b/pages/common/edgepaint.md
@@ -12,7 +12,7 @@
 
 `edgepaint -color-scheme={{accent7}} {{path/to/layout.gv}} > {{path/to/output.gv}}`
 
-- Perform layout, colorization, and output to a picture with one command:
+- Lay out a graph and colorize its edges, then convert to a PNG image:
 
 `dot {{path/to/input.gv}} | edgepaint | dot -T {{png}} > {{path/to/output.png}}`
 

--- a/pages/common/edgepaint.md
+++ b/pages/common/edgepaint.md
@@ -1,14 +1,14 @@
 # edgepaint
 
-> Colorize edges of a graph layout (that already has layout information) to clarify crossing edges.
+> Colorize edges of a graph layout to clarify crossing edges.
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/edgepaint.1.pdf>.
 
 - Colorize edges of a graph layout (that already has layout information) to clarify crossing edges:
 
-`edgepaint {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`edgepaint {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
-- Colorize edges using a color scheme (See <https://graphviz.org/doc/info/colors.html#brewer>.):
+- Colorize edges using a color scheme. (See <https://graphviz.org/doc/info/colors.html#brewer>):
 
 `edgepaint -color-scheme={{accent7}} {{path/to/layout.gv}} > {{path/to/output.gv}}`
 
@@ -16,6 +16,6 @@
 
 `dot {{path/to/input.gv}} | edgepaint | dot -T {{png}} > {{path/to/output.png}}`
 
-- Display help:
+- Display help for `edgepaint`:
 
 `edgepaint -?`

--- a/pages/common/edgepaint.md
+++ b/pages/common/edgepaint.md
@@ -1,0 +1,21 @@
+# edgepaint
+
+> Colorize edges of a graph layout (that already has layout information) to clarify crossing edges.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/edgepaint.1.pdf>.
+
+- Colorize edges of a graph layout (that already has layout information) to clarify crossing edges:
+
+`edgepaint {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Colorize edges using a color scheme (See <https://graphviz.org/doc/info/colors.html#brewer>.):
+
+`edgepaint -color-scheme={{accent7}} {{path/to/layout.gv}} > {{path/to/output.gv}}`
+
+- Perform layout, colorization, and output to a picture with one command:
+
+`dot {{path/to/input.gv}} | edgepaint | dot -T {{png}} > {{path/to/output.png}}`
+
+- Display help:
+
+`edgepaint -?`

--- a/pages/common/edgepaint.md
+++ b/pages/common/edgepaint.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/edgepaint.1.pdf>.
 
-- Colorize edges of a graph layout (that already has layout information) to clarify crossing edges:
+- Colorize edges of one or more graph layouts (that already have layout information) to clarify crossing edges:
 
 `edgepaint {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/gvcolor.md
+++ b/pages/common/gvcolor.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/gvcolor.1.pdf>.
 
-- Colorize a ranked digraph (that was already processed by `dot`):
+- Colorize one or more ranked digraph (that were already processed by `dot`):
 
 `gvcolor {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/gvcolor.md
+++ b/pages/common/gvcolor.md
@@ -1,0 +1,17 @@
+# gvcolor
+
+> Flow colors through a ranked digraph (that was already processed by `dot`).
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/gvcolor.1.pdf>.
+
+- Flow colors through a ranked digraph (that was already processed by `dot`):
+
+`gvcolor {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Perform layout, colorization, and output to a picture with one command:
+
+`dot {{path/to/input.gv}} | gvcolor | dot -T {{png}} > {{path/to/output.png}}`
+
+- Display help:
+
+`gvcolor -?`

--- a/pages/common/gvcolor.md
+++ b/pages/common/gvcolor.md
@@ -1,17 +1,17 @@
 # gvcolor
 
-> Flow colors through a ranked digraph (that was already processed by `dot`).
+> Colorize a ranked digraph with a range of colors.
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://graphviz.org/pdf/gvcolor.1.pdf>.
 
-- Flow colors through a ranked digraph (that was already processed by `dot`):
+- Colorize a ranked digraph (that was already processed by `dot`):
 
-`gvcolor {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`gvcolor {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
-- Perform layout, colorization, and output to a picture with one command:
+- Perform layout and colorization steps, then convert to a PNG image:
 
 `dot {{path/to/input.gv}} | gvcolor | dot -T {{png}} > {{path/to/output.png}}`
 
-- Display help:
+- Display help for `gvcolor`:
 
 `gvcolor -?`

--- a/pages/common/gvcolor.md
+++ b/pages/common/gvcolor.md
@@ -8,7 +8,7 @@
 
 `gvcolor {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
-- Perform layout and colorization steps, then convert to a PNG image:
+- Lay out a graph and colorize it, then convert to a PNG image:
 
 `dot {{path/to/input.gv}} | gvcolor | dot -T {{png}} > {{path/to/output.png}}`
 

--- a/pages/common/gvpack.md
+++ b/pages/common/gvpack.md
@@ -1,0 +1,25 @@
+# gvpack
+
+> Combine several graph layouts (that already have layout information).
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://graphviz.org/pdf/gvpack.1.pdf>.
+
+- Combine several graph layouts (that already have layout information):
+
+`gvpack {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Combine several graph layouts at the graph level, keeping graphs separate:
+
+`gvpack -g {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Combine several graph layouts at the node level, ignoring clusters:
+
+`gvpack -n {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Combine several graph layouts without packing:
+
+`gvpack -u {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Display help:
+
+`gvpack -?`

--- a/pages/common/gvpack.md
+++ b/pages/common/gvpack.md
@@ -6,20 +6,20 @@
 
 - Combine several graph layouts (that already have layout information):
 
-`gvpack {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`gvpack {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
 - Combine several graph layouts at the graph level, keeping graphs separate:
 
-`gvpack -g {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`gvpack -g {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
 - Combine several graph layouts at the node level, ignoring clusters:
 
-`gvpack -n {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`gvpack -n {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
 - Combine several graph layouts without packing:
 
-`gvpack -u {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`gvpack -u {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
-- Display help:
+- Display help for `gvpack`:
 
 `gvpack -?`

--- a/pages/common/mingle.md
+++ b/pages/common/mingle.md
@@ -6,12 +6,12 @@
 
 - Bundle the edges of a graph layout (that already has layout information):
 
-`mingle {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+`mingle {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 
 - Perform layout, bundling, and output to a picture with one command:
 
 `dot {{path/to/input.gv}} | mingle | dot -T {{png}} > {{path/to/output.png}}`
 
-- Display help:
+- Display help for `mingle`:
 
 `mingle -?`

--- a/pages/common/mingle.md
+++ b/pages/common/mingle.md
@@ -1,0 +1,17 @@
+# mingle
+
+> Bundle the edges of a graph layout (that already has layout information).
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://www.graphviz.org/pdf/mingle.1.pdf>.
+
+- Bundle the edges of a graph layout (that already has layout information):
+
+`mingle {{path/to/layout1.gv}} {{path/to/layout2.gv}} > {{path/to/output.gv}}`
+
+- Perform layout, bundling, and output to a picture with one command:
+
+`dot {{path/to/input.gv}} | mingle | dot -T {{png}} > {{path/to/output.png}}`
+
+- Display help:
+
+`mingle -?`

--- a/pages/common/mingle.md
+++ b/pages/common/mingle.md
@@ -1,10 +1,10 @@
 # mingle
 
-> Bundle the edges of a graph layout (that already has layout information).
+> Bundle the edges of a graph layout.
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/mingle.1.pdf>.
 
-- Bundle the edges of a graph layout (that already has layout information):
+- Bundle the edges of one or more graph layouts (that already have layout information):
 
 `mingle {{path/to/layout1.gv}} {{path/to/layout2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/nop.md
+++ b/pages/common/nop.md
@@ -8,7 +8,7 @@
 
 `nop {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Check the graph for validity, producing no output graph:
+- Check one or more graphs for validity, producing no output graph:
 
 `nop -p {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 

--- a/pages/common/nop.md
+++ b/pages/common/nop.md
@@ -6,12 +6,12 @@
 
 - Pretty-print graphs in canonical format:
 
-`nop {{path/to/input2.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`nop {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
 - Check the graph for validity, producing no output graph:
 
-`nop -p {{path/to/input2.gv}} {{path/to/input2.gv}}`
+`nop -p {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
-- Display help:
+- Display help for `nop`:
 
 `nop -?`

--- a/pages/common/nop.md
+++ b/pages/common/nop.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/nop.1.pdf>.
 
-- Pretty-print graphs in canonical format:
+- Pretty-print one or more graphs in canonical format:
 
 `nop {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/nop.md
+++ b/pages/common/nop.md
@@ -1,0 +1,17 @@
+# nop
+
+> Check validity and pretty-print graphs in canonical format.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://www.graphviz.org/pdf/nop.1.pdf>.
+
+- Pretty-print graphs in canonical format:
+
+`nop {{path/to/input2.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Check the graph for validity, producing no output graph:
+
+`nop -p {{path/to/input2.gv}} {{path/to/input2.gv}}`
+
+- Display help:
+
+`nop -?`

--- a/pages/common/sccmap.md
+++ b/pages/common/sccmap.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/sccmap.1.pdf>.
 
-- Extract strongly connected components of directed graphs, printing no statistics:
+- Extract strongly connected components of one or more directed graphs:
 
 `sccmap -S {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/sccmap.md
+++ b/pages/common/sccmap.md
@@ -6,12 +6,12 @@
 
 - Extract strongly connected components of directed graphs, printing no statistics:
 
-`sccmap -S {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`sccmap -S {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Print statistics about the graph, producing no output graph:
+- Print statistics about a graph, producing no output graph:
 
-`sccmap -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+`sccmap -v -s {{path/to/input1.gv}} {{path/to/input2.gv ...}}`
 
-- Display help:
+- Display help for `sccmap`:
 
 `sccmap -?`

--- a/pages/common/sccmap.md
+++ b/pages/common/sccmap.md
@@ -1,0 +1,17 @@
+# sccmap
+
+> Extract strongly connected components of directed graphs.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://www.graphviz.org/pdf/sccmap.1.pdf>.
+
+- Extract strongly connected components of directed graphs, printing no statistics:
+
+`sccmap -S {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Print statistics about the graph, producing no output graph:
+
+`sccmap -v -s {{path/to/input1.gv}} {{path/to/input2.gv}}`
+
+- Display help:
+
+`sccmap -?`

--- a/pages/common/tred.md
+++ b/pages/common/tred.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/tred.1.pdf>.
 
-- Generate the transitive reduction of directed graphs:
+- Generate the transitive reduction of one or more directed graphs:
 
 `tred {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/tred.md
+++ b/pages/common/tred.md
@@ -1,0 +1,13 @@
+# tred
+
+> Compute the transitive reduction of directed graphs.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://www.graphviz.org/pdf/tred.1.pdf>.
+
+- Compute the transitive reduction of directed graphs:
+
+`tred {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Display help:
+
+`tred -?`

--- a/pages/common/tred.md
+++ b/pages/common/tred.md
@@ -4,9 +4,9 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/tred.1.pdf>.
 
-- Compute the transitive reduction of directed graphs:
+- Generate the transitive reduction of directed graphs:
 
-`tred {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`tred {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
 - Display help:
 

--- a/pages/common/tred.md
+++ b/pages/common/tred.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/tred.1.pdf>.
 
-- Generate the transitive reduction of one or more directed graphs:
+- Construct the transitive reduction graph of one or more directed graphs:
 
 `tred {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/unflatten.md
+++ b/pages/common/unflatten.md
@@ -4,7 +4,7 @@
 > Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
 > More information: <https://www.graphviz.org/pdf/unflatten.1.pdf>.
 
-- Adjust directed graphs to improve the layout aspect ratio:
+- Adjust one or more directed graphs to improve the layout aspect ratio:
 
 `unflatten {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 

--- a/pages/common/unflatten.md
+++ b/pages/common/unflatten.md
@@ -1,0 +1,17 @@
+# unflatten
+
+> Adjust directed graphs to improve the layout aspect ratio.
+> Graphviz filters: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> More information: <https://www.graphviz.org/pdf/unflatten.1.pdf>.
+
+- Adjust directed graphs to improve the layout aspect ratio:
+
+`unflatten {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+
+- Use `unflatten` as a preprocessor for `dot` layout:
+
+`unflatten {{path/to/input.gv}} | dot -T {{png}} {{path/to/output.png}}`
+
+- Display help:
+
+`unflatten -?`

--- a/pages/common/unflatten.md
+++ b/pages/common/unflatten.md
@@ -6,12 +6,12 @@
 
 - Adjust directed graphs to improve the layout aspect ratio:
 
-`unflatten {{path/to/input1.gv}} {{path/to/input2.gv}} > {{path/to/output.gv}}`
+`unflatten {{path/to/input1.gv}} {{path/to/input2.gv ...}} > {{path/to/output.gv}}`
 
-- Use `unflatten` as a preprocessor for `dot` layout:
+- Use `unflatten` as a preprocessor for `dot` layout to improve aspect ratio:
 
 `unflatten {{path/to/input.gv}} | dot -T {{png}} {{path/to/output.png}}`
 
-- Display help:
+- Display help for `unflatten`:
 
 `unflatten -?`


### PR DESCRIPTION
Please see issue #2580.

This PR adds the `graphviz` filter commands: `acyclic`, `bcomps`,
`ccomps`, `edgepaint` (aka `clarify`), `gvcolor` (aka `colorize`),
`gvpack`, `mingle`, `nop`, `sccmap`, `tred`, and `unflatten`. These
commands all accept a graph in gv/dot format, transform it in some way
and output another graph in the same format.

Several of these filters require that the input graph be previously processed by `dot` or another layout engine (without using the -T option) to produce a text `layout.gv` file that includes layout information.

The multiple entries in this PR are substantially similar and were originally generated using `autogen` before manual editing to add unique flags and parameters.

Each filter command's entry includes a list of all Graphviz filters as there is otherwise no easy way for the user to learn the available filters in the package. I suggest that I modify the previously accepted sets of Graphviz layout commands and Graphviz convertor commands to include the word "Graphviz" like this set, instead of just "Layouts" and "Convertors".

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
