### PR TITLE
git-hash-object: add page

### DIFF
--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -9,7 +9,7 @@
 
 - Compute the ID and store it in git database:
 
-`git hash-object -w {{/path/to/file}}`
+`git hash-object -w {{path/to/file}}`
 
 - Compute the ID and specify the type of object:
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -11,7 +11,7 @@
 
 `git hash-object -w {{path/to/file}}`
 
-- Compute the ID and specify the type of object:
+- Compute the object ID specifying the object type:
 
 `git hash-object -t {{blob|commit|tag|tree}} {{path/to/file}}`
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -3,7 +3,7 @@
 > Computes the unique hash key of content and optionally creates an object with specified type.
 > More information: <https://git-scm.com/docs/git-hash-object>.
 
-- Compute the object ID without store it:
+- Compute the object ID without storing it:
 
 `git hash-object {{path/to/file}}`
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -15,6 +15,6 @@
 
 `git hash-object -t {{blob|commit|tag|tree}} {{path/to/file}}`
 
-- Compute the ID from stdin:
+- Compute the object ID from stdin:
 
 `cat {{path/to/file}} | git hash-object --stdin`

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -15,6 +15,6 @@
 
 `git hash-object -t {{blob|commit|tag|tree}} {{path/to/file}}`
 
-- Compute the ID from user input instead of a file:
+- Compute the ID from stdin:
 
 `git hash-object --stdin`

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -5,7 +5,7 @@
 
 - Compute the ID that would be used to store it in git database:
 
-`git hash-object {{/path/to/file}}`
+`git hash-object {{path/to/file}}`
 
 - Compute the ID and store it in git database:
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -13,7 +13,7 @@
 
 - Compute the ID and specify the type of object:
 
-`git hash-object -t {blob | tree | commit | tag} {{/path/to/file}}`
+`git hash-object -t {{blob|commit|tag|tree}} {{path/to/file}}`
 
 - Compute the ID from user input instead of a file:
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -3,7 +3,7 @@
 > Computes the unique hash key of content and optionally creates an object with specified type.
 > More information: <https://git-scm.com/docs/git-hash-object>.
 
-- Compute the ID that would be used to store it in git database:
+- Compute the object ID without store it:
 
 `git hash-object {{path/to/file}}`
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -7,7 +7,7 @@
 
 `git hash-object {{path/to/file}}`
 
-- Compute the ID and store it in git database:
+- Compute the object ID and store it in the Git database:
 
 `git hash-object -w {{path/to/file}}`
 

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -17,4 +17,4 @@
 
 - Compute the ID from stdin:
 
-`git hash-object --stdin`
+`cat {{path/to/file}} | git hash-object --stdin`

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -1,0 +1,20 @@
+# git hash-object
+
+> Computes the unique hash key of content and optionally creates an object with specified type.
+> More information: <https://git-scm.com/docs/git-hash-object>.
+
+- Compute the ID that would be used to store it in git database:
+
+`git hash-object {{/path/to/file}}`
+
+- Compute the ID and store it in git database:
+
+`git hash-object -w {{/path/to/file}}`
+
+- Compute the ID and specify the type of object:
+
+`git hash-object -t {blob | tree | commit | tag} {{/path/to/file}}`
+
+- Compute the ID from user input instead of a file:
+
+`git hash-object --stdin`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

