### PR TITLE
puppet: add subcomands

### DIFF
--- a/pages.de/common/puppet-agent.md
+++ b/pages.de/common/puppet-agent.md
@@ -1,0 +1,24 @@
+# puppet agent
+
+> Ruft die Client-Konfiguration vom Puppetserver ab und setzt diese auf dem System um.
+> Weitere Informationen: <https://puppet.com/docs/puppet/7/man/agent.html>.
+
+- Registriere die Node beim Puppetserver und setze den empfangenen Katalog um:
+
+`puppet agent --test --server {{puppetserver_fqdn}} --serverport {{port}} --waitforcert {{poll_zeit}}`
+
+- Führe den Agenten im Hintergrund aus (nutzt die Einstellungen von `/opt/puppetlabs/puppet/puppet.conf`):
+
+`puppet agent`
+
+- Führe den Agenten einmal im Vordergrund aus und beende:
+
+`puppet agent --test`
+
+- Führe den Agenten im Dry-Modus aus:
+
+`puppet agent --test --noop`
+
+- Protokolliere jede ausgewertete Ressource (selbst wenn sich nichts geändert hat):
+
+`puppet agent --test --evaltrace`

--- a/pages.de/common/puppet-apply.md
+++ b/pages.de/common/puppet-apply.md
@@ -1,0 +1,16 @@
+# puppet apply
+
+> Wende ein Puppet-Manifest lokal an.
+> Weitere Informationen: <https://puppet.com/docs/puppet/7/man/apply.html>.
+
+- Wende das Manifest an:
+
+`puppet apply {{pfad/zum/manifest}}`
+
+- Führe Puppetcode von der Kommandozeile aus:
+
+`puppet apply --execute {{code}}`
+
+- Nutze ein spezifisches Modul- und Hieraverzeichnis:
+
+`puppet apply --modulepath {{pfad/zum/ordner}} --hiera_data {{pfad/zum/ordner}} {{pfad/zum/manifest}}`

--- a/pages/common/puppet-agent.md
+++ b/pages/common/puppet-agent.md
@@ -1,0 +1,24 @@
+# puppet agent
+
+> Retrieves the client configuration from the Puppet server and applies it to the local host.
+> More information: <https://puppet.com/docs/puppet/7/man/agent.html>.
+
+- Register the node at the puppetserver and apply the received catalog:
+
+`puppet agent --test --server {{puppetserver_fqdn}} --serverport {{port}} --waitforcert {{poll_time}}`
+
+- Run the agent in the background (uses settings from `/opt/puppetlabs/puppet/puppet.conf`):
+
+`puppet agent`
+
+- Run the agent once in foreground, then exit:
+
+`puppet agent --test`
+
+- Run the agent in dry-mode:
+
+`puppet agent --test --noop`
+
+- Log every resource being evaluated (even if nothing is changed):
+
+`puppet agent --test --evaltrace`

--- a/pages/common/puppet-apply.md
+++ b/pages/common/puppet-apply.md
@@ -1,0 +1,16 @@
+# puppet apply
+
+> Apply Puppet manifests locally.
+> More information: <https://puppet.com/docs/puppet/7/man/apply.html>.
+
+- Apply a manifest:
+
+`puppet apply {{path/to/manifest}}`
+
+- Execute puppet code from the commandline:
+
+`puppet apply --execute {{code}}`
+
+- Use a specific module and hiera directory:
+
+`puppet apply --modulepath {{path/to/directory}} --hiera_data {{path/to/directory}} {{path/to/manifest}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 7.x
