### PR TITLE
grep: improve example to add color

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -23,9 +23,9 @@
 
 `grep --{{context|before-context|after-context}}={{3}} "{{search_pattern}}" {{path/to/file}}`
 
-- Print file name and line number for each match:
+- Print file name and line number for each match with color output:
 
-`grep --with-filename --line-number "{{search_pattern}}" {{path/to/file}}`
+`grep --with-filename --line-number --color=always "{{search_pattern}}" {{path/to/file}}`
 
 - Search for lines matching a pattern, printing only the matched text:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 3.6

It may help to add an example for enabling colour output in grep.