### PR TITLE
df, dig, du, ln, tree: add Spanish translation

### DIFF
--- a/pages.es/common/df.md
+++ b/pages.es/common/df.md
@@ -1,6 +1,6 @@
 # df
 
-> Entrega información general del uso de espacio de disco en sistemas de archivos.
+> Entrega información general del uso de espacio en disco del sistema de archivos.
 > Más información: <https://www.gnu.org/software/coreutils/df>.
 
 - Muestra todos los sistemas de archivos y sus usos de disco:

--- a/pages.es/common/df.md
+++ b/pages.es/common/df.md
@@ -1,0 +1,24 @@
+# df
+
+> Entrega información general del uso de espacio de disco en sistemas de archivos.
+> Más información: <https://www.gnu.org/software/coreutils/df>.
+
+- Muestra todos los sistemas de archivos y sus usos de disco:
+
+`df`
+
+- Muestra todos los sistemas de archivos y sus usos de disco en formato legible para humanos:
+
+`df -h`
+
+- Muestra el sistema de archivos que contiene determinado archivo o directorio y su uso de disco:
+
+`df {{ruta/al/archivo_o_directorio}}`
+
+- Muestra estadísticas sobre el número de inodos libres:
+
+`df -i`
+
+- Muestra sistemas de archivos excluyendo los tipos especificados:
+
+`df -x {{squashfs}} -x {{tmpfs}}`

--- a/pages.es/common/dig.md
+++ b/pages.es/common/dig.md
@@ -1,0 +1,36 @@
+# dig
+
+> Utilidad de consulta para DNS.
+> Más información: <https://manned.org/dig>.
+
+- Consulta la(s) IP(s) asociadas a un nombre de equipo (récords A):
+
+`dig +short {{example.com}}`
+
+- Obtiene una respuesta detallada para un dominio determinado (ŕecords A):
+
+`dig +noall +answer {{example.com}}`
+
+- Consulta un tipo de récord DNS específico asociado a un dominio determinado:
+
+`dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
+
+- Obtiene todos los tipos de récords para un dominio determinado:
+
+`dig {{example.com}} ANY`
+
+- Especifíca un servidor DNS alterno a consultar:
+
+`dig @{{8.8.8.8}} {{example.com}}`
+
+- Realiza una búsqueda DNS inversa para una dirección IP (récord PTR):
+
+`dig -x {{8.8.8.8}}`
+
+- Encuentra servidores de nombre autoritativos para la zona y muestra récords SOA:
+
+`dig +nssearch {{example.com}}`
+
+- Realiza consultas iterativas y muestra el trazado de ruta completo para resolver un dominio:
+
+`dig +trace {{example.com}}`

--- a/pages.es/common/dig.md
+++ b/pages.es/common/dig.md
@@ -3,19 +3,19 @@
 > Utilidad de consulta para DNS.
 > Más información: <https://manned.org/dig>.
 
-- Consulta la(s) IP(s) asociadas a un nombre de equipo (récords A):
+- Consulta la(s) IP(s) asociadas a un nombre de equipo (registros A):
 
 `dig +short {{example.com}}`
 
-- Obtiene una respuesta detallada para un dominio determinado (ŕecords A):
+- Obtiene una respuesta detallada para un dominio determinado (registros A):
 
 `dig +noall +answer {{example.com}}`
 
-- Consulta un tipo de récord DNS específico asociado a un dominio determinado:
+- Consulta un tipo de registro DNS específico asociado a un dominio determinado:
 
 `dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
-- Obtiene todos los tipos de récords para un dominio determinado:
+- Obtiene todos los tipos de registros para un dominio determinado:
 
 `dig {{example.com}} ANY`
 
@@ -23,11 +23,11 @@
 
 `dig @{{8.8.8.8}} {{example.com}}`
 
-- Realiza una búsqueda DNS inversa para una dirección IP (récord PTR):
+- Realiza una búsqueda DNS inversa para una dirección IP (registro PTR):
 
 `dig -x {{8.8.8.8}}`
 
-- Encuentra servidores de nombre autoritativos para la zona y muestra récords SOA:
+- Encuentra servidores de nombre autoritativos para la zona y muestra registros SOA:
 
 `dig +nssearch {{example.com}}`
 

--- a/pages.es/common/du.md
+++ b/pages.es/common/du.md
@@ -1,6 +1,6 @@
 # du
 
-> Uso de disco: estima y resume uso espacio de disco de archivos y directorios.
+> Uso de disco: estima y resume el uso de espacio en disco de archivos y directorios.
 > Más información: <https://www.gnu.org/software/coreutils/du>.
 
 - Lista los tamaños de un directorio y sus subdirectorios en las unidades dadas (B/KiB/MiB):

