### PR TITLE
dart: add French translation

### DIFF
--- a/pages.fr/common/dart.md
+++ b/pages.fr/common/dart.md
@@ -5,11 +5,11 @@
 
 - Initialise un nouveau projet Dart dans un dossier du même nom:
 
-`dart create {{project_name}}`
+`dart create {{nom_du_projet}}`
 
 - Exécuter un fichier Dart:
 
-`dart run {{path/to/file.dart}}`
+`dart run {{chemin/vers/fichier.dart}}`
 
 - Télécharger les dépendences pour le projet courant:
 
@@ -25,4 +25,4 @@
 
 - Compiler un fichier Dart vers un binaire natif:
 
-`dart compile exe {{path/to/file.dart}}`
+`dart compile exe {{chemin/vers/fichier.dart}}`

--- a/pages.fr/common/dart.md
+++ b/pages.fr/common/dart.md
@@ -3,26 +3,26 @@
 > Ligne de commande pour gérer un projet Dart.
 > Plus d'informations : <https://dart.dev/tools/dart-tool>.
 
-- Initialise un nouveau projet Dart dans un dossier du même nom:
+- Initialise un nouveau projet Dart dans un dossier du même nom :
 
 `dart create {{nom_du_projet}}`
 
-- Exécuter un fichier Dart:
+- Exécuter un fichier Dart :
 
 `dart run {{chemin/vers/fichier.dart}}`
 
-- Télécharger les dépendences pour le projet courant:
+- Télécharger les dépendences pour le projet courant :
 
 `dart pub get`
 
-- Exécuter les tests unitaire pour le projet courant:
+- Exécuter les tests unitaire pour le projet courant :
 
 `dart test`
 
-- Mettre à jour les dépendances d'un projet pour supporter null-safety:
+- Mettre à jour les dépendances d'un projet pour supporter null-safety :
 
 `dart pun upgrade --null-safety`
 
-- Compiler un fichier Dart vers un binaire natif:
+- Compiler un fichier Dart vers un binaire natif :
 
 `dart compile exe {{chemin/vers/fichier.dart}}`

--- a/pages.fr/common/dart.md
+++ b/pages.fr/common/dart.md
@@ -1,0 +1,28 @@
+# dart
+
+> Ligne de commande pour gérer un projet Dart.
+> Plus d'informations : <https://dart.dev/tools/dart-tool>.
+
+- Initialise un nouveau projet Dart dans un dossier du même nom:
+
+`dart create {{project_name}}`
+
+- Exécuter un fichier Dart:
+
+`dart run {{path/to/file.dart}}`
+
+- Télécharger les dépendences pour le projet courant:
+
+`dart pub get`
+
+- Exécuter les tests unitaire pour le projet courant:
+
+`dart test`
+
+- Mettre à jour les dépendances d'un projet pour supporter null-safety:
+
+`dart pun upgrade --null-safety`
+
+- Compiler un fichier Dart vers un binaire natif:
+
+`dart compile exe {{path/to/file.dart}}`


### PR DESCRIPTION
* translate the dart command from english to french

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
