### PR TITLE
vboxmanage: fix typo in example

### DIFF
--- a/pages/common/vboxmanage.md
+++ b/pages/common/vboxmanage.md
@@ -18,7 +18,7 @@
 
 - Start a virtual machine in headless mode:
 
-`VBoxManage startvm {{name|uuid}} -type headless`
+`VBoxManage startvm {{name|uuid}} --type headless`
 
 - Shutdown the virtual machine and save its current state:
 


### PR DESCRIPTION
double hyphen for long option --type correction, see usage:
vboxmanage startvm
Usage:

VBoxManage startvm          <uuid|vmname>...
                            [--type gui|sdl|headless|separate]
                            [-E|--putenv <NAME>[=<VALUE>]]

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [ ] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ ] The page has 8 or fewer examples.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
