### PR TITLE
strings: add more information link

### DIFF
--- a/pages/common/strings.md
+++ b/pages/common/strings.md
@@ -1,7 +1,7 @@
 # strings
 
 > Find printable strings in an object file or binary.
-> More information: <https://manned.org/strings>
+> More information: <https://manned.org/strings>.
 
 - Print all strings in a binary:
 


### PR DESCRIPTION
For #6062

- [x] The page description includes a link to documentation or a homepage (if applicable).