### PR TITLE
cgroups: explicitly declare non-existent man pages

### DIFF
--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -4,8 +4,6 @@
 > Cgroups however is not a command, but rather a collection of commands, see the relevant pages below.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
 
-cgroups does not have man page. `cgcreate`, `cgexec`, and `cgclassify` are the tools collectively known as cgroups. These tools are used or responsible for management of `cgroup`. Please refer to the respective man pages for futher info.
-
 - Show the tldr page for `cgclassify`:
 
 `tldr cgclassify`

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -3,6 +3,8 @@
 > Cgroups aka control groups is a Linux kernel feature for limiting, measuring, and controlling resource usage by processes.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
 
+cgroups does not have man page. `cgcreate`, `cgexec`, and `cgclassify` are the tools collectively known as cgroups. These tools are used or responsible for management of `cgroup`. Please refer to the respective man pages for futher info.
+
 - Show the tldr page for `cgclassify`:
 
 `tldr cgclassify`

--- a/pages/linux/cgroups.md
+++ b/pages/linux/cgroups.md
@@ -1,6 +1,7 @@
 # cgroups
 
 > Cgroups aka control groups is a Linux kernel feature for limiting, measuring, and controlling resource usage by processes.
+> Cgroups however is not a command, but rather a collection of commands, see the relevant pages below.
 > More information: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
 
 cgroups does not have man page. `cgcreate`, `cgexec`, and `cgclassify` are the tools collectively known as cgroups. These tools are used or responsible for management of `cgroup`. Please refer to the respective man pages for futher info.


### PR DESCRIPTION
... i hope thus will resolve #8123
#### sources
* https://www.kernel.org/doc/Documentation/cgroup-v2.txt
* https://en.wikipedia.org/wiki/Cgroups

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
