### PR TITLE
CLIENT-SPECIFICATION: Require support for long options

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -229,7 +229,7 @@ the commit hash changes when merging with squash or rebase.
  - Unreleased
    - Add recommendation to support `macos` alias for `osx` ([#7514](https://github.com/tldr-pages/tldr/pull/7514))
    - Drop the special "all" platform from `--list` flag ([#7561](https://github.com/tldr-pages/tldr/pull/7561))
-   - Require long options ([#9651](https://github.com/tldr-pages/tldr/pull/9651))
+   - Require support for long options ([#9651](https://github.com/tldr-pages/tldr/pull/9651))
 
  - [v1.5, March 17th 2021](https://github.com/tldr-pages/tldr/blob/v1.5/CLIENT-SPECIFICATION.md) ([#5428](https://github.com/tldr-pages/tldr/pull/5428))
    - Add requirement for converting command names to lowercase before running the page resolution algorithm.

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -41,7 +41,7 @@ Option             | Required?   | Meaning
 `-l`, `--list`     | No          | Lists all the pages in the current platform to the standard output.
 `-L`, `--language` | No          | Specifies the preferred language for the page returned. Overrides other language detection mechanisms. See the [language section](#language) for more information.
 
-Clients MAY choose to only implement the short version of an option, ignoring the long form.
+Clients MUST implement both the short and long version of an option.
 
 Additional decoration MAY be printed if the standard output is a [TTY](http://www.linusakesson.net/programming/tty/index.php). If not, then the output MUST not contain any additional decorations. For example a page list MUST be formatted with 1 page name per line (to enable easy manipulation using standard CLI tools such as `grep` etc.).
 

--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -227,8 +227,9 @@ the commit hash changes when merging with squash or rebase.
 -->
 
  - Unreleased
-   -  Add recommendation to support `macos` alias for `osx` ([#7514](https://github.com/tldr-pages/tldr/pull/7514))
-   -  Drop the special "all" platform from `--list` flag ([#7561](https://github.com/tldr-pages/tldr/pull/7561))
+   - Add recommendation to support `macos` alias for `osx` ([#7514](https://github.com/tldr-pages/tldr/pull/7514))
+   - Drop the special "all" platform from `--list` flag ([#7561](https://github.com/tldr-pages/tldr/pull/7561))
+   - Require long options ([#9651](https://github.com/tldr-pages/tldr/pull/9651))
 
  - [v1.5, March 17th 2021](https://github.com/tldr-pages/tldr/blob/v1.5/CLIENT-SPECIFICATION.md) ([#5428](https://github.com/tldr-pages/tldr/pull/5428))
    - Add requirement for converting command names to lowercase before running the page resolution algorithm.


### PR DESCRIPTION
Inspired by: https://github.com/tldr-pages/tldr/pull/9252#discussion_r1008695955
For a project that emphasizes long and readable options as much as we do (imho often to an unnecessary degree), it is honestly completely incomprehensible to me that we would only support short options, and I have yet to come across any reasonable excuse for that. If you have one, please comment.