### PR TITLE
chpasswd: add page

### DIFF
--- a/pages/linux/chpasswd.md
+++ b/pages/linux/chpasswd.md
@@ -3,18 +3,18 @@
 > Change passwords for multiple users via taking input from stdin.
 > More information: <https://manpages.debian.org/jessie/passwd/chpasswd.8.en.html>.
 
-- Change password for a user.
+- Change password for a user:
 
 `printf "{{username}}:{{new_password}}" | sudo chpasswd`
 
-- Change passwords for multiple users (Mind the lack of space in the stdin text).
+- Change passwords for multiple users (Mind the lack of space in the stdin text):
 
 `printf "{{username_one}}:{{new_password_one}}\n{{username_two}}:{{new_password_two}}" | sudo chpasswd`
 
-- Change password into the supplied encrypted password for a user.
+- Change password into the supplied encrypted password for a user:
 
 `printf "{{username}}:{{new_encrypted_password}}" | sudo chpasswd --encrypted`
 
-- Change password for a user and use a specific cryptographic method to encrypt the password to be stored.
+- Change password for a user and use a specific cryptographic method to encrypt the password to be stored:
 
-`printf "{{username}}:{{new_password}}" | sudo chpasswd --crypt-method {{NONE|DES|MD5|SHA256|SHA512}}` 
+`printf "{{username}}:{{new_password}}" | sudo chpasswd --crypt-method {{NONE|DES|MD5|SHA256|SHA512}}`

--- a/pages/linux/chpasswd.md
+++ b/pages/linux/chpasswd.md
@@ -7,7 +7,7 @@
 
 `printf "{{username}}:{{new_password}}" | sudo chpasswd`
 
-- Change the passwords for multiple users (the input text must not contain any spaces):
+- Change the passwords for multiple users (The input text must not contain any spaces.):
 
 `printf "{{username_1}}:{{new_password_1}}\n{{username_2}}:{{new_password_2}}" | sudo chpasswd`
 

--- a/pages/linux/chpasswd.md
+++ b/pages/linux/chpasswd.md
@@ -15,6 +15,6 @@
 
 `printf "{{username}}:{{new_encrypted_password}}" | sudo chpasswd --encrypted`
 
-- Change password for a user and use a specific cryptographic method to encrypt the password to be stored:
+- Change the password for a specific user, and use a specific encryption for the stored password:
 
 `printf "{{username}}:{{new_password}}" | sudo chpasswd --crypt-method {{NONE|DES|MD5|SHA256|SHA512}}`

--- a/pages/linux/chpasswd.md
+++ b/pages/linux/chpasswd.md
@@ -1,17 +1,17 @@
 # chpasswd
 
-> Change passwords for multiple users via taking input from stdin.
-> More information: <https://manpages.debian.org/jessie/passwd/chpasswd.8.en.html>.
+> Change the passwords for multiple users by using stdin.
+> More information: <https://manned.org/chpasswd.8>.
 
-- Change password for a user:
+- Change the password for a specific user:
 
 `printf "{{username}}:{{new_password}}" | sudo chpasswd`
 
-- Change passwords for multiple users (Mind the lack of space in the stdin text):
+- Change the passwords for multiple users (the input text must not contain any spaces):
 
-`printf "{{username_one}}:{{new_password_one}}\n{{username_two}}:{{new_password_two}}" | sudo chpasswd`
+`printf "{{username_1}}:{{new_password_1}}\n{{username_2}}:{{new_password_2}}" | sudo chpasswd`
 
-- Change password into the supplied encrypted password for a user:
+- Change the password for a specific user, and specify it in encrypted form:
 
 `printf "{{username}}:{{new_encrypted_password}}" | sudo chpasswd --encrypted`
 

--- a/pages/linux/chpasswd.md
+++ b/pages/linux/chpasswd.md
@@ -1,0 +1,20 @@
+# chpasswd
+
+> Change passwords for multiple users via taking input from stdin.
+> More information: <https://manpages.debian.org/jessie/passwd/chpasswd.8.en.html>.
+
+- Change password for a user.
+
+`printf "{{username}}:{{new_password}}" | sudo chpasswd`
+
+- Change passwords for multiple users (Mind the lack of space in the stdin text).
+
+`printf "{{username_one}}:{{new_password_one}}\n{{username_two}}:{{new_password_two}}" | sudo chpasswd`
+
+- Change password into the supplied encrypted password for a user.
+
+`printf "{{username}}:{{new_encrypted_password}}" | sudo chpasswd --encrypted`
+
+- Change password for a user and use a specific cryptographic method to encrypt the password to be stored.
+
+`printf "{{username}}:{{new_password}}" | sudo chpasswd --crypt-method {{NONE|DES|MD5|SHA256|SHA512}}` 


### PR DESCRIPTION
New page for linux command: [`chpasswd`](https://manpages.debian.org/jessie/passwd/chpasswd.8.en.html)


- Used `printf` instead of `echo` for consistency across systems.
  -- https://stackoverflow.com/a/8467449/11200630
  -- https://askubuntu.com/a/467756/1316257

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
