### PR TITLE
aws-ec2: Reorder commands in page

### DIFF
--- a/pages.de/common/aws-ec2.md
+++ b/pages.de/common/aws-ec2.md
@@ -4,14 +4,6 @@
 > AWS EC2 stellt eine sichere und skalierbare Einheit in der AWS Cloud zur Verfügung, um ein schnelleres Entwickeln und Ausrollen von Software zu ermöglichen.
 > Weitere Informationen: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
-- Liste alle verfügbaren EC2 Befehle auf:
-
-`aws ec2 help`
-
-- Zeige Hilfe für bestimmte EC2 Unterbefehle an:
-
-`aws ec2 {{unterbefehl}} help`
-
 - Liste Informationen zu einer bestimmten Instanz auf:
 
 `aws ec2 describe-instances --instance-ids {{instanz_id}}`
@@ -35,3 +27,11 @@
 - Liste alle verfügbaren AMIs (Amazon Machine Images) auf:
 
 `aws ec2 describe-images`
+
+- Liste alle verfügbaren EC2 Befehle auf:
+
+`aws ec2 help`
+
+- Zeige Hilfe für bestimmte EC2 Unterbefehle an:
+
+`aws ec2 {{unterbefehl}} help`

--- a/pages.fr/common/aws-ec2.md
+++ b/pages.fr/common/aws-ec2.md
@@ -4,14 +4,6 @@
 > Provisionne, sécurise et des capacités de calcul redimensionnable dans le cloud AWS pour accélérer le développement et le déploiement d'applications.
 > Plus d'informations : <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
-- Affiche la liste de toutes les commandes EC2 disponible :
-
-`aws ec2 help`
-
-- Affiche l'aide pour une sous-commande EC2 spécifique :
-
-`aws ec2 {{sous-commande}} help`
-
 - Affiche les informations sur une instance spécifique :
 
 `aws ec2 describe-instances --instance-ids {{id_d_instance}}`
@@ -35,3 +27,11 @@
 - Liste toutes les AMIs (Images de Machine Amazon) disponible :
 
 `aws ec2 describe-images`
+
+- Affiche la liste de toutes les commandes EC2 disponible :
+
+`aws ec2 help`
+
+- Affiche l'aide pour une sous-commande EC2 spécifique :
+
+`aws ec2 {{sous-commande}} help`

--- a/pages.pt_BR/common/aws-ec2.md
+++ b/pages.pt_BR/common/aws-ec2.md
@@ -4,14 +4,6 @@
 > Provê capacidade computacional segura e flexível na nuvem da AWS para proporcionar um desenvolvimento e subida para produção de aplicações rapidamente.
 > Mais informações: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
-- Lista todos os comandos EC2 disponíveis:
-
-`aws ec2 help`
-
-- Exibe ajuda específica para um subcomando da EC2:
-
-`aws ec2 {{subcomando}} help`
-
 - Exibe informações sobre uma insntância específica:
 
 `aws ec2 describe-instances --instance-ids {{id_da_instância}}`
@@ -35,3 +27,11 @@
 - Lista as AMIs (Imagem de Máquina da Amazon) disponíveis:
 
 `aws ec2 describe-images`
+
+- Lista todos os comandos EC2 disponíveis:
+
+`aws ec2 help`
+
+- Exibe ajuda específica para um subcomando da EC2:
+
+`aws ec2 {{subcomando}} help`

--- a/pages/common/aws-ec2.md
+++ b/pages/common/aws-ec2.md
@@ -4,14 +4,6 @@
 > Provides secure and resizable computing capacity in the AWS cloud to enable faster development and deployment of applications.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
-- Show list of all available EC2 commands:
-
-`aws ec2 help`
-
-- Show help for specific EC2 subcommand:
-
-`aws ec2 {{subcommand}} help`
-
 - Display information about a specific instance:
 
 `aws ec2 describe-instances --instance-ids {{instance_id}}`
@@ -35,3 +27,11 @@
 - List available AMIs (Amazon Machine Images):
 
 `aws ec2 describe-images`
+
+- Show list of all available EC2 commands:
+
+`aws ec2 help`
+
+- Show help for specific EC2 subcommand:
+
+`aws ec2 {{subcommand}} help`


### PR DESCRIPTION
As suggested in #8347, moving `help` after all subcommands. 

- [x] The page(s) are in the correct platform directories: `common`.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
