### PR TITLE
osx/*: add pt_BR translations

### DIFF
--- a/pages.pt_BR/osx/dark-mode.md
+++ b/pages.pt_BR/osx/dark-mode.md
@@ -1,0 +1,20 @@
+# dark-mode
+
+> Controla o modo escuro do macOS a partir da linha de comando.
+> Mais informações: <https://github.com/sindresorhus/dark-mode>.
+
+- Alterna o modo escuro (ativa se estiver desativado, desativa se estiver ativado):
+
+`dark-mode`
+
+- Ativa o modo escuro:
+
+`dark-mode on`
+
+- Desativa o modo escuro:
+
+`dark-mode off`
+
+- Verifica se o modo escuro está ativado:
+
+`dark-mode status`

--- a/pages.pt_BR/osx/date.md
+++ b/pages.pt_BR/osx/date.md
@@ -1,0 +1,20 @@
+# date
+
+> Define ou exibe a data do sistema.
+> Mais informações: <https://ss64.com/osx/date.html>.
+
+- Exibe a data atual usando o formato da localidade padrão:
+
+`date +%c`
+
+- Exibe a data atual no formato UTC e ISO 8601:
+
+`date -u +%Y-%m-%dT%H:%M:%SZ`
+
+- Exibe a data atual como um timestamp Unix (segundos desde a época Unix):
+
+`date +%s`
+
+- Exibe uma data específica (representada como um timestamp Unix) usando o formato padrão:
+
+`date -r 1473305798`

--- a/pages.pt_BR/osx/dd.md
+++ b/pages.pt_BR/osx/dd.md
@@ -1,0 +1,20 @@
+# dd
+
+> Converte e copia um arquivo.
+> Mais informações: <https://ss64.com/osx/dd.html>.
+
+- Cria uma unidade USB inicializável a partir de um arquivo isohybrid (tal como `archlinux-xxx.iso`):
+
+`dd if={{arquivo.iso}} of=/dev/{{unidade_usb}}`
+
+- Clona uma unidade para outra unidade com bloco de 4 MB e ignora erro:
+
+`dd if=/dev/{{unidade_origem}} of=/dev/{{unidade_destino}} bs=4m conv=noerror`
+
+- Gera um arquivo de 100 bytes aleatórios usando o driver aleatório do kernel:
+
+`dd if=/dev/urandom of={{arquivo_aleatório}} bs=100 count=1`
+
+- Compara o desempenho de gravação de um disco:
+
+`dd if=/dev/zero of={{arquivo_1GB}} bs=1024 count=1000000`

--- a/pages.pt_BR/osx/defaults.md
+++ b/pages.pt_BR/osx/defaults.md
@@ -1,0 +1,28 @@
+# defaults
+
+> Lê e grava a configuração do usuário do macOS para aplicativos.
+> Mais informações: <https://ss64.com/osx/defaults.html>.
+
+- Lê os padrões do sistema para uma opção do aplicativo:
+
+`defaults read "{{aplicativo}}" "{{opção}}"`
+
+- Lê os valores padrão para uma opção do aplicativo:
+
+`defaults read -app "{{aplicativo}}" "{{opção}}"`
+
+- Pesquisa uma palavra-chave em nomes de domínio, chaves, e valores:
+
+`defaults find "{{palavra-chave}}"`
+
+- Grava o valor padrão de uma opção do aplicativo:
+
+`defaults write "{{aplicativo}}" "{{opção}}" {{-tipo}} {{valor}}`
+
+- Acelera as animações do Mission Control:
+
+`defaults write com.apple.Dock expose-animation-duration -float 0.1`
+
+- Exclui todos os padrões de um aplicativo:
+
+`defaults delete "{{aplicativo}}"`

--- a/pages.pt_BR/osx/diskutil.md
+++ b/pages.pt_BR/osx/diskutil.md
@@ -1,0 +1,20 @@
+# diskutil
+
+> Utilitário para gerenciar discos e volumes locais.
+> Mais informações: <https://ss64.com/osx/diskutil.html>.
+
+- Lista todos os discos, partições, e volumes montados atualmente disponíveis:
+
+`diskutil list`
+
+- Repara as estruturas de dados do sistema de arquivos de um volume:
+
+`diskutil repairVolume {{/dev/diskX}}`
+
+- Desmonta um volume:
+
+`diskutil unmountDisk {{/dev/diskX}}`
+
+- Ejeta um CD/DVD (desmonta primeiro):
+
+`diskutil eject {{/dev/disk1}}`

--- a/pages.pt_BR/osx/distnoted.md
+++ b/pages.pt_BR/osx/distnoted.md
@@ -1,0 +1,9 @@
+# distnoted
+
+> Fornece serviços de notificação distribuídos.
+> Não deve ser invocado manualmente.
+> Mais informações: <https://www.manpagez.com/man/8/distnoted/>.
+
+- Inicia o daemon:
+
+`distnoted`

--- a/pages.pt_BR/osx/ditto.md
+++ b/pages.pt_BR/osx/ditto.md
@@ -1,0 +1,16 @@
+# ditto
+
+> Copia arquivos e diretórios.
+> Mais informações: <https://ss64.com/osx/ditto.html>.
+
+- Sobrescreve o conteúdo do diretório de destino pelo conteúdo do diretório de origem:
+
+`ditto {{caminho/para/origem}} {{caminho/para/destino}}`
+
+- Imprime uma linha na janela do Terminal para cada arquivo que está sendo copiado:
+
+`ditto -V {{caminho/para/origem}} {{caminho/para/destino}}`
+
+- Copia um determinado arquivo ou diretório, mantendo as permissões do arquivo original:
+
+`ditto -rsrc {{caminho/para/origem}} {{caminho/para/destino}}`

--- a/pages.pt_BR/osx/dmesg.md
+++ b/pages.pt_BR/osx/dmesg.md
@@ -1,0 +1,16 @@
+# dmesg
+
+> Exibe mensagens do kernel na saída padrão.
+> Mais informações: <https://www.manpagez.com/man/8/dmesg/>.
+
+- Exibe mensagens do kernel:
+
+`dmesg`
+
+- Exibe quanta memória física está disponível no sistema:
+
+`dmesg | grep -i memory`
+
+- Exibe mensagens do kernel, 1 página por vez:
+
+`dmesg | less`

--- a/pages.pt_BR/osx/dot_clean.md
+++ b/pages.pt_BR/osx/dot_clean.md
@@ -1,0 +1,28 @@
+# dot_clean
+
+> Mescla ._* arquivos com arquivos nativos correspondentes.
+> Mais informações: <https://ss64.com/osx/dot_clean.html>.
+
+- Mescla todos os `._*` arquivos recursivamente:
+
+`dot_clean {{caminho/para/diretório}}`
+
+- Não mescla recursivamente todos `._*` em um diretório (flat merge):
+
+`dot_clean -f {{caminho/para/diretório}}`
+
+- Mescla e exclui todos os arquivos `._*`:
+
+`dot_clean -m {{caminho/para/diretório}}`
+
+- Somente exclui arquivos `._*` se houver um arquivo nativo correspondente:
+
+`dot_clean -n {{caminho/para/diretório}}`
+
+- Segue os links simbólicos:
+
+`dot_clean -s {{caminho/para/diretório}}`
+
+- Imprime saída verbosa:
+
+`dot_clean -v {{caminho/para/diretório}}`

--- a/pages.pt_BR/osx/drutil.md
+++ b/pages.pt_BR/osx/drutil.md
@@ -1,0 +1,12 @@
+# drutil
+
+> Interage com gravadores de DVD.
+> Mais informações: <https://ss64.com/osx/drutil.html>.
+
+- Ejeta um disco da unidade:
+
+`drutil eject`
+
+- Grava um diretório como um sistema de arquivos ISO9660 em um DVD. Não verifica, e ejeta quando terminar:
+
+`drutil burn -noverify -eject -iso9660`

--- a/pages.pt_BR/osx/du.md
+++ b/pages.pt_BR/osx/du.md
@@ -1,0 +1,28 @@
+# du
+
+> Uso do Disco: estima e resume o uso do espaço de arquivos e diretórios.
+> Mais informações: <https://ss64.com/osx/du.html>.
+
+- Lista os tamanhos de um diretório e quaisquer subdiretórios, na unidade fornecida (KiB/MiB/GiB):
+
+`du -{{k|m|g}} {{caminho/para/diretório}}`
+
+- Lista os tamanhos de um diretório e quaisquer subdiretórios, em formato legível (ou seja, selecionando automaticamente a unidade apropriada para cada tamanho):
+
+`du -h {{caminho/para/diretório}}`
+
+- Exibe o tamanho de um único diretório, em unidades legíveis:
+
+`du -sh {{caminho/para/diretório}}`
+
+- Lista os tamanhos legíveis de um diretório e de todos os arquivos e diretórios dentro dele:
+
+`du -ah {{caminho/para/diretório}}`
+
+- Lista os tamanhos legíveis de um diretório e quaisquer subdiretórios, até N níveis de profundidade:
+
+`du -h -d {{N}} {{caminho/para/diretório}}`
+
+- Lista o tamanho legível de todos os arquivos `.jpg` nos subdiretórios do diretório atual e exibe um total cumulativo no final:
+
+`du -ch {{*/*.jpg}}`

--- a/pages.pt_BR/osx/duti.md
+++ b/pages.pt_BR/osx/duti.md
@@ -1,0 +1,28 @@
+# duti
+
+> Define os aplicativos padrão para tipos de documentos e esquemas de URL no macOS.
+> Mais informações: <https://github.com/moretension/duti>.
+
+- Define o Safari como o manipulador padrão de documentos HTML:
+
+`duti -s {{com.apple.Safari}} {{public.html}} all`
+
+- Define o VLC como visualizador padrão para arquivos com extensões `.m4v`:
+
+`duti -s {{org.videolan.vlc}} {{m4v}} viewer`
+
+- Define o Finder como o manipulador padrão para esquema de URL ftp://:
+
+`duti -s {{com.apple.Finder}} "{{ftp}}"`
+
+- Exibe informações sobre o aplicativo padrão para uma determinada extensão:
+
+`duti -x {{ext}}`
+
+- Exibe o manipulador padrão para um determinado UTI:
+
+`duti -d {{uti}}`
+
+- Exibe todos os manipuladores de um determinado UTI:
+
+`duti -l {{uti}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
https://github.com/tldr-pages/tldr/blob/main/pages/osx/dark-mode.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/date.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/dd.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/defaults.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/diskutil.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/distnoted.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/ditto.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/dmesg.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/dot_clean.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/drutil.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/du.md
https://github.com/tldr-pages/tldr/blob/main/pages/osx/duti.md
