### PR TITLE
style-guide: fix links

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -185,7 +185,7 @@ This can be resolved by inserting a comma before the "and" or "or" in the final 
 
 On the `More information` line, prefer linking to the author's provided documentation.
 
-When not available, use <https://manned.org/> as the default fallback. 
+When not available, use <https://manned.org> as the default fallback. 
 
 ## Chinese-Specific Rules
 
@@ -210,4 +210,4 @@ The following guidelines are applied to Chinese (zh) and traditional Chinese (zh
 
 In order to maintain readability and normalization, please comply the 6 rules above as much as possible when translating pages into Chinese.
 
-For more information and examples of Chinese-specific rules, check out [*Chinese Copywriting Guidelines*](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en-US.md).
+For more information and examples of Chinese-specific rules, check out [*Chinese Copywriting Guidelines*](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en.md).

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -101,8 +101,8 @@ Example:
 
 `tldr vim`
 
-Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md).
 ```
+- Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md).
 
 ## Token syntax
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Changes

- Removing trailing `/` from the manned link.
- Updating **Chinese Copywriting Guideline** link from <https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en-US.md> (The link doesn't work as the file name appears to have changed, In GitHub mobile app the link just defaults to the repository, I think updating the link would be better.) to <https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en.md>.
- Moving Line 104: "**Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md)**" outside codeblock. I think it is an error being placed inside the example codeblock.