### PR TITLE
CLIENT-SPECIFICATION: deny creating multiple copies for similar pages

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -20,7 +20,7 @@ tldr-pages consists of multiple _pages_ - each of which describes a specific com
 Pages are grouped by platform, i.e. operating systems — for example, `windows`, `linux`, `osx`.
 The special platform `common` contains pages for commands that work identically across more than one platform.
 
-If a page is common across multiple platforms, but slightly differently on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder.
+If a page is common across multiple platforms, but slightly different on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder.
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -20,10 +20,11 @@ tldr-pages consists of multiple _pages_ - each of which describes a specific com
 Pages are grouped by platform, i.e. operating systems — for example, `windows`, `linux`, `osx`.
 The special platform `common` contains pages for commands that work identically across more than one platform.
 
-If a page is common across multiple platforms, but slightly differently on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder.
+If a page is common across multiple platforms, but slightly differently on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder. 
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 
+Note that if the only difference between command functionality on two platforms is that one of them accepts additionally extra options with the same meaning as existing ones the new page copy from `common` MUST NOT be created.
 
 ## Command-line interface
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -20,7 +20,7 @@ tldr-pages consists of multiple _pages_ - each of which describes a specific com
 Pages are grouped by platform, i.e. operating systems — for example, `windows`, `linux`, `osx`.
 The special platform `common` contains pages for commands that work identically across more than one platform.
 
-If a page is common across multiple platforms, but slightly differently on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder. 
+If a page is common across multiple platforms, but slightly differently on a given platform, then the page is still stored in `common`, but a copy tailored for the differing platform is placed in that platform's specific folder.
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -24,7 +24,7 @@ If a page is common across multiple platforms, but slightly differently on a giv
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 
-Note that if the only difference between command functionality on two platforms is that one of them accepts additionally extra options with the same meaning as existing ones the new page copy from `common` MUST NOT be created.
+Note that if the only difference between command functionality on two platforms is that one of them accepts additionally extra options with the same meaning as existing ones the new page copy from `common` MUST NOT be created. For instance `linux/sed.md` page MUST NOT be created just to describe long options: you can use mnemonics with square brackets for short options to make `common/sed.md` easily memorable.
 
 ## Command-line interface
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -24,7 +24,7 @@ If a page is common across multiple platforms, but slightly different on a given
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 
-Note that if the only difference between command functionality on two platforms is that one of them accepts additionally extra options with the same meaning as existing ones the new page copy from `common` MUST NOT be created. For instance `linux/sed.md` page MUST NOT be created just to describe long options: you can use mnemonics with square brackets for short options to make `common/sed.md` easily memorable.
+Note that pages MUST NOT be created just to demonstrate another options which work exactly the same as already described in other pages. For instance it's illegal to create a page to just show `--bar` option which is an alias for `--foo`.
 
 ## Command-line interface
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -24,7 +24,12 @@ If a page is common across multiple platforms, but slightly different on a given
 
 For example, if the command `foo` is common to `mac`, `windows`, and `linux` but functions differently on `windows`, then the main page will be stored in `common`, and a copy will be placed in `windows` that's altered to match the different functionality.
 
-Note that pages MUST NOT be created just to demonstrate another options which work exactly the same as already described in other pages. For instance it's illegal to create a page to just show `--bar` option which is an alias for `--foo`.
+Note that:
+
+- If some short option is already described the new page MUST NOT be created to demonstrate another identical short option
+- If some long option is already described the new page MUST NOT be created to demonstrate another identical long option
+
+But it's fine to create pages to show long option which can be used instead of short one.
 
 ## Command-line interface
 


### PR DESCRIPTION
The motivation behind it is to reduce overhead of supporting multiple similar pages with one difference: option style. I know that we like long options but there is another way to give user ideas of memorizing commands: mnemonics. ;)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** unavailable
