### PR TITLE
getcap: add -r example

### DIFF
--- a/pages/linux/getcap.md
+++ b/pages/linux/getcap.md
@@ -7,6 +7,10 @@
 
 `getcap {{path/to/file1 path/to/file2 ...}}`
 
+- Get capabilities for all the files recursively under the given directories:
+
+`getcap -r {{path/to/directory1 path/to/directory2 ...}}`
+
 - Displays all searched entries even if no capabilities are set:
 
 `getcap -v {{path/to/file1 path/to/file2 ...}}`


### PR DESCRIPTION
Add a sample of getcap to look for all files under the given directories recursively.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
