### PR TITLE
dos2unix, mac2unix, unix2dos, unix2mac: fix error in descriptions

### DIFF
--- a/pages.ca/linux/dos2unix.md
+++ b/pages.ca/linux/dos2unix.md
@@ -1,7 +1,7 @@
 # dos2unix
 
 > Canvia salts de línia amb format DOS a salts de línia amb format Unix.
-> Reemplaça CRLF amb CR.
+> Reemplaça CRLF amb LF.
 > Més informació: <https://manned.org/dos2unix>.
 
 - Canvia els salts de línia en un arxiu:

--- a/pages.es/linux/dos2unix.md
+++ b/pages.es/linux/dos2unix.md
@@ -1,7 +1,7 @@
 # dos2unix
 
 > Cambia saltos de línea con formato DOS a saltos de línea con formato Unix.
-> Reemplaza CRLF con CR.
+> Reemplaza CRLF con LF.
 > Más información: <https://manned.org/dos2unix>.
 
 - Cambia los saltos de línea de un archivo:

--- a/pages.zh/linux/dos2unix.md
+++ b/pages.zh/linux/dos2unix.md
@@ -1,7 +1,7 @@
 # dos2unix
 
 > 将 DOS 样式的行尾更改为 Unix 样式。
-> 用 CR 替换 CRLF.
+> 用 LF 替换 CRLF.
 > 更多信息：<https://manned.org/dos2unix>.
 
 - 更改文件的行尾：

--- a/pages.zh/linux/mac2unix.md
+++ b/pages.zh/linux/mac2unix.md
@@ -1,7 +1,7 @@
 # mac2unix
 
 > 将 macOS 样式的行尾更改为 Unix 样式。
-> 用 CR 替换 LF.
+> 用 LF 替换 CR.
 > 更多信息：<https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - 更改文件的行尾：

--- a/pages.zh/linux/unix2dos.md
+++ b/pages.zh/linux/unix2dos.md
@@ -1,7 +1,7 @@
 # unix2dos
 
 > 将 Unix 样式的行尾更改为 DOS 样式。
-> 用 CRLF 替换 CR.
+> 用 CRLF 替换 LF.
 > 更多信息：<https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - 更改文件的行尾：

--- a/pages.zh/linux/unix2mac.md
+++ b/pages.zh/linux/unix2mac.md
@@ -1,7 +1,7 @@
 # unix2mac
 
 > 将 Unix 样式的行尾更改为 macOS 样式。
-> 用 LF 替换 CR.
+> 用 CR 替换 LF.
 > 更多信息：<https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - 更改文件的行尾：

--- a/pages/linux/dos2unix.md
+++ b/pages/linux/dos2unix.md
@@ -1,7 +1,7 @@
 # dos2unix
 
 > Change DOS-style line endings to Unix-style.
-> Replaces CRLF with CR.
+> Replaces CRLF with LF.
 > More information: <https://manned.org/dos2unix>.
 
 - Change the line endings of a file:

--- a/pages/linux/mac2unix.md
+++ b/pages/linux/mac2unix.md
@@ -1,7 +1,7 @@
 # mac2unix
 
 > Change macOS-style line endings to Unix-style.
-> Replaces LF with CR.
+> Replaces CR with LF.
 > More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - Change the line endings of a file:

--- a/pages/linux/unix2dos.md
+++ b/pages/linux/unix2dos.md
@@ -1,7 +1,7 @@
 # unix2dos
 
 > Change Unix-style line endings to DOS-style.
-> Replaces CR with CRLF.
+> Replaces LF with CRLF.
 > More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - Change the line endings of a file:

--- a/pages/linux/unix2mac.md
+++ b/pages/linux/unix2mac.md
@@ -1,7 +1,7 @@
 # unix2mac
 
 > Change Unix-style line endings to macOS-style.
-> Replaces CR with LF.
+> Replaces LF with CR.
 > More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
 
 - Change the line endings of a file:


### PR DESCRIPTION
Unix systems use the Line Feed character (LF) to specify a newline while
early macOS versions used a Carriage Return (CR). In the descriptions of
`dos2unix` and all related commands, this was reported the wrong way
round.

I fixed the error for all languages. I can speak English and Spanish but not Chinese, so I used Google Translate for that. Maybe someone speaking Chinese can verify that it is in the correct order now.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 7.4.2
