### PR TITLE
pihole: update more information link

### DIFF
--- a/pages/linux/pihole.md
+++ b/pages/linux/pihole.md
@@ -1,15 +1,15 @@
 # pihole
 
 > Terminal interface for the Pi-hole ad-blocking DNS server.
-> More information: <https://pi-hole.net>.
+> More information: <https://docs.pi-hole.net/core/pihole-command/>.
 
 - Check the Pi-hole daemon's status:
 
 `pihole status`
 
-- Update Pi-hole:
+- Update Pi-hole (software and adlists):
 
-`pihole updatePihole`
+`pihole -up`
 
 - Monitor detailed system status:
 

--- a/pages/linux/pihole.md
+++ b/pages/linux/pihole.md
@@ -7,7 +7,7 @@
 
 `pihole status`
 
-- Update Pi-hole (software and adlists):
+- Update Pi-hole and Gravity:
 
 `pihole -up`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Updates the more information link and replaces `pihole updatePihole` by the equivalent and more well-known `pihole -up`.

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** v5.10
