### PR TITLE
exiftool: Add "-gps*=" removal example

### DIFF
--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -11,6 +11,10 @@
 
 `exiftool -All= {{file1 file2 ...}}`
 
+- Remove GPS EXIF metadata from given image files:
+
+`exiftool "-gps*=" {{image1 image2 ...}}`
+
 - Remove all EXIF metadata from the given image files, then re-add metadata for color and orientation:
 
 `exiftool -All= -tagsfromfile @ -colorspacetags -orientation {{image1 image2 ...}}`

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -13,7 +13,7 @@
 
 - Remove GPS EXIF metadata from given image files:
 
-`exiftool "-gps*=" {{image1 image2 ...}}`
+`exiftool "-gps*=" {{path/to/image1 path/to/image2 ...}}`
 
 - Remove all EXIF metadata from the given image files, then re-add metadata for color and orientation:
 


### PR DESCRIPTION
A common use of exiftool is removing location data from photos.  One may wish to preserve most EXIF data (ex. rotation, date/time taken, etc.) but remove private location data.  This example accomplishes this common task.

The proposed example (including quotes) comes from exiftool's author, Phil Harvey: https://exiftool.org/forum/index.php?topic=6037.msg29731#msg29731

This example works to not only remove GPS data from EXIF but also from Adobe's XMP tags.

Tested with JPEG and HEIC photos using exiftool 12.50.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): 12.50**
