### PR TITLE
*: replace `file(s)` syntax and add `path/to/` to more things

### DIFF
--- a/pages.it/common/rm.md
+++ b/pages.it/common/rm.md
@@ -17,7 +17,7 @@
 
 - Rimuovi file interattivamente, chiedendo conferma prima di rimuovere ogni file:
 
-`rm -i {{percorso/a/file1 percorso/a/file2 ...}}`
+`rm -i {{percorso/del/file1 percorso/del/file2 ...}}`
 
 - Rimuovi file in modalità verbosa, scrivendo un messaggio a schermo per ogni file rimosso:
 

--- a/pages.it/common/rm.md
+++ b/pages.it/common/rm.md
@@ -17,7 +17,7 @@
 
 - Rimuovi file interattivamente, chiedendo conferma prima di rimuovere ogni file:
 
-`rm -i {{file1 file2 ...}}`
+`rm -i {{percorso/a/file1 percorso/a/file2 ...}}`
 
 - Rimuovi file in modalità verbosa, scrivendo un messaggio a schermo per ogni file rimosso:
 

--- a/pages.it/common/rm.md
+++ b/pages.it/common/rm.md
@@ -17,7 +17,7 @@
 
 - Rimuovi file interattivamente, chiedendo conferma prima di rimuovere ogni file:
 
-`rm -i {{file(s)}}`
+`rm -i {{file1 file2 ...}}`
 
 - Rimuovi file in modalità verbosa, scrivendo un messaggio a schermo per ogni file rimosso:
 

--- a/pages/common/awk.md
+++ b/pages/common/awk.md
@@ -5,27 +5,27 @@
 
 - Print the fifth column (a.k.a. field) in a space-separated file:
 
-`awk '{print $5}' {{filename}}`
+`awk '{print $5}' {{path/to/file}}`
 
 - Print the second column of the lines containing "foo" in a space-separated file:
 
-`awk '/{{foo}}/ {print $2}' {{filename}}`
+`awk '/{{foo}}/ {print $2}' {{path/to/file}}`
 
 - Print the last column of each line in a file, using a comma (instead of space) as a field separator:
 
-`awk -F ',' '{print $NF}' {{filename}}`
+`awk -F ',' '{print $NF}' {{path/to/file}}`
 
 - Sum the values in the first column of a file and print the total:
 
-`awk '{s+=$1} END {print s}' {{filename}}`
+`awk '{s+=$1} END {print s}' {{path/to/file}}`
 
 - Print every third line starting from the first line:
 
-`awk 'NR%3==1' {{filename}}`
+`awk 'NR%3==1' {{path/to/file}}`
 
 - Print different values based on conditions:
 
-`awk '{if ($1 == "foo") print "Exact match foo"; else if ($1 ~ "bar") print "Partial match bar"; else print "Baz"}' {{filename}}`
+`awk '{if ($1 == "foo") print "Exact match foo"; else if ($1 ~ "bar") print "Partial match bar"; else print "Baz"}' {{path/to/file}}`
 
 - Print all lines where the 10th column value equals the specified value:
 

--- a/pages/common/axel.md
+++ b/pages/common/axel.md
@@ -10,7 +10,7 @@
 
 - Download and specify filename:
 
-`axel {{url}} -o {{filename}}`
+`axel {{url}} -o {{path/to/file}}`
 
 - Download with multiple connections:
 

--- a/pages/common/base32.md
+++ b/pages/common/base32.md
@@ -5,11 +5,11 @@
 
 - Encode a file:
 
-`base32 {{filename}}`
+`base32 {{path/to/file}}`
 
 - Decode a file:
 
-`base32 --decode {{filename}}`
+`base32 --decode {{path/to/file}}`
 
 - Encode from `stdin`:
 

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -5,11 +5,11 @@
 
 - Encode the contents of a file as base64 and write the result to `stdout`:
 
