### PR TITLE
nixos-container: add page

### DIFF
--- a/pages/linux/nixos-container.md
+++ b/pages/linux/nixos-container.md
@@ -11,7 +11,7 @@
 
 `sudo nixos-container create {{container_name}} --config-file {{nix_config_file_path}}`
 
-- Start/stop/terminate/destroy a specific container:
+- Start, stop, terminate, or destroy a specific container:
 
 `sudo nixos-container {{start|stop|terminate|destroy|status}} {{container_name}}`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** not applicable.