### PR TITLE
cf: add login example

### DIFF
--- a/pages/common/cf.md
+++ b/pages/common/cf.md
@@ -3,6 +3,10 @@
 > Command-line tool to manage apps and services on Cloud Foundry.
 > More information: <https://docs.cloudfoundry.org>.
 
+- Log in to the Cloud Foundry API:
+
+`cf login -a {{api_url}}`
+
 - Push an app using the default settings:
 
 `cf push {{app_name}}`


### PR DESCRIPTION
The `cf login` command is very important and the first step to authenticate the end user.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
