### PR TITLE
gnatmake, gnatprep, gprbuild: add page

### DIFF
--- a/pages/common/gnatmake.md
+++ b/pages/common/gnatmake.md
@@ -1,0 +1,16 @@
+# gnatmake
+
+> A low-level build tool for Ada programs (part of the GNAT toolchain).
+> More information: <https://gcc.gnu.org/onlinedocs/gnat_ugn/Building-with-gnatmake.html>.
+
+- Compile an executable:
+
+`gnatmake {{source_file1.adb source_file2.adb ...}}`
+
+- Set a custom executable name:
+
+`gnatmake -o {{executable_name}} {{source_file.adb}}`
+
+- Force recompilation:
+
+`gnatmake -f {{source_file.adb}}`

--- a/pages/common/gnatmake.md
+++ b/pages/common/gnatmake.md
@@ -11,6 +11,6 @@
 
 `gnatmake -o {{executable_name}} {{source_file.adb}}`
 
-- Force recompilation:
+- [f]orce recompilation:
 
 `gnatmake -f {{source_file.adb}}`

--- a/pages/common/gnatprep.md
+++ b/pages/common/gnatprep.md
@@ -1,0 +1,12 @@
+# gnatprep
+
+> Preprocessor for Ada source code files (part of the GNAT toolchain).
+> More information: <https://gcc.gnu.org/onlinedocs/gnat_ugn/Preprocessing-with-gnatprep.html>.
+
+- Use symbol definitions from a file:
+
+`gnatprep {{source_file}} {{target_file}} {{definitions_file}}`
+
+- Specify symbol values in the command line:
+
+`gnatprep -D{{name}}={{value}} {{source_file}} {{target_file}}`

--- a/pages/common/gprbuild.md
+++ b/pages/common/gprbuild.md
@@ -7,7 +7,7 @@
 
 `gprbuild`
 
-- Specify the [P]roject file to build:
+- Build a specific [P]roject file:
 
 `gprbuild -P{{project_name}}`
 

--- a/pages/common/gprbuild.md
+++ b/pages/common/gprbuild.md
@@ -7,7 +7,7 @@
 
 `gprbuild`
 
-- Specify project file to build:
+- Specify the [P]roject file to build:
 
 `gprbuild -P{{project_name}}`
 

--- a/pages/common/gprbuild.md
+++ b/pages/common/gprbuild.md
@@ -1,0 +1,20 @@
+# gprbuild
+
+> A high-level build tool for projects written in Ada and other languages (C/C++/Fortran).
+> More information: <https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug.html>.
+
+- Build a project (assuming only one `*.gpr` file exists in the current directory):
+
+`gprbuild`
+
+- Specify project file to build:
+
+`gprbuild -P{{project_name}}`
+
+- Clean up the build workspace:
+
+`gprclean`
+
+- Install compiled binaries:
+
+`gprinstall --prefix {{path/to/installation/dir}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Add pages for [Ada](https://ada-lang.io/) build tools. gnatmake and gnatprep are from the GNAT toolchain (which is also a part of the GCC compiler suit), while gprbuild is a separate tool developed by AdaCore and released under the GNU GPL.  

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

