### PR TITLE
style-guide: add French verb tense guideline

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -162,7 +162,7 @@ Use backticks on the following:
 
 Example descriptions have to be phrased in imperative mood.  
 For example, use `List all files`, instead of `Listing all files` or `File listing`.  
-This also applies to all translations by default, unless this is not possible for some reason.  
+This also applies to all translations by default, unless otherwise specified in the language-specific section below.  
 
 ## Serial Comma
 
@@ -187,7 +187,9 @@ On the `More information` line, prefer linking to the author's provided document
 
 When not available, use <https://manned.org> as the default fallback. 
 
-## Chinese-Specific Rules
+## Language-Specific Rules
+
+### Chinese-Specific Rules
 
 When Chinese words, Latin words and Arabic numerals are written in the same sentence, more attention must be paid to copywriting.
 
@@ -211,3 +213,8 @@ The following guidelines are applied to Chinese (zh) and traditional Chinese (zh
 In order to maintain readability and normalization, please comply the 6 rules above as much as possible when translating pages into Chinese.
 
 For more information and examples of Chinese-specific rules, check out [*Chinese Copywriting Guidelines*](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en.md).
+
+### French-Specific Rules
+
+Example descriptions on pages in French must use the third person singular present indicative tense (présent de l'indicatif à la troisième personne du singulier).
+For example, use `Extrait une archive` rather than `Extraire une archive` or `Extrais une archive`.


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Hello,

There has been a lot of confusion surrounding the tense that must be used on French pages. (As seen in a recent PR [#8632](https://github.com/tldr-pages/tldr/pull/8632).) The imperative mood used on English pages is not desirable in French because it can seem rude and overly familiar.

Simply using the infinitive would be an option in French and many French-speakers will have that instinct. However, the closest tense to match the English imperative, while remaining respectful, is the third person singular indicative present, which was recommended in the now closed issue [Grammar in French - verbs #4714](https://github.com/tldr-pages/tldr/issues/4714).

To avoid confusion in future contributions, I am proposing adding this French-specific rule in the guidelines.

Please let me know if this is an acceptable change to the guidelines. I'd also love to hear other French-speaking contributors and collaborators' opinions on this (@Nico385412).