### PR TITLE
nohup: add background and output to file examples

### DIFF
--- a/pages/common/nohup.md
+++ b/pages/common/nohup.md
@@ -17,4 +17,4 @@
 
 - Run a process and write the output to a specific file:
 
-`nohup {{command}} {{command_arguments}} > {{path/to/output_file.log}} &`
+`nohup {{command}} {{command_arguments}} > {{path/to/output_file}} &`


### PR DESCRIPTION
there was only one basic example for 'nohup' command.
add more examples to show the possibility given by this command.

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
