### PR TITLE
aria2: update translations to match en page

### DIFF
--- a/pages.it/common/aria2.md
+++ b/pages.it/common/aria2.md
@@ -1,33 +1,7 @@
 # aria2
 
-> Strumento di download da linea di comando leggero, multi-protocollo e multi-sorgente.
-> Supporta HTTP, HTTPS, FTP, SFTP, BitTorrent e Metalink.
-> Maggiori informazioni: <https://aria2.github.io/>.
+> Questo comando è un alias per `aria2c`.
 
-- Scarica una risorsa web:
+- Consulta la documentazione del comando originale:
 
-`aria2c {{http://example.org/myLinux.iso}}`
-
-- Scarica una risorsa da sorgenti multiple:
-
-`aria2c {{http://mirror1.org/myLinux.iso}} {{http://mirror2.org/myLinux.iso}}`
-
-- Scarica utilizzando 2 connessioni per host:
-
-`aria2c -x{{2}} {{http://example.org/myLinux.iso}}`
-
-- Scarica un file da un URI Metalink:
-
-`aria2c {{http://example.org/myLinux.metalink}}`
-
-- Scarica da un URI BitTorrent:
-
-`aria2c {{http://example.org/myLinux.torrent}}`
-
-- Scarica da un Magnet URI BitTorrent:
-
-`aria2c {{'magnet:?xt=urn:btih:248D0A1CD08284299DE78D5C1ED359BB46717D8C'}}`
-
-- Scarica dagli URI listati in un file:
-
-`aria2c -i {{uris.txt}}`
+`tldr aria2c`

--- a/pages.ko/common/aria2.md
+++ b/pages.ko/common/aria2.md
@@ -1,33 +1,7 @@
 # aria2
 
-> 경량 멀티 프로토콜 및 멀티 소스 명령줄 다운로드 유틸리티입니다.
-> HTTP, HTTPS, FTP, SFTP, BitTorrent와 Metalink를 지원합니다.
-> 더 많은 정보: <https://aria2.github.io/>.
+> 이 명령은 `aria2c` 의 에일리어스 (별칭) 입니다.
 
-- 웹 리소스 다운로드:
+- 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`aria2c {{http://example.org/myLinux.iso}}`
-
-- 멀티 소스 리소스 다운로드:
-
-`aria2c {{http://mirror1.org/myLinux.iso}} {{http://mirror2.org/myLinux.iso}}`
-
-- 호스트당 2개의 연결을 사용하여 다운로드:
-
-`aria2c -x{{2}} {{http://example.org/myLinux.iso}}`
-
-- Metalink URL로 다운로드:
-
-`aria2c {{http://example.org/myLinux.metalink}}`
-
-- BitTorrent URI로 다운로드:
-
-`aria2c {{http://example.org/myLinux.torrent}}`
-
-- BitTorrent Magnet URI로 다운로드:
-
-`aria2c {{'magnet:?xt=urn:btih:248D0A1CD08284299DE78D5C1ED359BB46717D8C'}}`
-
-- 파일로 URls 다운로드:
-
-`aria2c -i {{uris.txt}}`
+`tldr aria2c`

--- a/pages.zh/common/aria2.md
+++ b/pages.zh/common/aria2.md
@@ -1,33 +1,7 @@
 # aria2
 
-> 一个轻量级多协议和多源命令行下载工具。
-> 支持 HTTP, HTTPS, FTP, SFTP, BitTorrent and Metalink.
-> 主页： <https://aria2.github.io/>.
+> 这是 `aria2c` 命令的一个别名。
 
-- 下载一个网络资源：
+- 原命令的文档在：
 
-`aria2c {{http://example.org/myLinux.iso}}`
-
-- 从多个源处下载一个资源：
-
-`aria2c {{http://mirror1.org/myLinux.iso}} {{http://mirror2.org/myLinux.iso}}`
-
-- 使用两个连接下载资源：
-
-`aria2c -x{{2}} {{http://example.org/myLinux.iso}}`
-
-- 从 Metalink URI 中下载资源：
-
-`aria2c {{http://example.org/myLinux.metalink}}`
-
-- 从 BitTorrent URI 中下载资源：
-
-`aria2c {{http://example.org/myLinux.torrent}}`
-
-- 从 BitTorrent Magnet URI 中下载资源：
-
-`aria2c {{'magnet:?xt=urn:btih:248D0A1CD08284299DE78D5C1ED359BB46717D8C'}}`
-
-- 从一个文件中下载资源：
-
-`aria2c -i {{uris.txt}}`
+`tldr aria2c`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

---

I noticed that these translated pages fell out of sync with the English version.

The English page is now an alias page, so the previous translations of it should be made alias pages as well.

I do realize there is one problem with this, which is that the English page says:

> View documentation for the updated command

But the alias page templates I used are translations of:

> View documentation for the original command

It'd be better if we could make them all match. :thinking: 