### PR TITLE
clang-tidy: add page

### DIFF
--- a/pages/common/clang-tidy.md
+++ b/pages/common/clang-tidy.md
@@ -5,7 +5,7 @@
 
 - Run default checks on a source file:
 
-`clang-tidy {{file.cpp}}`
+`clang-tidy {{path/to/file.cpp}}`
 
 - Don't run any checks other than the cppcoreguidelines checks on a file:
 

--- a/pages/common/clang-tidy.md
+++ b/pages/common/clang-tidy.md
@@ -9,7 +9,7 @@
 
 - Don't run any checks other than the cppcoreguidelines checks on a file:
 
-`clang-tidy {{file.cpp}} -checks={{-*,cppcoreguidelines-*}}`
+`clang-tidy {{path/to/file.cpp}} -checks={{-*,cppcoreguidelines-*}}`
 
 - List all checks:
 

--- a/pages/common/clang-tidy.md
+++ b/pages/common/clang-tidy.md
@@ -7,11 +7,11 @@
 
 `clang-tidy {{path/to/file.cpp}}`
 
-- Don't run any checks other than the cppcoreguidelines checks on a file:
+- Don't run any checks other than the `cppcoreguidelines` checks on a file:
 
 `clang-tidy {{path/to/file.cpp}} -checks={{-*,cppcoreguidelines-*}}`
 
-- List all checks:
+- List all available checks:
 
 `clang-tidy -checks={{*}} -list-checks`
 

--- a/pages/common/clang-tidy.md
+++ b/pages/common/clang-tidy.md
@@ -17,4 +17,4 @@
 
 - Specify defines and includes as compilation options (after `--`):
 
-`clang-tidy {{file.cpp}} -- -I{{my_project/include}} -D{{MY_DEFINITIONS}}`
+`clang-tidy {{path/to/file.cpp}} -- -I{{my_project/include}} -D{{definitions}}`

--- a/pages/common/clang-tidy.md
+++ b/pages/common/clang-tidy.md
@@ -1,0 +1,20 @@
+# clang-tidy
+
+> An LLVM-based C/C++ linter to find style violations, bugs and security flaws through static analysis.
+> More information: <https://clang.llvm.org/extra/clang-tidy/>.
+
+- Run default checks on a source file:
+
+`clang-tidy {{file.cpp}}`
+
+- Don't run any checks other than the cppcoreguidelines checks on a file:
+
+`clang-tidy {{file.cpp}} -checks={{-*,cppcoreguidelines-*}}`
+
+- List all checks:
+
+`clang-tidy -checks={{*}} -list-checks`
+
+- Specify defines and includes as compilation options (after `--`):
+
+`clang-tidy {{file.cpp}} -- -I{{my_project/include}} -D{{MY_DEFINITIONS}}`


### PR DESCRIPTION
A mention of the value of a compilation database (`compile-commands.json`) would be good, but i was unsure where to fit it in, briefly.

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
