### PR TITLE
vlc, ffmpeg, cp: add pt_BR translation

### DIFF
--- a/pages.pt_BR/common/ffmpeg.md
+++ b/pages.pt_BR/common/ffmpeg.md
@@ -1,0 +1,36 @@
+# ffmpeg
+
+> Ferramenta de conversão de vídeo.
+> Mais informações: <https://ffmpeg.org>.
+
+- Extrair o som de um vídeo e salvá-lo como MP3:
+
+`ffmpeg -i {{vídeo.mp4}} -vn {{som}}.mp3`
+
+- Converter quadros de um vídeo ou GIF para imagens numeradas individuais:
+
+`ffmpeg -i {{vídeo.mpg|vídeo.gif}} {{quadro_%d.png}}`
+
+- Combinar imagens numeradas (`quadro_1.jpg`, `quadro_2.jpg`, etc) em um vídeo ou GIF:
+
+`ffmpeg -i {{quadro_%d.jpg}} -f image2 {{vídeo.mpg|vídeo.gif}}`
+
+- Extrair um único quadro de um vídeo no tempo mm:ss e salvá-lo como uma imagem de resolução 128x128:
+
+`ffmpeg -ss {{mm:ss}} -i {{vídeo.mp4}} -frames 1 -s {{128x128}} -f image2 {{quadro.png}}`
+
+- Cortar um vídeo de um dado tempo inicial mm:ss até um tempo final mm2:ss2 (omita a opção -to para cortar o vídeo até o final):
+
+`ffmpeg -ss {{mm:ss}} -to {{mm2:ss2}} -i {{vídeo.mp4}} -codec copy {{vídeo_saída.mp4}}`
+
+- Converter um vídeo AVI para MP4. AAC Áudio @ 128kbit, h264 Vídeo @ CRF 23:
+
+`ffmpeg -i {{vídeo_entrada}}.avi -codec:audio aac -b:audio 128k -codec:video libx264 -crf 23 {{vídeo_saída}}.mp4`
+
+- Remuxar um vídeo MKV para MP4 sem recodificarg áudio ou vídeo:
+
+`ffmpeg -i {{vídeo_entrada}}.mkv -codec copy {{vídeo_saída}}.mp4`
+
+- Converter vídeo MP4 para o codec VP9. Para a melhor qualidade, use um valor CRF (faixa recomendada 15-35) e -b:video DEVE ser 0:
+
+`ffmpeg -i {{vídeo_entrada}}.mp4 -codec:video libvpx-vp9 -crf {{30}} -b:video 0 -codec:audio libopus -vbr on -threads {{número_de_threads}} {{vídeo_saída}}.webm`

--- a/pages.pt_BR/common/vlc.md
+++ b/pages.pt_BR/common/vlc.md
@@ -1,0 +1,24 @@
+# vlc
+
+> Reprodutor multimídia multi-plataforma.
+> Mais informação <shttps://wiki.videolan.org/Documentation:Command_line/>.
+
+- Reproduzir um arquivo:
+
+`vlc {{caminho/do/arquivo}}`
+
+- Reproduzir em tela cheia:
+
+`vlc --fullscreen {{caminho/do/arquivo}}`
+
+- Reproduzir mudo:
+
+`vlc --no-audio {{caminho/do/arquivo}}`
+
+- Reproduzir repetidamente:
+
+`vlc --loop {{caminho/do/arquivo}}`
+
+- Reproduzir vídeo de um URL:
+
+`vlc {{https://www.youtube.com/watch?v=oHg5SJYRHA0}}`

--- a/pages.pt_BR/linux/cp.md
+++ b/pages.pt_BR/linux/cp.md
@@ -1,0 +1,32 @@
+# cp
+
+> Copia arquivos e diretórios.
+> Mais informações: <https://www.gnu.org/software/coreutils/cp>.
+
+- Copiar um arquivo para outra localização:
+
+`cp {{caminho/do/arquivo_entrada.ext}} {{caminho/do/arquivo_saída.ext}}`
+
+- Copiar um arquivo para dentro de outro diretório, mantendo o nome:
+
+`cp {{caminho/do/arquivo.ext}} {{caminho/do/diretório}}`
+
+- Recursivamente copiar os conteúdos de um diretório para outra localização (se a destinação existe, o diretório é copiado para dentro dela):
+
+`cp -r {{caminho/do/diretório_fonte}} {{caminho/do/diretório_alvo}}`
+
+- Copiar um diretório recursivamente, em modo verboso (mostra os arquivos conforme eles são copiados):
+
+`cp -vr {{caminho/do/diretório_fonte}} {{caminho/do/diretório_alvo}}`
+
+- Copiar arquivos de texto para outra localização, em modo interativo (exige confirmação do usuário antes de sobrescrever):
+
+`cp -i {{*.txt}} {{caminho/do/diretório_alvo}}`
+
+- Seguir links simbólicos antes de copiar:
+
+`cp -L {{link}} {{caminho/do/diretório_alvo}}`
+
+- Usar todo o caminho dos arquivos fonte, criando quaisquer diretórios intermediários ausentes quando copia:
+
+`cp --parents {{fonte/caminho/do/arquivo}} {{caminho/do/arquivo_alvo}}`


### PR DESCRIPTION
- [ ] The page (if new), does not already exist in the repository.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

I have 2 questions. 
The cp description is both on /pages/common and /pages/Linux, where should put it? 
The VLC description has a broken YouTube URL and I have no idea what the original video was. Should we change it to some random video, maybe something made by an official FOSS non-profit developer? I think linking to a profit-driven channel would be running free ads for them on TLDR and a broken URL might make the user think VLC isn't working.