### PR TITLE
qtile: add page

### DIFF
--- a/pages/linux/qtile.md
+++ b/pages/linux/qtile.md
@@ -17,7 +17,7 @@
 
 - Open the program `xterm` as a floating window on the group named `test-group`:
 
-`qtile run-cmd -g {{test-group}} -f {{xterm}}`
+`qtile run-cmd --group {{test-group}} --float {{xterm}}`
 
 - Restart the window manager:
 

--- a/pages/linux/qtile.md
+++ b/pages/linux/qtile.md
@@ -1,0 +1,24 @@
+# qtile
+
+> A full-featured, hackable tiling window manager written and configured in Python.
+> More information: <https://docs.qtile.org/en/latest/manual/commands/shell/index.html>.
+
+- Start the window manager, if it is not running already (should ideally be run from `.xsession` or similar):
+
+`qtile start`
+
+- Check a configuration file for any compilation errors (default location is  `~/.config/qtile/config.py`):
+
+`qtile check`
+
+- Show current resource usage information:
+
+`qtile top --force`
+
+- Open the program `xterm` as a floating window on the group named `test-group`:
+
+`qtile run-cmd -g {{test-group}} -f {{xterm}}`
+
+- Restart the window manager:
+
+`qtile cmd-obj -o cmd -f restart`

--- a/pages/linux/qtile.md
+++ b/pages/linux/qtile.md
@@ -21,4 +21,4 @@
 
 - Restart the window manager:
 
-`qtile cmd-obj -o cmd -f restart`
+`qtile cmd-obj --object cmd --function restart`

--- a/pages/linux/qtile.md
+++ b/pages/linux/qtile.md
@@ -7,7 +7,7 @@
 
 `qtile start`
 
-- Check a configuration file for any compilation errors (default location is  `~/.config/qtile/config.py`):
+- Check the configuration file for any compilation errors (default location is  `~/.config/qtile/config.py`):
 
 `qtile check`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** `v0.22.1`

Added a page for the `qtile` tiling window manager for Linux with some examples of useful commands