### PR TITLE
*: fix token syntax for `{{file}}` and `{{directory}}`

### DIFF
--- a/pages/common/bat.md
+++ b/pages/common/bat.md
@@ -6,7 +6,7 @@
 
 - Print the contents of a file to the standard output:
 
-`bat {{file}}`
+`bat {{path/to/file}}`
 
 - Concatenate several files into the target file:
 
@@ -18,7 +18,7 @@
 
 - Number all output lines:
 
-`bat -n {{file}}`
+`bat -n {{path/to/file}}`
 
 - Syntax highlight a JSON file:
 

--- a/pages/common/betty.md
+++ b/pages/common/betty.md
@@ -25,7 +25,7 @@
 
 - Extract an archive into a directory:
 
-`betty unarchive {{archive.tar.gz}} to {{directory}}`
+`betty unarchive {{archive.tar.gz}} to {{path/to/directory}}`
 
 - Play Spotify:
 

--- a/pages/common/carbon-now.md
+++ b/pages/common/carbon-now.md
@@ -5,7 +5,7 @@
 
 - Create an image from a file using default settings:
 
-`carbon-now {{file}}`
+`carbon-now {{path/to/file}}`
 
 - Create an image from a text in clipboard using default settings:
 
@@ -17,20 +17,20 @@
 
 - Create images interactively for custom settings and optionally save a preset:
 
-`carbon-now -i {{file}}`
+`carbon-now -i {{path/to/file}}`
 
 - Create images from previously saved preset:
 
-`carbon-now -p {{preset}} {{file}}`
+`carbon-now -p {{preset}} {{path/to/file}}`
 
 - Start at a specified line of text:
 
-`carbon-now -s {{line}} {{file}}`
+`carbon-now -s {{line}} {{path/to/file}}`
 
 - End at a specific line of text:
 
-`carbon-now -e {{line}} {{file}}`
+`carbon-now -e {{line}} {{path/to/file}}`
 
 - Open image in a browser instead of saving:
 
-`carbon-now --open {{file}}`
+`carbon-now --open {{path/to/file}}`

--- a/pages/common/cosign.md
+++ b/pages/common/cosign.md
@@ -17,7 +17,7 @@
 
 - Sign a blob with a local key pair file:
 
-`cosign sign-blob --key {{cosign.key}} {{file}}`
+`cosign sign-blob --key {{cosign.key}} {{path/to/file}}`
 
 - Verify a container against a public key:
 

--- a/pages/common/cotton.md
+++ b/pages/common/cotton.md
@@ -5,12 +5,12 @@
 
 - Use a specific base URL:
 
-`cotton -u {{base_url}} {{file}}.md`
+`cotton -u {{base_url}} {{path/to/file}}.md`
 
 - Disable certificate verification (insecure mode):
 
-`cotton -u {{base_url}} -i {{file}}.md`
+`cotton -u {{base_url}} -i {{path/to/file}}.md`
 
 - Stop running when a test fails:
 
-`cotton -u {{base_url}} -s {{file}}.md`
+`cotton -u {{base_url}} -s {{path/to/file}}.md`

--- a/pages/common/detox.md
+++ b/pages/common/detox.md
@@ -6,12 +6,12 @@
 
 - Remove spaces and other undesirable characters from a file's name:
 
-`detox {{file}}`
+`detox {{path/to/file}}`
 
 - Show how detox would rename all the files in a directory tree:
 
-`detox --dry-run -r {{directory}}`
+`detox --dry-run -r {{path/to/directory}}`
 
 - Remove spaces and other undesirable characters from all files in a directory tree:
 
-`detox -r {{directory}}`
+`detox -r {{path/to/directory}}`

--- a/pages/common/dircolors.md
+++ b/pages/common/dircolors.md
@@ -9,7 +9,7 @@
 
 - Output commands to set LS_COLOR using colors from a file:
 
-`dircolors {{file}}`
+`dircolors {{path/to/file}}`
 
 - Output commands for Bourne shell:
 

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -5,7 +5,7 @@
 
 - Print the EXIF metadata for a given file:
 
