### PR TITLE
btrfs-rescue: add page

### DIFF
--- a/pages/linux/btrfs-rescue.md
+++ b/pages/linux/btrfs-rescue.md
@@ -3,7 +3,7 @@
 > Try to recover a damaged btrfs filesystem.
 > More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-rescue>.
 
-- Rebuild filesystem metadata tree (very slow):
+- Rebuild the filesystem metadata tree (very slow):
 
 `sudo btrfs rescue chunk-recover {{path/to/partition}}`
 
@@ -11,11 +11,11 @@
 
 `sudo btrfs rescue fix-device-size {{path/to/partition}}`
 
-- Recover corrupted superblock from correct copies (recover the root of filesystem tree):
+- Recover a corrupted superblock from correct copies (recover the root of filesystem tree):
 
 `sudo btrfs rescue super-recover {{path/to/partition}}`
 
-- Recover from interrupted transactions (fixes log replay problems):
+- Recover from an interrupted transactions (fixes log replay problems):
 
 `sudo btrfs rescue zero-log {{path/to/partition}}`
 


### PR DESCRIPTION
tldr page for btrfs rescue command

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** v5.14.1

Part of #5103 