### PR TITLE
clang: add -c example

### DIFF
--- a/pages/common/clang.md
+++ b/pages/common/clang.md
@@ -18,3 +18,7 @@
 - Compile source code into LLVM Intermediate Representation (IR):
 
 `clang -S -emit-llvm {{file.c}} -o {{file.ll}}`
+
+- Compile source code without linking:
+
+`clang -c {{input_source.c}}`


### PR DESCRIPTION
the `gcc` page also has it and it makes sense