### PR TITLE
aws-s3-ls: add page

### DIFF
--- a/pages/common/aws-s3-ls.md
+++ b/pages/common/aws-s3-ls.md
@@ -1,0 +1,28 @@
+# aws s3 ls
+
+> List AWS S3 buckets, folders (prefixes), and files (objects).
+> More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/ls.html>.
+
+- List all buckets:
+
+`aws s3 ls`
+
+- List files and folders in the root of a bucket (`s3://` is optional):
+
+`aws s3 ls s3://{{bucket_name}}`
+
+- List files and folders directly inside a directory:
+
+`aws s3 ls {{bucket_name}}/{{path/to/directory}}/`
+
+- List all files in a bucket:
+
+`aws s3 ls --recursive {{bucket_name}}`
+
+- List all files in a path with a given prefix:
+
+`aws s3 ls --recursive {{bucket_name}}/{{path/to/directory/}}{{prefix}}`
+
+- Display help:
+
+`aws s3 ls help`


### PR DESCRIPTION
Hello! I was a little bit concerned about how the wording, as AWS S3 uses "prefixes" and "objects" instead of "folders" and "files".

![Screenshot of the command `tldr --render pages/common/aws-s3-ls.md`](https://user-images.githubusercontent.com/8299832/194727639-b4b3edc1-706a-4485-af8e-2d5ca0162092.png)


- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- Tested using `aws-cli/1.23.12 Python/3.6.15 Linux/5.13.0-41-generic botocore/1.25.12`