### PR TITLE
lzip: app page

### DIFF
--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -2,7 +2,7 @@
 
 > Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2. 
 Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
-> More information: <https://www.nongnu.org/lzip/>.
+> More information: <https://www.nongnu.org/lzip>.
 
 - Archive a file, replacing it with an lzipped compressed version:
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,10 +1,10 @@
 # lzip
 
-> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.
+> Lzip is a lossless data compressor with a user interface similar to gzip or bzip2.
 > Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
 > More information: <https://www.nongnu.org/lzip>.
 
-- Archive a file, replacing it with an lzipped compressed version:
+- Archive a file, replacing it with with a compressed version:
 
 `lzip {{path/to/file}}`
 
@@ -22,16 +22,16 @@
 
 - Test the integrity of compressed file:
 
-`lzip --test {{compressed.ext}}.lz`
+`lzip --test {{path/to/archive.lz}}`
 
 - Decompress a file, replacing it with the original uncompressed version:
 
-`lzip -d {{compressed.ext}}.lz`
+`lzip -d {{path/to/archive.lz}}`
 
 - Decompress a file, keeping the archive:
 
-`lzip -d -k {{compressed.ext}}.lz`
+`lzip -d -k {{path/to/archive.lz}}
 
 - List files which are in an archive and show compression stats:
 
-`lzip --list {{compressed.ext}}.lz`
+`lzip --list {{path/to/archive.lz}}

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -16,7 +16,7 @@
 
 `lzip -k {{path/to/file}} --best`
 
-- Archive a file at the fastest speed (level=0): 
+- Archive a file at the fastest speed (level=0):
 
 `lzip -k {{path/to/file}} --fast`
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -34,4 +34,4 @@
 
 - List files which are in an archive and show compression stats:
 
-`lzip --list {{path/to/archive.lz}}
+`lzip --list {{path/to/archive.lz}}`

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -32,6 +32,6 @@
 
 `lzip -d -k {{compressed.ext}}.lz`
 
-- List files of archive and compression stats:
+- List files which are in an archive and show compression stats:
 
 `lzip --list {{compressed.ext}}.lz`

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,6 +1,6 @@
 # lzip
 
-> Lzip is a lossless data compressor with a user interface similar to gzip or bzip2.
+> Lzip is a lossless data compressor with a user interface similar to `gzip` or `bzip2`.
 > Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
 > More information: <https://www.nongnu.org/lzip>.
 
@@ -30,7 +30,7 @@
 
 - Decompress a file, keeping the archive:
 
-`lzip -d -k {{path/to/archive.lz}}
+`lzip -d -k {{path/to/archive.lz}}`
 
 - List files which are in an archive and show compression stats:
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,7 +1,8 @@
 # lzip
 
-> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2. Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm" (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
-> More information: https://www.nongnu.org/lzip/.
+> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2. 
+Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
+> More information: <https://www.nongnu.org/lzip/>.
 
 - Archive a file, replacing it with an lzipped compressed version:
 
@@ -9,7 +10,7 @@
 
 - Archive a file keeping the input file:
 
-`lzip -k {{path/to/file}} `
+`lzip -k {{path/to/file}}`
 
 - Archive a file with best compression (level=9):
 
@@ -31,6 +32,6 @@
 
 `lzip -d -k {{compressed.ext}}.lz`
 
-- List files of archive and compression stats
+- List files of archive and compression stats:
 
 `lzip --list {{compressed.ext}}.lz`

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,0 +1,39 @@
+# lzip
+
+>Lzip is a lossless data compressor with a user interface similar to the one
+of gzip or bzip2. Lzip uses a simplified form of the 'Lempel-Ziv-Markov
+chain-Algorithm' (LZMA) stream format and provides a 3 factor integrity
+checking to maximize interoperability and optimize safety.
+> More information: https://www.nongnu.org/lzip/
+
+- Archive a file, replacing it with an lzipped compressed version:
+
+`lzip {{path/to/file}}`
+
+- Archive a file keeping the input file:
+
+`lzip -k {{path/to/file}} `
+
+- Archive a file with best compression (level=9):
+
+`lzip -k {{path/to/file}} --best`
+
+- Archive a file at the fastest speed (level=0): 
+
+`lzip -k {{path/to/file}} --fast`
+
+- Test integrity of compressed file:
+
+`lzip --test {{compressed.ext}}.lz`
+
+- Decompress a file, replacing it with the original uncompressed version:
+
+`lzip -d {{compressed.ext}}.lz`
+
+- Decompress a file keeping the input file:
+
+`lzip -d -k {{compressed.ext}}.lz`
+
+- List files of archive and compression stats
+
+`lzip --list {{compressed.ext}}.lz`

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -8,7 +8,7 @@
 
 `lzip {{path/to/file}}`
 
-- Archive a file keeping the input file:
+- Archive a file, keeping the input file:
 
 `lzip -k {{path/to/file}}`
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -12,7 +12,7 @@
 
 `lzip -k {{path/to/file}}`
 
-- Archive a file with best compression (level=9):
+- Archive a file with the best compression (level=9):
 
 `lzip -k {{path/to/file}} --best`
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -28,7 +28,7 @@
 
 `lzip -d {{compressed.ext}}.lz`
 
-- Decompress a file keeping the input file:
+- Decompress a file, keeping the archive:
 
 `lzip -d -k {{compressed.ext}}.lz`
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,10 +1,10 @@
 # lzip
 
->Lzip is a lossless data compressor with a user interface similar to the one
-of gzip or bzip2. Lzip uses a simplified form of the 'Lempel-Ziv-Markov
-chain-Algorithm' (LZMA) stream format and provides a 3 factor integrity
+> Lzip is a lossless data compressor with a user interface similar to the one
+of gzip or bzip2. Lzip uses a simplified form of the Lempel-Ziv-Markov
+chain-Algorithm (LZMA) stream format and provides a 3 factor integrity
 checking to maximize interoperability and optimize safety.
-> More information: https://www.nongnu.org/lzip/
+> More information: https://www.nongnu.org/lzip/.
 
 - Archive a file, replacing it with an lzipped compressed version:
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,6 +1,6 @@
 # lzip
 
-> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2. 
+> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.
 Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
 > More information: <https://www.nongnu.org/lzip>.
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,9 +1,6 @@
 # lzip
 
-> Lzip is a lossless data compressor with a user interface similar to the one
-of gzip or bzip2. Lzip uses a simplified form of the Lempel-Ziv-Markov
-chain-Algorithm (LZMA) stream format and provides a 3 factor integrity
-checking to maximize interoperability and optimize safety.
+> Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2. Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm" (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
 > More information: https://www.nongnu.org/lzip/.
 
 - Archive a file, replacing it with an lzipped compressed version:

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -1,7 +1,7 @@
 # lzip
 
 > Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.
-Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
+> Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm"z (LZMA) stream format and provides a 3 factor integrity checking to maximize interoperability and optimize safety.
 > More information: <https://www.nongnu.org/lzip>.
 
 - Archive a file, replacing it with an lzipped compressed version:

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -20,7 +20,7 @@
 
 `lzip -k {{path/to/file}} --fast`
 
-- Test integrity of compressed file:
+- Test the integrity of compressed file:
 
 `lzip --test {{compressed.ext}}.lz`
 


### PR DESCRIPTION
Added lzip common page, based on the 7z example (commands are very similar)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.23
