### PR TITLE
cargo-clippy: use long arguments

### DIFF
--- a/pages/common/cargo-clippy.md
+++ b/pages/common/cargo-clippy.md
@@ -27,6 +27,6 @@
 
 `cargo clippy -- --allow warnings`
 
-- Apply suggestions automatically:
+- Apply Clippy suggestions automatically:
 
 `cargo clippy --fix`

--- a/pages/common/cargo-clippy.md
+++ b/pages/common/cargo-clippy.md
@@ -21,12 +21,12 @@
 
 - Treat warnings as errors:
 
-`RUSTFLAGS="-Dwarnings" cargo clippy -- -D warnings`
+`cargo clippy -- --deny warnings`
 
 - Run checks and ignore warnings:
 
-`cargo clippy -- -A warnings`
+`cargo clippy -- --allow warnings`
 
 - Apply Clippy suggestion automatically (experimental and only supported on the nightly channel):
 
-`cargo clippy --fix -Z unstable-options`
+`cargo clippy --fix --allow-features unstable-options`

--- a/pages/common/cargo-clippy.md
+++ b/pages/common/cargo-clippy.md
@@ -27,6 +27,6 @@
 
 `cargo clippy -- --allow warnings`
 
-- Apply Clippy suggestion automatically (experimental and only supported on the nightly channel):
+- Apply suggestions automatically:
 
-`cargo clippy --fix --allow-features unstable-options`
+`cargo clippy --fix`


### PR DESCRIPTION
See usage:

```
$ cargo clippy --help | egrep "(--deny|--allow)"
    -A --allow OPT      Set lint allowed
    -D --deny OPT       Set lint denied
```

Also removed experimental feature for `--fix` (see [the doc](https://github.com/rust-lang/rust-clippy#automatically-applying-clippy-suggestions)).

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
