### PR TITLE
gpg: add notice that command is often symlinked

### DIFF
--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -1,7 +1,7 @@
 # gpg
 
 > GNU Privacy Guard.
-> See `gpg2` for GNU Privacy Guard 2. Most operating systems symlink gpg to gpg2.
+> See `gpg2` for GNU Privacy Guard 2. Most operating systems symlink `gpg` to `gpg2`.
 > More information: <https://gnupg.org>.
 
 - Create a GPG public and private key interactively:

--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -1,7 +1,7 @@
 # gpg
 
 > GNU Privacy Guard.
-> See `gpg2` for GNU Privacy Guard 2.
+> See `gpg2` for GNU Privacy Guard 2. Most operating systems symlink gpg to gpg2.
 > More information: <https://gnupg.org>.
 
 - Create a GPG public and private key interactively:


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 2.2.35