-`exiftool {{file}}`
+`exiftool {{path/to/file}}`
 
 - Remove all EXIF metadata from the given files:
 

--- a/pages/common/expand.md
+++ b/pages/common/expand.md
@@ -5,7 +5,7 @@
 
 - Convert tabs in each file to spaces, writing to standard output:
 
-`expand {{file}}`
+`expand {{path/to/file}}`
 
 - Convert tabs to spaces, reading from standard input:
 
@@ -13,11 +13,11 @@
 
 - Do not convert tabs after non blanks:
 
-`expand -i {{file}}`
+`expand -i {{path/to/file}}`
 
 - Have tabs a certain number of characters apart, not 8:
 
-`expand -t={{number}} {{file}}`
+`expand -t={{number}} {{path/to/file}}`
 
 - Use a comma separated list of explicit tab positions:
 

--- a/pages/common/fdupes.md
+++ b/pages/common/fdupes.md
@@ -5,7 +5,7 @@
 
 - Search a single directory:
 
-`fdupes {{directory}}`
+`fdupes {{path/to/directory}}`
 
 - Search multiple directories:
 
@@ -13,7 +13,7 @@
 
 - Search a directory recursively:
 
-`fdupes -r {{directory}}`
+`fdupes -r {{path/to/directory}}`
 
 - Search multiple directories, one recursively:
 
@@ -21,12 +21,12 @@
 
 - Search recursively and replace duplicates with hardlinks:
 
-`fdupes -rH {{directory}}`
+`fdupes -rH {{path/to/directory}}`
 
 - Search recursively for duplicates and display interactive prompt to pick which ones to keep, deleting the others:
 
-`fdupes -rd {{directory}}`
+`fdupes -rd {{path/to/directory}}`
 
 - Search recursively and delete duplicates without prompting:
 
-`fdupes -rdN {{directory}}`
+`fdupes -rdN {{path/to/directory}}`

--- a/pages/common/ffsend.md
+++ b/pages/common/ffsend.md
@@ -5,7 +5,7 @@
 
 - Upload a file:
 
-`ffsend upload {{file}}`
+`ffsend upload {{path/to/file}}`
 
 - Download a file:
 
@@ -13,12 +13,12 @@
 
 - Upload a file with password:
 
-`ffsend upload {{file}} -p {{password}}`
+`ffsend upload {{path/to/file}} -p {{password}}`
 
 - Download a file protected by password:
 
-`ffsend download {{file}} -p {{password}}`
+`ffsend download {{path/to/file}} -p {{password}}`
 
 - Upload a file and allow 4 downloads:
 
-`ffsend upload {{file}} -d {{4}}`
+`ffsend upload {{path/to/file}} -d {{4}}`

--- a/pages/common/fold.md
+++ b/pages/common/fold.md
@@ -5,12 +5,12 @@
 
 - Wrap each line to default width (80 characters):
 
-`fold {{file}}`
+`fold {{path/to/file}}`
 
 - Wrap each line to width "30":
 
-`fold -w30 {{file}}`
+`fold -w30 {{path/to/file}}`
 
 - Wrap each line to width "5" and break the line at spaces (puts each space separated word in a new line, words with length > 5 are wrapped):
 
-`fold -w5 -s {{file}}`
+`fold -w5 -s {{path/to/file}}`

--- a/pages/common/git-rm.md
+++ b/pages/common/git-rm.md
@@ -5,12 +5,12 @@
 
 - Remove file from repository index and filesystem:
 
-`git rm {{file}}`
+`git rm {{path/to/file}}`
 
 - Remove directory:
 
-`git rm -r {{directory}}`
+`git rm -r {{path/to/directory}}`
 
 - Remove file from repository index but keep it untouched locally:
 
-`git rm --cached {{file}}`
+`git rm --cached {{path/to/file}}`

--- a/pages/common/goimports.md
+++ b/pages/common/goimports.md
@@ -5,16 +5,16 @@
 
 - Display the completed import source file:
 
-`goimports {{file}}.go`
+`goimports {{path/to/file}}.go`
 
 - Write the result back to the source file instead of the standard output:
 
-`goimports -w {{file}}.go`
+`goimports -w {{path/to/file}}.go`
 
 - Display diffs and write the result back to the source file:
 
