### PR TITLE
docker-compose: update command to v2

### DIFF
--- a/pages.de/common/docker-compose.md
+++ b/pages.de/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Starte und verwalte Anwendungen, welche aus mehreren Docker Containern bestehen.
 > Weitere Informationen: <https://docs.docker.com/compose/reference/>.
 
 - Liste alle laufenden Container auf:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Erzeuge und starte alle Container im Hintergrund unter der Verwendung der Datei `docker-compose.yml` im aktuellen Verzeichnis:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Starte alle Container. Erzeuge zugehörige Docker Images bei Bedarf neu:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Starte alle Container unter Verwendung einer alternativen Compose Datei:
 
-`docker-compose --file {{pfad/zu/verzeichnis}} up`
+`docker compose --file {{pfad/zu/verzeichnis}} up`
 
 - Stoppe alle laufenden Container:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Stoppe und entferne alle Container inklusive zugehöriger Netzwerke, Volumes und Images:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Zeige die Logs aller Container kontinuierlich an:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Zeige die Logs eines spezifischen Containers kontinuierlich an:
 
-`docker-compose logs --follow {{container_name}}`
+`docker compose logs --follow {{container_name}}`

--- a/pages.es/common/docker-compose.md
+++ b/pages.es/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Ejecuta y gestiona múltiples contenedores Docker.
 > Más información: <https://docs.docker.com/compose/reference/>.
 
 - Lista los contenedores en ejecución:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Crea e inicia todos los contenedores en segundo plano usando el archivo `docker-compose.yml` en el directorio actual:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Inicia todos los contenedores y reconstruye si es ncesario:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Inicia todos los contenedores usando un archivo compose alternativo:
 
-`docker-compose --file {{ruta/al/directorio}} up`
+`docker compose --file {{ruta/al/directorio}} up`
 
 - Detiene todos los contenedores en ejecución:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Detiene y elimina todos los contenedores, redes, imágenes y volúmenes:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Sigue los registros de todos los contenedores:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Sigue los registros de un contenedor específico:
 
-`docker-compose logs --follow {{nombre_de_contenedor}}`
+`docker compose logs --follow {{nombre_de_contenedor}}`

--- a/pages.fr/common/docker-compose.md
+++ b/pages.fr/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Exécute et gère des applications au travers de plusieurs conteneurs Docker.
 > Plus d'informations : <https://docs.docker.com/compose/reference/>.
 
 - Liste tous les conteneurs en cours d'exécution :
 
-`docker-compose ps`
+`docker compose ps`
 
 - Crée et démarre en arrière-plan tous les conteneurs décrits dans le fichier `docker-compose.yml` du répertoire courant :
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Démarre tous les conteneurs après les avoir recréés si nécessaire :
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Démarre tous les conteneurs spécifiés dans un fichier compose alternatif :
 
-`docker-compose --file {{chemin/vers/fichier}} up`
+`docker compose --file {{chemin/vers/fichier}} up`
 
 - Arrête tous les conteneurs en cours d'exécution :
 
-`docker-compose stop`
+`docker compose stop`
 
 - Arrête et supprime tous les conteneurs, réseaux, images et volumes :
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Affiche et suit la journalisation de tous les conteneurs :
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Affiche et suit la journalisation pour un conteneurs spécifique :
 
-`docker-compose logs --follow {{nom_container}}`
+`docker compose logs --follow {{nom_container}}`

--- a/pages.it/common/docker-compose.md
+++ b/pages.it/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Esegui e gestisci applicazioni Docker composte da più container.
 > Maggiori informazioni: <https://docs.docker.com/compose/reference/>.
 
 - Elenca i container in esecuzione:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Crea ed avvia tutti i container in background utilizzando il file `docker-compose.yml` nella directory corrente:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Avvia tutti i container, buildandoli di nuovo se necessario:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Avvia tutti i container utilizzando un file compose alternativo:
 
-`docker-compose --file {{percorso/a/file}} up`
+`docker compose --file {{percorso/a/file}} up`
 
 - Ferma tutti i container in esecuzione:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Ferma e rimuovi tutti i container, reti, immagini e volumi:
 
-`docker-compose down`
+`docker compose down`
 
 - Segui i log di tutti i container:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Segui i log di un container specifico:
 
-`docker-compose logs --follow {{nome_container}}`
+`docker compose logs --follow {{nome_container}}`

--- a/pages.ko/common/docker-compose.md
+++ b/pages.ko/common/docker-compose.md
@@ -1,32 +1,32 @@
-# docker-compose
+# docker compose
 
 > 다중 도커 응용 프로그램 실행 및 관리합니다.
 > 더 많은 정보: <https://docs.docker.com/compose/reference/>.
 
 - 실행 중인 모든 컨테이너들 목록:
 
