### PR TITLE
codespell.yml: ignore package-lock.json

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,18 +8,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26.1
         with:
           # Ignore all other languages except English
-          files_ignore: pages.*/*/* 
-        
+          files_ignore: |
+            pages.*/*/*
+            package-lock.json
+
       - uses: codespell-project/actions-codespell@master
         with:
           ignore_words_file: .github/codespell-ignore
           # Exit with 0 regardless of typos.
-          only_warn: 1 
+          only_warn: 1
           # Only check files in the PR
-          path: ${{ steps.changed-files.outputs.all_changed_files }} 
+          path: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Signed-off-by: Seth Falco <seth@falco.fun>

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

We're getting complaints in other PRs when we shouldn't atm, it seems to only occur when one of non-English pages are touched or added. Testing on my private branch, the problem seems to get resolved just from trimming spaces. :thinking: 

Regardless, I explicitly add to ignore `package-lock.json` as well to avoid having it try to provide corrections from there.

See the following for an example of the issue:
* https://github.com/tldr-pages/tldr/pull/9427/files
* https://github.com/tldr-pages/tldr/pull/9425/files
* https://github.com/tldr-pages/tldr/pull/9424/files
* https://github.com/tldr-pages/tldr/pull/9422/files

![image](https://user-images.githubusercontent.com/22801583/198858007-9a80eaaa-bed5-4b9c-86ed-e1891abd4565.png)

![image](https://user-images.githubusercontent.com/22801583/198858013-44489aff-cdd6-4198-91aa-72d2f0b3722d.png)
