### PR TITLE
vite: add page

### DIFF
--- a/pages/common/vite.md
+++ b/pages/common/vite.md
@@ -13,7 +13,7 @@
 
 `npm create vite@latest my-react-app -- --template react-ts`
 
-- Setup using  yarn:
+- Setup using yarn:
 
 `yarn create vite my-react-app --template react-ts`
 

--- a/pages/common/vite.md
+++ b/pages/common/vite.md
@@ -5,18 +5,18 @@
 > Available templates: vanilla, vanilla-ts, vue, vue-ts, react, react-ts, react-swc, react-swc-ts, preact, preact-ts, lit, lit-ts, svelte, svelte-ts.
 > More information: <https://vitejs.dev/guide>.
 
-- Setup using npm 6.x:
+- Setup using `npm` 6.x:
 
 `npm create vite@latest my-react-app --template react-ts`
 
-- Setup using npm 7+, extra double-dash is needed:
+- Setup using `npm` 7+, extra double-dash is needed:
 
 `npm create vite@latest my-react-app -- --template react-ts`
 
-- Setup using yarn:
+- Setup using `yarn`:
 
 `yarn create vite my-react-app --template react-ts`
 
-- Setup using pnpm:
+- Setup using `pnpm`:
 
 `pnpm create vite my-react-app --template react-ts`

--- a/pages/common/vite.md
+++ b/pages/common/vite.md
@@ -1,0 +1,22 @@
+# Vite
+
+> Create a Vite project.
+> Used to build JavaScript projects.
+> Available templates: vanilla, vanilla-ts, vue, vue-ts, react, react-ts, react-swc, react-swc-ts, preact, preact-ts, lit, lit-ts, svelte, svelte-ts.
+> More information: <https://vitejs.dev/guide>.
+
+- Setup using npm 6.x:
+
+`npm create vite@latest my-react-app --template react-ts`
+
+- Setup using npm 7+, extra double-dash is needed:
+
+`npm create vite@latest my-react-app -- --template react-ts`
+
+- Setup using  yarn:
+
+`yarn create vite my-react-app --template react-ts`
+
+- Setup using pnpm:
+
+`pnpm create vite my-react-app --template react-ts`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

# Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 4.0.3

# Brief Description

This adds a new page for [vite](https://vitejs.dev/). It's a common JS build tool.

I always forget the command and have to go to their website so I thought I'd just add it to the tldr pages. 
