### PR TITLE
gum: add page

### DIFF
--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -11,7 +11,7 @@
 
 `gum input --placeholder "{{value}}"`
 
-- Interactvely pick an option which will exit if "No" is chosen:
+- Open an interactive confirmation prompt and exit with either `0` or `1`:
 
 `gum confirm "{{Continue?}}" --default=false --affirmative "{{Yes}}" --negative "{{No}}" {{&& echo "Yes selected" || echo "No selected"}}`
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -21,7 +21,7 @@
 
 - Format text to include emojis:
 
-`echo "{{:smile: :heart hello}}" | gum format -t {{emoji}}`
+`echo "{{:smile: :heart: hello}}" | gum format -t {{emoji}}`
 
 - Interactively prompt for multi-line text (CTRL + D to save) and write to `data.txt`:
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -15,7 +15,6 @@
 
 `gum confirm "{{Continue?}}" --default=false --affirmative "{{Yes}}" --negative "{{No}}" {{&& : || exit 1}}`
 
-
 - Show a spinner while a command is taking place with text alongside:
 
 `gum spin --spinner {{dot|line|minidot|jump|pulse|points|globe|moon|monkey|meter|hamburger}} --title "{{loading...}}" -- {{command}}`

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -21,7 +21,7 @@
 
 - Format text to include emojis:
 
-`echo "{{:smile: :heart: hello}}" | gum format -t {{emoji}}`
+`gum format -t {{emoji}} "{{:smile: :heart: hello}}"`
 
 - Interactively prompt for multi-line text (CTRL + D to save) and write to `data.txt`:
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -7,7 +7,7 @@
 
 `gum choose "{{option_1}}" "{{option_2}}" "{{option_3}}"`
 
-- Open an interactive prompt for the user to input a string with a placeholder:
+- Open an interactive prompt for the user to input a string with a specific placeholder:
 
 `gum input --placeholder "{{placeholder_string}}"`
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -3,7 +3,7 @@
 > A tool for making glamorous shell scripts.
 > More information: <https://github.com/charmbracelet/gum>.
 
-- Interactively pick an option to print to `STDOUT`:
+- Interactively pick a specific option to print to `stdout`:
 
 `gum choose "{{option_1}}" "{{option_2}}" "{{option_3}}"`
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -9,7 +9,7 @@
 
 - Open an interactive prompt for the user to input a string with a specific placeholder:
 
-`gum input --placeholder "{{placeholder_string}}"`
+`gum input --placeholder "{{value}}"`
 
 - Interactvely pick an option which will exit if "No" is chosen:
 

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -1,0 +1,29 @@
+# gum
+
+> A tool for making glamorous shell scripts.
+> More information: <https://github.com/charmbracelet/gum>.
+
+- Interactively pick an option to print to `STDOUT`:
+
+`gum choose "{{option_1}}" "{{option_2}}" "{{option_3}}"`
+
+- Open an interactive prompt for the user to input a string with a placeholder:
+
+`gum input --placeholder "{{placeholder_string}}"`
+
+- Interactvely pick an option which will exit if "No" is chosen:
+
+`gum confirm "{{Continue?}}" --default=false --affirmative "{{Yes}}" --negative "{{No}}" {{&& : || exit 1}}`
+
+
+- Show a spinner while a command is taking place with text alongside:
+
+`gum spin --spinner {{dot|line|minidot|jump|pulse|points|globe|moon|monkey|meter|hamburger}} --title "{{loading...}}" -- {{command}}`
+
+- Format text to include emojis:
+
+`echo "{{:smile: :heart hello}}" | gum format -t {{emoji}}`
+
+- Interactively prompt for multi-line text (CTRL + D to save) and write to `data.txt`:
+
+`gum write > {{data.txt}}`

--- a/pages/common/gum.md
+++ b/pages/common/gum.md
@@ -13,7 +13,7 @@
 
 - Interactvely pick an option which will exit if "No" is chosen:
 
-`gum confirm "{{Continue?}}" --default=false --affirmative "{{Yes}}" --negative "{{No}}" {{&& : || exit 1}}`
+`gum confirm "{{Continue?}}" --default=false --affirmative "{{Yes}}" --negative "{{No}}" {{&& echo "Yes selected" || echo "No selected"}}`
 
 - Show a spinner while a command is taking place with text alongside:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** gum version 0.4.0 (131ae3b)
