### PR TITLE
security: add trusted cert add/remove examples

### DIFF
--- a/pages/osx/security.md
+++ b/pages/osx/security.md
@@ -1,19 +1,19 @@
 # security
 
-> Administer Keychains, keys, certificates and the Security framework.
+> Administer keychains, keys, certificates and the Security framework.
 > More information: <https://ss64.com/osx/security.html>.
 
-- List the available keychains:
+- List available keychains:
 
 `security list-keychains`
 
-- Delete a specific keychain:
+- Delete a keychain:
 
-`security delete-keychain {{path}}`
+`security delete-keychain {{path/to/file.keychain}}`
 
 - Create a keychain:
 
-`security create-keychain -p {{password}} {{keychain.name}}`
+`security create-keychain -p {{password}} {{path/to/file.keychain}}`
 
 - Set a certificate to use with a website or [s]ervice by its [c]ommon name (fails if several certificates with the same common name exist):
 
@@ -21,12 +21,12 @@
 
 - Add a certificate from file to a [k]eychain (if -k isn't specified, the default keychain is used):
 
-`security add-certificates -k {{keychain.name}} {{path/to/file.pem}}`
+`security add-certificates -k {{keychain.name}} {{path/to/cert.pem}}`
 
 - Add a CA certificate to the per-user Trust Settings:
 
-`security add-trusted-cert -k {{path/to/login.keychain-db}} {{ca-cert.pem}}`
+`security add-trusted-cert -k {{path/to/user-keychain.keychain-db}} {{path/to/ca-cert.pem}}`
 
 - Remove a CA certificate from the per-user Trust Settings:
 
-`security remove-trusted-cert -d {{ca-cert.pem}}`
+`security remove-trusted-cert {{path/to/ca-cert.pem}}`

--- a/pages/osx/security.md
+++ b/pages/osx/security.md
@@ -3,11 +3,11 @@
 > Administer keychains, keys, certificates and the Security framework.
 > More information: <https://ss64.com/osx/security.html>.
 
-- List available keychains:
+- List all available keychains:
 
 `security list-keychains`
 
-- Delete a keychain:
+- Delete a specific keychain:
 
 `security delete-keychain {{path/to/file.keychain}}`
 

--- a/pages/osx/security.md
+++ b/pages/osx/security.md
@@ -22,3 +22,11 @@
 - Add a certificate from file to a [k]eychain (if -k isn't specified, the default keychain is used):
 
 `security add-certificates -k {{keychain.name}} {{path/to/file.pem}}`
+
+- Add a CA certificate to the per-user Trust Settings:
+
+`security add-trusted-cert -k {{path/to/login.keychain-db}} {{ca-cert.pem}}`
+
+- Remove a CA certificate from the per-user Trust Settings:
+
+`security remove-trusted-cert -d {{ca-cert.pem}}`


### PR DESCRIPTION
This commit adds examples of adding custom CA certificates to the MacOS
trusted settings keychain. This allows developers working with locally
generated self-signed certificates to quickly trust a CA certificate for
testing purposes and remove them when done testing.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **MacOS 12.4 Monterey, PROJECT:Security-60158.120.9**  (note that the `security` binary doesn't have a version flags, but running `strings $(which security)|grep PROJECT` will emit the packaged security version.)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
