### PR TITLE
git-revert: use HEAD in example

### DIFF
--- a/pages.es/common/git-revert.md
+++ b/pages.es/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Revierte el commit más reciente:
 
-`git revert {{@}}`
+`git revert HEAD`
 
 - Revierte el quinto último commit:
 

--- a/pages.es/common/git-revert.md
+++ b/pages.es/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Revierte el commit más reciente:
 
-`git revert HEAD`
+`git revert {{HEAD}}`
 
 - Revierte el quinto último commit:
 

--- a/pages.fr/common/git-revert.md
+++ b/pages.fr/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Crée un commit qui annule les changements du dernier commit :
 
-`git revert {{@}}`
+`git revert HEAD`
 
 - Crée un commit qui annule les changements des 5 dernier commit :
 

--- a/pages.fr/common/git-revert.md
+++ b/pages.fr/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Crée un commit qui annule les changements du dernier commit :
 
-`git revert HEAD`
+`git revert {{HEAD}}`
 
 - Crée un commit qui annule les changements des 5 dernier commit :
 

--- a/pages.it/common/git-revert.md
+++ b/pages.it/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Inverti il commit più recente:
 
-`git revert {{@}}`
+`git revert HEAD`
 
 - Inverti il quintùltimo commit:
 

--- a/pages.it/common/git-revert.md
+++ b/pages.it/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Inverti il commit più recente:
 
-`git revert HEAD`
+`git revert {{HEAD}}`
 
 - Inverti il quintùltimo commit:
 

--- a/pages/common/git-revert.md
+++ b/pages/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Revert the most recent commit:
 
-`git revert {{@}}`
+`git revert HEAD`
 
 - Revert the 5th last commit:
 

--- a/pages/common/git-revert.md
+++ b/pages/common/git-revert.md
@@ -5,7 +5,7 @@
 
 - Revert the most recent commit:
 
-`git revert HEAD`
+`git revert {{HEAD}}`
 
 - Revert the 5th last commit:
 


### PR DESCRIPTION
As of git v1.8.5 `@` is an alias for HEAD, so for clarity changing the docs to simply use HEAD.

Closes #6624

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
