### PR TITLE
style-guide: mention tldr-lint instead of tldrl

### DIFF
--- a/contributing-guides/style-guide.de.md
+++ b/contributing-guides/style-guide.de.md
@@ -32,7 +32,7 @@
  ```
 
  Für andere Optionen von `tldr-lint`, wie zum Beispiel das Linten eines ganzen Verzeichnisses:
- [`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternativ, kann man auch den Alias `tldrl` verwenden.
+ [`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternativ, kann man auch den Alias `tldrl` verwenden.
 
  Viele Clients unterstützen die `--render` Flag zum Anzeigen einer Seite:
 

--- a/contributing-guides/style-guide.de.md
+++ b/contributing-guides/style-guide.de.md
@@ -27,12 +27,12 @@
  er kann aber auch manuell installiert werden, um seine Seiten schon vorher zu überprüfen:
 
  ```
- npm install tldr-lint
- tldrl -f {{seite.md}}
+ npm install --global tldr-lint
+ tldr-lint -f {{seite.md}}
  ```
 
- Für andere Optionen von `tldrl`, wie zum Beispiel das Linten eines ganzen Verzeichnisses:
- [`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldrl.md)
+ Für andere Optionen von `tldr-lint`, wie zum Beispiel das Linten eines ganzen Verzeichnisses:
+ [`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternativ, kann man auch den Alias `tldrl` verwenden.
 
  Viele Clients unterstützen die `--render` Flag zum Anzeigen einer Seite:
 

--- a/contributing-guides/style-guide.de.md
+++ b/contributing-guides/style-guide.de.md
@@ -28,7 +28,7 @@
 
  ```
  npm install --global tldr-lint
- tldr-lint -f {{seite.md}}
+ tldr-lint {{seite.md}}
  ```
 
  Für andere Optionen von `tldr-lint`, wie zum Beispiel das Linten eines ganzen Verzeichnisses:

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -27,12 +27,12 @@ It is run automatically on every pull request,
 but you may install it to test your contributions locally before submitting them:
 
 ```
-npm install tldr-lint
-tldrl -f {{page.md}}
+npm install --global tldr-lint
+tldr-lint -f {{page.md}}
 ```
 
-For other ways to use `tldrl`, such as linting an entire directory, check out (what else!)
-[`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldrl.md).
+For other ways to use `tldr-lint`, such as linting an entire directory, check out (what else!)
+[`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternatively, you can also use it's alias `tldrl`.
 
 Your client may be able to preview a page locally using the `--render` flag:
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -28,7 +28,7 @@ but you may install it to test your contributions locally before submitting them
 
 ```
 npm install --global tldr-lint
-tldr-lint -f {{page.md}}
+tldr-lint {{page.md}}
 ```
 
 For other ways to use `tldr-lint`, such as linting an entire directory, check out (what else!)

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -32,7 +32,7 @@ tldr-lint -f {{page.md}}
 ```
 
 For other ways to use `tldr-lint`, such as linting an entire directory, check out (what else!)
-[`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternatively, you can also use it's alias `tldrl`.
+[`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/main/pages/common/tldr-lint.md). Alternatively, you can also use its alias `tldrl`.
 
 Your client may be able to preview a page locally using the `--render` flag:
 

--- a/contributing-guides/style-guide.zh.md
+++ b/contributing-guides/style-guide.zh.md
@@ -30,7 +30,7 @@
 
 ```
 npm install --global tldr-lint
-tldr-lint -f {{page.md}}
+tldr-lint {{page.md}}
 ```
 
 关于 `tldr-lint` 的更多使用方法，例如检查批量检查一整个目录的格式，[`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/master/pages/common/tldr-lint.md) 是你的不二去处！

--- a/contributing-guides/style-guide.zh.md
+++ b/contributing-guides/style-guide.zh.md
@@ -29,11 +29,11 @@
 你也可以在提交前在本地测试自己的贡献：
 
 ```
-npm install tldr-lint
-tldrl -f {{page.md}}
+npm install --global tldr-lint
+tldr-lint -f {{page.md}}
 ```
 
-关于 `tldrl` 的更多使用方法，例如检查批量检查一整个目录的格式，[`tldr tldrl`](https://github.com/tldr-pages/tldr/blob/master/pages/common/tldrl.md) 是你的不二去处！
+关于 `tldr-lint` 的更多使用方法，例如检查批量检查一整个目录的格式，[`tldr tldr-lint`](https://github.com/tldr-pages/tldr/blob/master/pages/common/tldr-lint.md) 是你的不二去处！
 
 如果你用 tldr-pages 的 Node.js 客户端，你可以在命令后加 `-f` (`--render`) 来在本地预览自己的页面：
 


### PR DESCRIPTION
* I added the `--global` flag, because otherwise, it wouldn't be available as command.
* I replaced `tldrl` with `tldr-lint`, because with `tldr tldrl` you just get the alias page.