### PR TITLE
pages/common/*.md: REPL Normalization

### DIFF
--- a/pages/common/cake.md
+++ b/pages/common/cake.md
@@ -31,6 +31,6 @@
 
 `cake server`
 
-- Start a REPL interactive shell instance:
+- Start a REPL (interactive shell):
 
 `cake console`

--- a/pages/common/clj.md
+++ b/pages/common/clj.md
@@ -4,7 +4,7 @@
 > All options can be defined in a `deps.edn` file.
 > More information: <https://clojure.org/guides/deps_and_cli>.
 
-- Start a REPL:
+- Start a REPL (interactive shell):
 
 `clj`
 

--- a/pages/common/coffee.md
+++ b/pages/common/coffee.md
@@ -15,7 +15,7 @@
 
 `coffee --compile {{path/to/file.coffee}} --output {{path/to/file.js}}`
 
-- Run interactive REPL:
+- Start a REPL (interactive shell):
 
 `coffee --interactive`
 

--- a/pages/common/ghc.md
+++ b/pages/common/ghc.md
@@ -20,7 +20,7 @@
 
 `ghc -c {{file.hs}}`
 
-- Run Haskell interactive interpreter (REPL):
+- Start a REPL (interactive shell):
 
 `ghci`
 

--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -3,7 +3,7 @@
 > Guile Scheme interpreter.
 > More information: <https://www.gnu.org/software/guile>.
 
-- Start the Guile Scheme REPL:
+- Start a REPL (interactive shell):
 
 `guile`
 

--- a/pages/common/ipython.md
+++ b/pages/common/ipython.md
@@ -3,7 +3,7 @@
 > A Python shell with automatic history, dynamic object introspection, easier configuration, command completion, access to the system shell and more.
 > More information: <https://ipython.org/documentation.html>.
 
-- Start an interactive IPython session:
+- Start a REPL (interactive shell):
 
 `ipython`
 

--- a/pages/common/julia.md
+++ b/pages/common/julia.md
@@ -3,7 +3,7 @@
 > A high-level, high-performance dynamic programming language for technical computing.
 > More information: <https://docs.julialang.org/en/v1/manual/getting-started/>.
 
-- Start a Julia REPL session:
+- Start a REPL (interactive shell):
 
 `julia`
 

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -3,7 +3,7 @@
 > Python language interpreter.
 > More information: <https://www.python.org>.
 
-- Call a Python interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `python`
 

--- a/pages/common/r.md
+++ b/pages/common/r.md
@@ -3,7 +3,7 @@
 > R language interpreter.
 > More information: <https://www.r-project.org>.
 
-- Start an R interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `R`
 

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -3,7 +3,7 @@
 > Ruby programming language interpreter.
 > More information: <https://www.ruby-lang.org>.
 
-- Open an Interactive Ruby Shell (REPL):
+- Start a REPL (interactive shell):
 
 `irb`
 

--- a/pages/common/sbcl.md
+++ b/pages/common/sbcl.md
@@ -3,7 +3,7 @@
 > High performance Common Lisp compiler.
 > More information: <http://www.sbcl.org/>.
 
-- Start an SBCL interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `sbcl`
 

--- a/pages/common/sbt.md
+++ b/pages/common/sbt.md
@@ -3,7 +3,7 @@
 > Build tool for Scala and Java projects.
 > More information: <https://www.scala-sbt.org/1.0/docs/>.
 
-- Start the SBT interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `sbt`
 

--- a/pages/common/scala.md
+++ b/pages/common/scala.md
@@ -3,7 +3,7 @@
 > Scala application launcher and interactive interpreter.
 > More information: <https://scala-lang.org>.
 
-- Start a Scala interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `scala`
 

--- a/pages/common/scheme.md
+++ b/pages/common/scheme.md
@@ -3,7 +3,7 @@
 > MIT Scheme language interpreter and REPL (interactive shell).
 > More information: <https://www.gnu.org/software/mit-scheme>.
 
-- Open an interactive shell (REPL):
+- Start a REPL (interactive shell):
 
 `scheme`
 

--- a/pages/common/swift.md
+++ b/pages/common/swift.md
@@ -3,7 +3,7 @@
 > Create, run and build Swift projects.
 > More information: <https://swift.org>.
 
-- Invoke the interactive interpreter (REPL):
+- Start a REPL (interactive shell):
 
 `swift`
 


### PR DESCRIPTION
Normalized almost all references to a REPL to `Start a REPL (interactive shell)`.

I think that it is unacceptable for any serious project to have so many conflicting styles:

- `Start a(n) $LANG interactive shell (REPL)`
- `Run interactive REPL`
- `Start a REPL (interactive shell)`
- `Start a REPL`
- `Start the $LANG REPL`
- `Start a(n) $LANG REPL session`
- `Open an Interactive $LANG Shell (REPL)`
- (maybe more)

You might have cases in this diff, where you think that different descriptions might fit better and that is ok. But most of these should be normalized.