### PR TITLE
nsenter: update more information link to man page

### DIFF
--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -2,7 +2,7 @@
 
 > Run a new command in a running process' namespace.
 > Particularly useful for docker images or chroot jails.
-> More information: <https://github.com/jpetazzo/nsenter/>.
+> More information: <https://man7.org/linux/man-pages/man1/nsenter.1.html>.
 
 - Run command in existing processes network namespace:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

util-linux-2.37.4

- - -

nsenter is maintained as part of the util-linux package; https://github.com/jpetazzo/nsenter is archived and has the note that it's not maintained and read only:

> Important notice: this repository was useful in the early days of Docker, because nsenter was missing from major distributions back then. nsenter was written in early 2013, and included in util-linux release 2.23. If we look at Ubuntu LTS releases, trusty (14.04) shipped util-linux 2.20, and xenial (16.04) shipped 2.27. In other words, if you were using Ubuntu LTS, you had to wait until 2016 to get nsenter through the main, official packages. That being said, all modern distros now ship with nsenter, and this repository is no longer useful, except for historical or curiosity purposes. It is no longer maintained.
