### PR TITLE
style-guide: add rule for describing default placeholder values

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -111,6 +111,8 @@ Example:
 
 - Mention default values for placeholders via the following syntax:
   `({{placeholder}} defaults to {{value}})` like `(path/to/config defaults to .myrc)`.
+  Default values must be placed as much closer as possible to the option description like:
+  `Start an interactive shell session with a specific config (--rcfile defaults to ~/.bashrc)`.
 - If there are multiple defauls available, use comma to separate them:
   `(\`path/to/config\` defaults to .myrc, \`color\` defaults to red)`
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -113,8 +113,7 @@ Example:
   `({{placeholder}} defaults to {{value}})` like `(path/to/config defaults to .myrc)`.
   Default values must be placed as much closer as possible to the option description like:
   `Start an interactive shell session with a specific config (--rcfile defaults to ~/.bashrc)`.
-- If there are multiple defaults available, use comma to separate them:
-  `(\`path/to/config\` defaults to .myrc, \`color\` defaults to red)`
+- If there are multiple defaults available, use comma to separate them.
 
 ## Option syntax
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -105,6 +105,15 @@ Example:
 
 - Pre-translated alias page templates can be found [here](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-templates/alias-pages.md).
 
+## Description syntax
+
+### Default values
+
+- Mention default values for placeholders via the following syntax:
+  `({{placeholder}} defaults to {{value}})` like `(path/to/config defaults to .myrc)`.
+- If there are multiple defauls available, use comma to separate them:
+  `(\`path/to/config\` defaults to .myrc, \`color\` defaults to red)`
+
 ## Option syntax
 
 - Use GNU-style **long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms).

--- a/pages/linux/adig.md
+++ b/pages/linux/adig.md
@@ -11,14 +11,14 @@
 
 `adig -d {{example.com}}`
 
-- Connect to [s]pecified DNS server:
+- Connect to a specific DNS [s]erver:
 
 `adig -s {{1.2.3.4}} {{example.com}}`
 
-- Use specified TCP port to connect to DNS server:
+- Use a specific TCP port to connect to a DNS server:
 
 `adig -T {{port}} {{example.com}}`
 
-- Use specified UDP port to connect to DNS server:
+- Use a specific UDP port to connect to a DNS server:
 
 `adig -U {{port}} {{example.com}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
