### PR TITLE
pv: fix 'stop at' example

### DIFF
--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -7,9 +7,9 @@
 
 `pv {{path/to/file}}`
 
-- Measure the speed and amount of data flow between pipes (`-s` is optional):
+- Measure the speed and amount of data flow between pipes (`--size` is optional):
 
-`command1 | pv -s {{expected_amount_of_data_for_eta}} | command2`
+`command1 | pv --size {{expected_amount_of_data_for_eta}} | command2`
 
 - Filter a file, see both progress and amount of output data:
 
@@ -25,4 +25,4 @@
 
 - Stop reading after reading specified amount of data, rate limit to 1K/s:
 
-`pv -L 1K -S {{maximum_file_size_to_be_read}}`
+`pv -L 1K --stop-at --size {{maximum_file_size_to_be_read}}`


### PR DESCRIPTION
* fix 'stop at' option by including --size parameter
* replace -s and -S with their spelled out variants

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.6.20
