### PR TITLE
iptables: add Italian translation

### DIFF
--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -27,6 +27,6 @@
 
 `sudo iptables-save -t {{nome tabella}} > {{percorso/al/file_iptables}}`
 
-- Ripristina la configurazione di iptables da un file
+- Ripristina la configurazione di iptables da un file:
 
 `sudo iptables-restore < {{percorso/al/file_iptables}}`

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -11,7 +11,7 @@
 
 `sudo iptables -P {{catena}} {{regola}}`
 
-- Appendi regola ad una catena di policy per IP
+- Appendi regola ad una catena di policy per IP:
 
 `sudo iptables -A {{catena}} -s {{ip}} -j {{regola}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -21,7 +21,7 @@
 
 - Cancella regola da una catena
 
-`sudo iptables -D {{catena}} {{numero di linea della regola}}`
+`sudo iptables -D {{catena}} {{numero_di_linea_della_regola}}`
 
 - Salva la configurazione di ip tables di una specifica tabella in un file
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -15,7 +15,7 @@
 
 `sudo iptables -A {{catena}} -s {{ip}} -j {{regola}}`
 
-- Appendi regola ad una catena di policy per IP considerando protocollo e porta
+- Appendi regola ad una catena di policy per IP considerando protocollo e porta:
 
 `sudo iptables -A {{catena}} -s {{ip}} -p {{protocollo}} --dport {{porta}} -j {{regola}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -23,7 +23,7 @@
 
 `sudo iptables -D {{catena}} {{numero_di_linea_della_regola}}`
 
-- Salva la configurazione di ip tables di una specifica tabella in un file
+- Salva la configurazione di ip tables di una specifica tabella in un file:
 
 `sudo iptables-save -t {{nome tabella}} > {{percorso/al/file_iptables}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -19,7 +19,7 @@
 
 `sudo iptables -A {{catena}} -s {{ip}} -p {{protocollo}} --dport {{porta}} -j {{regola}}`
 
-- Cancella regola da una catena
+- Cancella regola da una catena:
 
 `sudo iptables -D {{catena}} {{numero_di_linea_della_regola}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -7,7 +7,7 @@
 
 `sudo iptables -vnL`
 
-- Imposta regola ad una catena
+- Imposta regola ad una catena:
 
 `sudo iptables -P {{catena}} {{regola}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -8,24 +8,24 @@
 
 - Imposta regola ad una catena
 
-`sudo iptables -P {{chain}} {{rule}}`
+`sudo iptables -P {{catena}} {{regola}}`
 
 - Appendi regola ad una catena di policy per IP
 
-`sudo iptables -A {{chain}} -s {{ip}} -j {{rule}}`
+`sudo iptables -A {{catena}} -s {{ip}} -j {{regola}}`
 
 - Appeni regola ad una catena di policy per IP considerando protocollo e porta
 
-`sudo iptables -A {{chain}} -s {{ip}} -p {{protocol}} --dport {{port}} -j {{rule}}`
+`sudo iptables -A {{catena}} -s {{ip}} -p {{protocollo}} --dport {{porta}} -j {{regola}}`
 
 - Cancella regola da una catena
 
-`sudo iptables -D {{chain}} {{rule_line_number}}`
+`sudo iptables -D {{catena}} {{numero di linea della regola}}`
 
 - Salva la configurazione di ip tables di una specifica tabella in un file
 
-`sudo iptables-save -t {{tablename}} > {{path/to/iptables_file}}`
+`sudo iptables-save -t {{nome tabella}} > {{percorso/al/file_iptables}}`
 
 - Ripristina la configurazione di iptables da un file
 
-`sudo iptables-restore < {{path/to/iptables_file}}`
+`sudo iptables-restore < {{percorso/al/file_iptables}}`

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -14,7 +14,7 @@
 
 `sudo iptables -A {{catena}} -s {{ip}} -j {{regola}}`
 
-- Appeni regola ad una catena di policy per IP considerando protocollo e porta
+- Appendi regola ad una catena di policy per IP considerando protocollo e porta
 
 `sudo iptables -A {{catena}} -s {{ip}} -p {{protocollo}} --dport {{porta}} -j {{regola}}`
 

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -1,0 +1,31 @@
+# iptables
+> Programma che permette di configurare tabelle, catene e regole fornite dal firewall del kernel Linux.
+> Maggiori informazioni: <https://www.netfilter.org/projects/iptables/>.
+
+- Visualizza catene, regole e contatori di pacchetti/byte per la tabella dei filtri:
+
+`sudo iptables -vnL`
+
+- Imposta regola ad una catena
+
+`sudo iptables -P {{chain}} {{rule}}`
+
+- Appendi regola ad una catena di policy per IP
+
+`sudo iptables -A {{chain}} -s {{ip}} -j {{rule}}`
+
+- Appeni regola ad una catena di policy per IP considerando protocollo e porta
+
+`sudo iptables -A {{chain}} -s {{ip}} -p {{protocol}} --dport {{port}} -j {{rule}}`
+
+- Cancella regola da una catena
+
+`sudo iptables -D {{chain}} {{rule_line_number}}`
+
+- Salva la configurazione di ip tables di una specifica tabella in un file
+
+`sudo iptables-save -t {{tablename}} > {{path/to/iptables_file}}`
+
+- Ripristina la configurazione di iptables da un file
+
+`sudo iptables-restore < {{path/to/iptables_file}}`

--- a/pages.it/linux/iptables.md
+++ b/pages.it/linux/iptables.md
@@ -1,4 +1,5 @@
 # iptables
+
 > Programma che permette di configurare tabelle, catene e regole fornite dal firewall del kernel Linux.
 > Maggiori informazioni: <https://www.netfilter.org/projects/iptables/>.
 


### PR DESCRIPTION
Added iptables to the italian documentation

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
