### PR TITLE
conntrack: add page

### DIFF
--- a/pages/linux/conntrack.md
+++ b/pages/linux/conntrack.md
@@ -1,0 +1,25 @@
+# conntrack
+
+> Interact with the Netfilter connection tracking system.
+> Search, list, inspect, modify, and delete connection flows.
+> More information: <https://manned.org/conntrack>.
+
+- List all currently tracked connections:
+
+`conntrack --dump`
+
+- Display a real-time event log of connection changes:
+
+`conntrack --event`
+
+- Display a real-time event log of connection changes and associated timestamps:
+
+`conntrack --event -o timestamp`
+
+- Display a real-time event log of connection changes for a specific IP address:
+
+`conntrack --event --orig-src {{ip_address}}`
+
+- Delete all flows to the specified source IP address:
+
+`conntrack --delete --orig-src {{ip_address}}`

--- a/pages/linux/conntrack.md
+++ b/pages/linux/conntrack.md
@@ -20,6 +20,6 @@
 
 `conntrack --event --orig-src {{ip_address}}`
 
-- Delete all flows to the specified source IP address:
+- Delete all flows for a specific source IP address:
 
 `conntrack --delete --orig-src {{ip_address}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Fedora 35 IoT, conntrack-tools-1.4.5-8.fc35.aarch64 