### PR TITLE
git-*: add Dutch translation

### DIFF
--- a/pages.nl/common/git-add.md
+++ b/pages.nl/common/git-add.md
@@ -1,0 +1,36 @@
+# git add
+
+> Voegt veranderde bestanden toe aan de stage-lijst.
+> Meer informatie: <https://git-scm.com/docs/git-add>.
+
+- Voeg een bestand toe:
+
+`git add {{voorbeeld-bestand.txt}}`
+
+- Voeg een map toe:
+
+`git add {{pad/naar/voorbeeld-map}}
+
+- Voeg alle bestanden toe (getrackde en ongetrackde)
+
+`git add -A`
+
+- Voeg getrackde bestanden toe:
+
+`git add -u`
+
+- Voeg niet-getrackde bestanden toe:
+
+`git add -f`
+
+- Voeg delen van bestanden toe via een menu:
+
+`git add -p`
+
+- Voeg delen van een specifiek bestand toe via een menu:
+
+`git add -p {{pad/naar/bestand}}`
+
+- Voeg bestanden toe via een alternatief menu:
+
+`git add -i`

--- a/pages.nl/common/git-add.md
+++ b/pages.nl/common/git-add.md
@@ -9,7 +9,7 @@
 
 - Voeg een map toe:
 
-`git add {{pad/naar/voorbeeld-map}}
+`git add {{pad/naar/voorbeeld-map}}`
 
 - Voeg alle bestanden toe (getrackde en ongetrackde)
 

--- a/pages.nl/common/git-clone.md
+++ b/pages.nl/common/git-clone.md
@@ -1,0 +1,36 @@
+# git clone
+
+> Kloon een bestaande repository.
+> Meer informatie: <https://git-scm.com/docs/git-clone>.
+
+- Kloon een bestaande repository:
+
+`git clone {{remote_repository_locatie}}`
+
+- Kloon een bestaande repository in een specifieke map:
+
+`git clone {{remote_repository_locatie}} {{pad/naar/map}}`
+
+- Kloon een bestaande repository en haar submodules:
+
+`git clone --recursive {{remote_repository_locatie}}`
+
+- Kloon een lokale repository:
+
+`git clone -l {{pad/naar/lokale-repository}}`
+
+- Kloon stilletjes:
+
+`git clone -q {{remote_repository_locatie}}`
+
+- Kloon een bestaande repository, maar haal enkel de recentste tien commits op van de standaard branch (handig op tijd te besparen):
+
+`git clone --depth {{10}} {{remote_repository_locatie}}`
+
+- Kloon een bestaande repository, haal enkel een specifiek branch op:
+
+`git clone --branch {{naam}} --single-branch {{remote_repository_locatie}}`
+
+- Kloon een bestaande repository, en maak gebruik van een specifieke SSH commando:
+
+`git clone --config core.sshCommand="{{ssh -i pad/naar/ssh_prive_sleutel}}" {{remote_repository_locatie}}`

--- a/pages.nl/common/git-commit.md
+++ b/pages.nl/common/git-commit.md
@@ -1,0 +1,36 @@
+# git commit
+
+> Commit bestanden en veranderingen naar de repository.
+> Meer informatie: <https://git-scm.com/docs/git-commit>.
+
+- Commit gestagede bestanden (dit opent een venster):
+
+`git commit`
+
+- Commit gestagede bestanden naar de repository met een bericht:
+
+`git commit -m "{{bericht}}"`
+
+- Commit gestagede bestanden met een bericht uit een bestand:
+
+`git commit --file {{pad/naar/bestand_met_commit_bericht}}`
+
+- Stage automatisch alle veranderde bestanden en commit met een bericht:
+
+`git commit -a -m "{{bericht}}"`
+
+- Commit gestagede bestanden en onderteken hen met de geconfigureerde GPG sleutel:
+
+`git commit -S -m "{{bericht}}"`
+
+- Update de laatste commit en voeg nieuwe gestagede veranderingen toe:
+
+`git commit --amend`
+
+- Commit enkel specifieke (al gestagede) bestanden:
+
+`git commit {{pad/naar/bestand-1}} {{pad/naar/bestand-2}}`
+
+- Maak een commit, ook al zijn er geen gestagede veranderingen:
+
+`git commit -m "{{bericht}}" --allow-empty`

