### PR TITLE
git-lock: add page

### DIFF
--- a/pages/common/git-lock.md
+++ b/pages/common/git-lock.md
@@ -1,0 +1,9 @@
+# git lock
+
+> Lock git from following changes of a local file.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-lock>.
+
+- Disable the ability to commit changes of a local file:
+
+`git lock {{file}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [X] The page (if new), does not already exist in the repository.
- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

Add git lock command from tj/git-extras (#5137)

**Version of the command being documented (if known):**
 6.2.0