### PR TITLE
code: fix typo in --user-data-dir example

### DIFF
--- a/pages/common/code.md
+++ b/pages/common/code.md
@@ -33,4 +33,4 @@
 
 - Start the editor as a superuser (root) while storing user data in a specific directory:
 
-`sudo code --user-data-dir {[path/to/directory}}`
+`sudo code --user-data-dir {{path/to/directory}}`


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).

**Version of the command being documented (if known):** `1.69.0`
