### PR TITLE
ogr2ogr, ogrinfo: refresh

### DIFF
--- a/pages/common/ogr2ogr.md
+++ b/pages/common/ogr2ogr.md
@@ -1,11 +1,15 @@
 # ogr2ogr
 
-> Convert Simple Features data between file formats.
+> Convert geospatial vector data between file formats.
 > More information: <https://gdal.org/programs/ogr2ogr.html>.
 
 - Convert a Shapefile into a GeoPackage:
 
 `ogr2ogr -f GPKG {{path/to/output}}.gpkg {{path/to/input}}.shp`
+
+- Reduce a GeoJSON to features matching a condition:
+
+`ogr2ogr -where '{{myProperty > 42}}' -f {{GeoJSON}} {{path/to/output.geojson}} {{path/to/input.geojson}}`
 
 - Change coordinate reference system of a GeoPackage from `EPSG:4326` to `EPSG:3857`:
 

--- a/pages/common/ogrinfo.md
+++ b/pages/common/ogrinfo.md
@@ -29,4 +29,4 @@
 
 - Update a layer in the data source with SQL:
 
-`ogrinfo {{path/to/input.geojson}} -dialect SQLite -sql {{"UPDATE input SET attribute_name='foo'"}}`
+`ogrinfo {{path/to/input.geojson}} -dialect SQLite -sql "{{UPDATE input SET attribute_name = 'foo'}}"`

--- a/pages/common/ogrinfo.md
+++ b/pages/common/ogrinfo.md
@@ -15,6 +15,18 @@
 
 `ogrinfo {{path/to/input.gpkg}} {{layer_name}}`
 
-- Only show summary information about a specific layer of a data source:
+- Show summary information about a specific layer of a data source:
 
 `ogrinfo -so {{path/to/input.gpkg}} {{layer_name}}`
+
+- Show summary of all layers of the data source:
+
+`ogrinfo -so -al {{path/to/input.gpkg}}`
+
+- Show detailed information of features matching a condition:
+
+`ogrinfo -where '{{myProperty > 42}}' {{path/to/input.gpkg}} {{layer_name}}`
+
+- Update a layer in the data source with SQL:
+
+`ogrinfo {{path/to/input.geojson}} -dialect SQLite -sql {{"UPDATE input SET attribute_name='foo'"}}`

--- a/pages/common/ogrinfo.md
+++ b/pages/common/ogrinfo.md
@@ -25,7 +25,7 @@
 
 - Show detailed information of features matching a condition:
 
-`ogrinfo -where '{{myProperty > 42}}' {{path/to/input.gpkg}} {{layer_name}}`
+`ogrinfo -where '{{my_attribute > 42}}' {{path/to/input.gpkg}} {{layer_name}}`
 
 - Update a layer in the data source with SQL:
 

--- a/pages/common/ogrinfo.md
+++ b/pages/common/ogrinfo.md
@@ -25,7 +25,7 @@
 
 - Show detailed information of features matching a condition:
 
-`ogrinfo -where '{{my_attribute > 42}}' {{path/to/input.gpkg}} {{layer_name}}`
+`ogrinfo -where '{{attribute_name > 42}}' {{path/to/input.gpkg}} {{layer_name}}`
 
 - Update a layer in the data source with SQL:
 


### PR DESCRIPTION
This pull request updates the pages `ogr2ogr` and `ogrinfo`

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
`GDAL 3.2.2, released 2021/03/05`