-`base64 {{filename}}`
+`base64 {{path/to/file}}`
 
 - Decode the base64 contents of a file and write the result to `stdout`:
 
-`base64 --decode {{filename}}`
+`base64 --decode {{path/to/file}}`
 
 - Encode from `stdin`:
 

--- a/pages/common/blender.md
+++ b/pages/common/blender.md
@@ -6,27 +6,27 @@
 
 - Render all frames of an animation in the background, without loading the UI (output is saved to `/tmp`):
 
-`blender --background {{filename}}.blend --render-anim`
+`blender --background {{path/to/file}}.blend --render-anim`
 
 - Render an animation using a specific image naming pattern, in a path relative (`//`) to the .blend file:
 
-`blender --background {{filename}}.blend --render-output //{{render/frame_###.png}} --render-anim`
+`blender --background {{path/to/file}}.blend --render-output //{{render/frame_###.png}} --render-anim`
 
 - Render the 10th frame of an animation as a single image, saved to an existing directory (absolute path):
 
-`blender --background {{filename}}.blend --render-output {{/path/to/output_directory}} --render-frame {{10}}`
+`blender --background {{path/to/file}}.blend --render-output {{/path/to/output_directory}} --render-frame {{10}}`
 
 - Render the second last frame in an animation as a JPEG image, saved to an existing directory (relative path):
 
-`blender --background {{filename}}.blend --render-output //{{output_directory}} --render-frame {{JPEG}} --render-frame {{-2}}`
+`blender --background {{path/to/file}}.blend --render-output //{{output_directory}} --render-frame {{JPEG}} --render-frame {{-2}}`
 
 - Render the animation of a specific scene, starting at frame 10 and ending at frame 500:
 
-`blender --background {{filename}}.blend --scene {{scene_name}} --frame-start {{10}} -e {{500}} --render-anim`
+`blender --background {{path/to/file}}.blend --scene {{scene_name}} --frame-start {{10}} -e {{500}} --render-anim`
 
 - Render an animation at a specific resolution, by passing a Python expression:
 
-`blender --background {{filename}}.blend --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' --render-anim`
+`blender --background {{path/to/file}}.blend --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' --render-anim`
 
 - Start an interactive Blender session in the terminal with a python console (do `import bpy` after starting):
 

--- a/pages/common/ctags.md
+++ b/pages/common/ctags.md
@@ -9,7 +9,7 @@
 
 - Generate tags for all files in the current directory, and output them to a specific file, overwriting the file if it exists:
 
-`ctags -f {{filename}} *`
+`ctags -f {{path/to/file}} *`
 
 - Generate tags for all files in the current directory and all subdirectories:
 

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -6,7 +6,7 @@
 
 - Download the contents of a URL to a file:
 
-`curl {{http://example.com}} --output {{filename}}`
+`curl {{http://example.com}} --output {{path/to/file}}`
 
 - Download a file, saving the output under the filename indicated by the URL:
 

--- a/pages/common/enca.md
+++ b/pages/common/enca.md
@@ -5,15 +5,15 @@
 
 - Detect file(s) encoding according to the system's locale:
 
-`enca {{file1 file2 ...}}`
+`enca {{path/to/file1 path/to/file2 ...}}`
 
 - Detect file(s) encoding specifying a language in the POSIX/C locale format (e.g. zh_CN, en_US):
 
-`enca -L {{language}} {{file1 file2 ...}}`
+`enca -L {{language}} {{path/to/file1 path/to/file2 ...}}`
 
 - Convert file(s) to a specific encoding:
 
-`enca -L {{language}} -x {{to_encoding}} {{file1 file2 ...}}`
+`enca -L {{language}} -x {{to_encoding}} {{path/to/file1 path/to/file2 ...}}`
 
 - Create a copy of an existing file using a different encoding:
 

--- a/pages/common/espeak.md
+++ b/pages/common/espeak.md
@@ -9,7 +9,7 @@
 
 - Speak a file aloud:
 
