### PR TITLE
xrandr: remove duplicate example

### DIFF
--- a/pages.de/linux/xrandr.md
+++ b/pages.de/linux/xrandr.md
@@ -26,7 +26,3 @@
 - Setze die Bildschirmhelligkeit von LVDS1 auf 50%:
 
 `xrandr --output {{LVDS1}} --brightness {{0.5}}`
-
-- Zeige Hardwareinformation der Bildschirme an:
-
-`xrandr -q`

--- a/pages.tr/linux/xrandr.md
+++ b/pages.tr/linux/xrandr.md
@@ -26,7 +26,3 @@
 - LVDS1 için parlaklığı 50% yap:
 
 `xrandr --output {{LVDS1}} --brightness {{0.5}}`
-
-- Ekran donanımı bilgisini göster:
-
-`xrandr -q`

--- a/pages/linux/xrandr.md
+++ b/pages/linux/xrandr.md
@@ -23,10 +23,6 @@
 
 `xrandr --output {{VGA1}} --off`
 
-- Set brightness for LVDS1 to 50%:
+- Set the brightness for LVDS1 to 50%:
 
 `xrandr --output {{LVDS1}} --brightness {{0.5}}`
-
-- See display hardware information:
-
-`xrandr -q`


### PR DESCRIPTION
The last example (`-q`) is the same as the first one (`--query`)