### PR TITLE
dnf: add history example

### DIFF
--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -15,7 +15,7 @@
 
 `dnf info {{package}}`
 
-- Install a new package:
+- Install a new package (use `-y` to confirm all prompts automatically):
 
 `sudo dnf install {{package}}`
 

--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -19,10 +19,6 @@
 
 `sudo dnf install {{package}}`
 
-- Install a new package and assume yes to all questions:
-
-`sudo dnf -y install {{package}}`
-
 - Remove a package:
 
 `sudo dnf remove {{package}}`
@@ -38,7 +34,3 @@
 - View all past operations:
 
 `dnf history`
-
-- View details of past install/remove/update operations of a package:
-
-`dnf history info {{package}}`

--- a/pages/linux/dnf.md
+++ b/pages/linux/dnf.md
@@ -34,3 +34,11 @@
 - Find which packages provide a given file:
 
 `dnf provides {{file}}`
+
+- View all past operations:
+
+`dnf history`
+
+- View details of past install/remove/update operations of a package:
+
+`dnf history info {{package}}`


### PR DESCRIPTION
The history command shows well formatted installation log. Gives quick idea about what has happened so far.
Also, you retrieve the list and repeat the same operations on the new system to get up and running quickly.

Sample output of `dnf --reverse history`:
```
ID    | Command line                                                                                           | Date and time    | Action(s)      | Altered
------------------------------------------------------------------------------------------------------------------------------------------------------------
    1 | install chrome                                                                                         | 2022-01-31 11:06 | Install        |    4 E<
    2 | module install nodejs:16                                                                               | 2022-01-31 12:21 | Install        |    6   
    3 | install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-36.noarch.rpm               | 2022-02-02 13:22 | Install        |    1   
    4 | install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-36.noarch.rpm         | 2022-02-02 13:23 | Install        |    1 > 
    5 | install akmod-nvidia                                                                                   | 2022-02-02 13:34 | Install        |   66 E<
    6 | install xorg-x11-drv-nvidia-cuda                                                                       | 2022-02-02 13:35 | Install        |    4   
```


- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).