### PR TITLE
wipefs: add --all example with glob pattern

### DIFF
--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -13,7 +13,7 @@
 
 - Wipe all available signature types for the device and partitions using a glob pattern:
 
-`sudo wipefs --all {{/dev/sdX*}}`
+`sudo wipefs --all {{/dev/sdX}}*`
 
 - Perform dry run:
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -7,7 +7,7 @@
 
 `sudo wipefs {{/dev/sdX}}`
 
-- Wipe all available signature types for a specific device (no recursion into partitions):
+- Wipe all available signature types for a specific device with no recursion into partitions:
 
 `sudo wipefs --all {{/dev/sdX}}`
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -7,11 +7,11 @@
 
 `sudo wipefs {{/dev/sdX}}`
 
-- Wipe all available signatures for specified device level (no recursion to sub-level block layers):
+- Wipe all available signature types for the device (no recursion into partitions):
 
 `sudo wipefs --all {{/dev/sdX}}`
 
-- Wipd all available signatures for the specified device at all block levels using a glob pattern:
+- Wipe all available signature types for the device and partitions using a glob pattern:
 
 `sudo wipefs --all {{/dev/sdX*}}`
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -11,7 +11,7 @@
 
 `sudo wipefs --all {{/dev/sdX}}`
 
-- Wipd all available signatures for specified device at all block levels using a glob pattern:
+- Wipd all available signatures for the specified device at all block levels using a glob pattern:
 
 `sudo wipefs --all {{/dev/sdX*}}`
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -7,9 +7,13 @@
 
 `sudo wipefs {{/dev/sdX}}`
 
-- Wipe all available signatures for specified device:
+- Wipe all available signatures for specified device level (no recursion to sub-level block layers):
 
 `sudo wipefs --all {{/dev/sdX}}`
+
+- Wipd all available signatures for specified device at all block levels using a glob pattern:
+
+`sudo wipefs --all {{/dev/sdX*}}
 
 - Perform dry run:
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -7,7 +7,7 @@
 
 `sudo wipefs {{/dev/sdX}}`
 
-- Wipe all available signature types for the device (no recursion into partitions):
+- Wipe all available signature types for a specific device (no recursion into partitions):
 
 `sudo wipefs --all {{/dev/sdX}}`
 

--- a/pages/linux/wipefs.md
+++ b/pages/linux/wipefs.md
@@ -13,7 +13,7 @@
 
 - Wipd all available signatures for specified device at all block levels using a glob pattern:
 
-`sudo wipefs --all {{/dev/sdX*}}
+`sudo wipefs --all {{/dev/sdX*}}`
 
 - Perform dry run:
 


### PR DESCRIPTION
It may often be misconceived that `wipefs --all /dev/sdX` will recurse and wipe sub-level block signatures, i.e. those for filesystems, etc. However `--all` does not recurse the layers. In order to more fully wipe at all layers, the glob pattern can help make the wiping more thorough.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
