### PR TITLE
cron: add alias page

### DIFF
--- a/pages/common/cron.md
+++ b/pages/common/cron.md
@@ -1,0 +1,8 @@
+# cron
+
+> `cron` is a system scheduler for running jobs or tasks unattended.
+> The command to submit, edit or delete entries to `cron` is called `crontab`.
+ 
+- View documentation for the original command:
+
+`tldr crontab`

--- a/pages/common/cron.md
+++ b/pages/common/cron.md
@@ -2,7 +2,7 @@
 
 > `cron` is a system scheduler for running jobs or tasks unattended.
 > The command to submit, edit or delete entries to `cron` is called `crontab`.
- 
+
 - View documentation for the original command:
 
 `tldr crontab`

--- a/pages/common/ripgrep.md
+++ b/pages/common/ripgrep.md
@@ -2,6 +2,6 @@
 
 > `ripgrep` is the common name for the command `rg`.
 
-- View documentation for the actual command:
+- View documentation for the original command:
 
 `tldr rg`

--- a/pages/common/todoman.md
+++ b/pages/common/todoman.md
@@ -4,6 +4,6 @@
 > `todoman` is a common name for the command `todo`, but not a command itself.
 > More information: <https://todoman.readthedocs.io/>.
 
-- View documentation for the actual command:
+- View documentation for the original command:
 
 `tldr todo`


### PR DESCRIPTION
This was one of the oldest requests that motivated the need for [alias pages](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#aliases), so I'm surprised it hadn't been added yet.

Fixes #904 (finally!!)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

I've also fixed the text of the `ripgrep` and `todoman` alias pages, which used a wording slightly different from the standard alias description [defined in the guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#aliases).