### PR TITLE
git-unlock: add page

### DIFF
--- a/pages/common/git-lock.md
+++ b/pages/common/git-lock.md
@@ -1,8 +1,7 @@
 # git lock
 
 > Lock a file in a Git repository from being modified by a commit.
-> Part of `git-extras`.
-> See also: `git-unlock`.
+> Part of `git-extras`. See also `git-unlock`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-lock>.
 
 - Disable the ability to commit changes of a local file:

--- a/pages/common/git-unlock.md
+++ b/pages/common/git-unlock.md
@@ -1,8 +1,7 @@
 # git unlock
 
 > Unlock a file in a Git repository so it can be modified by a commit.
-> Part of `git-extras`.
-> See also: `git-lock`.
+> Part of `git-extras`. See also `git lock`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-unlock>.
 
 - Enable the ability to commit changes of a previously-locked local file:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
