### PR TITLE
mkfile: move to common

### DIFF
--- a/pages.zh/common/mkfile.md
+++ b/pages.zh/common/mkfile.md
@@ -1,7 +1,7 @@
 # mkfile
 
 > 创建一个或多个任意大小的空文件。
-> 更多信息：<https://ss64.com/osx/mkfile.html>.
+> 更多信息：<https://manned.org/mkfile>.
 
 - 创建一个 15 千字节的空文件：
 

--- a/pages/common/mkfile.md
+++ b/pages/common/mkfile.md
@@ -1,7 +1,7 @@
 # mkfile
 
 > Create one or more empty files of any size.
-> More information: <https://ss64.com/osx/mkfile.html>.
+> More information: <https://manned.org/mkfile>.
 
 - Create an empty file of 15 kilobytes:
 


### PR DESCRIPTION
As far as I know, this command first appeared in `sunos` (Solaris), then FreeBSD cloned it, and macOS got it from them.