### PR TITLE
systemd-analyze: add link and add security example

### DIFF
--- a/pages/linux/systemd-analyze.md
+++ b/pages/linux/systemd-analyze.md
@@ -1,6 +1,8 @@
 # systemd-analyze
 
+> Analyze and debug system manager.
 > Show timing details about the boot process of units (services, mount points, devices, sockets).
+> More information: <https://manned.org/systemd-analyze>.
 
 - List time of each unit to start up:
 
@@ -17,3 +19,7 @@
 - Plot a dependency graph and convert it to an SVG file:
 
 `systemd-analyze dot | dot -T{{svg}} > {{path/to/file.svg}}`
+
+- Show security scores of running units:
+
+`systemd-analyze security`


### PR DESCRIPTION
This adds also a link to the manual page.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** `systemd v249`