### PR TITLE
btrfs*, mkfs.btrfs: update link to new website

### DIFF
--- a/pages.fr/linux/btrfs-check.md
+++ b/pages.fr/linux/btrfs-check.md
@@ -1,7 +1,7 @@
 # btrfs check
 
 > Vérifier l'état, ou réparer un système de fichiers de type btrfs.
-> Plus d'informations : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-check>.
+> Plus d'informations : <https://btrfs.readthedocs.io/en/latest/btrfs-check.html>.
 
 - Vérifier l'état d'un système de fichiers btrfs :
 

--- a/pages.fr/linux/btrfs-device.md
+++ b/pages.fr/linux/btrfs-device.md
@@ -1,7 +1,7 @@
 # btrfs device
 
 > Gestion des partitions dans un système de fichiers BTRFS.
-> Plus d'information : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-device>.
+> Plus d'information : <https://btrfs.readthedocs.io/en/latest/btrfs-device.html>.
 
 - Ajouter un ou plusieurs périphériques à un système de fichiers btrfs :
 

--- a/pages.fr/linux/btrfs-filesystem.md
+++ b/pages.fr/linux/btrfs-filesystem.md
@@ -1,7 +1,7 @@
 # btrfs filesystem
 
 > Gérer les systèmes de fichiers btrfs.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html>.
 
 - Afficher l'utilisation du système de fichiers (affiche les informations détaillées si executé en tant que `root`) :
 

--- a/pages.fr/linux/btrfs-inspect-internal.md
+++ b/pages.fr/linux/btrfs-inspect-internal.md
@@ -1,7 +1,7 @@
 # btrfs inspect-internal
 
 > Recherche des informations internes concernant un système de fichier btrfs.
-> Plus d'information : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-inspect-internal>.
+> Plus d'information : <https://btrfs.readthedocs.io/en/latest/btrfs-inspect-internal.html>.
 
 - Afficher les informations du superbloc :
 

--- a/pages.fr/linux/btrfs-rescue.md
+++ b/pages.fr/linux/btrfs-rescue.md
@@ -1,7 +1,7 @@
 # btrfs rescue
 
 > Essayer de récupérer un système de fichiers btrfs endommagé.
-> Plus d'informations : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-rescue>.
+> Plus d'informations : <https://btrfs.readthedocs.io/en/latest/btrfs-rescue.html>.
 
 - Reconstruire les méta-données du système de fichiers (très lent) :
 

--- a/pages.fr/linux/btrfs-restore.md
+++ b/pages.fr/linux/btrfs-restore.md
@@ -1,7 +1,7 @@
 # btrfs restore
 
 > Tenter de récupérer des fichiers depuis un système de fichiers btrfs endommagé.
-> Plus d'information : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-restore>.
+> Plus d'information : <https://btrfs.readthedocs.io/en/latest/btrfs-restore.html>.
 
 - Restaurer tout les fichiers depuis un système de fichier btrfs vers un répertoire cible indiqué :
 

--- a/pages.fr/linux/btrfs-scrub.md
+++ b/pages.fr/linux/btrfs-scrub.md
@@ -2,7 +2,7 @@
 
 > Éxaminer un système de fichiers btrfs pour vérifier l'intégrité de ses données.
 > Il est recommandé de faire tourner une vérification tous les mois.
-> Plus d'informations : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-scrub>.
+> Plus d'informations : <https://btrfs.readthedocs.io/en/latest/btrfs-scrub.html>.
 
 - Démarrer un examen :
 

--- a/pages.fr/linux/btrfs-subvolume.md
+++ b/pages.fr/linux/btrfs-subvolume.md
@@ -1,7 +1,7 @@
 # btrfs subvolume
 
 > Gestion des sous-volumes et instantanés btrfs.
-> Plus d'information : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume>.
+> Plus d'information : <https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html>.
 
 - Créer un nouveau sous-volume vide :
 

--- a/pages.fr/linux/btrfs-version.md
+++ b/pages.fr/linux/btrfs-version.md
@@ -1,7 +1,7 @@
 # btrfs version
 
 > Afficher les informations de version des outils btrfs, et accéder aux pages d'aide.
-> Plus d'informations : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> Plus d'informations : <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Afficher les informations de version des outils btrfs :
 

--- a/pages.fr/linux/btrfs.md
+++ b/pages.fr/linux/btrfs.md
@@ -2,7 +2,7 @@
 
 > Système de fichiers basé sur le principe de copie à l’écriture ("copy-on-write", souvent désigné par son sigle anglais COW) pour Linux.
 > Certaines sous-commandes comme `btrfs device` ont leur propre documentation.
-> Plus d'informations : <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> Plus d'informations : <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Créer un sous-volume :
 

--- a/pages.id/linux/mkfs.btrfs.md
+++ b/pages.id/linux/mkfs.btrfs.md
@@ -2,7 +2,7 @@
 
 > Membuat sistem file btrfs.
 > Default ke `raid1`, yang menyatakan 2 salinan sebuah blok data disebar ke 2 perangkat yang berbeda.
