### PR TITLE
xdg-desktop-menu: fix incorrectly documented command

### DIFF
--- a/pages/linux/xdg-desktop-menu.md
+++ b/pages/linux/xdg-desktop-menu.md
@@ -17,4 +17,4 @@
 
 - Force an update of the desktop menu system:
 
-`xdg-desktop-menu --forceupdate {{user|system}}`
+`xdg-desktop-menu forceupdate --mode {{user|system}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
1.1.3

---

I don't know how I managed that, should be correct this time.