### PR TITLE
tail: fix wording

### DIFF
--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -19,7 +19,7 @@
 
 `tail -f {{file}}`
 
-- Keep reading file until `Ctrl + C`, even if the file is rotated:
+- Keep reading file until `Ctrl + C`, even if the file is inaccessible:
 
 `tail -F {{file}}`
 


### PR DESCRIPTION
I'm not sure if this is even an error, but it sounds very weird.
From the man page:

 	-F     same as --follow=name --retry

	--retry
              keep trying to open a file if it is inaccessible

	-f, --follow[={name|descriptor}]
              output appended data as the file grows;

              an absent option argument means 'descriptor
