### PR TITLE
cal: add German translation

### DIFF
--- a/pages.de/linux/cal.md
+++ b/pages.de/linux/cal.md
@@ -3,7 +3,7 @@
 > Zeigt einen Kalender an, in dem der aktuelle Tag markiert ist.
 > Weitere Informationen: <https://manned.org/cal>.
 
-- Zeige einen Kalender für den aktuellen Monat an:
+- Zeige den Kalender für den aktuellen Monat an:
 
 `cal`
 


### PR DESCRIPTION
I noticed that '--monday' does not work on Ubuntu. So I couldn't test it. This seems to be a bigger problem and has something to do with cal and ncal and different versions in GNU and UNIX. I think we don't need to dig into that, do we?