### PR TITLE
ncdu: add `--color` example and link

### DIFF
--- a/pages/linux/ncdu.md
+++ b/pages/linux/ncdu.md
@@ -7,9 +7,9 @@
 
 `ncdu`
 
-- Colorize output (available colors `off`, `dark`):
+- Colorize output:
 
-`ncdu --color {{dark}}`
+`ncdu --color {{dark|off}}`
 
 - Analyze a given directory:
 

--- a/pages/linux/ncdu.md
+++ b/pages/linux/ncdu.md
@@ -6,6 +6,10 @@
 
 `ncdu`
 
+- Colorize output:
+
+`ncdu --color dark`
+
 - Analyze a given directory:
 
 `ncdu {{path/to/directory}}`

--- a/pages/linux/ncdu.md
+++ b/pages/linux/ncdu.md
@@ -1,6 +1,7 @@
 # ncdu
 
 > Disk usage analyzer with an ncurses interface.
+> More information: <https://manned.org/ncdu>.
 
 - Analyze the current working directory:
 

--- a/pages/linux/ncdu.md
+++ b/pages/linux/ncdu.md
@@ -7,9 +7,9 @@
 
 `ncdu`
 
-- Colorize output:
+- Colorize output (available colors `off`, `dark`):
 
-`ncdu --color dark`
+`ncdu --color {{dark}}`
 
 - Analyze a given directory:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

`ncdu 1.16`