### PR TITLE
asdf: remove hyphens from subcommands

### DIFF
--- a/pages/common/asdf.md
+++ b/pages/common/asdf.md
@@ -5,15 +5,15 @@
 
 - List all available plugins:
 
-`asdf plugin-list-all`
+`asdf plugin list all`
 
 - Install a plugin:
 
-`asdf plugin-add {{name}}`
+`asdf plugin add {{name}}`
 
 - List all available versions for a package:
 
-`asdf list-all {{name}}`
+`asdf list all {{name}}`
 
 - Install a specific version of a package:
 


### PR DESCRIPTION
Recent versions of asdf have [subcommands that have their own subcommands](https://asdf-vm.com/manage/commands.html#all-commands), so hyphens are no longer valid

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 0.10.2
