### PR TITLE
emacs: add `--script` example

### DIFF
--- a/pages/common/emacs.md
+++ b/pages/common/emacs.md
@@ -12,6 +12,10 @@
 
 `emacs +{{line_number}} {{path/to/file}}`
 
+- Run an Emacs Lisp file as a script:
+
+`emacs --script {{path/to/file.el}}`
+
 - Start Emacs in console mode (without an X window):
 
 `emacs --no-window-system`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

I think it's valuable to acknowledge Emacs's capability as a script backend. It seems a lot of people seem to forget/miss this, even when they're testing their own Elisp files or performing script-like actions with Emacs.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 28.1
