### PR TITLE
security: fix typo in example

### DIFF
--- a/pages/osx/security.md
+++ b/pages/osx/security.md
@@ -21,7 +21,7 @@
 
 - Add a certificate from file to a [k]eychain (if -k isn't specified, the default keychain is used):
 
-`security add-certificates -k {{keychain.name}} {{path/to/cert.pem}}`
+`security add-certificates -k {{file.keychain}} {{path/to/cert.pem}}`
 
 - Add a CA certificate to the per-user Trust Settings:
 


### PR DESCRIPTION
Documentation available here: https://ss64.com/osx/security-internet.html. Apple keychains end with *.keychain.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