-> Informasi lebih lanjut: <https://btrfs.wiki.kernel.org/index.php/Manpage/mkfs.btrfs>.
+> Informasi lebih lanjut: <https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html>.
 
 - Membuat sebuah sistem file btrfs di satu perangkat:
 

--- a/pages.pt_BR/linux/btrfs-balance.md
+++ b/pages.pt_BR/linux/btrfs-balance.md
@@ -1,7 +1,7 @@
 # btrfs balance
 
 > Balanceia grupos de blocos em um sistema de arquivos btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-balance>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-balance.html>.
 
 - Mostra o status de uma operação balance em execução ou pausada:
 

--- a/pages.pt_BR/linux/btrfs-check.md
+++ b/pages.pt_BR/linux/btrfs-check.md
@@ -1,7 +1,7 @@
 # btrfs check
 
 > Verifica ou repara um sistema de arquivos btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-check>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-check.html>.
 
 - Verifica um sistema de arquivos btrfs:
 

--- a/pages.pt_BR/linux/btrfs-device.md
+++ b/pages.pt_BR/linux/btrfs-device.md
@@ -1,7 +1,7 @@
 # btrfs device
 
 > Gerencia dispositivos em um sistema de arquivos btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-device>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-device.html>.
 
 - Adiciona um ou mais dispositivos a um sistema de arquivos btrfs:
 

--- a/pages.pt_BR/linux/btrfs-filesystem.md
+++ b/pages.pt_BR/linux/btrfs-filesystem.md
@@ -1,7 +1,7 @@
 # btrfs filesystem
 
 > Gerencia sistemas de arquivos btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html>.
 
 - Mostra uso do sistema de arquivos (opcionalmente execute como root para mostrar informações detalhadas):
 

--- a/pages.pt_BR/linux/btrfs-inspect-internal.md
+++ b/pages.pt_BR/linux/btrfs-inspect-internal.md
@@ -1,7 +1,7 @@
 # btrfs inspect-internal
 
 > Consulta informações internas de um sistema de arquivos btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-inspect-internal>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-inspect-internal.html>.
 
 - Imprime informações de superblocos:
 

--- a/pages.pt_BR/linux/btrfs-property.md
+++ b/pages.pt_BR/linux/btrfs-property.md
@@ -1,7 +1,7 @@
 # btrfs property
 
 > Obtém, define ou lista propriedades para um determinado objeto de sistema de arquivos btrfs (arquivos, diretórios, subvolumes, sistemas de arquivos ou dispositivos).
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-property>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-property.html>.
 
 - Lista as propriedades disponíveis (e descrições) para o objeto btrfs fornecido:
 

--- a/pages.pt_BR/linux/btrfs-rescue.md
+++ b/pages.pt_BR/linux/btrfs-rescue.md
@@ -1,7 +1,7 @@
 # btrfs rescue
 
 > Tenta recuperar um sistema de arquivos btrfs danificado.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-rescue>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-rescue.html>.
 
 - Reconstrói a árvore de metadados do sistema de arquivos (muito lento):
 

--- a/pages.pt_BR/linux/btrfs-subvolume.md
+++ b/pages.pt_BR/linux/btrfs-subvolume.md
@@ -1,7 +1,7 @@
 # btrfs subvolume
 
 > Gerencia subvolumes e snapshots btrfs.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html>.
 
 - Cria um novo subvolume vazio:
 

--- a/pages.pt_BR/linux/btrfs.md
+++ b/pages.pt_BR/linux/btrfs.md
@@ -2,7 +2,7 @@
 
 > Um sistema de arquivos baseado no princípio copy-on-write (COW) para Linux.
 > Alguns subcomandos como `btrfs device` têm sua própria documentação de uso.
-> Mais informações: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Cria subvolume:
 

--- a/pages.zh/linux/btrfs-device.md
+++ b/pages.zh/linux/btrfs-device.md
@@ -1,7 +1,7 @@
 # btrfs device
 
 > 管理 btrfs 文件系统中的设备。
-> 更多信息：<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-device>.
+> 更多信息：<https://btrfs.readthedocs.io/en/latest/btrfs-device.html>.
 
 - 将一个或多个设备添加到 btrfs 文件系统中：
 

--- a/pages.zh/linux/btrfs-filesystem.md
+++ b/pages.zh/linux/btrfs-filesystem.md
@@ -1,7 +1,7 @@
 # btrfs filesystem
 
 > 管理 btrfs 文件系统。
-> 更多信息：<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem>.
+> 更多信息：<https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html>.
 
 - 显示文件系统使用情况（可以选择以 root 身份运行以显示详细信息）：
 

--- a/pages.zh/linux/btrfs-scrub.md
+++ b/pages.zh/linux/btrfs-scrub.md
@@ -2,7 +2,7 @@
 
 > 清理 btrfs 文件系统以验证数据完整性。
 > 建议每月运行一次 scrub.
-> 更多信息：<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-scrub>.
+> 更多信息：<https://btrfs.readthedocs.io/en/latest/btrfs-scrub.html>.
 
 - 开始 scrub：
 

