### PR TITLE
git-pr: fix grammar

### DIFF
--- a/pages/common/git-pr.md
+++ b/pages/common/git-pr.md
@@ -7,7 +7,7 @@
 
 `git pr {{pr_number}}`
 
-- Check out a pull request for a specific remote:
+- Check out a pull request from a specific remote:
 
 `git pr {{pr_number}} {{remote}}`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


