### PR TITLE
find: add -daystart argument in example

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -29,7 +29,7 @@
 
 - Find files modified in the last 7 days and delete them:
 
-`find {{root_path}} -mtime -{{7}} -delete`
+`find {{root_path}} -daystart -mtime -{{7}} -delete`
 
 - Find empty (0 byte) files and delete them:
 


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Option is wrong. want to display files older than 7 days, should use the `-daystart -mtime -7`  or `-ctime -6`.
for example:
```
$ find . -daystart -mtime -7
.
./test_2021-09-04.log
./test_2021-09-07.log
./test_2021-09-05.log
./test_2021-09-08.log
./test_2021-09-03.log
./test_2021-09-06.log
./test_2021-09-09.log

$ find . -ctime -6
.
./test_2021-09-04.log
./test_2021-09-07.log
./test_2021-09-05.log
./test_2021-09-08.log
./test_2021-09-03.log
./test_2021-09-06.log
./test_2021-09-09.log
```