### PR TITLE
cdk: fix typo in example

### DIFF
--- a/pages/common/cdk.md
+++ b/pages/common/cdk.md
@@ -29,4 +29,4 @@
 
 - Open the CDK API reference in your browser:
 
-`cdk doc`
+`cdk docs`


### PR DESCRIPTION
As per https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-ref The proper command is `cdk docs`

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
