### PR TITLE
perl: fix -i option description

### DIFF
--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -19,7 +19,7 @@
 
 `perl -d {{script.pl}}`
 
-- Edit all file lines [i]n-place with a specific replacement [e]xpression and save a file with a new extension:
+- Edit all file lines [i]n-place with a specific replacement [e]xpression, saving a backup with a new extension:
 
 `perl -p -i'.{{extension}}' -e 's/{{regular_expression}}/{{replacement}}/g' {{path/to/file}}`
 


### PR DESCRIPTION
Description was kind of misleading, since optional parameter for -i provides extension for saving backup, not the edited file.
Basically I've only edited description for one option, so no checklist boxes apply :)

- [ ] Check grammar.