### PR TITLE
aws-s3api: add --region to create-bucket example

### DIFF
--- a/pages/common/aws-s3api.md
+++ b/pages/common/aws-s3api.md
@@ -5,7 +5,7 @@
 
 - Create bucket in a specific region:
 
-`aws s3api create-bucket --bucket {{bucket_name}} --region ap-south-1 --create-bucket-configuration LocationConstraint=ap-south-1`
+`aws s3api create-bucket --bucket {{bucket_name}} --region {{region}} --create-bucket-configuration LocationConstraint={{region}}`
 
 - Delete a bucket:
 

--- a/pages/common/aws-s3api.md
+++ b/pages/common/aws-s3api.md
@@ -7,6 +7,10 @@
 
 `aws s3api create-bucket --bucket {{bucket_name}}`
 
+- Create bucket outside us-east-1:
+
+`aws s3api create-bucket --bucket {{bucket_name}} --region ap-south-1 --create-bucket-configuration LocationConstraint=ap-south-1`
+
 - Delete a bucket:
 
 `aws s3api delete-bucket --bucket {{bucket_name}}`

--- a/pages/common/aws-s3api.md
+++ b/pages/common/aws-s3api.md
@@ -3,11 +3,7 @@
 > Create and delete Amazon S3 buckets and edit bucket properties.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/index.html>.
 
-- Create a bucket:
-
-`aws s3api create-bucket --bucket {{bucket_name}}`
-
-- Create bucket outside us-east-1:
+- Create bucket in a specific region:
 
 `aws s3api create-bucket --bucket {{bucket_name}} --region ap-south-1 --create-bucket-configuration LocationConstraint=ap-south-1`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** aws-cli/1.25.71
