### PR TITLE
slmgr, slmgr.vbs: add page

### DIFF
--- a/pages/windows/slmgr.md
+++ b/pages/windows/slmgr.md
@@ -4,11 +4,11 @@
 > This command may override, deactivate, and/or remove your current Windows license. Please proceed with caution.
 > More information: <https://docs.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
 
-- [D]isplay the current Windows [l]icense [i]nformation:
+- [d]isplay the current Windows [l]icense [i]nformation:
 
 `slmgr /dli`
 
-- [D]isplays the ins[t]allation [I]D for the current device. Useful for offline license activation:
+- [d]isplay the ins[t]allation [i]D for the current device. Useful for offline license activation:
 
 `slmgr /dti`
 
@@ -16,22 +16,22 @@
 
 `slmgr /xpr`
 
-- [I]nstalls a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
+- [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
 
-`slmgr /ipk`
+`slmgr /ipk {{product_key}}`
 
-- [A]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
+- [a]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
 
 `slmgr /ato`
 
-- [A]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
+- [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
 
 `slmgr /atp {{confirmation_id}}`
 
-- [C]lears the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevent the key from being stolen by malicious programs in the future:
+- [c]lear the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevents the key from being stolen by malicious programs in the future:
 
 `slmgr /cpky`
 
-- [U]ninstall the current license (by its [p]roduct [k]ey):
+- [u]ninstall the current license (by its [p]roduct [k]ey):
 
 `slmgr /upk`

--- a/pages/windows/slmgr.md
+++ b/pages/windows/slmgr.md
@@ -1,0 +1,37 @@
+# slmgr
+
+> Install, activate, and manage Windows licenses.
+> This command may override, deactivate, and/or remove your current Windows license. Please proceed with caution.
+> More information: <https://docs.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
+
+- [D]isplay the current Windows [l]icense [i]nformation:
+
+`slmgr /dli`
+
+- [D]isplays the ins[t]allation [I]D for the current device. Useful for offline license activation:
+
+`slmgr /dti`
+
+- Display the current license's e[xp]i[r]ation date and time:
+
+`slmgr /xpr`
+
+- [I]nstalls a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
+
+`slmgr /ipk`
+
+- [A]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
+
+`slmgr /ato`
+
+- [A]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
+
+`slmgr /atp {{confirmation_id}}`
+
+- [C]lears the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevent the key from being stolen by malicious programs in the future:
+
+`slmgr /cpky`
+
+- [U]ninstall the current license (by its [p]roduct [k]ey):
+
+`slmgr /upk`

--- a/pages/windows/slmgr.md
+++ b/pages/windows/slmgr.md
@@ -1,6 +1,7 @@
 # slmgr
 
 > This command is an alias of `slmgr.vbs`.
+> More information: <https://docs.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
 
 - View documentation for the original command:
 

--- a/pages/windows/slmgr.md
+++ b/pages/windows/slmgr.md
@@ -1,37 +1,7 @@
 # slmgr
 
-> Install, activate, and manage Windows licenses.
-> This command may override, deactivate, and/or remove your current Windows license. Please proceed with caution.
-> More information: <https://docs.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
+> This command is an alias of `slmgr.vbs`.
 
-- [d]isplay the current Windows [l]icense [i]nformation:
+- View documentation for the original command:
 
-`slmgr /dli`
-
-- [d]isplay the ins[t]allation [i]D for the current device. Useful for offline license activation:
-
-`slmgr /dti`
-
-- Display the current license's e[xp]i[r]ation date and time:
-
-`slmgr /xpr`
-
-- [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
-
-`slmgr /ipk {{product_key}}`
-
-- [a]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
-
-`slmgr /ato`
-
-- [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
-
-`slmgr /atp {{confirmation_id}}`
-
-- [c]lear the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevents the key from being stolen by malicious programs in the future:
-
-`slmgr /cpky`
-
-- [u]ninstall the current license (by its [p]roduct [k]ey):
-
-`slmgr /upk`
+`tldr slmgr.vbs`

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -1,0 +1,6 @@
+# slmgr.vbs
+
+> This command is an alias of `slmgr`.
+- View documentation for the original command:
+
+`tldr slmgr`

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -24,7 +24,7 @@
 
 `slmgr /ato`
 
-- [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
+- [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator privileges and an Confirmation ID provided by Microsoft Product Activation Center:
 
 `slmgr /atp {{confirmation_id}}`
 

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -1,7 +1,37 @@
 # slmgr.vbs
 
-> This command is an alias of `slmgr`.
+> Install, activate, and manage Windows licenses.
+> This command may override, deactivate, and/or remove your current Windows license. Please proceed with caution.
+> More information: <https://docs.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
 
-- View documentation for the original command:
+- [d]isplay the current Windows [l]icense [i]nformation:
 
-`tldr slmgr`
+`slmgr /dli`
+
+- [d]isplay the ins[t]allation [i]D for the current device. Useful for offline license activation:
+
+`slmgr /dti`
+
+- Display the current license's e[xp]i[r]ation date and time:
+
+`slmgr /xpr`
+
+- [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
+
+`slmgr /ipk {{product_key}}`
+
+- [a]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
+
+`slmgr /ato`
+
+- [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator priviledges and an Confirmation ID provided by Microsoft Product Activation Center:
+
+`slmgr /atp {{confirmation_id}}`
+
+- [c]lear the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevents the key from being stolen by malicious programs in the future:
+
+`slmgr /cpky`
+
+- [u]ninstall the current license (by its [p]roduct [k]ey):
+
+`slmgr /upk`

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -16,11 +16,11 @@
 
 `slmgr /xpr`
 
-- [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator priviledges and will override your existing license:
+- [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator privileges and will override the existing license:
 
 `slmgr /ipk {{product_key}}`
 
-- [a]c[t]ivate the Windows product license [o]nline. Requires Administrator priviledges to do so:
+- [a]c[t]ivate the Windows product license [o]nline. Requires Administrator privileges to do so:
 
 `slmgr /ato`
 

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -1,6 +1,7 @@
 # slmgr.vbs
 
 > This command is an alias of `slmgr`.
+
 - View documentation for the original command:
 
 `tldr slmgr`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** Windows 10 (also applies to Windows 7 and up)

The official program name for this is `slmgr.vbs`. However, users might be bothered after finding out they need to use `tldr slmgr.vbs` instead of `tldr slmgr` to view this documentation. This is why I decided to set the otherwise, where `slmgr.vbs` is an alias of `slmgr`. This will also be useful for documenting other Windows-specific `.vbs` scripts such as [`ospp.vbs`](https://docs.microsoft.com/en-us/deployoffice/vlactivation/tools-to-manage-volume-activation-of-office) as long as the unprefixed command is still acceptable for use in the Command Prompt.