### PR TITLE
tldr: fix typo

### DIFF
--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -9,7 +9,7 @@
 
 - Show the tldr page for `cd`, overriding the default platform:
 
-`tldr -p {{android|linux|osx|sunos|windows}} {{cd}}`
+`tldr -o {{android|linux|osx|sunos|windows}} {{cd}}`
 
 - Show the tldr page for a subcommand:
 


### PR DESCRIPTION
Fixed typo. It seems `-o` is `--os` selection. 

Maybe `--update` instead of `-u` is more convenient, because old tldr-hs client on Ubuntu/Debian doesn't understand -u.
