### PR TITLE
chsh: Fix `chsh -s SHELL` syntax

### DIFF
--- a/pages/common/chsh.md
+++ b/pages/common/chsh.md
@@ -7,7 +7,7 @@
 
 `chsh`
 
-- Change the current user's login shell:
+- Change the login shell of the current user:
 
 `chsh -s {{path/to/shell}}`
 

--- a/pages/common/chsh.md
+++ b/pages/common/chsh.md
@@ -9,7 +9,7 @@
 
 - Change the current user's login shell:
 
-`chsh {{path/to/shell}}`
+`chsh -s {{path/to/shell}}`
 
 - Change the login shell for a given user:
 

--- a/pages/linux/chsh.md
+++ b/pages/linux/chsh.md
@@ -7,13 +7,13 @@
 
 `chsh`
 
-- Change the login shell of the current user:
+- Change the current user's login shell:
 
-`chsh -s {{path/to/shell}}`
+`chsh --shell {{path/to/shell}}`
 
 - Change the login shell for a given user:
 
-`chsh -s {{path/to/shell}} {{username}}`
+`chsh --shell {{path/to/shell}} {{username}}`
 
 - List available shells:
 


### PR DESCRIPTION
Fixes #7800

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):** The behavior is the same on recent macOS and Linux (and I think other unix too)

I checked and none of the non-English translations have this bug.

I've used just `-s` because that seems very idiomatic (it's used in all the translations), it may work on older machines where `--shell` does not, and anyhow there's an example with `--shell`.