### PR TITLE
objdump: add intel syntax command

### DIFF
--- a/pages/common/objdump.md
+++ b/pages/common/objdump.md
@@ -7,9 +7,13 @@
 
 `objdump -f {{binary}}`
 
-- Display the dis-assembled output of executable sections:
+- Display the disassembled output of executable sections:
 
 `objdump -d {{binary}}`
+
+- Disaply the disassembled executable sections in intel syntax:
+
+`objdump -M intel -d {{binary}}`
 
 - Display a complete binary hex dump of all sections:
 

--- a/pages/common/objdump.md
+++ b/pages/common/objdump.md
@@ -11,7 +11,7 @@
 
 `objdump -d {{binary}}`
 
-- Disaply the disassembled executable sections in intel syntax:
+- Display the disassembled executable sections in intel syntax:
 
 `objdump -M intel -d {{binary}}`
 


### PR DESCRIPTION
Also remove hyphen from disassemble to use more common form.

Maybe make a mention intel syntax applies to x86 asm but that should be obvious.

Resolves #8389 
