### PR TITLE
llvm-gcc: add page

### DIFF
--- a/pages/common/llvm-gcc.md
+++ b/pages/common/llvm-gcc.md
@@ -1,0 +1,7 @@
+# llvm-gcc
+
+> This command is an alias of `clang`.
+
+- View documentation for the original command:
+
+`tldr clang`


### PR DESCRIPTION
alias of `clang`