### PR TITLE
cp: add French translation

### DIFF
--- a/pages.fr/linux/cp.md
+++ b/pages.fr/linux/cp.md
@@ -1,0 +1,32 @@
+# cp
+
+> Copier fichiers et répertoires.
+> Plus d'information: <https://www.gnu.org/software/coreutils/cp>.
+
+- Copier un fichier vers un autre emplacement:
+
+`cp {{chemin/vers/fichier_original.ext}} {{chemin/vers/fichier_cible.ext}}`
+
+- Copier un ficher d'un répertoire vers un autre en conservant le nom du fichier :
+
+`cp {{chemin/vers/fichier_original.ext}} {{chemin/vers/repertoire_cible}}`
+
+- Copier récursivement le contenu d'un répertoire vers un autre emplacement (si la destination existe, le répertoire est copié dans celle-ci) :
+
+`cp -r {{chemin/vers/repertoire_source}} {{chemin/vers/repertoire_cible}}`
+
+- Copier récursivement le contenu d'un répertoire vers un autre emplacement en mode verbeux (affichage des noms fichiers à mesure de leur copie):  
+
+`cp -vr {{chemin/vers/repertoire_source}} {{chemin/vers/repertoire_cible}}`
+
+- Copier les fichiers textes vers un autre emplacement, en mode interactive (demande une confirmation avant d'écrire par dessus un fichier du même nom):
+
+`cp -i {{*.txt}} {{chemin/vers/repertoire_cible}}`
+
+- Suivre le lien symbolique avant de copier (copie le fichier lié, et non le lien) :
+
+`cp -L {{link}} {{chemin/vers/repertoire_cible}}`
+
+- Utiliser le chemin complet du fichier source, créant tout répertoire manquant lors de la copie :
+
+`cp --parents {{chemin/vers/fichier_source}} {{chemin/vers/fichier_cible}}`

--- a/pages.fr/linux/cp.md
+++ b/pages.fr/linux/cp.md
@@ -15,11 +15,11 @@
 
 `cp -r {{chemin/vers/repertoire_source}} {{chemin/vers/repertoire_cible}}`
 
-- Copier récursivement le contenu d'un répertoire vers un autre emplacement en mode verbeux (affichage des noms fichiers à mesure de leur copie):  
+- Copier récursivement le contenu d'un répertoire vers un autre emplacement en mode verbeux (affichage des noms fichiers à mesure de leur copie) :
 
 `cp -vr {{chemin/vers/repertoire_source}} {{chemin/vers/repertoire_cible}}`
 
-- Copier les fichiers textes vers un autre emplacement, en mode interactive (demande une confirmation avant d'écrire par dessus un fichier du même nom):
+- Copier les fichiers textes vers un autre emplacement, en mode interactive (demande une confirmation avant d'écrire par dessus un fichier du même nom) :
 
 `cp -i {{*.txt}} {{chemin/vers/repertoire_cible}}`
 


### PR DESCRIPTION
Create pages.fr/linux/cp.md as translation from linux directory english page.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
