### PR TITLE
warp-cli, warp-diag: add page

### DIFF
--- a/pages/common/warp-cli.md
+++ b/pages/common/warp-cli.md
@@ -1,7 +1,7 @@
 # warp-cli
 
 > Official command-line client for Cloudflare's WARP service.
-> More information: <https://developers.cloudflare.com/warp-client/setting-up/linux>.
+> More information: <https://developers.cloudflare.com/warp-client/>.
 
 - Register the current device to WARP (must be run before first connection):
 

--- a/pages/common/warp-diag.md
+++ b/pages/common/warp-diag.md
@@ -2,7 +2,7 @@
 
 > Diagnostic and feedback tool for Cloudflare's WARP service.
 > See also: `warp-cli`.
-> More information: <https://developers.cloudflare.com/warp-client/setting-up/linux>.
+> More information: <https://developers.cloudflare.com/warp-client/>.
 
 - Generate a zip file with information about the system configuration and the WARP connection:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** WARP 2021.8.1

As far as I know the CLI client for WARP is only available on Linux. That's why I put it inside `linux/` instead of `common/`.