### PR TITLE
enum4linux: remove enum.exe from command description

### DIFF
--- a/pages/linux/enum4linux.md
+++ b/pages/linux/enum4linux.md
@@ -1,7 +1,6 @@
 # enum4linux
 
 > Tool for enumerating Windows and Samba information from remote systems.
-> It attempts to offer similar functionality to enum.exe formerly available from www.bindview.com.
 > More information: <https://labs.portcullis.co.uk/tools/enum4linux/>.
 
 - Try to enumerate using all methods:


### PR DESCRIPTION
Removed connection to a dead link and related information

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
