### PR TITLE
cat: fix a translation error

### DIFF
--- a/pages.zh/linux/apt.md
+++ b/pages.zh/linux/apt.md
@@ -1,7 +1,7 @@
 # apt
 
 > 基于 Debian 的发行版上的软件包管理工具。
-> 在 Ubuntu 16.04 及之后版本推荐使用 `apt-get` 来代替。
+> 在 Ubuntu 16.04 及之后版本推荐用它代替 `apt-get` 。
 > 更多信息：<https://manpages.debian.org/latest/apt/apt.8.html>.
 
 - 更新可用软件包及其版本列表（推荐在运行其他 apt 命令前首先运行该命令）：


### PR DESCRIPTION
Previously, it means "It is better to use apt-get in Ubuntu versions 16.04 and later."
Now, it means "It is better to use apt in Ubuntu versions 16.04 and later."

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
