### PR TITLE
brew: add install --cask example

### DIFF
--- a/pages/common/brew.md
+++ b/pages/common/brew.md
@@ -7,6 +7,10 @@
 
 `brew install {{formula}}`
 
+- Install the latest stable version of a cask (when a GUI and CLI version both exist for a given application):
+
+`brew install --cask {{cask}}`
+
 - List all installed formulae and casks:
 
 `brew list`
@@ -20,10 +24,6 @@
 `brew update`
 
 - Show formulae and casks that have a more recent version available:
-
-`brew outdated`
-
-- Search for available formulae (i.e. packages) and casks (i.e. native packages):
 
 `brew search {{text}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

To maintainer — I think `brew` is a good candidate for more than 8 examples. `brew install --cask {{cask}}` is a crucial command for people to see when they type `tldr brew` (ever since `brew cask install` was deprecated). I think we should allow a 9th example in this case. Else, we should identify one of the other examples to replace with this one.

I think this command is more important than the `brew outdated` command.

Please let me know your thoughts on this. Just trying to help out others.
