### PR TITLE
git-diff-files: add page

### DIFF
--- a/pages/common/git-diff-files.md
+++ b/pages/common/git-diff-files.md
@@ -1,6 +1,6 @@
 # git diff-files
 
-> Compare files in the working tree and index.
+> Compare files using their sha1 hashes and modes.
 > More information: <https://git-scm.com/docs/git-diff-files>.
 
 - Compare all changed files:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Tested with git 2.33.0
