### PR TITLE
nodemon: make --inspect a generic example

### DIFF
--- a/pages/common/nodemon.md
+++ b/pages/common/nodemon.md
@@ -5,7 +5,7 @@
 
 - Execute the specified file and watch a specific file for changes:
 
-`nodemon --inspect {{path/to/file.js}}`
+`nodemon {{path/to/file.js}}`
 
 - Manually restart nodemon (note nodemon must already be active for this to work):
 

--- a/pages/common/nodemon.md
+++ b/pages/common/nodemon.md
@@ -19,6 +19,10 @@
 
 `nodemon {{path/to/file.js}} {{arguments}}`
 
+- Pass arguments to node itself if they're not nodemon arguments already (e.g. --inspect):
+
+`nodemon {{arguments}} {{path/to/file.js}}`
+
 - Run non-node scripts:
 
 `nodemon --exec "{{python --verbose}}" {{path/to/file.py}}`

--- a/pages/common/nodemon.md
+++ b/pages/common/nodemon.md
@@ -19,7 +19,7 @@
 
 `nodemon {{path/to/file.js}} {{arguments}}`
 
-- Pass arguments to node itself if they're not nodemon arguments already (e.g. --inspect):
+- Pass arguments to node itself if they're not nodemon arguments already (e.g. `--inspect`):
 
 `nodemon {{arguments}} {{path/to/file.js}}`
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

If you give `--inspect` as an argument to nodemon, it passes it through to nodejs, which then listens for a Debugger. It is not meant as "inspect the given file for changes".