### PR TITLE
gh*, glab*: standardize documentation

### DIFF
--- a/pages/common/gh-issue.md
+++ b/pages/common/gh-issue.md
@@ -3,11 +3,15 @@
 > Manage GitHub issues from the command-line.
 > More information: <https://cli.github.com/manual/gh_issue>.
 
-- Print out the issue:
+- Display a specific issue:
 
 `gh issue view {{issue_number}}`
 
-- Create a new issue in the web browser:
+- Display a specific issue in the default web browser:
+
+`gh issue view {{issue_number}} --web`
+
+- Create a new issue in the default web browser:
 
 `gh issue create --web`
 
@@ -23,6 +27,6 @@
 
 `gh issue status --repo {{owner}}/{{repository}}`
 
-- Reopen an issue:
+- Reopen a specific issue:
 
 `gh issue reopen {{issue_number}}`

--- a/pages/common/gh-pr-create.md
+++ b/pages/common/gh-pr-create.md
@@ -19,6 +19,6 @@
 
 `gh pr create --base {{base_branch}} --title "{{title}}" --body "{{body}}"`
 
-- Start opening a pull request in the default browser:
+- Start opening a pull request in the default web browser:
 
 `gh pr create --web`

--- a/pages/common/gh-pr-create.md
+++ b/pages/common/gh-pr-create.md
@@ -19,6 +19,6 @@
 
 `gh pr create --base {{base_branch}} --title "{{title}}" --body "{{body}}"`
 
-- Start opening a pull request in the browser:
+- Start opening a pull request in the default browser:
 
 `gh pr create --web`

--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -11,7 +11,7 @@
 
 `gh pr checkout {{pr_number}}`
 
-- View the changes made in the pull request:
+- View the changes made in the pull request for the current branch:
 
 `gh pr diff`
 

--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -31,6 +31,6 @@
 
 `gh pr edit --base {{branch_name}}`
 
-- Check the status of a repository's pull requests:
+- Check the status of the current repository's pull requests:
 
 `gh pr status`

--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -7,15 +7,15 @@
 
 `gh pr create`
 
-- Check out a pull request locally:
+- Check out a specific pull request locally:
 
 `gh pr checkout {{pr_number}}`
 
-- View the changes made in the PR:
+- View the changes made in the pull request:
 
 `gh pr diff`
 
-- Approve the pull request of the current branch:
+- Approve the pull request for the current branch:
 
 `gh pr review --approve`
 
@@ -30,3 +30,7 @@
 - Edit the base branch of a pull request:
 
 `gh pr edit --base {{branch_name}}`
+
+- Check the status of a repository's pull requests:
+
+`gh pr status`

--- a/pages/common/gh-repo.md
+++ b/pages/common/gh-repo.md
@@ -15,7 +15,7 @@
 
 `gh repo fork {{owner}}/{{repository}} --clone`
 
-- View a repository in the web browser:
+- View a repository in the default web browser:
 
 `gh repo view {{repository}} --web`
 

--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -16,7 +16,7 @@
 
 `gh issue list`
 
-- View an issue in the browser:
+- View an issue in the default browser:
 
 `gh issue view --web {{issue_number}}`
 
@@ -24,11 +24,11 @@
 
 `gh pr create`
 
-- View a pull request in the browser:
+- View a pull request in the default web browser:
 
 `gh pr view --web {{pr_number}}`
 
-- Locally check out the branch of a pull request, given its number:
+- Check out a specific pull request locally:
 
 `gh pr checkout {{pr_number}}`
 

--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -16,7 +16,7 @@
 
 `gh issue list`
 
-- View an issue in the default browser:
+- View an issue in the default web browser:
 
 `gh issue view --web {{issue_number}}`
 

--- a/pages/common/glab-alias.md
+++ b/pages/common/glab-alias.md
@@ -13,7 +13,7 @@
 
 - Create a `glab` subcommand alias:
 
-`glab alias set {{pv}} '{{pr view}}'`
+`glab alias set {{mrv}} '{{mr view}}'`
 
 - Set a shell command as a `glab` subcommand:
 

--- a/pages/common/glab-issue.md
+++ b/pages/common/glab-issue.md
@@ -7,6 +7,10 @@
 
 `glab issue view {{issue_number}}`
 
+- Display a specific issue in the default web browser:
+
+`glab issue view {{issue_number}} --web`
+
 - Create a new issue in the default web browser:
 
 `glab issue create --web`

--- a/pages/common/glab-mr.md
+++ b/pages/common/glab-mr.md
@@ -8,7 +8,7 @@
 
 `glab mr create`
 
-- Check out a merge request locally:
+- Check out a specific merge request locally:
 
 `glab mr checkout {{mr_number}}`
 

--- a/pages/common/glab-repo.md
+++ b/pages/common/glab-repo.md
@@ -15,7 +15,7 @@
 
 `glab repo fork {{owner}}/{{repository}} --clone`
 
-- View a repository in the web browser:
+- View a repository in the default web browser:
 
 `glab repo view {{owner}}/{{repository}} --web`
 

--- a/pages/common/glab.md
+++ b/pages/common/glab.md
@@ -1,28 +1,33 @@
 # glab
 
-> GitLab CLI tool to help working with GitLab from the command-line.
+> Work seamlessly with GitLab from the command-line.
+> Some subcommands such as `glab config` have their own usage documentation.
 > More information: <https://github.com/profclems/glab>.
 
-- Create a merge request:
+- Clone a GitLab repository locally:
 
-`glab mr create`
-
-- List merge requests:
-
-`glab mr list`
+`glab repo clone {{owner}}/{{repository}}`
 
 - Create a new issue:
 
 `glab issue create`
 
-- View and filter the current repository's open issues:
+- View and filter the open issues of the current repository:
 
 `glab issue list`
 
-- List pipelines:
+- View an issue in the default browser:
 
-`glab pipeline list`
+`glab issue view --web {{issue_number}}`
 
-- Clone a repository into a specific directory:
+- Create a merge request:
 
-`glab repo clone {{user}}/{{repository}} {{directory}}`
+`glab mr create`
+
+- View a pull request in the default web browser:
+
+`glab mr view --web {{pr_number}}`
+
+- Check out a specific pull request locally:
+
+`glab mr checkout {{pr_number}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

This PR synchronizes changes between the `gh` and `glab` pages so the documentation within can be standardized for easier maintenance. Inspired by #7416 and #7423 for shell pages.