### PR TITLE
java related pages: fix command description case

### DIFF
--- a/pages/common/jar.md
+++ b/pages/common/jar.md
@@ -1,6 +1,6 @@
 # jar
 
-> Java Applications/Libraries Packager.
+> Java applications/libraries packager.
 > More information: <https://docs.oracle.com/javase/tutorial/deployment/jar/basicsindex.html>.
 
 - Recursively archive all files in the current directory into a .jar file:

--- a/pages/common/jarsigner.md
+++ b/pages/common/jarsigner.md
@@ -1,6 +1,6 @@
 # jarsigner
 
-> Sign and verify Java Archive (JAR) files.
+> Sign and verify Java archive (JAR) files.
 > More information: <https://docs.oracle.com/javase/9/tools/jarsigner.htm>.
 
 - Sign a JAR file:

--- a/pages/common/java.md
+++ b/pages/common/java.md
@@ -1,6 +1,6 @@
 # java
 
-> Java Application Launcher.
+> Java application launcher.
 > More information: <https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html>.
 
 - Execute a java `.class` file that contains a main method by using just the class name:

--- a/pages/common/javac.md
+++ b/pages/common/javac.md
@@ -1,6 +1,6 @@
 # javac
 
-> Java Application Compiler.
+> Java application compiler.
 > More information: <https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html>.
 
 - Compile a `.java` file:

--- a/pages/common/jhat.md
+++ b/pages/common/jhat.md
@@ -1,6 +1,6 @@
 # jhat
 
-> Java Heap Analysis Tool.
+> Java heap analysis tool.
 > More information: <https://docs.oracle.com/javase/8/docs/technotes/tools/unix/jhat.html>.
 
 - Analyze a heap dump (from `jmap`), view via HTTP on port 7000:

--- a/pages/common/jmap.md
+++ b/pages/common/jmap.md
@@ -1,6 +1,6 @@
 # jmap
 
-> Java Memory Map Tool.
+> Java memory map tool.
 > More information: <https://docs.oracle.com/javase/7/docs/technotes/tools/share/jmap.html>.
 
 - Print shared object mappings for a Java process (output like pmap):

--- a/pages/common/jps.md
+++ b/pages/common/jps.md
@@ -1,6 +1,6 @@
 # jps
 
-> Show JVM Process Status of current user.
+> Show JVM process status of current user.
 > More information: <https://docs.oracle.com/en/java/javase/11/tools/jps.html>.
 
 - List all JVM processes:

--- a/pages/common/jstack.md
+++ b/pages/common/jstack.md
@@ -1,6 +1,6 @@
 # jstack
 
-> Java Stack Trace Tool.
+> Java stack trace tool.
 > More information: <https://manned.org/jstack>.
 
 - Print Java stack traces for all threads in a Java process:

--- a/pages/common/kotlin.md
+++ b/pages/common/kotlin.md
@@ -1,6 +1,6 @@
 # kotlin
 
-> Kotlin Application Launcher.
+> Kotlin application launcher.
 > More information: <https://kotlinlang.org>.
 
 - Run a jar file:


### PR DESCRIPTION
As mentioned in https://github.com/tldr-pages/tldr/pull/8758#discussion_r991419458 this PR is to adjust various java related pages so that the titles are consistent and don't use title case. By java related pages I mainly mean the ones listed in https://docs.oracle.com/en/java/javase/18/docs/specs/man/ and additionally also the Kotlin page as it is tangentially related and had the same issue.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
