### PR TITLE
ld: add page

### DIFF
--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -1,0 +1,16 @@
+# ld
+
+> The GNU ELF linker.
+> More information: <https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_mono/ld.html>
+
+- "Link" an object file with no dependencies into an executable:
+
+`ld {{file.o}} -o {{executable}}`
+
+- Link two object files together:
+
+`ld {{file.o}} {{file1.o}} -o {{executable}}`
+
+- Dynamically link a 64-bit program to glibc (file paths change depending on system):
+
+`ld -o {{executable}} -dynamic-linker /lib/ld-linux-x86-64.so.2 /lib/crt1.o /lib/crti.o -lc {{file.o}} /lib/crtn.o`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
GNU ld (GNU Binutils) 2.38