### PR TITLE
go-build: add clarity

### DIFF
--- a/pages/common/go-build.md
+++ b/pages/common/go-build.md
@@ -3,7 +3,7 @@
 > Compile Go sources.
 > More information: <https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies>.
 
-- Compile a 'package main' file (output will be filename without extension):
+- Compile a 'package main' file (output will be the filename without extension):
 
 `go build {{path/to/main.go}}`
 
@@ -15,6 +15,6 @@
 
 `go build -o {{path/to/binary}} {{path/to/package}}`
 
-- Compile a main package into an executable, with data race detection:
+- Compile a main package into an executable, enabling data race detection:
 
 `go build -race -o {{path/to/executable}} {{path/to/main/package}}`

--- a/pages/common/go-build.md
+++ b/pages/common/go-build.md
@@ -3,7 +3,7 @@
 > Compile Go sources.
 > More information: <https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies>.
 
-- Compile a file:
+- Compile a file (output will be filename without extension):
 
 `go build {{path/to/main.go}}`
 

--- a/pages/common/go-build.md
+++ b/pages/common/go-build.md
@@ -3,7 +3,7 @@
 > Compile Go sources.
 > More information: <https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies>.
 
-- Compile a file (output will be filename without extension):
+- Compile a 'package main' file (output will be filename without extension):
 
 `go build {{path/to/main.go}}`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