--- a/pages.nl/common/git-diff.md
+++ b/pages.nl/common/git-diff.md
@@ -1,0 +1,32 @@
+# git diff
+
+> Geef verandering weer in bijgehouden bestanden.
+> Meer informatie: <https://git-scm.com/docs/git-diff>.
+
+- Laat niet-gestagede, ongecommitte veranderingen zien:
+
+`git diff`
+
+- Laat alle ongecommitte veranderingen zien (inclusief gestagede veranderingen):
+
+`git diff HEAD`
+
+- Laat enkel gestagede veranderingen zien (deze zijn toegevoegd maar niet gecommit):
+
+`git diff --staged`
+
+- Laat enkel de namen zien van veranderde bestanden sinds een commit:
+
+`git diff --name-only {{commit}}`
+
+- Geef een overzicht van aangemaakte, hernoemde en mode-veranderde bestanden sinds een commit:
+
+`git diff --summary {{commit}}`
+
+- Vergelijk een bestand tussen twee branches of commits:
+
+`git diff {{branch_1}}..{{branch_2}} [--] {{pad/naar/bestand}}`
+
+- Vergelijk verschillende bestanden van een andere branch met een van de huidige branch:
+
+`git diff {{branch}}:{{pad/naar/bestand-1}} {{pad/naar/bestand-2}}`

--- a/pages.nl/common/git-init.md
+++ b/pages.nl/common/git-init.md
@@ -1,0 +1,20 @@
+# git init
+
+> Initialiseer een nieuwe lokale Git repository:
+> Meer informatie: <https://git-scm.com/docs/git-init>.
+
+- Initialiseer een nieuwe lokale repository:
+
+`git init`
+
+- Initialiseer een repository met een specifieke naam for de eerste branch:
+
+`git init --initial-branch={{branch_name}}`
+
+- Initialiseer een repository met SHA256 for object hashes (vereist Git versie 2.29 of hoger):
+
+`git init --object-format={{sha256}}`
+
+- Initialisser een bare-bones repository, geschikt voor gebruik over SSH:
+
+`git init --bare`

--- a/pages.nl/common/git-log.md
+++ b/pages.nl/common/git-log.md
@@ -21,7 +21,7 @@
 
 - Geef een grafiek van alle commits, tags en branches in the complete repository:
 
-git log --oneline --decorate --all --graph`
+`git log --oneline --decorate --all --graph`
 
 - Geef enkel commits aan met welke bericht een specifieke tekst bevat:
 

--- a/pages.nl/common/git-log.md
+++ b/pages.nl/common/git-log.md
@@ -1,0 +1,40 @@
+# git log
+
+> Geef de commit geschiedenis.
+> Meer informatie: <https://git-scm.com/docs/git-log>.
+
+- Geef de commit reeks startend bij de huidge, in omgekeerde volgerde:
+
+`git log`
+
+- Geef de geschiedenis van een specifieke bestand of map, inclusief de veranderingen:
+
+`git log -p {{pad/naar/bestand_of_map}}`
+
+- Geef een overzicht van welk(e) bestand(en) zijn veranderd in elke commit:
+
+`git log --stat`
+
+- Geef een grafiek van commits in de huidige branch:
+
+`git log --graph`
+
+- Geef de commit reeks, met enkel de eerste lijn van de commit weergegeven:
+
+`git log --oneline`
+
+- Geef een grafiek van alle commits, tags en branches in the complete repository:
+
+`git log --oneline --decorate --all --graph`
+
+- Geef enkel commits aan met welke bericht een specifieke tekst bevat:
+
+`git log -i --grep {{zoek-tekst}}`
+
+- Geef de laatste N commits van een specifieke auteur:
+
+`git log -n {{number}} --author={{author}}`
+
+- Geef commits tussen twee data:
+
+`git log --before={{datum}} --after={{datum}}`

--- a/pages.nl/common/git-log.md
+++ b/pages.nl/common/git-log.md
@@ -19,9 +19,9 @@
 
 `git log --oneline --graph`
 
--- Geef een grafiek van alle commits, tags en branches in the complete repository:
--
--`git log --oneline --decorate --all --graph`
+- Geef een grafiek van alle commits, tags en branches in the complete repository:
+
+git log --oneline --decorate --all --graph`
 
 - Geef enkel commits aan met welke bericht een specifieke tekst bevat:
 

