### PR TITLE
linux/*: replace man.archlinux.com link

### DIFF
--- a/pages/linux/dunstify.md
+++ b/pages/linux/dunstify.md
@@ -2,7 +2,7 @@
 
 > A notification tool that is an extension of notify-send, but has more features based around dunst.
 > Works with all options that work for notify-send.
-> More information: <https://wiki.archlinux.org/title/Dunst#Dunstify>.
+> More information: <https://github.com/dunst-project/dunst/wiki/Guides>.
 
 - Show a notification with a given title and message:
 

--- a/pages/linux/homectl.md
+++ b/pages/linux/homectl.md
@@ -1,7 +1,7 @@
 # homectl
 
 > Create, remove, change or inspect home directories using the systemd-homed service.
-> More information: <https://man.archlinux.org/man/homectl.1>.
+> More information: <https://manned.org/homectl>.
 
 - List user accounts and their associated home directories:
 

--- a/pages/linux/nmcli-connection.md
+++ b/pages/linux/nmcli-connection.md
@@ -1,7 +1,7 @@
 # nmcli connection
 
 > Connection management with NetworkManager.
-> More information: <https://man.archlinux.org/man/nmcli.1>.
+> More information: <https://manned.org/nmcli>.
 
 - List all NetworkManager connections (shows name, UUID, type and device):
 

--- a/pages/linux/nmcli-connection.md
+++ b/pages/linux/nmcli-connection.md
@@ -1,7 +1,7 @@
 # nmcli connection
 
 > Connection management with NetworkManager.
-> More information: <https://manned.org/nmcli>.
+> More information: <https://networkmanager.dev/docs/api/latest/nmcli.html>.
 
 - List all NetworkManager connections (shows name, UUID, type and device):
 

--- a/pages/linux/nmcli-device.md
+++ b/pages/linux/nmcli-device.md
@@ -1,7 +1,7 @@
 # nmcli device
 
 > Hardware device management with NetworkManager.
-> More information: <https://man.archlinux.org/man/nmcli.1>.
+> More information: <https://manned.org/nmcli>.
 
 - Print the statuses of all network interfaces:
 

--- a/pages/linux/nmcli-device.md
+++ b/pages/linux/nmcli-device.md
@@ -1,7 +1,7 @@
 # nmcli device
 
 > Hardware device management with NetworkManager.
-> More information: <https://manned.org/nmcli>.
+> More information: <https://networkmanager.dev/docs/api/latest/nmcli.html>.
 
 - Print the statuses of all network interfaces:
 

--- a/pages/linux/xdg-open.md
+++ b/pages/linux/xdg-open.md
@@ -1,7 +1,7 @@
 # xdg-open
 
 > Opens a file or URL in the user's preferred application.
-> More information: <https://man.archlinux.org/man/xdg-open.1>.
+> More information: <https://portland.freedesktop.org/doc/xdg-open.html>.
 
 - Open the current directory in the default file explorer:
 


### PR DESCRIPTION
Does not replace links of pages directly associated with archlinux (eg: pacman)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
