### PR TITLE
fgrep: remove incorrect use of 'regular expression'

### DIFF
--- a/pages/common/fgrep.md
+++ b/pages/common/fgrep.md
@@ -1,7 +1,6 @@
 # fgrep
 
-> Matches patterns in files.
-> Supports simple patterns and regular expressions.
+> Matches fixed strings in files.
 > More information: <https://manned.org/fgrep>.
 
 - Search for an exact string in a file:
@@ -20,10 +19,10 @@
 
 `fgrep -n {{search_string}} {{path/to/file}}`
 
-- Display all lines except those that contain the given regular expression:
+- Display all lines except those that contain the search string:
 
-`fgrep -v {{regular_expression}} {{path/to/file}}`
+`fgrep -v {{search_string}} {{path/to/file}}`
 
-- Display filenames whose content matches the regular expression at least once:
+- Display filenames whose content matches the search string at least once:
 
-`fgrep -l {{regular_expression}} {{path/to/file1}} {{path/to/file2}}`
+`fgrep -l {{search_string}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/fgrep.md
+++ b/pages/common/fgrep.md
@@ -1,6 +1,7 @@
 # fgrep
 
 > Matches fixed strings in files.
+> Equivalent to `grep -F`.
 > More information: <https://www.gnu.org/software/grep/manual/grep.html>.
 
 - Search for an exact string in a file:

--- a/pages/common/fgrep.md
+++ b/pages/common/fgrep.md
@@ -1,7 +1,7 @@
 # fgrep
 
 > Matches fixed strings in files.
-> More information: <https://manned.org/fgrep>.
+> More information: <https://www.gnu.org/software/grep/manual/grep.html>.
 
 - Search for an exact string in a file:
 


### PR DESCRIPTION
The language used before was misleading, since fgrep specifically does
not match regular expressions nor patterns. The man page reads:

> -F, --fixed-strings
>       Interpret PATTERNS as fixed strings, not regular expressions.

---

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).