--- a/pages.nl/common/git-log.md
+++ b/pages.nl/common/git-log.md
@@ -15,13 +15,13 @@
 
 `git log --stat`
 
-- Geef een grafiek van commits in de huidige branch:
+- Geef een grafiek van commits in de huidige branch, met enkel de eerste lijk van de commit weergegeven:
 
-`git log --graph`
+`git log --oneline --graph`
 
-- Geef de commit reeks, met enkel de eerste lijn van de commit weergegeven:
-
-`git log --oneline`
+-- Geef een grafiek van alle commits, tags en branches in the complete repository:
+-
+-`git log --oneline --decorate --all --graph`
 
 - Geef enkel commits aan met welke bericht een specifieke tekst bevat:
 

--- a/pages.nl/common/git-log.md
+++ b/pages.nl/common/git-log.md
@@ -23,10 +23,6 @@
 
 `git log --oneline`
 
-- Geef een grafiek van alle commits, tags en branches in the complete repository:
-
-`git log --oneline --decorate --all --graph`
-
 - Geef enkel commits aan met welke bericht een specifieke tekst bevat:
 
 `git log -i --grep {{zoek-tekst}}`

--- a/pages.nl/common/git-push.md
+++ b/pages.nl/common/git-push.md
@@ -1,0 +1,36 @@
+# git push
+
+> Push (upload) commits naar de remote repository.
+> Meer informatie: <https://git-scm.com/docs/git-push>.
+
+- Verstuur lokale commits in de huidge branch naar de standaard remote (b.v. origin):
+
+`git push`
+
+- Verstuur commits vanaf een specifieke lokale branch naar de bijhorende remote:
+
+`git push {{remote_naam}} {{lokale_branch}}`
+
+- Verstuur commits vanaf een specifieke branch naar de bijhorende remote, en stel deze remote in als standaard remote:
+
+`git push -u {{remote_naam}} {{lokale_branch}}`
+
+- Verstuur commits vanaf een specifieke lokale branch naar een specifieke remote branch:
+
+`git push {{remote_naam}} {{lokale_branch}}:{{remote_branch}}`
+
+- Verstuur commits van alle branches naar een gegeven remote repository:
+
+`git push --all {{remote_naam}}`
+
+- Verwijder een branch uit een remote repository:
+
+`git push {{remote_naam}} --delete {{remote_branch}}`
+
+- Haal remote branches weg die geen lokale soortgelijke hebben:
+
+`git push --prune {{remote_naam}}`
+
+- Publiceer tags (labels) die nog niet in de remote repository zitten:
+
+`git push --tags`

--- a/pages.nl/common/git-status.md
+++ b/pages.nl/common/git-status.md
@@ -1,0 +1,21 @@
+# git status
+
+> Geef de veranderde bestanden weer in een Git repository.
+> Geeft de veranderde, toegevoegde en verwijderde bestanden weer, vergeleken met de huidige commit.
+> Meer informatie: <https://git-scm.com/docs/git-status>.
+
+- Geef veranderde bestanden weer welke nog niet zijn gecommit.
+
+`git status`
+
+- Geef uitvoer in een kort formaat:
+
+`git status -s`
+
+- Laat enkel getrackede bestanden zien:
+
+`git status --untracked-files=no`
+
+- Geef uitvoer weer in een kort formaat samen met informatie of de branch:
+
+`git status -sb`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Since the Dutch translations only had the `git` command described, here are some translated pages of subcommands  that I use often :)