### PR TITLE
pulseaudio: add Italian translation

### DIFF
--- a/pages.it/linux/pulseaudio.md
+++ b/pages.it/linux/pulseaudio.md
@@ -1,0 +1,24 @@
+# pulseaudio
+
+> Programma che permette di gestire il daemon audio di sistema.
+> Maggiori informazioni: <https://www.freedesktop.org/wiki/Software/PulseAudio/>.
+
+- Controlla se PulseAudio è in esecuzione. Se il programma non è attivo viene restituito un exit code diverso da 0:
+
+`pulseaudio --check`
+
+- Esegui il daemon di PulseAudio in background:
+
+`pulseaudio --start`
+
+- Interrompi l'esecuzione del daemon di PulseAudio:
+
+`pulseaudio --kill`
+
+- Mostra i moduli disponibili:
+
+`pulseaudio --dump-modules`
+
+- Carica un modulo all'interno del daemon in esecuzione con gli argomenti specificati:
+
+`pulseaudio --load="{{nome_modulo}} {{argomenti}}"`

--- a/pages.it/linux/pulseaudio.md
+++ b/pages.it/linux/pulseaudio.md
@@ -7,7 +7,7 @@
 
 `pulseaudio --check`
 
-- Esegui il daemon di PulseAudio in background:
+- Esegue il daemon di PulseAudio in background:
 
 `pulseaudio --start`
 

--- a/pages.it/linux/pulseaudio.md
+++ b/pages.it/linux/pulseaudio.md
@@ -11,7 +11,7 @@
 
 `pulseaudio --start`
 
-- Interrompi l'esecuzione del daemon di PulseAudio:
+- Interrompe l'esecuzione del daemon di PulseAudio:
 
 `pulseaudio --kill`
 


### PR DESCRIPTION
I kept "daemon" as an English noun since it makes it more recognizable as a system function. Otherwise it can be translated in "servizio"

<!-- Thank you for sending a PR! -->
<!-- Relevant links - https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message -->
<!-- https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
