### PR TITLE
ip-neighbour: fix command name

### DIFF
--- a/pages.tr/linux/ip-neighbour.md
+++ b/pages.tr/linux/ip-neighbour.md
@@ -1,4 +1,4 @@
-# ip-neighbour
+# ip neighbour
 
 > Komşu/ARP tablosu yönetimi IP alt komutu.
 > Daha fazla bilgi: <https://manned.org/ip-neighbour.8>.

--- a/pages/linux/ip-neighbour.md
+++ b/pages/linux/ip-neighbour.md
@@ -1,4 +1,4 @@
-# ip-neighbour
+# ip neighbour
 
 > Neighbour/ARP tables management IP subcommand.
 > More information: <https://manned.org/ip-neighbour.8>.


### PR DESCRIPTION
the syntax of title is now consistent with the others commands
