### PR TITLE
ogrmerge.py: add page

### DIFF
--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -1,0 +1,20 @@
+# ogrmerge.py
+
+> Merge several vector datasets into a single one.
+> More information: <https://gdal.org/programs/ogrmerge.html>.
+
+- Create a GeoPackage with a layer for each input Shapefile:
+
+`ogrmerge.py -f {{GPKG}} -o {{path/to/merged}}.gpkg {{path/to/}}*.shp`
+
+- Create a virtual datasource (VRT) with a layer for each input Shapefile:
+
+`ogrmerge.py -f {{VRT}} -o {{merged}}.vrt {{path/to/}}*.shp`
+
+- Concatenate three vector datasets into one:
+
+`ogrmerge.py -single -o {{path/to/output.geojson}} {{path/to/input_a.geojson}} {{path/to/input_b.geojson}} {{path/to/input_c.geojson}}`
+
+- Concatenate two vector datasets and store source name of dataset in attribute 'source_name':
+
+`ogrmerge.py -single -o {{path/to/output.geojson}} {{path/to/input_a.geojson}} {{path/to/input_b.geojson}} -src_layer_field_name country {{source_name}}`

--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -13,4 +13,4 @@
 
 - Concatenate two vector datasets and store source name of dataset in attribute 'source_name':
 
-`ogrmerge.py -single -f {{GeoJSON}} -o {{path/to/output.geojson}} -src_layer_field_name country {{source_name}} {{path/to/input_1.shp path/to/input_2.shp ...}}`
+`ogrmerge.py -single -f {{GeoJSON}} -o {{path/to/output.geojson}} -src_layer_field_name country {{source_name}} {{path/to/input1.shp path/to/input2.shp ...}}`

--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -5,7 +5,7 @@
 
 - Create a GeoPackage with a layer for each input Shapefile:
 
-`ogrmerge.py -f {{GPKG}} -o {{path/to/output}}.gpkg {{path/to/input_a.shp path/to/input_b.shp ...}}`
+`ogrmerge.py -f {{GPKG}} -o {{path/to/output.gpkg}} {{path/to/input1.shp path/to/input2.shp ...}}`
 
 - Create a virtual datasource (VRT) with a layer for each input GeoJSON:
 

--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -5,16 +5,12 @@
 
 - Create a GeoPackage with a layer for each input Shapefile:
 
-`ogrmerge.py -f {{GPKG}} -o {{path/to/merged}}.gpkg {{path/to/}}*.shp`
+`ogrmerge.py -f {{GPKG}} -o {{path/to/output}}.gpkg {{path/to/input_a.shp path/to/input_b.shp ...}}`
 
-- Create a virtual datasource (VRT) with a layer for each input Shapefile:
+- Create a virtual datasource (VRT) with a layer for each input GeoJSON:
 
-`ogrmerge.py -f {{VRT}} -o {{merged}}.vrt {{path/to/}}*.shp`
-
-- Concatenate three vector datasets into one:
-
-`ogrmerge.py -single -o {{path/to/output.geojson}} {{path/to/input_a.geojson}} {{path/to/input_b.geojson}} {{path/to/input_c.geojson}}`
+`ogrmerge.py -f {{VRT}} -o {{path/to/output}}.vrt {{path/to/input_a.geojson path/to/input_b.geojson ...}}`
 
 - Concatenate two vector datasets and store source name of dataset in attribute 'source_name':
 
-`ogrmerge.py -single -o {{path/to/output.geojson}} {{path/to/input_a.geojson}} {{path/to/input_b.geojson}} -src_layer_field_name country {{source_name}}`
+`ogrmerge.py -single -o {{path/to/output.geojson}} -src_layer_field_name country {{source_name}} {{path/to/input_a.shp path/to/input_b.shp ...}}`

--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -9,7 +9,7 @@
 
 - Create a virtual datasource (VRT) with a layer for each input GeoJSON:
 
-`ogrmerge.py -f {{VRT}} -o {{path/to/output.vrt}} {{path/to/input_1.geojson path/to/input_2.geojson ...}}`
+`ogrmerge.py -f {{VRT}} -o {{path/to/output.vrt}} {{path/to/input1.geojson path/to/input2.geojson ...}}`
 
 - Concatenate two vector datasets and store source name of dataset in attribute 'source_name':
 

--- a/pages/common/ogrmerge.py.md
+++ b/pages/common/ogrmerge.py.md
@@ -9,8 +9,8 @@
 
 - Create a virtual datasource (VRT) with a layer for each input GeoJSON:
 
-`ogrmerge.py -f {{VRT}} -o {{path/to/output}}.vrt {{path/to/input_a.geojson path/to/input_b.geojson ...}}`
+`ogrmerge.py -f {{VRT}} -o {{path/to/output.vrt}} {{path/to/input_1.geojson path/to/input_2.geojson ...}}`
 
 - Concatenate two vector datasets and store source name of dataset in attribute 'source_name':
 
-`ogrmerge.py -single -o {{path/to/output.geojson}} -src_layer_field_name country {{source_name}} {{path/to/input_a.shp path/to/input_b.shp ...}}`
+`ogrmerge.py -single -f {{GeoJSON}} -o {{path/to/output.geojson}} -src_layer_field_name country {{source_name}} {{path/to/input_1.shp path/to/input_2.shp ...}}`


### PR DESCRIPTION
This pull request adds the page `ogrmerge.py`. The official documentation is on: https://gdal.org/programs/ogrmerge.html

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
`GDAL 3.2.2, released 2021/03/05`
