### PR TITLE
rsync: clarify files to be deleted with --delete

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -27,7 +27,7 @@
 
 `rsync -rauL {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
 
-- Transfer file over SSH and delete local files that do not exist on remote host:
+- Transfer file over SSH and delete files on remote host that do not exist in local dir:
 
 `rsync -e ssh --delete {{remote_host}}:{{path/to/remote_file}} {{path/to/local_file}}`
 


### PR DESCRIPTION
According to man rsync, the effect of --delete is *not* "delete local files that do not exist on remote host" but "delete files on remote host that do not exist in local dir".

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] The page (if new), does not already exist in the repository.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
