### PR TITLE
pypy: add page

### DIFF
--- a/pages/common/pypy.md
+++ b/pages/common/pypy.md
@@ -1,7 +1,7 @@
 # pypy
 
 > Fast and compliant alternative implementation of the Python language.
-> More information: <https://doc.pypy.org/en/latest/>.
+> More information: <https://doc.pypy.org>.
 
 - Start a REPL (interactive shell):
 
@@ -9,11 +9,11 @@
 
 - Execute script in a given Python file:
 
-`pypy {{script.py}}`
+`pypy {{path/to/file.py}}`
 
 - Execute script as part of an interactive shell:
 
-`pypy -i {{script.py}}`
+`pypy -i {{path/to/file.py}}`
 
 - Execute a Python expression:
 
@@ -29,4 +29,4 @@
 
 - Interactively debug a Python script:
 
-`pypy -m pdb {{script.py}}`
+`pypy -m pdb {{path/to/file.py}}`


### PR DESCRIPTION
- add pypy python interpreter alternative.
- retake examples from tldr python page.

**associated issue**: #6412 

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
