### PR TITLE
CLIENT-SPECIFICATION: Add entry to unreleased changelog

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -228,6 +228,7 @@ the commit hash changes when merging with squash or rebase.
 
  - Unreleased
    -  Add recommendation to support `macos` alias for `osx` ([#7514](https://github.com/tldr-pages/tldr/pull/7514))
+   -  Drop the special "all" platform from `--list` flag ([#7561](https://github.com/tldr-pages/tldr/pull/7561))
 
  - [v1.5, March 17th 2021](https://github.com/tldr-pages/tldr/blob/v1.5/CLIENT-SPECIFICATION.md) ([#5428](https://github.com/tldr-pages/tldr/pull/5428))
    - Add requirement for converting command names to lowercase before running the page resolution algorithm.


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

The last PR merged into the client specification did not add an entry to the changelog list. This PR recitifies this, and keeps it most up-to-date.