### PR TITLE
groff: add --RAW-CONTROL-CHARS to pager example

### DIFF
--- a/pages/common/groff.md
+++ b/pages/common/groff.md
@@ -9,7 +9,7 @@
 
 - Render a man page using the ASCII output device, and display it using a pager:
 
-`groff -man -T ascii {{path/to/manpage.1}} | less`
+`groff -man -T ascii {{path/to/manpage.1}} | less --RAW-CONTROL-CHARS`
 
 - Render a man page into an HTML file:
 


### PR DESCRIPTION
Without --RAW-CONTROL-CHARS less in the example would mangle the display by converting the control characters into the caret notation.