### PR TITLE
a2query, dpkg*, check-support-status, netselect-apt, reportbug: update Debian link

### DIFF
--- a/pages.de/linux/a2query.md
+++ b/pages.de/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Zeigt Apache Laufzeitkonfigurationen auf Debian-basierten Betriebssystemen an.
-> Weitere Informationen: <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> Weitere Informationen: <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - Zeige aktivierte Apache Module an:
 

--- a/pages.de/linux/dpkg.md
+++ b/pages.de/linux/dpkg.md
@@ -2,7 +2,7 @@
 
 > Debian Paketmanager.
 > Manche Unterbefehle wie `dpkg deb` sind separat dokumentiert.
-> Weitere Informationen: <https://manpages.debian.org/buster/dpkg/dpkg.1.en.html>.
+> Weitere Informationen: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 
 - Installiere ein Paket:
 

--- a/pages.fr/linux/a2query.md
+++ b/pages.fr/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Retourne la configuration d'exécution d'Apache sur une distribution Debian.
-> Plus d'informations : <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> Plus d'informations : <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - Liste les [m]odules Apache actifs :
 

--- a/pages.id/linux/dpkg.md
+++ b/pages.id/linux/dpkg.md
@@ -2,7 +2,7 @@
 
 > Manajer paket Debian.
 > Beberapa subperintah seperti `dpkg deb` memiliki dokumentasi penggunaannya sendiri.
-> Informasi lebih lanjut: <https://manpages.debian.org/buster/dpkg/dpkg.1.en.html>.
+> Informasi lebih lanjut: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 
 - Memasang paket dari sebuah file DEB:
 

--- a/pages.it/linux/a2query.md
+++ b/pages.it/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Recupera la configurazione di runtime da Apache su sistemi operativi basati su Debian.
-> Maggiori informazioni: <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> Maggiori informazioni: <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - Lista i moduli Apache attivi:
 

--- a/pages.it/linux/dpkg-deb.md
+++ b/pages.it/linux/dpkg-deb.md
@@ -1,7 +1,7 @@
 # dpkg-deb
 
 > Impacchetta, spacchetta e fornisce informazioni su archivi Debian.
-> Maggiori informazioni: <https://manpages.debian.org/buster/dpkg/dpkg-deb.1.en.html>.
+> Maggiori informazioni: <https://manpages.debian.org/latest/dpkg/dpkg-deb.html>.
 
 - Mostra le informazioni riguardo ad un pacchetto:
 

--- a/pages.it/linux/dpkg.md
+++ b/pages.it/linux/dpkg.md
@@ -2,7 +2,7 @@
 
 > Gestore di pacchetti Debian.
 > Alcuni comandi aggiuntivi, come `dpkg deb`, hanno la propria documentazione.
-> Maggiori informazioni: <https://manpages.debian.org/buster/dpkg/dpkg.1.en.html>.
+> Maggiori informazioni: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 
 - Installa un pacchetto:
 

--- a/pages.pt_BR/linux/a2query.md
+++ b/pages.pt_BR/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Exibe configurações de execução do Apache em sistemas operacionais baseados no Debian.
-> Mais informações: <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> Mais informações: <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - Lista módulos ativos do Apache:
 

--- a/pages.pt_BR/linux/dpkg.md
+++ b/pages.pt_BR/linux/dpkg.md
@@ -2,7 +2,7 @@
 
 > Gerenciador de pacotes Debian.
 > Alguns subcomandos como `dpkg deb` tem sua própia documentação de uso.
-> Mais informações: <https://manpages.debian.org/buster/dpkg/dpkg.1.en.html>.
+> Mais informações: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 
 - Instalar um pacote:
 

--- a/pages.pt_PT/linux/a2query.md
+++ b/pages.pt_PT/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Mostra configurações runtime do Apache em distribuições baseadas em Debian.
-> Mais informações: <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> Mais informações: <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - Lista módulos Apache activados:
 

--- a/pages.zh/linux/a2query.md
+++ b/pages.zh/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > 在基于 Debian 的操作系统上查看 Apache 运行配置。
-> 更多信息：<https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> 更多信息：<https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - 列出启用的 Apache 模块：
 

--- a/pages/linux/a2query.md
+++ b/pages/linux/a2query.md
@@ -1,7 +1,7 @@
 # a2query
 
 > Retrieve runtime configuration from Apache on Debian-based OSes.
-> More information: <https://manpages.debian.org/buster/apache2/a2query.1.en.html>.
+> More information: <https://manpages.debian.org/latest/apache2/a2query.html>.
 
 - List enabled Apache modules:
 

--- a/pages/linux/check-support-status.md
+++ b/pages/linux/check-support-status.md
@@ -1,7 +1,7 @@
 # check-support-status
 
 > Identify installed Debian packages for which support has had to be limited or prematurely ended.
-> More information: <https://manpages.debian.org/buster/debian-security-support/check-support-status.1.en.html>.
+> More information: <https://manpages.debian.org/latest/debian-security-support/check-support-status.html>.
 
 - Display packages whose support is limited, has already ended or will end earlier than the distribution's end of life:
 

--- a/pages/linux/dpkg-deb.md
+++ b/pages/linux/dpkg-deb.md
@@ -1,7 +1,7 @@
 # dpkg-deb
 
 > Pack, unpack and provide information about Debian archives.
-> More information: <https://manpages.debian.org/buster/dpkg/dpkg-deb.1.en.html>.
+> More information: <https://manpages.debian.org/latest/dpkg/dpkg-deb.html>.
 
 - Display information about a package:
 

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -2,7 +2,7 @@
 
 > Debian package manager.
 > Some subcommands such as `dpkg deb` have their own usage documentation.
-> More information: <https://manpages.debian.org/buster/dpkg/dpkg.1.en.html>.
+> More information: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 
 - Install a package:
 

--- a/pages/linux/netselect-apt.md
+++ b/pages/linux/netselect-apt.md
@@ -1,7 +1,7 @@
 # netselect-apt
 
 > Create a `sources.list` file for a Debian mirror with the lowest latency.
-> More information: <https://manpages.debian.org/buster/netselect-apt/netselect-apt.1.html>.
+> More information: <https://manpages.debian.org/latest/netselect-apt/netselect-apt.html>.
 
 - Create `sources.list` using the lowest latency server:
 

--- a/pages/linux/reportbug.md
+++ b/pages/linux/reportbug.md
@@ -1,7 +1,7 @@
 # reportbug
 
 > Bug report tool of Debian distribution.
-> More information: <https://manpages.debian.org/buster/reportbug/reportbug.1.en.html>.
+> More information: <https://manpages.debian.org/latest/reportbug/reportbug.html>.
 
 - Generate a bug report about a specific package, then send it by e-mail:
 


### PR DESCRIPTION

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
