### PR TITLE
wifi-password: add Spanish translation

### DIFF
--- a/pages.es/osx/wifi-password.md
+++ b/pages.es/osx/wifi-password.md
@@ -1,0 +1,16 @@
+# wifi-password
+
+> Obtiene la contraseña del Wi-Fi.
+> Más información: <https://github.com/rauchg/wifi-password>.
+
+- Obtiene la contraseña de la red Wi-Fi en la que está conectado actualmente:
+
+`wifi-password`
+
+- Obtiene la contraseña para el Wi-Fi con un SSID específico:
+
+`wifi-password {{ssid}}`
+
+- Imprime solo la contraseña como salida:
+
+`wifi-password -q`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