-`goimports -w -d {{file}}.go`
+`goimports -w -d {{path/to/file}}.go`
 
 - Set the import prefix string after 3rd-party packages (comma-separated list):
 
-`goimports -local {{path/to/package}} {{file}}.go`
+`goimports -local {{path/to/package}} {{path/to/file}}.go`

--- a/pages/common/goreload.md
+++ b/pages/common/goreload.md
@@ -5,11 +5,11 @@
 
 - Set the name of the binary file to watch (defaults to `.goreload`):
 
-`goreload -b {{path/to/binary}} {{file}}.go`
+`goreload -b {{path/to/binary}} {{path/to/file}}.go`
 
 - Set a custom log prefix (defaults to `goreload`):
 
-`goreload --logPrefix {{prefix}} {{file}}.go`
+`goreload --logPrefix {{prefix}} {{path/to/file}}.go`
 
 - Reload whenever any file changes:
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -10,7 +10,7 @@
 
 - Add a directory and its files recursively from local to the filesystem and print the relative hash:
 
-`ipfs add -r {{directory}}`
+`ipfs add -r {{path/to/directory}}`
 
 - Save a remote file and give it a name but not pin it:
 

--- a/pages/common/jdupes.md
+++ b/pages/common/jdupes.md
@@ -5,7 +5,7 @@
 
 - Search a single directory:
 
-`jdupes {{directory}}`
+`jdupes {{path/to/directory}}`
 
 - Search multiple directories:
 
@@ -13,11 +13,11 @@
 
 - Search all directories recursively:
 
-`jdupes --recurse {{directory}}`
+`jdupes --recurse {{path/to/directory}}`
 
 - Search directory recursively and let user choose files to preserve:
 
-`jdupes --delete --recurse {{directory}}`
+`jdupes --delete --recurse {{path/to/directory}}`
 
 - Search multiple directories and follow subdirectores under directory2, not directory1:
 

--- a/pages/common/lz4.md
+++ b/pages/common/lz4.md
@@ -5,7 +5,7 @@
 
 - Compress a file:
 
-`lz4 {{file}}`
+`lz4 {{path/to/file}}`
 
 - Decompress a file:
 
@@ -25,4 +25,4 @@
 
 - Compress a file using the best compression:
 
-`lz4 -9 {{file}}`
+`lz4 -9 {{path/to/file}}`

--- a/pages/common/lzop.md
+++ b/pages/common/lzop.md
@@ -5,12 +5,12 @@
 
 - Compress a file into a new file with the `.lzo` suffix:
 
-`lzop {{file}}`
+`lzop {{path/to/file}}`
 
 - Decompress a file:
 
-`lzop -d {{file}}.lzo`
+`lzop -d {{path/to/file}}.lzo`
 
 - Compress a file, while specifying the compression level. 0 = Worst, 9 = Best (Default level is 3):
 
-`lzop -{{level}} {{file}}`
+`lzop -{{level}} {{path/to/file}}`

--- a/pages/common/mailx.md
+++ b/pages/common/mailx.md
@@ -25,4 +25,4 @@
 
 - Send mail with an attachment:
 
-`mailx -a {{file}} -s "{{subject}}" {{to_addr}}`
+`mailx -a {{path/to/file}} -s "{{subject}}" {{to_addr}}`

--- a/pages/common/make.md
+++ b/pages/common/make.md
@@ -18,11 +18,11 @@
 
 - Use a specific Makefile:
 
-`make --file {{file}}`
+`make --file {{path/to/file}}`
 
 - Execute make from another directory:
 
-`make --directory {{directory}}`
+`make --directory {{path/to/directory}}`
 
 - Force making of a target, even if source files are unchanged:
 

--- a/pages/common/micro.md
+++ b/pages/common/micro.md
@@ -6,7 +6,7 @@
 
 - Open a file:
 
-`micro {{file}}`
+`micro {{path/to/file}}`
 
 - Save a file:
 

--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -5,7 +5,7 @@
 
 - Create a directory in current directory or given path:
 
-`mkdir {{directory}}`
+`mkdir {{path/to/directory}}`
 
 - Create multiple directories in the current directory:
 

