### PR TITLE
common/ssh*: add more information link

### DIFF
--- a/pages.de/common/ssh-agent.md
+++ b/pages.de/common/ssh-agent.md
@@ -3,6 +3,7 @@
 > Erstelle einen SSH Agenten-Prozess.
 > Ein SSH Agent behält die hinzugefügten SSH Schlüssel solange verschlüsselt im Arbeitsspeicher, bis diese entfernt werden oder der Agenten-Prozess beendet wird.
 > Siehe auch `ssh-add`, um Schlüssel zu verwalten.
+> Weitere Informationen: <https://manned.org/ssh-agent>.
 
 - Starte einen SSH Agenten-Prozesses für die aktuelle Shell:
 

--- a/pages.de/common/ssh-agent.md
+++ b/pages.de/common/ssh-agent.md
@@ -3,7 +3,7 @@
 > Erstelle einen SSH Agenten-Prozess.
 > Ein SSH Agent behält die hinzugefügten SSH Schlüssel solange verschlüsselt im Arbeitsspeicher, bis diese entfernt werden oder der Agenten-Prozess beendet wird.
 > Siehe auch `ssh-add`, um Schlüssel zu verwalten.
-> Weitere Informationen: <https://manned.org/ssh-agent>.
+> Weitere Informationen: <https://man.openbsd.org/ssh-agent>.
 
 - Starte einen SSH Agenten-Prozesses für die aktuelle Shell:
 

--- a/pages.de/common/ssh-copy-id.md
+++ b/pages.de/common/ssh-copy-id.md
@@ -1,6 +1,7 @@
 # ssh-copy-id
 
 > Installiere den öffentlichen Teil eines SSH Schlüssels in der `authorized_keys` Datei auf einem externen Server.
+> Weitere Informationen: <https://manned.org/ssh-copy-id>.
 
 - Kopiere den eigenen öffentlichen SSH Schlüssels zu einem externen Server:
 

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -1,7 +1,7 @@
 # ssh-keygen
 
 > Generiert ssh Schlüssel für Authentifizierung, Passwort-lose Logins und mehr.
-> Weitere Informationen: <https://manned.org/ssh-keygen>.
+> Weitere Informationen: <https://man.openbsd.org/ssh-keygen>.
 
 - Erstelle ein SSH Schlüssel-Paar interaktiv:
 

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -1,6 +1,7 @@
 # ssh-keygen
 
 > Generiert ssh Schlüssel für Authentifizierung, Passwort-lose Logins und mehr.
+> Weitere Informationen: <https://manned.org/ssh-keygen>.
 
 - Erstelle ein SSH Schlüssel-Paar interaktiv:
 

--- a/pages.de/common/ssh-keyscan.md
+++ b/pages.de/common/ssh-keyscan.md
@@ -1,7 +1,7 @@
 # ssh-keyscan
 
 > Rufe öffentliche SSH Schlüssel eines externen Servers ab.
-> Weitere Informationen: <https://manned.org/ssh-keyscan>.
+> Weitere Informationen: <https://man.openbsd.org/ssh-keyscan>.
 
 - Rufe alle öffentlichen SSH Schlüssel eines Servers ab:
 

--- a/pages.de/common/ssh-keyscan.md
+++ b/pages.de/common/ssh-keyscan.md
@@ -1,6 +1,7 @@
 # ssh-keyscan
 
 > Rufe öffentliche SSH Schlüssel eines externen Servers ab.
+> Weitere Informationen: <https://manned.org/ssh-keyscan>.
 
 - Rufe alle öffentlichen SSH Schlüssel eines Servers ab:
 

--- a/pages.de/common/sshpass.md
+++ b/pages.de/common/sshpass.md
@@ -1,6 +1,7 @@
 # sshpass
 
 > Stelle SSH Passwörtern bereit.
+> Weitere Informationen: <https://manned.org/sshpass>.
 
 - Stelle eine Verbindung zu einem externen Server über ein Passwort aus einem Datei-Objekt her (in diesem Fall stdin):
 

--- a/pages.zh/common/ssh-add.md
+++ b/pages.zh/common/ssh-add.md
@@ -2,7 +2,7 @@
 
 > 在 ssh 代理中管理加载的 ssh 密钥。
 > 需要确保 ssh 代理已启动并正在运行以加载其中的密钥。
-> 更多信息：<https://manned.org/ssh-add>.
+> 更多信息：<https://man.openbsd.org/ssh-add>.
 
 - 将 `~/.ssh` 中的默认 ssh 密钥添加到 `ssh` 代理：
 

--- a/pages.zh/common/ssh-add.md
+++ b/pages.zh/common/ssh-add.md
@@ -2,6 +2,7 @@
 
 > 在 ssh 代理中管理加载的 ssh 密钥。
 > 需要确保 ssh 代理已启动并正在运行以加载其中的密钥。
+> 更多信息：<https://manned.org/ssh-add>.
 
 - 将 `~/.ssh` 中的默认 ssh 密钥添加到 `ssh` 代理：
 