-`espeak -f {{filename}}`
+`espeak -f {{path/to/file}}`
 
 - Save output to a WAV audio file, rather than speaking it directly:
 

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -9,7 +9,7 @@
 
 - Remove all EXIF metadata from the given files:
 
-`exiftool -All= {{file1 file2 ...}}`
+`exiftool -All= {{path/to/file1 path/to/file2 ...}}`
 
 - Remove GPS EXIF metadata from given image files:
 

--- a/pages/common/file.md
+++ b/pages/common/file.md
@@ -5,7 +5,7 @@
 
 - Give a description of the type of the specified file. Works fine for files with no file extension:
 
-`file {{filename}}`
+`file {{path/to/file}}`
 
 - Look inside a zipped file and determine the file type(s) inside:
 
@@ -13,12 +13,12 @@
 
 - Allow file to work with special or device files:
 
-`file -s {{filename}}`
+`file -s {{path/to/file}}`
 
 - Don't stop at first file type match; keep going until the end of the file:
 
-`file -k {{filename}}`
+`file -k {{path/to/file}}`
 
 - Determine the MIME encoding type of a file:
 
-`file -i {{filename}}`
+`file -i {{path/to/file}}`

--- a/pages/common/fortune.md
+++ b/pages/common/fortune.md
@@ -25,4 +25,4 @@
 
 - Print a quotation from one of the database files listed by `fortune -f`:
 
-`fortune {{filename}}`
+`fortune {{path/to/file}}`

--- a/pages/common/fzf.md
+++ b/pages/common/fzf.md
@@ -14,7 +14,7 @@
 
 - Select multiple files with `Shift + Tab` and write to a file:
 
-`find {{path/to/directory}} -type f | fzf --multi > {{filename}}`
+`find {{path/to/directory}} -type f | fzf --multi > {{path/to/file}}`
 
 - Start fzf with a specified query:
 

--- a/pages/common/gh-gist.md
+++ b/pages/common/gh-gist.md
@@ -9,7 +9,7 @@
 
 - Create a new Gist with a description:
 
-`gh gist create {{filename}} --desc "{{description}}"`
+`gh gist create {{path/to/file}} --desc "{{description}}"`
 
 - Edit a Gist:
 

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -29,8 +29,8 @@
 
 - Discard unstaged changes to a given file:
 
-`git checkout {{filename}}`
+`git checkout {{path/to/file}}`
 
 - Replace a file in the current directory with the version of it committed in a given branch:
 
-`git checkout {{branch_name}} -- {{filename}}`
+`git checkout {{branch_name}} -- {{path/to/file}}`

--- a/pages/common/git-reset.md
+++ b/pages/common/git-reset.md
@@ -10,7 +10,7 @@
 
 - Unstage specific file(s):
 
-`git reset {{path/to/file(s)}}`
+`git reset {{path/to/file1 path/to/file2 ...}}`
 
 - Interactively unstage portions of a file:
 

--- a/pages/common/hugo.md
+++ b/pages/common/hugo.md
@@ -13,7 +13,7 @@
 
 - Create a new page:
 
-`hugo new {{section_name}}/{{filename}}`
+`hugo new {{section_name}}/{{path/to/file}}`
 
 - Build a site to the `./public/` directory:
 

--- a/pages/common/ignite.md
+++ b/pages/common/ignite.md
@@ -9,7 +9,7 @@
 
 - Generate file from a plugin:
 
-`ignite generate {{plugin_name}} {{filename}}`
+`ignite generate {{plugin_name}} {{path/to/file}}`
 
 - Add an Ignite plugin to the project:
 

--- a/pages/common/ipfs.md
+++ b/pages/common/ipfs.md
@@ -6,7 +6,7 @@
 
 - Add a file from local to the filesystem, pin it and print the relative hash:
 
