### PR TITLE
git-pr: add git-extras note in the command description

### DIFF
--- a/pages/common/git-pr.md
+++ b/pages/common/git-pr.md
@@ -1,7 +1,7 @@
 # git pr
 
 > Check out GitHub pull requests locally.
-> Part of `git-extras`
+> Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-pr>.
 
 - Check out a specific pull request:

--- a/pages/common/git-pr.md
+++ b/pages/common/git-pr.md
@@ -1,6 +1,7 @@
 # git pr
 
 > Check out GitHub pull requests locally.
+> Part of `git-extras`
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-pr>.
 
 - Check out a specific pull request:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).


