### PR TITLE
gh-pr: mention subcommand pages in command description

### DIFF
--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -1,6 +1,7 @@
 # gh pr
 
 > Manage GitHub pull requests from the command-line.
+> Some subcommands such as `gh pr create` have their own usage documentation.
 > More information: <https://cli.github.com/manual/gh_pr>.
 
 - Create a pull request:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.16.1

For #7470 