### PR TITLE
dune: add page

### DIFF
--- a/pages/common/dune.md
+++ b/pages/common/dune.md
@@ -1,0 +1,20 @@
+# dune
+
+> A build system for OCaml programs.
+> More information: <https://dune.build>.
+
+- Build all targets:
+
+`dune build`
+
+- Clean up the workspace:
+
+`dune clean`
+
+- Run tests:
+
+`dune runtest`
+
+- Start the [utop](https://github.com/ocaml-community/utop) REPL with compiled modules automatically loaded into it, to remove the need to load them by hand:
+
+`dune utop`

--- a/pages/common/dune.md
+++ b/pages/common/dune.md
@@ -11,7 +11,7 @@
 
 `dune clean`
 
-- Run tests:
+- Run all tests:
 
 `dune runtest`
 

--- a/pages/common/dune.md
+++ b/pages/common/dune.md
@@ -15,6 +15,6 @@
 
 `dune runtest`
 
-- Start the [utop](https://github.com/ocaml-community/utop) REPL with compiled modules automatically loaded into it, to remove the need to load them by hand:
+- Start the utop REPL with compiled modules automatically loaded into it, to remove the need to load them by hand:
 
 `dune utop`


### PR DESCRIPTION
[Dune](https://dune.build) is the most popular build system for the OCaml programming language now, used by many (if not most) packages from the OPAM repository.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

 - **Version of the command being documented (if known):** 2.9, but commands used in examples existed for a long time and the interface is stable