### PR TITLE
keyctl: add page

### DIFF
--- a/pages/linux/keyctl.md
+++ b/pages/linux/keyctl.md
@@ -15,7 +15,7 @@
 
 `keyctl add {{type_keyring}} {{key_name}} {{key_value}} {{target_keyring}}`
 
-- Store a key with its value on the standard input:
+- Store a key with its value from standard input:
 
 `echo -n {{key_value}} | keyctl padd {{type_keyring}} {{key_name}} {{target_keyring}}`
 
@@ -23,11 +23,11 @@
 
 `keyctl timeout {{key_name}} {{timeout_in_seconds}}`
 
-- Read a key and formats it as a hex-dump if not printable:
+- Read a key and format it as a hex-dump if not printable:
 
 `keyctl read {{key_name}}`
 
-- Read a key and formats as-is:
+- Read a key and format as-is:
 
 `keyctl pipe {{key_name}}`
 

--- a/pages/linux/keyctl.md
+++ b/pages/linux/keyctl.md
@@ -1,0 +1,36 @@
+# keyctl
+
+> Manipulate the Linux kernel keyring.
+> More information: <https://manned.org/keyctl.1>.
+
+- List keys in a specific keyring:
+
+`keyctl list {{target_keyring}}`
+
+- List current keys in the user default session:
+
+`keyctl list @us`
+
+- Store a key in a specific keyring:
+
+`keyctl add {{type_keyring}} {{key_name}} {{key_value}} {{target_keyring}}`
+
+- Store a key with its value on the standard input:
+
+`echo -n {{key_value}} | keyctl padd {{type_keyring}} {{key_name}} {{target_keyring}}`
+
+- Put a timeout on a key:
+
+`keyctl timeout {{key_name}} {{timeout_in_seconds}}`
+
+- Read a key and formats it as a hex-dump if not printable:
+
+`keyctl read {{key_name}}`
+
+- Read a key and formats as-is:
+
+`keyctl pipe {{key_name}}`
+
+- Revoke a key and prevents any further action on it:
+
+`keyctl revoke {{key_name}}`

--- a/pages/linux/keyctl.md
+++ b/pages/linux/keyctl.md
@@ -9,7 +9,7 @@
 
 - List current keys in the user default session:
 
-`keyctl list @us`
+`keyctl list {{@us}}`
 
 - Store a key in a specific keyring:
 

--- a/pages/linux/keyctl.md
+++ b/pages/linux/keyctl.md
@@ -31,6 +31,6 @@
 
 `keyctl pipe {{key_name}}`
 
-- Revoke a key and prevents any further action on it:
+- Revoke a key and prevent any further action on it:
 
 `keyctl revoke {{key_name}}`

--- a/pages/linux/keyctl.md
+++ b/pages/linux/keyctl.md
@@ -1,7 +1,7 @@
 # keyctl
 
 > Manipulate the Linux kernel keyring.
-> More information: <https://manned.org/keyctl.1>.
+> More information: <https://manned.org/keyctl>.
 
 - List keys in a specific keyring:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** `keyctl from keyutils-1.6.3`