### PR TITLE
gcc: add -g to -Wall -Og example

### DIFF
--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -7,9 +7,9 @@
 
 `gcc {{path/to/source1.c path/to/source2.c ...}} -o {{path/to/output_executable}}`
 
-- Show common warnings, debug symbols in output:
+- Show common warnings, debug symbols in output, and optimize without affecting debugging:
 
-`gcc {{path/to/source.c}} -Wall -Og -o {{path/to/output_executable}}`
+`gcc {{path/to/source.c}} -Wall -g -Og -o {{path/to/output_executable}}`
 
 - Include libraries from a different path:
 


### PR DESCRIPTION
I believe "-g" is the flag for debug symbols. The tldr could do without "-Og" but it is usual to include both.

[-g](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) Produce debugging information in the operating system’s native format (stabs, COFF, XCOFF, or DWARF). GDB can work with this debugging information.

[-Og](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options) Optimize debugging experience. -Og should be the optimization level of choice for the standard edit-compile-debug cycle, offering a reasonable level of optimization while maintaining fast compilation and a good debugging experience. It is a better choice than -O0 for producing debuggable code because some compiler passes that collect debug information are disabled at -O0.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
