### PR TITLE
scoop: improve example to update all packages

### DIFF
--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -13,7 +13,7 @@
 
 - Update all installed packages:
 
-`scoop update -a`
+`scoop update --all`
 
 - List installed packages:
 
@@ -29,4 +29,4 @@
 
 - Remove old versions of all packages and clear the download cache:
 
-`scoop cleanup -k *`
+`scoop cleanup --cache --all`

--- a/pages/windows/scoop.md
+++ b/pages/windows/scoop.md
@@ -13,7 +13,7 @@
 
 - Update all installed packages:
 
-`scoop update *`
+`scoop update -a`
 
 - List installed packages:
 


### PR DESCRIPTION
# scoop

## Issue

`Scoop.md` advises to update all packages with `scoop update *`. 

The result of that command is dependent on the shell being used. When using bash, `*` is error-prone as it is expanded to the content of the directory where the command is executed.

## Fix

`scoop update -a` guarantees consistent results and is supported by scoop's built-in help.

```shell
$ scoop update --help
Usage: scoop update <app> [options]
...
  -a, --all                 Update all apps (alternative to '*')
```

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** `v0.3.0 - Released at 2022-10-10`
