### PR TITLE
linux/*: fix typos

### DIFF
--- a/pages/linux/create_ap.md
+++ b/pages/linux/create_ap.md
@@ -13,7 +13,7 @@
 
 - Create an access point without Internet sharing:
 
-`create_ap -n {{wlan0}} {{acces_point_ssid}} {{passphrase}}`
+`create_ap -n {{wlan0}} {{access_point_ssid}} {{passphrase}}`
 
 - Create a bridged network with Internet sharing:
 

--- a/pages/linux/ctr.md
+++ b/pages/linux/ctr.md
@@ -17,4 +17,4 @@
 
 - Tag an image:
 
-`ctr images tag {{souce_image}}:{{source_tag}} {{target_image}}:{{target_tag}}`
+`ctr images tag {{source_image}}:{{source_tag}} {{target_image}}:{{target_tag}}`

--- a/pages/linux/f5fpc.md
+++ b/pages/linux/f5fpc.md
@@ -1,6 +1,6 @@
 # f5fpc
 
-> A proprietry commercial SSL VPN client by BIG-IP Edge.
+> A proprietary commercial SSL VPN client by BIG-IP Edge.
 > More information: <https://techdocs.f5.com/kb/en-us/products/big-ip_apm/manuals/product/apm-client-configuration-11-4-0/4.html>.
 
 - Open a new VPN connection:

--- a/pages/linux/htpdate.md
+++ b/pages/linux/htpdate.md
@@ -11,7 +11,7 @@
 
 `htpdate -q {{host}}`
 
-- Compensate the systematisch clock drift:
+- Compensate the systematic clock drift:
 
 `sudo htpdate -x {{host}}`
 

--- a/pages/linux/ipcmk.md
+++ b/pages/linux/ipcmk.md
@@ -17,4 +17,4 @@
 
 - Create a shared memory segment with specific permissions (default is 0644):
 
-`ipcmk --shmem {{segment_size_in_bytes}} {{octal_permissons}}`
+`ipcmk --shmem {{segment_size_in_bytes}} {{octal_permissions}}`

--- a/pages/linux/paru.md
+++ b/pages/linux/paru.md
@@ -5,7 +5,7 @@
 
 - Interactively search for and install a package:
 
-`paru {{package_name_or_seach_term}}`
+`paru {{package_name_or_search_term}}`
 
 - Synchronize and update all packages:
 

--- a/pages/linux/rc-service.md
+++ b/pages/linux/rc-service.md
@@ -14,7 +14,7 @@
 
 - Stop a service:
 
-`sudo rc-servie {{service_name}} stop`
+`sudo rc-service {{service_name}} stop`
 
 - Restart a service:
 


### PR DESCRIPTION
Fixes a manually corrected selection of typos reported by [typos](https://github.com/crate-ci/typos) in `pages/linux`.