### PR TITLE
krunvm: add page, add Spanish translation

### DIFF
--- a/pages.es/common/krunvm.md
+++ b/pages.es/common/krunvm.md
@@ -1,0 +1,24 @@
+# krunvm
+
+> Utilidad basada en CLI para crear micro máquinas virtuales utilizando imagenes OCI.
+> Más información: <https://github.com/containers/krunvm>.
+
+- Crea una micro máquina virtual basada en Fedora:
+
+`krunvm create {{docker.io/fedora}} --cpus {{numero_de_vcpus}} --mem {{memoria_en_megabytes}} --name "{{nombre}}"`
+
+- Inicia una imagen especifica:
+
+`krunvm start "{{nombre}}"`
+
+- Lista las imagenes existentes:
+
+`krunvm list`
+
+- Cambia una imagen especifica:
+
+`krunvm changevm --cpus {{numero_de_vcpus}} --mem {{memoria_en_megabytes}} --name "{{nuevo_nombre}}" "{{nombre}}"`
+
+- Borra una imagen especifica:
+
+`krunvm delete "{{nombre}}"`

--- a/pages/common/krunvm.md
+++ b/pages/common/krunvm.md
@@ -1,0 +1,24 @@
+# krunvm
+
+> CLI-based utility for creating MicroVMs from OCI images.
+> More information: <https://github.com/containers/krunvm>.
+
+- Create MicroVM based on Fedora:
+
+`krunvm create {{docker.io/fedora}} --cpus {{number_of_vcpus}} --mem {{memory_in_megabytes}} --name "{{name}}"`
+
+- Start a specific image:
+
+`krunvm start "{{image_name}}"`
+
+- List images:
+
+`krunvm list`
+
+- Change a specific image:
+
+`krunvm changevm --cpus {{number_of_vcpus}} --mem {{memory_in_megabytes}} --name "{{new_vm_name}}" "{{current_vm_name}}"`
+
+- Delete a specific image:
+
+`krunvm delete "{{image_name}}"`


### PR DESCRIPTION
Adding Krunvm utility in english and spanish languages

This utility is compatible in Linux and OSX.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): krunvm 0.2.3**