--- a/pages.zh/common/sshuttle.md
+++ b/pages.zh/common/sshuttle.md
@@ -2,6 +2,7 @@
 
 > 通过 ssh 连接传输流量的透明代理服务器。
 > 不需要管理员或远程 ssh 服务器上的任何特殊设置。
+> 更多信息：<https://manned.org/sshuttle>.
 
 - 通过远程 ssh 服务器转发所有 IPv4 TCP 流量：
 

--- a/pages/common/ssh-add.md
+++ b/pages/common/ssh-add.md
@@ -2,7 +2,7 @@
 
 > Manage loaded ssh keys in the ssh-agent.
 > Ensure that ssh-agent is up and running for the keys to be loaded in it.
-> More information: <https://manned.org/ssh-add>.
+> More information: <https://man.openbsd.org/ssh-add>.
 
 - Add the default ssh keys in `~/.ssh` to the ssh-agent:
 

--- a/pages/common/ssh-add.md
+++ b/pages/common/ssh-add.md
@@ -2,6 +2,7 @@
 
 > Manage loaded ssh keys in the ssh-agent.
 > Ensure that ssh-agent is up and running for the keys to be loaded in it.
+> More information: <https://manned.org/ssh-add>.
 
 - Add the default ssh keys in `~/.ssh` to the ssh-agent:
 

--- a/pages/common/ssh-agent.md
+++ b/pages/common/ssh-agent.md
@@ -3,7 +3,7 @@
 > Spawn an SSH Agent process.
 > An SSH Agent holds SSH keys decrypted in memory until removed or the process is killed.
 > See also `ssh-add`, which can add and manage keys held by an SSH Agent.
-> More information: <https://manned.org/ssh-agent>.
+> More information: <https://man.openbsd.org/ssh-agent>.
 
 - Start an SSH Agent for the current shell:
 

--- a/pages/common/ssh-agent.md
+++ b/pages/common/ssh-agent.md
@@ -3,6 +3,7 @@
 > Spawn an SSH Agent process.
 > An SSH Agent holds SSH keys decrypted in memory until removed or the process is killed.
 > See also `ssh-add`, which can add and manage keys held by an SSH Agent.
+> More information: <https://manned.org/ssh-agent>.
 
 - Start an SSH Agent for the current shell:
 

--- a/pages/common/ssh-copy-id.md
+++ b/pages/common/ssh-copy-id.md
@@ -1,6 +1,7 @@
 # ssh-copy-id
 
 > Install your public key in a remote machine's authorized_keys.
+> More information: <https://manned.org/ssh-copy-id>.
 
 - Copy your keys to the remote machine:
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -1,6 +1,7 @@
 # ssh-keygen
 
 > Generate ssh keys used for authentication, password-less logins, and other things.
+> More information: <https://manned.org/ssh-keygen>.
 
 - Generate a key interactively:
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -1,7 +1,7 @@
 # ssh-keygen
 
 > Generate ssh keys used for authentication, password-less logins, and other things.
-> More information: <https://manned.org/ssh-keygen>.
+> More information: <https://man.openbsd.org/ssh-keygen>.
 
 - Generate a key interactively:
 

--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -1,6 +1,7 @@
 # ssh-keyscan
 
 > Get the public ssh keys of remote hosts.
+> More information: <https://manned.org/ssh-keyscan>.
 
 - Retrieve all public ssh keys of a remote host:
 

--- a/pages/common/ssh-keyscan.md
+++ b/pages/common/ssh-keyscan.md
@@ -1,7 +1,7 @@
 # ssh-keyscan
 
 > Get the public ssh keys of remote hosts.
-> More information: <https://manned.org/ssh-keyscan>.
+> More information: <https://man.openbsd.org/ssh-keyscan>.
 
 - Retrieve all public ssh keys of a remote host:
 

--- a/pages/common/sshpass.md
+++ b/pages/common/sshpass.md
@@ -2,6 +2,7 @@
 
 > An ssh password provider.
 > It works by creating a TTY, feeding the password into it, and then redirecting stdin to the ssh session.
+> More information: <https://manned.org/sshpass>.
 
 - Connect to a remote server using a password supplied on a file descriptor (in this case, stdin):
 

--- a/pages/common/sshuttle.md
+++ b/pages/common/sshuttle.md
@@ -2,6 +2,7 @@
 
 > Transparent proxy server that tunnels traffic over an SSH connection.
 > Doesn't require root or any special setup on the remote SSH server, though root access on the local machine is prompted for.
+> More information: <https://manned.org/sshuttle>.
 
 - Forward all IPv4 TCP traffic via a remote SSH server:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Relates to issue #6062

Extra Notes:
* Did not add information link to `/common/ssh` as it has been covered by https://github.com/tldr-pages/tldr/pull/6604 
* In the description of related issue https://github.com/tldr-pages/tldr/issues/6062#issue-905809548
  * `linux/sshuttle` is listed, but this file is actually in `common/sshuttle`

