### PR TITLE
fastmod, gnmic-subscribe, renice, s3cmd, virt-install, toolbox-init-container: fix typo

### DIFF
--- a/pages/common/fastmod.md
+++ b/pages/common/fastmod.md
@@ -12,7 +12,7 @@
 
 `fastmod --ignore-case {{regex_pattern}} {{replacement}} -- {{path/to/file path/to/directory ...}}`
 
-- Replace a regex pattern in in a specific directory files filtered with a case-insensitive glob pattern:
+- Replace a regex pattern in a specific directory in files filtered with a case-insensitive glob pattern:
 
 `fastmod {{regex}} {{replacement}} --dir {{path/to/directory}} --iglob {{'**/*.{js,json}'}}`
 

--- a/pages/common/gnmic-subscribe.md
+++ b/pages/common/gnmic-subscribe.md
@@ -19,6 +19,6 @@
 
 `gnmic -a {{ip:port}} subscribe --path {{path}} --mode once`
 
-- Subscribe to a target and specify reponse encoding (json_ietf):
+- Subscribe to a target and specify response encoding (json_ietf):
 
 `gnmic -a {{ip:port}} subscribe --path {{path}} --encoding json_ietf`

--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -1,6 +1,6 @@
 # renice
 
-> Alters the scheduling priority/nicenesses of one or more running processes.
+> Alters the scheduling priority/niceness of one or more running processes.
 > Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 > More information: <https://manned.org/renice>.
 

--- a/pages/common/s3cmd.md
+++ b/pages/common/s3cmd.md
@@ -1,6 +1,6 @@
 # s3cmd
 
-> Command line tool and client for uploading, retrieveing and managing data in S3 compatible object storage.
+> Command line tool and client for uploading, retrieving and managing data in S3 compatible object storage.
 > More information: <https://s3tools.org/s3cmd>.
 
 - Invoke configuration/reconfiguration tool:

--- a/pages/common/virt-install.md
+++ b/pages/common/virt-install.md
@@ -15,7 +15,7 @@
 
 `virt-install --name {{vm_name}} --memory {{512}} --disk {{none}} --controller {{type=usb,model=none}} --sound {{none}} --autoconsole {{none}} --install {{no_install=yes}}  --cdrom {{path/to/tails.iso}}`
 
-- Create a virtual machine with with 16 GiB RAM, 250 GiB storage, 8 cores with hyperthreading, a specific CPU topology, and a CPU model that shares most features with the host CPU:
+- Create a virtual machine with 16 GiB RAM, 250 GiB storage, 8 cores with hyperthreading, a specific CPU topology, and a CPU model that shares most features with the host CPU:
 
 `virt-install --name {{vm_name}} --cpu {{host-model}},topology.sockets={{1}},topology.cores={{4}},topology.threads={{2}} --memory {{16384}} --disk path={{path/to/image.qcow2}},size={{250}} --cdrom {{path/to/debian.iso}}`
 

--- a/pages/linux/toolbox-init-container.md
+++ b/pages/linux/toolbox-init-container.md
@@ -1,7 +1,7 @@
 # toolbox init-container
 
 > Initialize a running `toolbox` container.
-> This command is should not be executed by the user, and cannot be run on the host.
+> This command should not be executed by the user, and cannot be run on the host.
 > More information: <https://manned.org/toolbox-init-container.1>.
 
 - Initialize a running toolbox:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I noticed a typo, then checked to see if I can find some more and collected them into this PR :)
