### PR TITLE
scripts/deploy.sh: generate sha256sum of artifacts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,11 +30,11 @@ function upload_assets {
   git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git "$SITE_HOME"
   mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
   cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
+  cp -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" "${SITE_HOME}/assets/tldr-book.pdf"
 
-  # Copy PDF to assets
-  if [[ -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" ]]; then
-    cp -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" "${SITE_HOME}/assets/tldr-book.pdf"
-  fi
+  sha256sum "${SITE_HOME}/assets/${TLDR_ARCHIVE}" > "${SITE_HOME}/assets/tldr.sha256sums"
+  sha256sum "${SITE_HOME}/assets/index.json" >> "${SITE_HOME}/assets/tldr.sha256sums"
+  sha256sum "${SITE_HOME}/assets/tldr-book.pdf" >> "${SITE_HOME}/assets/tldr.sha256sums"
 
   cd "$SITE_HOME"
   git add -A

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,9 +32,11 @@ function upload_assets {
   cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
   cp -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" "${SITE_HOME}/assets/tldr-book.pdf"
 
-  sha256sum "${SITE_HOME}/assets/${TLDR_ARCHIVE}" > "${SITE_HOME}/assets/tldr.sha256sums"
-  sha256sum "${SITE_HOME}/assets/index.json" >> "${SITE_HOME}/assets/tldr.sha256sums"
-  sha256sum "${SITE_HOME}/assets/tldr-book.pdf" >> "${SITE_HOME}/assets/tldr.sha256sums"
+  sha256sum \
+    "${SITE_HOME}/assets/${TLDR_ARCHIVE}" \
+    "${SITE_HOME}/assets/index.json" \
+    "${SITE_HOME}/assets/tldr-book.pdf" \
+    > "${SITE_HOME}/assets/tldr.sha256sums"
 
   cd "$SITE_HOME"
   git add -A

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,8 +33,8 @@ function upload_assets {
   cp -f "${TLDRHOME}/scripts/pdf/tldr-pages.pdf" "${SITE_HOME}/assets/tldr-book.pdf"
 
   sha256sum \
-    "${SITE_HOME}/assets/${TLDR_ARCHIVE}" \
     "${SITE_HOME}/assets/index.json" \
+    "${SITE_HOME}/assets/${TLDR_ARCHIVE}" \    
     "${SITE_HOME}/assets/tldr-book.pdf" \
     > "${SITE_HOME}/assets/tldr.sha256sums"
 


### PR DESCRIPTION
PR modifies the deploy process so that a `sha256sums` file is generated that has the SHA256 hash of each asset file that was generated during the deploy. This can be used by folks to verify that the `zip` or `index.json` or `pdf` that they downloaded matches the one we built, as well as could be used as an easy way to tell if the source has changed at all since the previous update (which would help me tackle https://github.com/tldr-pages/tldr-c-client/issues/94).

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
