### PR TITLE
windows/*: add page

### DIFF
--- a/pages/windows/get-acl.md
+++ b/pages/windows/get-acl.md
@@ -4,9 +4,9 @@
 > This command can only be used through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.security/get-acl>.
 
-- Get an ACL for a folder:
+- Display the ACL for a specific directory:
 
-`Get-Acl C:\Windows`
+`Get-Acl {{path/to/directory}}`
 
 - Get an ACL for a registry key:
 

--- a/pages/windows/get-acl.md
+++ b/pages/windows/get-acl.md
@@ -1,0 +1,13 @@
+# Get-Acl
+
+> Gets the security descriptor for a resource, such as a file or registry key.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-acl>.
+
+- Get an ACL for a folder:
+
+`Get-Acl C:\Windows`
+
+- Get an ACL for a registry key:
+
+`Get-Acl -Path {{HKLM:\System\CurrentControlSet\Control}} | Format-List`

--- a/pages/windows/get-acl.md
+++ b/pages/windows/get-acl.md
@@ -2,7 +2,7 @@
 
 > Gets the security descriptor for a resource, such as a file or registry key.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-acl>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.security/get-acl>.
 
 - Get an ACL for a folder:
 

--- a/pages/windows/get-date.md
+++ b/pages/windows/get-date.md
@@ -2,7 +2,7 @@
 
 > Gets the current date and time.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-date>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date>.
 
 - Get the current date and time:
 

--- a/pages/windows/get-date.md
+++ b/pages/windows/get-date.md
@@ -4,15 +4,15 @@
 > This command can only be used through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date>.
 
-- Get the current date and time:
+- Display the current date and time:
 
 `Get-Date`
 
-- Get the date and time with a .NET format specifier:
+- Display the current date and time with a .NET format specifier:
 
-`Get-Date -Format {{"dddd MM/dd/yyyy HH:mm K"}}`
+`Get-Date -Format "{{yyyy-MM-dd HH:mm:ss}}"`
 
-- Convert the current time to UTC time:
+- Display the current date and time in UTC and ISO 8601 format:
 
 `(Get-Date).ToUniversalTime()`
 

--- a/pages/windows/get-date.md
+++ b/pages/windows/get-date.md
@@ -1,0 +1,21 @@
+# Get-Date
+
+> Gets the current date and time.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-date>.
+
+- Get the current date and time:
+
+`Get-Date`
+
+- Get the date and time with a .NET format specifier:
+
+`Get-Date -Format {{"dddd MM/dd/yyyy HH:mm K"}}`
+
+- Convert the current time to UTC time:
+
+`(Get-Date).ToUniversalTime()`
+
+- Convert a Unix timestamp:
+
+`Get-Date -UnixTimeSeconds {{1577836800}}`

--- a/pages/windows/measure-command.md
+++ b/pages/windows/measure-command.md
@@ -2,7 +2,7 @@
 
 > Measures the time it takes to run script blocks and cmdlets.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/measure-command>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/measure-command>.
 
 - Measure the time it takes to run a command:
 

--- a/pages/windows/measure-command.md
+++ b/pages/windows/measure-command.md
@@ -1,0 +1,13 @@
+# Measure-Command
+
+> Measures the time it takes to run script blocks and cmdlets.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/measure-command>.
+
+- Measure the time it takes to run a command:
+
+`Measure-Command { {{command}} }`
+
+- Pipe input to Measure-Command (objects that are piped to `Measure-Command` are available to the script block that is passed to the Expression parameter):
+
+`10, 20, 50 | Measure-Command -Expression { for ($i=0; $i -lt $_; $i++) {$i} }`

--- a/pages/windows/measure-object.md
+++ b/pages/windows/measure-object.md
@@ -10,4 +10,4 @@
 
 - Pipe input to Measure-Command (objects that are piped to `Measure-Command` are available to the script block that is passed to the Expression parameter):
 
-`"One", "Two", "Three", "Four" | Set-Content -Path "$env:temp\tmp.txt"; Get-Content "$env:temp\tmp.txt" | Measure-Object -Character -Line -Word`
+`"One", "Two", "Three", "Four" | Set-Content -Path "{{path/to/file}}"; Get-Content "{{path/to/file}}"; | Measure-Object -Character -Line -Word`

--- a/pages/windows/measure-object.md
+++ b/pages/windows/measure-object.md
@@ -1,0 +1,13 @@
+# Measure-Object
+
+> Calculates the numeric properties of objects, and the characters, words, and lines in string objects, such as files of text.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/measure-object>.
+
+- Count the files and folders in a directory:
+
+`Get-ChildItem | Measure-Object`
+
+- Pipe input to Measure-Command (objects that are piped to `Measure-Command` are available to the script block that is passed to the Expression parameter):
+
+`"One", "Two", "Three", "Four" | Set-Content -Path "$env:temp\tmp.txt"; Get-Content "$env:temp\tmp.txt" | Measure-Object -Character -Line -Word`

--- a/pages/windows/out-string.md
+++ b/pages/windows/out-string.md
@@ -2,7 +2,7 @@
 
 > Outputs input objects as a string.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/out-string>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/out-string>.
 
 - Print host information as string:
 

--- a/pages/windows/out-string.md
+++ b/pages/windows/out-string.md
@@ -1,0 +1,17 @@
+# Out-String
+
+> Outputs input objects as a string.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/out-string>.
+
+- Print host information as string:
+
+`Get-Alias | Out-String`
+
+- Convert each object to a string rather than concatenating all the objects into a single string:
+
+`Get-Alias | Out-String -Stream`
+
+- Use the `Width` parameter to prevent truncation:
+
+`@{TestKey = ('x' * 200)} | Out-String -Width {{250}}`

--- a/pages/windows/pwsh-where.md
+++ b/pages/windows/pwsh-where.md
@@ -1,0 +1,8 @@
+# where
+
+> This command is an alias of `Where-Object`.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object>.
+
+- View documentation for the original command:
+
+`tldr Where-Object`

--- a/pages/windows/pwsh-where.md
+++ b/pages/windows/pwsh-where.md
@@ -1,7 +1,7 @@
 # where
 
 > This command is an alias of `Where-Object`.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object>.
 
 - View documentation for the original command:
 

--- a/pages/windows/resolve-path.md
+++ b/pages/windows/resolve-path.md
@@ -2,7 +2,7 @@
 
 > Resolves the wildcard characters in a path, and displays the path contents.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/resolve-path>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/resolve-path>.
 
 - Resolve the home folder path:
 

--- a/pages/windows/resolve-path.md
+++ b/pages/windows/resolve-path.md
@@ -1,0 +1,17 @@
+# Resolve-Path
+
+> Resolves the wildcard characters in a path, and displays the path contents.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/resolve-path>.
+
+- Resolve the home folder path:
+
+`Resolve-Path {{~}}`
+
+- Resolve a UNC path:
+
+`Resolve-Path -Path {{"\\Server01\public"}}`
+
+- Get relative paths:
+
+`Resolve-Path -Path {{path/to/file_or_directory}} -Relative`

--- a/pages/windows/resolve-path.md
+++ b/pages/windows/resolve-path.md
@@ -10,7 +10,7 @@
 
 - Resolve a UNC path:
 
-`Resolve-Path -Path {{"\\Server01\public"}}`
+`Resolve-Path -Path "\\{{hostname}}\{{path/to/file}}"
 
 - Get relative paths:
 

--- a/pages/windows/resolve-path.md
+++ b/pages/windows/resolve-path.md
@@ -10,7 +10,7 @@
 
 - Resolve a UNC path:
 
-`Resolve-Path -Path "\\{{hostname}}\{{path/to/file}}"
+`Resolve-Path -Path "\\{{hostname}}\{{path/to/file}}"`
 
 - Get relative paths:
 

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -21,6 +21,6 @@
 
 `Select-String --Context {{2,3}} "{{search_pattern}}" {{path/to/file}}`
 
-- Search `stdin` for lines that do not match a pattern:
+- Search stdin for lines that do not match a pattern:
 
 `Get-Content {{path/to/file}} | Select-String --NotMatch "{{search_pattern}}"`

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -1,0 +1,26 @@
+# Select-String
+
+> Finds text in strings and files in PowerShell.
+> This command can only be used through PowerShell.
+> You can use `Select-String` similar to grep in UNIX or findstr.exe in Windows.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string>.
+
+- Search for a pattern within a file:
+
+`Select-String -Path "{{path/to/file}}" -Pattern '{{search_pattern}}'`
+
+- Search for an exact string (disables regular expressions):
+
+`Select-String -SimpleMatch "{{exact_string}}" {{path/to/file}}`
+
+- Search for pattern in all `.ext` files in current dir:
+
+`Select-String -Path "{{*.ext}}" -Pattern '{{search_pattern}}'`
+
+- Capture the specified number of lines before and after the line that matches the pattern:
+
+`Select-String --Context {{2,3}} "{{search_pattern}}" {{path/to/file}}`
+
+- Search `stdin` for lines that do not match a pattern:
+
+`Get-Content {{path/to/file}} | Select-String --NotMatch "{{search_pattern}}"`

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -3,7 +3,7 @@
 > Finds text in strings and files in PowerShell.
 > This command can only be used through PowerShell.
 > You can use `Select-String` similar to grep in UNIX or findstr.exe in Windows.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Search for a pattern within a file:
 

--- a/pages/windows/set-acl.md
+++ b/pages/windows/set-acl.md
@@ -2,7 +2,7 @@
 
 > Changes the security descriptor of a specified item, such as a file or a registry key.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-acl>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.security/set-acl>.
 
 - Copy a security descriptor from one file to another:
 

--- a/pages/windows/set-acl.md
+++ b/pages/windows/set-acl.md
@@ -1,0 +1,13 @@
+# Set-Acl
+
+> Changes the security descriptor of a specified item, such as a file or a registry key.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-acl>.
+
+- Copy a security descriptor from one file to another:
+
+`$OriginAcl = Get-Acl -Path {{path/to/file}}; Set-Acl -Path {{path/to/file}} -AclObject $OriginAcl`
+
+- Use the pipeline operator to pass a descriptor:
+
+`Get-Acl -Path {{path/to/file}} | Set-Acl -Path {{path/to/file}}`

--- a/pages/windows/set-date.md
+++ b/pages/windows/set-date.md
@@ -1,0 +1,17 @@
+# Set-Date
+
+> Changes the system time on the computer to a time that you specify.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-date>.
+
+- Add three days to the system date:
+
+`Set-Date -Date (Get-Date).AddDays(3)`
+
+- Set the system clock back 10 minutes:
+
+`Set-Date -Adjust -0:10:0 -DisplayHint Time`
+
+- Add 90 minutes to the system clock:
+
+`$90mins = New-TimeSpan -Minutes 90; Set-Date -Adjust $90mins`

--- a/pages/windows/set-date.md
+++ b/pages/windows/set-date.md
@@ -6,7 +6,7 @@
 
 - Add three days to the system date:
 
-`Set-Date -Date (Get-Date).AddDays(3)`
+`Set-Date -Date (Get-Date).AddDays({{3}})`
 
 - Set the system clock back 10 minutes:
 
@@ -14,4 +14,4 @@
 
 - Add 90 minutes to the system clock:
 
-`$90mins = New-TimeSpan -Minutes 90; Set-Date -Adjust $90mins`
+`$90mins = New-TimeSpan -Minutes {{90}}; Set-Date -Adjust $90mins`

--- a/pages/windows/set-date.md
+++ b/pages/windows/set-date.md
@@ -2,7 +2,7 @@
 
 > Changes the system time on the computer to a time that you specify.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-date>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/set-date>.
 
 - Add three days to the system date:
 

--- a/pages/windows/set-service.md
+++ b/pages/windows/set-service.md
@@ -2,7 +2,7 @@
 
 > Starts, stops, and suspends a service, and changes its properties.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-service>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-service>.
 
 - Change a display name:
 

--- a/pages/windows/set-service.md
+++ b/pages/windows/set-service.md
@@ -1,0 +1,17 @@
+# Set-Service
+
+> Starts, stops, and suspends a service, and changes its properties.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-service>.
+
+- Change a display name:
+
+`Set-Service -Name {{LanmanWorkstation}} -DisplayName {{"LanMan Workstation"}}`
+
+- Change the startup type of services:
+
+`Set-Service -Name {{BITS}} -StartupType {{Automatic}}`
+
+- Change the description of a service:
+
+`Set-Service -Name {{BITS}} -Description {{"Transfers files in the background using idle network bandwidth."}}`

--- a/pages/windows/set-service.md
+++ b/pages/windows/set-service.md
@@ -6,12 +6,12 @@
 
 - Change a display name:
 
-`Set-Service -Name {{LanmanWorkstation}} -DisplayName {{"LanMan Workstation"}}`
+`Set-Service -Name {{hostname}} -DisplayName "{{name}}"`
 
 - Change the startup type of services:
 
-`Set-Service -Name {{BITS}} -StartupType {{Automatic}}`
+`Set-Service -Name {{service_name}} -StartupType {{Automatic}}`
 
 - Change the description of a service:
 
-`Set-Service -Name {{BITS}} -Description {{"Transfers files in the background using idle network bandwidth."}}`
+`Set-Service -Name {{service_name}} -Description "{{description}}"`

--- a/pages/windows/show-markdown.md
+++ b/pages/windows/show-markdown.md
@@ -2,7 +2,7 @@
 
 > Shows a Markdown file or string in the console in a friendly way using VT100 escape sequences or in a browser using HTML.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/show-markdown>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/show-markdown>.
 
 - Render markdown to console from a file:
 

--- a/pages/windows/show-markdown.md
+++ b/pages/windows/show-markdown.md
@@ -1,0 +1,17 @@
+# Show-Markdown
+
+> Shows a Markdown file or string in the console in a friendly way using VT100 escape sequences or in a browser using HTML.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/show-markdown>.
+
+- Render markdown to console from a file:
+
+`Show-Markdown -Path {{path/to/file}}`
+
+- Render markdown to console from string:
+
+`{{"# Markdown content"}} | Show-Markdown`
+
+- Open Markdown file in a browser:
+
+`Show-Markdown -Path {{path/to/file}} -UseBrowser`

--- a/pages/windows/sls.md
+++ b/pages/windows/sls.md
@@ -5,4 +5,4 @@
 
 - View documentation for the original command:
 
-`tldr Select-String`
+`tldr where-object`

--- a/pages/windows/sls.md
+++ b/pages/windows/sls.md
@@ -1,7 +1,7 @@
 # sls
 
 > This command is an alias of `Select-String`.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sls.md
+++ b/pages/windows/sls.md
@@ -1,0 +1,8 @@
+# sls
+
+> This command is an alias of `Select-String`.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string>.
+
+- View documentation for the original command:
+
+`tldr Select-String`

--- a/pages/windows/sort-object.md
+++ b/pages/windows/sort-object.md
@@ -2,7 +2,7 @@
 
 > Sorts objects by property values.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/sort-object>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/sort-object>.
 
 - Sort the current directory by name:
 

--- a/pages/windows/sort-object.md
+++ b/pages/windows/sort-object.md
@@ -1,0 +1,25 @@
+# Sort-Object
+
+> Sorts objects by property values.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/sort-object>.
+
+- Sort the current directory by name:
+
+`Get-ChildItem | Sort-Object`
+
+- Sort the current directory by name descending:
+
+`Get-ChildItem | Sort-Object -Descending`
+
+- Sort items removing duplicates:
+
+`"a", "b", "a" | Sort-Object -Unique`
+
+- Sort the current directory by file length:
+
+`Get-ChildItem | Sort-Object -Property Length`
+
+- Sort processes with the highest memory usage based on their working set (WS) size:
+
+`Get-Process | Sort-Object -Property WS`

--- a/pages/windows/start-service.md
+++ b/pages/windows/start-service.md
@@ -2,7 +2,7 @@
 
 > Starts one or more stopped services.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-service>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/start-service>.
 
 - Start a service by using its name:
 

--- a/pages/windows/start-service.md
+++ b/pages/windows/start-service.md
@@ -1,0 +1,17 @@
+# Start-Service
+
+> Starts one or more stopped services.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-service>.
+
+- Start a service by using its name:
+
+`Start-Service -Name {{"eventlog"}}`
+
+- Display information without starting a service:
+
+`Start-Service -DisplayName {{*remote*}} -WhatIf`
+
+- Start a disabled service:
+
+`Set-Service {{<service_name>}} -StartupType {{manual}}; Start-Service {{<service_name>}}`

--- a/pages/windows/start-service.md
+++ b/pages/windows/start-service.md
@@ -6,12 +6,12 @@
 
 - Start a service by using its name:
 
-`Start-Service -Name {{"eventlog"}}`
+`Start-Service -Name {{service_name}}`
 
 - Display information without starting a service:
 
-`Start-Service -DisplayName {{*remote*}} -WhatIf`
+`Start-Service -DisplayName *{{name}}* -WhatIf`
 
 - Start a disabled service:
 
-`Set-Service {{<service_name>}} -StartupType {{manual}}; Start-Service {{<service_name>}}`
+`Set-Service {{service_name}} -StartupType {{manual}}; Start-Service {{service_name}}`

--- a/pages/windows/stop-service.md
+++ b/pages/windows/stop-service.md
@@ -6,12 +6,12 @@
 
 - Stop a service on the local computer:
 
-`Stop-Service -Name {{"sysmonlog"}}`
+`Stop-Service -Name {{service_name}}`
 
 - Stop a service by using the display name:
 
-`Stop-Service -DisplayName {{"telnet"}}`
+`Stop-Service -DisplayName "{{name}}"`
 
 - Stop a service that has dependent services:
 
-`Stop-Service -Name {{"iisadmin"}} -Force -Confirm`
+`Stop-Service -Name {{service_name}} -Force -Confirm`

--- a/pages/windows/stop-service.md
+++ b/pages/windows/stop-service.md
@@ -2,7 +2,7 @@
 
 > Stops one or more running services.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-service>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-service>.
 
 - Stop a service on the local computer:
 

--- a/pages/windows/stop-service.md
+++ b/pages/windows/stop-service.md
@@ -1,0 +1,17 @@
+# Stop-Service
+
+> Stops one or more running services.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-service>.
+
+- Stop a service on the local computer:
+
+`Stop-Service -Name {{"sysmonlog"}}`
+
+- Stop a service by using the display name:
+
+`Stop-Service -DisplayName {{"telnet"}}`
+
+- Stop a service that has dependent services:
+
+`Stop-Service -Name {{"iisadmin"}} -Force -Confirm`

--- a/pages/windows/tee-object.md
+++ b/pages/windows/tee-object.md
@@ -1,0 +1,13 @@
+# Tee-Object
+
+> Saves command output in a file or variable and also sends it down the pipeline.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/tee-object>.
+
+- Output processes to a file and to the console:
+
+`Get-Process | Tee-Object -FilePath {{path/to/file}}`
+
+- Output processes to a variable and `Select-Object`:
+
+`Get-Process notepad | Tee-Object -Variable {{proc}} | Select-Object processname,handles`

--- a/pages/windows/tee-object.md
+++ b/pages/windows/tee-object.md
@@ -2,7 +2,7 @@
 
 > Saves command output in a file or variable and also sends it down the pipeline.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/tee-object>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/tee-object>.
 
 - Output processes to a file and to the console:
 

--- a/pages/windows/test-json.md
+++ b/pages/windows/test-json.md
@@ -2,7 +2,7 @@
 
 > Tests whether a string is a valid JSON document.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/test-json>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/test-json>.
 
 - Test if an object is valid JSON:
 

--- a/pages/windows/test-json.md
+++ b/pages/windows/test-json.md
@@ -1,0 +1,13 @@
+# Test-Json
+
+> Tests whether a string is a valid JSON document.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/test-json>.
+
+- Test if an object is valid JSON:
+
+`"{'name': 'Ashley', 'age': 25}" | Test-Json`
+
+- Test if an object is valid JSON:
+
+`'{"name": "James", "hobbies": [".NET", "Blogging"]}' | Test-Json -SchemaFile {{path/to/file}}`

--- a/pages/windows/test-json.md
+++ b/pages/windows/test-json.md
@@ -4,10 +4,14 @@
 > This command can only be used through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/test-json>.
 
-- Test if an object is valid JSON:
+- Test if a string from stdin is in JSON format:
 
-`"{'name': 'Ashley', 'age': 25}" | Test-Json`
+`'{{string}}' | Test-Json`
 
-- Test if an object is valid JSON:
+- Test if a string JSON format:
 
-`'{"name": "James", "hobbies": [".NET", "Blogging"]}' | Test-Json -SchemaFile {{path/to/file}}`
+`Test-Json -Json '{{json_to_test}}'`
+
+- Test if a string from stdin matches a specific schema file:
+
+`'{{string}}' | Test-Json -SchemaFile {{path/to/schema.json}}`

--- a/pages/windows/wait-process.md
+++ b/pages/windows/wait-process.md
@@ -2,7 +2,7 @@
 
 > Waits for the processes to be stopped before accepting more input.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/wait-process>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process>.
 
 - Stop a process and wait:
 

--- a/pages/windows/wait-process.md
+++ b/pages/windows/wait-process.md
@@ -1,0 +1,13 @@
+# Wait-Process
+
+> Waits for the processes to be stopped before accepting more input.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/wait-process>.
+
+- Stop a process and wait:
+
+`Stop-Process -Id {{process_id}}; Wait-Process -Id {{process_id}}`
+
+- Wait for processes for a specified time:
+
+`Wait-Process -Name {{process_name}} -Timeout {{30}}`

--- a/pages/windows/where-object.md
+++ b/pages/windows/where-object.md
@@ -2,7 +2,7 @@
 
 > Selects objects from a collection based on their property values.
 > This command can only be used through PowerShell.
-> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object>.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object>.
 
 - Filter aliases by its name:
 

--- a/pages/windows/where-object.md
+++ b/pages/windows/where-object.md
@@ -1,0 +1,17 @@
+# Where-Object
+
+> Selects objects from a collection based on their property values.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object>.
+
+- Filter aliases by its name:
+
+`Get-Alias | Where-Object -{{Property}} {{Name}} -{{eq}} {{name}}`
+
+- Get a list of all services that are currently stopped. The `$_` automatic variable represents each object that is passed to the `Where-Object` cmdlet:
+
+`Get-Service | Where-Object {$_.Status -eq "Stopped"}`
+
+- Use multiple conditions:
+
+`Get-Module -ListAvailable | Where-Object { $_.Name -NotLike "Microsoft*" -And $_.Name -NotLike "PS*" }`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Thanks for this amazing project. Many times I needed to know how to run a command but the help/manpage was too complex.

I'm still working on adding more commands to this PR. Please hold from verifying until done.

Question: I noticed that some PowerShell related aliases have the same name of other tools. Is it possible to group utility related commands in a sub folder for disambiguation?

eg:
```
pages/
  windows/
    powershel/
      where.md
      ...
```

For #6621