### PR TITLE
handbrakecli: add rip DVD examples; use long arguments

### DIFF
--- a/pages/common/handbrakecli.md
+++ b/pages/common/handbrakecli.md
@@ -1,15 +1,15 @@
 # handbrakecli
 
-> Command-line interface to the HandBrake video conversion tool.
+> Command-line interface to the HandBrake video conversion and DVD ripping tool.
 > More information: <https://handbrake.fr/>.
 
 - Convert a video file to MKV (AAC 160kbit audio and x264 CRF20 video):
 
-`handbrakecli -i {{input.avi}} -o {{output.mkv}} -e x264 -q 20 -B 160`
+`handbrakecli --input {{input.avi}} --output {{output.mkv}} --encoder x264 --quality 20 --ab 160`
 
 - Resize a video file to 320x240:
 
-`handbrakecli -i {{input.mp4}} -o {{output.mp4}} -w 320 -l 240`
+`handbrakecli --input {{input.mp4}} --output {{output.mp4}} --width 320 --height 240`
 
 - List available presets:
 
@@ -17,4 +17,12 @@
 
 - Convert an AVI video to MP4 using the Android preset:
 
-`handbrakecli --preset="Android" -i {{input.ext}} -o {{output.mp4}}`
+`handbrakecli --preset="Android" --input {{input.ext}} --output {{output.mp4}}`
+
+- Print the content of a DVD, getting the CSS keys in the process:
+
+`handbrakecli --input {{/dev/sr0}} --title 0`
+
+- Rip the first track of a DVD in the specified device. Audiotracks and subtitle languages are specified as lists:
+
+`handbrakecli --input {{/dev/sr0}} --title 1 --output {{out.mkv}} --format av_mkv --encoder x264 --subtitle {{1,4,5}} --audio {{1,2}} --aencoder copy --quality {{23}}`


### PR DESCRIPTION
<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [ ] ~~The page (if new), does not already exist in the repository.~~
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

1.3.1+ds1-1build1 