-`ipfs add {{filename}}`
+`ipfs add {{path/to/file}}`
 
 - Add a directory and its files recursively from local to the filesystem and print the relative hash:
 
@@ -14,7 +14,7 @@
 
 - Save a remote file and give it a name but not pin it:
 
-`ipfs get {{hash}} -o {{filename}}`
+`ipfs get {{hash}} -o {{path/to/file}}`
 
 - Pin a remote file locally:
 

--- a/pages/common/jmap.md
+++ b/pages/common/jmap.md
@@ -17,4 +17,4 @@
 
 - Dump contents of the heap into a binary file for analysis with jhat:
 
-`jmap -dump:format=b,file={{filename}} {{java_pid}}`
+`jmap -dump:format=b,file={{path/to/file}} {{java_pid}}`

--- a/pages/common/license.md
+++ b/pages/common/license.md
@@ -9,7 +9,7 @@
 
 - Generate a license and save it to a file:
 
-`license -o {{filename}} {{license_name}}`
+`license -o {{path/to/file}} {{license_name}}`
 
 - List all available licenses:
 

--- a/pages/common/meshlabserver.md
+++ b/pages/common/meshlabserver.md
@@ -13,7 +13,7 @@
 
 - Dump a list of all the available processing filters into a file:
 
-`meshlabserver -d {{filename}}`
+`meshlabserver -d {{path/to/file}}`
 
 - Process a 3D file using a filter script created in the MeshLab GUI (Filters > Show current filter script > Save Script):
 

--- a/pages/common/mitmdump.md
+++ b/pages/common/mitmdump.md
@@ -6,7 +6,7 @@
 
 - Start a proxy and save all output to a file:
 
-`mitmdump -w {{filename}}`
+`mitmdump -w {{path/to/file}}`
 
 - Filter a saved traffic file to just POST requests:
 
@@ -14,4 +14,4 @@
 
 - Replay a saved traffic file:
 
-`mitmdump -nc {{filename}}`
+`mitmdump -nc {{path/to/file}}`

--- a/pages/common/mkfile.md
+++ b/pages/common/mkfile.md
@@ -5,11 +5,11 @@
 
 - Create an empty file of 15 kilobytes:
 
-`mkfile -n {{15k}} {{filename}}`
+`mkfile -n {{15k}} {{path/to/file}}`
 
 - Create a file of a given size and unit (bytes, KB, MB, GB):
 
-`mkfile -n {{size}}{{b|k|m|g}} {{filename}}`
+`mkfile -n {{size}}{{b|k|m|g}} {{path/to/file}}`
 
 - Create two files of 4 megabytes each:
 

--- a/pages/common/mongod.md
+++ b/pages/common/mongod.md
@@ -5,7 +5,7 @@
 
 - Specify a config file:
 
-`mongod --config {{filename}}`
+`mongod --config {{path/to/file}}`
 
 - Specify the port to listen on:
 

--- a/pages/common/mp4box.md
+++ b/pages/common/mp4box.md
@@ -5,7 +5,7 @@
 
 - Display information about an existing MP4 file:
 
-`mp4box -info {{filename}}`
+`mp4box -info {{path/to/file}}`
 
 - Add an SRT subtitle file into an MP4 file:
 

--- a/pages/common/mupdf.md
+++ b/pages/common/mupdf.md
@@ -5,23 +5,23 @@
 
 - Open a PDF on the first page:
 
-`mupdf {{filename}}`
+`mupdf {{path/to/file}}`
 
 - Open a PDF on page 3:
 
-`mupdf {{filename}} {{3}}`
+`mupdf {{path/to/file}} {{3}}`
 
 - Open a password secured PDF:
 
-`mupdf -p {{password}} {{filename}}`
+`mupdf -p {{password}} {{path/to/file}}`
 
 - Open a PDF with an initial zoom level, specified as DPI, of 72:
 
