### PR TITLE
gdal2tiles.py: add page

### DIFF
--- a/pages/common/gdal2tiles.py.md
+++ b/pages/common/gdal2tiles.py.md
@@ -1,0 +1,12 @@
+# gdal2tiles.py
+
+> Generate TMS or XYZ tiles for a raster dataset.
+> More information: <https://gdal.org/programs/gdal2tiles.html>.
+
+- Generate TMS tiles for the zoom levels 2-5 of a raster dataset:
+
+`gdal2tiles.py --zoom={{2-5}} {{path/to/input.tif}} {{path/to/output_directory}}`
+
+- Generate XYZ tiles for the zoom levels 2-5 of a raster dataset:
+
+`gdal2tiles.py --zoom={{2-5}} --xyz {{path/to/input.tif}} {{path/to/output_directory}}`


### PR DESCRIPTION
Add the CLI tool [gdal2tiles.py](https://gdal.org/programs/gdal2tiles.html) from the GDAL/OGR suite.

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
3.2.2