### PR TITLE
icalbuddy: Add long options on examples

### DIFF
--- a/pages/osx/icalbuddy.md
+++ b/pages/osx/icalbuddy.md
@@ -5,7 +5,7 @@
 
 - Show events later today:
 
-`icalBuddy -n eventsToday`
+`icalBuddy --includeOnlyEventsFromNowOn eventsToday`
 
 - Show uncompleted tasks:
 
@@ -13,11 +13,11 @@
 
 - Show a formatted list separated by calendar for all events today:
 
-`icalBuddy -f -sc eventsToday`
+`icalBuddy --formatOutput --separateByCalendar eventsToday`
 
 - Show tasks for a specified number of days:
 
-`icalBuddy -n "tasksDueBefore:today+{{days}}"`
+`icalBuddy --includeOnlyEventsFromNowOn "tasksDueBefore:today+{{days}}"`
 
 - Show events in a time range:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
- https://github.com/tldr-pages/tldr/blob/main/pages/osx/icalbuddy.md

Add long options on `icalbuddy` examples as requested on PR: https://github.com/tldr-pages/tldr/pull/9495#discussion_r1027005180