### PR TITLE
hydra: replace telnet with brute force example

### DIFF
--- a/pages/common/hydra.md
+++ b/pages/common/hydra.md
@@ -12,7 +12,7 @@
 
 `hydra -l {{username}} -P {{path/to/wordlist.txt}} {{host_ip}} {{ssh}}`
 
-- Guess HTTPS webform credentials using a list of usernames and a list of password:
+- Guess HTTPS webform credentials using a list of usernames and a list of passwords:
 
 `hydra -L {{path/to/usernames.txt}} -P {{path/to/wordlist.txt}} {{host_ip}} {{https-post-form}} "{{url_without_host}}:{{https_post_request}}:{{login_failed_string}}"`
 

--- a/pages/common/hydra.md
+++ b/pages/common/hydra.md
@@ -12,9 +12,9 @@
 
 `hydra -l {{username}} -P {{path/to/wordlist.txt}} {{host_ip}} {{ssh}}`
 
-- Guess Telnet credentials using a list of usernames and a single password, specifying a non-standard port and IPv6:
+- Guess HTTPS webform credentials using a list of usernames and a list of password:
 
-`hydra -L {{path/to/usernames.txt}} -p {{password}} -s {{port}} -6 {{host_ip}} {{telnet}}`
+`hydra -L {{path/to/usernames.txt}} -P {{path/to/wordlist.txt}} {{host_ip}} {{https-post-form}} "{{url_without_host}}:{{https_post_request}}:{{login_failed_string}}"`
 
 - Guess FTP credentials using usernames and passwords lists, specifying the number of threads:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
