### PR TITLE
windows/curl,windows/wget: fix tldr client param inconsistencies

### DIFF
--- a/pages/windows/curl.md
+++ b/pages/windows/curl.md
@@ -8,7 +8,11 @@
 
 - View documentation for the original `curl` command:
 
-`tldr curl -p common`
+`tldr curl --platform common`
+
+- View documentation for the original `curl` command in older versions of `tldr` command-line client:
+
+`tldr curl --os common`
 
 - View documentation for PowerShell's `Invoke-WebRequest` command:
 

--- a/pages/windows/curl.md
+++ b/pages/windows/curl.md
@@ -8,11 +8,11 @@
 
 - View documentation for the original `curl` command:
 
-`tldr curl --platform common`
+`tldr curl -p common`
 
 - View documentation for the original `curl` command in older versions of `tldr` command-line client:
 
-`tldr curl --os common`
+`tldr curl -o common`
 
 - View documentation for PowerShell's `Invoke-WebRequest` command:
 

--- a/pages/windows/wget.md
+++ b/pages/windows/wget.md
@@ -8,7 +8,11 @@
 
 - View documentation for the original `wget` command:
 
-`tldr wget -p common`
+`tldr wget --platform common`
+
+- View documentation for the original `wget` command in older versions of `tldr` command-line client:
+
+`tldr wget --os common`
 
 - View documentation for PowerShell's `Invoke-WebRequest` command:
 

--- a/pages/windows/wget.md
+++ b/pages/windows/wget.md
@@ -8,11 +8,11 @@
 
 - View documentation for the original `wget` command:
 
-`tldr wget --platform common`
+`tldr wget -p common`
 
 - View documentation for the original `wget` command in older versions of `tldr` command-line client:
 
-`tldr wget --os common`
+`tldr wget -o common`
 
 - View documentation for PowerShell's `Invoke-WebRequest` command:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Due to tldr-pages/tldr-node-client#336 impacting some Windows users who are using the Node.js version of `tldr` client, I decided to add the non-standard `--os` version to the documentation as a workaround.

Hopefully tldr-pages/tldr-node-client#337 can be merged to fix this issue.