### PR TITLE
pwd: refresh page

### DIFF
--- a/pages/common/pwd.md
+++ b/pages/common/pwd.md
@@ -10,7 +10,3 @@
 - Print the current directory, and resolve all symlinks (i.e. show the "physical" path):
 
 `pwd -P`
-
-- Print the current logical directory:
-
-`pwd -L`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** latest

## Changes

- according to [this](https://unixhealthcheck.com/blog?id=157) site `-L` example redundant

I think we can always omit options that are enabled by default unless documentation explicitly tells not to rely on this behavior.