### PR TITLE
scripts: improve generated PDF bookmark layout

### DIFF
--- a/scripts/pdf/basic.css
+++ b/scripts/pdf/basic.css
@@ -34,3 +34,13 @@ h1, h2, h4, ul {
     margin-top: 8.2em;
     font-size: 300%;
 }
+
+/*
+The same is to have this look like a H1 tag, but we want the H2 tag so the
+bookmarks list makes sense.
+*/
+h2.title-page {
+    font-size: 2em;
+    margin-top: 0.67em;
+    margin-bottom: 0.67em;
+}

--- a/scripts/pdf/render.py
+++ b/scripts/pdf/render.py
@@ -10,7 +10,6 @@ through CSS, and finally rendering them as PDF. There is no LaTeX dependency for
 import os
 import sys
 import glob
-import re
 import markdown
 import argparse
 from datetime import datetime
@@ -34,10 +33,10 @@ def main(loc, colorscheme):
     html = (
         '<!doctype html><html><head><meta charset="utf-8"></head>'
         + "<body><h1 class=title-main>tldr pages</h1>"
-        + "<h4 class=title-sub>Simplified and community-driven man pages</h4>"
-        + "<h6 class=title-sub><em><small>Generated on "
+        + "<div class=title-sub>Simplified and community-driven man pages</div>"
+        + "<div class=title-sub><em><small>Generated on "
         + datetime.now().strftime("%c")
-        + "</small></em></h6>"
+        + "</small></em></div>"
         + '<p style="page-break-before: always" ></p>'
     )
 
@@ -46,9 +45,9 @@ def main(loc, colorscheme):
 
         # Required string to create directory title pages
         html += (
-            "<h2 class=title-dir>"
+            "<h1 class=title-dir>"
             + operating_sys.capitalize()
-            + "</h2>"
+            + "</h1>"
             + '<p style="page-break-before: always" ></p>'
         )
 
@@ -58,9 +57,12 @@ def main(loc, colorscheme):
         ):
             with open(md, "r") as inp:
                 text = inp.readlines()
+                # modify our page to have an H2 header, so that it is grouped under
+                # the H1 header for the directory
+                text[0] = "<h2 class='title-page'>" + text[0][2:] + "</h2>"
                 for line in text:
-                    if re.match(r"^>", line):
-                        line = line[:0] + "####" + line[1:]
+                    if line.startswith(">"):
+                        line = "####" + line[1:]
                     html += markdown.markdown(line)
             html += '<p style="page-break-before: always" ></p>'
             print(f"Rendered page {page_number} of the directory {operating_sys}")


### PR DESCRIPTION
PR fixes #7870, improving how the PDF bookmarks is laid out such that each command is listed underneath its directory. I also modified the title page such that it doesn't have an entry in the bookmark list for its subtitles.

The problem for why this is happening is that weasyprint uses the header tags to determine how content should be logically grouped. The way the tags were laid out prior to this PR was essentially (each 2 space indentation indicates another header level)

```
* tldr-pages
        * Simplified and community-driven man pages
        *  Generated on ...
  * android
* am
...
* wm
  * common
* 2to3
...
```  

And so, we end up with a weird setup where the directory page separator for `common` ends up under the `wm` page in android, etc.

To address this, I moved the directory page separators up to `h1` tags (so they're at the root) and then each page is given an `h2` tag so they nest under it, giving us:

```
* tldr-pages
* android
  * am
  ...
  * wm
* common 
  * 2to3
...
```

and this gives us a nicer looking bookmark list in PDF viewers (I show only android here for speed of testing):
![tldr-pdf](https://user-images.githubusercontent.com/1845314/194655113-0a0f42cd-9161-4d74-9d0f-0488200fa2d1.png)

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
