### PR TITLE
fuser: add example to kill processes bound to a specific socket

### DIFF
--- a/pages/linux/fuser.md
+++ b/pages/linux/fuser.md
@@ -22,3 +22,7 @@
 - Find which processes are accessing the filesystem containing a specific file or directory:
 
 `fuser --mount {{path/to/file_or_directory}}`
+
+- Kill all processes with a TCP connection on a specific port:
+
+`fuser --kill {{port/tcp}}`

--- a/pages/linux/fuser.md
+++ b/pages/linux/fuser.md
@@ -25,4 +25,4 @@
 
 - Kill all processes with a TCP connection on a specific port:
 
-`fuser --kill {{port/tcp}}`
+`fuser --kill {{port}}/tcp`


### PR DESCRIPTION
Closes: #8160

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
