### PR TITLE
Linux pages refresh: add missing "More information" links

### DIFF
--- a/pages/linux/ctrlaltdel.md
+++ b/pages/linux/ctrlaltdel.md
@@ -1,6 +1,7 @@
 # ctrlaltdel
 
 > Utility to control what happens when CTRL+ALT+DEL is pressed.
+> More information: <https://manned.org/ctrlaltdel.8>.
 
 - Get current setting:
 

--- a/pages/linux/kde-inhibit.md
+++ b/pages/linux/kde-inhibit.md
@@ -1,6 +1,7 @@
 # kde-inhibit
 
 > Inhibit various desktop functions while a command runs.
+> More information: <https://www.phoronix.com/scan.php?page=news_item&px=KDE-Inhibit-Script-Plus-More>.
 
 - Inhibit power management:
 

--- a/pages/linux/namei.md
+++ b/pages/linux/namei.md
@@ -2,6 +2,7 @@
 
 > Follows a pathname (which can be a symbolic link) until a terminal point is found (a file/directory/char device etc).
 > This program is useful for finding "too many levels of symbolic links" problems.
+> More information: <https://manned.org/namei.1>.
 
 - Resolve the pathnames specified as the argument parameters:
 

--- a/pages/linux/ncal.md
+++ b/pages/linux/ncal.md
@@ -1,6 +1,7 @@
 # ncal
 
 > This command is an alias of `cal`.
+> More information: <https://manned.org/ncal.1>.
 
 - View documentation for the original command:
 

--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -1,6 +1,7 @@
 # ncat
 
 > Use the normal `cat` functionality over networks.
+> More information: <https://manned.org/ncat.1>.
 
 - Listen for input on the specified port and write it to the specified file:
 

--- a/pages/linux/ndctl.md
+++ b/pages/linux/ndctl.md
@@ -1,6 +1,7 @@
 # ndctl
 
 > Utility for managing Non-Volatile DIMMs.
+> More information: <https://manned.org/ndctl.1>.
 
 - Create an 'fsdax' mode namespace:
 

--- a/pages/linux/newgrp.md
+++ b/pages/linux/newgrp.md
@@ -1,6 +1,7 @@
 # newgrp
 
 > Switch primary group membership.
+> More information: <https://manned.org/newgrp.1>.
 
 - Change user's primary group membership:
 

--- a/pages/linux/nmon.md
+++ b/pages/linux/nmon.md
@@ -1,6 +1,7 @@
 # nmon
 
 > A system administrator, tuner, and benchmark tool.
+> More information: <https://manned.org/nmon.1>.
 
 - Start nmon:
 

--- a/pages/linux/nologin.md
+++ b/pages/linux/nologin.md
@@ -1,6 +1,7 @@
 # nologin
 
 > Alternative shell that prevents a user from logging in.
+> More information: <https://manned.org/nologin.5>.
 
 - Set a user's login shell to `nologin` to prevent the user from logging in:
 

--- a/pages/linux/notify-send.md
+++ b/pages/linux/notify-send.md
@@ -1,6 +1,7 @@
 # notify-send
 
 > Uses the current desktop environment's notification system to create a notification.
+> More information: <https://manned.org/notify-send.1>.
 
 - Show a notification with the title "Test" and the content "This is a test":
 

--- a/pages/linux/ntfsfix.md
+++ b/pages/linux/ntfsfix.md
@@ -1,6 +1,7 @@
 # ntfsfix
 
 > Fix common problems on an NTFS partition.
+> More information: <https://manned.org/ntfsfix.8>.
 
 - Fix a given NTFS partition:
 

--- a/pages/linux/opkg.md
+++ b/pages/linux/opkg.md
@@ -1,6 +1,7 @@
 # opkg
 
 > A lightweight package manager used to install OpenWrt packages.
+> More information: <https://openwrt.org/docs/guide-user/additional-software/opkg>.
 
 - Install a package:
 

