### PR TITLE
windows/*: fix placeholders, flags and code descriptions (PR 3)

### DIFF
--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -1,37 +1,32 @@
 # comp
 
-> Compare the contents of two files or sets of files.
-> Use wildcards (*) to compare sets of files.
+> Compare the contents of two files or sets of files. Wildcards supported: `*` and `?`.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/comp>.
 
 - Compare files interactively:
 
 `comp`
 
-- Compare two specified files:
+- Compare the specified files:
 
-`comp {{path/to/file_1}} {{path/to/file_2}}`
+`comp {{path/to/file1}} {{path/to/file2}}`
 
-- Compare two sets of files:
+- Print the differences in [d]ecimal format:
 
-`comp {{path/to/directory_1/*}} {{path/to/directory_2/*}}`
+`comp /d {{path/to/file1}} {{path/to/file2}}`
 
-- Display differences in decimal format:
+- Print the differences in ASCII format:
 
-`comp /d {{path/to/file_1}} {{path/to/file_2}}`
+`comp /a {{path/to/file1}} {{path/to/file2}}`
 
-- Display differences in ASCII format:
+- Print the [l]ine numbers for differences:
 
-`comp /a {{path/to/file_1}} {{path/to/file_2}}`
+`comp /l {{path/to/file1}} {{path/to/file2}}`
 
-- Display line numbers for differences:
+- Compare the specified files [c]ase-insensitively:
 
-`comp /l {{path/to/file_1}} {{path/to/file_2}}`
+`comp /c {{path/to/file1}} {{path/to/file2}}`
 
-- Compare files case-insensitively:
+- Compare the first 5 lines of each file:
 
-`comp /c {{path/to/file_1}} {{path/to/file_2}}`
-
-- Compare only the first 5 lines of each file:
-
-`comp /n={{5}} {{path/to/file_1}} {{path/to/file_2}}`
+`comp /n={{5}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -1,6 +1,6 @@
 # comp
 
-> Compare the contents of two files or sets of files. Wildcards supported: `*` and `?`.
+> Compare the contents of two files or sets of files. Wildcards are supported.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/comp>.
 
 - Compare files interactively:

--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -27,6 +27,6 @@
 
 `comp /c {{path/to/file1}} {{path/to/file2}}`
 
-- Compare the first 5 lines of each file:
+- Compare the specified first lines (`5`) of each file:
 
 `comp /n={{5}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/windows/del.md
+++ b/pages/windows/del.md
@@ -1,32 +1,32 @@
 # del
 
-> Delete one or more files.
+> Delete one or more files. Wildcards are supported.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/del>.
 
-- Delete one or more space-separated files or patterns:
+- Delete the specified files:
 
-`del {{file_pattern}}`
-
-- Prompt for confirmation before deleting each file:
-
-`del {{file_pattern}} /p`
+`del {{path/to/file1 path/to/file2 ...}}`
 
 - Force the deletion of read-only files:
 
-`del {{file_pattern}} /f`
+`del {{path/to/file1 path/to/file2 ...}} /f`
 
-- Recursively delete file(s) from all subdirectories:
+- Prompt for the confirmation before deleting each file:
 
-`del {{file_pattern}} /s`
+`del /p {{path/to/file1 path/to/file2 ...}}`
 
-- Do not prompt when deleting files based on a global wildcard:
+- Do not prompt for the confirmation before deleting each file:
 
-`del {{file_pattern}} /q`
+`del /q {{path/to/file1 path/to/file2 ...}}`
 
-- Display the help and list available attributes:
+- Delete files with the specified [a]ttributes:
+
+`del /a {{attributes}} {{path/to/file1 path/to/file2 ...}}`
+
+- Recur[s]ively delete files from the specified directories:
+
+`del /s {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
+
+- Print the help:
 
 `del /?`
-
-- Delete files based on specified attributes:
-
-`del {{file_pattern}} /a {{attribute}}`

--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -1,20 +1,16 @@
 # dir
 
-> List directory contents.
+> List directory contents. Wildcards are supported.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/dir>.
 
-- Show the contents of the current directory:
+- Print the contents of the current directory:
 
 `dir`
 
-- Show the contents of a given directory:
+- Print the contents of the specified directories:
 
-`dir {{path/to/directory}}`
+`dir {{path/to/directory1 path/to/directory2 ...}}`
 
-- Show the contents of the current directory, including hidden ones:
+- Print the files/subdirectories of the current directory with the specified [a]ttributes:
 
-`dir /A`
-
-- Show the contents of a given directory, including hidden ones:
-
-`dir {{path/to/directory}} /A`
+`dir /a {{attributes}}`

--- a/pages/windows/diskpart.md
+++ b/pages/windows/diskpart.md
@@ -3,23 +3,23 @@
 > Disk, volume and partition manager.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/diskpart>.
 
-- Run diskpart by itself in an administrative command prompt to enter its command line:
+- Start diskpart (requires administrative rights):
 
 `diskpart`
 
-- List all disks:
+- Print all disks:
 
 `list disk`
 
-- Select a volume:
+- Select the specified volume:
 
 `select volume {{volume}}`
 
-- Assign a drive letter to the selected volume:
+- Assign the drive letter to the selected volume:
 
 `assign letter {{letter}}`
 
-- Create a new partition:
+- Create the new partition:
 
 `create partition primary`
 

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -9,7 +9,7 @@
 
 - Create the new macro:
 
-`doskey {{name}} = "{{command}}"`
+`doskey {{name}} = {{command}}`
 
 - Create the new macro for the specified executable:
 

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -3,30 +3,30 @@
 > Manage macros, windows commands and command-lines.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/doskey>.
 
-- List available macros:
+- Print all macros:
 
 `doskey /macros`
 
-- Create a new macro:
+- Create the new macro:
 
 `doskey {{name}} = "{{command}}"`
 
-- Create a new macro for a specific executable:
+- Create the new macro for the specified executable:
 
 `doskey /exename={{executable}} {{name}} = "{{command}}"`
 
-- Remove a macro:
+- Remove the macro:
 
 `doskey {{name}} =`
 
-- Display all commands that are stored in memory:
+- Print all commands that are stored in memory:
 
 `doskey /history`
 
-- Save macros to a file for portability:
+- Save macros to the file for portability:
 
 `doskey /macros > {{macinit}}`
 
-- Load macros from a file:
+- Load macros from the specified file:
 
 `doskey /macrofile = {{macinit}}`

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -13,7 +13,7 @@
 
 - Create the new macro for the specified executable:
 
-`doskey /exename={{executable}} {{name}} = "{{command}}"`
+`doskey /exename={{executable}} {{name}} = {{command}}`
 
 - Remove the macro:
 

--- a/pages/windows/driverquery.md
+++ b/pages/windows/driverquery.md
@@ -3,15 +3,15 @@
 > Display information about installed device drivers.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/driverquery>.
 
-- Display a list of all installed device drivers:
+- Print all drivers:
 
 `driverquery`
 
-- Display a list of drivers in the specified format:
+- Print all drivers in the specified format:
 
 `driverquery /fo {{table|list|csv}}`
 
-- Display a list of drivers with a column to indicate if they are signed:
+- Print all drivers with the column to indicate if they are signed:
 
 `driverquery /si`
 
@@ -19,14 +19,14 @@
 
 `driverquery /nh`
 
-- Display a list of drivers for a remote machine:
+- Print all drivers for the remote machine:
 
 `driverquery /s {{hostname}} /u {{username}} /p {{password}}`
 
-- Display a list of drivers with verbose information:
+- Print all drivers in the verbose format:
 
 `driverquery /v`
 
-- Display detailed usage information:
+- Print the help:
 
 `driverquery /?`

--- a/pages/windows/eventcreate.md
+++ b/pages/windows/eventcreate.md
@@ -4,18 +4,18 @@
 > Event IDs can be any number between 1 and 1000.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/eventcreate>.
 
-- Create a new event with a given ID (1-1000) in the log:
+- Create the event with the specified ID (1-1000) in the log:
 
 `eventcreate /t {{success|error|warning|information}} /id {{id}} /d "{{message}}"`
 
-- Create an event in a specific event log:
+- Create the event in the specified event log:
 
 `eventcreate /l {{log_name}} /t {{type}} /id {{id}} /d "{{message}}"`
 
-- Create an event with a specific source:
+- Create the event with the specified source:
 
 `eventcreate /so {{source_name}} /t {{type}} /id {{id}} /d "{{message}}"`
 
-- Create an event in a remote machine's event log:
+- Create the event in the remote machine's event log:
 
 `eventcreate /s {{hostname}} /u {{username}} /p {{password}} /t {{type}} /id {{id}} /d "{{message}}"`

--- a/pages/windows/exit.md
+++ b/pages/windows/exit.md
@@ -3,14 +3,14 @@
 > Quit the current CMD instance or the current batch file.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/exit>.
 
-- Quit the current CMD instance:
+- Exit the current CMD instance:
 
 `exit`
 
-- Quit the current batch script:
+- Exit the current batch script:
 
 `exit /b`
 
-- Quit using a specific exit code:
+- Exit with the specified exit code:
 
 `exit {{exit_code}}`

--- a/pages/windows/expand.md
+++ b/pages/windows/expand.md
@@ -1,13 +1,13 @@
 # expand
 
-> Uncompress one or more Windows Cabinet files.
+> Uncompress one or more Windows Cabinet files. Wildcards are supported.
 > More information: <https://docs.microsoft.com/windows-server/administration/windows-commands/expand>.
 
-- Uncompress a single-file Cabinet file to the specified directory:
+- Uncompress the single-file Cabinet file to the specified directory:
 
 `expand {{path/to/file.cab}} {{path/to/directory}}`
 
-- Display the list of files in a source Cabinet file:
+- Print all files in the specified Cabinet file:
 
 `expand {{path/to/file.cab}} {{path/to/directory}} -d`
 
@@ -15,10 +15,10 @@
 
 `expand {{path/to/file.cab}} {{path/to/directory}} -f:*`
 
-- Uncompress a specific file from a Cabinet file:
+- Uncompress the specified file from the Cabinet file:
 
-`expand {{path/to/file.cab}} {{path/to/directory}} -f:{{file}}`
+`expand {{path/to/file.cab}} {{path/to/directory}} -f:{{path/to/file}}`
 
-- Ignore the directory structure when uncompressing, and add them to a single directory:
+- Ignore the directory structure when uncompressing, and add them to the single directory:
 
 `expand {{path/to/file.cab}} {{path/to/directory}} -i`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

## ToDo

- [x] `comp`
- [x] `cuninst`
- [x] `del`
- [x] `dir`
- [x] `diskpart`
- [x] `doskey`
- [x] `driverquery`
- [x] `eventcreate`
- [x] `exit`
- [x] `expand`

----

[Previous PR][prev] | Next PR

[prev]: https://github.com/tldr-pages/tldr/pull/7894
[next]: https://github.com/unavailable