### PR TITLE
qm-showcmd: refresh page

### DIFF
--- a/pages/linux/qm-showcmd.md
+++ b/pages/linux/qm-showcmd.md
@@ -11,6 +11,6 @@
 
 `qm showcmd --pretty {{true}} {{vm_id}}`
 
-- Fetch config values from a given snapshot:
+- Fetch config values from a specific snapshot:
 
 `qm showcmd --snapshot {{string}} {{vm_id}}`


### PR DESCRIPTION
- Use `specific` instead of `given`: standardization

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
