### PR TITLE
translation-templates: add Tamil translation

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -31,7 +31,7 @@ Only the left-alignment of the header gets lost and has to be readded again (`|-
 | sh    |                      |                        |                                   |           |                   |
 | sr    |                      |                        |                                   |           |                   |
 | sv    |                      |                        |                                   |           |                   |
-| ta    |                      |                        |                                   |           |                   |
+| ta    | கோப்பு               | அடைவு                | கோப்போ/அடைவோ                | நிரல்தொகுப்பு | பயனர்ப்பெயர்   |
 | th    |                      |                        |                                   |           |                   |
 | tr    |                      |                        |                                   |           |                   |
 | uk    |                      |                        |                                   |           |                   |

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -182,7 +182,9 @@ Not translated yet.
 ---
 ### ta
 
-Not translated yet.
+```markdown
+`example command` போன்ற சிலச் சார்கட்டளைகளுக்குத் தனிப் பக்கம் உள்ளது.
+```
 
 ---
 ### th


### PR DESCRIPTION
I have added Tamil snippets to `translation-templates`. Sorry about the slightly misaligned table column separators. The Tamil script has no monospace font.

This pull request came up in the context of #7350

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).