### PR TITLE
conky: fix align example

### DIFF
--- a/pages/linux/conky.md
+++ b/pages/linux/conky.md
@@ -21,7 +21,7 @@
 
 - Align Conky on the desktop:
 
-`conky -a {{{top,bottom,middle}_{left,right,middle}}}`
+`conky -a {{top|bottom|middle}}_{{left|right|middle}}`
 
 - Pause for 5 seconds at startup before launching:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

---

The examples for the Conky command were formed incorrectly.

> `conky -a top_left -x 5 -y 500 -d`
> 
> — https://www.mankier.com/1/conky#Examples

> `conky -a top_left -x 5 -y 500 -d`
> 
> — https://manned.org/conky.1#head10

Fun fact btw, not too familiar with Mankier, seems to be a browser based frontend for man pages, similar to manned. Except at the top it puts a tldr page before showing a man page. :o

![image](https://user-images.githubusercontent.com/22801583/200002596-b1eef2ee-236e-4d0b-a638-305ad6a2b08a.png)
> Note how it shows a tldr page first, then the man page.