### PR TITLE
llvm-bcanalyzer: add page

### DIFF
--- a/pages/common/llvm-bcanalyzer.md
+++ b/pages/common/llvm-bcanalyzer.md
@@ -1,0 +1,16 @@
+# llvm-bcanalyzer
+
+> LLVM Bitcode (`.bc`) analyzer.
+> More information: <https://llvm.org/docs/CommandGuide/llvm-bcanalyzer.html>.
+
+- Print statistics on a Bitcode file:
+
+`llvm-bcanalyzer {{path/to/file.bc}}`
+
+- Print an SGML representation of and statistics on a Bitcode file:
+
+`llvm-bcanalyzer -dump {{path/to/file.bc}}`
+
+- Read a Bitcode file from `stdin` and analyze it:
+
+`cat {{path/to/file.bc}} | llvm-bcanalyzer`

--- a/pages/common/llvm-bcanalyzer.md
+++ b/pages/common/llvm-bcanalyzer.md
@@ -3,11 +3,11 @@
 > LLVM Bitcode (`.bc`) analyzer.
 > More information: <https://llvm.org/docs/CommandGuide/llvm-bcanalyzer.html>.
 
-- Print statistics on a Bitcode file:
+- Print statistics about a Bitcode file:
 
 `llvm-bcanalyzer {{path/to/file.bc}}`
 
-- Print an SGML representation of and statistics on a Bitcode file:
+- Print an SGML representation and statistics about a Bitcode file:
 
 `llvm-bcanalyzer -dump {{path/to/file.bc}}`
 


### PR DESCRIPTION
**There is one big problem with this page: The official documentation is outdated.** (can't bug report this to them, because their sign-ups for the bugtracker are unnecessarily annoying) **It contains `-nodetails` and `-verify`, which don't work.** (as of `12.0.1` from Homebrew on macOS and from reading the code from HEAD in Git) **We might want to consider just linking to the source code, as it has [a nice comment that documents the tool](https://github.com/llvm/llvm-project/blob/main/llvm/tools/llvm-bcanalyzer/llvm-bcanalyzer.cpp#L9-L25).**

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
