### PR TITLE
grep: remove token markup around without-match

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -13,7 +13,7 @@
 
 - Search for a pattern in all files recursively in a directory, showing line numbers of matches, ignoring binary files:
 
-`grep --recursive --line-number --binary-files={{without-match}} "{{search_pattern}}" {{path/to/directory}}`
+`grep --recursive --line-number --binary-files=without-match "{{search_pattern}}" {{path/to/directory}}`
 
 - Use extended regular expressions (supports `?`, `+`, `{}`, `()` and `|`), in case-insensitive mode:
 


### PR DESCRIPTION
Hi,

On the grep page, the `without-match` in `--binary-files=without-match` is not a user-provided token.

Cheers!