### PR TITLE
sdk: add current example

### DIFF
--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -20,6 +20,10 @@
 
 `sdk list`
 
+- List all installed Software Development Kits:
+
+`sdk current`
+
 - Update Gradle to the latest version:
 
 `sdk upgrade {{gradle}}`


### PR DESCRIPTION
Example on my machine:
```sh
$ sdk current

Using:

java: 21.2.0.r11-grl
mvnd: 0.6.0
scala: 3.0.2
visualvm: 2.1
```

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