--- a/pages/linux/pacaur.md
+++ b/pages/linux/pacaur.md
@@ -1,6 +1,7 @@
 # pacaur
 
 > A utility for Arch Linux to build and install packages from the Arch User Repository.
+> More information: <https://github.com/rmarquis/pacaur>.
 
 - Synchronize and update all packages (includes AUR):
 

--- a/pages/linux/paccache.md
+++ b/pages/linux/paccache.md
@@ -1,6 +1,7 @@
 # paccache
 
 > A pacman cache cleaning utility.
+> More information: <https://manned.org/paccache.8>.
 
 - Remove all but the 3 most recent package versions from the pacman cache:
 

--- a/pages/linux/pasuspender.md
+++ b/pages/linux/pasuspender.md
@@ -1,6 +1,7 @@
 # pasuspender
 
 > Temporarily suspends `pulseaudio` while another command is running to allow access to alsa.
+> More information: <https://manned.org/pasuspender.1>.
 
 - Suspend PulseAudio while running `jackd`:
 

--- a/pages/linux/perl-rename.md
+++ b/pages/linux/perl-rename.md
@@ -2,6 +2,7 @@
 
 > Rename multiple files.
 > NOTE: this page refers to the command from the `perl-rename` Arch Linux package.
+> More information: <https://manned.org/rename.1>.
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):
 

--- a/pages/linux/phpquery.md
+++ b/pages/linux/phpquery.md
@@ -1,6 +1,7 @@
 # phpquery
 
 > PHP extension manager for Debian-based OSes.
+> More information: <https://helpmanual.io/help/phpquery/>.
 
 - List available PHP versions:
 

--- a/pages/linux/pidof.md
+++ b/pages/linux/pidof.md
@@ -1,6 +1,7 @@
 # pidof
 
 > Gets the ID of a process using its name.
+> More information: <https://manned.org/pidof.1>.
 
 - List all process IDs with given name:
 

--- a/pages/linux/pidstat.md
+++ b/pages/linux/pidstat.md
@@ -1,6 +1,7 @@
 # pidstat
 
 > Show system resource usage, including CPU, memory, IO etc.
+> More information: <https://manned.org/pidstat.1>.
 
 - Show CPU statistics at a 2 second interval for 10 times:
 

--- a/pages/linux/pkgadd.md
+++ b/pages/linux/pkgadd.md
@@ -1,6 +1,7 @@
 # pkgadd
 
 > Add a package to a CRUX system.
+> More information: <https://docs.oracle.com/cd/E19253-01/816-5166/pkgadd-1m/index.html>.
 
 - Install a local software package:
 

--- a/pages/linux/pkgmk.md
+++ b/pages/linux/pkgmk.md
@@ -1,6 +1,7 @@
 # pkgmk
 
 > Make a binary package for use with pkgadd on CRUX.
+> More information: <https://docs.oracle.com/cd/E19683-01/816-0210/6m6nb7mha/index.html>.
 
 - Make and download a package:
 

--- a/pages/linux/pkgrm.md
+++ b/pages/linux/pkgrm.md
@@ -1,6 +1,7 @@
 # pkgrm
 
 > Remove a package from a CRUX system.
+> More information: <https://docs.oracle.com/cd/E86824_01/html/E54764/pkgrm-1m.html>.
 
 - Remove an installed package:
 

--- a/pages/linux/ports.md
+++ b/pages/linux/ports.md
@@ -1,6 +1,7 @@
 # ports
 
 > Update/list the ports tree on a CRUX system.
+> More information: <https://www.freebsd.org/cgi/man.cgi?ports(7)>.
 
 - Update the ports tree:
 

--- a/pages/linux/prename.md
+++ b/pages/linux/prename.md
@@ -2,6 +2,7 @@
 
 > Rename multiple files.
 > NOTE: this page refers to the command from the `prename` Fedora package.
