### PR TITLE
g++: add multiple file example

### DIFF
--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -4,10 +4,6 @@
 > Part of GCC (GNU Compiler Collection).
 > More information: <https://gcc.gnu.org>.
 
-- Display version:
-
-`g++ --version`
-
 - Compile a source code file into an executable binary:
 
 `g++ {{path/to/source.cpp}} -o {{path/to/output_executable}}`
@@ -27,3 +23,7 @@
 - Compile and link multiple source code files into executable binary:
 
 `g++ -c {{path/to/source_1.cpp}} {{path/to/source_2.cpp}} && g++ -o {{path/to/output_executable}} {{path/to/source_1.o}} {{path/to/source_2.o}}`
+
+- Display version:
+
+`g++ --version`

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -22,7 +22,7 @@
 
 - Compile and link multiple source code files into executable binary:
 
-`g++ -c {{path/to/source_1.cpp}} {{path/to/source_2.cpp}} && g++ -o {{path/to/output_executable}} {{path/to/source_1.o}} {{path/to/source_2.o}}`
+`g++ -c {{path/to/source_1.cpp path/to/source_2.cpp ...}} && g++ -o {{path/to/output_executable}} {{path/to/source_1.o path/to/source_2.o ...}}`
 
 - Display version:
 

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -4,7 +4,7 @@
 > Part of GCC (GNU Compiler Collection).
 > More information: <https://gcc.gnu.org>.
 
-- Check compiler version information:
+- Display version:
 
 `g++ --version`
 

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -4,6 +4,10 @@
 > Part of GCC (GNU Compiler Collection).
 > More information: <https://gcc.gnu.org>.
 
+- Check compiler version information:
+
+`g++ --version`
+
 - Compile a source code file into an executable binary:
 
 `g++ {{path/to/source.cpp}} -o {{path/to/output_executable}}`
@@ -19,3 +23,7 @@
 - Include libraries located at a different path than the source file:
 
 `g++ {{path/to/source.cpp}} -o {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
+
+- Compile and link multiple source code files into executable binary:
+
+`g++ -c {{path/to/source_1.cpp}} {{path/to/source_2.cpp}} && g++ -o {{path/to/output_executable}} {{path/to/source_1.o}} {{path/to/source_2.o}}`

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -20,7 +20,7 @@
 
 `g++ {{path/to/source.cpp}} -o {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
 
-- Compile and link multiple source code files into executable binary:
+- Compile and link multiple source code files into an executable binary:
 
 `g++ -c {{path/to/source_1.cpp path/to/source_2.cpp ...}} && g++ -o {{path/to/output_executable}} {{path/to/source_1.o path/to/source_2.o ...}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->
Added the version command as well as multiple file compile and link commands for g++.

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
