### PR TITLE
llvm-ar, llvm-nm, llvm-strings: add page

### DIFF
--- a/pages/common/llvm-ar.md
+++ b/pages/common/llvm-ar.md
@@ -1,0 +1,7 @@
+# llvm-ar
+
+> This command is an alias of `ar`.
+
+- View documentation for the original command:
+
+`tldr ar`

--- a/pages/common/llvm-nm.md
+++ b/pages/common/llvm-nm.md
@@ -1,0 +1,7 @@
+# llvm-nm
+
+> This command is an alias of `nm`.
+
+- View documentation for the original command:
+
+`tldr nm`

--- a/pages/common/llvm-strings.md
+++ b/pages/common/llvm-strings.md
@@ -1,0 +1,7 @@
+# llvm-strings
+
+> This command is an alias of `strings`.
+
+- View documentation for the original command:
+
+`tldr strings`


### PR DESCRIPTION
aliases of `binutils` equivalents