### PR TITLE
make: add variable override example

### DIFF
--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -32,6 +32,6 @@
 
 `make --environment-overrides {{target}}`
 
-- Override a variable defined in the Makefile via the command line:
+- Override a variable defined in the Makefile:
 
-`make {{target}} {{variable}}={{override}}`
+`make {{target}} {{variable}}={{new_value}}`

--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -31,3 +31,7 @@
 - Override variables defined in the Makefile by the environment:
 
 `make --environment-overrides {{target}}`
+
+- Override a variable defined in the Makefile via the command line:
+
+`make {{target}} {{variable}}={{override}}`

--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -28,10 +28,10 @@
 
 `make --always-make {{target}}`
 
-- Override variables defined in the Makefile by the environment:
-
-`make --environment-overrides {{target}}`
-
 - Override a variable defined in the Makefile:
 
 `make {{target}} {{variable}}={{new_value}}`
+
+- Override variables defined in the Makefile by the environment:
+
+`make --environment-overrides {{target}}`


### PR DESCRIPTION
Makefile variables can be overridden via the command line in the form of
`{{variable}}={{override}}` See the [Make manual section 9.5] for more
information.

[Make manual section 9.5]: https://www.gnu.org/software/make/manual/html_node/Overriding.html

- - -

**Note:** This syntax seems very useful but doesn't seem commonly used or discussed. I see value in adding it but it's a bit further out of the core set of functions that user might need, so I'd like a rationality check on if this seems useful enough for inclusion.

This allows for make invocations such as `make cleanup cloud=aws version=stable`.
 
- - -

- **GNU Make 3.81**  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