+> More information: <https://www.systutorials.com/docs/linux/man/1-prename/>.
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):
 

--- a/pages/linux/print.md
+++ b/pages/linux/print.md
@@ -2,6 +2,7 @@
 
 > An alias to a `run-mailcap`'s action print.
 > Originally `run-mailcap` is used to process mime-type/file.
+> More information: <https://manned.org/print.1>.
 
 - Print action can be used to print any file on default run-mailcap tool:
 

--- a/pages/linux/prt-get.md
+++ b/pages/linux/prt-get.md
@@ -1,6 +1,7 @@
 # prt-get
 
 > The CRUX package manager.
+> More information: <https://crux.nu/doc/prt-get%20-%20User%20Manual.html>.
 
 - Install a package:
 

--- a/pages/linux/pwdx.md
+++ b/pages/linux/pwdx.md
@@ -1,6 +1,7 @@
 # pwdx
 
 > Print working directory of a process.
+> More information: <https://manned.org/pwdx.1>.
 
 - Print current working directory of a process:
 

--- a/pages/linux/qsub.md
+++ b/pages/linux/qsub.md
@@ -1,6 +1,7 @@
 # qsub
 
 > Submits a script to the queue management system TORQUE.
+> More information: <https://manned.org/qsub.1>.
 
 - Submit a script with default settings (depends on TORQUE settings):
 

--- a/pages/linux/quotacheck.md
+++ b/pages/linux/quotacheck.md
@@ -2,6 +2,7 @@
 
 > Scan a filesystem for disk usage; create, check and repair quota files.
 > It is best to run quota check with quotas turned off to prevent damage or loss to quota files.
+> More information: <https://manned.org/quotacheck.8>.
 
 - Check quotas on all mounted non-NFS filesystems:
 

--- a/pages/linux/rdesktop.md
+++ b/pages/linux/rdesktop.md
@@ -2,6 +2,7 @@
 
 > Remote Desktop Protocol client.
 > It can be used to connect the remote computer using the RDP protocol.
+> More information: <https://manned.org/rdesktop.1>.
 
 - Connect to a remote computer (default port is 3389):
 

--- a/pages/linux/reflector.md
+++ b/pages/linux/reflector.md
@@ -1,6 +1,7 @@
 # reflector
 
 > Arch script to fetch and sort mirrorlists.
+> More information: <https://manned.org/reflector.1>.
 
 - Get all mirrors, sort for download speed and save them:
 

--- a/pages/linux/rename.md
+++ b/pages/linux/rename.md
@@ -4,6 +4,7 @@
 > NOTE: this page refers to the command from the `util-linux` package.
 > For the Perl version, see `file-rename` or `perl-rename`.
 > Warning: This command has no safeguards and will overwrite files without prompting.
+> More information: <https://manned.org/rename.1>.
 
 - Rename files using simple substitutions (substitute 'foo' with 'bar' wherever found):
 

--- a/pages/linux/repquota.md
+++ b/pages/linux/repquota.md
@@ -1,6 +1,7 @@
 # repquota
 
 > Display a summary of existing file quotas for a filesystem.
+> More information: <https://manned.org/repquota.8>.
 
 - Report stats for all quotas in use:
 

--- a/pages/linux/reset.md
+++ b/pages/linux/reset.md
@@ -1,6 +1,7 @@
 # reset
 
 > Reinitialises the current terminal. Clears the entire terminal screen.
+> More information: <https://manned.org/reset.1>.
 
 - Reinitialise the current terminal:
 

--- a/pages/linux/resize2fs.md
+++ b/pages/linux/resize2fs.md
@@ -2,6 +2,7 @@
 
 > Resize an ext2, ext3 or ext4 filesystem.
 > Does not resize the underlying partition. The filesystem may have to be unmounted first, read the man page for more details.
+> More information: <https://manned.org/resize2fs.8>.
 
 - Automatically resize a filesystem:
 

