### PR TITLE
set-more-info-link: fix Turkish translation

### DIFF
--- a/scripts/set-more-info-link.py
+++ b/scripts/set-more-info-link.py
@@ -35,7 +35,7 @@ labels = {
     "sv": "Mer information:",
     "ta": "மேலும் தகவல்:",
     "th": "ดูเพิ่มเติม:",
-    "tr": "Daha fazla bilgi için:",
+    "tr": "Daha fazla bilgi:",
     "uk": "Більше інформації:",
     "zh_TW": "更多資訊：",
     "zh": "更多信息：",


### PR DESCRIPTION
`Daha fazla bilgi için` means `For more information`. I think this is a more exact translation for Turkish pages.