### PR TITLE
git commit: Use spelled-out version of single letter options 

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -5,7 +5,7 @@
 
 - Commit staged files to the repository with a message:
 
-`git commit -m "{{message}}"`
+`git commit --message="{{message}}"`
 
 - Commit staged files with a message read from a file:
 
@@ -13,11 +13,11 @@
 
 - Auto stage all modified files and commit with a message:
 
-`git commit -a -m "{{message}}"`
+`git commit --all --message="{{message}}"`
 
 - Commit staged files and [S]ign them with the GPG key defined in `~/.gitconfig`:
 
-`git commit -S -m "{{message}}"`
+`git commit --gpg-sign --message="{{message}}"`
 
 - Update the last commit by adding the currently staged changes, changing the commit's hash:
 
@@ -29,4 +29,4 @@
 
 - Create a commit, even if there are no staged files:
 
-`git commit -m "{{message}}" --allow-empty`
+`git commit --message="{{message}}" --allow-empty`


### PR DESCRIPTION
Implement point 3 of https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
