### PR TITLE
qmv: add -f do example

### DIFF
--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -22,3 +22,7 @@
 - Move files, but swap the positions of the source and the target filenames in the editor:
 
 `qmv --option swap {{*.jpg}}`
+
+- Rename all files and folders in the current directory, but show only target filenames in the editor (you can think of it as a kind of simple mode):
+
+`qmv --format=do .`


### PR DESCRIPTION
This PR re-applies #9620 to the `main` branch. That PR was made against `master` and I believe that when the commit to `main` happened, the commit on `master` got detached (see message at top of on https://github.com/tldr-pages/tldr/commit/896abba2455e13f31186040077aee6471c600c38). So in the interest of not having that work lost to the ether, creating this PR, with the commit under the original author. On merging this PR, will need to make sure their name / email is attached to the commit in `Co-authored-by` field to keep it intact.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
