### PR TITLE
masscan: correct typo in hypen

### DIFF
--- a/pages/common/masscan.md
+++ b/pages/common/masscan.md
@@ -14,11 +14,11 @@
 
 - Scan a class B subnet avoiding ranges from a specific exclude file:
 
-`masscan {{10.0.0.0/16}} ‐‐top-ports {{100}} ‐‐excludefile {{path/to/file}}`
+`masscan {{10.0.0.0/16}} --top-ports {{100}} --excludefile {{path/to/file}}`
 
 - Scan the Internet for port 443:
 
-`masscan {{0.0.0.0/0}} --ports {{443}} ––rate {{10000000}}`
+`masscan {{0.0.0.0/0}} --ports {{443}} --rate {{10000000}}`
 
 - Scan the Internet for a specific port range and export to a file:
 


### PR DESCRIPTION
showed on tldr.sh as ```masscan {{10.0.0.0/16}} ââtop-ports {{100}} ââexcludefile {{path/to/file}}```

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
