### PR TITLE
qmrestore: add examples

### DIFF
--- a/pages/linux/qmrestore.md
+++ b/pages/linux/qmrestore.md
@@ -1,8 +1,20 @@
 # qmrestore
 
-> Restore QemuServer vzdump Backups.
+> Restore QemuServer vzdump backups.
 > More information: <https://pve.proxmox.com/pve-docs/qmrestore.1.html>.
 
-- Restore KVM-based virtual machine to local storage:
+- Restore virtual machine from given backup file on the original storage:
 
-`qmrestore {{/var/lib/vz/dump/backup_file.vma.lzo}} {{vm_id}} --storage {{local}}`
+`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}}`
+
+- Overwrite existing virtual machine from given backup file on the original storage:
+
+`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --force true`
+
+- Restore virtual machine from given backup file on a specific [storage]:
+
+`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --storage {{local}}`
+
+- Start virtual machine immediately from the backup while restoring in the background (only on Proxmox Backup Server):
+
+`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --live-restore true`

--- a/pages/linux/qmrestore.md
+++ b/pages/linux/qmrestore.md
@@ -11,7 +11,7 @@
 
 `qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --force true`
 
-- Restore virtual machine from given backup file on a specific [storage]:
+- Restore the virtual machine from a given backup file on specific storage:
 
 `qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --storage {{local}}`
 

--- a/pages/linux/qmrestore.md
+++ b/pages/linux/qmrestore.md
@@ -7,7 +7,7 @@
 
 `qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}}`
 
-- Overwrite existing virtual machine from given backup file on the original storage:
+- Overwrite existing virtual machine from a given backup file on the original storage:
 
 `qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --force true`
 

--- a/pages/linux/qmrestore.md
+++ b/pages/linux/qmrestore.md
@@ -5,16 +5,16 @@
 
 - Restore virtual machine from given backup file on the original storage:
 
-`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}}`
+`qmrestore {{path/to/vzdump-qemu-100.vma.lzo}} {{100}}`
 
 - Overwrite existing virtual machine from a given backup file on the original storage:
 
-`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --force true`
+`qmrestore {{path/to/vzdump-qemu-100.vma.lzo}} {{100}} --force true`
 
 - Restore the virtual machine from a given backup file on specific storage:
 
-`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --storage {{local}}`
+`qmrestore {{path/to/vzdump-qemu-100.vma.lzo}} {{100}} --storage {{local}}`
 
 - Start virtual machine immediately from the backup while restoring in the background (only on Proxmox Backup Server):
 
-`qmrestore {{path/to/vzdump-qemu-100-2022_10_07-09_10_10.vma.lzo}} {{100}} --live-restore true`
+`qmrestore {{path/to/vzdump-qemu-100.vma.lzo}} {{100}} --live-restore true`


### PR DESCRIPTION
Add examples for basic usage (without options!), --force and --live-restore

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
version 7.2, Wed 04 May 2022 07:30:00 AM CEST ( https://pve.proxmox.com/pve-docs/qmrestore.1.html )