### PR TITLE
ldd: add more info

### DIFF
--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -16,7 +16,7 @@
 
 `ldd --unused {{path/to/binary}}`
 
-- Report missing data objects and perform data relocations (ELF ONLY):
+- Report missing data objects and perform data relocations:
 
 `ldd --data-relocs {{path/to/binary}}`
 

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -20,6 +20,6 @@
 
 `ldd --data-relocs {{path/to/binary}}`
 
-- Report missing data objects and functions, and perform relocations for both (ELF ONLY):
+- Report missing data objects and functions, and perform relocations for both:
 
 `ldd --function-relocs {{path/to/binary}}`

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -8,7 +8,7 @@
 
 `ldd {{path/to/binary}}`
 
-- Display _all_ information about dependencies:
+- Display all information about dependencies:
 
 `ldd --verbose {{path/to/binary}}`
 

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -3,8 +3,6 @@
 > Display shared library dependencies of a binary.
 > More information: <https://manned.org/ldd>.
 
-**WARNING** do not use on an unstrusted executable, for that refer to `tldr objdump`
-
 - Display shared library dependencies of a binary:
 
 `ldd {{path/to/binary}}`
@@ -24,3 +22,7 @@
 - Report missing data objects and functions, and perform relocations for both (ELF ONLY):
 
 `ldd --function-relocs {{path/to/binary}}`
+
+- **WARNING** do not use on an unstrusted executable, for that refer to 
+
+`tldr objdump`

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -1,12 +1,26 @@
 # ldd
 
-> Display shared library dependencies.
+> Display shared library dependencies of a binary.
 > More information: <https://manned.org/ldd>.
+
+**WARNING** do not use on an unstrusted executable, for that refer to `tldr objdump`
 
 - Display shared library dependencies of a binary:
 
 `ldd {{path/to/binary}}`
 
+- Display _all_ information about dependencies:
+
+`ldd --verbose {{path/to/binary}}`
+
 - Display unused direct dependencies:
 
-`ldd -u {{path/to/binary}}`
+`ldd --unused {{path/to/binary}}`
+
+- Report missing data objects and perform data relocations (ELF ONLY):
+
+`ldd --data-relocs {{path/to/binary}}`
+
+- Report missing data objects and functions, and perform relocations for both (ELF ONLY):
+
+`ldd --function-relocs {{path/to/binary}}`

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -1,7 +1,7 @@
 # ldd
 
 > Display shared library dependencies of a binary.
-> Warning: do not use on an untrusted binary, use objdump for that instead
+> Do not use on an untrusted binary, use objdump for that instead.
 > More information: <https://manned.org/ldd>.
 
 - Display shared library dependencies of a binary:
@@ -22,4 +22,4 @@
 
 - Report missing data objects and functions, and perform relocations for both (ELF ONLY):
 
-`ldd --function-relocs {{path/to/binary}}
+`ldd --function-relocs {{path/to/binary}}`

--- a/pages/linux/ldd.md
+++ b/pages/linux/ldd.md
@@ -1,6 +1,7 @@
 # ldd
 
 > Display shared library dependencies of a binary.
+> Warning: do not use on an untrusted binary, use objdump for that instead
 > More information: <https://manned.org/ldd>.
 
 - Display shared library dependencies of a binary:
@@ -21,8 +22,4 @@
 
 - Report missing data objects and functions, and perform relocations for both (ELF ONLY):
 
-`ldd --function-relocs {{path/to/binary}}`
-
-- **WARNING** do not use on an unstrusted executable, for that refer to 
-
-`tldr objdump`
+`ldd --function-relocs {{path/to/binary}}


### PR DESCRIPTION
The script to automatically add more tldr entries is great, but it's lacking some information that I think will be important for the cheatsheet. So I've gone ahead and clarified the tldr to be a bit more helpful.

This is to hopefully help and close [this issue](https://github.com/tldr-pages/tldr/issues/8998)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.35 as of the time of writing.
