### PR TITLE
qm-monitor: fix filename

### DIFF
--- a/pages/linux/qm-monitor.md
+++ b/pages/linux/qm-monitor.md
@@ -1,8 +1,8 @@
 # qm monitor
 
-> Enter Qemu Monitor interface.
+> Enter the QEMU Monitor interface.
 > More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
-- Enter Qemu Monitor interface of a specific virtual machine:
+- Enter the QEMU Monitor interface of a specific virtual machine:
 
 `qm monitor {{vm_id}}`

--- a/pages/linux/qm-monitor.md
+++ b/pages/linux/qm-monitor.md
@@ -1,0 +1,8 @@
+# qm monitor
+
+> Enter Qemu Monitor interface.
+> More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Enter Qemu Monitor interface of a specific virtual machine:
+
+`qm monitor {{vm_id}}`

--- a/pages/linux/qmmonitor.md
+++ b/pages/linux/qmmonitor.md
@@ -1,8 +1,0 @@
-# qm monitor
-
-> Enter QEMU monitor interfaces.
-> More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
-
-- Enter a QEMU monitor interface:
-
-`qm monitor {{vm_id}}`


### PR DESCRIPTION
Refers #8537

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
