### PR TITLE
warp-cli: add systemctl command to start WARP service.

### DIFF
--- a/pages/common/warp-cli.md
+++ b/pages/common/warp-cli.md
@@ -3,6 +3,10 @@
 > Official command-line client for Cloudflare's WARP service.
 > More information: <https://developers.cloudflare.com/warp-client/>.
 
+- Start WARP service if it is not already enabled:
+
+`sudo systemctl start warp-svc`
+
 - Register the current device to WARP (must be run before first connection):
 
 `warp-cli register`


### PR DESCRIPTION
added a new command

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
