### PR TITLE
shopt: add more information link

### DIFF
--- a/pages/common/shopt.md
+++ b/pages/common/shopt.md
@@ -2,6 +2,7 @@
 
 > Manage Bash shell options: variables (stored in `$BASHOPTS`) that control behavior specific to the Bash shell.
 > Generic POSIX shell variables (stored in `$SHELLOPTS`) are managed with the `set` command instead.
+> More information: <https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html>
 
 - List of all settable options and whether they are set:
 

--- a/pages/common/shopt.md
+++ b/pages/common/shopt.md
@@ -2,7 +2,7 @@
 
 > Manage Bash shell options: variables (stored in `$BASHOPTS`) that control behavior specific to the Bash shell.
 > Generic POSIX shell variables (stored in `$SHELLOPTS`) are managed with the `set` command instead.
-> More information: <https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html>
+> More information: <https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html>.
 
 - List of all settable options and whether they are set:
 


### PR DESCRIPTION
See #6062

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page description includes a link to documentation or a homepage (if applicable).

I put the gnu.org link over the manned.org link because there is more explanations of the options.
