### PR TITLE
cut: use `--delimiter` with `--fields`

### DIFF
--- a/pages/common/cut.md
+++ b/pages/common/cut.md
@@ -9,7 +9,7 @@
 
 - Print a range of each line with a specific delimiter:
 
-`{{command}} | cut --delimiter="{{,}}" --{{characters}}={{1}}`
+`{{command}} | cut --delimiter="{{,}}" --{{fields}}={{1}}`
 
 - Print a range of each line of the specific file:
 


### PR DESCRIPTION
The `--delimiter` option only applies when separating fields. I have changed the second example to use `--fields` instead of `--characters`, which threw an error.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
