### PR TITLE
uuidgen, warm: fix Spanish translation

### DIFF
--- a/pages.es/osx/uuidgen.md
+++ b/pages.es/osx/uuidgen.md
@@ -1,8 +1,8 @@
 # uuidgen
 
-> Genere nuevas cadenas UUID (Identificador único universal).
+> Genera nuevas cadenas UUID (Identificador único universal).
 > Más información: <https://www.ss64.com/osx/uuidgen.html>.
 
-- Genere una cadena UUID:
+- Genera una cadena UUID:
 
 `uuidgen`

--- a/pages.es/osx/warm.md
+++ b/pages.es/osx/warm.md
@@ -1,9 +1,9 @@
 # warmd
 
-> Controle los cachés utilizados durante el arranque y el inicio de sesión.
+> Controla los cachés utilizados durante el arranque y el inicio de sesión.
 > No debe invocarse manualmente.
 > Más información: <https://www.manpagez.com/man/8/warmd/>.
 
-- Inicie el daemon:
+- Inicia el daemon:
 
 `warmd`


### PR DESCRIPTION


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
