### PR TITLE
install: use long arguments format

### DIFF
--- a/pages.fr/common/install.md
+++ b/pages.fr/common/install.md
@@ -10,16 +10,16 @@
 
 - Copie des fichiers vers une destination en mettant à jour leur propriétaire :
 
-`install -o {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --owner={{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers vers une destination en mettant à jour leur groupe d'appartenance :
 
-`install -g {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --group={{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers vers une destination en mettant à jour leur mode :
 
-`install -m {{+x}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --mode={{+x}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers en mettant à jour leur dates d'accès et de modification à partir de leurs sources respectives :
 
-`install -p {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --preserve-timestamps {{chemin/fichier/source}} {{chemin/repertoire/destination}}`

--- a/pages.fr/common/install.md
+++ b/pages.fr/common/install.md
@@ -10,15 +10,15 @@
 
 - Copie des fichiers vers une destination en mettant à jour leur propriétaire :
 
-`install --owner={{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --owner {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers vers une destination en mettant à jour leur groupe d'appartenance :
 
-`install --group={{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --group {{utilisateur}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers vers une destination en mettant à jour leur mode :
 
-`install --mode={{+x}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
+`install --mode {{+x}} {{chemin/fichier/source}} {{chemin/repertoire/destination}}`
 
 - Copie des fichiers en mettant à jour leur dates d'accès et de modification à partir de leurs sources respectives :
 

--- a/pages/common/install.md
+++ b/pages/common/install.md
@@ -10,15 +10,15 @@
 
 - Copy files to the destination, setting their ownership:
 
-`install --owner={{user}} {{path/to/source}} {{path/to/destination}}`
+`install --owner {{user}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files to the destination, setting their group ownership:
 
-`install --group={{user}} {{path/to/source}} {{path/to/destination}}`
+`install --group {{user}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files to the destination, setting their `mode`:
 
-`install --mode={{+x}} {{path/to/source}} {{path/to/destination}}`
+`install --mode {{+x}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files and apply access/modification times of source to the destination:
 

--- a/pages/common/install.md
+++ b/pages/common/install.md
@@ -10,16 +10,16 @@
 
 - Copy files to the destination, setting their ownership:
 
-`install -o {{user}} {{path/to/source}} {{path/to/destination}}`
+`install --owner={{user}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files to the destination, setting their group ownership:
 
-`install -g {{user}} {{path/to/source}} {{path/to/destination}}`
+`install --group={{user}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files to the destination, setting their `mode`:
 
-`install -m {{+x}} {{path/to/source}} {{path/to/destination}}`
+`install --mode={{+x}} {{path/to/source}} {{path/to/destination}}`
 
 - Copy files and apply access/modification times of source to the destination:
 
-`install -p {{path/to/source}} {{path/to/destination}}`
+`install --preserve-timestamps {{path/to/source}} {{path/to/destination}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Citing from our contributing guidelines,

> Try to incorporate the spelled-out version of single-letter options in the example's description. The goal is to allow people to *understand* the syntax of the commands, not just *memorize* it.