### PR TITLE
volta: add page

### DIFF
--- a/pages/common/volta.md
+++ b/pages/common/volta.md
@@ -19,7 +19,7 @@
 
 `volta pin {{node|npm|yarn}}@version`
 
-- Print help listings all sub-commands and all flags:
+- Display help:
 
 `volta help`
 

--- a/pages/common/volta.md
+++ b/pages/common/volta.md
@@ -1,6 +1,6 @@
 # volta
 
-> A JavaScript Tool Manager that installs Node.js runtimes, Npm and Yarn package managers, or any binaries from Npm.
+> A JavaScript Tool Manager that installs Node.js runtimes, npm and Yarn package managers, or any binaries from npm.
 > More information: <https://volta.sh>.
 
 - List all installed tools:

--- a/pages/common/volta.md
+++ b/pages/common/volta.md
@@ -23,6 +23,6 @@
 
 `volta help`
 
-- Print detailed help for a single sub-command:
+- Display help for a subcommand:
 
 `volta help {{fetch|install|uninstall|pin|list|completions|which|setup|run|help}}`

--- a/pages/common/volta.md
+++ b/pages/common/volta.md
@@ -1,0 +1,28 @@
+# volta
+
+> A JavaScript Tool Manager that installs Node.js runtimes, Npm and Yarn package managers, or any binaries from Npm.
+> More information: <https://volta.sh>.
+
+- List all installed tools:
+
+`volta list`
+
+- Install the latest version of a tool:
+
+`volta install {{node|npm|yarn}}`
+
+- Install a specific version of a tool:
+
+`volta install {{node|npm|yarn}}@version`
+
+- Choose a tool version for a project (will store it in `package.json`):
+
+`volta pin {{node|npm|yarn}}@version`
+
+- Print help listings all sub-commands and all flags:
+
+`volta help`
+
+- Print detailed help for a single sub-command:
+
+`volta help {{fetch|install|uninstall|pin|list|completions|which|setup|run|help}}`

--- a/pages/common/volta.md
+++ b/pages/common/volta.md
@@ -9,7 +9,7 @@
 
 - Install the latest version of a tool:
 
-`volta install {{node|npm|yarn}}`
+`volta install {{node|npm|yarn|package_name}}`
 
 - Install a specific version of a tool:
 


### PR DESCRIPTION
I discovered [`Volta`](https://volta.sh) recently, I use it for some personal/professional JavaScript projects. 🤓

- [x] The page does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
Version `1.0.5` (as seen via `volta --version`).