### PR TITLE
git-blame: add commit examples

### DIFF
--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -11,6 +11,6 @@
 
 `git blame -e {{file}}`
 
-- Run git blame on file as it was before a specified commit:
+- Print file with author name and commit hash on each line at a specific commit:
 
 `git blame {{commit}}~ {{path/to/file}}`

--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -10,3 +10,7 @@
 - Print file with author email and commit hash on each line:
 
 `git blame -e {{file}}`
+
+- Run git blame on file as it was before a specified commit:
+
+`git blame {{commit_hash}}~ {{file}}`

--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -13,4 +13,4 @@
 
 - Run git blame on file as it was before a specified commit:
 
-`git blame {{commit_hash}}~ {{file}}`
+`git blame {{commit}}~ {{path/to/file}}`

--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -13,4 +13,8 @@
 
 - Print file with author name and commit hash on each line at a specific commit:
 
+`git blame {{commit}} {{path/to/file}}`
+
+- Print file with author name and commit hash on each line before a specific commit:
+
 `git blame {{commit}}~ {{path/to/file}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

This just adds an explanation for running git blame on an older commit. I have used this very often recently, like when the commit shown by blame already contained the bug I was looking for and I wanted to continue blaming deeper into the past. Since the TLDR page of blame was so short, I thought it would be a nice addition.