-`docker-compose ps`
+`docker compose ps`
 
 - 현재 디렉토리로로부터 `docker-compose.yml` 파일을 사용하여 백그라운드에서 모든 컨테이너들을 생성하고 실행하기:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - 모든 컨테이너들을 실행하고, 필요 시 재조립:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - 대체 구성 파일을 사용하여 모든 컨테이너들 실행하기:
 
-`docker-compose --file {{경로/파일명}} up`
+`docker compose --file {{경로/파일명}} up`
 
 - 실행중인 모든 컨테이너들 중지하기:
 
-`docker-compose stop`
+`docker compose stop`
 
 - 모든 컨테이너들, 네트워크, 이미지, 그리고 볼륨을 중지하고 제거하기:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - 모든 컨테이너들에 대한 로그들 팔로우:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`

--- a/pages.pt_BR/common/docker-compose.md
+++ b/pages.pt_BR/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Executa e gerencia multi-containers de aplicações Docker
 > Mais informações: <https://docs.docker.com/compose/reference/>.
 
 - Lista todos os containers em execução:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Cria e inicia todos os containers em segundo plano usando um arquivo `docker-compose.yml` do seu diretório atual:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Inicia todos os containers. Se necessário, realiza um rebuild:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Inicia todos os containers que estão usando um arquivo compose alternativo:
 
-`docker-compose --file {{caminho/para/arquivo}} up`
+`docker compose --file {{caminho/para/arquivo}} up`
 
 - Encerra todos os containers em execução:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Encerra e remove todos os containers, networks, imagens e volumes:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Segue os logs de todos os containers:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Segue os logs de um container específico
 
-`docker-compose logs --follow {{nome_container}}`
+`docker compose logs --follow {{nome_container}}`

--- a/pages.tr/common/docker-compose.md
+++ b/pages.tr/common/docker-compose.md
@@ -5,32 +5,32 @@
 
 - Tüm konteynerleri listele:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Mevcut dizinde bir `docker-compose.yml` dosyası çalıştırarak arkaplandaki tüm konteynerleri çalıştırın ve başlatın:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Tüm konteynerleri çalıştırın ve gerekiyorsa yeniden oluşturun:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Tüm konteynerleri alternatif bir beste dosyasıyla başlatın:
 
-`docker-compose --file {{yoldan/dosyaya}} up`
+`docker compose --file {{yoldan/dosyaya}} up`
 
 - Çalışan tüm konteynerleri durdurun:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Tüm konteynerleri, ağları, imgeleri ve alanları durdurun ve silin:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Tüm konteynerler için logları takip edin:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Belirtilmiş bir konteyner için logları takip edin:
 
-`docker-compose logs --follow {{konteyner_ismi}}`
+`docker compose logs --follow {{konteyner_ismi}}`

--- a/pages/common/docker-compose.md
+++ b/pages/common/docker-compose.md
@@ -1,36 +1,36 @@
-# docker-compose
+# docker compose
 
 > Run and manage multi container docker applications.
 > More information: <https://docs.docker.com/compose/reference/>.
 
 - List all running containers:
 
-`docker-compose ps`
+`docker compose ps`
 
 - Create and start all containers in the background using a `docker-compose.yml` file from the current directory:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 - Start all containers, rebuild if necessary:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Start all containers using an alternate compose file:
 
-`docker-compose --file {{path/to/file}} up`
+`docker compose --file {{path/to/file}} up`
 
 - Stop all running containers:
 
-`docker-compose stop`
+`docker compose stop`
 
 - Stop and remove all containers, networks, images, and volumes:
 
-`docker-compose down --rmi all --volumes`
+`docker compose down --rmi all --volumes`
 
 - Follow logs for all containers:
 
-`docker-compose logs --follow`
+`docker compose logs --follow`
 
 - Follow logs for a specific container:
 
-`docker-compose logs --follow {{container_name}}`
+`docker compose logs --follow {{container_name}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Docker Compose version v2.6.0

A while back docker-compose (v1) was deprecated in favor of a plugin for Docker called compose (v2).

Because of this change, we now do `docker compose` instead of `docker-compose`.

> The new Compose V2, which supports the compose command as part of the Docker CLI, is now available.
> 
> Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
> 
> — https://docs.docker.com/compose/reference/

This does spotlight a potential problem with our current naming convention, however.
For example, a hypothetical binary `make file` would be named and indexed as `make-file`, while the binary `make` with command `file` (i.e. `make file`) would also be indexed as `make-file`. Not an immediate problem as I can't think of a real-world scenario that may've caused problems, but figured I'd make a note of it.