### PR TITLE
git-symbolic-ref: add page

### DIFF
--- a/pages/common/git-symbolic-ref.md
+++ b/pages/common/git-symbolic-ref.md
@@ -1,6 +1,6 @@
 # git symbolic-ref
 
-> Read, change or delete files that store references.
+> Read, change, or delete files that store references.
 > More information: <https://git-scm.com/docs/git-symbolic-ref>.
 
 - Store a reference by a name:


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
- [x] The test (`npm test`) passes. 😅 

Relates to #3953 

**Version of the command being documented (if known):**

2.33 

I'm using 2.33 and it's also the version listed on the referenced https://git-scm.com/docs/git-symbolic-ref


This git-symbolic-ref is used internally by git all the time! :)

Here's a short illustration:
➜  tldr git:(main) ✗ git rev-parse HEAD
e717d057ab3ca35640cbb9a95193b062785b0237
➜  tldr git:(main) ✗ git symbolic-ref -m TEST refs/hej HEAD
➜  tldr git:(main) ✗ git rev-parse refs/hej
e717d057ab3ca35640cbb9a95193b062785b0237
➜  tldr git:(main) ✗ git symbolic-ref --delete refs/hej
