### PR TITLE
brightnessctl: fix typo in decrease example

### DIFF
--- a/pages.zh/linux/brightnessctl.md
+++ b/pages.zh/linux/brightnessctl.md
@@ -21,4 +21,4 @@
 
 - 将亮度降低指定的递减量：
 
-`brightnessctl set {{-10%}}`
+`brightnessctl set {{10%-}}`

--- a/pages/linux/brightnessctl.md
+++ b/pages/linux/brightnessctl.md
@@ -21,4 +21,4 @@
 
 - Decrease brightness by a specified decrement:
 
-`brightnessctl set {{-10%}}`
+`brightnessctl set {{10%-}}`


### PR DESCRIPTION
Fixed incorrect example of negative brightness offset.

According to the docs, the `-` sign should come **after** the value, not **before** it. Placing the minus sign before the value yields nothing.

<https://github.com/Hummer12007/brightnessctl#usage>

```
Valid values:
  specific value		Example: 500
  percentage value		Example: 50%
  specific delta		Example: 50- or +10
  percentage delta		Example: 50%- or +10%
```

---

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 0.5.1
