### PR TITLE
gcc: fix debug symbols example

### DIFF
--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -9,7 +9,7 @@
 
 - Allow warnings, debug symbols in output:
 
-`gcc {{source.c}} -Wall -Og --output {{executable}}`
+`gcc {{source.c}} -Wall -g --output {{executable}}`
 
 - Include libraries from a different path:
 


### PR DESCRIPTION
The `-Og` option enables optimization, it does **not** add debug info to the output. That's what `-g` does.
