### PR TITLE
inotifywait: refresh

### DIFF
--- a/pages/linux/inotifywait.md
+++ b/pages/linux/inotifywait.md
@@ -3,30 +3,34 @@
 > Waits for changes to one or more files.
 > More information: <https://manned.org/inotifywait>.
 
-- Run a command when a file changes:
+- Watch a specific file for events, exiting after the first one:
 
-`while inotifywait {{path/to/file}}; do {{command}}; done`
-
-- Be quiet about watching for changes:
-
-`while inotifywait --quiet {{path/to/file}}; do {{command}}; done`
-
-- Watch a directory recursively for changes:
-
-`while inotifywait --recursive {{path/to/directory}}; do {{command}}; done`
-
-- Exclude files matching a regular expression:
-
-`while inotifywait --recursive {{path/to/directory}} --exclude '{{regular_expression}}'; do {{command}}; done`
-
-- Wait at most 30 seconds:
-
-`while inotifywait --timeout {{30}} {{path/to/file}}; do {{command}}; done`
-
-- Only watch for file modification events:
-
-`while inotifywait --event {{modify}} {{path/to/file}}; do {{command}}; done`
+`inotifywait {{path/to/file}}`
 
 - Continuously watch a specific file for events without exiting:
 
-`while inotifywait --monitor {{path/to/file}}; do {{command}}; done`
+`inotifywait --monitor {{path/to/file}}`
+
+- Watch a directory recursively for events:
+
+`inotifywait --monitor --recursive {{path/to/directory}}`
+
+- Watch a directory for changes, excluding files, whose names match a regular expression:
+
+`inotifywait --monitor --recursive --exclude "{{regular_expression}}" {{path/to/directory}}`
+
+- Watch a file for changes, exiting when no event occurs for 30 seconds:
+
+`inotifywait --monitor --timeout {{30}} {{path/to/file}}`
+
+- Only watch a file for file modification events:
+
+`inotifywait --event {{modify}} {{path/to/file}}`
+
+- Watch a file printing only events, and no status messages:
+
+`inotifywait --quiet {{path/to/file}}`
+
+- Run a command when a file is accessed:
+
+`inotifywait --event {{access}} {{path/to/file}} && {{command}}`


### PR DESCRIPTION
This is mostly to remove the confusing `while` loops. 
I'm not so sure about the last example, but it kind of was there in the previous version, and I didn't want to completely remove it.