### PR TITLE
sleep: refresh page

### DIFF
--- a/pages/common/sleep.md
+++ b/pages/common/sleep.md
@@ -1,16 +1,12 @@
 # sleep
 
 > Delay for a specified amount of time.
-> More information: <https://www.gnu.org/software/coreutils/sleep>.
+> More information: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sleep.html>.
 
 - Delay in seconds:
 
 `sleep {{seconds}}`
 
-- Delay in minutes:
+- Execute a specific command after 20 seconds delay:
 
-`sleep {{minutes}}m`
-
-- Delay in hours:
-
-`sleep {{hours}}h`
+`sleep 20 && {{command}}`

--- a/pages/linux/sleep.md
+++ b/pages/linux/sleep.md
@@ -1,0 +1,20 @@
+# sleep
+
+> Delay for a specified amount of time.
+> More information: <https://www.gnu.org/software/coreutils/sleep>.
+
+- Delay in seconds:
+
+`sleep {{seconds}}`
+
+- Delay in [m]inutes. (Other units [d]ay, [h]our, [s]econd, [inf]inity can also be used):
+
+`sleep {{minutes}}m`
+
+- Delay for 1 [d]ay 3 [h]ours:
+
+`sleep 1d 3h`
+
+- Execute a specific command after 20 [m]inutes delay:
+
+`sleep 20m && {{command}}`


### PR DESCRIPTION
The PR adds some practical uses of the `sleep` command:
- The `sleep` command is mostly used for delaying other commands.
- Also multiple arguments with different time units are allowed.

PR checks:
- [x] The page(s) have at most 8 examples.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).