### PR TITLE
*: remove unnecesary trailing .1 of manned.org links

### DIFF
--- a/pages/linux/spectre-meltdown-checker.md
+++ b/pages/linux/spectre-meltdown-checker.md
@@ -1,7 +1,7 @@
 # spectre-meltdown-checker
 
 > Spectre and Meltdown mitigation detection tool.
-> More information: <https://manned.org/spectre-meltdown-checker.1>.
+> More information: <https://manned.org/spectre-meltdown-checker>.
 
 - Check the currently running kernel for Spectre or Meltdown:
 

--- a/pages/linux/timedatectl.md
+++ b/pages/linux/timedatectl.md
@@ -1,7 +1,7 @@
 # timedatectl
 
 > Control the system time and date.
-> More information: <https://manned.org/timedatectl.1>.
+> More information: <https://manned.org/timedatectl>.
 
 - Check the current system clock time:
 

--- a/pages/linux/xcursorgen.md
+++ b/pages/linux/xcursorgen.md
@@ -2,7 +2,7 @@
 
 > Create an X cursor file from a collection of PNGs.
 > If `--prefix` is omitted, the image files must be located in the current working directory.
-> More information: <https://manned.org/xcursorgen.1>.
+> More information: <https://manned.org/xcursorgen>.
 
 - Create an X cursor file using a config file:
 


### PR DESCRIPTION
As far as i know, we only put extra information in the link if it is needed.