### PR TITLE
rpm: use long arguments format

### DIFF
--- a/pages/linux/rpm.md
+++ b/pages/linux/rpm.md
@@ -5,28 +5,28 @@
 
 - Show version of httpd package:
 
-`rpm -q {{httpd}}`
+`rpm --query {{httpd}}`
 
 - List versions of all matching packages:
 
-`rpm -qa '{{mariadb*}}'`
+`rpm --query --all '{{mariadb*}}'`
 
 - Forcibly install a package regardless of currently installed versions:
 
-`rpm -U {{package_name.rpm}} --force`
+`rpm --upgrade {{package_name.rpm}} --force`
 
 - Identify owner of a file and show version of the package:
 
-`rpm -qf {{/etc/postfix/main.cf}}`
+`rpm --query --file {{/etc/postfix/main.cf}}`
 
 - List package-owned files:
 
-`rpm -ql {{kernel}}`
+`rpm --query --list {{kernel}}`
 
 - Show scriptlets from an RPM file:
 
-`rpm -qp --scripts {{package_name.rpm}}`
+`rpm --query --package --scripts {{package_name.rpm}}`
 
 - Show changed, missing and/or incorrectly installed files of matching packages:
 
-`rpm -Va '{{php-*}}'`
+`rpm --verify --all '{{php-*}}'`


### PR DESCRIPTION
Updated to  use long options per guidelines

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
4.17.0