### PR TITLE
wasm-objdump, wasm-opt, wasm2c, wasm2wat: add link

### DIFF
--- a/pages/common/wasm-objdump.md
+++ b/pages/common/wasm-objdump.md
@@ -1,6 +1,7 @@
 # wasm-objdump
 
 > Display information from WebAssembly binaries.
+> More information: <https://github.com/WebAssembly/wabt>.
 
 - Display the section headers of a given binary:
 

--- a/pages/common/wasm-opt.md
+++ b/pages/common/wasm-opt.md
@@ -1,6 +1,7 @@
 # wasm-opt
 
 > Optimize WebAssembly binary files.
+> More information: <https://github.com/webassembly/binaryen>.
 
 - Apply default optimizations and write to a given file:
 

--- a/pages/common/wasm2c.md
+++ b/pages/common/wasm2c.md
@@ -1,6 +1,7 @@
 # wasm2c
 
 > Convert a file from the WebAssembly binary format to a C source file and header.
+> More information: <https://github.com/WebAssembly/wabt>.
 
 - Convert a file to a C source file and header and display it to the console:
 

--- a/pages/common/wasm2wat.md
+++ b/pages/common/wasm2wat.md
@@ -1,6 +1,7 @@
 # wasm2wat
 
 > Convert a file from the WebAssembly binary format to the text format.
+> More information: <https://github.com/WebAssembly/wabt>.
 
 - Convert a file to the text format and display it to the console:
 


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

Adds more links to address part of #6062.

I hope the mass change is acceptible given that they are all almost the same.

`wasm-objdump`, `wasm2c` and `wasm2wat` are all from [wabt](https://github.com/WebAssembly/wabt), which they all link to, as [`wat2wasm` does](
https://github.com/tldr-pages/tldr/blob/a178733e8e19d07f54d90abdea24e4f79676169d/pages/common/wat2wasm.md?plain=1#L4). `wasm-opt` is from [binaryen](https://github.com/webassembly/binaryen).