### PR TITLE
man: correct syntax

### DIFF
--- a/pages.it/common/man.md
+++ b/pages.it/common/man.md
@@ -9,7 +9,7 @@
 
 - Mostra la pagina di manuale per un comando dalla sezione 7:
 
-`man {{comando}}.{{7}}`
+`man {{7}} {{comando}}`
 
 - Mostra il percorso in cui vengono cercate le pagine:
 

--- a/pages.pt_BR/common/man.md
+++ b/pages.pt_BR/common/man.md
@@ -9,7 +9,7 @@
 
 - Visualizar a página da seção 7 do manual de um comando:
 
-`man {{comando}}.{{7}}`
+`man {{7}} {{comando}}`
 
 - Visualizar o caminho procurado pelas páginas do manual:
 

--- a/pages.tr/common/man.md
+++ b/pages.tr/common/man.md
@@ -9,7 +9,7 @@
 
 - Sayfanın 7. bölümündeki bir komut için man sayfasını görüntüle:
 
-`man {{komut}}.{{7}}`
+`man {{7}} {{komut}}`
 
 - Mansayfaları için aratılan yolu göster:
 

--- a/pages/common/man.md
+++ b/pages/common/man.md
@@ -9,7 +9,7 @@
 
 - Display the man page for a command from section 7:
 
-`man {{command}}.{{7}}`
+`man {{7}} {{command}}`
 
 - Display the path searched for manpages:
 


### PR DESCRIPTION
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Update the `man` syntax for sections. I have tested the previous syntax `<command>.<section>` on Linux and macOS:
```shell
~ $ man 3 strcmp >/dev/null 2&>1 && echo "Exit status: $?"
Exit status: 0
~ $ man strcmp.3
No manual entry for strcmp.3
~ $ echo "Exit status: $?"
Exit status: 1
```

E: I had a typo in one of my commands. I reran it and updated the results.