### PR TITLE
psql: clarify default host behaviour

### DIFF
--- a/pages/common/psql.md
+++ b/pages/common/psql.md
@@ -3,7 +3,7 @@
 > PostgreSQL command-line client.
 > More information: <https://www.postgresql.org/docs/current/app-psql.html>.
 
-- Connect to the database. It connects to localhost using default port 5432 with default user as currently logged in user:
+- Connect to the database. By default, it connects to the local socket using port 5432 with the currently logged in user:
 
 `psql {{database}}`
 


### PR DESCRIPTION
- **Version of the command being documented (if known):**  12.11

The first example for psql is wrong or at least misleading. It lets users to believe that `psql my_db` is the same as `psql -h 127.0.0.1` which is not. By default (at least in v12.11), it connects via Unix Socket. 

This makes a difference for instance for access configuration in the `pg_hba.conf` file. I could not connect because usually by default (afaik), only the postgres user is allowed to access via socket. 

Alternatively one could say "... connects to the local database..." or something without naming localhost.