-`mupdf -r {{72}} {{filename}}`
+`mupdf -r {{72}} {{path/to/file}}`
 
 - Open a PDF with inverted color:
 
-`mupdf -I {{filename}}`
+`mupdf -I {{path/to/file}}`
 
 - Open a PDF tinted red #FF0000 (hexadecimal color syntax RRGGBB):
 

--- a/pages/common/p4.md
+++ b/pages/common/p4.md
@@ -21,7 +21,7 @@
 
 - Open a file to edit:
 
-`p4 edit -c {{changelist_number}} {{filename}}`
+`p4 edit -c {{changelist_number}} {{path/to/file}}`
 
 - Open a new file to add it to the depot:
 

--- a/pages/common/pigz.md
+++ b/pages/common/pigz.md
@@ -5,19 +5,19 @@
 
 - Compress a file with default options:
 
-`pigz {{filename}}`
+`pigz {{path/to/file}}`
 
 - Compress a file using the best compression method:
 
-`pigz -9 {{filename}}`
+`pigz -9 {{path/to/file}}`
 
 - Compress a file using no compression and 4 processors:
 
-`pigz -0 -p{{4}} {{filename}}`
+`pigz -0 -p{{4}} {{path/to/file}}`
 
 - Compress a directory using tar:
 
-`tar cf - {{path/to/directory}} | pigz > {{filename}}.tar.gz`
+`tar cf - {{path/to/directory}} | pigz > {{path/to/file}}.tar.gz`
 
 - Decompress a file:
 

--- a/pages/common/readlink.md
+++ b/pages/common/readlink.md
@@ -5,8 +5,8 @@
 
 - Get the actual file to which the symlink points:
 
-`readlink {{filename}}`
+`readlink {{path/to/file}}`
 
 - Get the absolute path to a file:
 
-`readlink -f {{filename}}`
+`readlink -f {{path/to/file}}`

--- a/pages/common/rm.md
+++ b/pages/common/rm.md
@@ -17,7 +17,7 @@
 
 - Interactively remove multiple files, with a prompt before every removal:
 
-`rm -i {{file(s)}}`
+`rm -i {{path/to/file1 path/to/file2 ...}}`
 
 - Remove files in verbose mode, printing a message for each removed file:
 

--- a/pages/common/sc-im.md
+++ b/pages/common/sc-im.md
@@ -6,7 +6,7 @@
 
 - Start SC-IM:
 
-`scim {{filename}}.csv`
+`scim {{path/to/file}}.csv`
 
 - Enter a string into the current cell:
 

--- a/pages/common/shuf.md
+++ b/pages/common/shuf.md
@@ -5,15 +5,15 @@
 
 - Randomize the order of lines in a file and output the result:
 
-`shuf {{filename}}`
+`shuf {{path/to/file}}`
 
 - Only output the first 5 entries of the result:
 
-`shuf --head-count={{5}} {{filename}}`
+`shuf --head-count={{5}} {{path/to/file}}`
 
 - Write the output to another file:
 
-`shuf {{filename}} --output={{output_filename}}`
+`shuf {{path/to/input}} --output={{path/to/output}}`
 
 - Generate 3 random numbers in the range 1-10 (inclusive):
 

--- a/pages/common/sk.md
+++ b/pages/common/sk.md
@@ -18,4 +18,4 @@
 
 - Select multiple files with `Shift + Tab` and write to a file:
 
-`find {{path/to/directory}} -type f | sk --multi > {{filename}}`
+`find {{path/to/directory}} -type f | sk --multi > {{path/to/file}}`

--- a/pages/common/split.md
+++ b/pages/common/split.md
@@ -5,16 +5,16 @@
 
 - Split a file, each split having 10 lines (except the last split):
 
-`split -l {{10}} {{filename}}`
+`split -l {{10}} {{path/to/file}}`
 
 - Split a file into 5 files. File is split such that each split has same size (except the last split):
 
