### PR TITLE
cargo: use long argument --jobs

### DIFF
--- a/pages.de/common/cargo.md
+++ b/pages.de/common/cargo.md
@@ -30,4 +30,4 @@
 
 - Erstelle (bzw. kompiliere) ein Rust-Projekt mit einer bestimmten Anzahl an Threads (standardmäßig die Anzahl der CPU-Kerne):
 
-`cargo build -j {{thread_anzahl}}`
+`cargo build --jobs {{thread_anzahl}}`

--- a/pages.it/common/cargo.md
+++ b/pages.it/common/cargo.md
@@ -30,4 +30,4 @@
 
 - Builda utilizzando più job (thread) paralleli:
 
-`cargo build -j {{numero_job}}`
+`cargo build --jobs {{numero_job}}`

--- a/pages.ko/common/cargo.md
+++ b/pages.ko/common/cargo.md
@@ -30,4 +30,4 @@
 
 - 특정 쓰레드 수를 사용하여 구축(기본값은 CPU 코어 수):
 
-`cargo build -j {{작업}}`
+`cargo build --jobs {{작업}}`

--- a/pages.nl/common/cargo.md
+++ b/pages.nl/common/cargo.md
@@ -30,4 +30,4 @@
 
 - Bouw met een gegeven aantal taken. (Standaard is het aantal CPU-kernen):
 
-`cargo build -j {{taken}}`
+`cargo build --jobs {{aantal_taken}}`

--- a/pages/common/cargo.md
+++ b/pages/common/cargo.md
@@ -30,4 +30,4 @@
 
 - Build using a specific number of threads (default is the number of CPU cores):
 
-`cargo build -j {{jobs}}`
+`cargo build --jobs {{number_of_threads}}`


### PR DESCRIPTION
For information, usage is:

```
$ cargo build --help | grep jobs
    -j, --jobs <N>                   Number of parallel jobs, defaults to # of CPUs
```

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
