### PR TITLE
ac: add page

### DIFF
--- a/pages/common/ac.md
+++ b/pages/common/ac.md
@@ -1,0 +1,20 @@
+# ac
+
+> Print statistics on how long users have been connected.
+> More information: <https://man.openbsd.org/ac>.
+
+- Print how long the current user has been connected in hours:
+
+`ac`
+
+- Print how long users have been connected in hours:
+
+`ac -p`
+
+- Print how long a particular user has been connected in hours:
+
+`ac -p {{username}}`
+
+- Print how long a particular user has been connected in hours per day (with total):
+
+`ac -dp {{username}}`


### PR DESCRIPTION
Closes #7859.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Version 5 AT&T UNIX
