### PR TITLE
dumpcap: add page

### DIFF
--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -17,4 +17,4 @@
 
 - Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
 
-`dumpcap --interface 1 -w {{path/to/output_file.pcapng}} --ring-buffer filesize:500000 --ring-buffer files:10`
+`dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}} --ring-buffer filesize:{{500000}} --ring-buffer files:{{10}}`

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -5,7 +5,7 @@
 
 - Get a list of available interfaces:
 
-`dumpcap -D`
+`dumpcap --list-interfaces`
 
 - Start capturing packets on the first interface:
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -13,7 +13,7 @@
 
 - Start capturing packets on the first interface to a specific location:
 
-`dumpcap -i 1 -w path/to/write/file/to.pcapng`
+`dumpcap --interface 1 -w {{path/to/output_file.pcapng}}`
 
 - Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -13,7 +13,7 @@
 
 - Start capturing packets on the first interface to a specific location:
 
-`dumpcap --interface 1 -w {{path/to/output_file.pcapng}}`
+`dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}}`
 
 - Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -1,4 +1,4 @@
-# dumpcap - Dump network traffic
+# dumpcap
 
 > A network traffic dump tool.
 > More information: <https://www.wireshark.org/docs/man-pages/dumpcap.html>.

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -15,6 +15,6 @@
 
 `dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}}`
 
-- Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
+- Write to a ring buffer with a specific max file limit of a specific size:
 
 `dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}} --ring-buffer filesize:{{500000}} --ring-buffer files:{{10}}`

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -9,7 +9,7 @@
 
 - Start capturing packets on the first interface:
 
-`dumpcap -i 1`
+`dumpcap --interface 1`
 
 - Start capturing packets on the first interface to a specific location:
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -7,7 +7,7 @@
 
 `dumpcap --list-interfaces`
 
-- Start capturing packets on the first interface:
+- Capture packets on a specific interface:
 
 `dumpcap --interface {{1}}`
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -1,7 +1,6 @@
 # dumpcap - Dump network traffic
 
 > A network traffic dump tool.
-> Preferably one line; two are acceptable if necessary.
 > More information: <https://www.wireshark.org/docs/man-pages/dumpcap.html>.
 
 - Get a list of available interfaces:

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -11,7 +11,7 @@
 
 `dumpcap --interface {{1}}`
 
-- Start capturing packets on the first interface to a specific location:
+- Capture packets to a specific location:
 
 `dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}}`
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -9,7 +9,7 @@
 
 - Start capturing packets on the first interface:
 
-`dumpcap --interface 1`
+`dumpcap --interface {{1}}`
 
 - Start capturing packets on the first interface to a specific location:
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -1,0 +1,21 @@
+# dumpcap - Dump network traffic
+
+> A network traffic dump tool.
+> Preferably one line; two are acceptable if necessary.
+> More information: <https://www.wireshark.org/docs/man-pages/dumpcap.html>.
+
+- Get a list of available interfaces:
+
+`dumpcap -D`
+
+- Start capturing packets on the first interface:
+
+`dumpcap -i 1`
+
+- Start capturing packets on the first interface to a specific location:
+
+`dumpcap -i 1 -w path/to/write/file/to.pcapng`
+
+- Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
+
+`dumpcap -i 1 -w path/to/write/file/to.pcapng -b filesize:500000 -b files:10`

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -3,7 +3,7 @@
 > A network traffic dump tool.
 > More information: <https://www.wireshark.org/docs/man-pages/dumpcap.html>.
 
-- Get a list of available interfaces:
+- Display available interfaces:
 
 `dumpcap --list-interfaces`
 

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -17,4 +17,4 @@
 
 - Start capturing packets on the first interface to a specific location and writing to a ring buffer with a max of 10 files of 500MB each:
 
-`dumpcap -i 1 -w path/to/write/file/to.pcapng -b filesize:500000 -b files:10`
+`dumpcap --interface 1 -w {{path/to/output_file.pcapng}} --ring-buffer filesize:500000 --ring-buffer files:10`


### PR DESCRIPTION
Add some common commands when trying to capture packets using dumpcap, which is part of wireshark.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X ] The page (if new), does not already exist in the repository.
- [X ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ X] The page has 8 or fewer examples.
- [ X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [X ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ X] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
