### PR TITLE
tooling: add PR labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: PR Labeler
+on: pull_request_target
+permissions:
+  pull-requests: write
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tldr-pages/tldr-labeler-action@v0.1.0
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Add a new GH action that acts on any new PR to automatically update its labels. I've added rules for the adding the following:

    new command
    page edit
    translation
    documentation
    tooling

While dealing with these labels could probably be done by using the existing actions/labeler, I've gone with writing our own as we may add to it to support things like mass edit, reviews wanted, etc. which will require more complex logic than simple globing, but will re-use a lot of the logic written here.

Comes from #7330 

Close #7325