### PR TITLE
pidof: fix bug in kill example

### DIFF
--- a/pages.it/linux/pidof.md
+++ b/pages.it/linux/pidof.md
@@ -16,4 +16,4 @@
 
 - Uccide tutti i processi con un dato nome:
 
-`kill $(pidof {{nome}}) `
+`kill $(pidof {{nome}})`

--- a/pages/linux/pidof.md
+++ b/pages/linux/pidof.md
@@ -16,4 +16,4 @@
 
 - Kill all processes with given name:
 
-`kill $(pidof {{name}}) `
+`kill $(pidof {{name}})`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

need word splitting to kill multiple pids\
fit in the exception of `shellchek`: <https://github.com/koalaman/shellcheck/wiki/SC2046#exceptions>\
also see a correct example in tldr-pages: <https://github.com/tldr-pages/tldr/blob/fcc03f1e6ff9776ca4433447e9859a3c1a42e539/pages/common/leave.md#L4>
