### PR TITLE
enum4linux: fix typo

### DIFF
--- a/pages/linux/enum4linux.md
+++ b/pages/linux/enum4linux.md
@@ -10,16 +10,16 @@
 
 - Enumerate using given login credentials:
 
-`enum4liux -u {{user_name}} -p {{password}} {{remote_host}}`
+`enum4linux -u {{user_name}} -p {{password}} {{remote_host}}`
 
 - List usernames from a given host:
 
-`enum4liux -U {{remote_host}}`
+`enum4linux -U {{remote_host}}`
 
 - List shares:
 
-`enum4liux -S {{remote_host}}`
+`enum4linux -S {{remote_host}}`
 
 - Get OS information:
 
-`enum4liux -o {{remote_host}}`
+`enum4linux -o {{remote_host}}`


### PR DESCRIPTION
fix typo in enum4linux.md

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
