### PR TITLE
pages.de/*: fix typo in German translation

### DIFF
--- a/pages.de/common/aws-kinesis.md
+++ b/pages.de/common/aws-kinesis.md
@@ -11,7 +11,7 @@
 
 `aws kinesis put-record --stream-name {{name}} --partition-key {{schlüssel}} --data {{base64_codierte_nachricht}}`
 
-- Schreibe einen Datensatze in einen Kinesis Stream mit base64 inline Encodierung:
+- Schreibe einen Datensatz in einen Kinesis Stream mit base64 inline Encodierung:
 
 `aws kinesis put-record --stream-name {{name}} --partition-key {{schlüssel}} --data "$( echo "{{meine nachricht}}" | base64 )"`
 

--- a/pages.de/common/aws-s3.md
+++ b/pages.de/common/aws-s3.md
@@ -23,6 +23,6 @@
 
 `aws s3 rm s3://{{bucket}}/{{pfad/zu/datei}}`
 
-- Probelauf eines angegeben Kommandos ohne diesen auszuführen:
+- Probelauf eines angegebenen Kommandos ohne dieses auszuführen:
 
 `aws s3 {{befehl}} --dryrun`

--- a/pages.de/common/aws.md
+++ b/pages.de/common/aws.md
@@ -16,7 +16,7 @@
 
 `aws {{befehl}} help`
 
-- Zeige Informationen über die eigene angenomme Identität (häufig benutzt zur Fehlersuche):
+- Zeige Informationen über die eigene angenommene Identität (häufig benutzt zur Fehlersuche):
 
 `aws sts get-caller-identity`
 
@@ -28,7 +28,7 @@
 
 `aws iam create-user --cli-auto-prompt`
 
-- Öffne einen Assitenten für eine AWS Ressource:
+- Öffne einen Assistenten für eine AWS Ressource:
 
 `aws dynamodb wizard {{neue_tabelle}}`
 

--- a/pages.de/common/bat.md
+++ b/pages.de/common/bat.md
@@ -8,7 +8,7 @@
 
 `bat {{pfad/zu/datei}}`
 
-- Verkette mehrere Dateien zu eine Zieldatei:
+- Verkette mehrere Dateien zu einer Zieldatei:
 
 `bat {{pfad/zu/datei1}} {{pfad/zu/datei2}} > {{pfad/zu/ziel_datei}}`
 
@@ -20,7 +20,7 @@
 
 `bat -n {{pfad/zu/datei}}`
 
-- Hebe den Syntax einer JSON-Datei hervor:
+- Hebe die Syntax einer JSON-Datei hervor:
 
 `bat --language {{json}} {{pfad/zu/datei.json}}`
 

--- a/pages.de/common/chmod.md
+++ b/pages.de/common/chmod.md
@@ -31,6 +31,6 @@
 
 `chmod -R g+w,o+w {{pfad/zu/verzeichnis}}`
 
-- Gib [a]llen Benutzern rekursiv Rechte zum Lesen ([r]ead) von Dateien und Ausführen (e[X]ecute) von Unterverzeichnissen innerhalb eines Verzeichnis:
+- Gib [a]llen Benutzern rekursiv Rechte zum Lesen ([r]ead) von Dateien und Ausführen (e[X]ecute) von Unterverzeichnissen innerhalb eines Verzeichnisses:
 
 `chmod -R a+rX {{pfad/zu/verzeichnis}}`

--- a/pages.de/common/cmake.md
+++ b/pages.de/common/cmake.md
@@ -1,6 +1,6 @@
 # cmake
 
-> Plattformübergreifndes Build-Automatisierungs-System, das Vorlagen für native Build-Systeme erzeugt.
+> Plattformübergreifendes Build-Automatisierungs-System, das Vorlagen für native Build-Systeme erzeugt.
 > Weitere Informationen: <https://cmake.org/cmake/help/latest/manual/cmake.1.html>.
 
 - Erzeuge eine Build-Vorlage im aktuellen Verzeichnis mit `CMakeLists.txt` eines Projektordners:
@@ -15,7 +15,7 @@
 
 `cmake --build {{pfad/zu/build_verzeichnis}}`
 
-- Installiere die Build-Artifakte in `/usr/local/` und enferne Debugsymbole:
+- Installiere die Build-Artifakte in `/usr/local/` und entferne Debugsymbole:
 
 `cmake --install {{pfad/zu/build_verzeichnis}} --strip`
 

--- a/pages.de/common/dd.md
+++ b/pages.de/common/dd.md
@@ -27,6 +27,6 @@
 
 `dd if={{pfad/zu/datei.img}} of=/dev/{{laufwerk}} status=progress`
 
-- Überprüfe den Fortschritt eines laufenden dd-Prozsses (Führe diesen Befehl von einer anderen Shell aus):
+- Überprüfe den Fortschritt eines laufenden dd-Prozesses (Führe diesen Befehl von einer anderen Shell aus):
 
 `kill -USR1 $(pgrep ^dd)`

--- a/pages.de/common/docker-service.md
+++ b/pages.de/common/docker-service.md
@@ -19,7 +19,7 @@
 
 `docker service ps {{service_name|ID}}`
 
-- Skaliere die angegebenen Services auf einen bestimmte Anzahl an Replikaten:
+- Skaliere die angegebenen Services auf eine bestimmte Anzahl an Replikaten:
 
 `docker service scale {{service_name}}={{anzahl_an_replikaten}}`
 

--- a/pages.de/common/docker-system.md
+++ b/pages.de/common/docker-system.md
@@ -19,7 +19,7 @@
 
 `docker system prune`
 
-- Entferne nicht-verwendete Daten, die älter als die angegeben Zeit sind:
+- Entferne nicht-verwendete Daten, die älter als die angegebene Zeit sind:
 
 `docker system prune --filter="until={{stunden}}h{{minuten}}m"`
 

--- a/pages.de/common/dotnet.md
+++ b/pages.de/common/dotnet.md
@@ -1,6 +1,6 @@
 # dotnet
 
-> Plattformübergreifende Kommandozeilenandwendungen für .NET Core.
+> Plattformübergreifende Kommandozeilenanwendungen für .NET Core.
 > Manche Unterbefehle wie `dotnet build` sind separat dokumentiert.
 > Weitere Informationen: <https://learn.microsoft.com/dotnet/core/tools>.
 

--- a/pages.de/common/ffmpeg.md
+++ b/pages.de/common/ffmpeg.md
@@ -7,11 +7,11 @@
 
 `ffmpeg -i {{pfad/zu/video.mp4}} -vn {{pfad/zu/audio.mp3}}`
 
-- Konvertiere Frames eines Videos oder Gifs zu individuellen, numerierten Bildern:
+- Konvertiere Frames eines Videos oder Gifs zu individuellen, nummerierten Bildern:
 
 `ffmpeg -i {{video.mpg|video.gif}} {{pfad/zu/frame_%d.png}}`
 
-- Kombiniere numerierte Bilder (`frame_1.jpg`, `frame_2.jpg`, etc) in ein Video oder Gif:
+- Kombiniere nummerierte Bilder (`frame_1.jpg`, `frame_2.jpg`, etc) in ein Video oder Gif:
 
 `ffmpeg -i {{pfad/zu/frame_%d.jpg}} -f bild2 {{video.mpg|video.gif}}`
 

--- a/pages.de/common/git-bisect.md
+++ b/pages.de/common/git-bisect.md
@@ -1,7 +1,7 @@
 # git bisect
 
-> Benuzt binäre Suche um den commit ausfindig zu machen, welcher einen Fehler beinhaltet.
-> Git springt im Commit-Graph automatisch vor und zurück, um den fehlerhaften Commit schrittweise einzugrenzen zu können.
+> Benutzt binäre Suche um den commit ausfindig zu machen, welcher einen Fehler beinhaltet.
+> Git springt im Commit-Graph automatisch vor und zurück, um den fehlerhaften Commit schrittweise eingrenzen zu können.
 > Weitere Informationen: <https://git-scm.com/docs/git-bisect>.
 
 - Starte eine Bisect-Session in einem Commit-Bereich, der durch einen bekannten fehlerhaften Commit und einen sauberen Commit begrenzt wird:

--- a/pages.de/common/gpg.md
+++ b/pages.de/common/gpg.md
@@ -8,7 +8,7 @@
 
 `gpg --full-generate-key`
 
-- Signiere `doc.txt` ohne Verschlüsselung (Ausabe nach `doc.txt.asc`):
+- Signiere `doc.txt` ohne Verschlüsselung (Ausgabe nach `doc.txt.asc`):
 
 `gpg --clearsign {{doc.txt}}`
 

--- a/pages.de/common/mount.md
+++ b/pages.de/common/mount.md
@@ -3,7 +3,7 @@
 > Ermöglicht den Zugriff auf ein gesamtes Dateisystem in einem Verzeichnis.
 > Weitere Informationen: <https://manned.org/mount.8>.
 
-- Zeige alle eingehängten Dateisyteme:
+- Zeige alle eingehängten Dateisysteme:
 
 `mount`
 

--- a/pages.de/common/plantuml.md
+++ b/pages.de/common/plantuml.md
@@ -7,7 +7,7 @@
 
 `plantuml {{pfad/zu/diagramm1.puml}} {{pfad/zu/diagramm2.puml}}`
 
-- Rendere eine Diagramm im vorgegebenen Format (z.B. `png`, `pdf`, `svg`, `txt`):
+- Rendere ein Diagramm im vorgegebenen Format (z.B. `png`, `pdf`, `svg`, `txt`):
 
 `plantuml -t {{format}} {{pfad/zu/diagramm.puml}}`
 

--- a/pages.de/common/ssh.md
+++ b/pages.de/common/ssh.md
@@ -32,6 +32,6 @@
 
 `ssh -J {{benutzer@sring_server}} {{benutzer}}@{{externer_server}}`
 
-- Agenten Weiterleitung: Leite die eigenen Authentifizierungs-Information an den externen Server weiter (siehe `man ssh_config` für mehr Optionen):
+- Agenten Weiterleitung: Leite die eigenen Authentifizierungs-Informationen an den externen Server weiter (siehe `man ssh_config` für mehr Optionen):
 
 `ssh -A {{benutzer}}@{{externer_server}}`

--- a/pages.de/linux/addr2line.md
+++ b/pages.de/linux/addr2line.md
@@ -3,7 +3,7 @@
 > Konvertiere Adressen von Binärdateien in Dateinamen und Zeilennummern.
 > Weitere Informationen: <https://manned.org/addr2line>.
 
-- Zeige den Dateinamen und die Zeilennummer des Quellcodes von einer Befehlssadresse einer ausführbaren Datei an:
+- Zeige den Dateinamen und die Zeilennummer des Quellcodes von einer Befehlsadresse einer ausführbaren Datei an:
 
 `addr2line --exe={{pfad/zur/ausführbaren_datei}} {{adresse}}`
 

--- a/pages.de/linux/alpine.md
+++ b/pages.de/linux/alpine.md
@@ -4,7 +4,7 @@
 > Unterstützt die meisten modernen IMAP Server.
 > Weitere Informationen: <https://manned.org/alpine>.
 
-- Öffne Apline:
+- Öffne Alpine:
 
 `alpine`
 

--- a/pages.de/linux/arithmetic.md
+++ b/pages.de/linux/arithmetic.md
@@ -7,7 +7,7 @@
 
 `arithmetic`
 
-- Spezifiziere einen oder mehr arithemtische [O]peratoren um Probleme mit ihnen zu bekommen:
+- Spezifiziere einen oder mehr arithmetische [O]peratoren um Probleme mit ihnen zu bekommen:
 
 `arithmetic -o {{+|-|x|/}}`
 

--- a/pages.de/linux/certbot.md
+++ b/pages.de/linux/certbot.md
@@ -24,6 +24,6 @@
 
 `sudo certbot --webroot --webroot-path {{pfad/zu/webroot}} --domain {{subdomain.beispiel.de}} --dry-run`
 
-- Beziehe eine Test-Zertifikat:
+- Beziehe ein Test-Zertifikat:
 
 `sudo certbot --webroot --webroot-path {{pfad/zu/webroot}} --domain {{subdomain.beispiel.de}} --test-cert`

--- a/pages.de/linux/nordvpn.md
+++ b/pages.de/linux/nordvpn.md
@@ -23,7 +23,7 @@
 
 `nordvpn connect {{Germany}}`
 
-- Stelle eine Verbinding zu einem NordVPN-Server in einem bestimmten Land und einer bestimmten Stadt her:
+- Stelle eine Verbindung zu einem NordVPN-Server in einem bestimmten Land und einer bestimmten Stadt her:
 
 `nordvpn connect {{Germany}} {{Berlin}}`
 

--- a/pages.de/linux/pacman-files.md
+++ b/pages.de/linux/pacman-files.md
@@ -16,7 +16,7 @@
 
 `pacman --files {{dateiname}}`
 
-- Finde das Paket, welches eine bestimmte Datei besitzt, mittels einem regulärem Ausdruck:
+- Finde das Paket, welches eine bestimmte Datei besitzt, mittels eines regulären Ausdrucks:
 
 `pacman --files --regex '{{suchmuster}}'`
 

--- a/pages.de/linux/pacman-sync.md
+++ b/pages.de/linux/pacman-sync.md
@@ -15,7 +15,7 @@
 
 `sudo pacman --sync --refresh --sysupgrade --noconfirm {{paketname}}`
 
-- Suche in der Paketdatenbank mit einem regulärem Ausdruck oder Schlüsselwort:
+- Suche in der Paketdatenbank mit einem regulären Ausdruck oder Schlüsselwort:
 
 `pacman --sync --search "{{suchmuster}}"`
 

--- a/pages.de/linux/zathura.md
+++ b/pages.de/linux/zathura.md
@@ -1,6 +1,6 @@
 # zathura
 
-> Ein vim-artiger modaler Dokumentenbetracher mit integrierter Kommandozeile.
+> Ein vim-artiger modaler Dokumentenbetrachter mit integrierter Kommandozeile.
 > Stelle sicher, dass ein Backend installiert ist (poppler, Postscript oder DjVu).
 > Weitere Informationen: <https://pwmt.org/projects/zathura/>.
 

--- a/pages.de/windows/color.md
+++ b/pages.de/windows/color.md
@@ -7,7 +7,7 @@
 
 `color`
 
-- Liste alle verfügbaren Farben und detailierte Informationen auf:
+- Liste alle verfügbaren Farben und detaillierte Informationen auf:
 
 `color /?`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Related to https://github.com/tldr-pages/tldr/pull/8761 but I wanted to split this into a separate PR since I'd imagine that since it's about a different language maybe different people would review the changes.

So like the title describes, these are just a bunch of typos I found in some german translations :)
