### PR TITLE
git-standup: add page

### DIFF
--- a/pages/common/git-standup.md
+++ b/pages/common/git-standup.md
@@ -1,6 +1,7 @@
 # git standup
 
 > See commits from a specified user.
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-standup>.
 
 - Show someones commits from the last 10 days:

--- a/pages/common/git-standup.md
+++ b/pages/common/git-standup.md
@@ -1,0 +1,20 @@
+# git standup
+
+> See commits from a specified user.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-standup>.
+
+- Show someones commits from the last 10 days:
+
+`git standup -a {{name|email}} -d {{10}}`
+
+- Show someones commits from the last 10 days and if they are GPG signed:
+
+`git standup -a {[name|email}} -d {{10}} -g`
+
+- Show all the commits from all contributors for the last 10 days:
+
+`git standup -a all -d {{10}}`
+
+- Display help:
+
+`git standup -h`

--- a/pages/common/git-standup.md
+++ b/pages/common/git-standup.md
@@ -4,7 +4,7 @@
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-standup>.
 
-- Show someones commits from the last 10 days:
+- Show a given author's commits from the last 10 days:
 
 `git standup -a {{name|email}} -d {{10}}`
 

--- a/pages/common/git-standup.md
+++ b/pages/common/git-standup.md
@@ -8,7 +8,7 @@
 
 `git standup -a {{name|email}} -d {{10}}`
 
-- Show someones commits from the last 10 days and if they are GPG signed:
+- Show a given author's commits from the last 10 days and whether they are GPG signed:
 
 `git standup -a {[name|email}} -d {{10}} -g`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
