### PR TITLE
egrep: add French translation

### DIFF
--- a/pages.fr/common/egrep.md
+++ b/pages.fr/common/egrep.md
@@ -1,7 +1,6 @@
 # egrep
 
-> Recherche de motifs dans un texte.
-> Supporte la version étendues des expressions regulieres (`?`, `+`, `{}`, `()`, et `|`).
+> Recherche de motifs dans un texte. Supporte la version étendues des expressions regulieres (`?`, `+`, `{}`, `()`, et `|`).
 > Plus d'informations: <https://manned.org/egrep>.
 
 - Recherche une chaîne de caractères précise :


### PR DESCRIPTION
add a franch translation for the existing `egrep` page.

It resolve one step on this issue: #6382 

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
