### PR TITLE
wsl: improve --set-version example description

### DIFF
--- a/pages/windows/wsl.md
+++ b/pages/windows/wsl.md
@@ -27,7 +27,7 @@
 
 `wsl --import {{distribution}} {{path/to/install_location}} {{path/to/distro_fs.tar}}`
 
-- Change the version of the specified distribution:
+- Change the version of wsl used for the specified distribution:
 
 `wsl --set-version {{distribution}} {{version}}`
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


The `--set-version` flag does not set the version of the distro, it sets the version of wsl used for the distro. The new example description makes this clearer. See: [Microsoft Documentation](https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-wsl-version-to-1-or-2)

**Version of the command being documented (if known):**
