### PR TITLE
osx/*: add pt_BR translations

### DIFF
--- a/pages.pt_BR/osx/caffeinate.md
+++ b/pages.pt_BR/osx/caffeinate.md
@@ -1,0 +1,16 @@
+# caffeinate
+
+> Evita que o macOS entre em suspensão (repouso).
+> Mais informações: <https://ss64.com/osx/caffeinate.html>.
+
+- Evitar a suspensão por uma hora (3600 segundos):
+
+`caffeinate -u -t {{3600}}`
+
+- Evitar a suspensão até que um comando seja concluído:
+
+`caffeinate -s "{{comando}}"`
+
+- Evitar a suspensão até que você digite Ctrl-C:
+
+`caffeinate -i`

--- a/pages.pt_BR/osx/caffeinate.md
+++ b/pages.pt_BR/osx/caffeinate.md
@@ -3,14 +3,14 @@
 > Evita que o macOS entre em suspensão (repouso).
 > Mais informações: <https://ss64.com/osx/caffeinate.html>.
 
-- Evitar a suspensão por uma hora (3600 segundos):
+- Evita a suspensão por uma hora (3600 segundos):
 
 `caffeinate -u -t {{3600}}`
 
-- Evitar a suspensão até que um comando seja concluído:
+- Evita a suspensão até que um comando seja concluído:
 
 `caffeinate -s "{{comando}}"`
 
-- Evitar a suspensão até que você digite Ctrl-C:
+- Evita a suspensão até que você digite Ctrl-C:
 
 `caffeinate -i`

--- a/pages.pt_BR/osx/cal.md
+++ b/pages.pt_BR/osx/cal.md
@@ -1,0 +1,32 @@
+# cal
+
+> Exibir informações de calendário.
+> Mais informações: <https://ss64.com/osx/cal.html>.
+
+- Exibir um calendário para o mês atual:
+
+`cal`
+
+- Exibir os meses anterior, atual, e próximo:
+
+`cal -3`
+
+- Exibir um calendário para um mês específico (1-12 ou nome):
+
+`cal -m {{mês}}`
+
+- Exibir um calendário para o ano atual:
+
+`cal -y`
+
+- Exibir um calendário para um ano específico (4 dígitos):
+
+`cal {{ano}}`
+
+- Exibir um calendário para um mês e ano específicos:
+
+`cal {{mês}} {{ano}}`
+
+- Exibir a data da Páscoa (igrejas cristãs ocidentais) em um determinado ano:
+
+`ncal -e {{ano}}`

--- a/pages.pt_BR/osx/cal.md
+++ b/pages.pt_BR/osx/cal.md
@@ -1,32 +1,32 @@
 # cal
 
-> Exibir informações de calendário.
+> Exibe informações de calendário.
 > Mais informações: <https://ss64.com/osx/cal.html>.
 
-- Exibir um calendário para o mês atual:
+- Exibe um calendário para o mês atual:
 
 `cal`
 
-- Exibir os meses anterior, atual, e próximo:
+- Exibe os meses anterior, atual, e próximo:
 
 `cal -3`
 
-- Exibir um calendário para um mês específico (1-12 ou nome):
+- Exibe um calendário para um mês específico (1-12 ou nome):
 
 `cal -m {{mês}}`
 
-- Exibir um calendário para o ano atual:
+- Exibe um calendário para o ano atual:
 
 `cal -y`
 
-- Exibir um calendário para um ano específico (4 dígitos):
+- Exibe um calendário para um ano específico (4 dígitos):
 
 `cal {{ano}}`
 
-- Exibir um calendário para um mês e ano específicos:
+- Exibe um calendário para um mês e ano específicos:
 
 `cal {{mês}} {{ano}}`
 
-- Exibir a data da Páscoa (igrejas cristãs ocidentais) em um determinado ano:
+- Exibe a data da Páscoa (igrejas cristãs ocidentais) em um determinado ano:
 
 `ncal -e {{ano}}`

--- a/pages.pt_BR/osx/carthage.md
+++ b/pages.pt_BR/osx/carthage.md
@@ -1,0 +1,24 @@
+# carthage
+
+> Ferramenta de gerenciamento de dependências para aplicativos Cocoa.
+> Mais informações: <https://github.com/Carthage/Carthage>.
+
+- Baixar a versão mais recente de todas as dependências mencionadas no Cartfile e realizar o build delas:
+
+`carthage update`
+
+- Atualizar as dependências, mas faz apenas build para iOS:
+
+`carthage update --platform ios`
+
+- Atualizar as dependências, mas sem realizar build de nenhuma delas:
+
+`carthage update --no-build`
+
+- Download e rebuild da versão atual das dependências (sem atualizá-las):
+
+`carthage bootstrap`
+
+- Rebuild de uma dependência específica:
+
+`carthage build {{dependência}}`

--- a/pages.pt_BR/osx/carthage.md
+++ b/pages.pt_BR/osx/carthage.md
@@ -3,22 +3,22 @@
 > Ferramenta de gerenciamento de dependências para aplicativos Cocoa.
 > Mais informações: <https://github.com/Carthage/Carthage>.
 
-- Baixar a versão mais recente de todas as dependências mencionadas no Cartfile e realizar o build delas:
+- Baixa a versão mais recente de todas as dependências mencionadas no Cartfile e realiza o build delas:
 
 `carthage update`
 
-- Atualizar as dependências, mas faz apenas build para iOS:
+- Atualiza as dependências, e faz build apenas para o iOS:
 
 `carthage update --platform ios`
 
-- Atualizar as dependências, mas sem realizar build de nenhuma delas:
+- Atualiza as dependências, sem realizar build de nenhuma delas:
 
 `carthage update --no-build`
 
-- Download e rebuild da versão atual das dependências (sem atualizá-las):
+- Faz o download e rebuild da versão atual das dependências (sem atualizá-las):
 
 `carthage bootstrap`
 
-- Rebuild de uma dependência específica:
+- Faz o rebuild de uma dependência específica:
 
 `carthage build {{dependência}}`

--- a/pages.pt_BR/osx/cfprefsd.md
+++ b/pages.pt_BR/osx/cfprefsd.md
@@ -1,0 +1,9 @@
+# cfprefsd
+
+> Fornece serviços de preferências (`CFPreferences`, `NSUserDefaults`).
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.unix.com/man-page/osx/8/cfprefsd/>.
+
+- Iniciar o daemon:
+
+`cfprefsd`

--- a/pages.pt_BR/osx/cfprefsd.md
+++ b/pages.pt_BR/osx/cfprefsd.md
@@ -4,6 +4,6 @@
 > Não deve ser invocado manualmente.
 > Mais informações: <https://www.unix.com/man-page/osx/8/cfprefsd/>.
 
-- Iniciar o daemon:
+- Inicia o daemon:
 
 `cfprefsd`

--- a/pages.pt_BR/osx/chflags.md
+++ b/pages.pt_BR/osx/chflags.md
@@ -3,18 +3,18 @@
 > Altera flags de arquivo ou diretório.
 > Mais informações: <https://ss64.com/osx/chflags.html>.
 
-- Definir a flag `hidden` para um arquivo:
+- Define a flag `hidden` para um arquivo:
 
 `chflags {{hidden}} {{caminho/para/arquivo}}`
 
-- Remover a flag `hidden` de um arquivo:
+- Remove a flag `hidden` de um arquivo:
 
 `chflags {{nohidden}} {{caminho/para/arquivo}}`
 
-- Definir recursivamente a flag `uchg` para um diretório:
+- Define recursivamente a flag `uchg` para um diretório:
 
 `chflags -R {{uchg}} {{caminho/para/diretório}}`
 
-- Remover recursivamente a flag `uchg` de um diretório:
+- Remove recursivamente a flag `uchg` de um diretório:
 
 `chflags -R {{nouchg}} {{caminho/para/diretório}}`

--- a/pages.pt_BR/osx/chflags.md
+++ b/pages.pt_BR/osx/chflags.md
@@ -1,0 +1,20 @@
+# chflags
+
+> Altera flags de arquivo ou diretório.
+> Mais informações: <https://ss64.com/osx/chflags.html>.
+
+- Definir a flag `hidden` para um arquivo:
+
+`chflags {{hidden}} {{caminho/para/arquivo}}`
+
+- Remover a flag `hidden` de um arquivo:
+
+`chflags {{nohidden}} {{caminho/para/arquivo}}`
+
+- Definir recursivamente a flag `uchg` para um diretório:
+
+`chflags -R {{uchg}} {{caminho/para/diretório}}`
+
+- Remover recursivamente a flag `uchg` de um diretório:
+
+`chflags -R {{nouchg}} {{caminho/para/diretório}}`

--- a/pages.pt_BR/osx/cloudphotod.md
+++ b/pages.pt_BR/osx/cloudphotod.md
@@ -4,6 +4,6 @@
 > Não deve ser invocado manualmente.
 > Mais informações: <https://www.manpagez.com/man/8/cloudphotosd/>.
 
-- Iniciar o daemon:
+- Inicia o daemon:
 
 `cloudphotod`

--- a/pages.pt_BR/osx/cloudphotod.md
+++ b/pages.pt_BR/osx/cloudphotod.md
@@ -1,0 +1,9 @@
+# cloudphotod
+
+> Sincroniza fotos do iCloud.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.manpagez.com/man/8/cloudphotosd/>.
+
+- Iniciar o daemon:
+
+`cloudphotod`

--- a/pages.pt_BR/osx/codesign.md
+++ b/pages.pt_BR/osx/codesign.md
@@ -1,0 +1,12 @@
+# codesign
+
+> Criar e manipular assinaturas de código para macOS.
+> Mais informações: <https://www.unix.com/man-page/osx/1/codesign/>.
+
+- Assinar um aplicativo com um certificado:
+
+`codesign --sign "{{Nome da Minha Empresa}}" {{caminho/para/App.app}}`
+
+- Verificar o certificado de um aplicativo:
+
+`codesign --verify {{caminho/para/App.app}}`

--- a/pages.pt_BR/osx/codesign.md
+++ b/pages.pt_BR/osx/codesign.md
@@ -1,12 +1,12 @@
 # codesign
 
-> Criar e manipular assinaturas de código para macOS.
+> Cria e manipula assinaturas de código para macOS.
 > Mais informações: <https://www.unix.com/man-page/osx/1/codesign/>.
 
-- Assinar um aplicativo com um certificado:
+- Assina um aplicativo com um certificado:
 
 `codesign --sign "{{Nome da Minha Empresa}}" {{caminho/para/App.app}}`
 
-- Verificar o certificado de um aplicativo:
+- Verifica o certificado de um aplicativo:
 
 `codesign --verify {{caminho/para/App.app}}`

--- a/pages.pt_BR/osx/coreaudiod.md
+++ b/pages.pt_BR/osx/coreaudiod.md
@@ -1,0 +1,9 @@
+# coreaudiod
+
+> Serviço para o Core Audio, o sistema de áudio da Apple.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/WhatisCoreAudio/WhatisCoreAudio.html>.
+
+- Iniciar o daemon:
+
+`coreaudiod`

--- a/pages.pt_BR/osx/coreaudiod.md
+++ b/pages.pt_BR/osx/coreaudiod.md
@@ -4,6 +4,6 @@
 > Não deve ser invocado manualmente.
 > Mais informações: <https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/WhatisCoreAudio/WhatisCoreAudio.html>.
 
-- Iniciar o daemon:
+- Inicia o daemon:
 
 `coreaudiod`

--- a/pages.pt_BR/osx/coreautha.md
+++ b/pages.pt_BR/osx/coreautha.md
@@ -4,6 +4,6 @@
 > Não deve ser invocado manualmente. Veja também: `coreauthd`.
 > Mais informações: <https://www.manpagez.com/man/8/coreautha/>.
 
-- Iniciar o agente:
+- Inicia o agente:
 
 `coreautha`

--- a/pages.pt_BR/osx/coreautha.md
+++ b/pages.pt_BR/osx/coreautha.md
@@ -1,0 +1,9 @@
+# coreautha
+
+> Um agente de sistema que fornece o framework `LocalAuthentication`.
+> Não deve ser invocado manualmente. Veja também: `coreauthd`.
+> Mais informações: <https://www.manpagez.com/man/8/coreautha/>.
+
+- Iniciar o agente:
+
+`coreautha`

--- a/pages.pt_BR/osx/coreauthd.md
+++ b/pages.pt_BR/osx/coreauthd.md
@@ -1,0 +1,9 @@
+# coreauthd
+
+> Um daemon de sistema que fornece o framework `LocalAuthentication`.
+> Não deve ser invocado manualmente. Veja também: `coreautha`.
+> Mais informações: <https://www.manpagez.com/man/8/coreauthd/>.
+
+- Iniciar o daemon:
+
+`coreauthd`

--- a/pages.pt_BR/osx/coreauthd.md
+++ b/pages.pt_BR/osx/coreauthd.md
@@ -4,6 +4,6 @@
 > Não deve ser invocado manualmente. Veja também: `coreautha`.
 > Mais informações: <https://www.manpagez.com/man/8/coreauthd/>.
 
-- Iniciar o daemon:
+- Inicia o daemon:
 
 `coreauthd`

--- a/pages.pt_BR/osx/cot.md
+++ b/pages.pt_BR/osx/cot.md
@@ -1,0 +1,24 @@
+# cot
+
+> Editor de texto puro para macOS.
+> Mais informações: <https://coteditor.com/>.
+
+- Iniciar o CotEditor:
+
+`cot`
+
+- Abrir arquivos específicos:
+
+`cot {{caminho/para/arquivo1 caminho/para/arquivo2 ...}}`
+
+- Abrir um novo documento em branco:
+
+`cot --new`
+
+- Abrir um arquivo específico e bloquear o terminal até que o arquivo seja fechado:
+
+`cot --wait {{caminho/para/arquivo}}`
+
+- Abrir um arquivo específico com o cursor em uma linha e coluna especificada:
+
+`cot --line {{número_da_linha}} --column {{número_da_coluna}} {{caminho/para/arquivo}}`

--- a/pages.pt_BR/osx/cot.md
+++ b/pages.pt_BR/osx/cot.md
@@ -3,22 +3,22 @@
 > Editor de texto puro para macOS.
 > Mais informações: <https://coteditor.com/>.
 
-- Iniciar o CotEditor:
+- Inicia o CotEditor:
 
 `cot`
 
-- Abrir arquivos específicos:
+- Abre arquivos específicos:
 
 `cot {{caminho/para/arquivo1 caminho/para/arquivo2 ...}}`
 
-- Abrir um novo documento em branco:
+- Abre um novo documento em branco:
 
 `cot --new`
 
-- Abrir um arquivo específico e bloquear o terminal até que o arquivo seja fechado:
+- Abre um arquivo específico e bloqueia o terminal até que o arquivo seja fechado:
 
 `cot --wait {{caminho/para/arquivo}}`
 
-- Abrir um arquivo específico com o cursor em uma linha e coluna especificada:
+- Abre um arquivo específico com o cursor em uma linha e coluna especificada:
 
 `cot --line {{número_da_linha}} --column {{número_da_coluna}} {{caminho/para/arquivo}}`

--- a/pages.pt_BR/osx/csrutil.md
+++ b/pages.pt_BR/osx/csrutil.md
@@ -1,0 +1,28 @@
+# csrutil
+
+> Gerenciar a configuração do System Integrity Protection (SIP).
+> Mais informações: <https://ss64.com/osx/csrutil.html>.
+
+- Exibir o status do System Integrity Protection:
+
+`csrutil status`
+
+- Desabilitar o System Integrity Protection:
+
+`csrutil disable`
+
+- Habilitar o System Integrity Protection:
+
+`csrutil enable`
+
+- Exibir a lista de origens permitidas do NetBoot:
+
+`csrutil netboot list`
+
+- Adicionar um endereço IPv4 à lista de origens permitidas do NetBoot:
+
+`csrutil netboot add {{endereço_ip}}`
+
+- Resetar o status do System Integrity Protection e limpar a lista do NetBoot:
+
+`csrutil clear`

--- a/pages.pt_BR/osx/csrutil.md
+++ b/pages.pt_BR/osx/csrutil.md
@@ -1,28 +1,28 @@
 # csrutil
 
-> Gerenciar a configuração do System Integrity Protection (SIP).
+> Gerencia a configuração do System Integrity Protection (SIP).
 > Mais informações: <https://ss64.com/osx/csrutil.html>.
 
-- Exibir o status do System Integrity Protection:
+- Exibe o status do System Integrity Protection:
 
 `csrutil status`
 
-- Desabilitar o System Integrity Protection:
+- Desabilita o System Integrity Protection:
 
 `csrutil disable`
 
-- Habilitar o System Integrity Protection:
+- Habilita o System Integrity Protection:
 
 `csrutil enable`
 
-- Exibir a lista de origens permitidas do NetBoot:
+- Exibe a lista de origens permitidas do NetBoot:
 
 `csrutil netboot list`
 
-- Adicionar um endereço IPv4 à lista de origens permitidas do NetBoot:
+- Adiciona um endereço IPv4 à lista de origens permitidas do NetBoot:
 
 `csrutil netboot add {{endereço_ip}}`
 
-- Resetar o status do System Integrity Protection e limpar a lista do NetBoot:
+- Reseta o status do System Integrity Protection e limpa a lista do NetBoot:
 
 `csrutil clear`

--- a/pages.pt_BR/osx/csshx.md
+++ b/pages.pt_BR/osx/csshx.md
@@ -1,0 +1,16 @@
+# csshX
+
+> Ferramenta de Cluster SSH para macOS.
+> Mais informações: <https://github.com/brockgr/csshx>.
+
+- Conectar a vários hosts:
+
+`csshX {{nomedohost1}} {{nomedohost2}}`
+
+- Conectar a vários hosts com uma determinada chave SSH:
+
+`csshX {{user@nomedohost1}} {{user@nomedohost2}} --ssh_args "-i {{caminho/para/ssh_key.pem}}"`
+
+- Conectar a um cluster predefinido em `/etc/clusters`:
+
+`csshX cluster1`

--- a/pages.pt_BR/osx/csshx.md
+++ b/pages.pt_BR/osx/csshx.md
@@ -3,14 +3,14 @@
 > Ferramenta de Cluster SSH para macOS.
 > Mais informações: <https://github.com/brockgr/csshx>.
 
-- Conectar a vários hosts:
+- Conecta a vários hosts:
 
 `csshX {{nomedohost1}} {{nomedohost2}}`
 
-- Conectar a vários hosts com uma determinada chave SSH:
+- Conecta a vários hosts com uma determinada chave SSH:
 
 `csshX {{user@nomedohost1}} {{user@nomedohost2}} --ssh_args "-i {{caminho/para/ssh_key.pem}}"`
 
-- Conectar a um cluster predefinido em `/etc/clusters`:
+- Conecta a um cluster predefinido em `/etc/clusters`:
 
 `csshX cluster1`

--- a/pages.pt_BR/osx/cut.md
+++ b/pages.pt_BR/osx/cut.md
@@ -1,0 +1,16 @@
+# cut
+
+> Recortar campos de stdin ou arquivos.
+> Mais informações: <https://manned.org/man/freebsd-13.0/cut.1>.
+
+- Imprimir um intervalo específico de caracteres/campos de cada linha:
+
+`{{comando}} | cut -{{c|f}} {{1|1,10|1-10|1-|-10}}`
+
+- Imprimir um intervalo de cada linha com um delimitador específico:
+
+`{{comando}} | cut -d "{{,}}" -{{c}} {{1}}`
+
+- Imprimir um intervalo de cada linha de um arquivo específico:
+
+`cut -{{c}} {{1}} {{caminho/para/arquivo}}`

--- a/pages.pt_BR/osx/cut.md
+++ b/pages.pt_BR/osx/cut.md
@@ -1,16 +1,16 @@
 # cut
 
-> Recortar campos de stdin ou arquivos.
+> Recorta campos de stdin ou arquivos.
 > Mais informações: <https://manned.org/man/freebsd-13.0/cut.1>.
 
-- Imprimir um intervalo específico de caracteres/campos de cada linha:
+- Imprime um intervalo específico de caracteres/campos de cada linha:
 
 `{{comando}} | cut -{{c|f}} {{1|1,10|1-10|1-|-10}}`
 
-- Imprimir um intervalo de cada linha com um delimitador específico:
+- Imprime um intervalo de cada linha com um delimitador específico:
 
 `{{comando}} | cut -d "{{,}}" -{{c}} {{1}}`
 
-- Imprimir um intervalo de cada linha de um arquivo específico:
+- Imprime um intervalo de cada linha de um arquivo específico:
 
 `cut -{{c}} {{1}} {{caminho/para/arquivo}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

**Version of the command being translated (if known):**
https://github.com/tldr-pages/tldr/blob/main/pages/osx/caffeinate.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/cal.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/carthage.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/cfprefsd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/chflags.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/cloudphotod.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/codesign.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/coreaudiod.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/coreautha.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/coreauthd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/cot.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/csrutil.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/csshx.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/cut.md
