### PR TITLE
Fix warning when piping lz4 decompression

### DIFF
--- a/pages/common/lz4.md
+++ b/pages/common/lz4.md
@@ -21,7 +21,7 @@
 
 - Decompress and unpack a directory and its contents:
 
-`lz4 -d {{dir.tar.lz4}} | tar -xv`
+`lz4 -dc {{dir.tar.lz4}} | tar -xv`
 
 - Compress a file using the best compression:
 


### PR DESCRIPTION
Without '-c' lz4 prints warning:
    using stdout as default output. Do not rely on this behavior: use explicit `-c` instead !

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
