### PR TITLE
date: fix typo in -u example

### DIFF
--- a/pages.it/common/date.md
+++ b/pages.it/common/date.md
@@ -9,7 +9,7 @@
 
 - Mostra la data corrente in UTC e formato ISO 8601:
 
-`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+`date -u +"%Y-%m-%dT%H:%M:%S%Z"`
 
 - Mostra la data corrente come timestamp Unix (secondi dall'epoca Unix):
 

--- a/pages.ko/common/date.md
+++ b/pages.ko/common/date.md
@@ -9,7 +9,7 @@
 
 - 현재 날짜를 UTC 및 ISO 8601 형식으로 표시:
 
-`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+`date -u +"%Y-%m-%dT%H:%M:%S%Z"`
 
 - 현재 날짜를 Unix 타임스탬프로 표시 (Unix epoch 이후 몇 초):
 

--- a/pages.pt_BR/common/date.md
+++ b/pages.pt_BR/common/date.md
@@ -9,7 +9,7 @@
 
 - Exibe a data atual no formato UTC e ISO 8601:
 
-`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+`date -u +"%Y-%m-%dT%H:%M:%S%Z"`
 
 - Mostra a data atual em Unix timestamp - segundos desde 00:00:00 UTC de 1 de janeiro de 1970 (Unix epoch):
 

--- a/pages.tr/common/date.md
+++ b/pages.tr/common/date.md
@@ -9,7 +9,7 @@
 
 - Geçerli tarihi UTC ve ISO 8601 formatında görüntüleyin:
 
-`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+`date -u +"%Y-%m-%dT%H:%M:%S%Z"`
 
 - Geçerli tarihi bir Unix zaman damgası olarak görüntüleyin (Unix zamanından bu yana geçen saniyeler):
 

--- a/pages/common/date.md
+++ b/pages/common/date.md
@@ -9,7 +9,7 @@
 
 - Display the current date in UTC, using the ISO 8601 format:
 
-`date -u +%Y-%m-%dT%H:%M:%SZ`
+`date -u +%Y-%m-%dT%H:%M:%S%Z`
 
 - Display the current date as a Unix timestamp (seconds since the Unix epoch):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** GNU coreutils 9.1, Arch Linux


Adding a missing percent sign. Without it, `Z` is just displayed as the letter `Z`. This is clearly not intentional.
Adding the `%` causes `%Z` to evaluate to `UTC`.
It generally evaluates to the timezone's abbreviation, but the -u flag forces UTC.