### PR TITLE
code: add --new-window example

### DIFF
--- a/pages/common/code.md
+++ b/pages/common/code.md
@@ -19,6 +19,10 @@
 
 `code --reuse-window {{path/to/file_or_directory}}`
 
+- Open a file or directory in a new VS Code window:
+
+`code --new-window {{path/to/file_or_directory}}`
+
 - Compare two files in VS Code:
 
 `code -d {{file1}} {{file2}}`


### PR DESCRIPTION
It seems to be VS Code's default behavior (when opened from a terminal) to open files in an existing window, so I end up having to look up --new-window much more than --reuse-window.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

**Version of the command being documented (if known):**
1.63.2