### PR TITLE
elink, esearch: add page

### DIFF
--- a/pages/linux/elink.md
+++ b/pages/linux/elink.md
@@ -1,12 +1,13 @@
 # elink
 
-> Elink looks up precomputed neighbors within a database, or finds associated records in other databases.
-> It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
+> Look up precomputed neighbors within a database, or find associated records in other databases.
+> It is part of the edirect package.
+> More information: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
-- Search pubmed and then find related sequences:
+- Search pubmed then find related sequences:
 
-`esearch -db pubmed -query "selective serotonin reuptake inhibitor" | elink -target nuccore`
+`esearch -db pubmed -query "{{selective serotonin reuptake inhibitor}}" | elink -target nuccore`
 
-- Search nucleotide and then find related biosamples:
+- Search nucleotide then find related biosamples:
 
-`esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]" | elink -target biosample`
+`esearch -db nuccore -query "{{insulin [PROT] AND rodents [ORGN]}}" | elink -target biosample`

--- a/pages/linux/elink.md
+++ b/pages/linux/elink.md
@@ -10,4 +10,3 @@
 - Search nucleotide and then find related biosamples:
 
 `esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]" | elink -target biosample`
-

--- a/pages/linux/elink.md
+++ b/pages/linux/elink.md
@@ -1,7 +1,7 @@
 # elink
 
 > Look up precomputed neighbors within a database, or find associated records in other databases.
-> It is part of the edirect package.
+> It is part of the `edirect` package.
 > More information: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
 - Search pubmed then find related sequences:

--- a/pages/linux/elink.md
+++ b/pages/linux/elink.md
@@ -1,0 +1,13 @@
+# elink
+
+> Elink looks up precomputed neighbors within a database, or finds associated records in other databases.
+> It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
+
+- Search pubmed and then find related sequences:
+
+`esearch -db pubmed -query "selective serotonin reuptake inhibitor" | elink -target nuccore`
+
+- Search nucleotide and then find related biosamples:
+
+`esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]" | elink -target biosample`
+

--- a/pages/linux/esearch.md
+++ b/pages/linux/esearch.md
@@ -1,0 +1,14 @@
+# esearch
+
+> Esearch performs a new Entrez search using terms in indexed fields. 
+> It requires a `-db` argument for the database name and uses `-query` for the search terms.
+> It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
+
+- Search pubmed:
+
+`esearch -db pubmed -query "selective serotonin reuptake inhibitor"`
+
+- Search nucleotide:
+
+`esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]"`
+

--- a/pages/linux/esearch.md
+++ b/pages/linux/esearch.md
@@ -2,12 +2,13 @@
 
 > Perform a new Entrez search using terms in indexed fields.
 > It requires a `-db` argument for the database name and uses `-query` for the search terms.
-> It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
+> It is part of the edirect package.
+> More information: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
-- Search pubmed:
+- Search the pubmed database for selective serotonin reuptake inhibitor:
 
 `esearch -db pubmed -query "{{selective serotonin reuptake inhibitor}}"`
 
-- Search nucleotide:
+- Search the nucleotide database for sequences whose metadata contain insulin and rodents:
 
 `esearch -db nuccore -query "{{insulin [PROT] AND rodents [ORGN]}}"`

--- a/pages/linux/esearch.md
+++ b/pages/linux/esearch.md
@@ -1,13 +1,13 @@
 # esearch
 
-> Esearch performs a new Entrez search using terms in indexed fields.
+> Perform a new Entrez search using terms in indexed fields.
 > It requires a `-db` argument for the database name and uses `-query` for the search terms.
 > It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
 - Search pubmed:
 
-`esearch -db pubmed -query "selective serotonin reuptake inhibitor"`
+`esearch -db pubmed -query "{{selective serotonin reuptake inhibitor}}"`
 
 - Search nucleotide:
 
-`esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]"`
+`esearch -db nuccore -query "{{insulin [PROT] AND rodents [ORGN]}}"`

--- a/pages/linux/esearch.md
+++ b/pages/linux/esearch.md
@@ -1,6 +1,6 @@
 # esearch
 
-> Esearch performs a new Entrez search using terms in indexed fields. 
+> Esearch performs a new Entrez search using terms in indexed fields.
 > It requires a `-db` argument for the database name and uses `-query` for the search terms.
 > It is part of the edirect package: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
@@ -11,4 +11,3 @@
 - Search nucleotide:
 
 `esearch -db nuccore -query "insulin [PROT] AND rodents [ORGN]"`
-

--- a/pages/linux/esearch.md
+++ b/pages/linux/esearch.md
@@ -1,8 +1,7 @@
 # esearch
 
 > Perform a new Entrez search using terms in indexed fields.
-> It requires a `-db` argument for the database name and uses `-query` for the search terms.
-> It is part of the edirect package.
+> It is part of the `edirect` package.
 > More information: <https://www.ncbi.nlm.nih.gov/books/NBK179288/>.
 
 - Search the pubmed database for selective serotonin reuptake inhibitor:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
7.40

There are several executables in the edirect package and so I am starting with two of them, esearch and elink.