### PR TITLE
errno: fix grammar in example description

### DIFF
--- a/pages/common/errno.md
+++ b/pages/common/errno.md
@@ -11,10 +11,10 @@
 
 `errno --list`
 
-- Search for code who's description contains all of the given text:
+- Search for code whose description contains all of the given text:
 
 `errno --search {{text}}`
 
-- Search for code who's description contains all of the given text (all locales):
+- Search for code whose description contains all of the given text (all locales):
 
 `errno --search-all-locales {{text}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
