### PR TITLE
nixos-option: add page

### DIFF
--- a/pages/linux/nixos-option.md
+++ b/pages/linux/nixos-option.md
@@ -1,0 +1,28 @@
+# nixos-option
+
+> Inspect a NixOS configuration.
+> More information: <https://nixos.org/manual/nixos/stable/index.html#sec-modularity>
+
+- List all keys of an option key:
+
+`nixos-option {{option_key}}`
+
+- List current boot kernel modules:
+
+`nixos-option boot.kernelModules`
+
+- List authorized keys for a given user:
+
+`nixos-option users.users.{{user}}.openssh.authorizedKeys.{{keyFiles|keys}}`
+
+- List all remote builders:
+
+`nixos-option nix.buildMachines`
+
+- List key on another NixOS configuration:
+
+`NIXOS_CONFIG={{path_to_configuration.nix}} nixos-option {{option_key}}`
+
+- Show recursively all values of a user:
+
+`nixos-option -r users.users.{{user}}`

--- a/pages/linux/nixos-option.md
+++ b/pages/linux/nixos-option.md
@@ -3,7 +3,7 @@
 > Inspect a NixOS configuration.
 > More information: <https://nixos.org/manual/nixos/stable/index.html#sec-modularity>.
 
-- List all keys of an option key:
+- List all subkeys of a given option key:
 
 `nixos-option {{option_key}}`
 
@@ -19,7 +19,7 @@
 
 `nixos-option nix.buildMachines`
 
-- List key on another NixOS configuration:
+- List all subkeys of a given key on another NixOS configuration:
 
 `NIXOS_CONFIG={{path_to_configuration.nix}} nixos-option {{option_key}}`
 

--- a/pages/linux/nixos-option.md
+++ b/pages/linux/nixos-option.md
@@ -1,7 +1,7 @@
 # nixos-option
 
 > Inspect a NixOS configuration.
-> More information: <https://nixos.org/manual/nixos/stable/index.html#sec-modularity>
+> More information: <https://nixos.org/manual/nixos/stable/index.html#sec-modularity>.
 
 - List all keys of an option key:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** not applicable.