### PR TITLE
docker-run: use long options for examples

### DIFF
--- a/pages.de/common/docker-run.md
+++ b/pages.de/common/docker-run.md
@@ -9,20 +9,20 @@
 
 - Führe einen Befehl in einem neuen Container im Hintergrund aus und zeige die ID:
 
-`docker run -d {{image}} {{befehl}}`
+`docker run --detach {{image}} {{befehl}}`
 
 - Führe einen Befehl in einem kurzlebigen Container im interaktiven Modus mit einem Pseudo-TTY aus:
 
-`docker run --rm -it {{image}} {{befehl}}`
+`docker run --rm --interactive --tty {{image}} {{befehl}}`
 
 - Führe einen Befehl in einem neuen Container mit übergebenen Umgebungsvariablen aus:
 
-`docker run -e '{{variable}}={{wert}}' -e {{variable}} {{image}} {{befehl}}`
+`docker run --env '{{variable}}={{wert}}' --env {{variable}} {{image}} {{befehl}}`
 
 - Führe einen Befehl in einem neuen Container mit eingebundenen Datenträgern aus:
 
-`docker run -v {{pfad/zu/host_verzeichnis}}:{{pfad/zu/container_verzeichnis}} {{image}} {{befehl}}`
+`docker run --volume {{pfad/zu/host_verzeichnis}}:{{pfad/zu/container_verzeichnis}} {{image}} {{befehl}}`
 
 - Führe einen Befehl in einem neuen Container mit veröffentlichten Ports aus:
 
-`docker run -p {{host_port}}:{{container_port}} {{image}} {{befehl}}`
+`docker run --publish {{host_port}}:{{container_port}} {{image}} {{befehl}}`

--- a/pages.pt_BR/common/docker-run.md
+++ b/pages.pt_BR/common/docker-run.md
@@ -9,20 +9,20 @@
 
 - Executa um comando em um novo container em background e exibe o ID:
 
-`docker run -d {{image}} {{command}}`
+`docker run --detach {{image}} {{command}}`
 
 - Executa um comando em um novo container que será removido após a execução em um modo interativo e com um terminal TTY:
 
-`docker run --rm -it {{image}} {{command}}`
+`docker run --rm --interactive --tty {{image}} {{command}}`
 
 - Executa um comando em um novo container com variáveis de ambiente:
 
-`docker run -e '{{variável}}={{valor}}' -e {{variável}} {{imagem}} {{comando}}`
+`docker run --env '{{variável}}={{valor}}' --env {{variável}} {{imagem}} {{comando}}`
 
 - Executa um comando em um novo container montando volumes nos caminhos específicos:
 
-`docker run -v {{caminho/no/host_local}}:{{caminho/no/container}} {{imagem}} {{comando}}`
+`docker run --volume {{caminho/no/host_local}}:{{caminho/no/container}} {{imagem}} {{comando}}`
 
 - Executa um comando em um novo container e abre as portas para acesso:
 
-`docker run -p {{porta_do_host_local}}:{{porta_do_container}} {{imagem}} {{comando}}`
+`docker run --publish {{porta_do_host_local}}:{{porta_do_container}} {{imagem}} {{comando}}`

--- a/pages.tr/common/docker-run.md
+++ b/pages.tr/common/docker-run.md
@@ -9,20 +9,20 @@
 
 - Yeni bir konteynerde arkaplanda çalışacak şekilde komut çalıştır ve ID'sini göster:
 
-`docker run -d {{imge}} {{komut}}`
+`docker run --detach {{imge}} {{komut}}`
 
 - İnteraktif mod ve pseudo-TTY'deki bir açık-kapalı konteynerde komut çalıştır:
 
-`docker run --rm -it {{imge}} {{komut}}`
+`docker run --rm --interactive --tty {{imge}} {{komut}}`
 
 - Yeni bir konteynerde geçebilmiş çevresel değişkenler ile komut çalıştır:
 
-`docker run -e '{{değişken}}={{değer}}' -e {{değişken}} {{imge}} {{komut}}`
+`docker run --env '{{değişken}}={{değer}}' --env {{değişken}} {{imge}} {{komut}}`
 
 - Yeni bir konteynerde bağlama takılı hacimlerle komut çalıştır:
 
-`docker run -v {{örnek/host}}:{{örnek/konteyner}} {{imge}} {{komut}}`
+`docker run --volume {{örnek/host}}:{{örnek/konteyner}} {{imge}} {{komut}}`
 
 - Yayınlanmış portları içeren yeni bir konteynerde komut çalıştır:
 
-`docker run -p {{host_portu}}:{{konteyner_portu}} {{imge}} {{komut}}`
+`docker run --publish {{host_portu}}:{{konteyner_portu}} {{imge}} {{komut}}`

--- a/pages/common/docker-run.md
+++ b/pages/common/docker-run.md
@@ -9,23 +9,23 @@
 
 - Run command in a new container in background and display its ID:
 
-`docker run -d {{image}} {{command}}`
+`docker run --detach {{image}} {{command}}`
 
 - Run command in a one-off container in interactive mode and pseudo-TTY:
 
-`docker run --rm -it {{image}} {{command}}`
+`docker run --rm --interactive --tty {{image}} {{command}}`
 
 - Run command in a new container with passed environment variables:
 
-`docker run -e '{{variable}}={{value}}' -e {{variable}} {{image}} {{command}}`
+`docker run --env '{{variable}}={{value}}' --env {{variable}} {{image}} {{command}}`
 
 - Run command in a new container with bind mounted volumes:
 
-`docker run -v {{/path/to/host_path}}:{{/path/to/container_path}} {{image}} {{command}}`
+`docker run --volume {{/path/to/host_path}}:{{/path/to/container_path}} {{image}} {{command}}`
 
 - Run command in a new container with published ports:
 
-`docker run -p {{host_port}}:{{container_port}} {{image}} {{command}}`
+`docker run --publish {{host_port}}:{{container_port}} {{image}} {{command}}`
 
 - Run command in a new container overwriting the entrypoint of the image:
 


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
