### PR TITLE
zsh: add noglob example

### DIFF
--- a/pages.de/common/zsh.md
+++ b/pages.de/common/zsh.md
@@ -23,3 +23,7 @@
 - Starte eine interaktive Eingabeaufforderung, in der jeder Befehl ausgegeben wird, bevor er ausgeführt wird:
 
 `zsh --verbose`
+
+- Führe einen Befehl innerhalb von `zsh` mit ausgeschalteten Glob-Mustern aus:
+
+`noglob {{befehl}}`

--- a/pages/common/zsh.md
+++ b/pages/common/zsh.md
@@ -24,6 +24,6 @@
 
 `zsh --verbose`
 
-- Execute a command inside `zsh` with disabled glob patterns:
+- Execute a specific command inside `zsh` with disabled glob patterns:
 
 `noglob {{command}}`

--- a/pages/common/zsh.md
+++ b/pages/common/zsh.md
@@ -23,3 +23,7 @@
 - Start an interactive shell session in verbose mode, printing each command before executing it:
 
 `zsh --verbose`
+
+- Execute a command inside `zsh` with disabled glob patterns:
+
+`noglob {{command}}`


### PR DESCRIPTION
I'm not sure if this should be in the `zsh`-page, but adding a new `noglob.md` page didn't feel right either.

I'm also not sure if we should maybe use a more specific example, like `noglob calc 3*sqrt(2)`.