### PR TITLE
git-config: add --show-origin example

### DIFF
--- a/pages/common/git-config.md
+++ b/pages/common/git-config.md
@@ -12,9 +12,9 @@
 
 `git config --list --global`
 
-- List all configuration entries that have been defined either locally or globally:
+- List only system configuration entries (stored in `/etc/gitconfig`), and show their file location:
 
-`git config --list`
+`git config --list --system --show-origin`
 
 - Get the value of a given configuration entry:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
git version 2.37.1


`git config --show-origin` is very helpful when troubleshooting git configs that have `include` and/or `includeif` directives. It shows you where a configuration object comes from.

The purpose of this PR was just to introduce the `--show-origin` flag; but I had to find a way to correct the assumptions made by the two previous commands (showing `--local` and `--global`, but obscuring that `--system` is another configuration scope). So, following TLDR tradition, of making successive commands more complex; I added both `--global` and `--show-origin` to my example.