### PR TITLE
git-mr: add page

### DIFF
--- a/pages/common/git-mr.md
+++ b/pages/common/git-mr.md
@@ -1,0 +1,20 @@
+# git mr
+
+> Check out GitLab merge requests locally.
+> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-mr>.
+
+- Check out a specific merge request:
+
+`git mr {{mr_number}}`
+
+- Check out a merge request for a specific remote:
+
+`git mr {{mr_number}} {{remote}}`
+
+- Checkout a merge request from its URL:
+
+`git mr {{url}}`
+
+- Clean up old merge request branches:
+
+`git mr clean`

--- a/pages/common/git-mr.md
+++ b/pages/common/git-mr.md
@@ -1,13 +1,14 @@
 # git mr
 
 > Check out GitLab merge requests locally.
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-mr>.
 
 - Check out a specific merge request:
 
 `git mr {{mr_number}}`
 
-- Check out a merge request for a specific remote:
+- Check out a merge request from a specific remote:
 
 `git mr {{mr_number}} {{remote}}`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
