### PR TITLE
dnf-automatic: add page

### DIFF
--- a/pages/linux/dnf-automatic.md
+++ b/pages/linux/dnf-automatic.md
@@ -5,11 +5,11 @@
 
 - Override config file and only notify of available updates:
 
-`systemctl enable --now dnf-automatic-notifyonly.timer`
+`sudo systemctl enable --now dnf-automatic-notifyonly.timer`
 
 - Run with default config file:
 
-`systemctl enable --now dnf-automatic.timer`
+`sudo systemctl enable --now dnf-automatic.timer`
 
 - Use dnf-automatic in a custom systemd timer:
 

--- a/pages/linux/dnf-automatic.md
+++ b/pages/linux/dnf-automatic.md
@@ -1,0 +1,16 @@
+# dnf-automatic
+
+> A tool for automating the checking, downloading, and/or applying package updates via dnf.
+> More information: <https://dnf.readthedocs.io/en/latest/automatic.html>.
+
+- Override config file and only notify of available updates:
+
+`systemctl enable --now dnf-automatic-notifyonly.timer`
+
+- Run with default config file:
+
+`systemctl enable --now dnf-automatic.timer`
+
+- Use dnf-automatic in a custom systemd timer:
+
+`/usr/bin/dnf-automatic /path/to/automatic.conf --timer`

--- a/pages/linux/dnf-automatic.md
+++ b/pages/linux/dnf-automatic.md
@@ -13,4 +13,4 @@
 
 - Use dnf-automatic in a custom systemd timer:
 
-`/usr/bin/dnf-automatic /path/to/automatic.conf --timer`
+`/usr/bin/dnf-automatic {{/path/to/automatic.conf}} --timer`


### PR DESCRIPTION
Adding a new entry for enabling dnf-automatic using systemd units.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 4.9.0
