### PR TITLE
makepkg: fix command to match standard

### DIFF
--- a/pages/linux/makepkg.md
+++ b/pages/linux/makepkg.md
@@ -28,6 +28,5 @@
 
 `makepkg --verifysource`
 
-- Generate and save the source information into `.srcinfo`:
-
-`makepkg --printsrcinfo > .srcinfo`
+- Generate and save the source information into `.SRCINFO`:
+`makepkg --printsrcinfo > .SRCINFO`

--- a/pages/linux/makepkg.md
+++ b/pages/linux/makepkg.md
@@ -29,4 +29,5 @@
 `makepkg --verifysource`
 
 - Generate and save the source information into `.SRCINFO`:
+
 `makepkg --printsrcinfo > .SRCINFO`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**


This matches the Arch Wiki, since it needs to be in capitals for the pkgbuild compliance 