--- a/pages/common/most.md
+++ b/pages/common/most.md
@@ -13,7 +13,7 @@
 
 - Open a file at the first occurrence of "string":
 
-`most {{file}} +/{{string}}`
+`most {{path/to/file}} +/{{string}}`
 
 - Move through opened files:
 

--- a/pages/common/multitail.md
+++ b/pages/common/multitail.md
@@ -9,7 +9,7 @@
 
 - Tail all files in a directory in a single stream:
 
-`multitail -Q 1 '{{directory}}/*'`
+`multitail -Q 1 '{{path/to/directory}}/*'`
 
 - Automatically add new files to a window:
 

--- a/pages/common/mutt.md
+++ b/pages/common/mutt.md
@@ -17,8 +17,8 @@
 
 - Specify a file to include as the message body:
 
-`mutt -i {{file}} {{recipient@example.com}}`
+`mutt -i {{path/to/file}} {{recipient@example.com}}`
 
 - Specify a draft file containing the header and the body of the message, in RFC 5322 format:
 
-`mutt -H {{file}} {{recipient@example.com}}`
+`mutt -H {{path/to/file}} {{recipient@example.com}}`

--- a/pages/common/nl.md
+++ b/pages/common/nl.md
@@ -5,20 +5,20 @@
 
 - Number non-blank lines in a file:
 
-`nl {{file}}`
+`nl {{path/to/file}}`
 
 - Read from standard output:
 
-`cat {{file}} | nl {{options}} -`
+`cat {{path/to/file}} | nl {{options}} -`
 
 - Number only the lines with printable text:
 
-`nl -t {{file}}`
+`nl -t {{path/to/file}}`
 
 - Number all lines including blank lines:
 
-`nl -b a {{file}}`
+`nl -b a {{path/to/file}}`
 
 - Number only the body lines that match a basic regular expression (BRE) pattern:
 
-`nl -b p'FooBar[0-9]' {{file}}`
+`nl -b p'FooBar[0-9]' {{path/to/file}}`

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -7,7 +7,7 @@
 
 - Open a file:
 
-`nvim {{file}}`
+`nvim {{path/to/file}}`
 
 - Enter text editing mode (insert mode):
 

--- a/pages/common/odps-tunnel.md
+++ b/pages/common/odps-tunnel.md
@@ -6,16 +6,16 @@
 
 - Download table to local file:
 
-`tunnel download {{table_name}} {{file}};`
+`tunnel download {{table_name}} {{path/to/file}};`
 
 - Upload local file to a table partition:
 
-`tunnel upload {{file}} {{table_name}}/{{partition_spec}};`
+`tunnel upload {{path/to/file}} {{table_name}}/{{partition_spec}};`
 
 - Upload table specifying field and record delimiters:
 
-`tunnel upload {{file}} {{table_name}} -fd {{field_delim}} -rd {{record_delim}};`
+`tunnel upload {{path/to/file}} {{table_name}} -fd {{field_delim}} -rd {{record_delim}};`
 
 - Upload table using multiple threads:
 
-`tunnel upload {{file}} {{table_name}} -threads {{num}};`
+`tunnel upload {{path/to/file}} {{table_name}} -threads {{num}};`

--- a/pages/common/paste.md
+++ b/pages/common/paste.md
@@ -5,11 +5,11 @@
 
 - Join all the lines into a single line, using TAB as delimiter:
 
-`paste -s {{file}}`
+`paste -s {{path/to/file}}`
 
 - Join all the lines into a single line, using the specified delimiter:
 
-`paste -s -d {{delimiter}} {{file}}`
+`paste -s -d {{delimiter}} {{path/to/file}}`
 
 - Merge two files side by side, each in its column, using TAB as delimiter:
 

--- a/pages/common/php.md
+++ b/pages/common/php.md
@@ -5,11 +5,11 @@
 
 - Parse and execute a PHP script:
 
-`php {{file}}`
+`php {{path/to/file}}`
 
 - Check syntax on (i.e. lint) a PHP script:
 
-`php -l {{file}}`
+`php -l {{path/to/file}}`
 
 - Run PHP interactively:
 

