### PR TITLE
doctl-kubernetes-options: add page

### DIFF
--- a/pages/common/doctl-kubernetes-options.md
+++ b/pages/common/doctl-kubernetes-options.md
@@ -1,6 +1,6 @@
 # doctl kubernetes options
 
-> Provides values available for use with doctl's kubernetes commands.
+> Provides values available for use with doctl's Kubernetes commands.
 > More information: <https://docs.digitalocean.com/reference/doctl/reference/kubernetes/options/>.
 
 - List regions that support Kubernetes clusters:

--- a/pages/common/doctl-kubernetes-options.md
+++ b/pages/common/doctl-kubernetes-options.md
@@ -1,0 +1,16 @@
+# doctl kubernetes options
+
+> Provides values available for use with doctl's kubernetes commands.
+> More information: <https://docs.digitalocean.com/reference/doctl/reference/kubernetes/options/>.
+
+- List regions that support Kubernetes clusters:
+
+`doctl kubernetes options regions`
+
+- List machine sizes that can be used in a Kubernetes cluster:
+
+`doctl kubernetes options sizes`
+
+- List Kubernetes versions that can be used with DigitalOcean clusters:
+
+`doctl kubernetes options versions`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
doctl version 1.82.0-release

Addresses  #7475
doctl kubernetes command has 3 main subcommands (create, options, and 1-click). This covers the options subcommand