### PR TITLE
sed: fix -i example

### DIFF
--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -13,7 +13,7 @@
 
 - Replace all occurrences of a string [i]n a file, overwriting the file (i.e. in-place):
 
-`sed -i '' 's/{{find}}/{{replace}}/g' {{filename}}`
+`sed -i 's/{{find}}/{{replace}}/g' {{filename}}`
 
 - Replace only on lines matching the line pattern:
 


### PR DESCRIPTION
The empty argument '' causes the command to return an error.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

