### PR TITLE
exec, javac: add more information link

### DIFF
--- a/pages.it/common/exec.md
+++ b/pages.it/common/exec.md
@@ -1,6 +1,7 @@
 # exec
 
 > Sostituisci il processo corrente con un altro.
+> Maggiori informazioni: <https://linuxcommand.org/lc3_man_pages/exech.html>.
 
 - Sostituisci con il comando specificato utilizzando le variabili di ambiente correnti:
 

--- a/pages.ta/common/javac.md
+++ b/pages.ta/common/javac.md
@@ -1,6 +1,7 @@
 # javac
 
 > ஜாவா நிரல்மொழிமாற்றி.
+> மேலும் தகவல்: <https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
 
 - `.java` கோப்பை நிரல்மொழிமாற்ற:
 

--- a/pages.ta/common/javac.md
+++ b/pages.ta/common/javac.md
@@ -1,7 +1,7 @@
 # javac
 
 > ஜாவா நிரல்மொழிமாற்றி.
-> மேலும் தகவல்: <https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
+> மேலும் தகவல்: <https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html>.
 
 - `.java` கோப்பை நிரல்மொழிமாற்ற:
 

--- a/pages.zh/common/javac.md
+++ b/pages.zh/common/javac.md
@@ -1,7 +1,7 @@
 # javac
 
 > Java 程序编译器。
-> 更多信息：<https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
+> 更多信息：<https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html>.
 
 - 编译一个 `.java` 文件：
 

--- a/pages.zh/common/javac.md
+++ b/pages.zh/common/javac.md
@@ -1,6 +1,7 @@
 # javac
 
 > Java 程序编译器。
+> 更多信息：<https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
 
 - 编译一个 `.java` 文件：
 

--- a/pages/common/exec.md
+++ b/pages/common/exec.md
@@ -1,6 +1,7 @@
 # exec
 
 > Replace the current process with another process.
+> More information: <https://linuxcommand.org/lc3_man_pages/exech.html>.
 
 - Replace with the specified command using the current environment variables:
 

--- a/pages/common/javac.md
+++ b/pages/common/javac.md
@@ -1,6 +1,7 @@
 # javac
 
 > Java Application Compiler.
+> More information: <https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
 
 - Compile a `.java` file:
 

--- a/pages/common/javac.md
+++ b/pages/common/javac.md
@@ -1,7 +1,7 @@
 # javac
 
 > Java Application Compiler.
-> More information: <https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html>.
+> More information: <https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html>.
 
 - Compile a `.java` file:
 


### PR DESCRIPTION
issue #6062 

- **exec:** Since `exec` is a shell builtin, https://manned.org/exec.1 ask you to redirect to `bash` man page. However `bash` man page is too massive to find out the usage of `exec`. So I choose https://linuxcommand.org/lc3_man_pages/exech.html.
- **history:** The information link added by #5825 is fine since it's from an official source https://www.gnu.org/software/bash/manual/html_node/Bash-History-Builtins.html. Therefore I didn't change it.
- **javac:** I choose oracle's man page https://docs.oracle.com/en/java/javase/13/docs/specs/man/javac.html.