### PR TITLE
android/*: add pt_PT translations

### DIFF
--- a/pages.pt_PT/android/am.md
+++ b/pages.pt_PT/android/am.md
@@ -15,6 +15,6 @@
 
 `am start -a {{android.intent.action.MAIN}} -c {{android.intent.category.HOME}}`
 
-- Converter um intent num URI:
+- Converter um `intent` num URI:
 
 `am to-uri -a {{android.intent.action.VIEW}} -d {{tel:123}}`

--- a/pages.pt_PT/android/am.md
+++ b/pages.pt_PT/android/am.md
@@ -1,0 +1,20 @@
+# am
+
+> Gestor de atividades do Android (Activity Manager).
+> Mais informações: <https://developer.android.com/studio/command-line/adb#am>.
+
+- Iniciar uma atividade específica:
+
+`am start -n {{com.android.settings/.Settings}}`
+
+- Iniciar uma atividade e passar-lhe dados:
+
+`am start -a {{android.intent.action.VIEW}} -d {{tel:123}}`
+
+- Iniciar uma atividade com uma ação e categoria específicas:
+
+`am start -a {{android.intent.action.MAIN}} -c {{android.intent.category.HOME}}`
+
+- Converter um intent num URI:
+
+`am to-uri -a {{android.intent.action.VIEW}} -d {{tel:123}}`

--- a/pages.pt_PT/android/bugreport.md
+++ b/pages.pt_PT/android/bugreport.md
@@ -4,6 +4,6 @@
 > Este comando só pode ser utilizado com a `adb shell`.
 > Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreport>.
 
-- Mostra um relatório completo de bugs de um dispositivo Android:
+- Mostrar um relatório completo de bugs de um dispositivo Android:
 
 `bugreport`

--- a/pages.pt_PT/android/bugreport.md
+++ b/pages.pt_PT/android/bugreport.md
@@ -1,0 +1,9 @@
+# bugreport
+
+> Mostra um relatório de bugs do Android.
+> Este comando só pode ser utilizado com a `adb shell`.
+> Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreport>.
+
+- Mostra um relatório completo de bugs de um dispositivo Android:
+
+`bugreport`

--- a/pages.pt_PT/android/bugreportz.md
+++ b/pages.pt_PT/android/bugreportz.md
@@ -1,21 +1,21 @@
 # bugreportz
 
 > Gera um relatório de bugs do Android em formato .zip.
-> Esse comando só pode ser utilizado com a `adb shell`.
+> Este comando só pode ser utilizado com a `adb shell`.
 > Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreportz>.
 
-- Mostra um relatório completo de bugs de um dispositivo Android em formato .zip:
+- Mostrar um relatório completo de bugs de um dispositivo Android em formato .zip:
 
 `bugreportz`
 
-- Mostra o progresso de `bugreportz` em execução:
+- Mostrar o progresso de `bugreportz` em execução:
 
 `bugreportz -p`
 
-- Mostra a versão de `bugreportz`:
+- Mostrar a versão de `bugreportz`:
 
 `bugreportz -v`
 
-- Mostra a ajuda:
+- Mostrar a ajuda:
 
 `bugreportz -h`

--- a/pages.pt_PT/android/bugreportz.md
+++ b/pages.pt_PT/android/bugreportz.md
@@ -1,0 +1,21 @@
+# bugreportz
+
+> Gera um relatório de bugs do Android em formato .zip.
+> Esse comando só pode ser utilizado com a `adb shell`.
+> Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/bugreportz>.
+
+- Mostra um relatório completo de bugs de um dispositivo Android em formato .zip:
+
+`bugreportz`
+
+- Mostra o progresso de `bugreportz` em execução:
+
+`bugreportz -p`
+
+- Mostra a versão de `bugreportz`:
+
+`bugreportz -v`
+
+- Mostra a ajuda:
+
+`bugreportz -h`

--- a/pages.pt_PT/android/cmd.md
+++ b/pages.pt_PT/android/cmd.md
@@ -1,0 +1,16 @@
+# cmd
+
+> Gestor de serviços do Android (service manager).
+> Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/cmd/>.
+
+- Lista todos os serviços em execução:
+
+`cmd -l`
+
+- Executa um serviço específico:
+
+`cmd {{alarm}}`
+
+- Executa um serviço com parâmetros:
+
+`cmd {{vibrator}} {{vibrate 300}}`

--- a/pages.pt_PT/android/cmd.md
+++ b/pages.pt_PT/android/cmd.md
@@ -1,16 +1,16 @@
 # cmd
 
-> Gestor de serviços do Android (service manager).
+> Gestor de serviços (service manager) do Android.
 > Mais informações: <https://cs.android.com/android/platform/superproject/+/master:frameworks/native/cmds/cmd/>.
 
-- Lista todos os serviços em execução:
+- Listar todos os serviços em execução:
 
 `cmd -l`
 
-- Executa um serviço específico:
+- Executar um serviço específico:
 
 `cmd {{alarm}}`
 
-- Executa um serviço com parâmetros:
+- Executar um serviço com parâmetros:
 
 `cmd {{vibrator}} {{vibrate 300}}`

--- a/pages.pt_PT/android/dalvikvm.md
+++ b/pages.pt_PT/android/dalvikvm.md
@@ -1,0 +1,8 @@
+# dalvikvm
+
+> A máquina virtual Java do Android.
+> Mais informações: <https://source.android.com/devices/tech/dalvik>.
+
+- Inicia um programa Java:
+
+`dalvikvm -classpath {{caminho/para/arquivo.jar}} {{nome_da_classe}}`

--- a/pages.pt_PT/android/dalvikvm.md
+++ b/pages.pt_PT/android/dalvikvm.md
@@ -3,6 +3,6 @@
 > A máquina virtual Java do Android.
 > Mais informações: <https://source.android.com/devices/tech/dalvik>.
 
-- Inicia um programa Java:
+- Iniciar um programa Java:
 
 `dalvikvm -classpath {{caminho/para/arquivo.jar}} {{nome_da_classe}}`

--- a/pages.pt_PT/android/dumpsys.md
+++ b/pages.pt_PT/android/dumpsys.md
@@ -4,26 +4,26 @@
 > Este comando só pode ser usado com a `adb shell`.
 > Mais informações: <https://developer.android.com/studio/command-line/dumpsys>.
 
-- Gera um diagnóstico de todos os serviços do sistema:
+- Gerar um diagnóstico de todos os serviços do sistema:
 
 `dumpsys`
 
-- Gera um diagnóstico de um serviço do sistema específico:
+- Gerar um diagnóstico de um serviço do sistema específico:
 
 `dumpsys {{servico}}`
 
-- Lista todos os serviços dos quais o `dumpsys` pode obter informações:
+- Listar todos os serviços dos quais o `dumpsys` pode obter informações:
 
 `dumpsys -l`
 
-- Lista argumentos específicos de um serviço para um serviço:
+- Listar argumentos específicos de um serviço para um serviço:
 
 `dumpsys {{servico}} -h`
 
-- Omite um serviço em específico do diagnóstico:
+- Omitir um serviço em específico do diagnóstico:
 
 `dumpsys --skip {{servico}}`
 
-- Específica um periodo de _timeout_ (por padrão é 10s):
+- Especificar um periodo de _timeout_ (por padrão é 10s):
 
 `dumpsys -t {{segundos}}`

--- a/pages.pt_PT/android/dumpsys.md
+++ b/pages.pt_PT/android/dumpsys.md
@@ -1,0 +1,29 @@
+# dumpsys
+
+> Fornece informações sobre os serviços do sistema Android.
+> Este comando só pode ser usado com a `adb shell`.
+> Mais informações: <https://developer.android.com/studio/command-line/dumpsys>.
+
+- Gera um diagnóstico de todos os serviços do sistema:
+
+`dumpsys`
+
+- Gera um diagnóstico de um serviço do sistema específico:
+
+`dumpsys {{servico}}`
+
+- Lista todos os serviços dos quais o `dumpsys` pode obter informações:
+
+`dumpsys -l`
+
+- Lista argumentos específicos de um serviço para um serviço:
+
+`dumpsys {{servico}} -h`
+
+- Omite um serviço em específico do diagnóstico:
+
+`dumpsys --skip {{servico}}`
+
+- Específica um periodo de _timeout_ (por padrão é 10s):
+
+`dumpsys -t {{segundos}}`

--- a/pages.pt_PT/android/getprop.md
+++ b/pages.pt_PT/android/getprop.md
@@ -1,0 +1,32 @@
+# getprop
+
+> Obtém informações sobre propriedades do sistema Android (system props).
+> Mais informações: <https://manned.org/getprop>.
+
+- Mostra todas as propriedades do sistema:
+
+`getprop`
+
+- Mostra o valor de uma propriedade específica:
+
+`getprop {{prop}}`
+
+- Mostra o nível de API:
+
+`getprop {{ro.build.version.sdk}}`
+
+- Mostra a versão do Android:
+
+`getprop {{ro.build.version.release}}`
+
+- Mostra o modelo do dispositivo:
+
+`getprop {{ro.vendor.product.model}}`
+
+- Mostra o status de desbloqueio OEM:
+
+`getprop {{ro.oem_unlock_supported}}`
+
+- Mostra o endereço MAC da placa de Wi-Fi do dispositivo:
+
+`getprop {{ro.boot.wifimacaddr}}`

--- a/pages.pt_PT/android/getprop.md
+++ b/pages.pt_PT/android/getprop.md
@@ -3,30 +3,30 @@
 > Obtém informações sobre propriedades do sistema (system props) Android.
 > Mais informações: <https://manned.org/getprop>.
 
-- Mostra todas as propriedades do sistema:
+- Mostrar todas as propriedades do sistema:
 
 `getprop`
 
-- Mostra o valor de uma propriedade específica:
+- Mostrar o valor de uma propriedade específica:
 
 `getprop {{prop}}`
 
-- Mostra o nível de API:
+- Mostrar o nível de API:
 
 `getprop {{ro.build.version.sdk}}`
 
-- Mostra a versão do Android:
+- Mostrar a versão do Android:
 
 `getprop {{ro.build.version.release}}`
 
-- Mostra o modelo do dispositivo:
+- Mostrar o modelo do dispositivo:
 
 `getprop {{ro.vendor.product.model}}`
 
-- Mostra o status de desbloqueio OEM:
+- Mostrar o status de desbloqueio OEM:
 
 `getprop {{ro.oem_unlock_supported}}`
 
-- Mostra o endereço MAC da placa de Wi-Fi do dispositivo:
+- Mostrar o endereço MAC da placa de Wi-Fi do dispositivo:
 
 `getprop {{ro.boot.wifimacaddr}}`

--- a/pages.pt_PT/android/getprop.md
+++ b/pages.pt_PT/android/getprop.md
@@ -1,6 +1,6 @@
 # getprop
 
-> Obtém informações sobre propriedades do sistema Android (system props).
+> Obtém informações sobre propriedades do sistema (system props) Android.
 > Mais informações: <https://manned.org/getprop>.
 
 - Mostra todas as propriedades do sistema:

--- a/pages.pt_PT/android/input.md
+++ b/pages.pt_PT/android/input.md
@@ -4,22 +4,22 @@
 > Esse comando só pode ser usado com a `adb shell`.
 > Mais informações: <https://developer.android.com/reference/android/view/KeyEvent.html#constants_1>.
 
-- Envia um código de evento de um caractere para um dispositivo Android:
+- Enviar um código de evento de um caractere para um dispositivo Android:
 
 `input keyevent {{codigo_de_evento}}`
 
-- Envia texto para um dispositivo Android (`%s` representa espaços):
+- Enviar texto para um dispositivo Android (`%s` representa espaços):
 
 `input text "{{texto}}"`
 
-- Envia um único toque para um dispositivo Android:
+- Enviar um único toque para um dispositivo Android:
 
 `input tap {{x_pos}} {{y_pos}}`
 
-- Envia um gesto de deslizar para um dispositivo Android:
+- Enviar um gesto de deslizar para um dispositivo Android:
 
 `input swipe {{x_inicio}} {{y_inicio}} {{x_fim}} {{y_fim}} {{duração_em_ms}}`
 
-- Envia um toque prolongado usando um gesto de deslize para um dispositivo Android:
+- Enviar um toque prolongado usando um gesto de deslize para um dispositivo Android:
 
 `input swipe {{x_pos}} {{y_pos}} {{x_pos}} {{y_pos}} {{duração_em_ms}}`

--- a/pages.pt_PT/android/input.md
+++ b/pages.pt_PT/android/input.md
@@ -1,0 +1,25 @@
+# input
+
+> Envia códigos de eventos ou toques no ecrã para um dispositivo Android.
+> Esse comando só pode ser usado com a `adb shell`.
+> Mais informações: <https://developer.android.com/reference/android/view/KeyEvent.html#constants_1>.
+
+- Envia um código de evento de um caractere para um dispositivo Android:
+
+`input keyevent {{codigo_de_evento}}`
+
+- Envia texto para um dispositivo Android (`%s` representa espaços):
+
+`input text "{{texto}}"`
+
+- Envia um único toque para um dispositivo Android:
+
+`input tap {{x_pos}} {{y_pos}}`
+
+- Envia um gesto de deslizar para um dispositivo Android:
+
+`input swipe {{x_inicio}} {{y_inicio}} {{x_fim}} {{y_fim}} {{duração_em_ms}}`
+
+- Envia um toque duradouro usando um gesto de deslize para um dispositivo Android:
+
+`input swipe {{x_pos}} {{y_pos}} {{x_pos}} {{y_pos}} {{duração_em_ms}}`

--- a/pages.pt_PT/android/input.md
+++ b/pages.pt_PT/android/input.md
@@ -20,6 +20,6 @@
 
 `input swipe {{x_inicio}} {{y_inicio}} {{x_fim}} {{y_fim}} {{duração_em_ms}}`
 
-- Envia um toque duradouro usando um gesto de deslize para um dispositivo Android:
+- Envia um toque prolongado usando um gesto de deslize para um dispositivo Android:
 
 `input swipe {{x_pos}} {{y_pos}} {{x_pos}} {{y_pos}} {{duração_em_ms}}`

--- a/pages.pt_PT/android/input.md
+++ b/pages.pt_PT/android/input.md
@@ -1,7 +1,7 @@
 # input
 
 > Envia códigos de eventos ou toques no ecrã para um dispositivo Android.
-> Esse comando só pode ser usado com a `adb shell`.
+> Este comando só pode ser usado com a `adb shell`.
 > Mais informações: <https://developer.android.com/reference/android/view/KeyEvent.html#constants_1>.
 
 - Enviar um código de evento de um caractere para um dispositivo Android:

--- a/pages.pt_PT/android/logcat.md
+++ b/pages.pt_PT/android/logcat.md
@@ -1,6 +1,6 @@
 # logcat
 
-> Exibe um conjunto de mensagens de sistema, incluindo a stack de execução do programa quando um erro ocorreu e mensagens de informação criadas por aplicações.
+> Exibe um conjunto de mensagens de sistema, incluindo a stack de execução do programa em caso de erro, e mensagens de informação criadas por aplicações.
 > Mais informações: <https://developer.android.com/studio/command-line/logcat>.
 
 - Mostra mensagens de sistema:

--- a/pages.pt_PT/android/logcat.md
+++ b/pages.pt_PT/android/logcat.md
@@ -3,14 +3,14 @@
 > Exibe um conjunto de mensagens de sistema, incluindo a stack de execução do programa em caso de erro, e mensagens de informação criadas por aplicações.
 > Mais informações: <https://developer.android.com/studio/command-line/logcat>.
 
-- Mostra mensagens de sistema:
+- Mostrar mensagens de sistema:
 
 `logcat`
 
-- Escreve as mensagens de sistema num ficheiro:
+- Escrever as mensagens de sistema num ficheiro:
 
 `logcat -f {{caminho/para/arquivo}}`
 
-- Mostra mensagens que correspondem a uma expressão regular:
+- Mostrar mensagens que correspondem a uma expressão regular:
 
 `logcat --regex {{expressao_regular}}`

--- a/pages.pt_PT/android/logcat.md
+++ b/pages.pt_PT/android/logcat.md
@@ -1,0 +1,16 @@
+# logcat
+
+> Exibe um conjunto de mensagens de sistema, incluindo a stack de execução do programa quando um erro ocorreu e mensagens de informação criadas por aplicações.
+> Mais informações: <https://developer.android.com/studio/command-line/logcat>.
+
+- Mostra mensagens de sistema:
+
+`logcat`
+
+- Escreve as mensagens de sistema num ficheiro:
+
+`logcat -f {{caminho/para/arquivo}}`
+
+- Mostra mensagens que correspondem a uma expressão regular:
+
+`logcat --regex {{expressao_regular}}`

--- a/pages.pt_PT/android/pkg.md
+++ b/pages.pt_PT/android/pkg.md
@@ -1,0 +1,24 @@
+# pkg
+
+> Gestor de pacotes para o Termux.
+> Mais informações: <https://wiki.termux.com/wiki/Package_Management>.
+
+- Atualiza todos os pacotes instalados:
+
+`pkg upgrade`
+
+- Instala um pacote:
+
+`pkg install {{pacote}}`
+
+- Desinstala um pacote:
+
+`pkg uninstall {{pacote}}`
+
+- Reinstala um pacote:
+
+`pkg reinstall {{pacote}}`
+
+- Busca por um pacote:
+
+`pkg search {{pacote}}`

--- a/pages.pt_PT/android/pkg.md
+++ b/pages.pt_PT/android/pkg.md
@@ -3,22 +3,22 @@
 > Gestor de pacotes para o Termux.
 > Mais informações: <https://wiki.termux.com/wiki/Package_Management>.
 
-- Atualiza todos os pacotes instalados:
+- Atualizar todos os pacotes instalados:
 
 `pkg upgrade`
 
-- Instala um pacote:
+- Instalar um pacote:
 
 `pkg install {{pacote}}`
 
-- Desinstala um pacote:
+- Desinstalar um pacote:
 
 `pkg uninstall {{pacote}}`
 
-- Reinstala um pacote:
+- Reinstalar um pacote:
 
 `pkg reinstall {{pacote}}`
 
-- Busca por um pacote:
+- Procurar um pacote:
 
 `pkg search {{pacote}}`

--- a/pages.pt_PT/android/pm.md
+++ b/pages.pt_PT/android/pm.md
@@ -3,22 +3,22 @@
 > Mostra informações sobre aplicações num dispositivo Android.
 > Mais informações: <https://developer.android.com/studio/command-line/adb#pm>.
 
-- Exibe uma lista com todas as aplicações instaladas:
+- Exibir uma lista com todas as aplicações instaladas:
 
 `pm list packages`
 
-- Exibe uma lista com todas as aplicações do sistema instaladas:
+- Exibir uma lista com todas as aplicações do sistema instaladas:
 
 `pm list packages -s`
 
-- Exibe uma lista todas as aplicações de terceiros instaladas:
+- Exibir uma lista todas as aplicações de terceiros instaladas:
 
 `pm list packages -3`
 
-- Exibe uma lista com todas as aplicações cujos nomes estejam incluídos em palavras-chave:
+- Exibir uma lista com todas as aplicações cujos nomes estejam incluídos em palavras-chave:
 
 `pm list packages {{palavras_chave}}`
 
-- Exibe o caminho para o APK de um app:
+- Exibir o caminho para o APK de um app:
 
 `pm path {{app}}`

--- a/pages.pt_PT/android/pm.md
+++ b/pages.pt_PT/android/pm.md
@@ -1,0 +1,24 @@
+# pm
+
+> Mostra informações sobre aplicações num dispositivo Android.
+> Mais informações: <https://developer.android.com/studio/command-line/adb#pm>.
+
+- Exibe uma lista com todas as aplicações instaladas:
+
+`pm list packages`
+
+- Exibe uma lista com todas as aplicações do sistema instaladas:
+
+`pm list packages -s`
+
+- Exibe uma lista todas as aplicações de terceiros instaladas:
+
+`pm list packages -3`
+
+- Exibe uma lista com todas as aplicações cujos nomes estejam incluídos em palavras-chave:
+
+`pm list packages {{palavras_chave}}`
+
+- Exibe o caminho para o APK de um app:
+
+`pm path {{app}}`

--- a/pages.pt_PT/android/settings.md
+++ b/pages.pt_PT/android/settings.md
@@ -1,0 +1,20 @@
+# settings
+
+> Exibe, edita e apaga configurações do sistema Android.
+> Mais informações: <https://adbinstaller.com/commands/adb-shell-settings-5b670d5ee7958178a2955536>.
+
+- Exibe a lista de configurações no namespace `global`:
+
+`settings list {{global}}`
+
+- Obtém o valor de uma configuração específica:
+
+`settings get {{global}} {{airplane_mode_on}}`
+
+- Edita o valor de uma configuração:
+
+`settings put {{system}} {{screen_brightness}} {{42}}`
+
+- Apaga uma configuração:
+
+`settings delete {{secure}} {{screensaver_enabled}}`

--- a/pages.pt_PT/android/settings.md
+++ b/pages.pt_PT/android/settings.md
@@ -3,18 +3,18 @@
 > Exibe, edita e apaga configurações do sistema Android.
 > Mais informações: <https://adbinstaller.com/commands/adb-shell-settings-5b670d5ee7958178a2955536>.
 
-- Exibe a lista de configurações no namespace `global`:
+- Exibir a lista de configurações no namespace `global`:
 
 `settings list {{global}}`
 
-- Obtém o valor de uma configuração específica:
+- Obter o valor de uma configuração específica:
 
 `settings get {{global}} {{airplane_mode_on}}`
 
-- Edita o valor de uma configuração:
+- Editar o valor de uma configuração:
 
 `settings put {{system}} {{screen_brightness}} {{42}}`
 
-- Apaga uma configuração:
+- Apagar uma configuração:
 
 `settings delete {{secure}} {{screensaver_enabled}}`

--- a/pages.pt_PT/android/wm.md
+++ b/pages.pt_PT/android/wm.md
@@ -1,13 +1,13 @@
 # wm
 
 > Exibe informações da tela de um dispositivo Android
-> Esse comando só pode ser usado através da `adb shell`.
+> Este comando só pode ser usado através da `adb shell`.
 > Mais informações: <https://adbinstaller.com/commands/adb-shell-wm-5b672b17e7958178a2955538>.
 
 - Mostrar o tamanho da tela de um dispositivo Android:
 
 `wm {{size}}`
 
-- Mostrar a densidade de pixeis da tela de um dispositivo Android:
+- Mostrar a densidade de píxeis da tela de um dispositivo Android:
 
 `wm {{density}}`

--- a/pages.pt_PT/android/wm.md
+++ b/pages.pt_PT/android/wm.md
@@ -1,0 +1,13 @@
+# wm
+
+> Exibe informações da tela de um dispositivo Android
+> Esse comando só pode ser usado através da `adb shell`.
+> Mais informações: <https://adbinstaller.com/commands/adb-shell-wm-5b672b17e7958178a2955538>.
+
+- Mostra o tamanho da tela de um dispositivo Android:
+
+`wm {{size}}`
+
+- Mostra a densidade de pixeis da tela de um dispositivo Android:
+
+`wm {{density}}`

--- a/pages.pt_PT/android/wm.md
+++ b/pages.pt_PT/android/wm.md
@@ -4,10 +4,10 @@
 > Esse comando só pode ser usado através da `adb shell`.
 > Mais informações: <https://adbinstaller.com/commands/adb-shell-wm-5b672b17e7958178a2955538>.
 
-- Mostra o tamanho da tela de um dispositivo Android:
+- Mostrar o tamanho da tela de um dispositivo Android:
 
 `wm {{size}}`
 
-- Mostra a densidade de pixeis da tela de um dispositivo Android:
+- Mostrar a densidade de pixeis da tela de um dispositivo Android:
 
 `wm {{density}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
