### PR TITLE
find: remove redundant -delete from -daystart example

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -27,9 +27,9 @@
 
 `find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }}\;`
 
-- Find files modified in the last 7 days and delete them:
+- Find files modified in the last 7 days:
 
-`find {{root_path}} -daystart -mtime -{{7}} -delete`
+`find {{root_path}} -daystart -mtime -{{7}}`
 
 - Find empty (0 byte) files and delete them:
 


### PR DESCRIPTION
I can see people woken up at 4am for some alert they're on-call to resolve, trying to remember the syntax for finding files modified in the last week, and accidentally deleting them because, in a sleep induced haze, they copied and pasted `find root_path -daystart -mtime -7 -delete`, then only modified `root_path` and forgot to take out `-delete`.

This PR makes it a bit less likely they'll do that.

If people want to delete files, tldr already shows them how to do that in the 8th (last) example.  (Edit: To make this clear - there are **two** examples for delete. This PR only modifies one of them to hopefully prevent accidental data loss.)

<sup><sub>As an aside, perhaps suitable for a different PR, `-daystart` is an invalid operator on macOS (and maybe *BSD too?)</sup></sub>

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.  [Should this be moved from common to linux due to daystart example?]
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).