### PR TITLE
zoxide: make remove interactive

### DIFF
--- a/pages/common/zoxide.md
+++ b/pages/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{path/to/directory}}`
 
-- Remove a directory from `zoxide`'s database:
+- Remove a directory from `zoxide`'s database interactively:
 
-`zoxide remove {{path/to/directory}}`
+`zoxide remove {{path/to/directory}} --interactive`
 
 - Generate shell configuration for command aliases (`z`, `za`, `zi`, `zq`, `zr`):
 


### PR DESCRIPTION
zoxide's remove command requires options _after_ the query string, and this is not well explained in either the built-in help or the current tldr database.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [X] The page has 8 or fewer examples.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
v0.8.0