### PR TITLE
openssl s_client: add '-servername'

### DIFF
--- a/pages/common/openssl-s_client.md
+++ b/pages/common/openssl-s_client.md
@@ -11,6 +11,10 @@
 
 `openssl s_client -connect {{host}}:{{port}} </dev/null`
 
+- Set the Server Name Indicator (SNI) when connecting to the SSL/TLS server:
+
+`openssl s_client -connect {{host}}:{{port}} -servername {{hostname}}`
+
 - Display the complete certificate chain of an HTTPS server:
 
 `openssl s_client -connect {{host}}:443 -showcerts </dev/null`


### PR DESCRIPTION
This adds `-servername` to `openssl s_client`.

It's one of the most common options to `openssl s_client` I use -- it's very useful when checking that a TLS cert is working correctly before you've updated the DNS.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).