### PR TITLE
add-apt-repository: improve --enable-source example description

### DIFF
--- a/pages/linux/add-apt-repository.md
+++ b/pages/linux/add-apt-repository.md
@@ -15,6 +15,6 @@
 
 `add-apt-repository --update {{repository_spec}}`
 
-- Enable source packages:
+- Allow source packages to be downloaded from the repository:
 
 `add-apt-repository --enable-source {{repository_spec}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Based on [http://manpages.ubuntu.com/manpages/bionic/man1/add-apt-repository.1.html](http://manpages.ubuntu.com/manpages/bionic/man1/add-apt-repository.1.html)


**Version of the command being documented (if known):**
