### PR TITLE
sdef, xml2man: add page

### DIFF
--- a/pages/osx/sdef.md
+++ b/pages/osx/sdef.md
@@ -1,0 +1,8 @@
+# sdef
+
+> Get or generate a scripting definitions (`sdef`) file from a scriptable application.
+> More information: <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_creating_sdef/SAppsCreateSdef.html>.
+
+- Print the scripting definitions of the given application:
+
+`sdef {{/Applications/XCode.app}}`

--- a/pages/osx/xml2man.md
+++ b/pages/osx/xml2man.md
@@ -5,12 +5,12 @@
 
 - Compile an MPGL file to a viewable man page:
 
-`xml2man {{command.mxml}}`
+`xml2man {{path/to/command.mxml}}`
 
 - Compile an MPGL file to a specific output file:
 
-`xml2man {{service.mxml}} {{service.7}}`
+`xml2man {{path/to/service.mxml}} {{path/to/service.7}}`
 
 - Compile an MPGL file to a specific output file, overwriting if it already exists:
 
-`xml2man -f {{function.mxml}} {{function.3}}`
+`xml2man -f {{path/to/function.mxml}} {{path/to/function.3}}`

--- a/pages/osx/xml2man.md
+++ b/pages/osx/xml2man.md
@@ -1,0 +1,16 @@
+# xml2man
+
+> Compile MPGL to mdoc.
+> More information: <https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/HeaderDoc/mpgl/mpgl.html>.
+
+- Compile an MPGL file to a viewable man page:
+
+`xml2man {{command.mxml}}`
+
+- Compile an MPGL file to a specific output file:
+
+`xml2man {{service.mxml}} {{service.7}}`
+
+- Compile an MPGL file to a specific output file, overwriting if it already exists:
+
+`xml2man -f {{function.mxml}} {{function.3}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
XCode 13.3
