### PR TITLE
docker-run: fix paths in -v example

### DIFF
--- a/pages/common/docker-run.md
+++ b/pages/common/docker-run.md
@@ -21,7 +21,7 @@
 
 - Run command in a new container with bind mounted volumes:
 
-`docker run -v {{path/to/host_path}}:{{path/to/container_path}} {{image}} {{command}}`
+`docker run -v {{/path/to/host_path}}:{{/path/to/container_path}} {{image}} {{command}}`
 
 - Run command in a new container with published ports:
 


### PR DESCRIPTION
Docker complains if I try non-absolute paths when adding volumes:
```
$ docker run -it -v example/foo:/example fedora
docker: Error response from daemon: create example/foo: "example/foo" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
$ docker run -it -v ~/example/foo:example fedora
docker: Error response from daemon: invalid volume specification: '/home/user/example/foo:example': invalid mount config for type "bind": invalid mount path: 'example' mount path must be absolute.
See 'docker run --help'.
```

- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):**

```
cat /etc/fedora-release 
Fedora release 34 (Thirty Four)
rpm -q --file `which docker`
moby-engine-20.10.12-1.fc34.x86_64
docker --version
Docker version 20.10.12, build 485636f
```