### PR TITLE
vswhere: remove invalid quotes in example

### DIFF
--- a/pages/windows/vswhere.md
+++ b/pages/windows/vswhere.md
@@ -5,7 +5,7 @@
 
 - Find the path of vcvarsall.bat to set environment variables:
 
-`vswhere -products * -latest -prerelease -find "**/VC/Auxiliary/Build/vcvarsall.bat"`
+`vswhere -products * -latest -prerelease -find **/VC/Auxiliary/Build/vcvarsall.bat`
 
 - Find the directory of the x64 MSVC compiler (cl.exe, etc):
 


### PR DESCRIPTION
```
Visual Studio Locator version 2.8.4+ff0de50053 [query version 3.0.4492.23473]
Copyright (C) Microsoft Corporation. All rights reserved.

Error 0x57: The pattern ""**/VC/Auxiliary/Build/vcvarsall.bat"" is invalid
exit status 87
```

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** All