### PR TITLE
style-guide: add information about links

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -117,6 +117,12 @@ This can be resolved by inserting a comma before the "and" or "or" in the final 
 
 > Delete the Git branches, tags, and remotes.
 
+## More information links
+
+On the `More information` line, prefer linking to the author's provided documentation.
+
+When not available, use <https://manned.org/> as the default fallback. 
+
 ## Chinese-Specific Rules
 
 When Chinese words, Latin words and Arabic numerals are written in the same sentence, it takes more attention to copywriting.


### PR DESCRIPTION
A simple but needed addition to the guide, considering that most of the
newcomers are unaware of this convention as it's not very explicit.

I consider this as a temporary quick-fix while the refactoring of the style
guide is ongoing (#7441).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):**