--- a/pages/linux/rfkill.md
+++ b/pages/linux/rfkill.md
@@ -1,6 +1,7 @@
 # rfkill
 
 > Enable and disable wireless devices.
+> More information: <https://manned.org/rfkill.1>.
 
 - List devices:
 

--- a/pages/linux/rpcinfo.md
+++ b/pages/linux/rpcinfo.md
@@ -1,6 +1,7 @@
 # rpcinfo
 
 > Makes an RPC call to an RPC server and reports what it finds.
+> More information: <https://manned.org/rpcinfo.7>.
 
 - Show full table of all RPC services registered on localhost:
 

--- a/pages/linux/rspamc.md
+++ b/pages/linux/rspamc.md
@@ -1,6 +1,7 @@
 # rspamc
 
 > Command-line client for rspamd servers.
+> More information: <https://manned.org/rspamc.1>.
 
 - Train the bayesian filter to recognise an email as spam:
 

--- a/pages/linux/rtcwake.md
+++ b/pages/linux/rtcwake.md
@@ -1,6 +1,7 @@
 # rtcwake
 
 > Enter a system sleep state until specified wakeup time relative to your BIOS clock.
+> More information: <https://manned.org/rtcwake.8>.
 
 - Show whether an alarm is set or not:
 

--- a/pages/linux/run-mailcap.md
+++ b/pages/linux/run-mailcap.md
@@ -2,6 +2,7 @@
 
 > Run MailCap Programs.
 > Run mailcap view, see, edit, compose, print - execute programs via entries in the mailcap file (or any of its aliases) will use the given action to process each mime-type/file.
+> More information: <https://manned.org/run-mailcap.1>.
 
 - Individual actions/programs on run-mailcap can be invoked with action flag:
 

--- a/pages/linux/runuser.md
+++ b/pages/linux/runuser.md
@@ -1,6 +1,7 @@
 # runuser
 
 > Run commands as a specific user and group without asking for password (needs root privileges).
+> More information: <https://manned.org/runuser.1>.
 
 - Run command as a different user:
 

--- a/pages/linux/sa.md
+++ b/pages/linux/sa.md
@@ -2,6 +2,7 @@
 
 > Summarizes accounting information. Part of the acct package.
 > Shows commands called by users, including basic info on CPU time spent processing and I/O rates.
+> More information: <https://linux.die.net/man/8/sa>.
 
 - Display executable invocations per user (username not displayed):
 

--- a/pages/linux/sar.md
+++ b/pages/linux/sar.md
@@ -1,6 +1,7 @@
 # sar
 
 > Monitor performance of various Linux subsystems.
+> More information: <https://manned.org/sar.1>.
 
 - Report I/O and transfer rate issued to physical devices, one per second (press CTRL+C to quit):
 

--- a/pages/linux/sbatch.md
+++ b/pages/linux/sbatch.md
@@ -1,6 +1,7 @@
 # sbatch
 
 > Submit a batch job to the SLURM scheduler.
+> More information: <https://manned.org/sbatch.1>.
 
 - Submit a batch job:
 

--- a/pages/linux/script.md
+++ b/pages/linux/script.md
@@ -1,6 +1,7 @@
 # script
 
 > Record all terminal output to file.
+> More information: <https://manned.org/script.1>.
 
 - Record a new session to a file named `typescript` in the current directory:
 

--- a/pages/linux/scriptreplay.md
+++ b/pages/linux/scriptreplay.md
@@ -1,6 +1,7 @@
 # scriptreplay
 
 > Replay a typescript created by the `script` command to the standard output.
+> More information: <https://manned.org/scriptreplay.1>.
 
 - Replay a typescript at the speed it was recorded:
 

--- a/pages/linux/see.md
+++ b/pages/linux/see.md
@@ -2,6 +2,7 @@
 
 > Alias to `run-mailcap`'s view.
 > An alias to a `run-mailcap`'s action print.
