### PR TITLE
rsync: fix remote_directory in -rauL example

### DIFF
--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -26,7 +26,7 @@
 
 - Transfer a directory [r]ecursively, in [a]rchive to preserve attributes, resolving contained soft[l]inks , and ignoring already transferred files [u]nless newer:
 
-`rsync -rauL {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
+`rsync -rauL {{remote_host}}:{{path/to/remote_directory}} {{path/to/local_directory}}`
 
 - Transfer file over SSH and delete remote files that do not exist locally:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

The example talks about transferring a directory, but the code block says file. Fixed so they both say directory. 
