### PR TITLE
zip2john: add page

### DIFF
--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -5,12 +5,12 @@
 
 - Extract the password hash from an archive, will list all files in the archive:
 
-`zip2john {{file.zip}}`
+`zip2john {{path/to/file.zip}}`
 
 - Extract the password has using [o]nly the specified file within the archive:
 
-`zip2john -o {{compressed_file_in_zip}} {{file.zip}}`
+`zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}}`
 
 - Output the extracted hash into a file so that it can be used with John the Ripper:
 
-`zip2john -o {{compressed_file_in_zip}} {{file.zip}} > {{file.hash}}`
+`zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}} > {{file.hash}}`

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -8,10 +8,10 @@
 
 `zip2john {{path/to/file.zip}}`
 
-- Extract the password hash using [o]nly the specified compressed file:
+- Extract the password hash using [o]nly a specific compressed file:
 
 `zip2john -o {{path/to/compressed_file}} {{path/to/file.zip}}`
 
-- Output the extracted hash into a file so that it can be used with John the Ripper:
+- Extract the password hash from a compressed file to a specific file (for use with John the Ripper):
 
-`zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}} > {{file.hash}}`
+`zip2john -o {{path/to/compressed_file}} {{path/to/file.zip}} > {{file.hash}}`

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -10,7 +10,7 @@
 
 - Extract the password hash using [o]nly the specified compressed file:
 
-`zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}}`
+`zip2john -o {{path/to/compressed_file}} {{path/to/file.zip}}`
 
 - Output the extracted hash into a file so that it can be used with John the Ripper:
 

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -1,0 +1,16 @@
+# zip2john
+
+> A tool to extract password hashes from zip files for use with John the Ripper password cracker.
+> This is a utility tool usually installed as part of the John the Ripper installation.
+
+- Extract the password hash from an archive, will list all files in the archive:
+
+`zip2john {{file.zip}}`
+
+- Extract the password has using [o]nly the specified file within the archive:
+
+`zip2john -o {{compressed_file_in_zip}} {{file.zip}}`
+
+- Output the extracted hash into a file so that it can be used with John the Ripper:
+
+`zip2john -o {{compressed_file_in_zip}} {{file.zip}} > {{file.hash}}`

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -8,7 +8,7 @@
 
 `zip2john {{path/to/file.zip}}`
 
-- Extract the password has using [o]nly the specified file within the archive:
+- Extract the password hash using [o]nly the specified file within the archive:
 
 `zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}}`
 

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -2,8 +2,9 @@
 
 > A tool to extract password hashes from zip files for use with John the Ripper password cracker.
 > This is a utility tool usually installed as part of the John the Ripper installation.
+> More information: <https://www.openwall.com/john/>.
 
-- Extract the password hash from an archive, will list all files in the archive:
+- Extract the password hash from an archive, listing all files in the archive:
 
 `zip2john {{path/to/file.zip}}`
 

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -8,7 +8,7 @@
 
 `zip2john {{path/to/file.zip}}`
 
-- Extract the password hash using [o]nly the specified file within the archive:
+- Extract the password hash using [o]nly the specified compressed file:
 
 `zip2john -o {{compressed_file_in_zip}} {{path/to/file.zip}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.9.0

A utility tool for extracting password hashes from zip archives for use with John the Ripper password cracker
