### PR TITLE
arpspoof: add page

### DIFF
--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -1,0 +1,15 @@
+# arpspoof
+
+> Intercept packets on a switched LAN.
+> Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies. This is an effective way of sniffing traffic on a switch.
+> Kernel IP forwarding must be turned on ahead of time.
+> For more information: <https://linux.die.net/man/8/arpspoof>
+
+- Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):
+
+`arpspoof -i {{eth0}} -t {{192.168.0.1}} {{192.168.0.2}}`
+`arpspoof -i {{eth0}} -t {{192.168.0.2}} {{192.168.0.1}}`
+
+- Make a simple man-in-the-middle attack for all local clients:
+
+`arpspoof -i {{eth0}} {{192.168.0.1}}`

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -3,7 +3,7 @@
 > Intercept packets on a switched LAN.
 > Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies. This is an effective way of sniffing traffic on a switch.
 > Kernel IP forwarding must be turned on ahead of time.
-> For more information: <https://linux.die.net/man/8/arpspoof>
+> More information: <https://manned.org/arpspoof>
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):
 

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -9,6 +9,6 @@
 `sudo arpspoof -i {{eth0}} -t {{192.168.0.1}} {{192.168.0.2}}`
 `sudo arpspoof -i {{eth0}} -t {{192.168.0.2}} {{192.168.0.1}}`
 
-- Make a simple man-in-the-middle attack for all local clients:
+- Perform a simple man-in-the-middle attack for all local clients:
 
 `sudo arpspoof -i {{eth0}} {{192.168.0.1}}`

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -1,7 +1,7 @@
 # arpspoof
 
 > Intercept packets on a switched LAN.
-> Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies. This is an effective way of sniffing traffic on a switch.
+> Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies.
 > More information: <https://manned.org/arpspoof>
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -2,7 +2,6 @@
 
 > Intercept packets on a switched LAN.
 > Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies. This is an effective way of sniffing traffic on a switch.
-> Kernel IP forwarding must be turned on ahead of time.
 > More information: <https://manned.org/arpspoof>
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -2,7 +2,7 @@
 
 > Intercept packets on a switched LAN.
 > Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies.
-> More information: <https://manned.org/arpspoof>
+> More information: <https://manned.org/arpspoof>.
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):
 

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -1,7 +1,7 @@
 # arpspoof
 
 > Intercept packets on a switched LAN.
-> Redirects packets from a target host (or all hosts) on the LAN intended for another host on the LAN by forging ARP replies.
+> Redirects packets from a target host (or all hosts) on the LAN intended to another host on the LAN by forging ARP replies.
 > More information: <https://manned.org/arpspoof>.
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):

--- a/pages/linux/arpspoof.md
+++ b/pages/linux/arpspoof.md
@@ -7,9 +7,9 @@
 
 - Make a simple man-in-the-middle attack between two local hosts (run both at the same time, via `screen` or multiple terminal sessions):
 
-`arpspoof -i {{eth0}} -t {{192.168.0.1}} {{192.168.0.2}}`
-`arpspoof -i {{eth0}} -t {{192.168.0.2}} {{192.168.0.1}}`
+`sudo arpspoof -i {{eth0}} -t {{192.168.0.1}} {{192.168.0.2}}`
+`sudo arpspoof -i {{eth0}} -t {{192.168.0.2}} {{192.168.0.1}}`
 
 - Make a simple man-in-the-middle attack for all local clients:
 
-`arpspoof -i {{eth0}} {{192.168.0.1}}`
+`sudo arpspoof -i {{eth0}} {{192.168.0.1}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
2.4