### PR TITLE
cgroups: fix typo in command description

### DIFF
--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -1,6 +1,6 @@
 # cgroups
 
-> Cgroups aka control groups is a Linux kernel feature for limiting, measuring, and controling resource usage by processes.
+> Cgroups aka control groups is a Linux kernel feature for limiting, measuring, and controlling resource usage by processes.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
 
 - Show the tldr page for `cgclassify`:


### PR DESCRIPTION
* please see https://github.com/tldr-pages/tldr/issues/8123

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ ] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
