### PR TITLE
kubectl-*: move .yaml inside token syntax

### DIFF
--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -29,4 +29,4 @@
 
 - Delete resources defined in a YAML manifest:
 
-`kubectl delete --filename {{path/to/manifest.yaml}}`
+`kubectl delete --filename {{path/to/manifest}}.yaml`

--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -29,4 +29,4 @@
 
 - Delete resources defined in a YAML manifest:
 
-`kubectl delete --filename {{path/to/manifest}}.yaml`
+`kubectl delete --filename {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-describe.md
+++ b/pages/common/kubectl-describe.md
@@ -21,4 +21,4 @@
 
 - Show details of Kubernetes objects defined in a YAML manifest:
 
-`kubectl describe -f {{path/to/manifest}}.yaml`
+`kubectl describe -f {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-get.md
+++ b/pages/common/kubectl-get.md
@@ -29,4 +29,4 @@
 
 - Get Kubernetes objects defined in a YAML manifest:
 
-`kubectl get -f {{path/to/manifest}}.yaml`
+`kubectl get -f {{path/to/manifest.yaml}}`


### PR DESCRIPTION
Ref: #8746; In order to better align with other `kubectl` pages having a `.yaml` file extension outside the path, I am updating this page.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).