### PR TITLE
flameshot: fix time unit in --delay example

### DIFF
--- a/pages/linux/flameshot.md
+++ b/pages/linux/flameshot.md
@@ -32,6 +32,6 @@
 
 `flameshot gui --clipboard`
 
-- Create a screenshot with a specific delay in seconds:
+- Create a screenshot with a specific delay in milliseconds:
 
-`flameshot full --delay {{5}}`
+`flameshot full --delay {{5000}}`


### PR DESCRIPTION
This is already correct in fr, de.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
