### PR TITLE
git-terminal: update instructions to amend author

### DIFF
--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -68,24 +68,25 @@ git push --force-with-lease
 
 # Changing the email of any commit(s)
 
-Let's take this commit history as an example:
-
-| Commit Hash | Author Email
-|---|---
-| A | wrong@example.org
-| B | correct@example.org
-| C | correct@example.org
-| D | wrong@example.org
-| E | correct@example.org
-| F (HEAD) | correct@example.org
-
-To change the email of commits A and D, run
+1. Perform an [interactive rebase](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt--i) specifying the reference of the earliest commit to modify as the argument. For example, if the earlist commit with the wrong email address was 6 commits ago, you can specify the commit hash or just `HEAD~6`.
 
 ```bash
-git reset A
-git commit --amend --author="Your Name <correct@example.org>"
-git cherry-pick B^..D # re-apply commits B to D
-git commit --amend --author="Your Name <correct@example.org>"
-git cherry-pick E^..HEAD
+git rebase --interactive HEAD~6
+```
+
+2. You'll see a list of commits starting from the referenced commit to `HEAD`. All of them will default to the instruction `pick`, this means use the commit as-is when replaying them. For the commits you want to edit, replace the word `pick` for `edit`, then save and exit the editor.
+
+3. The branch will rewind to the referenced commit, then replay them until it reaches a commit with the `edit` instruction. Amend the commit for the correct email address, then continue rebasing. Repeat this step until you've succesfully finishing rebasing and replayed all commits.
+
+```bash
+git commit --amend --author "Your Name <correct@example.org>"
+git rebase --continue
+```
+
+4. Finally, because you modified the branch history, you'll need to force push back to your remote repository.
+
+```bash
 git push --force-with-lease
 ```
+
+[![asciicast](https://asciinema.org/a/fFMZzQOgJyfUf8HTnXyRj0v02.svg)](https://asciinema.org/a/fFMZzQOgJyfUf8HTnXyRj0v02)


### PR DESCRIPTION
Updates the docs for updating an old email address. This way is _much_ better than before, and much simpler to perform.

It might be worth revising the instructions, I wanted them to be verbose so people could maybe take the knowledge away with them, but at the same time explaining things rather than providing flat instructions might be daunting. 🤔 

For example, the fact that an interactive rebase works by rewinding the commit history and replaying commits might be redundant information.

Example of me performing the instructions for a single commit:
![Peek 2021-12-05 19-11](https://user-images.githubusercontent.com/22801583/144758254-e7268366-5d80-451c-ab8b-eab7829e4db9.gif)

