### PR TITLE
package.json: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "glob": "7.2.0",
-        "markdownlint-cli": "0.30.0",
+        "markdownlint-cli": "^0.31.1",
         "tldr-lint": "^0.0.13"
       },
       "devDependencies": {
@@ -35,11 +35,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-map": {
@@ -69,11 +69,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -167,20 +167,10 @@
         "uc.micro": "^1.0.1"
       }
     },
-    "node_modules/lodash.differencewith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc="
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
     "node_modules/markdown-it": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
-      "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -193,34 +183,30 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.24.0.tgz",
-      "integrity": "sha512-OJIGsGFV/rC9irI5E1FMy6v9hdACSwaa+EN3224Y5KG8zj2EYzdHOw0pOJovIYmjNfEZ9BtxUY4P7uYHTSNnbQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "dependencies": {
-        "markdown-it": "12.2.0"
+        "markdown-it": "12.3.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.30.0.tgz",
-      "integrity": "sha512-NiG8iERjwsRZtJAIyLMDdYL2O3bJVn3fUxzDl+6Iv61/YYz9H9Nzgke/v0/cW9HfGvgZHhbfI19LFMp6gbKdyw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+      "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
       "dependencies": {
-        "commander": "~8.3.0",
-        "deep-extend": "~0.6.0",
-        "get-stdin": "~8.0.0",
+        "commander": "~9.0.0",
+        "get-stdin": "~9.0.0",
         "glob": "~7.2.0",
-        "ignore": "~5.1.9",
+        "ignore": "~5.2.0",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "~3.0.0",
-        "lodash.differencewith": "~4.5.0",
-        "lodash.flatten": "~4.4.0",
-        "markdownlint": "~0.24.0",
-        "markdownlint-rule-helpers": "~0.15.0",
-        "minimatch": "~3.0.4",
-        "minimist": "~1.2.5",
+        "markdownlint": "~0.25.1",
+        "markdownlint-rule-helpers": "~0.16.0",
+        "minimatch": "~3.0.5",
         "run-con": "~1.2.10"
       },
       "bin": {
@@ -230,10 +216,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/markdownlint-cli/node_modules/minimatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.7.tgz",
+      "integrity": "sha512-pYjbG0o9W2Wb3KVBuV6s7R/bzS/iS3HPiHcFcDee5GGiN1M5MErXqgS4jGn8pwVwTZAoy7B8bYb/+AqQU0NhZA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/markdownlint-rule-helpers": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.15.0.tgz",
-      "integrity": "sha512-A+9mswc3m/kkqpJCqntmte/1VKhDJ+tjZsERLz5L4h/Qr7ht2/BkGkgY5E7/wsxIhcpl+ctIfz+oS3PQrMOB2w=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -241,9 +238,9 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -309,6 +306,14 @@
         "tldrl": "lib/tldr-lint-cli.js"
       }
     },
+    "node_modules/tldr-lint/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -341,9 +346,9 @@
       }
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -366,9 +371,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA=="
     },
     "glob": {
       "version": "7.2.0",
@@ -390,9 +395,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -434,20 +439,10 @@
         "uc.micro": "^1.0.1"
       }
     },
-    "lodash.differencewith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
     "markdown-it": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
-      "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -457,38 +452,44 @@
       }
     },
     "markdownlint": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.24.0.tgz",
-      "integrity": "sha512-OJIGsGFV/rC9irI5E1FMy6v9hdACSwaa+EN3224Y5KG8zj2EYzdHOw0pOJovIYmjNfEZ9BtxUY4P7uYHTSNnbQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "requires": {
-        "markdown-it": "12.2.0"
+        "markdown-it": "12.3.2"
       }
     },
     "markdownlint-cli": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.30.0.tgz",
-      "integrity": "sha512-NiG8iERjwsRZtJAIyLMDdYL2O3bJVn3fUxzDl+6Iv61/YYz9H9Nzgke/v0/cW9HfGvgZHhbfI19LFMp6gbKdyw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+      "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
       "requires": {
-        "commander": "~8.3.0",
-        "deep-extend": "~0.6.0",
-        "get-stdin": "~8.0.0",
+        "commander": "~9.0.0",
+        "get-stdin": "~9.0.0",
         "glob": "~7.2.0",
-        "ignore": "~5.1.9",
+        "ignore": "~5.2.0",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "~3.0.0",
-        "lodash.differencewith": "~4.5.0",
-        "lodash.flatten": "~4.4.0",
-        "markdownlint": "~0.24.0",
-        "markdownlint-rule-helpers": "~0.15.0",
-        "minimatch": "~3.0.4",
-        "minimist": "~1.2.5",
+        "markdownlint": "~0.25.1",
+        "markdownlint-rule-helpers": "~0.16.0",
+        "minimatch": "~3.0.5",
         "run-con": "~1.2.10"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.7.tgz",
+          "integrity": "sha512-pYjbG0o9W2Wb3KVBuV6s7R/bzS/iS3HPiHcFcDee5GGiN1M5MErXqgS4jGn8pwVwTZAoy7B8bYb/+AqQU0NhZA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "markdownlint-rule-helpers": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.15.0.tgz",
-      "integrity": "sha512-A+9mswc3m/kkqpJCqntmte/1VKhDJ+tjZsERLz5L4h/Qr7ht2/BkGkgY5E7/wsxIhcpl+ctIfz+oS3PQrMOB2w=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -496,9 +497,9 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -543,6 +544,13 @@
       "integrity": "sha512-xPIg5465dypL4szZpUmQMenFF8uMnI0Fq6h2CADMso47w8xe5zZVrn7TSocd3I5mZxJDqxNoGG82g1Kzvz1wdA==",
       "requires": {
         "commander": "^8.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
       }
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://tldr.sh/",
   "dependencies": {
     "glob": "7.2.0",
-    "markdownlint-cli": "0.30.0",
+    "markdownlint-cli": "^0.31.1",
     "tldr-lint": "^0.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump markdownlint-cli to v0.31.1 to fix a security vulnerability in markdown-it package.