### PR TITLE
twine: add examples

### DIFF
--- a/pages/common/twine.md
+++ b/pages/common/twine.md
@@ -22,3 +22,15 @@
 - Check that your distribution’s long description should render correctly on PyPI:
 
 `twine check dist/*`
+
+- Upload with a specific pypirc configuration file (<https://packaging.python.org/en/latest/specifications/pypirc>):
+
+`twine upload --config-file {{config_file}} dist/*`
+
+- Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other implementations may not support this.):
+
+`twine upload --skip-existing dist/*`
+
+- Display extra verbosity during upload:
+
+`twine upload --verbose dist/*`

--- a/pages/common/twine.md
+++ b/pages/common/twine.md
@@ -1,13 +1,13 @@
 # twine
 
 > Utility for publishing Python packages on PyPI.
-> More information: <https://twine.readthedocs.io>.
+> More information: <https://twine.readthedocs.io/en/stable/#commands>.
 
 - Upload to PyPI:
 
 `twine upload dist/*`
 
-- Upload to the Test PyPI [r]epository and verify things look right:
+- Upload to the Test PyPI [r]epository to verify things look right:
 
 `twine upload -r testpypi dist/*`
 
@@ -27,7 +27,7 @@
 
 `twine upload --config-file {{configuration_file}} dist/*`
 
-- Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other implementations may not support this.):
+- Continue uploading files if one already exists (only valid when uploading to PyPI):
 
 `twine upload --skip-existing dist/*`
 

--- a/pages/common/twine.md
+++ b/pages/common/twine.md
@@ -1,16 +1,15 @@
 # twine
 
 > Utility for publishing Python packages on PyPI.
-> Subcommands such as `twine upload` have their own usage documentation.
 > More information: <https://twine.readthedocs.io>.
-
-- Upload to the Test PyPI [r]epository and verify things look right:
-
-`twine upload -r testpypi dist/*`
 
 - Upload to PyPI:
 
 `twine upload dist/*`
+
+- Upload to the Test PyPI [r]epository and verify things look right:
+
+`twine upload -r testpypi dist/*`
 
 - Upload to PyPI with a specified [u]sername and [p]assword:
 
@@ -19,3 +18,7 @@
 - Upload to an alternative repository URL:
 
 `twine upload --repository-url {{repository_url}} dist/*`
+
+- Check that your distribution’s long description should render correctly on PyPI:
+
+`twine check dist/*`

--- a/pages/common/twine.md
+++ b/pages/common/twine.md
@@ -19,18 +19,18 @@
 
 `twine upload --repository-url {{repository_url}} dist/*`
 
-- Check that your distribution’s long description should render correctly on PyPI:
+- Check that your distribution's long description should render correctly on PyPI:
 
 `twine check dist/*`
 
-- Upload with a specific pypirc configuration file (<https://packaging.python.org/en/latest/specifications/pypirc>):
+- Upload using a specific pypirc configuration file:
 
-`twine upload --config-file {{config_file}} dist/*`
+`twine upload --config-file {{configuration_file}} dist/*`
 
 - Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other implementations may not support this.):
 
 `twine upload --skip-existing dist/*`
 
-- Display extra verbosity during upload:
+- Upload to PyPI showing detailed information:
 
 `twine upload --verbose dist/*`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Follow up to https://github.com/tldr-pages/tldr/pull/8624.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
```
$ twine --version
twine version 4.0.1 (importlib-metadata: 4.13.0, keyring: 23.9.3, pkginfo: 1.8.3, requests: 2.28.1, requests-toolbelt: 0.9.1, urllib3: 1.26.12)
```
