### PR TITLE
pip: add install from requirements.txt example

### DIFF
--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -27,3 +27,7 @@
 - Show installed package info:
 
 `pip show {{package_name}}`
+
+- Install packages from a file:
+
+`pip install --requirement {{requirements.txt}}`


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**

Cherry-Picked the example from `pip3`