### PR TITLE
hub: add example to raise PR against a specific branch

### DIFF
--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -24,9 +24,9 @@
 
 `gh pr create`
 
-- Create a pull request to a specified branch instead of the default:
+- View a pull request in the browser:
 
-`gh pr create --base {{dev}}`
+`gh pr view --web {{pr_number}}`
 
 - Locally check out the branch of a pull request, given its number:
 

--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -24,9 +24,9 @@
 
 `gh pr create`
 
-- View a pull request in the browser:
+- Create a pull request to a specified branch instead of the default:
 
-`gh pr view --web {{pr_number}}`
+`gh pr create --base {{dev}}`
 
 - Locally check out the branch of a pull request, given its number:
 

--- a/pages/common/hub.md
+++ b/pages/common/hub.md
@@ -20,6 +20,10 @@
 
 `hub pull-request --no-edit`
 
+- Create a PR against a specified branch instead of the default branch:
+
+`hub pull-request --base {{dev}}`
+
 - Create a new branch with the contents of a pull request and switch to it:
 
 `hub pr checkout {{pr_number}}`


### PR DESCRIPTION
- hub: add example to raise PR against a specified branch

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Closes: #7470
