### PR TITLE
journalctl: add --vacuum-time example

### DIFF
--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -11,8 +11,7 @@
 
 `journalctl -b -1`
 
-- Delete journal logs which are older than 2 days 
-
+- Delete journal logs which are older than 2 days:
 
 `journalctl --vacuum-time{{2d}}`
 

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -3,17 +3,18 @@
 > Query the systemd journal.
 > More information: <https://manned.org/journalctl>.
 
-- Show all messages from this [b]oot:
+- Show all messages with priority level 3 (errors) from this [b]oot:
 
-`journalctl -b`
+`journalctl -b --priority={{3}}`
 
 - Show all messages from last [b]oot:
 
 `journalctl -b -1`
 
-- Show all messages with priority level 3 (errors) from this [b]oot:
+- Delete journal logs which are older than 2 days 
 
-`journalctl -b --priority={{3}}`
+
+`journalctl --vacuum-time{{2d}}`
 
 - [f]ollow new messages (like `tail -f` for traditional syslog):
 

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -13,7 +13,7 @@
 
 - Delete journal logs which are older than 2 days:
 
-`journalctl --vacuum-time{{2d}}`
+`journalctl --vacuum-time={{2d}}`
 
 - [f]ollow new messages (like `tail -f` for traditional syslog):
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 251 
