### PR TITLE
notify-send: Add `--app-name` to example

### DIFF
--- a/pages/linux/notify-send.md
+++ b/pages/linux/notify-send.md
@@ -14,6 +14,6 @@
 
 `notify-send -t 5000 "{{Test}}" "{{This is a test}}"`
 
-- Show a notification with an app's icon:
+- Show a notification with an app's icon and app name:
 
-`notify-send "{{Test}}" --icon={{google-chrome}}`
+`notify-send "{{Test}}" --icon={{google-chrome}} --app-name="{{Google Chrome}}"`

--- a/pages/linux/notify-send.md
+++ b/pages/linux/notify-send.md
@@ -14,6 +14,6 @@
 
 `notify-send -t 5000 "{{Test}}" "{{This is a test}}"`
 
-- Show a notification with an app's icon and app name:
+- Show a notification with an app's icon and name:
 
 `notify-send "{{Test}}" --icon={{google-chrome}} --app-name="{{Google Chrome}}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

`notify-send 0.7.9`