### PR TITLE
git-delete-tag: add backticks to git-extras

### DIFF
--- a/pages/common/git-delete-tag.md
+++ b/pages/common/git-delete-tag.md
@@ -1,7 +1,7 @@
 # git delete-tag
 
 > Delete existing local and remote tags.
-> Part of git-extras.
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-delete-tag>.
 
 - Delete a tag:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


