### PR TITLE
timidity: add page

### DIFF
--- a/pages/common/timidity.md
+++ b/pages/common/timidity.md
@@ -11,7 +11,7 @@
 
 `timidity --loop {{path/to/file.mid}}`
 
-- Play a MIDI file in a specific key (0 = C major/a minor, -1 = F major/d minor, +1 = G major/e minor etc.):
+- Play a MIDI file in a specific key (0 = C major/A minor, -1 = F major/D minor, +1 = G major/E minor, etc.):
 
 `timidity --force-keysig={{-flats|+sharps}} {{path/to/file.mid}}`
 


### PR DESCRIPTION
Timidity++ is a MIDI player and convertor.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 2.14.0