+> More information: <https://manned.org/see.1>.
 
 - See action can be used to view any file (usually image) on default mailcap explorer:
 

--- a/pages/linux/sensible-browser.md
+++ b/pages/linux/sensible-browser.md
@@ -1,6 +1,7 @@
 # sensible-browser
 
 > Open the default browser.
+> More information: <https://manned.org/sensible-browser.1>.
 
 - Open a new window of the default browser:
 

--- a/pages/linux/sensible-editor.md
+++ b/pages/linux/sensible-editor.md
@@ -1,6 +1,7 @@
 # sensible-editor
 
 > Open the default editor.
+> More information: <https://manned.org/sensible-editor.1>.
 
 - Open a file in the default editor:
 

--- a/pages/linux/sensors.md
+++ b/pages/linux/sensors.md
@@ -1,6 +1,7 @@
 # sensors
 
 > Report sensors information.
+> More information: <https://manned.org/sensors.1>.
 
 - Show the current readings of all sensor chips:
 

--- a/pages/linux/service.md
+++ b/pages/linux/service.md
@@ -2,6 +2,7 @@
 
 > Manage services by running init scripts.
 > The full script path should be omitted (`/etc/init.d/` is assumed).
+> More information: <https://manned.org/service.1>.
 
 - List the name and status of all services:
 

--- a/pages/linux/setfacl.md
+++ b/pages/linux/setfacl.md
@@ -1,6 +1,7 @@
 # setfacl
 
 > Set file access control lists (ACL).
+> More information: <https://manned.org/setfacl.1>.
 
 - Modify ACL of a file for user with read and write access:
 

--- a/pages/linux/setxkbmap.md
+++ b/pages/linux/setxkbmap.md
@@ -1,6 +1,7 @@
 # setxkbmap
 
 > Set the keyboard using the X Keyboard Extension.
+> More information: <https://manned.org/setxkbmap.1>.
 
 - Set the keyboard in French AZERTY:
 

--- a/pages/linux/slapt-get.md
+++ b/pages/linux/slapt-get.md
@@ -2,6 +2,7 @@
 
 > An apt like system for Slackware package management.
 > Package sources need to be configured in the slapt-getrc file.
+> More information: <https://software.jaos.org/>.
 
 - Update the list of available packages and versions:
 

--- a/pages/linux/smbclient.md
+++ b/pages/linux/smbclient.md
@@ -1,6 +1,7 @@
 # smbclient
 
 > FTP-like client to access SMB/CIFS resources on servers.
+> More information: <https://manned.org/smbclient.1>.
 
 - Connect to a share (user will be prompted for password; `exit` to quit the session):
 

--- a/pages/linux/snap.md
+++ b/pages/linux/snap.md
@@ -2,6 +2,7 @@
 
 > Tool for managing the "snap" self-contained software packages.
 > Similar to what `apt` is for ".deb".
+> More information: <https://manned.org/snap.1>.
 
 - Search for a package:
 

--- a/pages/linux/squeue.md
+++ b/pages/linux/squeue.md
@@ -1,6 +1,7 @@
 # squeue
 
 > View the jobs queued in the SLURM scheduler.
+> More information: <https://manned.org/squeue.1>.
 
 - View the queue:
 

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -1,6 +1,7 @@
 # strace
 
 > Troubleshooting tool for tracing system calls.
+> More information: <https://manned.org/strace.1>.
 
 - Start tracing a specific process by its PID:
 

--- a/pages/linux/stress.md
+++ b/pages/linux/stress.md
@@ -1,6 +1,7 @@
 # stress
 
 > A tool to stress test CPU, memory, and IO on a Linux system.
+> More information: <https://manned.org/stress.1>.
 
 - Spawn 4 workers to stress test CPU:
 

--- a/pages/linux/taskset.md
+++ b/pages/linux/taskset.md
@@ -1,6 +1,7 @@
 # taskset
 
 > Get or set a process' CPU affinity or start a new process with a defined CPU affinity.
