### PR TITLE
black: adjust example descriptions for `--diff` and `--check` examples

### DIFF
--- a/pages/common/black.md
+++ b/pages/common/black.md
@@ -15,7 +15,7 @@
 
 `black --check {{path/to/file_or_directory}}`
 
-- Output any changes that would be made to a file or a directory if they were to be formatted:
+- Output changes that would be made to a file or a directory without performing them (dry-run):
 
 `black --diff {{path/to/file_or_directory}}`
 

--- a/pages/common/black.md
+++ b/pages/common/black.md
@@ -1,7 +1,7 @@
 # black
 
 > A Python auto code formatter.
-> More information: <https://github.com/psf/black>.
+> More information: <https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html>.
 
 - Auto-format a file or entire directory:
 

--- a/pages/common/black.md
+++ b/pages/common/black.md
@@ -11,15 +11,15 @@
 
 `black -c "{{code}}"`
 
-- Output the changes that would be applied for each file:
-
-`black --diff {{path/to/file_or_directory}}`
-
-- Perform a dry run (print what would be done without actually doing it):
+- Output whether a file or a directory would have changes made to them if they were to be formatted:
 
 `black --check {{path/to/file_or_directory}}`
 
-- Auto-format a file or directory emitting exclusively error messages to stderr:
+- Output any changes that would be made to a file or a directory if they were to be formatted:
+
+`black --diff {{path/to/file_or_directory}}`
+
+- Auto-format a file or directory, emitting exclusively error messages to stderr:
 
 `black --quiet {{path/to/file_or_directory}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** black, 22.10.0 (compiled: no)

Just some minor changes, modified the order and description of the examples using `--diff` and `--check` to more accurately reflect the difference between them, and made the link point to the project's documentation page.
