### PR TITLE
rpi-imager: add page

### DIFF
--- a/pages/common/rpi-imager.md
+++ b/pages/common/rpi-imager.md
@@ -1,6 +1,6 @@
 # rpi-imager
 
-> Flash images onto storage drives.
+> Flash images onto storage devices.
 > More information: <https://github.com/raspberrypi/rpi-imager>.
 
 - Write a specific image to a specific block device:

--- a/pages/common/rpi-imager.md
+++ b/pages/common/rpi-imager.md
@@ -1,0 +1,16 @@
+# rpi-imager
+
+> Flash images onto storage drives.
+> More information: <https://github.com/raspberrypi/rpi-imager>.
+
+- Write a specific image to a specific block device:
+
+`rpi-imager --cli {{path/to/image.zip}} {{/dev/sdX}}`
+
+- Write a specific image to a block device, disabling the checksum verification:
+
+`rpi-imager --cli --disable-verify {{path/to/image.zip}} {{/dev/sdX}}`
+
+- Write a specific image to a block device, which will expect a specific checksum when running the verification:
+
+`rpi-imager --cli --sha256 {{expected_hash}} {{path/to/image.zip}} {{/dev/sdX}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

