### PR TITLE
fc: remove subcommand mention

### DIFF
--- a/pages.pt_BR/common/fc.md
+++ b/pages.pt_BR/common/fc.md
@@ -1,7 +1,6 @@
 # fc
 
 > Abre o último comando executado em um editor de texto.
-> Alguns subcomandos como `fc list` tem sua própia documentação de uso.
 > Mais informações: <https://manned.org/fc>.
 
 - Abrir o último comando executado no editor de texto padrão do sistema:

--- a/pages/common/fc.md
+++ b/pages/common/fc.md
@@ -1,7 +1,6 @@
 # fc
 
 > Open the most recent command and edit it.
-> Some subcommands such as `fc list` have their own usage documentation.
 > More information: <https://manned.org/fc>.
 
 - Open in the default system editor:


### PR DESCRIPTION
The command `fc list` doesn't exist. We only have `fc-list`, which is a completely different command.