### PR TITLE
wal: fix examples

### DIFF
--- a/pages.ca/common/wal.md
+++ b/pages.ca/common/wal.md
@@ -13,15 +13,15 @@
 
 - Crea un esquema de colors clars:
 
-`wal -il {{imatge.png}}`
+`wal -i {{imatge.png}} -l`
 
 - No canvia el fons de pantalla:
 
-`wal -in {{imatge.png}}`
+`wal -i {{imatge.png}} -n`
 
 - No canvia els colors de la terminal:
 
-`wal -is {{imatge.png}}`
+`wal -i {{imatge.png}} -s`
 
 - Restableix l'anterior fonts de pantalla i esquema de colors generat:
 

--- a/pages/common/wal.md
+++ b/pages/common/wal.md
@@ -13,15 +13,15 @@
 
 - Create a light color scheme:
 
-`wal -il {{image.png}}`
+`wal -i {{image.png}} -l`
 
 - Skip setting the desktop wallpaper:
 
-`wal -in {{image.png}}`
+`wal -i {{image.png}} -n`
 
 - Skip setting the terminal colors:
 
-`wal -is {{image.png}}`
+`wal -i {{image.png}} -s`
 
 - Restore the previously generated color scheme and wallpaper:
 


### PR DESCRIPTION
pywal expects a path after the -i argument.
![pywal_fix](https://user-images.githubusercontent.com/7192535/169668751-6c94a14e-9747-4ea0-b962-4eb30922e81c.gif)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known): 3.3.0
