### PR TITLE
errno: add page

### DIFF
--- a/pages/common/errno.md
+++ b/pages/common/errno.md
@@ -5,7 +5,7 @@
 
 - Lookup errno description by name or code:
 
-`errno {{name_or_code}}`
+`errno {{name|code}}`
 
 - List all errno names, codes, and descriptions:
 

--- a/pages/common/errno.md
+++ b/pages/common/errno.md
@@ -9,12 +9,12 @@
 
 - List all errno names, codes, and descriptions:
 
-`errno -l`
+`errno --list`
 
 - Search for code who's description contains all of the given text:
 
-`errno -s {{text}}`
+`errno --search {{text}}`
 
 - Seach for code who's description contains all of the given text (all locales):
 
-`errno -S {{text}}`
+`errno --search-all-locales {{text}}`

--- a/pages/common/errno.md
+++ b/pages/common/errno.md
@@ -1,0 +1,20 @@
+# errno
+
+> Look up errno names and descriptions.
+> More information: <https://joeyh.name/code/moreutils/>.
+
+- Lookup errno description by name or code:
+
+`errno {{name_or_code}}`
+
+- List all errno names, codes, and descriptions:
+
+`errno -l`
+
+- Search for code who's description contains all of the given text:
+
+`errno -s {{text}}`
+
+- Seach for code who's description contains all of the given text (all locales):
+
+`errno -S {{text}}`

--- a/pages/common/errno.md
+++ b/pages/common/errno.md
@@ -15,6 +15,6 @@
 
 `errno --search {{text}}`
 
-- Seach for code who's description contains all of the given text (all locales):
+- Search for code who's description contains all of the given text (all locales):
 
 `errno --search-all-locales {{text}}`


### PR DESCRIPTION
Added a page for the `errno` command provided by the `moreutils` package

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
