### PR TITLE
module: fix bug in examples

### DIFF
--- a/pages/linux/module.md
+++ b/pages/linux/module.md
@@ -9,7 +9,7 @@
 
 - Search for a module by name:
 
-`module spider {{module_name}}`
+`module avail {{module_name}}`
 
 - Load a module:
 
@@ -21,7 +21,7 @@
 
 - Unload a specific loaded module:
 
-`module {{module_name}}`
+`module unload {{module_name}}`
 
 - Unload all loaded modules:
 


### PR DESCRIPTION
The module unload and module search functionalities were not described in accordance with the linked documentation. Changes made as per <https://lmod.readthedocs.io/en/latest/010_user.html>.

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

**Version of the command being documented (if known):** 8.5.18
