### PR TITLE
licensor: add page

### DIFF
--- a/pages/common/licensor.md
+++ b/pages/common/licensor.md
@@ -7,7 +7,7 @@
 
 `licensor {{MIT}} > {{LICENSE}}`
 
-- Write the MIT license with a placeholder copyright notice to a file named `LICENSE`:
+- Write the MIT license with a [p]laceholder copyright notice to a file named `LICENSE`:
 
 `licensor -p {{MIT}} > {{LICENSE}}`
 

--- a/pages/common/licensor.md
+++ b/pages/common/licensor.md
@@ -17,7 +17,7 @@
 
 - Specify licence exceptions with a WITH expression:
 
-`licensor {{"Apache-2.0 WITH LLVM-exception"}} > {{LICENSE}}`
+`licensor "{{Apache-2.0 WITH LLVM-exception}}" > {{LICENSE}}`
 
 - List all available licenses:
 

--- a/pages/common/licensor.md
+++ b/pages/common/licensor.md
@@ -1,0 +1,28 @@
+# licensor
+
+> Write licenses to stdout.
+> More information: <https://github.com/raftario/licensor>.
+
+- Write the MIT license to a file named `LICENSE`:
+
+`licensor {{MIT}} > {{LICENSE}}`
+
+- Write the MIT license with a placeholder copyright notice to a file named `LICENSE`:
+
+`licensor -p {{MIT}} > {{LICENSE}}`
+
+- Specify a copyright holder named Bobby Tables:
+
+`licensor {{MIT}} {{"Bobby Tables"}} > {{LICENSE}}`
+
+- Specify licence exceptions with a WITH expression:
+
+`licensor {{"Apache-2.0 WITH LLVM-exception"}} > {{LICENSE}}`
+
+- List all available licenses:
+
+`licensor --licenses`
+
+- List all available exceptions:
+
+`licensor --exceptions`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** `licensor 2.1.0`
