### PR TITLE
exiftool: add print example and image metadata example

### DIFF
--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -13,7 +13,7 @@
 
 - Remove all EXIF metadata from the given image files, then re-add metadata for color and orientation:
 
-`exiftool -All= -tagsfromfile @ -colorspacetags -orientation {{image1}} {{image2}} {{image3}}`
+`exiftool -All= -tagsfromfile @ -colorspacetags -orientation {{image1 image2 ...}}`
 
 - Move the date at which all photos in a directory were taken 1 hour forward:
 

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -3,9 +3,17 @@
 > Read and write meta information in files.
 > More information: <https://exiftool.org>.
 
+- Print the EXIF metadata for a given file:
+
+`exiftool {{file}}`
+
 - Remove all EXIF metadata from the given files:
 
-`exiftool -All= {{file1 file2 ...}}`
+`exiftool -All= {{file1}} {{file2}} {{file3}}`
+
+- Remove all EXIF metadata from the given image files, then re-add metadata for color and orientation:
+
+`exiftool -All= -tagsfromfile @ -colorspacetags -orientation {{image1}} {{image2}} {{image3}}`
 
 - Move the date at which all photos in a directory were taken 1 hour forward:
 

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -9,7 +9,7 @@
 
 - Remove all EXIF metadata from the given files:
 
-`exiftool -All= {{file1}} {{file2}} {{file3}}`
+`exiftool -All= {{file1 file2 ...}}`
 
 - Remove all EXIF metadata from the given image files, then re-add metadata for color and orientation:
 


### PR DESCRIPTION
The second new example shows how to remove most image metadata (e.g., geolocation, camera model) without messing up the image's appearance.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).