### PR TITLE
ssh: fix typo in German translation

### DIFF
--- a/pages.de/common/ssh.md
+++ b/pages.de/common/ssh.md
@@ -31,6 +31,6 @@
 
 `ssh -J {{benutzer@sring_server}} {{benutzer}}@{{externer_server}}`
 
-- Agenten Weiterleitung: Leite ie eigenen Authentifizierungs-Information an den externen Server weiter (siehe `man ssh_config` für mehr Optionen):
+- Agenten Weiterleitung: Leite die eigenen Authentifizierungs-Information an den externen Server weiter (siehe `man ssh_config` für mehr Optionen):
 
 `ssh -A {{benutzer}}@{{externer_server}}`


### PR DESCRIPTION
Fixed a typo in the German translation. Let me know if I got the commit message right. :)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).