+> More information: <https://manned.org/taskset.1>.
 
 - Get a running process' CPU affinity by PID:
 

--- a/pages/linux/tcpflow.md
+++ b/pages/linux/tcpflow.md
@@ -1,6 +1,7 @@
 # tcpflow
 
 > Capture TCP traffic for debugging and analysis.
+> More information: <https://manned.org/tcpflow.1>.
 
 - Show all data on the given interface and port:
 

--- a/pages/linux/tcpkill.md
+++ b/pages/linux/tcpkill.md
@@ -1,6 +1,7 @@
 # tcpkill
 
 > Kills specified in-progress TCP connections.
+> More information: <https://manned.org/tcpkill.8>.
 
 - Kill in-progress connections at a specified interface, host and port:
 

--- a/pages/linux/ubuntu-bug.md
+++ b/pages/linux/ubuntu-bug.md
@@ -1,6 +1,7 @@
 # ubuntu-bug
 
 > This command is an alias of `apport-bug`.
+> More information: <https://manned.org/ubuntu-bug.1>.
 
 - View documentation for the original command:
 

--- a/pages/linux/uprecords.md
+++ b/pages/linux/uprecords.md
@@ -1,6 +1,7 @@
 # uprecords
 
 > Displays a summary of historical uptime records.
+> More information: <https://manned.org/uprecords.1>.
 
 - Display a summary of the top 10 historical uptime records:
 

--- a/pages/linux/utmpdump.md
+++ b/pages/linux/utmpdump.md
@@ -1,6 +1,7 @@
 # utmpdump
 
 > Dump and load btmp, utmp and wtmp accounting files.
+> More information: <https://manned.org/utmpdump.1>.
 
 - Dump the `/var/log/wtmp` file to the standard output as plain text:
 

--- a/pages/linux/uvcdynctrl.md
+++ b/pages/linux/uvcdynctrl.md
@@ -1,6 +1,7 @@
 # uvcdynctrl
 
 > A libwebcam command-line tool to manage dynamic controls in uvcvideo.
+> More information: <https://manned.org/uvcdynctrl.1>.
 
 - List all available cameras:
 

--- a/pages/linux/viewnior.md
+++ b/pages/linux/viewnior.md
@@ -1,6 +1,7 @@
 # viewnior
 
 > Simple and elegant image viewer.
+> More information: <https://manned.org/viewnior.1>.
 
 - View an image:
 

--- a/pages/linux/vmware-checkvm.md
+++ b/pages/linux/vmware-checkvm.md
@@ -1,6 +1,7 @@
 # vmware-checkvm
 
 > Checks to see if the current host is a VMware VM or not.
+> More information: <https://manned.org/vmware-checkvm.1>.
 
 - Return the current VMware software version (exit status determines whether the system is a VM or not):
 

--- a/pages/linux/vncserver.md
+++ b/pages/linux/vncserver.md
@@ -1,6 +1,7 @@
 # vncserver
 
 > Launches a VNC (Virtual Network Computing) desktop.
+> More information: <https://manned.org/vncserver.1>.
 
 - Launch a VNC Server on next available display:
 

--- a/pages/linux/vncviewer.md
+++ b/pages/linux/vncviewer.md
@@ -1,6 +1,7 @@
 # vncviewer
 
 > Launches a VNC (Virtual Network Computing) client.
+> More information: <https://manned.org/vncviewer.1>.
 
 - Launch a VNC client which connects to a host on a given display:
 

--- a/pages/linux/vnstat.md
+++ b/pages/linux/vnstat.md
@@ -1,6 +1,7 @@
 # vnstat
 
 > A console-based network traffic monitor.
+> More information: <https://manned.org/vnstat.1>.
 
 - Display traffic summary for all interfaces:
 

