### PR TITLE
retroarch: add page

### DIFF
--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -18,7 +18,7 @@
 
 - Set the path to configuration file:
 
-`retroarch --config={path/to/config_file}`
+`retroarch --config={{path/to/config_file}}`
 
 - Display general help:
 

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -4,7 +4,7 @@
 > It is the reference implementation of libretro API.
 > More information: <https://github.com/libretro/RetroArch>.
 
-- Start `retroarch` in menu mode:
+- Start in the menu mode:
 
 `retroarch`
 

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -16,7 +16,7 @@
 
 `retroarch --features`
 
-- Set the path to configuration file:
+- Set the path of a configuration file:
 
 `retroarch --config={{path/to/config_file}}`
 

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -8,7 +8,7 @@
 
 `retroarch`
 
-- Start in the full screen mode:
+- Start in full screen mode:
 
 `retroarch --fullscreen`
 
@@ -20,10 +20,10 @@
 
 `retroarch --config={{path/to/config_file}}`
 
-- Display the help:
+- Display help:
 
 `retroarch --help`
 
-- Display the version:
+- Display version:
 
 `retroarch --version`

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -12,7 +12,7 @@
 
 `retroarch --fullscreen`
 
-- List all features compiled into `retroarch`:
+- List all compiled features:
 
 `retroarch --features`
 

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -1,0 +1,29 @@
+# retroarch
+
+> RetroArch is a frontend for emulators, game engines and media players.
+> It is the reference implementation of libretro API.
+> More information: <https://github.com/libretro/RetroArch>.
+
+- Start `retroarch` in menu mode:
+
+`retroarch`
+
+- Start `retroarch` in full screen mode:
+
+`retroarch --fullscreen`
+
+- List all features compiled into `retroarch`:
+
+`retroarch --features`
+
+- Set the path to configuration file:
+
+`retroarch --config={path/to/config_file}`
+
+- Display general help:
+
+`retroarch --help`
+
+- Display `retroarch` version:
+
+`retroarch --version`

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -20,10 +20,10 @@
 
 `retroarch --config={{path/to/config_file}}`
 
-- Display general help:
+- Display the help:
 
 `retroarch --help`
 
-- Display `retroarch` version:
+- Display the version:
 
 `retroarch --version`

--- a/pages/linux/retroarch.md
+++ b/pages/linux/retroarch.md
@@ -8,7 +8,7 @@
 
 `retroarch`
 
-- Start `retroarch` in full screen mode:
+- Start in the full screen mode:
 
 `retroarch --fullscreen`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `linux`.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I added the GitHub repo link in `More information:`. We can replace it with [manned](https://manned.org/retroarch.1) if needed.

_Note: I had skipped some advanced commands like shaders, netplay, etc as there are a lot of examples and people rarely use it from the command line. I think basic commands are enough. Do I need to add more commands? What do you think?_ 
