### PR TITLE
osx/*: add pt_BR translations

### DIFF
--- a/pages.pt_BR/osx/aa.md
+++ b/pages.pt_BR/osx/aa.md
@@ -1,0 +1,7 @@
+# aa
+
+> Este comando é um alias de `yaa`.
+
+- Veja a documentação do comando original:
+
+`tldr yaa`

--- a/pages.pt_BR/osx/afinfo.md
+++ b/pages.pt_BR/osx/afinfo.md
@@ -1,0 +1,29 @@
+# afinfo
+
+> Parser de metadados de arquivos de áudio para OS X.
+> Comando nativo do OS X.
+> Mais informações: <https://ss64.com/osx/afinfo.html>.
+
+- Exibir informações de um determinado arquivo de áudio:
+
+`afinfo {{caminho/para/arquivo}}`
+
+- Imprimir uma descrição de uma linha do arquivo de áudio:
+
+`afinfo --brief {{caminho/para/arquivo}}`
+
+- Imprimir informações de metadados e conteúdo do InfoDictionary do arquivo de áudio:
+
+`afinfo --info {{caminho/para/arquivo}}`
+
+- Imprimir saída em formato XML:
+
+`afinfo --xml {{caminho/para/arquivo}}`
+
+- Imprimir avisos para o arquivo de áudio, se houver:
+
+`afinfo --warnings {{caminho/para/arquivo}}`
+
+- Exibir ajuda sobre o uso completo:
+
+`afinfo --help`

--- a/pages.pt_BR/osx/afplay.md
+++ b/pages.pt_BR/osx/afplay.md
@@ -1,0 +1,20 @@
+# afplay
+
+> Player de áudio para linha de comando.
+> Mais informações: <https://ss64.com/osx/afplay.html>.
+
+- Reproduzir um arquivo de som (espera até que a reprodução termine):
+
+`afplay {{caminho/para/arquivo}}`
+
+- Reproduzir um arquivo de som em velocidade 2x (taxa de reprodução):
+
+`afplay --rate {{2}} {{caminho/para/arquivo}}`
+
+- Reproduzir um arquivo de som em meia velocidade:
+
+`afplay --rate {{0.5}} {{caminho/para/arquivo}}`
+
+- Reproduzir os N primeiros segundos de um arquivo de som:
+
+`afplay --time {{segundos}} {{caminho/para/arquivo}}`

--- a/pages.pt_BR/osx/airport.md
+++ b/pages.pt_BR/osx/airport.md
@@ -1,0 +1,20 @@
+# airport
+
+> Utilitário de configuração de rede sem fio.
+> Mais informações: <https://ss64.com/osx/airport.html>.
+
+- Mostrar informações de status da rede sem fio atual:
+
+`airport --getinfo`
+
+- Farejar tráfego de rede sem fio no canal 1:
+
+`airport sniff {{1}}`
+
+- Procurar redes sem fio disponíveis:
+
+`airport --scan`
+
+- Desassociar da rede airport atual:
+
+`sudo airport --disassociate`

--- a/pages.pt_BR/osx/airportd.md
+++ b/pages.pt_BR/osx/airportd.md
@@ -1,0 +1,9 @@
+# airportd
+
+> Gerencia interfaces sem fio.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.manpagez.com/man/8/airportd/>.
+
+- Iniciar o daemon:
+
+`airportd`

--- a/pages.pt_BR/osx/apachectl.md
+++ b/pages.pt_BR/osx/apachectl.md
@@ -1,0 +1,16 @@
+# apachectl
+
+> Interface de controle do Servidor HTTP Apache para macOS.
+> Mais informações: <https://www.unix.com/man-page/osx/8/apachectl/>.
+
+- Iniciar o job launchd `org.apache.httpd`:
+
+`apachectl start`
+
+- Parar o job launchd:
+
+`apachectl stop`
+
+- Parar, e então iniciar o job launchd:
+
+`apachectl restart`

--- a/pages.pt_BR/osx/applecamerad.md
+++ b/pages.pt_BR/osx/applecamerad.md
@@ -1,0 +1,9 @@
+# applecamerad
+
+> Gerenciador de câmera.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.theiphonewiki.com/wiki/Services>.
+
+- Iniciar o daemon:
+
+`applecamerad`

--- a/pages.pt_BR/osx/appsleepd.md
+++ b/pages.pt_BR/osx/appsleepd.md
@@ -1,0 +1,9 @@
+# appsleepd
+
+> Fornece serviços app sleep.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://keith.github.io/xcode-man-pages/appsleepd.8.html>.
+
+- Iniciar o daemon:
+
+`appsleepd`

--- a/pages.pt_BR/osx/arch.md
+++ b/pages.pt_BR/osx/arch.md
@@ -1,0 +1,13 @@
+# arch
+
+> Exibe o nome da arquitetura do sistema ou executa um comando em uma arquitetura diferente.
+> Veja também `uname`.
+> Mais informações: <https://www.unix.com/man-page/osx/1/arch/>.
+
+- Exibir o nome da arquitetura do sistema:
+
+`arch`
+
+- Executar um comando usando a arquitetura x86_64:
+
+`arch -x86_64 "{{comando}}"`

--- a/pages.pt_BR/osx/archey.md
+++ b/pages.pt_BR/osx/archey.md
@@ -1,0 +1,20 @@
+# archey
+
+> Ferramenta simples para exibir as informações do sistema com estilo.
+> Mais informações: <https://github.com/joshfinnie/archey-osx>.
+
+- Mostrar informações do sistema:
+
+`archey`
+
+- Mostrar informações do sistema sem saída colorida:
+
+`archey --nocolor`
+
+- Mostrar informações do sistema, usando MacPorts em vez de Homebrew:
+
+`archey --macports`
+
+- Mostrar informações do sistema sem verificação de endereço IP:
+
+`archey --offline`

--- a/pages.pt_BR/osx/as.md
+++ b/pages.pt_BR/osx/as.md
@@ -1,0 +1,21 @@
+# as
+
+> Montador (assembler) GNU portável.
+> Principalmente destinado a montar a saída do `gcc` para ser usada pelo `ld`.
+> Mais informações: <https://www.unix.com/man-page/osx/1/as/>.
+
+- Montar (compilar) um arquivo, escrevendo a saída para `a.out`:
+
+`as {{arquivo.s}}`
+
+- Montar a saída para um determinado arquivo:
+
+`as {{arquivo.s}} -o {{saida.o}}`
+
+- Gerar saída mais rapidamente ignorando espaços em branco e pré-processamento de comentários. (Só deve ser usado para compiladores confiáveis)
+
+`as -f {{arquivo.s}}`
+
+- Incluir um determinado caminho na lista de diretórios para pesquisar os arquivos especificados nas diretivas `.include`:
+
+`as -I {{caminho/para/diretório}} {{arquivo.s}}`

--- a/pages.pt_BR/osx/asr.md
+++ b/pages.pt_BR/osx/asr.md
@@ -1,0 +1,21 @@
+# asr
+
+> Restaurar (copiar) uma imagem de disco em um volume.
+> O nome do comando significa Apple Software Restore.
+> Mais informações: <https://www.unix.com/man-page/osx/8/asr/>.
+
+- Restaurar uma imagem de disco para um volume de destino:
+
+`sudo asr restore --source {{nome_da_imagem}}.dmg --target {{caminho/para/volume}}`
+
+- Apagar o volume de destino antes de restaurar:
+
+`sudo asr restore --source {{nome_da_imagem}}.dmg --target {{caminho/para/volume}} --erase`
+
+- Ignorar a verificação após a restauração:
+
+`sudo asr restore --source {{nome_da_imagem}}.dmg --target {{caminho/para/volume}} --noverify`
+
+- Clonar volumes sem o uso de uma imagem de disco intermediária:
+
+`sudo asr restore --source {{caminho/para/volume}} --target {{caminho/para/volume_clonado}}`

--- a/pages.pt_BR/osx/automountd.md
+++ b/pages.pt_BR/osx/automountd.md
@@ -1,0 +1,13 @@
+# automountd
+
+> Um daemon de montagem/desmontagem automática para `autofs`. Iniciado sob demanda por `launchd`.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.manpagez.com/man/8/automountd/>.
+
+- Iniciar o daemon:
+
+`automountd`
+
+- Log de mais detalhes em `syslog`:
+
+`automountd -v`

--- a/pages.pt_BR/osx/avbdeviced.md
+++ b/pages.pt_BR/osx/avbdeviced.md
@@ -1,0 +1,9 @@
+# avbdeviced
+
+> Serviço para gerenciar dispositivos Audio Video Bridging (AVB).
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.manpagez.com/man/1/avbdeviced/>.
+
+- Iniciar o daemon:
+
+`avbdeviced`

--- a/pages.pt_BR/osx/base64.md
+++ b/pages.pt_BR/osx/base64.md
@@ -1,0 +1,20 @@
+# base64
+
+> Codifica e decodifica usando a representação Base64.
+> Mais informações: <https://www.unix.com/man-page/osx/1/base64/>.
+
+- Codificar um arquivo:
+
+`base64 --input={{arquivo}}`
+
+- Decodificar um arquivo:
+
+`base64 --decode --input={{arquivo_base64}}`
+
+- Codificar de stdin:
+
+`echo -n "{{texto}}" | base64`
+
+- Decodificar de stdin:
+
+`echo -n {{texto_base64}} | base64 --decode`

--- a/pages.pt_BR/osx/bc.md
+++ b/pages.pt_BR/osx/bc.md
@@ -1,0 +1,29 @@
+# bc
+
+> Linguagem e calculadora com precisão arbitrária.
+> Veja também: `dc`.
+> Mais informações: <https://manned.org/man/freebsd-13.0/bc.1>.
+
+- Iniciar uma sessão interativa:
+
+`bc`
+
+- Iniciar uma sessão interativa com a biblioteca matemática padrão habilitada:
+
+`bc --mathlib`
+
+- Calcular uma expressão:
+
+`bc --expression='{{5 / 3}}'`
+
+- Executar um script:
+
+`bc {{caminho/para/script.bc}}`
+
+- Calcular uma expressão com a escala especificada:
+
+`bc --expression='scale = {{10}}; {{5 / 3}}'`
+
+- Calcular uma função sine/cosine/arctangent/natural logarithm/exponential usando `mathlib`:
+
+`bc --mathlib --expression='{{s|c|a|l|e}}({{1}})'`

--- a/pages.pt_BR/osx/bird.md
+++ b/pages.pt_BR/osx/bird.md
@@ -1,0 +1,9 @@
+# bird
+
+> Suporta a sincronização do iCloud e iCloud Drive.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.unix.com/man-page/mojave/8/bird/>.
+
+- Iniciar o daemon:
+
+`bird`

--- a/pages.pt_BR/osx/bless.md
+++ b/pages.pt_BR/osx/bless.md
@@ -1,0 +1,20 @@
+# bless
+
+> Define a capacidade de inicialização por volume e as opções de disco de inicialização. Set volume boot capability and startup disk options.
+> Mais informações: <https://ss64.com/osx/bless.html>.
+
+- Definir um volume somente com Mac OS X ou Darwin, e criar os arquivos BootX e `boot.efi` se necessário:
+
+`bless --folder {{/Volumes/Mac OS X/System/Library/CoreServices}} --bootinfo --bootefi`
+
+- Definir um volume contendo Mac OS 9 ou Mac OS X como o volume ativo:
+
+`bless --mount {{/Volumes/Mac OS}} --setBoot`
+
+- Definir o sistema para NetBoot e transmitir para um servidor disponível:
+
+`bless --netboot --server {{bsdp://255.255.255.255}}`
+
+- Coletar informações sobre o volume atualmente selecionado (conforme determinado pelo firmware), adequado para piping para um programa capaz de analisar listas de propriedades:
+
+`bless --info --plist`

--- a/pages.pt_BR/osx/bnepd.md
+++ b/pages.pt_BR/osx/bnepd.md
@@ -1,0 +1,9 @@
+# bnepd
+
+> Serviço que lida com todas as conexões de rede Bluetooth.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.unix.com/man-page/osx/8/bnepd/>.
+
+- Iniciar o daemon:
+
+`bnepd`

--- a/pages.pt_BR/osx/brightness.md
+++ b/pages.pt_BR/osx/brightness.md
@@ -1,0 +1,16 @@
+# brightness
+
+> Obtém e define o nível de brilho de todos os monitores internos e alguns monitores externos.
+> Mais informações: <https://github.com/nriley/brightness>.
+
+- Mostrar o brilho atual:
+
+`brightness -l`
+
+- Definir o brilho para 100%:
+
+`brightness {{1}}`
+
+- Definir o brilho para 50%:
+
+`brightness {{0.5}}`


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being translated (if known):**
https://github.com/tldr-pages/tldr/blob/main/pages/osx/aa.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/afinfo.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/afplay.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/airport.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/airportd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/apachectl.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/applecamerad.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/appsleepd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/arch.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/archey.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/as.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/asr.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/automountd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/avbdeviced.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/base64.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/bc.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/bird.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/bless.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/bnepd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/brightness.md
