### PR TITLE
nix: fix deprecated optimise-store example

### DIFF
--- a/pages/common/nix.md
+++ b/pages/common/nix.md
@@ -13,7 +13,7 @@
 
 - Optimise Nix store disk usage by combining duplicate files:
 
-`nix optimise-store`
+`nix store optimise`
 
 - Start an interactive environment for evaluating Nix expressions:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):** latest, 2.8.0
