### PR TITLE
aws-google-auth, aws-help, aws-history: add pt_BR translation

### DIFF
--- a/pages.pt_BR/common/aws-google-auth.md
+++ b/pages.pt_BR/common/aws-google-auth.md
@@ -1,0 +1,20 @@
+# aws-google-auth
+
+> Linha de comando para obter credenciais (STS) temporárias AWS usando o Google Apps como um provedor (Single Sign-On) federado.
+> Mais informações: <https://github.com/cevoaustralia/aws-google-auth>.
+
+- Loga com o Google SSO usando identificadores IDP e SP e criar credenciais com duração de uma hora:
+
+`aws-google-auth -u {{exemplo@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}}`
+
+- Loga perguntando ([a]sking) qual papel usar (no caso de diversos papeis SAML disponíveis):
+
+`aws-google-auth -u {{examplo@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}} -a`
+
+- Resolve aliases para contas AWS:
+
+`aws-google-auth -u {{examplo@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}} -a --resolve-aliases`
+
+- Exibe informações de ajuda:
+
+`aws-google-auth -h`

--- a/pages.pt_BR/common/aws-help.md
+++ b/pages.pt_BR/common/aws-help.md
@@ -1,0 +1,16 @@
+# aws help
+
+> Exibe ajuda sobre o AWS CLI.
+> Mais informações: <https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-help.html>.
+
+- Exibe a ajuda:
+
+`aws help`
+
+- Lista todos os tópicos disponíveis:
+
+`aws help topics`
+
+- Exibe ajuda sobre um tópico específico:
+
+`aws help {{nome_do_tópico}}`

--- a/pages.pt_BR/common/aws-history.md
+++ b/pages.pt_BR/common/aws-history.md
@@ -1,0 +1,12 @@
+# aws history
+
+> Exibe o histórico dos comandos para o AWS CLI (o armazenamento do hisitórico dos comandos do AWS CLI deve estar habilitado).
+> Mais informações: <https://docs.aws.amazon.com/cli/latest/reference/history/>.
+
+- Lista histórico dos comandos e seus IDs:
+
+`aws history list`
+
+- Exibe eventos relacionados a um comando específico dado um ID do comando:
+
+`aws history show {{id_do_comando}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
