### PR TITLE
Style guide: refresh placeholder syntax

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -121,6 +121,20 @@ in order to allow `tldr` clients to highlight them.
 
 [snake_case]: https://wikipedia.org/wiki/snake_case
 
+### Quoting
+
+- Don't quote path placeholders for page simplicity although shell may require quotes.
+  In other cases quote arguments just when documentation mandates quotes explicitly or
+  you exactly know they are required and the documentation just missing information about this.
+- Use double quotes for placeholders where variable or another substitution occures.
+  In other cases prefer single quotes.
+
+> :bulb: Many shells have [word splitting][word_splitting] enabled by default so unquoted arguments may be splitted to
+several ones. But the main goal of Tl;Dr pages is to provide easy to read and simple in use pages but
+not to strictly follow POSIX shell syntax.
+
+[word_splitting]: https://mywiki.wooledge.org/WordSplitting
+
 ### Paths
 - Use `{{filename}}` rather than `{{file_name}}`.
 - For any reference to paths of files or directories,

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -116,7 +116,7 @@ in order to allow `tldr` clients to highlight them.
 - Use [snake_case][snake_case] for multi-word placeholders.
   Examples: `{{path/to/csharp_solution.sln}}` or `{{language_id}}`.
 - Use an actual value in a placeholder rather than a placeholder
-  with a value description inside it when one of the following conditions are met:
+  with a value description inside it when at least one of the following conditions are met:
   - there is a long (consisting of several letters) option immidiately before
     this placeholder 
     Examples: `pwsh -Command "{{echo 'Hello world!'}}"` or `cut --delimiter="{{,}}" --{{characters}}={{1}}`.
@@ -126,6 +126,18 @@ in order to allow `tldr` clients to highlight them.
     Examples: `bash -c "echo 'Hello world!'"` with `Execute specific [c]ommands:` description.
   - the command or it's the most nested subcommand have just one placeholder mentioned above
     Examples: `wine {{explorer}}` or `iostat {{5}}`.
+- Use the following actual placeholders when they are valid values for a command
+  and at least one of the previous three conditions are met:
+  - `5` for integers:
+    Example: `iostat {{5}}`
+  - `5.2` for floats:
+    Example: `sleep {{5.2}}`
+  - `hello` for strings:
+    Example: `expr length '{{hello}}'`.
+  - `echo "Hello world!"` for commands:
+    Example: `bash -c "{{echo 'Hello world!'}}"`.
+  - `~/.emacs` for files:
+    Example: `touch --no-create --time={{access|modify}} --reference={{~/.emacs}} {{path/to/file1 path/to/file2 ...}}`.
 
 That's why we prefer `expr substr {{string}} {{from}} {{length}}` over `expr substr {{hello}} {{2}} {{3}}`.
 Code sample descriptions must be concise and don't refer to placeholders by their position.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -112,12 +112,22 @@ in order to allow `tldr` clients to highlight them.
 ### General rules
 
 - Use short but descriptive placeholders,
-  such as `{{path/to/source.cs}}` or `{{wallet.txt}}`.
+  such as `{{path/to/source.cs}}` or `{{drive}}`.
 - Use [snake_case][snake_case] for multi-word tokens.
-- Use an actual value rather than a generic placeholder where appropriate.
-  For example, use `iostat {{2}}` rather than `iostat {{interval_in_secs}}`.
+- Use an actual value in placeholder such as `{{5}}` rather than
+  a placeholder with value description inside it such as `{{seconds}}`
+  when one of the following conditions are met:
+  - there is long (consisting of several letters) option immidiately before
+    this placeholder which allows us understand the meaning of
+    an actual value
+  - there is a short (consisting of one letter) option immidiately before this
+    placeholder with a mnemonic provided via square brackets in a code
+    example description
+  - the command or it's the most nested subcommand performs one simple task such as `sleep` 
+   
+  For example, use `iostat {{2}}` rather than `iostat {{seconds}}`.
 
-> :bulb: Formal rules are described below.
+> :bulb: More formal rules are described below.
 
 [snake_case]: https://wikipedia.org/wiki/snake_case
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -100,9 +100,9 @@ Example:
 - View documentation for the original command:
 
 `tldr vim`
