### PR TITLE
common/l*: add more information link

### DIFF
--- a/pages.pt_BR/common/lsof.md
+++ b/pages.pt_BR/common/lsof.md
@@ -2,6 +2,7 @@
 
 > Lista arquivos abertos e os seus processos correspondentes.
 > Nota: Privilégios de administrador (ou sudo) são necessários para listar arquivos abertos por outros.
+> Mais informações: <https://manned.org/lsof>.
 
 - Localizar os processos que têm um certo arquivo aberto:
 

--- a/pages/common/last.md
+++ b/pages/common/last.md
@@ -1,6 +1,7 @@
 # last
 
 > View the last logged in users.
+> More information: <https://manned.org/last>.
 
 - View last logins, their duration and other information as read from `/var/log/wtmp`:
 

--- a/pages/common/ldapsearch.md
+++ b/pages/common/ldapsearch.md
@@ -1,6 +1,7 @@
 # ldapsearch
 
 > CLI utility for querying an LDAP directory.
+> More information: <https://docs.ldap.com/ldap-sdk/docs/tool-usages/ldapsearch.html>.
 
 - Query an LDAP server for all items that are a member of the given group and return the object's displayName value:
 

--- a/pages/common/leave.md
+++ b/pages/common/leave.md
@@ -2,6 +2,7 @@
 
 > Set a reminder for when it's time to leave.
 > To remove reminders use `kill $(pidof leave)`.
+> More information: <https://www.freebsd.org/cgi/man.cgi?query=leave>.
 
 - Set a reminder at a given time:
 

--- a/pages/common/lex.md
+++ b/pages/common/lex.md
@@ -2,6 +2,7 @@
 
 > Lexical analyser generator.
 > Given the specification for a lexical analyser, generates C code implementing it.
+> More information: <https://manned.org/lex.1>.
 
 - Generate an analyser from a Lex file:
 

--- a/pages/common/lorem.md
+++ b/pages/common/lorem.md
@@ -1,6 +1,7 @@
 # lorem
 
 > Create more or less random lorem ipsum text.
+> More information: <https://manned.org/lorem>.
 
 - Print the specified number of words:
 

--- a/pages/common/lp.md
+++ b/pages/common/lp.md
@@ -1,6 +1,7 @@
 # lp
 
 > Print files.
+> More information: <https://manned.org/lp>.
 
 - Print the output of a command to the default printer (see `lpstat` command):
 

--- a/pages/common/lpstat.md
+++ b/pages/common/lpstat.md
@@ -1,6 +1,7 @@
 # lpstat
 
 > Show status information about printers.
+> More information: <https://manned.org/lpstat>.
 
 - List printers present on the machine and whether they are enabled for printing:
 

--- a/pages/common/lsof.md
+++ b/pages/common/lsof.md
@@ -2,6 +2,7 @@
 
 > Lists open files and the corresponding processes.
 > Note: Root privileges (or sudo) is required to list files opened by others.
+> More information: <https://manned.org/lsof>.
 
 - Find the processes that have a given file open:
 


### PR DESCRIPTION
issue #6062

- Apple doesn't provide pages of `lp`, `lpstat`.
- Repositories of `last`, `lsof`, `lex` don't provide human readable man pages.
- I didn't find an official source of `lorem`.
