### PR TITLE
python: update deprecated script/file path

### DIFF
--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -9,11 +9,11 @@
 
 - Execute script in a given Python file:
 
-`python {{script.py}}`
+`python {{path/to/file.py}}`
 
 - Execute script as part of an interactive shell:
 
-`python -i {{script.py}}`
+`python -i {{path/to/file.py}}`
 
 - Execute a Python expression:
 
@@ -29,7 +29,7 @@
 
 - Interactively debug a Python script:
 
-`python -m pdb {{script.py}}`
+`python -m pdb {{path/to/file.py}}`
 
 - Start the built-in HTTP server on port 8000 in the current directory:
 

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -7,11 +7,11 @@
 
 `python`
 
-- Execute script in a given Python file:
+- Execute a specific Python file:
 
 `python {{path/to/file.py}}`
 
-- Execute script as part of an interactive shell:
+- Execute a specific Python file and start a REPL:
 
 `python -i {{path/to/file.py}}`
 

--- a/pages/common/python.md
+++ b/pages/common/python.md
@@ -25,11 +25,11 @@
 
 - Install a package using `pip`:
 
-`python -m pip install {{package_name}}`
+`python -m {{pip}} install {{package_name}}`
 
 - Interactively debug a Python script:
 
-`python -m pdb {{path/to/file.py}}`
+`python -m {{pdb}} {{path/to/file.py}}`
 
 - Start the built-in HTTP server on port 8000 in the current directory:
 


### PR DESCRIPTION
After a discussion with @navarroaxel , I fix the python deprecated documentation,

* update deprecated script path for each python command example.
* replace {{script.py}} to {{path/to/file.py}}

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
