### PR TITLE
ffmpeg: replace with -vf and -r example

### DIFF
--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -9,7 +9,7 @@
 
 - Save a video as GIF, scaling the height to 1000px and setting framerate to 15:
 
-`ffmpeg -i {{video.mp4}} -vf 'scale=-1:1000' -r 15 {{output}}.gif`
+`ffmpeg -i {{video.mp4}} -vf 'scale=-1:{{1000}}' -r {{15}} {{output.gif}}`
 
 - Combine numbered images (`frame_1.jpg`, `frame_2.jpg`, etc) into a video or GIF:
 

--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -7,9 +7,9 @@
 
 `ffmpeg -i {{video.mp4}} -vn {{sound}}.mp3`
 
-- Convert frames from a video or GIF into individual numbered images:
+- Save a video as GIF, scaling the height to 1000px and setting framerate to 15:
 
-`ffmpeg -i {{video.mpg|video.gif}} {{frame_%d.png}}`
+`ffmpeg -i {{video.mp4}} -vf 'scale=-1:1000' -r 15 {{output}}.gif`
 
 - Combine numbered images (`frame_1.jpg`, `frame_2.jpg`, etc) into a video or GIF:
 


### PR DESCRIPTION
Swap one of similar examples for a much more useful one that shows scaling and framerate

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 5.0.1