--- a/pages.zh/linux/btrfs-subvolume.md
+++ b/pages.zh/linux/btrfs-subvolume.md
@@ -1,7 +1,7 @@
 # btrfs subvolume
 
 > 管理 btrfs 子卷和快照。
-> 更多信息：<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume>.
+> 更多信息：<https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html>.
 
 - 创建一个新的空子卷：
 

--- a/pages.zh/linux/btrfs.md
+++ b/pages.zh/linux/btrfs.md
@@ -2,7 +2,7 @@
 
 > 一种基于写时复制（COW）原理的 Linux 文件系统。
 > 此命令也有关于其子命令的文件，例如：`btrfs device`.
-> 更多信息：<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> 更多信息：<https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - 创建子卷：
 

--- a/pages/linux/btrfs-balance.md
+++ b/pages/linux/btrfs-balance.md
@@ -1,7 +1,7 @@
 # btrfs balance
 
 > Balance block groups on a btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-balance>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-balance.html>.
 
 - Show the status of a running or paused balance operation:
 

--- a/pages/linux/btrfs-check.md
+++ b/pages/linux/btrfs-check.md
@@ -1,7 +1,7 @@
 # btrfs check
 
 > Check or repair a btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-check>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-check.html>.
 
 - Check a btrfs filesystem:
 

--- a/pages/linux/btrfs-device.md
+++ b/pages/linux/btrfs-device.md
@@ -1,7 +1,7 @@
 # btrfs device
 
 > Manage devices in a btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-device>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-device.html>.
 
 - Add one or more devices to a btrfs filesystem:
 

--- a/pages/linux/btrfs-filesystem.md
+++ b/pages/linux/btrfs-filesystem.md
@@ -1,7 +1,7 @@
 # btrfs filesystem
 
 > Manage btrfs filesystems.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html>.
 
 - Show filesystem usage (optionally run as root to show detailed information):
 

--- a/pages/linux/btrfs-inspect-internal.md
+++ b/pages/linux/btrfs-inspect-internal.md
@@ -1,7 +1,7 @@
 # btrfs inspect-internal
 
 > Query internal information of a btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-inspect-internal>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-inspect-internal.html>.
 
 - Print superblock's information:
 

--- a/pages/linux/btrfs-property.md
+++ b/pages/linux/btrfs-property.md
@@ -1,7 +1,7 @@
 # btrfs property
 
 > Get, set, or list properties for a given btrfs filesystem object (files, directories, subvolumes, filesystems, or devices).
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-property>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-property.html>.
 
 - List available properties (and descriptions) for the given btrfs object:
 

--- a/pages/linux/btrfs-rescue.md
+++ b/pages/linux/btrfs-rescue.md
@@ -1,7 +1,7 @@
 # btrfs rescue
 
 > Try to recover a damaged btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-rescue>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-rescue.html>.
 
 - Rebuild the filesystem metadata tree (very slow):
 

--- a/pages/linux/btrfs-restore.md
+++ b/pages/linux/btrfs-restore.md
@@ -1,7 +1,7 @@
 # btrfs restore
 
 > Try to salvage files from a damaged btrfs filesystem.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-restore>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-restore.html>.
 
 - Restore all files from a btrfs filesystem to a given directory:
 

--- a/pages/linux/btrfs-scrub.md
+++ b/pages/linux/btrfs-scrub.md
@@ -2,7 +2,7 @@
 
 > Scrub btrfs filesystems to verify data integrity.
 > It is recommended to run a scrub once a month.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-scrub>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-scrub.html>.
 
 - Start a scrub:
 

--- a/pages/linux/btrfs-subvolume.md
+++ b/pages/linux/btrfs-subvolume.md
@@ -1,7 +1,7 @@
 # btrfs subvolume
 
 > Manage btrfs subvolumes and snapshots.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html>.
 
 - Create a new empty subvolume:
 

--- a/pages/linux/btrfs-version.md
+++ b/pages/linux/btrfs-version.md
@@ -1,7 +1,7 @@
 # btrfs version
 
 > Display btrfs-progs version.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Display btrfs-progs version:
 

--- a/pages/linux/btrfs.md
+++ b/pages/linux/btrfs.md
@@ -2,7 +2,7 @@
 
 > A filesystem based on the copy-on-write (COW) principle for Linux.
 > Some subcommands such as `btrfs device` have their own usage documentation.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs>.
+> More information: <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Create subvolume:
 

--- a/pages/linux/mkfs.btrfs.md
+++ b/pages/linux/mkfs.btrfs.md
@@ -2,7 +2,7 @@
 
 > Create a btrfs filesystem.
 > Defaults to `raid1`, which specifies 2 copies of a given data block spread across 2 different devices.
-> More information: <https://btrfs.wiki.kernel.org/index.php/Manpage/mkfs.btrfs>.
+> More information: <https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html>.
 
 - Create a btrfs filesystem on a single device:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

This pull request updates the urls in the btrfs commands from <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-device> to <https://btrfs.readthedocs.io/en/latest/btrfs-device.html> as they are already a (manual) redirect.