-`split -n {{5}} {{filename}}`
+`split -n {{5}} {{path/to/file}}`
 
 - Split a file with 512 bytes in each split (except the last split; use 512k for kilobytes and 512m for megabytes):
 
-`split -b {{512}} {{filename}}`
+`split -b {{512}} {{path/to/file}}`
 
 - Split a file with at most 512 bytes in each split without breaking lines:
 
-`split -C {{512}} {{filename}}`
+`split -C {{512}} {{path/to/file}}`

--- a/pages/common/standard.md
+++ b/pages/common/standard.md
@@ -9,7 +9,7 @@
 
 - Lint specific JavaScript file(s):
 
-`standard {{path/to/file(s)}}`
+`standard {{path/to/file1 path/to/file2 ...}}`
 
 - Apply automatic fixes during linting:
 

--- a/pages/common/terminalizer.md
+++ b/pages/common/terminalizer.md
@@ -9,16 +9,16 @@
 
 - Record the terminal and create a recording file:
 
-`terminalizer record {{filename}}`
+`terminalizer record {{path/to/file}}`
 
 - Play a recorded file on the terminal:
 
-`terminalizer play {{filename}}`
+`terminalizer play {{path/to/file}}`
 
 - Render a recording file as an animated GIF image:
 
-`terminalizer render {{filename}}`
+`terminalizer render {{path/to/file}}`
 
 - Upload a video to terminalizer.com:
 
-`terminalizer share {{filename}}`
+`terminalizer share {{path/to/file}}`

--- a/pages/common/tpp.md
+++ b/pages/common/tpp.md
@@ -5,8 +5,8 @@
 
 - View a presentation:
 
-`tpp {{filename}}`
+`tpp {{path/to/file}}`
 
 - Output a presentation:
 
-`tpp -t {{type}} -o {{outputname}} {{filename}}`
+`tpp -t {{type}} -o {{path/to/output}} {{path/to/file}}`

--- a/pages/common/tr.md
+++ b/pages/common/tr.md
@@ -5,7 +5,7 @@
 
 - Replace all occurrences of a character in a file, and print the result:
 
-`tr {{find_character}} {{replace_character}} < {{filename}}`
+`tr {{find_character}} {{replace_character}} < {{path/to/file}}`
 
 - Replace all occurrences of a character from another command's output:
 
@@ -13,20 +13,20 @@
 
 - Map each character of the first set to the corresponding character of the second set:
 
-`tr '{{abcd}}' '{{jkmn}}' < {{filename}}`
+`tr '{{abcd}}' '{{jkmn}}' < {{path/to/file}}`
 
 - Delete all occurrences of the specified set of characters from the input:
 
-`tr -d '{{input_characters}}' < {{filename}}`
+`tr -d '{{input_characters}}' < {{path/to/file}}`
 
 - Compress a series of identical characters to a single character:
 
-`tr -s '{{input_characters}}' < {{filename}}`
+`tr -s '{{input_characters}}' < {{path/to/file}}`
 
 - Translate the contents of a file to upper-case:
 
-`tr "[:lower:]" "[:upper:]" < {{filename}}`
+`tr "[:lower:]" "[:upper:]" < {{path/to/file}}`
 
 - Strip out non-printable characters from a file:
 
-`tr -cd "[:print:]" < {{filename}}`
+`tr -cd "[:print:]" < {{path/to/file}}`


### PR DESCRIPTION
Breakout # 3 for #9578. I actually intended for this to just be a `file(s)` thing, but I just found so many more cases of missing `path/to/`.

```sh
fd -t f . pages | xe -j20 -- -i {} sed 's/{{\([\/a-zA-Z_]*file\)(s)}}/{{\11 \12 ...}}/g;s/{{filename}}/{{path\/to\/file}}/g;s/{{file1 file2 ...}}/{{path\/to\/file1 path\/to\/file2 ...}}/g
```