### PR TITLE
git-locked: add page

### DIFF
--- a/pages/common/git-locked.md
+++ b/pages/common/git-locked.md
@@ -1,0 +1,9 @@
+# git locked
+
+> List locked files in a Git repository.
+> Part of `git-extras`.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-locked>.
+
+- List all local locked files:
+
+`git locked`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
