### PR TITLE
mate: add page

### DIFF
--- a/pages/osx/mate.md
+++ b/pages/osx/mate.md
@@ -15,7 +15,7 @@
 
 `mate --type {{filetype}} {{path/to/file}}`
 
-- Open and wait until done editing a specific file:
+- Open and wait until finished editing a specific file:
 
 `mate --wait {{path/to/file}}`
 

--- a/pages/osx/mate.md
+++ b/pages/osx/mate.md
@@ -1,0 +1,24 @@
+# mate
+
+> General-purpose text editor for macOS.
+> More information: <https://macromates.com/>.
+
+- Start TextMate:
+
+`mate`
+
+- Open specific files:
+
+`mate {{path/to/file1 path/to/file2 ...}}`
+
+- Specify the filetype of a file:
+
+`mate --type {{filetype}} {{path/to/file}}`
+
+- Open and wait until done editing a specific file:
+
+`mate --wait {{path/to/file}}`
+
+- Open a file with the cursor at a specific line and column:
+
+`mate --line {{line_number}}:{{column_number}} {{path/to/file}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** `mate 2.13.3 (Oct 12 2021)`