+```
 
 Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md).
-```
 
 ## Placeholder syntax
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -104,22 +104,22 @@ Example:
 Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md).
 ```
 
-## Token syntax
+## Placeholder syntax
 
-User-provided values should use the `{{token}}` syntax
+User-provided values should use the `{{placeholder}}` syntax
 in order to allow `tldr` clients to highlight them.
-
-Keep the following guidelines in mind when choosing tokens:
 
 ### General rules
 
-- Use short but descriptive tokens,
+- Use short but descriptive placeholders,
   such as `{{path/to/source.cs}}` or `{{wallet.txt}}`.
-- Use [`snake_case`](https://wikipedia.org/wiki/snake_case) for multi-word tokens.
+- Use [snake_case][snake_case] for multi-word tokens.
 - Use an actual value rather than a generic placeholder where appropriate.
   For example, use `iostat {{2}}` rather than `iostat {{interval_in_secs}}`.
 
 > :bulb: Formal rules are described below.
+
+[snake_case]: https://wikipedia.org/wiki/snake_case
 
 ### Paths
 - Use `{{filename}}` rather than `{{file_name}}`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -111,12 +111,15 @@ in order to allow `tldr` clients to highlight them.
 
 Keep the following guidelines in mind when choosing tokens:
 
-### Naming
+### General rules
+
 - Use short but descriptive tokens,
-  such as `{{source_file}}` or `{{wallet.txt}}`.
+  such as `{{path/to/source.cs}}` or `{{wallet.txt}}`.
 - Use [`snake_case`](https://wikipedia.org/wiki/snake_case) for multi-word tokens.
 - Use an actual value rather than a generic placeholder where appropriate.
   For example, use `iostat {{2}}` rather than `iostat {{interval_in_secs}}`.
+
+> :bulb: Formal rules are described below.
 
 ### Paths
 - Use `{{filename}}` rather than `{{file_name}}`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -151,8 +151,9 @@ Code sample descriptions must be concise and don't refer to placeholders by thei
 - Don't quote path placeholders for page simplicity although shell may require quotes.
   In other cases quote placeholders just when:
   - documentation mandates quotes explicitly.
-  - you exactly know they are required and the documentation is just missing information about this.
-- Use double quotes for placeholders where variable or another substitution occures.
+  - you exactly know they are required because command argument may contain spaces
+    and the documentation is just missing information about this.
+- Use double quotes for placeholders where variable or another substitution occures (in the tldr page).
   In other cases use single quotes.
 
 > :bulb: Many shells have [word splitting][word_splitting] enabled by default so unquoted arguments may be splitted to

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -135,7 +135,7 @@ in order to allow `tldr` clients to highlight them.
 - Don't quote path placeholders for page simplicity although shell may require quotes.
   In other cases quote placeholders just when:
   - documentation mandates quotes explicitly
-  - you exactly know they are required and the documentation just missing information about this
+  - you exactly know they are required and the documentation is just missing information about this.
 - Use double quotes for placeholders where variable or another substitution occures.
   In other cases use single quotes.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -111,21 +111,25 @@ in order to allow `tldr` clients to highlight them.
 
 ### General rules
 
-- Use short but descriptive placeholders,
-  such as `{{path/to/source.cs}}` or `{{drive}}`.
+- Use short but descriptive placeholders.
+  Examples: `{{path/to/source.cs}}` or `{{drive}}`.
 - Use [snake_case][snake_case] for multi-word placeholders.
-- Use an actual value in placeholder such as `{{5}}` rather than
-  a placeholder with a value description inside it such as `{{seconds}}`
-  when one of the following conditions are met:
+  Examples: `{{path/to/csharp_solution.sln}}` or `{{language_id}}`.
+- Use an actual value in a placeholder rather than a placeholder
+  with a value description inside it when one of the following conditions are met:
   - there is a long (consisting of several letters) option immidiately before
     this placeholder 
+    Examples: `pwsh -Command "{{echo 'Hello world!'}}"` or `cut --delimiter="{{,}}" --{{characters}}={{1}}`.
   - there is a short (consisting of one letter) option immidiately before this
     placeholder with a mnemonic provided via square brackets in a code
     example description
-  - the command or it's the most nested subcommand performs one simple task such as `sleep` 
-   
-  For example, use `iostat {{2}}` rather than `iostat {{seconds}}`.
+    Examples: `bash -c "echo 'Hello world!'"` with `Execute specific [c]ommands:` description.
+  - the command or it's the most nested subcommand have just one placeholder mentioned above
+    Examples: `wine {{explorer}}` or `iostat {{5}}`.
 
+That's why we prefer `expr substr {{string}} {{from}} {{length}}` over `expr substr {{hello}} {{2}} {{3}}`.
+Code sample descriptions must be concise and don't refer to placeholders by their position.
+ 
 > :bulb: More formal rules are described below.
 
 [snake_case]: https://wikipedia.org/wiki/snake_case

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -124,8 +124,9 @@ in order to allow `tldr` clients to highlight them.
 ### Quoting
 
 - Don't quote path placeholders for page simplicity although shell may require quotes.
-  In other cases quote arguments just when documentation mandates quotes explicitly or
-  you exactly know they are required and the documentation just missing information about this.
+  In other cases quote arguments just when:
+  - documentation mandates quotes explicitly
+  - you exactly know they are required and the documentation just missing information about this
 - Use double quotes for placeholders where variable or another substitution occures.
   In other cases use single quotes.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -158,6 +158,8 @@ not to strictly follow POSIX shell syntax.
   - documentation describes command argument semantics explicitly
   - you exactly know placeholder meaning (maybe from source code) and the documentation just missing information about this.
 
+> :bulb: If some command is cross-platform then Unix-style path placeholders are preferred.
+
 ### Extensions
 
 - Append `.ext` to the end of a file path placeholder just when:

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -113,13 +113,12 @@ in order to allow `tldr` clients to highlight them.
 
 - Use short but descriptive placeholders,
   such as `{{path/to/source.cs}}` or `{{drive}}`.
-- Use [snake_case][snake_case] for multi-word tokens.
+- Use [snake_case][snake_case] for multi-word placeholders.
 - Use an actual value in placeholder such as `{{5}}` rather than
-  a placeholder with value description inside it such as `{{seconds}}`
+  a placeholder with a value description inside it such as `{{seconds}}`
   when one of the following conditions are met:
-  - there is long (consisting of several letters) option immidiately before
-    this placeholder which allows us understand the meaning of
-    an actual value
+  - there is a long (consisting of several letters) option immidiately before
+    this placeholder 
   - there is a short (consisting of one letter) option immidiately before this
     placeholder with a mnemonic provided via square brackets in a code
     example description

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -127,7 +127,7 @@ in order to allow `tldr` clients to highlight them.
   In other cases quote arguments just when documentation mandates quotes explicitly or
   you exactly know they are required and the documentation just missing information about this.
 - Use double quotes for placeholders where variable or another substitution occures.
-  In other cases prefer single quotes.
+  In other cases use single quotes.
 
 > :bulb: Many shells have [word splitting][word_splitting] enabled by default so unquoted arguments may be splitted to
 several ones. But the main goal of Tl;Dr pages is to provide easy to read and simple in use pages but
@@ -136,25 +136,26 @@ not to strictly follow POSIX shell syntax.
 [word_splitting]: https://mywiki.wooledge.org/WordSplitting
 
 ### Paths
-- Use `{{filename}}` rather than `{{file_name}}`.
-- For any reference to paths of files or directories,
-  use the format `{{path/to/<placeholder>}}`,
-  except when the location is implicit.
-- When the path cannot be relative,
-  but has to start at the root of the filesystem,
-  prefix it with a slash,
-  such as `get {{/path/to/remote_file}}`.
-- In case of a possible reference both to a file or a directory,
-  use `{{path/to/file_or_directory}}`.
 
-Extensions
+- Use `{{path/to/file}}` or `{{path/to/directory}}` placeholders for file and directory paths respectively.
+- Where file and directory paths are vaild use `{{path/to/file_or_directory}}` placeholder.
+- For absolute paths add leading slash at the beggining of placeholder such as `{{/path/to/file}}` or `{{/path/to/directory}}`.
+- Replace `file` and `directory` words from placeholders above with more descriptive ones
+  just when documentation describes command argument semantics explicitly or you exactly know placeholder meaning
+  and the documentation just missing information about this.
 
-- If a particular extension is expected for the file, append it.
-  For example, `unrar x {{compressed.rar}}`.
-- In case a generic extension is needed, use `{{.ext}}`, but **only** if an extension is required.
-  For instance, in `find.md`'s example "Find files by extension" (`find {{root_path}} -name '{{*.ext}}'`)
-  using `{{*.ext}}` explains the command without being unnecessarily specific;
-  while in `wc -l {{file}}` using `{{file}}` (without extension) is sufficient.
+### Extensions
+
+- Append `.ext` to the end of a file path placeholder just when:
+  - documentation requires extension explicitly
+  - you exactly know it is required (maybe from source code) and the documentation just missing information about this
+  - adding extension is an good practise described anywhere
+  
+  For example: `unrar x {{path/to/compressed.rar}}`
+- Replace `ext` word from placeholder above with one of concreete extensions
+  just when:
+  - documentation describes valid extensions explicitly
+  - you exactly know them (maybe from source code) and the documentation just missing information about this
 
 ### Special cases
 - If a command performs irreversible changes to a file system or devices,

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -133,7 +133,7 @@ in order to allow `tldr` clients to highlight them.
 ### Quoting
 
 - Don't quote path placeholders for page simplicity although shell may require quotes.
-  In other cases quote arguments just when:
+  In other cases quote placeholders just when:
   - documentation mandates quotes explicitly
   - you exactly know they are required and the documentation just missing information about this
 - Use double quotes for placeholders where variable or another substitution occures.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -147,9 +147,12 @@ not to strictly follow POSIX shell syntax.
 
 ### Paths
 
-- Use `{{path/to/file}}` or `{{path/to/directory}}` placeholders for file and directory paths respectively.
-- Where file and directory paths are both vaild use `{{path/to/file_or_directory}}` placeholder.
-- For absolute paths add leading slash at the beggining of placeholder such as `{{/path/to/file}}` or `{{/path/to/directory}}`.
+- Use `{{path/to/file}}` or `{{path/to/directory}}` placeholders for Unix-like command pages for file and directory paths respectively.
+  For Windows command pages use `{{path\to\file}}` or `{{path\to\directory}}` placeholders.
+- Where file and directory paths are both vaild use `{{path/to/file_or_directory}}` placeholder for Unix-like command pages
+  or `{{path\to\file_or_directory}}` for Windows command pages.
+- For absolute paths add leading slash (or backslash for Windows command pages) at the beggining of placeholder such
+  as `{{/path/to/file}}` or `{{/path/to/directory}}`.
 - Replace `file` and `directory` words from placeholders above with more descriptive ones
   just when:
   - documentation describes command argument semantics explicitly

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -139,11 +139,12 @@ not to strictly follow POSIX shell syntax.
 ### Paths
 
 - Use `{{path/to/file}}` or `{{path/to/directory}}` placeholders for file and directory paths respectively.
-- Where file and directory paths are vaild use `{{path/to/file_or_directory}}` placeholder.
+- Where file and directory paths are both vaild use `{{path/to/file_or_directory}}` placeholder.
 - For absolute paths add leading slash at the beggining of placeholder such as `{{/path/to/file}}` or `{{/path/to/directory}}`.
 - Replace `file` and `directory` words from placeholders above with more descriptive ones
-  just when documentation describes command argument semantics explicitly or you exactly know placeholder meaning
-  and the documentation just missing information about this.
+  just when:
+  - documentation describes command argument semantics explicitly
+  - you exactly know placeholder meaning (maybe from source code) and the documentation just missing information about this.
 
 ### Extensions
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -134,7 +134,7 @@ in order to allow `tldr` clients to highlight them.
 
 - Don't quote path placeholders for page simplicity although shell may require quotes.
   In other cases quote placeholders just when:
-  - documentation mandates quotes explicitly
+  - documentation mandates quotes explicitly.
   - you exactly know they are required and the documentation is just missing information about this.
 - Use double quotes for placeholders where variable or another substitution occures.
   In other cases use single quotes.


### PR DESCRIPTION
> ⚠️ This PR is a reference for other smaller PRs. It will be closed after all ideas from here are accepted.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## ToDo

- [Deny](https://github.com/tldr-pages/tldr/pull/8367#discussion_r956662403) substituting concrete usernames and passwords.
- [Prefer](https://github.com/tldr-pages/tldr/pull/8367#discussion_r956662260) `127.0.0.1` as an IP example.
- [Deny](https://github.com/tldr-pages/tldr/pull/9139#discussion_r1004134693) placeholders for concrete values.

## Next PRs

- Describe when and where use short and long options: #9527
- Describe quoting rules inside command descriptions: #9528
- Describe how to write globs and regex (not to over complicate pages)
- Describe how to write `--help` and `--version` options summary
- Add notes according to [this](https://github.com/tldr-pages/tldr/pull/8025#discussion_r948379968) question
- [Deny](https://github.com/tldr-pages/tldr/pull/8367#discussion_r954848116) placeholder usage in descriptions
- Describe how to write [interactive choices affecting command behaviour](https://github.com/tldr-pages/tldr/pull/8474#discussion_r974421653)
- Force writing [descriptive](https://github.com/tldr-pages/tldr/pull/7931#discussion_r906419677) code explanations rather generic. Describe what we want to do rather than how we do it.
- Require explicit type annotations such as in [sed](https://github.com/tldr-pages/tldr/pull/7931) page. Think about rules.
- Require specify where command writes output (stdout, stderr) explicitly. No exceptions.
- [Deny](https://github.com/tldr-pages/tldr/pull/9495#pullrequestreview-1186984875) short->long option conversion when more than 5 options can be converted.

Everything that can be standardized should be standardized ;) Some examples are removed because I want to replace them with smth better when find.