### PR TITLE
labeler.yml: use alias tag v0

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: tldr-pages/tldr-labeler-action@v0.1.0
+    - uses: tldr-pages/tldr-labeler-action@v0
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Automatically use new versions from our labeler actions using the same mechanism that use `actions/checkout@v2` or `actions/setup-node@v2`.

To receive new versions automatically the tag `v0` should be updated when a new tag, e.g. `v0.1.1`, is created.