### PR TITLE
Reorganize translation templates

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -1,3 +1,4 @@
+
 # Alias pages
 
 In order to document a command which is an alias of another command, you can
@@ -24,6 +25,7 @@ The templates can be changed when necessary.
 [pl](#pl) •
 [pt_BR](#pt_br) •
 [pt_PT](#pt_pt) •
+[ro](#ro) •
 [ru](#ru) •
 [sh](#sh) •
 [sv](#sv) •
@@ -224,6 +226,11 @@ Not translated yet.
 
 ---
 ### pt_PT
+
+Not translated yet.
+
+---
+### ro
 
 Not translated yet.
 

--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -1,4 +1,3 @@
-
 # Alias pages
 
 In order to document a command which is an alias of another command, you can

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -1,0 +1,183 @@
+
+# Mentioning sub-commands
+
+When a command has a sub-command, which can't be covered in the original page, it get's its own page.
+An example for this is `git` and it's sub-command pages like `git-commit`, `git-push`, etc.
+In order to notify the user that such sub-command pages exist, we put a little notice in the base command's description.
+This file contains the translation templates of this notice.
+
+[en](#en) •
+[bs](#bs) •
+[da](#da) •
+[de](#de) •
+[es](#es) •
+[fa](#fa) •
+[fr](#fr) •
+[hi](#hi) •
+[id](#id) •
+[it](#it) •
+[ja](#ja) •
+[ko](#ko) •
+[ml](#ml) •
+[nl](#nl) •
+[no](#no) •
+[pl](#pl) •
+[pt_BR](#pt_br) •
+[pt_PT](#pt_pt) •
+[ro](#ro) •
+[ru](#ru) •
+[sh](#sh) •
+[sv](#sv) •
+[ta](#ta) •
+[th](#th) •
+[tr](#tr) •
+[zh](#zh) •
+[zh_TW](#zh_tw)
+
+---
+### en
+
+```markdown
+Some subcommands such as `example command` have their own usage documentation.
+```
+
+---
+### bs
+
+Not translated yet
+
+---
+### da
+
+Not translated yet.
+
+---
+### de
+
+```markdown
+Manche Unterbefehle wie `example command` sind separat dokumentiert.
+```
+
+---
+### es
+
+```markdown
+Este comando también tiene documentación sobre sus subcomandos, ejemplo `example command`.
+```
+
+---
+### fa
+
+Not translated yet.
+
+---
+### fr
+
+Not translated yet.
+
+---
+### hi
+
+Not translated yet.
+
+---
+### id
+
+```markdown
+Kami mempunyai dokumentasi terpisah untuk menggunakan subperintah seperti `example command`.
+```
+
+---
+### it
+
+Not translated yet.
+
+---
+### ja
+
+Not translated yet.
+
+---
+### ko
+
+Not translated yet.
+
+---
+### ml
+
+Not translated yet.
+
+---
+### nl
+
+Not translated yet.
+
+---
+### no
+
+Not translated yet.
+
+---
+### pl
+
+Not translated yet.
+
+---
+### pt_BR
+
+Not translated yet.
+
+---
+### pt_PT
+
+Not translated yet.
+
+---
+### ro
+
+Not translated yet.
+
+---
+### ru
+
+Not translated yet.
+
+---
+### sh
+
+Not translated yet.
+
+---
+### sv
+
+Not translated yet.
+
+
+---
+### ta
+
+Not translated yet.
+
+---
+### th
+
+Not translated yet.
+
+---
+### tr
+
+Not translated yet.
+
+---
+### zh
+
+```markdown
+此命令也有关于其子命令的文件，例如：`example command`.
+```
+
+---
+### zh_TW
+
+```markdown
+此命令也有關於其子命令的文件，例如：`example command`.
+```

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -1,4 +1,3 @@
-
 # Mentioning sub-commands
 
 When a command has a sub-command, which can't be covered in the original page, it get's its own page.


### PR DESCRIPTION
Since we're now getting more of those templates we can't just dump them all into `contributing-guides`. I created a directory `contributing-guides/translation-templates`, where we can have one file per template. There was also the idea to put everything into a single file, but that's still open for discussion. Personally I think that would get messy after some time.