### PR TITLE
apktool, apm: add French translation, update

### DIFF
--- a/pages.fr/common/apktool.md
+++ b/pages.fr/common/apktool.md
@@ -1,0 +1,16 @@
+# apktool
+
+> Outil de Rétro-ingénierie pour les fichier APK.
+> Plus d'informations : <https://ibotpeaches.github.io/Apktool/>.
+
+- Décode un fichier APK :
+
+`apktool d {{fichier.apk}}`
+
+- Construit un fichier APK depuis un dossier :
+
+`apktool b {{chemin/vers/un/dossier}}`
+
+- Installe et enregistre le framework :
+
+`apktool if {{framework.apk}}`

--- a/pages.fr/common/apm.md
+++ b/pages.fr/common/apm.md
@@ -1,0 +1,17 @@
+# apm
+
+> Manageur de paquets pour Atom.
+> Voir `atom`.
+> Plus d'informations : <https://github.com/atom/apm>.
+
+- Installe un paquet depuis http://atom.io/packages ou un thème depuis http://atom.io/themes :
+
+`apm install {{nom_du_paquet}}`
+
+- Supprime un paquet ou un thème :
+
+`apm remove {{nom_du_paquet}}`
+
+- Mets à jour un paquet ou un thème :
+
+`apm upgrade {{nom_du_paquet}}`

--- a/pages.fr/common/apm.md
+++ b/pages.fr/common/apm.md
@@ -1,6 +1,6 @@
 # apm
 
-> Manageur de paquets pour Atom.
+> Gestionnaire de paquets pour Atom.
 > Voir `atom`.
 > Plus d'informations : <https://github.com/atom/apm>.
 

--- a/pages/common/apktool.md
+++ b/pages/common/apktool.md
@@ -11,6 +11,6 @@
 
 `apktool b {{path/to/directory}}`
 
-- Install and store framework:
+- Install and store a framework:
 
 `apktool if {{framework.apk}}`

--- a/pages/common/apktool.md
+++ b/pages/common/apktool.md
@@ -11,6 +11,6 @@
 
 `apktool b {{path/to/directory}}`
 
-- Install and store frameworks:
+- Install and store framework:
 
 `apktool if {{framework.apk}}`

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -4,14 +4,14 @@
 > See `atom`.
 > More information: <https://github.com/atom/apm>.
 
-- Install packages from http://atom.io/packages and themes from http://atom.io/themes:
+- Install package from http://atom.io/packages or theme from http://atom.io/themes:
 
 `apm install {{package_name}}`
 
-- Remove packages/themes:
+- Remove package/theme:
 
 `apm remove {{package_name}}`
 
-- Upgrade packages/themes:
+- Upgrade package/theme:
 
 `apm upgrade {{package_name}}`

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -8,7 +8,7 @@
 
 `apm install {{package_name}}`
 
-- Remove package/theme:
+- Remove a package/theme:
 
 `apm remove {{package_name}}`
 

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -4,7 +4,7 @@
 > See `atom`.
 > More information: <https://github.com/atom/apm>.
 
-- Install package from http://atom.io/packages or theme from http://atom.io/themes:
+- Install a package from http://atom.io/packages or theme from http://atom.io/themes:
 
 `apm install {{package_name}}`
 

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -12,6 +12,6 @@
 
 `apm remove {{package_name}}`
 
-- Upgrade package/theme:
+- Upgrade a package/theme:
 
 `apm upgrade {{package_name}}`

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -4,7 +4,7 @@
 > See `atom`.
 > More information: <https://github.com/atom/apm>.
 
-- Install a package from http://atom.io/packages or theme from http://atom.io/themes:
+- Install a package from http://atom.io/packages or a theme from http://atom.io/themes:
 
 `apm install {{package_name}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

---

Hi everyone 👋 
I translated this 2 pages, but also suggest editing the original english pages.

### apktool

I removed an `s` to framework because we handle [only one framework at a time ](https://forum.xda-developers.com/t/how-to-use-and-install-apktool.1760133/)

Also `framework` does not have a translation in french. (can you confirm @nicokosi ?)

### apm

Same thing as apktool, they say we install `packages` and `themes` but we do not install multiple elements. so i changed the sentence to use singular.

