### PR TITLE
ufw: use range in deny port example

### DIFF
--- a/pages/linux/ufw.md
+++ b/pages/linux/ufw.md
@@ -28,9 +28,9 @@
 
 `ufw deny {{80}}`
 
-- Deny all UDP traffic to port 22:
+- Deny all UDP traffic to ports in range 8412:8500:
 
-`ufw deny proto {{udp}} from {{any}} to {{any}} port {{22}}`
+`ufw deny proto {{udp}} from {{any}} to {{any}} port {{8412:8500}}`
 
 - Delete a particular rule. The rule number can be retrieved from the `ufw status numbered` command:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
