### PR TITLE
octave: add page

### DIFF
--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -11,7 +11,7 @@
 
 `octave {{path/to/script.m}}`
 
-- Execute a script file with arguments:
+- Execute a script file with specific arguments:
 
 `octave {{path/to/script.m}} {{arg1}} {{arg2}}`
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -7,7 +7,7 @@
 
 `octave`
 
-- Execute a script file:
+- Execute a specific script file:
 
 `octave {{path/to/script.m}}`
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -15,7 +15,7 @@
 
 `octave {{path/to/script.m}} {{arg1 arg2 ...}}`
 
-- Start an interactive Octave session with a GUI:
+- Start an interactive session with a GUI:
 
 `octave --gui`
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -13,7 +13,7 @@
 
 - Execute a script file with specific arguments:
 
-`octave {{path/to/script.m}} {{arg1}} {{arg2}}`
+`octave {{path/to/script.m}} {{arg1 arg2 ...}}`
 
 - Start an interactive Octave session with a GUI:
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -13,7 +13,7 @@
 
 - Execute a script file with specific arguments:
 
-`octave {{path/to/script.m}} {{arg1 arg2 ...}}`
+`octave {{path/to/script.m}} {{argument1 argument2 ...}}`
 
 - Start an interactive session with a GUI:
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -3,7 +3,7 @@
 > GNU Octave is a programming language for scientific computing.
 > More information: <https://docs.octave.org/latest/Invoking-Octave-from-the-Command-Line.html>.
 
-- Start an interactive Octave session:
+- Start an interactive session:
 
 `octave`
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -11,7 +11,7 @@
 
 `octave {{path/to/script.m}}`
 
-- Execute a script file and pass arguments:
+- Execute a script file with arguments:
 
 `octave {{path/to/script.m}} {{arg1}} {{arg2}}`
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -1,0 +1,28 @@
+# octave
+
+> GNU Octave is a programming language for scientific computing..
+> More information: <https://docs.octave.org/latest/>.
+
+- Start an interactive Octave session:
+
+`octave`
+
+- Execute a script file:
+
+`octave {{path/to/script.m}}`
+
+- Execute a script file and pass arguments:
+
+`octave {{path/to/script.m}} {{arg1}} {{arg2}}`
+
+- Start an interactive Octave session with a GUI:
+
+`octave --gui`
+
+- Display help:
+
+`octave --help`
+
+- Display version information:
+
+`octave --version`

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -1,7 +1,7 @@
 # octave
 
 > GNU Octave is a programming language for scientific computing..
-> More information: <https://docs.octave.org/latest/>.
+> More information: <https://docs.octave.org/latest/Invoking-Octave-from-the-Command-Line.html>.
 
 - Start an interactive Octave session:
 

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -1,6 +1,6 @@
 # octave
 
-> GNU Octave is a programming language for scientific computing..
+> GNU Octave is a programming language for scientific computing.
 > More information: <https://docs.octave.org/latest/Invoking-Octave-from-the-Command-Line.html>.
 
 - Start an interactive Octave session:

--- a/pages/common/octave.md
+++ b/pages/common/octave.md
@@ -23,6 +23,6 @@
 
 `octave --help`
 
-- Display version information:
+- Display version:
 
 `octave --version`


### PR DESCRIPTION
Adds a page for [GNU Octave](https://octave.org/). Addresses https://github.com/tldr-pages/tldr/issues/7419

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