--- a/pages/common/phpunit.md
+++ b/pages/common/phpunit.md
@@ -17,4 +17,4 @@
 
 - Run tests and generate a coverage report in HTML:
 
-`phpunit --coverage-html {{directory}}`
+`phpunit --coverage-html {{path/to/directory}}`

--- a/pages/common/pushd.md
+++ b/pages/common/pushd.md
@@ -5,7 +5,7 @@
 
 - Switch to directory and push it on the stack:
 
-`pushd {{directory}}`
+`pushd {{path/to/directory}}`
 
 - Switch first and second directories on the stack:
 

--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -5,7 +5,7 @@
 
 - Print the contents of the file and display a progress bar:
 
-`pv {{file}}`
+`pv {{path/to/file}}`
 
 - Measure the speed and amount of data flow between pipes (`-s` is optional):
 

--- a/pages/common/rapper.md
+++ b/pages/common/rapper.md
@@ -6,8 +6,8 @@
 
 - Convert an RDF/XML document to Turtle:
 
-`rapper -i rdfxml -o turtle {{file}}`
+`rapper -i rdfxml -o turtle {{path/to/file}}`
 
 - Count the number of triples in a Turtle file:
 
-`rapper -i turtle -c {{file}}`
+`rapper -i turtle -c {{path/to/file}}`

--- a/pages/common/rev.md
+++ b/pages/common/rev.md
@@ -9,4 +9,4 @@
 
 - Reverse an entire file and print to stdout:
 
-`rev {{file}}`
+`rev {{path/to/file}}`

--- a/pages/common/serialver.md
+++ b/pages/common/serialver.md
@@ -10,7 +10,7 @@
 
 - Display the serialVersionUID for a colon-separated list of classes and resources:
 
-`serialver -classpath {{directory}} {{classname1:classname2:...}}`
+`serialver -classpath {{path/to/directory}} {{classname1:classname2:...}}`
 
 - Use a specific option from reference page of Java application launcher to the Java Virtual Machine:
 

--- a/pages/common/shred.md
+++ b/pages/common/shred.md
@@ -5,16 +5,16 @@
 
 - Overwrite a file:
 
-`shred {{file}}`
+`shred {{path/to/file}}`
 
 - Overwrite a file, leaving zeroes instead of random data:
 
-`shred --zero {{file}}`
+`shred --zero {{path/to/file}}`
 
 - Overwrite a file 25 times:
 
-`shred -n25 {{file}}`
+`shred -n25 {{path/to/file}}`
 
 - Overwrite a file and remove it:
 
-`shred --remove {{file}}`
+`shred --remove {{path/to/file}}`

--- a/pages/common/sshpass.md
+++ b/pages/common/sshpass.md
@@ -14,4 +14,4 @@
 
 - Connect to a remote server using the first line of a file as the password, automatically accept unknown ssh keys, and launch a command:
 
-`sshpass -f {{file}} ssh -o StrictHostKeyChecking=no {{user}}@{{hostname}} "{{command}}"`
+`sshpass -f {{path/to/file}} ssh -o StrictHostKeyChecking=no {{user}}@{{hostname}} "{{command}}"`

--- a/pages/common/strings.md
+++ b/pages/common/strings.md
@@ -5,16 +5,16 @@
 
 - Print all strings in a binary:
 
-`strings {{file}}`
+`strings {{path/to/file}}`
 
 - Limit results to strings at least *length* characters long:
 
-`strings -n {{length}} {{file}}`
+`strings -n {{length}} {{path/to/file}}`
 
 - Prefix each result with its offset within the file:
 
-`strings -t d {{file}}`
+`strings -t d {{path/to/file}}`
 
 - Prefix each result with its offset within the file in hexadecimal:
 
-`strings -t x {{file}}`
+`strings -t x {{path/to/file}}`

--- a/pages/common/sum.md
+++ b/pages/common/sum.md
@@ -6,8 +6,8 @@
 
 - Compute a checksum with BSD-compatible algorithm and 1024-byte blocks:
 
-`sum {{file}}`
+`sum {{path/to/file}}`
 
 - Compute a checksum with System V-compatible algorithm and 512-byte blocks:
 
