### PR TITLE
nsenter: add --all example and refresh

### DIFF
--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -14,7 +14,7 @@
 
 - Run command in an existing process's PID namespace:
 
-`nsenter -t {{pid}} -p {{command}} {{command_arguments}}`
+`nsenter --target {{pid}} --pid {{command}} {{command_arguments}}`
 
 - Run command in an existing process's IPC namespace:
 

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -18,4 +18,4 @@
 
 - Run command in an existing process's IPC namespace:
 
-`nsenter -t {{pid}} -i {{command}} {{command_arguments}}`
+`nsenter --target {{pid}} --ipc {{command}} {{command_arguments}}`

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -10,7 +10,7 @@
 
 - Run command in an existing process's network namespace:
 
-`nsenter -t {{pid}} -n {{command}} {{command_arguments}}`
+`nsenter --target {{pid}} --net {{command}} {{command_arguments}}`
 
 - Run command in an existing process's PID namespace:
 

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -6,7 +6,7 @@
 
 - Run command using all the same namespaces as an existing process:
 
-`nsenter -t {{pid}} -a {{command}} {{command_arguments}}`
+`nsenter --target {{pid}} --all {{command}} {{command_arguments}}`
 
 - Run command in an existing process's network namespace:
 

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -4,18 +4,18 @@
 > Particularly useful for docker images or chroot jails.
 > More information: <https://manned.org/nsenter>.
 
-- Run command using all the same namespaces as an existing process:
+- Run a specific command using the same namespaces as an existing process:
 
 `nsenter --target {{pid}} --all {{command}} {{command_arguments}}`
 
-- Run command in an existing process's network namespace:
+- Run a specific command in an existing process's network namespace:
 
 `nsenter --target {{pid}} --net {{command}} {{command_arguments}}`
 
-- Run command in an existing process's PID namespace:
+- Run a specific command in an existing process's PID namespace:
 
 `nsenter --target {{pid}} --pid {{command}} {{command_arguments}}`
 
-- Run command in an existing process's IPC namespace:
+- Run a specific command in an existing process's IPC namespace:
 
 `nsenter --target {{pid}} --ipc {{command}} {{command_arguments}}`

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -4,14 +4,18 @@
 > Particularly useful for docker images or chroot jails.
 > More information: <https://github.com/jpetazzo/nsenter/>.
 
-- Run command in existing processes network namespace:
+- Run command using all the same namespaces as an existing process:
+
+`nsenter -t {{pid}} -a {{command}} {{command_arguments}}`
+
+- Run command in an existing process's network namespace:
 
 `nsenter -t {{pid}} -n {{command}} {{command_arguments}}`
 
-- Run a new command in an existing processes ps-table namespace:
+- Run command in an existing process's PID namespace:
 
 `nsenter -t {{pid}} -p {{command}} {{command_arguments}}`
 
-- Run command in existing processes IPC namespace:
+- Run command in an existing process's IPC namespace:
 
 `nsenter -t {{pid}} -i {{command}} {{command_arguments}}`

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -2,7 +2,7 @@
 
 > Run a new command in a running process' namespace.
 > Particularly useful for docker images or chroot jails.
-> More information: <https://github.com/jpetazzo/nsenter/>.
+> More information: <https://manned.org/nsenter>.
 
 - Run command using all the same namespaces as an existing process:
 


### PR DESCRIPTION
Add `-a` to nsenter (which I find quite useful) and adjust some of the grammar.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).
