### PR TITLE
poetry: added version, and list examples

### DIFF
--- a/pages/common/poetry.md
+++ b/pages/common/poetry.md
@@ -26,3 +26,11 @@
 - Execute a command inside the project's virtual environment:
 
 `poetry run {{command}}`
+
+- Bump the minor version of the project in `pyproject.toml`:
+
+`poetry version minor`
+
+- List all commands:
+
+`poetry list`


### PR DESCRIPTION
First contribution here so please let me know if I have done something incorrect.

This is a simple pr adding what I consider 2 very useful examples for the `poetry` tool, one for easily bumping project versions and one for listing all `poetry` commands (since `poetry -h` will only show a very minimal list of commands).

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).