-`sum --sysv {{file}}`
+`sum --sysv {{path/to/file}}`

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -22,7 +22,7 @@
 
 - E[x]tract a (compressed) archive [f]ile into the target directory:
 
-`tar xf {{source.tar[.gz|.bz2|.xz]}} --directory={{directory}}`
+`tar xf {{source.tar[.gz|.bz2|.xz]}} --directory={{path/to/directory}}`
 
 - [c]reate a compressed archive and write it to a [f]ile, using [a]rchive suffix to determine the compression program:
 

--- a/pages/common/tsort.md
+++ b/pages/common/tsort.md
@@ -6,4 +6,4 @@
 
 - Perform a topological sort consistent with a partial sort per line of input separated by blanks:
 
-`tsort {{file}}`
+`tsort {{path/to/file}}`

--- a/pages/common/unexpand.md
+++ b/pages/common/unexpand.md
@@ -5,7 +5,7 @@
 
 - Convert blanks in each file to tabs, writing to standard output:
 
-`unexpand {{file}}`
+`unexpand {{path/to/file}}`
 
 - Convert blanks to tabs, reading from standard output:
 
@@ -13,12 +13,12 @@
 
 - Convert all blanks, instead of just initial blanks:
 
-`unexpand -a {{file}}`
+`unexpand -a {{path/to/file}}`
 
 - Convert only leading sequences of blanks (overrides -a):
 
-`unexpand --first-only {{file}}`
+`unexpand --first-only {{path/to/file}}`
 
 - Have tabs a certain number of characters apart, not 8 (enables -a):
 
-`unexpand -t {{number}} {{file}}`
+`unexpand -t {{number}} {{path/to/file}}`

--- a/pages/common/uniq.md
+++ b/pages/common/uniq.md
@@ -6,20 +6,20 @@
 
 - Display each line once:
 
-`sort {{file}} | uniq`
+`sort {{path/to/file}} | uniq`
 
 - Display only unique lines:
 
-`sort {{file}} | uniq -u`
+`sort {{path/to/file}} | uniq -u`
 
 - Display only duplicate lines:
 
-`sort {{file}} | uniq -d`
+`sort {{path/to/file}} | uniq -d`
 
 - Display number of occurrences of each line along with that line:
 
-`sort {{file}} | uniq -c`
+`sort {{path/to/file}} | uniq -c`
 
 - Display number of occurrences of each line, sorted by the most frequent:
 
-`sort {{file}} | uniq -c | sort -nr`
+`sort {{path/to/file}} | uniq -c | sort -nr`

--- a/pages/common/upx.md
+++ b/pages/common/upx.md
@@ -5,11 +5,11 @@
 
 - Compress executable:
 
-`upx {{file}}`
+`upx {{path/to/file}}`
 
 - Decompress executable:
 
-`upx -d {{file}}`
+`upx -d {{path/to/file}}`
 
 - Detailed help:
 

--- a/pages/common/vale.md
+++ b/pages/common/vale.md
@@ -5,19 +5,19 @@
 
 - Check the style of a file:
 
-`vale {{file}}`
+`vale {{path/to/file}}`
 
 - Check the style of a file with a specified configuration:
 
-`vale --config='{{path/to/.vale.ini}}' {{file}}`
+`vale --config='{{path/to/.vale.ini}}' {{path/to/file}}`
 
 - Output the results in JSON format:
 
-`vale --output=JSON {{file}}`
+`vale --output=JSON {{path/to/file}}`
 
 - Check style issues at the specific severity and higher:
 
-`vale --minAlertLeve={{suggestion|warning|error}} {{file}}`
+`vale --minAlertLeve={{suggestion|warning|error}} {{path/to/file}}`
 
 - Check the style from stdin, specifying markup format:
 

--- a/pages/common/view.md
+++ b/pages/common/view.md
@@ -6,4 +6,4 @@
 
 - Open a file:
 
-`view {{file}}`
+`view {{path/to/file}}`

--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -5,7 +5,7 @@
 
 - Compress a file to the xz file format:
 
