### PR TITLE
smalltalkci: remove superfluous space

### DIFF
--- a/pages/common/smalltalkci.md
+++ b/pages/common/smalltalkci.md
@@ -21,7 +21,7 @@
 
 - Specify a custom Smalltalk image and VM:
 
-`smalltalkci --image {{path/to/Smalltalk.image}} -- vm {{path/to/vm}}`
+`smalltalkci --image {{path/to/Smalltalk.image}} --vm {{path/to/vm}}`
 
 - Clean up caches and delete builds:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

This was indeed a slip. `--vm` is a regular optional argument:

```
$ smalltalkci --help
  USAGE: run.sh [options] /path/to/project/your_smalltalk.ston

  This program prepares Smalltalk images/vms, loads projects, and runs tests.

  OPTIONS:
    --clean             Clear cache and delete builds.
    -d | --debug        Enable debug mode.
    -h | --help         Show this help text.
    --headful           Open vm in headful mode and do not close image.
    --image             Custom image for build (Squeak/Pharo).
    --install           Install symlink to this smalltalkCI instance.
    --print-env         Print all environment variables used by smalltalkCI
    --no-color          Disable colored output
    --no-tracking       Disable collection of anonymous build metrics (TravisCI & AppVeyor only).
    -s | --smalltalk    Overwrite Smalltalk image selection.
    --uninstall         Remove symlink to any smalltalkCI instance.
    -v | --verbose      Enable 'set -x'.
    --vm                Custom VM for build (Squeak/Pharo).

  GEMSTONE OPTIONS:
    --gs-BRANCH=<branch-SHA-tag>
                        Name of GsDevKit_home branch, SHA, or tag. Default is 'master'.

                        Environment variable GSCI_DEVKIT_BRANCH may be used to
                        specify <branch-SHA-tag>. Command line option overrides
                        value of environment variable.

    --gs-HOME=<GS_HOME-path>
                        Path to an existing GsDevKit_home clone to be used
                        instead of creating a fresh clone.

                        --gs-DEVKIT_BRANCH option is ignored.

    --gs-CLIENTS="<smalltalk-platform>..."
                        List of Smalltalk client versions to use as a GemStone client.

                        Environment variable GSCI_CLIENTS may also be used to
                        specify a list of <smalltalk-platform> client versions.
                        Command line option overrides value of environment variable.

                        If a client is specified, tests are run for both the client
                        and server based using the project .smalltalk.ston file.

  EXAMPLE:
    run.sh -s "Squeak64-trunk" --headfull /path/to/project/.smalltalk.ston
```

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** v3.0.0