--- a/pages/linux/vpnc.md
+++ b/pages/linux/vpnc.md
@@ -1,6 +1,7 @@
 # vpnc
 
 > A VPN client for the Cisco 3000 VPN Concentrator.
+> More information: <https://manned.org/vpnc.8>.
 
 - Connect with a defined configuration file:
 

--- a/pages/linux/whatis.md
+++ b/pages/linux/whatis.md
@@ -1,6 +1,7 @@
 # whatis
 
 > Display one-line descriptions from manual pages.
+> More information: <https://manned.org/whatis.1>.
 
 - Display a description from a man page:
 

--- a/pages/linux/wpa_cli.md
+++ b/pages/linux/wpa_cli.md
@@ -1,6 +1,7 @@
 # wpa_cli
 
 > Add and configure wlan interfaces.
+> More information: <https://manned.org/wpa_cli.1>.
 
 - Scan for available networks:
 

--- a/pages/linux/wpa_passphrase.md
+++ b/pages/linux/wpa_passphrase.md
@@ -1,6 +1,7 @@
 # wpa_passphrase
 
 > Generate a WPA-PSK key from an ASCII passphrase for a given SSID.
+> More information: <https://manned.org/wpa_passphrase.1>.
 
 - Compute and display the WPA-PSK key for a given SSID reading the passphrase from stdin:
 

--- a/pages/linux/x11vnc.md
+++ b/pages/linux/x11vnc.md
@@ -2,6 +2,7 @@
 
 > A VNC server that will enable VNC on an existing display server.
 > By default, the server will automatically terminate once all clients disconnect from it.
+> More information: <https://manned.org/x11vnc.1>.
 
 - Launch a VNC server that allows multiple clients to connect:
 

--- a/pages/linux/xclip.md
+++ b/pages/linux/xclip.md
@@ -2,6 +2,7 @@
 
 > X11 clipboard manipulation tool, similar to `xsel`.
 > Handles the X primary and secondary selections, plus the system clipboard (`Ctrl + C`/`Ctrl + V`).
+> More information: <https://manned.org/xclip.1>.
 
 - Copy the output from a command to the X11 primary selection area (clipboard):
 

--- a/pages/linux/xdotool.md
+++ b/pages/linux/xdotool.md
@@ -1,6 +1,7 @@
 # xdotool
 
 > Command-line automation for X11.
+> More information: <https://manned.org/xdotool.1>.
 
 - Retrieve the X-Windows window ID of the running Firefox window(s):
 

--- a/pages/linux/xeyes.md
+++ b/pages/linux/xeyes.md
@@ -1,6 +1,7 @@
 # xeyes
 
 > Display eyes on the screen that follow the mouse cursor.
+> More information: <https://manned.org/xeyes.1>.
 
 - Launch xeyes on the local machine's default display:
 

--- a/pages/linux/xsel.md
+++ b/pages/linux/xsel.md
@@ -1,6 +1,7 @@
 # xsel
 
 > X11 selection and clipboard manipulation tool.
+> More information: <https://manned.org/xsel.1>.
 
 - Use a command's output as input of the clip[b]oard (equivalent to `Ctrl + C`):
 

--- a/pages/linux/xsetwacom.md
+++ b/pages/linux/xsetwacom.md
@@ -1,6 +1,7 @@
 # xsetwacom
 
 > Command-line tool to change settings for Wacom pen tablets at runtime.
+> More information: <https://manned.org/xsetwacom.1>.
 
 - List all the available Wacom devices. The device name is in the first column:
 

--- a/pages/linux/xtrlock.md
+++ b/pages/linux/xtrlock.md
@@ -1,6 +1,7 @@
 # xtrlock
 
 > Lock the X display until the user supplies their password.
+> More information: <https://manned.org/xtrlock.1>.
 
 - Lock the display and show a padlock instead of the cursor:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

## ToDo

