### PR TITLE
apt-moo: add page

### DIFF
--- a/pages/common/apt-moo.md
+++ b/pages/common/apt-moo.md
@@ -1,0 +1,8 @@
+# apt moo
+
+> An `APT` easter egg.
+> More information: <https://manpages.debian.org/latest/apt/apt.8.html>.
+
+- Print a cow easter egg:
+
+`apt moo`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

This page is highly essential, yet extremely stupid. Nothing more than a joke in apt.

If we don't think this fits TLDR's aims and expectations then close!