--- a/pages.es/common/du.md
+++ b/pages.es/common/du.md
@@ -1,0 +1,28 @@
+# du
+
+> Uso de disco: estima y resume uso espacio de disco de archivos y directorios.
+> Más información: <https://www.gnu.org/software/coreutils/du>.
+
+- Lista los tamaños de un directorio y sus subdirectorios en las unidades dadas (B/KiB/MiB):
+
+`du -{{b|k|m}} {{ruta/al/directorio}}`
+
+- Lista los tamaños de un directorio y sus subdirectorios en formato legible para humanos (es decir, seleccionando automáticamente las unidades apropiadas para cada tamaño):
+
+`du -h {{ruta/al/directorio}}`
+
+- Muestra el tamaño de un solo directorio en formato legible para humanos:
+
+`du -sh {{ruta/al/directorio}}`
+
+- Lista los tamaños legibles para humanos de un directorio y de todos los archivos y directorios dentro del mismo:
+
+`du -ah {{ruta/al/directorio}}`
+
+- Lista los tamaños legibles para humanos de un directorio y sus subdirectorios hasta N niveles de profundidad:
+
+`du -h --max-depth=N {{ruta/al/directorio}}`
+
+- Lista el tamaño legible para humanos de todos los archivos `.jpg` en subdirectorios del directorio actual y muestra un total al final:
+
+`du -ch {{*/*.jpg}}`

--- a/pages.es/common/ln.md
+++ b/pages.es/common/ln.md
@@ -1,0 +1,16 @@
+# ln
+
+> Crea enlaces a archivos y directorios.
+> Más información: <https://www.gnu.org/software/coreutils/ln>.
+
+- Crea un enlace simbólico a un archivo o directorio:
+
+`ln -s {{/ruta/al/archivo_o_directorio}} {{ruta/al/enlace_simbólico}}`
+
+- Sobrescribe un enlace simbólico existente para que apunte a un archivo distinto:
+
+`ln -sf {{/ruta/al/nuevo_archivo}} {{ruta/al/enlace_simbólico}}`
+
+- Crea un enlace duro a un archivo:
+
+`ln {{/ruta/al/archivo}} {{ruta/al/enlace_duro}}`

--- a/pages.es/common/tree.md
+++ b/pages.es/common/tree.md
@@ -23,11 +23,11 @@
 
 `tree -s -h --du`
 
-- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón comodín, y excluye los directorios que no contengan archivos coincidentes:
+- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón comodín, excluyendo los directorios que no contengan archivos coincidentes:
 
 `tree -P '{{*.txt}}' --prune`
 
-- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón, y excluye los directorios que no sean ancestros del especificado:
+- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón, excluyendo los directorios que no sean ancestros del especificado:
 
 `tree -P {{nombre_del_directorio}} --matchdirs --prune`
 

--- a/pages.es/common/tree.md
+++ b/pages.es/common/tree.md
@@ -1,0 +1,36 @@
+# tree
+
+> Muestra los contenidos del directorio actual en forma de árbol.
+> Más información: <http://mama.indstate.edu/users/ice/tree/>.
+
+- Imprime archivos y directories hasta `num` niveles de profundidad (donde 1 significa el directorio actual):
+
+`tree -L {{num}}`
+
+- Imprime solo directorios:
+
+`tree -d`
+
+- Imprime también archivos ocultos, coloreando la salida:
+
+`tree -a -C`
+
+- Imprime el árbol sin sangría, mostrando la ruta completa en su lugar (use `-N` para evitar escapar caracteres no imprimibles):
+
+`tree -i -f`
+
+- Imprime el tamaño de cada archivo y el tamaño total de cada directorio en formato legible para humanos:
+
+`tree -s -h --du`
+
+- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón comodín, y excluye los directorios que no contengan archivos coincidentes:
+
+`tree -P '{{*.txt}}' --prune`
+
+- Imprime archivos dentro de la jerarquía de árbol, especificando un patrón, y excluye los directorios que no sean ancestros del especificado:
+
+`tree -P {{nombre_del_directorio}} --matchdirs --prune`
+
+- Imprime el árbol ignorando los directorios especificados:
+
+`tree -I '{{nombre_del_directorio1|nombre_del_directorio2}}'`


### PR DESCRIPTION
I chose not to translate `example.com` in the `dig` page because it is reserved by an RFC and neither `ejemplo.es` nor `ejemplo.com` are.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
