### PR TITLE
script: add more information link

### DIFF
--- a/pages/common/script.md
+++ b/pages/common/script.md
@@ -1,7 +1,7 @@
 # script
 
 > Make a typescript file of a terminal session.
-> More information: <https://manned.org/script>
+> More information: <https://manned.org/script>.
 
 - Start recording in file named "typescript":
 


### PR DESCRIPTION
For #6062

- [x] The page description includes a link to documentation or a homepage (if applicable).