-`xz {{file}}`
+`xz {{path/to/file}}`
 
 - Decompress a xz file:
 
@@ -13,7 +13,7 @@
 
 - Compress a file to the LZMA file format:
 
-`xz --format={{lzma}} {{file}}`
+`xz --format={{lzma}} {{path/to/file}}`
 
 - Decompress an LZMA file:
 
@@ -25,12 +25,12 @@
 
 - Compress a file, but don't delete the original:
 
-`xz -k {{file}}`
+`xz -k {{path/to/file}}`
 
 - Compress a file using the fastest compression:
 
-`xz -0 {{file}}`
+`xz -0 {{path/to/file}}`
 
 - Compress a file using the best compression:
 
-`xz -9 {{file}}`
+`xz -9 {{path/to/file}}`

--- a/pages/common/zstd.md
+++ b/pages/common/zstd.md
@@ -5,20 +5,20 @@
 
 - Compress a file into a new file with the `.zst` suffix:
 
-`zstd {{file}}`
+`zstd {{path/to/file}}`
 
 - Decompress a file:
 
-`zstd -d {{file}}.zst`
+`zstd -d {{path/to/file}}.zst`
 
 - Decompress to stdout:
 
-`zstd -dc {{file}}.zst`
+`zstd -dc {{path/to/file}}.zst`
 
 - Compress a file specifying the compression level, where 1=fastest, 19=slowest and 3=default:
 
-`zstd -{{level}} {{file}}`
+`zstd -{{level}} {{path/to/file}}`
 
 - Unlock higher compression levels (up to 22) using more memory (both for compression and decompression):
 
-`zstd --ultra -{{level}} {{file}}`
+`zstd --ultra -{{level}} {{path/to/file}}`

--- a/pages/linux/aspell.md
+++ b/pages/linux/aspell.md
@@ -9,7 +9,7 @@
 
 - List misspelled words from standard input:
 
-`cat {{file}} | aspell list`
+`cat {{path/to/file}} | aspell list`
 
 - Show available dictionary languages:
 
@@ -21,4 +21,4 @@
 
 - List misspelled words from standard input and ignore words from personal word list:
 
-`cat {{file}} | aspell --personal={{personal-word-list.pws}} list`
+`cat {{path/to/file}} | aspell --personal={{personal-word-list.pws}} list`

--- a/pages/linux/csplit.md
+++ b/pages/linux/csplit.md
@@ -6,20 +6,20 @@
 
 - Split a file at lines 5 and 23:
 
-`csplit {{file}} {{5}} {{23}}`
+`csplit {{path/to/file}} {{5}} {{23}}`
 
 - Split a file every 5 lines (this will fail if the total number of lines is not divisible by 5):
 
-`csplit {{file}} {{5}} {*}`
+`csplit {{path/to/file}} {{5}} {*}`
 
 - Split a file every 5 lines, ignoring exact-division error:
 
-`csplit -k {{file}} {{5}} {*}`
+`csplit -k {{path/to/file}} {{5}} {*}`
 
 - Split a file at line 5 and use a custom prefix for the output files:
 
-`csplit {{file}} {{5}} -f {{prefix}}`
+`csplit {{path/to/file}} {{5}} -f {{prefix}}`
 
 - Split a file at a line matching a regular expression:
 
-`csplit {{file}} /{{regular_expression}}/`
+`csplit {{path/to/file}} /{{regular_expression}}/`

--- a/pages/linux/pkginfo.md
+++ b/pages/linux/pkginfo.md
@@ -17,4 +17,4 @@
 
 - Print the footprint of a file:
 
-`pkginfo -f {{file}}`
+`pkginfo -f {{path/to/file}}`

--- a/pages/linux/pridecat.md
+++ b/pages/linux/pridecat.md
@@ -5,19 +5,19 @@
 
 - Print the contents of a file in pride colors to the standard output:
 
-`pridecat {{file}}`
+`pridecat {{path/to/file}}`
 
 - Print contents of a file in trans colors:
 
-`pridecat {{file}} --{{transgender|trans}}`
+`pridecat {{path/to/file}} --{{transgender|trans}}`
 
 - Alternate between lesbian and bisexual pride flags:
 
