### PR TITLE
register_new_matrix_user: add page

### DIFF
--- a/pages/linux/register_new_matrix_user.md
+++ b/pages/linux/register_new_matrix_user.md
@@ -1,7 +1,7 @@
 # register_new_matrix_user
 
 > Used to register new users with a given home server when registration has been disabled.
-> More information: <https://manned.org/register_new_matrix_user.1>.
+> More information: <https://manned.org/register_new_matrix_user>.
 
 - Create a user interactively:
 

--- a/pages/linux/register_new_matrix_user.md
+++ b/pages/linux/register_new_matrix_user.md
@@ -1,0 +1,16 @@
+# register_new_matrix_user
+
+> Used to register new users with a given home server when registration has been disabled.
+> More information: <https://manned.org/register_new_matrix_user.1>.
+
+- Create a user interactively:
+
+`register_new_matrix_user --config {{path/to/homeserver.yaml}}`
+
+- Create an admin user interactively:
+
+`register_new_matrix_user --config {{path/to/homeserver.yaml}} --admin`
+
+- Create an admin user non-interactively (not recommended):
+
+`register_new_matrix_user --config {{path/to/homeserver.yaml}} --user {{username}} --password {{password}} --admin`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

---

When self-hosting a Matrix server, this tool is used to register new users by the admin.

### Open Questions

Anyone have an idea of a simple and clean way to specify why the latter command is not recommended in most cases? (Shouldn't place passwords directly in commands.)