### PR TITLE
py-spy: add page

### DIFF
--- a/pages/common/py-spy.md
+++ b/pages/common/py-spy.md
@@ -1,0 +1,20 @@
+# py-spy
+
+> A sampling profiler for Python programs.
+> More information: <https://github.com/benfred/py-spy>.
+
+- Show a live view of the functions that take the most execution time of a running process:
+
+`py-spy top --pid {{pid}}`
+
+- Start a program and show a live view of the functions that take the most execution time:
+
+`py-spy top -- python {{path/to/file.py}}`
+
+- Produce an SVG flame graph of the function call execution time:
+
+`py-spy record -o profile.svg --pid {{pid}}`
+
+- Dump the call stack of a running process:
+
+`py-spy dump --pid {{pid}}`

--- a/pages/common/py-spy.md
+++ b/pages/common/py-spy.md
@@ -13,7 +13,7 @@
 
 - Produce an SVG flame graph of the function call execution time:
 
-`py-spy record -o profile.svg --pid {{pid}}`
+`py-spy record -o {{path/to/profile.svg}} --pid {{pid}}`
 
 - Dump the call stack of a running process:
 


### PR DESCRIPTION
py-spy is a sampling profiler for Python programs.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 0.3.10
