### PR TITLE
aws-route53: add page

### DIFF
--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -17,7 +17,7 @@
 
 - Delete a zone (if the zone has non-defaults SOA and NS records the command will fail):
 
-`aws route53 delete-hosted-zone --id {{zone_id}} `
+`aws route53 delete-hosted-zone --id {{zone_id}}`
 
 - Test DNS resolving by Amazon servers of a given zone:
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -11,7 +11,7 @@
 
 `aws route53 list-resource-record-sets --hosted-zone-id {{zone_id}}`
 
-- Create a new, public zone:
+- Create a new, public zone using a request identifier to retry the operation safely:
 
 `aws route53 create-hosted-zone --name {{name}} --caller-reference {{request_identifier}}`
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -5,7 +5,7 @@
 
 - List all hosted zones, private and public:
 
-`aws route53 list-hosted-zones `
+`aws route53 list-hosted-zones`
 
 - Show all records in a zone:
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -13,7 +13,7 @@
 
 - Create a new, public zone:
 
-`aws route53 create-hosted-zone --name {{name}} --caller-reference {{any-text-for-your-own-reference}}`
+`aws route53 create-hosted-zone --name {{name}} --caller-reference {{request_identifier}}`
 
 - Delete a zone (it has to be empty from any records but the default NS ones):
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -15,7 +15,7 @@
 
 `aws route53 create-hosted-zone --name {{name}} --caller-reference {{request_identifier}}`
 
-- Delete a zone (it has to be empty from any records but the default NS ones):
+- Delete a zone (if the zone has non-defaults SOA and NS records the command will fail):
 
 `aws route53 delete-hosted-zone --id {{zone_id}} `
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -1,7 +1,7 @@
 # aws route53
 
 > CLI for AWS Route53 - Route 53 is a highly available and scalable Domain Name System (DNS) web service.
-> More information: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/route53/index.html.
+> More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/route53/index.html>.
 
 - List all hosted zones, private and public:
 

--- a/pages/common/aws-route53.md
+++ b/pages/common/aws-route53.md
@@ -1,0 +1,24 @@
+# aws route53
+
+> CLI for AWS Route53 - Route 53 is a highly available and scalable Domain Name System (DNS) web service.
+> More information: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/route53/index.html.
+
+- List all hosted zones, private and public:
+
+`aws route53 list-hosted-zones `
+
+- Show all records in a zone:
+
+`aws route53 list-resource-record-sets --hosted-zone-id {{zone_id}}`
+
+- Create a new, public zone:
+
+`aws route53 create-hosted-zone --name {{name}} --caller-reference {{any-text-for-your-own-reference}}`
+
+- Delete a zone (it has to be empty from any records but the default NS ones):
+
+`aws route53 delete-hosted-zone --id {{zone_id}} `
+
+- Test DNS resolving by Amazon servers of a given zone:
+
+`aws route53 test-dns-answer --hosted-zone-id {{zone_id}}  --record-name {{name}} --record-type {{type}}`


### PR DESCRIPTION
Hi everyone, 
adding a new page for AWS Route53 CLI tool.
Thanks
Yuri.

N.B. I was thinking of showing how to add an A record to a zone, unfortunately, it requires the input to be in JSON (on CLI or from file), so not sure if it suits here. E.g.:

- Add A record www.example.com to the zone file "example.com":

aws route53 change-resource-record-sets --hosted-zone-id {{zone_id}} --change-batch ' {
"Comment": "Adding A record",
"Changes": [
{
"Action": "CREATE",
"ResourceRecordSet": {
"Name": "www.example.com",
"Type": "A",
"TTL": 600,
"ResourceRecords": [
{
"Value": "1.2.3.4"
}
]
}
}
]
}
'

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
