### PR TITLE
efibootmgr: add clarity

### DIFF
--- a/pages/linux/efibootmgr.md
+++ b/pages/linux/efibootmgr.md
@@ -3,7 +3,7 @@
 > Manipulate the UEFI Boot Manager.
 > More information: <https://manned.org/efibootmgr>.
 
-- List the current settings / bootnums:
+- List the current settings then bootnums (with their name):
 
 `efibootmgr`
 

--- a/pages/linux/efibootmgr.md
+++ b/pages/linux/efibootmgr.md
@@ -3,7 +3,7 @@
 > Manipulate the UEFI Boot Manager.
 > More information: <https://manned.org/efibootmgr>.
 
-- List the current settings then bootnums (with their name):
+- List the current settings then bootnums with their name:
 
 `efibootmgr`
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x]  The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** version 17

