### PR TITLE
mtr: add --aslookup example

### DIFF
--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -25,4 +25,4 @@
 
 - Show the Autonomous System Number (ASN) for each hop:
 
-`mtr -z {{host}}`
+`mtr --aslookup {{hostname}}`

--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -23,6 +23,6 @@
 
 `mtr -i {{seconds}} {{host}}`
 
-- Show the Autonomous System Number (ASN) for each hop:
+- Display the Autonomous System Number (ASN) for each hop:
 
 `mtr --aslookup {{hostname}}`

--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -22,3 +22,7 @@
 - Wait for a given time (in seconds) before sending another packet to the same hop:
 
 `mtr -i {{seconds}} {{host}}`
+
+- Show the Autonomous System Number (ASN) for each hop:
+
+`mtr -z {{host}}`


### PR DESCRIPTION
I think the '-z' option to `mtr` (to show the ASN) is very cool and useful, might be worth a 6th example.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).