### PR TITLE
pylint: add page

### DIFF
--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -1,0 +1,15 @@
+# pylint
+
+> A Python code linter.
+> More information: <https://pylint.pycqa.org/en/latest/>.
+- Show lint errors in a file:
+
+`pylint file`
+
+- Use the configuration from a configuration file, usually named `pylintrc`:
+
+`pylint --rcfile ~/path/to/pylintrc file`
+
+- Disable a specific error code:
+
+`pylint -d error_code file`

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -13,4 +13,4 @@
 
 - Lint a file and disable a specific error code:
 
-`pylint -d error_code file`
+`pylint --disable {{C,W,no-error,design}} {{path/to/file}}`

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -5,7 +5,7 @@
 
 - Show lint errors in a file:
 
-`pylint file`
+`pylint {{path/to/file.py}}`
 
 - Lint a file and use a configuration file (usually named `pylintrc`):
 

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -11,6 +11,6 @@
 
 `pylint --rcfile {{path/to/pylintrc}} {{path/to/file.py}}`
 
-- Disable a specific error code:
+- Lint a file and disable a specific error code:
 
 `pylint -d error_code file`

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -9,7 +9,7 @@
 
 - Lint a file and use a configuration file (usually named `pylintrc`):
 
-`pylint --rcfile ~/path/to/pylintrc file`
+`pylint --rcfile {{path/to/pylintrc}} {{path/to/file.py}}`
 
 - Disable a specific error code:
 

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -2,6 +2,7 @@
 
 > A Python code linter.
 > More information: <https://pylint.pycqa.org/en/latest/>.
+
 - Show lint errors in a file:
 
 `pylint file`

--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -7,7 +7,7 @@
 
 `pylint file`
 
-- Use the configuration from a configuration file, usually named `pylintrc`:
+- Lint a file and use a configuration file (usually named `pylintrc`):
 
 `pylint --rcfile ~/path/to/pylintrc file`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
pylint 2.11.1 on Python 3.10

