### PR TITLE
windows/*: fix placeholders, flags and code descriptions (PR 2)

### DIFF
--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -7,7 +7,7 @@
 
 `choice`
 
-- Use the custom list of [c]hoices (`AB`):
+- Use the specified list of [c]hoices (`AB`):
 
 `choice /c {{AB}}`
 
@@ -19,7 +19,7 @@
 
 `choice /c {{AB}} /t {{5}} /d {{A}}`
 
-- Use the custom [m]essage instead of default (`[A,B]?`):
+- Use the specified [m]essage instead of default (`[A,B]?`):
 
 `choice /c {{AB}} /m {{message}}`
 

--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -15,11 +15,11 @@
 
 `choice /cs {{AaBb}}`
 
-- Use the [d]efault choise (`A`) after a [t]imeout in seconds (`5`):
+- Use the [d]efault choise (`A`) after the [t]imeout in seconds (`5`):
 
 `choice /c {{AB}} /t {{5}} /d {{A}}`
 
-- Use the specified [m]essage instead of default (`[A,B]?`):
+- Use the specified [m]essage instead of the default (`[A,B]?`):
 
 `choice /c {{AB}} /m {{message}}`
 

--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -1,29 +1,28 @@
 # choice
 
 > Prompts the user to select one item from a list of single-character choices in a batch program, and then returns the index of the selected choice.
-> If used without parameters, choice displays the default choices Y and N.
 > More information: <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/choice>.
 
-- A,B and C as list of choices to be used:
-
-`choice /c {{ABC}}`
-
-- Use the default [Y,N] list of choices:
+- Use the default list (`YN`) of choices:
 
 `choice`
 
-- Specify that the choices are case-sensitive:
+- Use the custom list of [c]hoices (`AB`):
 
-`choice /CS {{AaBb}}`
+`choice /c {{AB}}`
 
-- Specify the number of seconds to pause before using the default choice specified by `/d`:
+- Use the [c]ase-[s]ensitive list of choices (`AaBb`):
 
-`choice /C {{AaBb}} /t {{3}} /d {{b}}`
+`choice /cs {{AaBb}}`
 
-- Specify a message to display before the list of choices. If `/m` is not specified, only the choice prompt is displayed:
+- Use the [d]efault choise (`A`) after a [t]imeout (`5`):
 
-`choice /m {{message}} /C {{ABC}}`
+`choice /c {{AB}} /t {{5}} /d {{A}}`
 
-- Display help message:
+- Use the custom [m]essage instead of default (`[A,B]?`):
+
+`choice /c {{AB}} /m {{message}}`
+
+- Print the help:
 
 `choice /?`

--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -15,7 +15,7 @@
 
 `choice /cs {{AaBb}}`
 
-- Use the [d]efault choise (`A`) after a [t]imeout (`5`):
+- Use the [d]efault choise (`A`) after a [t]imeout in seconds (`5`):
 
 `choice /c {{AB}} /t {{5}} /d {{A}}`
 

--- a/pages/windows/cipher.md
+++ b/pages/windows/cipher.md
@@ -3,14 +3,10 @@
 > Encrypt or decrypt files on NTFS drives.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cipher>.
 
-- Encrypt a file or directory:
+- [E]ncrypt/[d]ecrypt the file or directory:
 
-`cipher /e:{{path/to/file_or_directory}}`
+`cipher /{{e|d}}:{{path/to/file_or_directory}}`
 
-- Decrypt a file or directory:
-
-`cipher /d:{{path/to/file_or_directory}}`
-
-- Securely remove a file or directory:
+- Securely remove the file or directory:
 
 `cipher /w:{{path/to/file_or_directory}}`

--- a/pages/windows/cipher.md
+++ b/pages/windows/cipher.md
@@ -3,10 +3,10 @@
 > Encrypt or decrypt files on NTFS drives.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cipher>.
 
-- [E]ncrypt/[d]ecrypt the file or directory:
+- Encrypt/[d]ecrypt the specified file or directory:
 
 `cipher /{{e|d}}:{{path/to/file_or_directory}}`
 
-- Securely remove the file or directory:
+- Securely remove the specified file or directory:
 
 `cipher /w:{{path/to/file_or_directory}}`

--- a/pages/windows/clip.md
+++ b/pages/windows/clip.md
@@ -3,18 +3,10 @@
 > Copy input content to the Windows clipboard.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/clip>.
 
-- Pipe command-line output to the Windows clipboard:
+- Pipe the command (`dir`) output to the clipboard:
 
 `{{dir}} | clip`
 
-- Copy the contents of a file to the Windows clipboard:
+- Copy the contents of the file to the clipboard:
 
 `clip < {{path/to/file.ext}}`
-
-- Copy text with a trailing newline to the Windows clipboard:
-
-`echo {{some text}} | clip`
-
-- Copy text without a trailing newline to the Windows clipboard:
-
-`echo | set /p="some text" | clip`

--- a/pages/windows/cmstp.md
+++ b/pages/windows/cmstp.md
@@ -5,24 +5,24 @@
 
 - Install the specified profile:
 
-`cmstp "{{path/to/profile}}"`
+`cmstp {{path/to/profile}}`
 
 - [U]ninstall the specified profile:
 
-`cmstp /u "{{path/to/profile}}"`
+`cmstp /u {{path/to/profile}}`
 
 - Install the specified profile [s]ilently without any prompts:
 
-`cmstp /s "{{path/to/profile}}"`
+`cmstp /s {{path/to/profile}}`
 
 - Install the specified profile without checking for dependencies:
 
-`cmstp /nf "{{path/to/profile}}"`
+`cmstp /nf {{path/to/profile}}`
 
 - Install the specified profile for the current user:
 
-`cmstp /su "{{path/to/profile}}"`
+`cmstp /su {{path/to/profile}}`
 
 - Install the specified profile for [a]ll [u]sers (requires administrator privileges):
 
-`cmstp /au "{{path/to/profile}}"`
+`cmstp /au {{path/to/profile}}`

--- a/pages/windows/cmstp.md
+++ b/pages/windows/cmstp.md
@@ -7,7 +7,7 @@
 
 `cmstp {{path/to/profile}}`
 
-- [U]ninstall the specified profile:
+- Uninstall the specified profile:
 
 `cmstp /u {{path/to/profile}}`
 

--- a/pages/windows/cmstp.md
+++ b/pages/windows/cmstp.md
@@ -3,34 +3,26 @@
 > A command-line tool for managing connection service profiles.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/cmstp>.
 
-- Install a specific profile:
+- Install the specified profile:
 
 `cmstp "{{path/to/profile}}"`
 
-- Install without creating a desktop shortcut:
-
-`cmstp /ns "{{path/to/profile}}"`
-
-- Install without checking for dependencies:
-
-`cmstp /nf "{{path/to/profile}}"`
-
-- Only install for the current user:
-
-`cmstp /su "{{path/to/profile}}"`
-
-- Install for all users (requires administrator privileges):
-
-`cmstp /au "{{path/to/profile}}"`
-
-- Install silently without any prompts:
-
-`cmstp /s "{{path/to/profile}}"`
-
-- Uninstall a specific profile:
+- [U]ninstall the specified profile:
 
 `cmstp /u "{{path/to/profile}}"`
 
-- Uninstall silently without a confirmation prompt:
+- Install the specified profile [s]ilently without any prompts:
 
-`cmstp /u /s "{{path/to/profile}}"`
+`cmstp /s "{{path/to/profile}}"`
+
+- Install the specified profile without checking for dependencies:
+
+`cmstp /nf "{{path/to/profile}}"`
+
+- Install the specified profile for the current user:
+
+`cmstp /su "{{path/to/profile}}"`
+
+- Install the specified profile for [a]ll [u]sers (requires administrator privileges):
+
+`cmstp /au "{{path/to/profile}}"`

--- a/pages/windows/color.md
+++ b/pages/windows/color.md
@@ -3,14 +3,18 @@
 > Set the console foreground and background colors.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/color>.
 
-- Set the console colors to the default values:
+- Set the colors to the default values:
 
 `color`
 
-- List available color values and detailed information:
+- Set the specified foreground color:
+
+`color {{0-9|a-f}}`
+
+- Set the specified foreground and background colors:
+
+`color {{0-9|a-f}}{{0-9|a-f}}`
+
+- Print all available colors:
 
 `color /?`
-
-- Set the console foreground and background to a specific color using hexadecimal numbers (`1-9,a-f`):
-
-`color {{foreground_code}}{{background_code}}`

--- a/pages/windows/color.md
+++ b/pages/windows/color.md
@@ -15,6 +15,6 @@
 
 `color {{0-9|a-f}}{{0-9|a-f}}`
 
-- Print all available colors:
+- Print the help:
 
 `color /?`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

## ToDo

- [x] `choice`
- [x] `chrome`
- [x] `cinst`
- [x] `cipher`
- [x] `clip`
- [x] `clist`
- [x] `cls`
- [x] `cmd` (#7423 changes this page)
- [x] `cmstp`
- [x] `color`

----

[Previous PR][prev] | [Next PR][next]

[prev]: https://github.com/tldr-pages/tldr/pull/7874
[next]: https://github.com/tldr-pages/tldr/pull/7905