### PR TITLE
adduser: remove invalid example

### DIFF
--- a/pages/linux/adduser.md
+++ b/pages/linux/adduser.md
@@ -22,7 +22,3 @@
 - Create a new user belonging to the specified group:
 
 `adduser --ingroup {{group}} {{username}}`
-
-- Add an existing user to the specified group:
-
-`adduser {{username}} {{group}}`


### PR DESCRIPTION
tldr claims that adduser can add an *existing* user to an *existing* group:

https://github.com/tldr-pages/tldr/blob/0c99df4a332eb1c12b3617067a0f4c3a32a8feea/pages/linux/adduser.md#L26-L28

This does not work for me:

```sh
$ sudo adduser user docker
Usage: adduser [options] LOGIN
       adduser -D
       adduser -D [options]

Options:
      --badnames                do not check for bad names
  -b, --base-dir BASE_DIR       base directory for the home directory of the
                                new account
      --btrfs-subvolume-home    use BTRFS subvolume for home directory
  -c, --comment COMMENT         GECOS field of the new account
  -d, --home-dir HOME_DIR       home directory of the new account
  -D, --defaults                print or change default useradd configuration
  -e, --expiredate EXPIRE_DATE  expiration date of the new account
  -f, --inactive INACTIVE       password inactivity period of the new account
  -g, --gid GROUP               name or ID of the primary group of the new
                                account
  -G, --groups GROUPS           list of supplementary groups of the new
                                account
  -h, --help                    display this help message and exit
  -k, --skel SKEL_DIR           use this alternative skeleton directory
  -K, --key KEY=VALUE           override /etc/login.defs defaults
  -l, --no-log-init             do not add the user to the lastlog and
                                faillog databases
  -m, --create-home             create the user's home directory
  -M, --no-create-home          do not create the user's home directory
  -N, --no-user-group           do not create a group with the same name as
                                the user
  -o, --non-unique              allow to create users with duplicate
                                (non-unique) UID
  -p, --password PASSWORD       encrypted password of the new account
  -r, --system                  create a system account
  -R, --root CHROOT_DIR         directory to chroot into
  -P, --prefix PREFIX_DIR       prefix directory where are located the /etc/* files
  -s, --shell SHELL             login shell of the new account
  -u, --uid UID                 user ID of the new account
  -U, --user-group              create a group with the same name as the user
  -Z, --selinux-user SEUSER     use a specific SEUSER for the SELinux user mapping
```

system info:
```
cat /etc/fedora-release 
Fedora release 34 (Thirty Four)
rpm -q --file `which adduser`
shadow-utils-4.8.1-10.fc34.x86_64
```

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

**Version of the command being documented (if known):**

adduser from shadow-utils-4.8.1-10.fc34.x86_64