### PR TITLE
PULL_REQUEST_TEMPLATE: ask for command version number

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,5 @@
 - [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
 - [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
 - [ ] The page description includes a link to documentation or a homepage (if applicable).
+
+Version of the command being documented:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 - [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
 - [ ] The page description includes a link to documentation or a homepage (if applicable).
 
-Version of the command being documented:
+ - **Version of the command being documented (if known):**


### PR DESCRIPTION
When we get a new page, we don't know the version of the command being documented. This can lead to issues when some examples don't work anymore and we don't know why. I think it would help a lot if we can go back to that PR and look it up.