### PR TITLE
bird: fix capitalization in command description

### DIFF
--- a/pages/osx/bird.md
+++ b/pages/osx/bird.md
@@ -1,6 +1,6 @@
 # bird
 
-> This supports the syncing of iCloud and iCloud drive.
+> This supports the syncing of iCloud and iCloud Drive.
 > It should not be invoked manually.
 
 - Start the daemon:


### PR DESCRIPTION
I actually didn't notice this when reviewing the original PR, what a shame.