### PR TITLE
perl: improve matching pattern example, arg consistency, etc.

### DIFF
--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -29,7 +29,7 @@
 
 - Run a regular expression on stdin, printing out matching [l]ines:
 
-`cat {{filename}} | perl -n -l -e 'print if /{{pattern}}/'`
+`cat {{path/to/file}} | perl -n -l -e 'print if /{{regular_expression}}/'`
 
 - Run a regular expression on stdin, printing out only the first capture group for each matching [l]ine:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -31,6 +31,10 @@
 
 `perl -p0e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`
 
-- Run a regular expression on stdin, printing out the first capture group for each line:
+- Run a regular expression on stdin, printing out matching [l]ines:
 
-`cat {{path/to/input_file}} | perl -nle 'if (/.*({{foo}}).*/) {print "$1"; last;}'`
+`cat {{filename}} | perl -n -l -e 'print if /{{pattern}}/'`
+
+- Run a regular expression on stdin, printing out only the first capture group for each matching [l]ine:
+
+`cat {{filename}} | perl -n -l -e 'print $1 if /{{before}}({{pattern}}){{after}}/'`

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -19,7 +19,7 @@
 
 `perl -d {{script.pl}}`
 
-- Loo[p] over all lines of a file, editing them [i]n-place with a find/replace [e]xpression and saving the original file with a new extension:
+- Edit all file lines [i]n-place with a specific replacement [e]xpression and save a file with a new extension:
 
 `perl -p -i'.{{extension}}' -e 's/{{find}}/{{replace}}/g' {{filename}}`
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -23,7 +23,7 @@
 
 `perl -p -i'.{{extension}}' -e 's/{{regular_expression}}/{{replacement}}/g' {{path/to/file}}`
 
-- Run a multiline find/replace expression on a file, and save the result in another file:
+- Run a multi-line replacement expression on a file, and save the result in a specific file:
 
 `perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -23,14 +23,14 @@
 
 `perl -p -i'.{{extension}}' -e 's/{{regular_expression}}/{{replacement}}/g' {{path/to/file}}`
 
-- Run a multi-line replacement expression on a file, and save the result in a specific file:
+- Run a multi-line replacement [e]xpression on a file, and save the result in a specific file:
 
 `perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{path/to/input_file}} > {{path/to/output_file}}`
 
-- Run a regular expression on stdin, printing out matching [l]ines:
+- Run a regular [e]xpression on stdin, printing out matching [l]ines:
 
 `cat {{path/to/file}} | perl -n -l -e 'print if /{{regular_expression}}/'`
 
-- Run a regular expression on stdin, printing out only the first capture group for each matching [l]ine:
+- Run a regular [e]xpression on stdin, printing out only the first capture group for each matching [l]ine:
 
 `cat {{path/to/file}} | perl -n -l -e 'print $1 if /{{before}}({{regular_expression}}){{after}}/'`

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -19,13 +19,9 @@
 
 `perl -d {{script.pl}}`
 
-- Loo[p] over all lines of a file, editing them [i]n-place using a find/replace [e]xpression:
+- Loo[p] over all lines of a file, editing them [i]n-place with a find/replace [e]xpression and saving the original file with a new extension:
 
-`perl -p -i -e 's/{{find}}/{{replace}}/g' {{filename}}`
-
-- Run a find/replace expression on a file, saving the original file with a given extension:
-
-`perl -p -i'.old' -e 's/{{find}}/{{replace}}/g' {{filename}}`
+`perl -p -i'.{{extension}}' -e 's/{{find}}/{{replace}}/g' {{filename}}`
 
 - Run a multiline find/replace expression on a file, and save the result in another file:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -21,7 +21,7 @@
 
 - Edit all file lines [i]n-place with a specific replacement [e]xpression and save a file with a new extension:
 
-`perl -p -i'.{{extension}}' -e 's/{{find}}/{{replace}}/g' {{filename}}`
+`perl -p -i'.{{extension}}' -e 's/{{regular_expression}}/{{replacement}}/g' {{path/to/file}}`
 
 - Run a multiline find/replace expression on a file, and save the result in another file:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -27,10 +27,10 @@
 
 `perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{path/to/input_file}} > {{path/to/output_file}}`
 
-- Run a regular [e]xpression on stdin, printing out matching [l]ines:
+- Run a regular [e]xpression on stdin, printing matching [l]ines:
 
 `cat {{path/to/file}} | perl -n -l -e 'print if /{{regular_expression}}/'`
 
-- Run a regular [e]xpression on stdin, printing out only the first capture group for each matching [l]ine:
+- Run a regular [e]xpression on stdin, printing only the first capture group for each matching [l]ine:
 
 `cat {{path/to/file}} | perl -n -l -e 'print $1 if /{{before}}({{regular_expression}}){{after}}/'`

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -25,7 +25,7 @@
 
 - Run a multiline find/replace expression on a file, and save the result in another file:
 
-`perl -p0e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`
+`perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`
 
 - Run a regular expression on stdin, printing out matching [l]ines:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -25,7 +25,7 @@
 
 - Run a multi-line replacement expression on a file, and save the result in a specific file:
 
-`perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{input_file}} > {{output_file}}`
+`perl -p -e 's/{{foo\nbar}}/{{foobar}}/g' {{path/to/input_file}} > {{path/to/output_file}}`
 
 - Run a regular expression on stdin, printing out matching [l]ines:
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -33,4 +33,4 @@
 
 - Run a regular expression on stdin, printing out only the first capture group for each matching [l]ine:
 
-`cat {{filename}} | perl -n -l -e 'print $1 if /{{before}}({{pattern}}){{after}}/'`
+`cat {{path/to/file}} | perl -n -l -e 'print $1 if /{{before}}({{regular_expression}}){{after}}/'`


### PR DESCRIPTION
In this PR:
* A simplified matching pattern example
* A new example for printing matching lines
* More consistency of long-form arguments in all examples
* Nix the `-0` argument from the multiline find/replace example (it's not needed)
* Collapsed the in-place find/replace examples into one (it's always a good idea to use `-i'.ext'`!) to keep the total at 8, and turned `.old` into `.{{extension}}`

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):** Perl 5
