### PR TITLE
stale.yml: Change time for issues to be stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,10 +16,15 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
         # Number of days of inactivity before an issue or PR is considered stale
-        days-before-stale: 15
+        days-before-pr-stale: 15
+
+        days-before-issue-stale: 45
+
 
         # Number of days of inactivity before a stale issue or PR is closed
-        days-before-close: 30
+        days-before-pr-close: 30
+
+        days-before-issue-close: 90 
 
         # Issues or PRs with these labels will never be considered stale
         exempt-pr-labels: stalebot ignore

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,6 +29,8 @@ jobs:
         # Issues or PRs with these labels will never be considered stale
         exempt-pr-labels: stalebot ignore
 
+        exempt-issue-labels: stalebot ignore,help wanted
+        
         # Label to use when marking an issue or PR as stale
         stale-pr-label: waiting
 


### PR DESCRIPTION
Some issues are being marked as stale, when they shouldn't be such as page request

I suggest that we either: 

Do what is done here, increasing the time for issues to be marked as stale and be closed

OR

make stalebot ignore the help wanted labelled issues