### PR TITLE
cargo: add French translation

### DIFF
--- a/pages.fr/common/cargo.md
+++ b/pages.fr/common/cargo.md
@@ -1,0 +1,37 @@
+# cargo
+
+> Gestion d'un projet Rust et leur dependence (crates).
+> Certaines sous-commandes comme `cargo build` ont leurs propres documentations.
+> Plus d'informations: <https://crates.io/>.
+
+- Rechercher des crates:
+
+`cargo search {{recherche}}`
+
+- Installer un crate:
+
+`cargo install {{nom_du_crate}}`
+
+- Lister les crates déjà installés:
+
+`cargo install --list`
+
+- Créer un nouveau binaire ou librairie du projet Rust dans le dossier courant:
+
+`cargo init --{{bin|lib}}`
+
+- Créer un nouveau binaire ou librairie du projet Rust dans un dossier spécifique:
+
+`cargo new {{path/to/directory}} --{{bin|lib}}`
+
+- Compiler le projet Rust dans le dossier courant:
+
+`cargo build`
+
+- Compiler le projet Rust dans le dossier courant en utilisant le compilateur nightly:
+
+`cargo +nightly build`
+
+- Compiler en utilisant un nombre spécifique de thread (par défaut on prend le nombre de coeur du CPU):
+
+`cargo build --jobs {{nombre_de_threads}}`

--- a/pages.fr/common/cargo.md
+++ b/pages.fr/common/cargo.md
@@ -22,7 +22,7 @@
 
 - Créer un nouveau binaire ou librairie du projet Rust dans un dossier spécifique:
 
-`cargo new {{path/to/directory}} --{{bin|lib}}`
+`cargo new {{chemin/vers/dossier}} --{{bin|lib}}`
 
 - Compiler le projet Rust dans le dossier courant:
 

--- a/pages.fr/common/cargo.md
+++ b/pages.fr/common/cargo.md
@@ -1,6 +1,6 @@
 # cargo
 
-> Gestion d'un projet Rust et leur dependence (crates).
+> Gestion d'un projet Rust et ses dependences (crates).
 > Certaines sous-commandes comme `cargo build` ont leurs propres documentations.
 > Plus d'informations : <https://crates.io/>.
 
@@ -32,6 +32,6 @@
 
 `cargo +nightly build`
 
-- Compiler en utilisant un nombre spécifique de thread (par défaut on prend le nombre de coeur du CPU) :
+- Compiler en utilisant un nombre spécifique de threads (par défaut on prend le nombre de coeurs du CPU) :
 
 `cargo build --jobs {{nombre_de_threads}}`

--- a/pages.fr/common/cargo.md
+++ b/pages.fr/common/cargo.md
@@ -2,36 +2,36 @@
 
 > Gestion d'un projet Rust et leur dependence (crates).
 > Certaines sous-commandes comme `cargo build` ont leurs propres documentations.
-> Plus d'informations: <https://crates.io/>.
+> Plus d'informations : <https://crates.io/>.
 
-- Rechercher des crates:
+- Rechercher des crates :
 
 `cargo search {{recherche}}`
 
-- Installer un crate:
+- Installer un crate :
 
 `cargo install {{nom_du_crate}}`
 
-- Lister les crates déjà installés:
+- Lister les crates déjà installés :
 
 `cargo install --list`
 
-- Créer un nouveau binaire ou librairie du projet Rust dans le dossier courant:
+- Créer un nouveau binaire ou librairie du projet Rust dans le dossier courant :
 
 `cargo init --{{bin|lib}}`
 
-- Créer un nouveau binaire ou librairie du projet Rust dans un dossier spécifique:
+- Créer un nouveau binaire ou librairie du projet Rust dans un dossier spécifique :
 
 `cargo new {{chemin/vers/dossier}} --{{bin|lib}}`
 
-- Compiler le projet Rust dans le dossier courant:
+- Compiler le projet Rust dans le dossier courant :
 
 `cargo build`
 
-- Compiler le projet Rust dans le dossier courant en utilisant le compilateur nightly:
+- Compiler le projet Rust dans le dossier courant en utilisant le compilateur nightly :
 
 `cargo +nightly build`
 
-- Compiler en utilisant un nombre spécifique de thread (par défaut on prend le nombre de coeur du CPU):
+- Compiler en utilisant un nombre spécifique de thread (par défaut on prend le nombre de coeur du CPU) :
 
 `cargo build --jobs {{nombre_de_threads}}`


### PR DESCRIPTION
* add a french translation to cargo main documentation

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
