### PR TITLE
set-more-info-link.py: add Catalan translation

### DIFF
--- a/scripts/set-more-info-link.py
+++ b/scripts/set-more-info-link.py
@@ -12,6 +12,7 @@ labels = {
     "ar": "لمزيد من التفاصيل:",
     "bn": "আরও তথ্য পাবেন:",
     "bs": "Više informacija:",
+    "ca": "Més informació:",
     "da": "Mere information:",
     "de": "Weitere Informationen:",
     "es": "Más información:",


### PR DESCRIPTION
Catalan translation is created in #7736. A few pages use `Más información` rather than `Más informació`, I guess it might be a typo.
