### PR TITLE
mvn: simplify skip unit tests

### DIFF
--- a/pages.pt_BR/common/mvn.md
+++ b/pages.pt_BR/common/mvn.md
@@ -13,7 +13,7 @@
 
 - Criar um artefato de distribuição sem executar testes unitários:
 
-`mvn package -Dmaven.test.skip=true`
+`mvn package -DskipTests`
 
 - Instalar um artefato gerado em um repositório local:
 

--- a/pages.zh/common/mvn.md
+++ b/pages.zh/common/mvn.md
@@ -14,7 +14,7 @@
 
 - 编译和打包，跳过单元测试：
 
-`mvn package -skipTests`
+`mvn package -DskipTests`
 
 - 在本地 maven 存储库中安装构建的包（这也会调用 compile 和 package 命令）：
 

--- a/pages.zh/common/mvn.md
+++ b/pages.zh/common/mvn.md
@@ -14,7 +14,7 @@
 
 - 编译和打包，跳过单元测试：
 
-`mvn package -Dmaven.test.skip=true`
+`mvn package -skipTests`
 
 - 在本地 maven 存储库中安装构建的包（这也会调用 compile 和 package 命令）：
 

--- a/pages/common/mvn.md
+++ b/pages/common/mvn.md
@@ -14,7 +14,7 @@
 
 - Compile and package, skipping unit tests:
 
-`mvn package -Dmaven.test.skip=true`
+`mvn package -DskipTests`
 
 - Install the built package in local maven repository. (This will invoke the compile and package commands too):
 


### PR DESCRIPTION
Started with @hboutemy, @fbiville and @lydianeU during a [Paris Hackergarten session](https://www.meetup.com/Paris-Hackergarten/events/279653683/): `-Dmaven.test.skip` is simpler and correct.

Continued on myself, favoring `-DskipTests` (it compiles tests):

http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html#:

	You can also skip the tests via the command line by executing the following command:

	mvn install -DskipTests
	If you absolutely must, you can also use the maven.test.skip property to skip compiling the tests. maven.test.skip is honored by Surefire, Failsafe and the Compiler Plugin.

	mvn install -Dmaven.test.skip=true

http://maven.apache.org/surefire/maven-failsafe-plugin/verify-mojo.html:

	<skipTests>	boolean	2.4	Set this to 'true' to skip running tests, but still compile them. Its use is NOT RECOMMENDED, but quite convenient on occasion.
	User property is: skipTests.

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
