### PR TITLE
fnm: spell out the "list" subcommand

### DIFF
--- a/pages/common/fnm.md
+++ b/pages/common/fnm.md
@@ -10,7 +10,7 @@
 
 - List all available Node.js versions and highlight the default one:
 
-`fnm ls`
+`fnm list`
 
 - Use a specific version of Node.js in the current shell:
 


### PR DESCRIPTION
"ls" is an alias of [list](https://github.com/Schniz/fnm/blob/master/docs/commands.md#fnm-list), so besides being more obscure, it's not even the canonical name for the subcommand.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
v1.30.1