### PR TITLE
style-guide: refresh page: move ellipsis to a separate section and extend syntax

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -160,6 +160,13 @@ All borders of integer and float ranges get included. If you want to exclude the
   using `{{*.ext}}` explains the command without being unnecessarily specific;
   while in `wc -l {{path/to/file}}` using `{{path/to/file}}` (without extension) is sufficient.
 
+### Grouping placeholders
+
+- If a command can take 0 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
+  For instance if multiple paths are expected `{{path/to/directory1 path/to/directory2 ...}}` can be used.
+- If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
+  If there are more than 5 possible values use `|...` after the last item.
+
 ### Special cases
 
 - If a command performs irreversible changes to a file system or devices,
@@ -167,9 +174,6 @@ All borders of integer and float ranges get included. If you want to exclude the
   For example, instead of `ddrescue --force --no-scrape /dev/sda /dev/sdb`
   write `ddrescue --force --no-scrape {{/dev/sdX}} {{/dev/sdY}}`
   and use the `{{/dev/sdXY}}` placeholder for *block devices* instead of `/dev/sda1`.
-- If a command can take a variable number of arguments, use an ellipsis: `{{arg1 arg2 ...}}`.
-  If one of the multiple options is possible, write it as `{{either|or}}`.
-  If there are more than 5 alternatives, use `|...` for the ellipsis.
 
 In general, placeholders should make it as intuitive as possible
 to figure out how to use the command and fill it in with values.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -166,6 +166,8 @@ All borders of integer and float ranges get included. If you want to exclude the
   For instance if multiple paths are expected `{{path/to/directory1 path/to/directory2 ...}}` can be used.
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values use `|...` after the last item.
+- To restrict the minimum or (and) maximum placeholder count use range syntax after ellipsis:
+  For instance if 4 or more paths are expected `{{path/to/directory1 path/to/directory2 ...(4..infinity)}}` can be used.
 
 It's up to program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.
@@ -174,8 +176,6 @@ tells no info about whether items are mutually exclusive or not.
   `{{path/to/directory1}} {{path/to/directory2 path/to/directory3 ...}}` means that
   at least 1 directory must be passed. Note that consequtive placeholder count numbering
   has been continued after the first required placeholder.
-- There is no way to restrict the upper count for such placeholders via this syntax.
-  Mention such things in descriptions.
 
 ### Special cases
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -173,11 +173,6 @@ All borders of integer and float ranges get included. If you want to exclude the
 It's up to program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.
 
-- To represent command where at least `n` (> 0) are required duplicate placeholders:
-  `{{path/to/directory1}} {{path/to/directory2 path/to/directory3 ...}}` means that
-  at least 1 directory must be passed. Note that consequtive placeholder count numbering
-  has been continued after the first required placeholder.
-
 ### Special cases
 
 - If a command performs irreversible changes to a file system or devices,

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -167,6 +167,16 @@ All borders of integer and float ranges get included. If you want to exclude the
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values use `|...` after the last item.
 
+It's up to program to decide how to handle duplicating values, provided syntax
+tells no info about whether items are mutually exclusive or not.
+
+- To represent command where at least `n` (> 0) are required duplicate placeholders:
+  `{{path/to/directory1}} {{path/to/directory2 path/to/directory3 ...}}` means that
+  at least 1 directory must be passed. Note that consequtive placeholder count numbering
+  has been continued after the first required placeholder.
+- There is no way to restrict the upper count for such placeholders via this syntax.
+  Mention such things in descriptions.
+
 ### Special cases
 
 - If a command performs irreversible changes to a file system or devices,

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -166,11 +166,7 @@ All borders of integer and float ranges get included. If you want to exclude the
   For instance, if multiple paths are expected `{{path/to/directory1 path/to/directory2 ...}}` can be used.
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values use `|...` after the last item.
-- To restrict the minimum or (and) maximum placeholder count use the following syntax along with ellipsis:
-  - `{{n to m: placeholder1 placeholder2 ...}}`: expect `n..m` placeholders
-  - `{{n or more: placeholder1 placeholder2 ...}}`: expect `n..infinity` placeholders
-  - `{{n or less: placeholder1 placeholder2 ...}}`: expect `-infinity..n` placeholders
-  For instance if 4 or more paths are expected `{{4 or more: path/to/directory1 path/to/directory2 ...}}` can be used.
+- It's impossible to restrict the minimum or (and) maximum placeholder count via `ellipsis`.
 
 It's up to the program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -167,7 +167,8 @@ All borders of integer and float ranges get included. If you want to exclude the
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values use `|...` after the last item.
 - To restrict the minimum or (and) maximum placeholder count use range syntax after ellipsis:
-  For instance if 4 or more paths are expected `{{path/to/directory1 path/to/directory2 ...(4..infinity)}}` can be used.
+  For instance if 4 or more paths are expected `{{path/to/directory1 path/to/directory2 ...(4..)}}` can be used.
+  `-infinity` and `infinity` keywords must be omitted if no range `step` provided.
 
 It's up to program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -166,9 +166,11 @@ All borders of integer and float ranges get included. If you want to exclude the
   For instance, if multiple paths are expected `{{path/to/directory1 path/to/directory2 ...}}` can be used.
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values use `|...` after the last item.
-- To restrict the minimum or (and) maximum placeholder count use range syntax after the ellipsis:
-  For instance if 4 or more paths are expected `{{path/to/directory1 path/to/directory2 ...(4..)}}` can be used.
-  `-infinity` and `infinity` keywords must be omitted if no range `step` is provided.
+- To restrict the minimum or (and) maximum placeholder count use the following syntax along with ellipsis:
+  - `{{n to m: placeholder1 placeholder2 ...}}`: expect `n..m` placeholders
+  - `{{n or more: placeholder1 placeholder2 ...}}`: expect `n..infinity` placeholders
+  - `{{n or less: placeholder1 placeholder2 ...}}`: expect `-infinity..n` placeholders
+  For instance if 4 or more paths are expected `{{4 or more: path/to/directory1 path/to/directory2 ...}}` can be used.
 
 It's up to the program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.

--- a/pages/linux/adig.md
+++ b/pages/linux/adig.md
@@ -11,14 +11,14 @@
 
 `adig -d {{example.com}}`
 
-- Connect to [s]pecified DNS server:
+- Connect to a specific DNS [s]erver:
 
 `adig -s {{1.2.3.4}} {{example.com}}`
 
-- Use specified TCP port to connect to DNS server:
+- Use a specific TCP port to connect to a DNS server:
 
 `adig -T {{port}} {{example.com}}`
 
-- Use specified UDP port to connect to DNS server:
+- Use a specific UDP port to connect to a DNS server:
 
 `adig -U {{port}} {{example.com}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Tasks

- Move placeholder grouping rules to a separate sections
- Allow specifying duplication count for placeholders (as now it's impossible)

## Notes

If this PR and #9741 will be merged we will be able to use `{{path/to/directory1 path/to/directory2 ...(0..infinity..2)}}` where even number of directories expected for instance.