- [x] `pages/linux/ctrlaltdel.md`
- [x] `pages/linux/kde-inhibit.md`
- [x] `pages/linux/namei.md`
- [x] `pages/linux/ncal.md`
- [x] `pages/linux/ncat.md`
- [x] `pages/linux/ndctl.md`
- [x] `pages/linux/newgrp.md`
- [x] `pages/linux/nmon.md`
- [x] `pages/linux/nologin.md`
- [x] `pages/linux/notify-send.md`
- [x] `pages/linux/ntfsfix.md`
- [x] `pages/linux/opkg.md`
- [x] `pages/linux/pacaur.md`
- [x] `pages/linux/paccache.md`
- [x] `pages/linux/pasuspender.md`
- [x] `pages/linux/perl-rename.md`
- [x] `pages/linux/phpquery.md`
- [x] `pages/linux/pidof.md`
- [x] `pages/linux/pidstat.md`
- [x] `pages/linux/pkgadd.md`
- [x] `pages/linux/pkgmk.md`
- [x] `pages/linux/pkgrm.md`
- [x] `pages/linux/ports.md`
- [x] `pages/linux/prename.md`
- [x] `pages/linux/print.md`
- [x] `pages/linux/prt-get.md`
- [x] `pages/linux/pwdx.md`
- [x] `pages/linux/qsub.md`
- [x] `pages/linux/quotacheck.md`
- [x] `pages/linux/rdesktop.md`
- [x] `pages/linux/reflector.md`
- [x] `pages/linux/rename.md`
- [x] `pages/linux/repquota.md`
- [x] `pages/linux/reset.md`
- [x] `pages/linux/resize2fs.md`
- [x] `pages/linux/rfkill.md`
- [x] `pages/linux/rpcinfo.md`
- [x] `pages/linux/rspamc.md`
- [x] `pages/linux/rtcwake.md`
- [x] `pages/linux/run-mailcap.md`
- [x] `pages/linux/runuser.md`
- [x] `pages/linux/sa.md`
- [x] `pages/linux/sar.md`
- [x] `pages/linux/sbatch.md`
- [x] `pages/linux/script.md`
- [x] `pages/linux/scriptreplay.md`
- [x] `pages/linux/see.md`
- [x] `pages/linux/sensible-browser.md`
- [x] `pages/linux/sensible-editor.md`
- [x] `pages/linux/sensors.md`
- [x] `pages/linux/service.md`
- [x] `pages/linux/setfacl.md`
- [x] `pages/linux/setxkbmap.md`
- [x] `pages/linux/slapt-get.md`
- [x] `pages/linux/smbclient.md`
- [x] `pages/linux/snap.md`
- [x] `pages/linux/squeue.md`
- [x] `pages/linux/strace.md`
- [x] `pages/linux/stress.md`
- [x] `pages/linux/taskset.md`
- [x] `pages/linux/tcpflow.md`
- [x] `pages/linux/tcpkill.md`
- [x] `pages/linux/ubuntu-bug.md`
- [x] `pages/linux/uprecords.md`
- [x] `pages/linux/utmpdump.md`
- [x] `pages/linux/uvcdynctrl.md`
- [x] `pages/linux/viewnior.md`
- [x] `pages/linux/vmware-checkvm.md`
- [x] `pages/linux/vncserver.md`
- [x] `pages/linux/vncviewer.md`
- [x] `pages/linux/vnstat.md`
- [x] `pages/linux/vpnc.md`
- [x] `pages/linux/whatis.md`
- [x] `pages/linux/wpa_cli.md`
- [x] `pages/linux/wpa_passphrase.md`
- [x] `pages/linux/x11vnc.md`
- [x] `pages/linux/xclip.md`
- [x] `pages/linux/xdotool.md`
- [x] `pages/linux/xeyes.md`
- [x] `pages/linux/xsel.md`
- [x] `pages/linux/xsetwacom.md`
- [x] `pages/linux/xtrlock.md`