### PR TITLE
batcat: add page (bat alias)

### DIFF
--- a/pages/linux/batcat.md
+++ b/pages/linux/batcat.md
@@ -1,0 +1,7 @@
+# batcat
+
+> This command is an alias of `bat`.
+
+- View documentation for the original command:
+
+`tldr bat`


### PR DESCRIPTION
This page was added to the linux directory because the alias is only used in
Debian-based distros. See <https://github.com/sharkdp/bat#on-ubuntu-using-apt>.


<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**