### PR TITLE
glab-repo: add page

### DIFF
--- a/pages/common/glab-repo.md
+++ b/pages/common/glab-repo.md
@@ -1,7 +1,7 @@
 # glab repo
 
 > Work with Gitlab repositories on the command-line.
-> More infornmation: <https://glab.readthedocs.io/en/latest/repo/index.html#synopsis>.
+> More information: <https://glab.readthedocs.io/en/latest/repo/index.html#synopsis>.
 
 - Create a new repository (if the repository name is not set, the default name will be the name of the current directory):
 

--- a/pages/common/glab-repo.md
+++ b/pages/common/glab-repo.md
@@ -1,0 +1,24 @@
+# glab repo
+
+> Work with Gitlab repositories on the command-line.
+> More infornmation: <https://glab.readthedocs.io/en/latest/repo/index.html#synopsis>.
+
+- Create a new repository (if the repository name is not set, the default name will be the name of the current directory):
+
+`glab repo create {{name}}`
+
+- Clone a repository:
+
+`glab repo clone {{owner}}/{{repository}}`
+
+- Fork and clone a repository:
+
+`glab repo fork {{owner}}/{{repository}} --clone`
+
+- View a repository in the web browser:
+
+`glab repo view {{owner}}/{{repository}} --web`
+
+- Search some repositories in the Gitlab instance:
+
+`glab repo search -s {{search_string}}`

--- a/pages/common/glab-repo.md
+++ b/pages/common/glab-repo.md
@@ -1,6 +1,6 @@
 # glab repo
 
-> Work with Gitlab repositories on the command-line.
+> Work with GitLab repositories on the command-line.
 > More information: <https://glab.readthedocs.io/en/latest/repo/index.html#synopsis>.
 
 - Create a new repository (if the repository name is not set, the default name will be the name of the current directory):
@@ -19,6 +19,6 @@
 
 `glab repo view {{owner}}/{{repository}} --web`
 
-- Search some repositories in the Gitlab instance:
+- Search some repositories in the GitLab instance:
 
 `glab repo search -s {{search_string}}`


### PR DESCRIPTION
* add a page for the glab repo subcommand.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
