### PR TITLE
aws, aws-quicksight: add French translation

### DIFF
--- a/pages.fr/common/aws-quicksight.md
+++ b/pages.fr/common/aws-quicksight.md
@@ -24,6 +24,6 @@
 
 `aws quicksight describe-data-set --aws-account-id {{id_compte_aws}} --data-set-id {{id_data_set}}`
 
-- Affiche les personnes qui peuvent accéder au dataset et quels actions ils peuvent effectuer sur ce dernier :
+- Affiche les personnes qui peuvent accéder au dataset et quelles actions ils peuvent effectuer sur ce dernier :
 
 `aws quicksight describe-data-set-permissions --aws-account-id {{id_compte_aws}} --data-set-id {{id_data_set}}`

--- a/pages.fr/common/aws-quicksight.md
+++ b/pages.fr/common/aws-quicksight.md
@@ -1,0 +1,29 @@
+# aws quicksight
+
+> CLI pour AWS QuickSight.
+> Accès aux entrées QuickSight.
+> Plus d'informations : <https://docs.aws.amazon.com/cli/latest/reference/quicksight/>.
+
+- Liste les datasets:
+
+`aws quicksight list-data-sets --aws-account-id {{id_compte_aws}}`
+
+- Liste les utilisateurs :
+
+`aws quicksight list-users --aws-account-id {{id_compte_aws}} --namespace default`
+
+- Liste les groupes :
+
+`aws quicksight list-groups --aws-account-id {{id_compte_aws}} --namespace default`
+
+- Liste les tableaux de bords :
+
+`aws quicksight list-dashboards --aws-account-id {{id_compte_aws}}`
+
+- Affiche les informations détaillées sur un dataset :
+
+`aws quicksight describe-data-set --aws-account-id {{id_compte_aws}} --data-set-id {{id_data_set}}`
+
+- Affiche les personnes qui peuvent accéder au dataset et quels actions ils peuvent effectuer sur ce dernier :
+
+`aws quicksight describe-data-set-permissions --aws-account-id {{id_compte_aws}} --data-set-id {{id_data_set}}`

--- a/pages.fr/common/aws.md
+++ b/pages.fr/common/aws.md
@@ -24,7 +24,7 @@
 
 `aws dynamodb list-tables --region {{us-east-1}} --output yaml`
 
-- Utilise l'aide automatique au remplissage pour une commande :
+- Utilise l'aide automatique au remplissage d'une commande :
 
 `aws iam create-user --cli-auto-prompt`
 

--- a/pages.fr/common/aws.md
+++ b/pages.fr/common/aws.md
@@ -1,0 +1,37 @@
+# aws
+
+> La CLI officielle pour Amazon Web Services.
+> Certaines commandes comme `aws s3` ont leur propre documentation.
+> Plus d'informations : <https://aws.amazon.com/cli>.
+
+- Configure la ligne de commande AWS :
+
+`aws configure wizard`
+
+- Configure la ligne de commande AWS en utilisant le SSO :
+
+`aws configure sso`
+
+- Voir l'aide pour une commande AWS :
+
+`aws {{commande}} help`
+
+- Récupère l'identité de l'appelant (utilisé pour débogguer les permissions) :
+
+`aws sts get-caller-identity`
+
+- Liste les ressources AWS d'une région et affiche le résultat en YAML :
+
+`aws dynamodb list-tables --region {{us-east-1}} --output yaml`
+
+- Utilise l'aide automatique au remplissage pour une commande :
+
+`aws iam create-user --cli-auto-prompt`
+
+- Utilise un guide interactif pour une ressource AWS :
+
+`aws dynamodb wizard {{nouvelle_table}}`
+
+- Génère un squelette CLI en JSON (utile pour l'Infrastructure as Code) :
+
+`aws dynamodb update-table --generate-cli-skeleton`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Worries about this translation

I had some troubles to find a good translation, and i would be glad if another french can review my PR

The sentence is `Use auto prompt to help`. `prompt` is really hard to translate in french because there is no real direct translation, most of the time we must use a word which match the context.

I had a look at the AWS documentation and I notice that this flag just add auto-completion so, i translated `Utilise l'aide automatique au remplissage pour une commande` which means `Use the autocompletion help for this command`

I would like your point of view, is it ok ? (for native english speaker if it's ok to focus on the auto-completion)

