### PR TITLE
iptables, nft: add masquerade example

### DIFF
--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -21,7 +21,7 @@
 
 - Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
 
-`sudo iptables -t nat -A POSTROUTING -s 192.168.0.0/24 -j MASQUERADE`
+`sudo iptables -t {{nat}} -A {{POSTROUTING}} -s {{192.168.0.0/24}} -j {{MASQUERADE}}`
 
 - Delete chain rule:
 

--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -19,7 +19,7 @@
 
 `sudo iptables -A {{chain}} -s {{ip}} -p {{protocol}} --dport {{port}} -j {{rule}}`
 
-- Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
+- Add a NAT rule to translate all traffic from the `192.168.0.0/24` subnet to the host's public IP:
 
 `sudo iptables -t {{nat}} -A {{POSTROUTING}} -s {{192.168.0.0/24}} -j {{MASQUERADE}}`
 

--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -19,6 +19,10 @@
 
 `sudo iptables -A {{chain}} -s {{ip}} -p {{protocol}} --dport {{port}} -j {{rule}}`
 
+- Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
+
+`sudo iptables -t nat -A POSTROUTING -s 192.168.0.0/24 -j MASQUERADE`
+
 - Delete chain rule:
 
 `sudo iptables -D {{chain}} {{rule_line_number}}`

--- a/pages/linux/nft.md
+++ b/pages/linux/nft.md
@@ -19,7 +19,7 @@
 
 `sudo nft add rule {{inet}} {{filter}} {{input}} {{tcp}} {{dport \{ telnet, ssh, http, https \} accept}}`
 
-- Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
+- Add a NAT rule to translate all traffic from the 192.168.0.0/24 subnet to the host's public IP:
 
 `sudo nft add rule {{nat}} {{postrouting}} ip saddr {{192.168.0.0/24}} {{masquerade}}`
 

--- a/pages/linux/nft.md
+++ b/pages/linux/nft.md
@@ -19,6 +19,10 @@
 
 `sudo nft add rule {{inet}} {{filter}} {{input}} {{tcp}} {{dport \{ telnet, ssh, http, https \} accept}}`
 
+- Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
+
+`sudo nft add rule {{nat}} {{postrouting}} ip saddr 192.168.0.0/24 masquerade`
+
 - Show rule handles:
 
 `sudo nft --handle --numeric list chain {{family}} {{table}} {{chain}}`

--- a/pages/linux/nft.md
+++ b/pages/linux/nft.md
@@ -19,7 +19,7 @@
 
 `sudo nft add rule {{inet}} {{filter}} {{input}} {{tcp}} {{dport \{ telnet, ssh, http, https \} accept}}`
 
-- Add a NAT rule to translate all traffic from the 192.168.0.0/24 subnet to the host's public IP:
+- Add a NAT rule to translate all traffic from the `192.168.0.0/24` subnet to the host's public IP:
 
 `sudo nft add rule {{nat}} {{postrouting}} ip saddr {{192.168.0.0/24}} {{masquerade}}`
 

--- a/pages/linux/nft.md
+++ b/pages/linux/nft.md
@@ -21,7 +21,7 @@
 
 - Add a rule to NAT all traffic from the 192.168.0.0/24 subnet to the host's public IP:
 
-`sudo nft add rule {{nat}} {{postrouting}} ip saddr 192.168.0.0/24 masquerade`
+`sudo nft add rule {{nat}} {{postrouting}} ip saddr {{192.168.0.0/24}} {{masquerade}}`
 
 - Show rule handles:
 


### PR DESCRIPTION
If find the masquerade (NAT) functionality to be the one I actually use most, and it wasn't documented here.
I have to look it up myself sometimes and I think that other user can also benefit from the example.
For the nft page, it's a pity that you have to issue multiple commands (since a `nat` table or `postrouting` chain do not exist by default), but the TLDR guidelines don't allow multiple commands per example.

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).