### PR TITLE
windows/get-*: add PowerShell-only notice

### DIFF
--- a/pages/windows/get-childitem.md
+++ b/pages/windows/get-childitem.md
@@ -1,6 +1,7 @@
 # Get-ChildItem
 
 > List items in a directory.
+> This command can only be used through `powershell`.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem>.
 
 - List all non-hidden items in the current directory:

--- a/pages/windows/get-childitem.md
+++ b/pages/windows/get-childitem.md
@@ -1,7 +1,7 @@
 # Get-ChildItem
 
 > List items in a directory.
-> This command can only be used through `powershell`.
+> This command can only be used through PowerShell.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem>.
 
 - List all non-hidden items in the current directory:

--- a/pages/windows/get-content.md
+++ b/pages/windows/get-content.md
@@ -1,6 +1,7 @@
 # Get-Content
 
 > Get the content of the item at the specified location.
+> This command can only be used through `powershell`.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-content>.
 
 - Display the content of a file:

--- a/pages/windows/get-content.md
+++ b/pages/windows/get-content.md
@@ -1,7 +1,7 @@
 # Get-Content
 
 > Get the content of the item at the specified location.
-> This command can only be used through `powershell`.
+> This command can only be used through PowerShell.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-content>.
 
 - Display the content of a file:

--- a/pages/windows/get-filehash.md
+++ b/pages/windows/get-filehash.md
@@ -1,7 +1,7 @@
 # Get-FileHash
 
 > Calculate a hash for a file.
-> This command can only be used through `powershell`.
+> This command can only be used through PowerShell.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash>.
 
 - Calculate a hash for a specified file using the SHA256 algorithm:

--- a/pages/windows/get-filehash.md
+++ b/pages/windows/get-filehash.md
@@ -1,6 +1,7 @@
 # Get-FileHash
 
 > Calculate a hash for a file.
+> This command can only be used through `powershell`.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash>.
 
 - Calculate a hash for a specified file using the SHA256 algorithm:

--- a/pages/windows/get-history.md
+++ b/pages/windows/get-history.md
@@ -1,6 +1,7 @@
 # Get-History
 
 > Display PowerShell command history.
+> This command can only be used through `powershell`.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.core/get-history>.
 
 - Display the commands history list with ID:

--- a/pages/windows/get-history.md
+++ b/pages/windows/get-history.md
@@ -1,7 +1,7 @@
 # Get-History
 
 > Display PowerShell command history.
-> This command can only be used through `powershell`.
+> This command can only be used through PowerShell.
 > More information: <https://docs.microsoft.com/powershell/module/microsoft.powershell.core/get-history>.
 
 - Display the commands history list with ID:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Similar to the `This command can only be used through adb shell` notice for some `android/` commands, I decided to do the same for `windows/get-childitem`, `windows/get-content`, `windows/get-filehash`, and `windows/get-history` since they are exclusive to PowerShell and cannot be run from the regular, Command Prompt (`cmd.exe`).

![image](https://user-images.githubusercontent.com/17312341/141065155-4e4ca828-fe06-4c04-9d49-268550e1a061.png)
