### PR TITLE
gpupdate: fix target syntax

### DIFF
--- a/pages/windows/gpupdate.md
+++ b/pages/windows/gpupdate.md
@@ -9,7 +9,7 @@
 
 - Specify the target Group Policy settings to check for update:
 
-`gpupdate /target=:{{computer|user}}`
+`gpupdate /target:{{computer|user}}`
 
 - Force all Group Policy settings to be reapplied:
 


### PR DESCRIPTION
This is a fix to the `gpupdate /target` example removing the equal sign. See the linked Microsoft documentation for the correct syntax applied in this patch.
