### PR TITLE
ldapdomaindump: add page

### DIFF
--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -1,6 +1,6 @@
 # ldapdomaindump
 
-> Dumps users, computers, groups, OS and membership information via LDAP to HTML, JSON and greppable output.
+> Dump users, computers, groups, OS and membership information via LDAP to HTML, JSON and greppable output.
 > See also `ldapsearch`.
 > More information: <https://github.com/dirkjanm/ldapdomaindump>.
 

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -6,7 +6,7 @@
 
 - Dump all information using the given LDAP account:
 
-`ldapdomaindump --user {{domain}}\\{{administrator}} --password {{password|NTLM_hash}} {{hostname|ip}}`
+`ldapdomaindump --user {{domain}}\\{{administrator}} --password {{password|ntlm_hash}} {{hostname|ip}}`
 
 - Dump all information, resolving computer hostnames:
 

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -1,0 +1,20 @@
+# ldapdomaindump
+
+> Dumps users/computers/groups and OS/membership information via LDAP to HTML/JSON/greppable output.
+> More information: <https://github.com/dirkjanm/ldapdomaindump>.
+
+- Dump all information using the given LDAP account:
+
+`ldapdomaindump --user {{domain\\administrator}} --password {{password|NTLM_hash}} {{hostname|ip}}`
+
+- Dump all information, resolving computer hostnames:
+
+`ldapdomaindump --resolve --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`
+
+- Dump all information, resolving computer hostnames with the selected DNS server:
+
+`ldapdomaindump --resolve --dns-server {{domain_controller_ip}} --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`
+
+- Dump all information to the given directory without JSON output:
+
+`ldapdomaindump --no-json --outdir {{output/path}} --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -9,7 +9,7 @@
 
 - Dump all information, resolving computer hostnames:
 
-`ldapdomaindump --resolve --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`
+`ldapdomaindump --resolve --user {{domain}}\\{{administrator}} --password {{password}} {{hostname|ip}}`
 
 - Dump all information, resolving computer hostnames with the selected DNS server:
 

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -17,4 +17,4 @@
 
 - Dump all information to the given directory without JSON output:
 
-`ldapdomaindump --no-json --outdir {{output/path}} --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`
+`ldapdomaindump --no-json --outdir {{path/to/directory}} --user {{domain}}\\{{administrator}} --password {{password}} {{hostname|ip}}`

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -5,7 +5,7 @@
 
 - Dump all information using the given LDAP account:
 
-`ldapdomaindump --user {{domain\\administrator}} --password {{password|NTLM_hash}} {{hostname|ip}}`
+`ldapdomaindump --user {{domain}}\\{{administrator}} --password {{password|NTLM_hash}} {{hostname|ip}}`
 
 - Dump all information, resolving computer hostnames:
 

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -1,6 +1,6 @@
 # ldapdomaindump
 
-> Dumps users/computers/groups and OS/membership information via LDAP to HTML/JSON/greppable output.
+> Dumps users, computers, groups, OS and membership information via LDAP to HTML, JSON and greppable output.
 > More information: <https://github.com/dirkjanm/ldapdomaindump>.
 
 - Dump all information using the given LDAP account:

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -13,7 +13,7 @@
 
 - Dump all information, resolving computer hostnames with the selected DNS server:
 
-`ldapdomaindump --resolve --dns-server {{domain_controller_ip}} --user {{domain\\administrator}} --password {{password}} {{hostname|ip}}`
+`ldapdomaindump --resolve --dns-server {{domain_controller_ip}} --user {{domain}}\\{{administrator}} --password {{password}} {{hostname|ip}}`
 
 - Dump all information to the given directory without JSON output:
 

--- a/pages/linux/ldapdomaindump.md
+++ b/pages/linux/ldapdomaindump.md
@@ -1,6 +1,7 @@
 # ldapdomaindump
 
 > Dumps users, computers, groups, OS and membership information via LDAP to HTML, JSON and greppable output.
+> See also `ldapsearch`.
 > More information: <https://github.com/dirkjanm/ldapdomaindump>.
 
 - Dump all information using the given LDAP account:


### PR DESCRIPTION
- [X] The page (if new), does not already exist in the repository.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
