### PR TITLE
git: add more subcommand examples

### DIFF
--- a/pages/common/git.md
+++ b/pages/common/git.md
@@ -1,7 +1,7 @@
 # git
 
 > Distributed version control system.
-> Some subcommands such as `git commit` have their own usage documentation.
+> Some subcommands such as `commit`, `checkout`, etc. have their own usage documentation. To see tldr for them use `tldr git {{subcommand}}`.
 > More information: <https://git-scm.com/>.
 
 - Check the Git version:
@@ -12,7 +12,7 @@
 
 `git --help`
 
-- Show help on a Git subcommand (like `commit`, `log`, etc.):
+- Show help on a Git subcommand (like `clone`, `add`, `push`, `log`, etc.):
 
 `git help {{subcommand}}`
 

--- a/pages/common/git.md
+++ b/pages/common/git.md
@@ -1,7 +1,7 @@
 # git
 
 > Distributed version control system.
-> Some subcommands such as `commit`, `checkout`, etc. have their own usage documentation. To see tldr for them use `tldr git {{subcommand}}`.
+> Some subcommands such as `commit`, `add`, `branch`, `checkout`, `push`, etc. have their own usage documentation, accessible via `tldr git subcommand`.
 > More information: <https://git-scm.com/>.
 
 - Check the Git version:


### PR DESCRIPTION
Added notes for using tldr for git subcommands. This note feels more instinctive to me. A CLI user should be able to see how to use tldr without visiting its github repo.
Also elongated line #15 with common subcommands for mnemonic purpose. New users often forget subcommands, and they have no way to recall them with tldr.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).