### PR TITLE
grub-bios-setup: add page

### DIFF
--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -6,4 +6,4 @@
 
 - Set up a device to boot with GRUB:
 
-`grub-bios-setup {{/path/to/device/file}}`
+`grub-bios-setup {{/dev/sdX}}`

--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -1,6 +1,6 @@
 # grub-bios-setup
 
-> Set up a device to use GRUB.
+> Set up a device to use GRUB with a BIOS configuration.
 > You should use `grub-install` instead of `grub-bios-setup` in most cases.
 > More information: <https://manned.org/grub-bios-setup.8>.
 

--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -7,3 +7,7 @@
 - Set up a device to boot with GRUB:
 
 `grub-bios-setup {{/dev/sdX}}`
+
+- Install GRUB in a specific directory:
+
+`grub-bios-setup --directory={{/boot/grub}} {{/dev/sdX}}`

--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -8,6 +8,10 @@
 
 `grub-bios-setup {{/dev/sdX}}`
 
+- Install even if problems are detected:
+
+`grub-bios-setup --force {{/dev/sdX}}`
+
 - Install GRUB in a specific directory:
 
 `grub-bios-setup --directory={{/boot/grub}} {{/dev/sdX}}`

--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -1,6 +1,6 @@
 # grub-bios-setup
 
-> Set up a BIOS device to use GRUB.
+> Set up a device to use GRUB.
 > You should use `grub-install` instead of `grub-bios-setup` in most cases.
 > More information: <https://manned.org/grub-bios-setup.8>.
 

--- a/pages/linux/grub-bios-setup.md
+++ b/pages/linux/grub-bios-setup.md
@@ -1,0 +1,9 @@
+# grub-bios-setup
+
+> Set up a BIOS device to use GRUB.
+> You should use `grub-install` instead of `grub-bios-setup` in most cases.
+> More information: <https://manned.org/grub-bios-setup.8>.
+
+- Set up a device to boot with GRUB:
+
+`grub-bios-setup {{/path/to/device/file}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Resolves part of issue #8080