### PR TITLE
dig: fix more information link

### DIFF
--- a/pages.it/common/dig.md
+++ b/pages.it/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > Utilità di lookup DNS.
-> Maggiori informazioni: <https://manpages.debian.org/dnsutils/dig.1.html>.
+> Maggiori informazioni: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
 
 - Mostra gli IP associati ad un hostname (record A):
 

--- a/pages.it/common/dig.md
+++ b/pages.it/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > Utilità di lookup DNS.
-> Maggiori informazioni: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
+> Maggiori informazioni: <https://manned.org/dig>.
 
 - Mostra gli IP associati ad un hostname (record A):
 

--- a/pages.ja/common/dig.md
+++ b/pages.ja/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS 情報を調べるユーティリティーです。
-> 詳しくはこちら: <https://manpages.debian.org/dnsutils/dig.1.html>
+> 詳しくはこちら: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>
 
 - ホスト名に関連する IP を検索（A レコード）:
 

--- a/pages.ja/common/dig.md
+++ b/pages.ja/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS 情報を調べるユーティリティーです。
-> 詳しくはこちら: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>
+> 詳しくはこちら: <https://manned.org/dig>
 
 - ホスト名に関連する IP を検索（A レコード）:
 

--- a/pages.ko/common/dig.md
+++ b/pages.ko/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS 조회 유틸리티.
-> 더 많은 정보: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
+> 더 많은 정보: <https://manned.org/dig>.
 
 - 호스트이름과 관련된 IP 조회하기 (A records):
 

--- a/pages.ko/common/dig.md
+++ b/pages.ko/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS 조회 유틸리티.
-> 더 많은 정보: <https://manpages.debian.org/dnsutils/dig.1.html>.
+> 더 많은 정보: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
 
 - 호스트이름과 관련된 IP 조회하기 (A records):
 

--- a/pages.pt_BR/common/dig.md
+++ b/pages.pt_BR/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > Utilitário de pesquisa de DNS.
-> Mais informações: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
+> Mais informações: <https://manned.org/dig>.
 
 - Pesquisa o(s) IP(s) associados a um hostname (Registros A):
 

--- a/pages.pt_BR/common/dig.md
+++ b/pages.pt_BR/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > Utilitário de pesquisa de DNS.
-> Mais informações: <https://manpages.debian.org/dnsutils/dig.1.html>.
+> Mais informações: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
 
 - Pesquisa o(s) IP(s) associados a um hostname (Registros A):
 

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS Lookup utility.
-> More information: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
+> More information: <https://manned.org/dig>.
 
 - Lookup the IP(s) associated with a hostname (A records):
 

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -1,7 +1,7 @@
 # dig
 
 > DNS Lookup utility.
-> More information: <https://manpages.debian.org/dnsutils/dig.1.html>.
+> More information: <https://manpages.debian.org/bind9-dnsutils/dig.1.html>.
 
 - Lookup the IP(s) associated with a hostname (A records):
 


### PR DESCRIPTION
The old URL (<https://manpages.debian.org/dnsutils/dig.1.html>) is now 404ing.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** DiG 9.17.21-1-Debian
