### PR TITLE
alternatives: add alias page

### DIFF
--- a/pages/linux/alternatives.md
+++ b/pages/linux/alternatives.md
@@ -1,0 +1,7 @@
+# alternatives
+
+> This command is an alias of `update-alternatives`.
+
+- View documentation for the original command:
+
+`tldr update-alternatives`


### PR DESCRIPTION
Create a page for `alternatives` documenting it as an alias of `update-alternatives`.

Most RHEL/Fedora systems have this alias. I've only ever used `alternatives`, not `update-alternatives`, so this will help people searching for the shorter form.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** N/A
