### PR TITLE
gpg: add signing and multiple recipients

### DIFF
--- a/pages/common/gpg.md
+++ b/pages/common/gpg.md
@@ -12,9 +12,9 @@
 
 `gpg --clearsign {{doc.txt}}`
 
-- Encrypt `doc.txt` for alice@example.com (output to `doc.txt.gpg`):
+- Encrypt and sign `doc.txt` for alice@example.com and bob@example.com (output to `doc.txt.gpg`):
 
-`gpg --encrypt --recipient {{alice@example.com}} {{doc.txt}}`
+`gpg --encrypt --sign --recipient {{alice@example.com}} --recipient {{bob@example.com}} {{doc.txt}}`
 
 - Encrypt `doc.txt` with only a passphrase (output to `doc.txt.gpg`):
 


### PR DESCRIPTION
This updates the `gpg` encryption example to indicate that multiple recipients and signing is possible. One use-case for multiple recipients is being able to send a file to someone while also retaining the option to decrypt it oneself.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known): 2.2.4**
