### PR TITLE
ansible-doc, ansible-galaxy, ansible-inventory: add French translation

### DIFF
--- a/pages.fr/common/ansible-doc.md
+++ b/pages.fr/common/ansible-doc.md
@@ -1,0 +1,29 @@
+# ansible-doc
+
+> Affiche les informations des modules installés dans les librairies Ansible.
+> Affiche une liste concise des plugins et leurs description courte.
+> Plus d'informations : <https://docs.ansible.com/ansible/latest/cli/ansible-doc.html>.
+
+- Liste les plugins action (modules) disponibles :
+
+`ansible-doc --list`
+
+- Liste les plugins disponible d'un certain type :
+
+`ansible-doc --type {{type_de_plugin}} --list`
+
+- Affiche les informations sur un plugin action (module) spécifique :
+
+`ansible-doc {{nom_du_plugin}}`
+
+- Affiche les informations sur un plugin avec un certain type :
+
+`ansible-doc --type {{type_de_plugin}} {{nom_du_plugin}}`
+
+- Affiche le raccourci playbook d'un plugin action (module) :
+
+`ansible-doc --snippet {{nom_du_plugin}}`
+
+- Affiche les informations sur un plugin action (module) en JSON :
+
+`ansible-doc --json {{nom_du_plugin}}`

--- a/pages.fr/common/ansible-galaxy.md
+++ b/pages.fr/common/ansible-galaxy.md
@@ -1,0 +1,32 @@
+# ansible-galaxy
+
+> Crée et gère les rôles Ansible.
+> Plus d'informations : <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+
+- Installe un rôle :
+
+`ansible-galaxy install {{nom_d_utilisateur}}.{{nom_du_rôle}}`
+
+- Enlève un rôle :
+
+`ansible-galaxy remove {{nom_d_utilisateur}}.{{nom_du_rôle}}`
+
+- Liste les rôles installés :
+
+`ansible-galaxy list`
+
+- Recherche pour un role donné :
+
+`ansible-galaxy search {{nom_du_rôle}}`
+
+- Crée un nouveau rôle :
+
+`ansible-galaxy init {{nom_du_rôle}}`
+
+- Récupère les informations sur le rôle d'un utilisateur :
+
+`ansible-galaxy role info {{nom_d_utilisateur}}.{{nom_du_rôle}}`
+
+- Récupère les informations d'une collection :
+
+`ansible-galaxy collection info {{nom_d_utilisateur}}.{{nom_de_la_collection}}`

--- a/pages.fr/common/ansible-inventory.md
+++ b/pages.fr/common/ansible-inventory.md
@@ -1,0 +1,21 @@
+# ansible-inventory
+
+> Display or dump an Ansible inventory.
+> Voir aussi : `ansible`.
+> Plus d'informations : <https://docs.ansible.com/ansible/latest/cli/ansible-inventory.html>.
+
+- Affiche l'inventaire par défaut :
+
+`ansible-inventory --list`
+
+- Affiche un inventaire spécifique :
+
+`ansbile-inventory --list --inventory {{chemin/vers/fichier_ou_script_ou_dossier}}`
+
+- Affiche l'inventaire par défaut en YAML :
+
+`ansible-inventory --list --yaml`
+
+- Sauvegarde l'inventaire par défaut dans un fichier :
+
+`ansible-inventory --list --output {{chemin/vers/fichier}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):**