-`pridecat {{file}} --lesbian --bi`
+`pridecat {{path/to/file}} --lesbian --bi`
 
 - Print contents of a file with the background colors changed:
 
-`pridecat {{file}} -b`
+`pridecat {{path/to/file}} -b`
 
 - List directory contents in pride flag colors:
 

--- a/pages/linux/sensible-editor.md
+++ b/pages/linux/sensible-editor.md
@@ -5,15 +5,15 @@
 
 - Open a file in the default editor:
 
-`sensible-editor {{file}}`
+`sensible-editor {{path/to/file}}`
 
 - Open a file in the default editor, with the cursor at the end of the file:
 
-`sensible-editor + {{file}}`
+`sensible-editor + {{path/to/file}}`
 
 - Open a file in the default editor, with the cursor at the beginning of line 10:
 
-`sensible-editor +10 {{file}}`
+`sensible-editor +10 {{path/to/file}}`
 
 - Open 3 files in vertically split editor windows at the same time:
 

--- a/pages/linux/xsel.md
+++ b/pages/linux/xsel.md
@@ -9,7 +9,7 @@
 
 - Use the contents of a file as input of the clipboard:
 
-`cat {{file}} | xsel -ib`
+`cat {{path/to/file}} | xsel -ib`
 
 - Output the clipboard's contents into the terminal (equivalent to `Ctrl + V`):
 
@@ -17,7 +17,7 @@
 
 - Output the clipboard's contents into a file:
 
-`xsel -ob > {{file}}`
+`xsel -ob > {{path/to/file}}`
 
 - Clear the clipboard:
 

--- a/pages/osx/look.md
+++ b/pages/osx/look.md
@@ -5,8 +5,8 @@
 
 - Look for lines which begins with the given prefix:
 
-`look {{prefix}} {{file}}`
+`look {{prefix}} {{path/to/file}}`
 
 - Look for lines ignoring case:
 
-`look --ignore-case {{prefix}} {{file}}`
+`look --ignore-case {{prefix}} {{path/to/file}}`

--- a/pages/osx/pbpaste.md
+++ b/pages/osx/pbpaste.md
@@ -5,7 +5,7 @@
 
 - Write the contents of the clipboard to a file:
 
-`pbpaste > {{file}}`
+`pbpaste > {{path/to/file}}`
 
 - Use the contents of the clipboard as input to a command:
 

--- a/pages/osx/stat.md
+++ b/pages/osx/stat.md
@@ -5,20 +5,20 @@
 
 - Show file properties such as size, permissions, creation and access dates among others:
 
-`stat {{file}}`
+`stat {{path/to/file}}`
 
 - Same as above but verbose (more similar to Linux's `stat`):
 
-`stat -x {{file}}`
+`stat -x {{path/to/file}}`
 
 - Show only octal file permissions:
 
-`stat -f %Mp%Lp {{file}}`
+`stat -f %Mp%Lp {{path/to/file}}`
 
 - Show owner and group of the file:
 
-`stat -f "%Su %Sg" {{file}}`
+`stat -f "%Su %Sg" {{path/to/file}}`
 
 - Show the size of the file in bytes:
 
-`stat -f "%z %N" {{file}}`
+`stat -f "%z %N" {{path/to/file}}`

--- a/pages/windows/mkdir.md
+++ b/pages/windows/mkdir.md
@@ -5,7 +5,7 @@
 
 - Create a directory:
 
-`mkdir {{directory}}`
+`mkdir {{path/to/directory}}`
 
 - Create a nested directory tree recursively:
 

--- a/pages/windows/pushd.md
+++ b/pages/windows/pushd.md
@@ -6,4 +6,4 @@
 
 - Switch to directory and push it on the stack:
 
-`pushd {{directory}}`
+`pushd {{path/to/directory}}`


### PR DESCRIPTION
Breakout # 2 for #9578. Unlike some other people, I actually looked at everything in this PR before committing it 😉

```sh
fd -t f . pages | xe -j20 -- -i {} sed 's/{{file}}/{{path\/to\/file}}/g;s/{{directory}}/{{path\/to\/directory}}/g'
```