### PR TITLE
podman: examples parity with docker

### DIFF
--- a/pages/common/podman.md
+++ b/pages/common/podman.md
@@ -4,33 +4,33 @@
 > Podman provides a Docker-CLI comparable command-line. Simply put: `alias docker=podman`.
 > More information: <https://github.com/containers/podman/blob/main/commands-demo.md>.
 
-- Print out information about containers:
-
-`podman ps`
-
 - List all containers (both running and stopped):
 
 `podman ps --all`
 
-- Start one or more containers:
+- Create a container from an image, with a custom name:
 
-`podman start {{container_name}} {{container_id}}`
+`podman run --name {{container_name}} {{image}}`
 
-- Stop one or more running containers:
+- Start or stop an existing container:
 
-`podman stop {{container_name}} {{container_id}}`
+`podman {{start|stop}} {{container_name}}`
 
-- Pull an image from a registry (defaults to the Docker Hub):
+- Pull an image from a registry (defaults to Docker Hub):
 
-`podman pull {{image_name}}:{{image_tag}}`
+`podman pull {{image}}`
+
+- Display the list of already downloaded images:
+
+`podman images`
 
 - Open a shell inside an already running container:
 
 `podman exec --interactive --tty {{container_name}} {{sh}}`
 
-- Remove one or more stopped containers:
+- Remove a stopped container:
 
-`podman rm {{container_name}} {{container_id}}`
+`podman rm {{container_name}}`
 
 - Display the logs of one or more containers and follow log output:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): N/A (applies to most/all versions)**
