### PR TITLE
sdk: generalize for any SDKs and enhance explanations

### DIFF
--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -4,7 +4,7 @@
 > Supports Java, Groovy, Scala, Kotlin, Gradle, Maven, Vert.x and many others.
 > More information: <https://sdkman.io/usage>.
 
-- Install a SDK version:
+- Install an SDK version:
 
 `sdk install {{sdk_name}} {{sdk_version}}`
 

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -4,34 +4,34 @@
 > Supports Java, Groovy, Scala, Kotlin, Gradle, Maven, Vert.x and many others.
 > More information: <https://sdkman.io/usage>.
 
-- Install a specific version of Gradle:
+- Install a SDK version:
 
-`sdk install {{gradle}} {{gradle_version}}`
+`sdk install {{sdk_name}} {{sdk_version}}`
 
-- Switch to a specific version of Gradle:
+- Use a specific SDK version in the current terminal:
 
-`sdk use {{gradle}} {{gradle_version}}`
+`sdk use {{sdk_name}} {{sdk_version}}`
 
-- Check current Gradle version:
+- Show the stable version of a SDK:
 
-`sdk current {{gradle}}`
+`sdk current {{sdk_name}}`
 
-- List all Software Development Kits available to install:
-
-`sdk list`
-
-- List all available versions for a specific Software Development Kit:
-
-`sdk list {{sdk_name}}`
-
-- List all installed Software Development Kits:
+- Show the stable versions of installed SDKs:
 
 `sdk current`
 
-- Update Gradle to the latest version:
+- List all SDKs:
 
-`sdk upgrade {{gradle}}`
+`sdk list`
 
-- Uninstall a particular version of Gradle:
+- List all versions of a SDK:
 
-`sdk rm {{gradle}} {{gradle_version}}`
+`sdk list {{sdk_name}}`
+
+- Upgrade a SDK to the latest stable version:
+
+`sdk upgrade {{sdk_name}}`
+
+- Uninstall a SDK version:
+
+`sdk rm {{sdk_name}} {{sdk_version}}`

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -32,6 +32,6 @@
 
 `sdk upgrade {{sdk_name}}`
 
-- Uninstall a SDK version:
+- Uninstall a specific SDK version:
 
 `sdk rm {{sdk_name}} {{sdk_version}}`

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -8,7 +8,7 @@
 
 `sdk install {{sdk_name}} {{sdk_version}}`
 
-- Use a specific SDK version in the current terminal:
+- Use a specific SDK version for the current terminal session:
 
 `sdk use {{sdk_name}} {{sdk_version}}`
 

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -16,7 +16,7 @@
 
 `sdk current {{sdk_name}}`
 
-- Show the stable versions of installed SDKs:
+- Show the stable versions of all installed SDKs:
 
 `sdk current`
 

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -28,7 +28,7 @@
 
 `sdk list {{sdk_name}}`
 
-- Upgrade a SDK to the latest stable version:
+- Upgrade an SDK to the latest stable version:
 
 `sdk upgrade {{sdk_name}}`
 

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -12,7 +12,7 @@
 
 `sdk use {{sdk_name}} {{sdk_version}}`
 
-- Show the stable version of a SDK:
+- Show the stable version of any available SDK:
 
 `sdk current {{sdk_name}}`
 
@@ -20,7 +20,7 @@
 
 `sdk current`
 
-- List all SDKs:
+- List all available SDKs:
 
 `sdk list`
 

--- a/pages/common/sdk.md
+++ b/pages/common/sdk.md
@@ -24,7 +24,7 @@
 
 `sdk list`
 
-- List all versions of a SDK:
+- List all versions of an SDK:
 
 `sdk list {{sdk_name}}`
 


### PR DESCRIPTION
1. There was a mix between 'gradle' and 'SDK'. We now only refer to 'SDK'.
Using the acronym for conciseness (the description explains the acronym).

2. Explanation for 'sdk use' was misleading. See https://sdkman.io/usage#use:

> It is important to realise that this will switch the candidate version for the current shell only.

3. Explanation for 'sdk current' has been enhanced, introducing the stable version concept aka 'candidate'.
See https://sdkman.io/usage#listcandidates:

> This will render a searchable alphabetic list with name, current stable default version (...)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

~~**Version of the command being documented (if known):**~~
