### PR TITLE
android/*: use imperative mood on Indonesian translation

### DIFF
--- a/pages.id/android/am.md
+++ b/pages.id/android/am.md
@@ -3,18 +3,18 @@
 > Manajer aktivitas untuk Android.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/adb#am>.
 
-- Memulai aktivitas tertentu:
+- Mulaikan aktivitas tertentu:
 
 `am start -n {{com.android.settings/.Settings}}`
 
-- Memulai aktivitas dengan data yang ditentukan:
+- Mulaikan aktivitas dengan data yang ditentukan:
 
 `am start -a {{android.intent.action.VIEW}} -d {{tel:123}}`
 
-- Memulai aktivitas dengan aksi dan kategori tertentu:
+- Mulaikan aktivitas dengan aksi dan kategori tertentu:
 
 `am start -a {{android.intent.action.MAIN}} -c {{android.intent.category.HOME}}`
 
-- Mengubah sebuah Intent menjadi tautan URI:
+- Ubah sebuah Intent menjadi tautan URI:
 
 `am to-uri -a {{android.intent.action.VIEW}} -d {{tel:123}}`

--- a/pages.id/android/bugreport.md
+++ b/pages.id/android/bugreport.md
@@ -1,9 +1,9 @@
 # bugreport
 
-> Menunjukkan sebuah laporan masalah bagi Android.
+> Tunjukkan sebuah laporan masalah bagi Android.
 > Perintah ini hanya dapat digunakan di dalam `adb shell`.
 > Informasi lebih lanjut: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreport>.
 
-- Menunjukkan laporan masalah perangkat Android secara lengkap:
+- Tunjukkan laporan masalah perangkat Android secara lengkap:
 
 `bugreport`

--- a/pages.id/android/bugreportz.md
+++ b/pages.id/android/bugreportz.md
@@ -1,21 +1,21 @@
 # bugreportz
 
-> Membuat sebuah laporan masalah Android dalam format file arsip (zip).
+> Buat sebuah laporan masalah Android dalam format file arsip (zip).
 > Perintah ini hanya dapat digunakan di dalam `adb shell`.
 > Informasi lebih lanjut: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreportz>.
 
-- Membuat sebuah arsip laporan masalah perangkat Android secara lengkap:
+- Buatkan sebuah arsip laporan masalah perangkat Android secara lengkap:
 
 `bugreportz`
 
-- Menunjukkan kemajuan terhadap proses `bugreportz` yang sedang berlangsung:
+- Tunjukkan kemajuan terhadap proses `bugreportz` yang sedang berlangsung:
 
 `bugreportz -p`
 
-- Menunjukkan versi program `bugreportz`:
+- Tunjukkan versi program `bugreportz`:
 
 `bugreportz -v`
 
-- Menampilkan teks bantuan:
+- Tampilkan teks bantuan:
 
 `bugreportz -h`

--- a/pages.id/android/cmd.md
+++ b/pages.id/android/cmd.md
@@ -3,14 +3,14 @@
 > Manajer layanan (daemon) untuk Android.
 > Informasi lebih lanjut: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/cmd/>.
 
-- Melihat daftar layanan yang sedang berjalan:
+- Lihat daftar layanan yang sedang berjalan:
 
 `cmd -l`
 
-- Memanggil suatu layanan tertentu:
+- Panggil suatu layanan tertentu:
 
 `cmd {{alarm}}`
 
-- Memanggil layanan dengan argumen tertentu:
+- Panggil layanan dengan argumen tertentu:
 
 `cmd {{vibrator}} {{vibrate 300}}`

--- a/pages.id/android/dalvikvm.md
+++ b/pages.id/android/dalvikvm.md
@@ -3,6 +3,6 @@
 > Mesin virtual Java untuk Android.
 > Informasi lebih lanjut: <https://source.android.com/devices/tech/dalvik>.
 
-- Menjalankan sebuah program Java:
+- Jalankan sebuah program Java:
 
 `dalvikvm -classpath {{jalan/menuju/file.jar}} {{nama_kelas}}`

--- a/pages.id/android/dumpsys.md
+++ b/pages.id/android/dumpsys.md
@@ -1,29 +1,29 @@
 # dumpsys
 
-> Memberikan informasi tentang layanan (daemon) sistem milik Android.
+> Berikan informasi tentang layanan (daemon) sistem milik Android.
 > Perintah ini hanya dapat dijalankan melalui `adb shell`.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/dumpsys>.
 
-- Menampilkan informasi diagnostik terhadap seluruh layanan sistem Android:
+- Tampilkan informasi diagnostik terhadap seluruh layanan sistem Android:
 
 `dumpsys`
 
-- Menampilkan informasi diagnostik untuk layanan sistem tertentu:
+- Tampilkan informasi diagnostik untuk layanan sistem tertentu:
 
 `dumpsys {{layanan}}`
 
-- Menampilkan daftar layanan sistem yang diketahui oleh `dumpsys`:
+- Tampilkan daftar layanan sistem yang diketahui oleh `dumpsys`:
 
 `dumpsys -l`
 
-- Menampilkan daftar argumen yang diterima oleh sebuah layanan sistem:
+- Tampilkan daftar argumen yang diterima oleh sebuah layanan sistem:
 
 `dumpsys {{layanan}} -h`
 
-- Mengecualikan layanan sistem tertentu dari informasi diagnostik yang ditampilkan:
+- Kecualikan layanan sistem tertentu dari informasi diagnostik yang ditampilkan:
 
 `dumpsys --skip {{layanan}}`
 
-- Menetapkan periode waktu habis dalam hitungan detik (10 detik secara default):
+- Tetapkan periode waktu habis dalam hitungan detik (10 detik secara default):
 
 `dumpsys -t {{detik}}`

--- a/pages.id/android/getprop.md
+++ b/pages.id/android/getprop.md
@@ -1,32 +1,32 @@
 # getprop
 
-> Menampilkan informasi terhadap properti sistem operasi Android.
+> Tampilkan informasi terhadap properti sistem operasi Android.
 > Informasi lebih lanjut: <https://manned.org/getprop>.
 
-- Menampilkan informasi daftar properti sistem operasi Android:
+- Tampilkan informasi daftar properti sistem operasi Android:
 
 `getprop`
 
-- Menampilan informasi terhadap properti sistem tertentu:
+- Tampilkan informasi terhadap properti sistem tertentu:
 
 `getprop {{properti}}`
 
-- Menampilkan tingkat API SDK Android:
+- Tampilkan tingkat API SDK Android:
 
 `getprop {{ro.build.version.sdk}}`
 
-- Menampilkan versi sistem operasi Android:
+- Tampilkan versi sistem operasi Android:
 
 `getprop {{ro.build.version.release}}`
 
-- Menampilkan kode model perangkat Android:
+- Tampilkan kode model perangkat Android:
 
 `getprop {{ro.vendor.product.model}}`
 
-- Menampilkan status pembukaan kunci pembuat perangkat (OEM):
+- Tampilkan status pembukaan kunci pembuat perangkat (OEM):
 
 `getprop {{ro.oem_unlock_supported}}`
 
-- Menampilkan alamat MAC terhadap komponen Wi-Fi milik perangkat:
+- Tampilkan alamat MAC terhadap komponen Wi-Fi milik perangkat:
 
 `getprop {{ro.boot.wifimacaddr}}`

--- a/pages.id/android/input.md
+++ b/pages.id/android/input.md
@@ -1,25 +1,25 @@
 # input
 
-> Mengirim sinyal input terhadap sebuah perangkat Android.
+> Kirim sinyal input terhadap sebuah perangkat Android.
 > Perintah ini hanya dapat dijalankan melalui `adb shell`.
 > Informasi lebih lanjut: <https://developer.android.com/reference/android/view/KeyEvent.html#constants_1>.
 
-- Memasukkan input karakter (layaknya pada papan kunci / keyboard) terhadap perangkat Android:
+- Masukkan input karakter (layaknya pada papan kunci / keyboard) terhadap perangkat Android:
 
 `input keyevent {{kode_event}}`
 
-- Memasukkan input teks ke dalam perangkat Android (spasi ditandai dengan `%s`):
+- Masukkan input teks ke dalam perangkat Android (spasi ditandai dengan `%s`):
 
 `input text "{{teks}}"`
 
-- Memasukkan input sentuhan layar pada posisi tertentu:
+- Masukkan input sentuhan layar pada posisi tertentu:
 
 `input tap {{posisi_x}} {{posisi_y}}`
 
-- Mensimulasikan gerakan usap/swipe terhadap perangkat Android:
+- Simulasikan gerakan usap/swipe terhadap perangkat Android:
 
 `input swipe {{posisi_awal_x}} {{posisi_awal_y}} {{posisi_akhir_x}} {{posisi_akhir_y}} {{durasi_dalam_milidetik}}`
 
-- Mensimulasikan interaksi tekan-dan-tahan terhadap perangkat Android:
+- Simulasikan interaksi tekan-dan-tahan terhadap perangkat Android:
 
 `input swipe {{posisi_x}} {{posisi_y}} {{posisi_x}} {{posisi_y}} {{durasi_dalam_milidetik}}`

--- a/pages.id/android/logcat.md
+++ b/pages.id/android/logcat.md
@@ -1,16 +1,16 @@
 # logcat
 
-> Menampilkan dan menyimpan log sistem.
+> Tampilkan dan simpan log sistem.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/logcat>.
 
-- Menampilkan log sistem:
+- Tampilkan log sistem:
 
 `logcat`
 
-- Menyimpan log sistem di dalam sebuah file:
+- Simpan log sistem di dalam sebuah file:
 
 `logcat -f {{path/to/file}}`
 
-- Menyaring informasi log berdasarkan sintaks ekspresi reguler (regex) tertentu:
+- Saring informasi log berdasarkan sintaks ekspresi reguler (regex) tertentu:
 
 `logcat --regex {{regular_expression}}`

--- a/pages.id/android/pkg.md
+++ b/pages.id/android/pkg.md
@@ -1,6 +1,6 @@
 # pkg
 
-> Manager paket untuk Termux.
+> Manajer paket untuk Termux.
 > Informasi lebih lanjut: <https://wiki.termux.com/wiki/Package_Management>.
 
 - Mutakhirkan seluruh paket yang terpasang:
@@ -11,7 +11,7 @@
 
 `pkg install {{paket}}`
 
-- Membuang paket dari instalasi Termux:
+- Buang paket dari instalasi Termux:
 
 `pkg uninstall {{paket}}`
 

--- a/pages.id/android/pm.md
+++ b/pages.id/android/pm.md
@@ -1,24 +1,24 @@
 # pm
 
-> Menampilkan daftar pemasangan aplikasi di dalam sebuah perangkat Android.
+> Tampilkan daftar pemasangan aplikasi di dalam sebuah perangkat Android.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/adb#pm>.
 
-- Menampilkan daftar seluruh aplikasi yang terpasang:
+- Tampilkan daftar seluruh aplikasi yang terpasang:
 
 `pm list packages`
 
-- Menampilkan daftar seluruh aplikasi sistem yang terpasang:
+- Tampilkan daftar seluruh aplikasi sistem yang terpasang:
 
 `pm list packages -s`
 
-- Menampilkan daftar seluruh aplikasi pihak ketiga yang terpasang:
+- Tampilkan daftar seluruh aplikasi pihak ketiga yang terpasang:
 
 `pm list packages -3`
 
-- Menampilkan daftar aplikasi dengan kata kunci tertentu:
+- Tampilkan daftar aplikasi dengan kata kunci tertentu:
 
 `pm list packages {{kata_kunci}}`
 
-- Menampilkan jalan menuju file APK untuk sebuah aplikasi:
+- Tampilkan jalan menuju file APK untuk sebuah aplikasi:
 
 `pm path {{aplikasi}}`

--- a/pages.id/android/settings.md
+++ b/pages.id/android/settings.md
@@ -1,20 +1,20 @@
 # settings
 
-> Menampilkan informasi terhadap pengaturan sistem operasi Android.
+> Tampilkan informasi terhadap pengaturan sistem operasi Android.
 > Informasi lebih lanjut: <https://adbinstaller.com/commands/adb-shell-settings-5b670d5ee7958178a2955536>.
 
-- Menampilkan daftar pengaturan di dalam namespace `global`:
+- Tampilkan daftar pengaturan di dalam namespace `global`:
 
 `settings list {{global}}`
 
-- Menampilkan nilai dari pengaturan tertentu:
+- Tampilkan nilai dari pengaturan tertentu:
 
 `settings get {{global}} {{airplane_mode_on}}`
 
-- Menyetel nilai pengaturan tertentu:
+- Setel nilai pengaturan tertentu:
 
 `settings put {{system}} {{screen_brightness}} {{42}}`
 
-- Menghapus nilai pengaturan tertentu:
+- Hapus nilai pengaturan tertentu:
 
 `settings delete {{secure}} {{screensaver_enabled}}`

--- a/pages.id/android/wm.md
+++ b/pages.id/android/wm.md
@@ -4,10 +4,10 @@
 > Perintah ini hanya dapat dijalankan melalui `adb shell`.
 > Informasi lebih lanjut: <https://adbinstaller.com/commands/adb-shell-wm-5b672b17e7958178a2955538>.
 
-- Menampilkan ukuran fisik terhadap layar perangkat:
+- Tampilkan ukuran fisik terhadap layar perangkat:
 
 `wm {{size}}`
 
-- Menampilkan tingkat kepadatan resolusi terhadap layar perangkat:
+- Tampilkan tingkat kepadatan resolusi terhadap layar perangkat:
 
 `wm {{density}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

See #8576