### PR TITLE
cgroups: add page

### DIFF
--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -1,5 +1,5 @@
 # cgroups
 
-> cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
+> Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
 > See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
-> See more docs at: https://www.kernel.org/doc/Documentation/cgroup-v1/
+> More information: `https://www.kernel.org/doc/Documentation/cgroup-v1/`

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -2,4 +2,4 @@
 
 > Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
 > See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
-> More information: `https://www.kernel.org/doc/Documentation/cgroup-v1/`
+> More information: <https://www.kernel.org/doc/Documentation/cgroup-v1/>

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -1,0 +1,5 @@
+# cgroups
+
+> cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
+> See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
+> See more docs at: https://www.kernel.org/doc/Documentation/cgroup-v1/

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -2,4 +2,4 @@
 
 > Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
 > See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
-> More information: <https://www.kernel.org/doc/Documentation/cgroup-v1/>.
+> More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -2,4 +2,4 @@
 
 > Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
 > See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
-> More information: <https://www.kernel.org/doc/Documentation/cgroup-v1/>
+> More information: <https://www.kernel.org/doc/Documentation/cgroup-v1/>.

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -1,5 +1,16 @@
 # cgroups
 
 > Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
-> See `tldr cgcreate`, `tldr cgexec`, `tldr cgclassify` for more usage info.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
+
+- Show the tldr page for a cgclassify:
+
+`tldr cgclassify`
+
+- Show the tldr page for a cgcreate:
+
+`tldr cgcreate`
+
+- Show the tldr page for a cgexec:
+
+`tldr cgexec`

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -3,14 +3,14 @@
 > Cgroups aka control groups is a Linux kernel feature for limiting, mesuring, and controling resource usage by processes.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
 
-- Show the tldr page for a cgclassify:
+- Show the tldr page for `cgclassify`:
 
 `tldr cgclassify`
 
-- Show the tldr page for a cgcreate:
+- Show the tldr page for `cgcreate`:
 
 `tldr cgcreate`
 
-- Show the tldr page for a cgexec:
+- Show the tldr page for `cgexec`:
 
 `tldr cgexec`


### PR DESCRIPTION
cgroups are used via cgcreate, cgexec, and cgclassify, and users may look for `tldr cgcreate` or something, so i'll make individual pages for them.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).