### PR TITLE
CONTRIBUTING: fix link to alias-pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Some examples of valid locale tags:
  - Chinese (Singapore): `zh_SG`.
  - Portuguese (Brazil): `pt_BR`.
 
-A list of translated templates for alias pages can be found in [here](contributing-guides/alias-pages.md).
+A list of translated templates for alias pages can be found in [here](contributing-guides/translation-templates/alias-pages.md).
 
 ### Default language for newly added pages
 


### PR DESCRIPTION

The hyperlink for word `here`  over at [CONTRIBUTING.md](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#translations) on 107 line points to https://github.com/tldr-pages/tldr/blob/main/contributing-guides/alias-pages.md which does not exists.
The correct link is https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md.

This PR fixes the following issue.