### PR TITLE
pwd: fix flags

### DIFF
--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -9,8 +9,8 @@
 
 - Print the current directory, and resolve all symlinks (i.e. show the "physical" path):
 
-`pwd --physical`
+`pwd -P`
 
 - Print the current logical directory:
 
-`pwd --logical`
+`pwd -L`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

closes #7952 
