### PR TITLE
cargo: add example to compile using the nightly version

### DIFF
--- a/pages/common/cargo.md
+++ b/pages/common/cargo.md
@@ -28,6 +28,10 @@
 
 `cargo build`
 
+- Build the rust project in the current directory using the nightly compiler:
+
+`cargo +nightly build`
+
 - Build using a specific number of threads (default is the number of CPU cores):
 
 `cargo build --jobs {{number_of_threads}}`


### PR DESCRIPTION
The `+nightly` syntax is somewhat unusual and easy to forget. It composes nicely with many other cargo commands. None of the others have a +nightly example as yet.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.62.1
