### PR TITLE
hexdump: fix path placeholders

### DIFF
--- a/pages/common/hexdump.md
+++ b/pages/common/hexdump.md
@@ -5,16 +5,16 @@
 
 - Print the hexadecimal representation of a file, replacing duplicate lines by '*':
 
-`hexdump {{file}}`
+`hexdump {{path/to/file}}`
 
 - Display the input offset in hexadecimal and its ASCII representation in two columns:
 
-`hexdump -C {{file}}`
+`hexdump -C {{path/to/file}}`
 
 - Display the hexadecimal representation of a file, but interpret only n bytes of the input:
 
-`hexdump -C -n{{number_of_bytes}} {{file}}`
+`hexdump -C -n{{number_of_bytes}} {{path/to/file}}`
 
 - Don't replace duplicate lines with '*':
 
-`hexdump --no-squeezing {{file}}`
+`hexdump --no-squeezing {{path/to/file}}`


### PR DESCRIPTION
- should be merged before #9129 PR

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** latest
