### PR TITLE
xargs: replace url

### DIFF
--- a/pages/common/xargs.md
+++ b/pages/common/xargs.md
@@ -2,7 +2,7 @@
 
 > Execute a command with piped arguments coming from another command, a file, etc.
 > The input is treated as a single block of text and split into separate pieces on spaces, tabs, newlines and end-of-file.
-> More information: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html>.
+> More information: <https://man7.org/linux/man-pages/man1/xargs.1p.html>.
 
 - Run a command using the input data as arguments:
 


### PR DESCRIPTION
https://man7.org is a more correct (maybe even more trusted) reference than https://pubs.opengroup.org for the man page

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
