### PR TITLE
rsync: fix --delete example description

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -28,7 +28,7 @@
 
 `rsync -rauL {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
 
-- Transfer file over SSH and delete local files that do not exist on remote host:
+- Transfer file over SSH and delete remote files that do not exist locally:
 
 `rsync -e ssh --delete {{remote_host}}:{{path/to/remote_file}} {{path/to/local_file}}`
 


### PR DESCRIPTION
The page said that the --delete parameter deletes local files that don't exist on remote.

But the actual behaviour is OPPOSITE of that!

From the man page:

```
--delete                delete extraneous files from dest dirs
```

https://www.mankier.com/1/rsync#--delete