### PR TITLE
gdalwarp: add page

### DIFF
--- a/pages/common/gdalwarp.md
+++ b/pages/common/gdalwarp.md
@@ -1,0 +1,16 @@
+# gdalwarp
+
+> Image reprojection and warping utility.
+> More information: <https://gdal.org/programs/gdalwarp>.
+
+- Reproject a raster dataset:
+
+`gdalwarp -t_srs {{EPSG:4326}} {{path/to/input.tif}} {{path/to/output.tif}}`
+
+- Crop a raster dataset by coordinates:
+
+`gdalwarp -te {{min_x}} {{min_y}} {{max_x}} {{max_y}} -te_srs {{EPSG:4326}} {{path/to/input.tif}} {{path/to/output.tif}}`
+
+- Crop a raster dataset by a vector layer:
+
+`gdalwarp -cutline {{path/to/area_to_cut.geojson}} -crop_to_cutline {{path/to/input.tif}} {{path/to/output.tif}}`

--- a/pages/common/gdalwarp.md
+++ b/pages/common/gdalwarp.md
@@ -7,10 +7,10 @@
 
 `gdalwarp -t_srs {{EPSG:4326}} {{path/to/input.tif}} {{path/to/output.tif}}`
 
-- Crop a raster dataset by coordinates:
+- Crop a raster dataset by using specific coordinates:
 
 `gdalwarp -te {{min_x}} {{min_y}} {{max_x}} {{max_y}} -te_srs {{EPSG:4326}} {{path/to/input.tif}} {{path/to/output.tif}}`
 
-- Crop a raster dataset by a vector layer:
+- Crop a raster dataset using a vector layer:
 
 `gdalwarp -cutline {{path/to/area_to_cut.geojson}} -crop_to_cutline {{path/to/input.tif}} {{path/to/output.tif}}`


### PR DESCRIPTION
- Add the CLI tool [gdalwarp](https://gdal.org/programs/gdalwarp) from the GDAL/OGR suite.
- Version of the command: `3.2.2`

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
