### PR TITLE
logcat: improve command description

### DIFF
--- a/pages.es/android/logcat.md
+++ b/pages.es/android/logcat.md
@@ -1,16 +1,16 @@
 # logcat
 
-> Vuelca un registro de mensajes del sistema, incluidos los seguimientos de pila, los casos de error del sistema y los mensajes que escribes desde tu app con la clase Log.
+> Vuelca un registro de mensajes del sistema, incluyendo seguimientos de pila cuando ocurren errores, y mensajes informativos enviados por las aplicaciones.
 > Más información: <https://developer.android.com/studio/command-line/logcat>.
 
-- Mostrar registros del sistema:
+- Muestra registros del sistema:
 
 `logcat`
 
-- Escribir registros del sistema a un archivo:
+- Escribe registros del sistema a un archivo:
 
 `logcat -f {{ruta/al/archivo}}`
 
-- Mostrar líneas que coincidan con una expresión regular:
+- Muestra líneas que coincidan con una expresión regular:
 
 `logcat --regex {{expresión_regular}}`

--- a/pages.es/android/logcat.md
+++ b/pages.es/android/logcat.md
@@ -1,0 +1,16 @@
+# logcat
+
+> Vuelca un registro de mensajes del sistema, incluidos los seguimientos de pila, los casos de error del sistema y los mensajes que escribes desde tu app con la clase Log.
+> Más información: <https://developer.android.com/studio/command-line/logcat>.
+
+- Mostrar registros del sistema:
+
+`logcat`
+
+- Escribir registros del sistema a un archivo:
+
+`logcat -f {{ruta/al/archivo}}`
+
+- Mostrar líneas que coincidan con una expresión regular:
+
+`logcat --regex {{expresión_regular}}`

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -1,6 +1,6 @@
 # logcat
 
-> Dump a log of system messages, including stack traces when the device throws an error and messages that you have written from your app with the Log class.
+> Dump a log of system messages, including stack traces when an error occurred, and information messages logged by applications.
 > More information: <https://developer.android.com/studio/command-line/logcat>.
 
 - Display system logs:

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -1,6 +1,6 @@
 # logcat
 
-> Dump a log of system messages.
+> Dump a log of system messages, including stack traces when the device throws an error and messages that you have written from your app with the Log class.
 > More information: <https://developer.android.com/studio/command-line/logcat>.
 
 - Display system logs:


### PR DESCRIPTION
Start with Spanish translations for Android commands.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
