### PR TITLE
bundler: add page

### DIFF
--- a/pages/common/bundler
+++ b/pages/common/bundler
@@ -1,0 +1,5 @@
+# bundler
+
+> Dependency manager for the Ruby programming language.
+> More information: <https://bundler.io/man/bundle.1.html>.
+> see `tldr bundle`.


### PR DESCRIPTION
bundle = bundler. Many users fail to find `tldr bundler` and don't proceed to see `tldr bundle`.

- [x*] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known): `2.2.16`**
