### PR TITLE
find: add double quotes in examples

### DIFF
--- a/pages/windows/find.md
+++ b/pages/windows/find.md
@@ -5,16 +5,16 @@
 
 - Find lines that contain a specified string:
 
-`find {{string}} {{path/to/file_or_directory}}`
+`find "{{string}}" {{path/to/file_or_directory}}`
 
 - Display lines that do not contain the specified string:
 
-`find {{string}} {{path/to/file_or_directory}} /v`
+`find "{{string}}" {{path/to/file_or_directory}} /v`
 
 - Display the count of lines that contain the specified string:
 
-`find {{string}} {{path/to/file_or_directory}} /c`
+`find "{{string}}" {{path/to/file_or_directory}} /c`
 
 - Display line numbers with the list of lines:
 
-`find {{string}} {{path/to/file_or_directory}} /n`
+`find "{{string}}" {{path/to/file_or_directory}} /n`


### PR DESCRIPTION
The search string must be quoted, and iit must be double quotes.