### PR TITLE
xcopy: add Indonesian translation

### DIFF
--- a/pages.id/windows/xcopy.md
+++ b/pages.id/windows/xcopy.md
@@ -1,0 +1,36 @@
+# xcopy
+
+> Membuat salinan file dan direktori.
+> Informasi lebih lanjut: <https://docs.microsoft.com/windows-server/administration/windows-commands/xcopy>.
+
+- Membuat salinan file atau direktori ke lokasi lain:
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}}`
+
+- Melihat daftar file yang akan disalin sebelum proses salinan dimulai:
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /p`
+
+- Membuat salinan struktur direktori saja (tanpa file di dalamnya):
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /t`
+
+- Membuat salinan direktori termasuk direktori-direktori kosong (tanpa file):
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /e`
+
+- Membuat salinan file atau direktori dengan daftar hak akses pengguna (ACL) yang sama:
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /o`
+
+- Mempersilakan proses penyalinan file atau direktori saat koneksi jaringan komputer terputus:
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /z`
+
+- Mempersilakan `xcopy` untuk tetap mengganti file yang sudah ada di lokasi tujuan dengan file yang berada di lokasi sumber:
+
+`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /y`
+
+- Menampilkan cara penggunaan secara lengkap:
+
+`xcopy /?`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Here's my translation for `windows/xcopy`, with some notes:
+ I closely follow `common/cp`'s translation style for consistency, and
+ The translation for `xcopy {{path/to/file_or_directory}} {{path/to/destination}} /y` is quite different than the ones in English, which in this case means "allows `xcopy` to keep override/overwrite existing files" instead of disabling the overwrite prompt.