### PR TITLE
CLIENT-SPECIFICATION: drop the special "all" platform

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -38,7 +38,7 @@ Option             | Required?   | Meaning
 `-v`, `--version`  | Yes         | Shows the current version of the client, and the version of this specification that it implements.
 `-p`, `--platform` | Yes         | Specifies the platform to be used to perform the action (either listing or searching) as an argument. If this option is specified, the selected platform MUST be checked first instead of the current platform as described below.
 `-u`, `--update`   | Conditional | Updates the offline cache of pages. MUST be implemented if cache is supported.
-`-l`, `--list`     | No          | Lists all the pages in the current platform to the standard output. If the special platform `all` is specified a list of all pages in all platforms MUST be displayed.
+`-l`, `--list`     | No          | Lists all the pages in the current platform to the standard output.
 `-L`, `--language` | No          | Specifies the preferred language for the page returned. Overrides other language detection mechanisms. See the [language section](#language) for more information.
 
 Clients MAY choose to only implement the short version of an option, ignoring the long form.


### PR DESCRIPTION
As discussed in #7528 and [here](https://github.com/tldr-pages/tldr/pull/7561#issuecomment-997473651):

Drop the special `all` platform.