### PR TITLE
git ls-files: add --others --exclude-standard example

### DIFF
--- a/pages/common/git-ls-files.md
+++ b/pages/common/git-ls-files.md
@@ -14,3 +14,7 @@
 - Show ignored and untracked files:
 
 `git ls-files --others`
+
+- Show untracked files, not ignored:
+
+`git ls-files --others --exclude-standard`


### PR DESCRIPTION
Taken from https://fix.code-error.com/git-list-only-untracked-files-also-custom-commands/

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Tested on  git version 2.35.1
