### PR TITLE
getopt: use long argument for --options

### DIFF
--- a/pages/linux/getopt.md
+++ b/pages/linux/getopt.md
@@ -5,16 +5,16 @@
 
 - Parse optional `verbose`/`version` flags with shorthands:
 
-`getopt -o vV --longoptions verbose,version -- --version --verbose`
+`getopt --options vV --longoptions verbose,version -- --version --verbose`
 
 - Add a `--file` option with a required argument with shorthand `-f`:
 
-`getopt -o f: --longoptions file: -- --file=somefile`
+`getopt --options f: --longoptions file: -- --file=somefile`
 
 - Add a `--verbose` option with an optional argument with shorthand `-v`, and pass a non-option parameter `arg`:
 
-`getopt -o v:: --longoptions verbose:: -- --verbose arg`
+`getopt --options v:: --longoptions verbose:: -- --verbose arg`
 
 - Accept a `-r` and `--verbose` flag, a `--accept` option with an optional argument and add a `--target` with a required argument option with shorthands:
 
-`getopt -o rv::s::t: --longoptions verbose,source::,target: -- -v --target target`
+`getopt --options rv::s::t: --longoptions verbose,source::,target: -- -v --target target`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** getopt from util-linux 2.34
