### PR TITLE
style-guide: refresh page: use `n` instead of `infinity` in ranges

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -134,7 +134,8 @@ All borders of integer and float ranges get included. If you want to exclude the
 `{{1..5}}` == `[1-6)`.
 
 - Use `{{from..to}}` syntax for closed ranges.
-- Use `{{-infinity..to}}` or `{{from..infinity}}` syntax for integer partially closed ranges.
+- Use `{{-n..to}}` or `{{from..n}}` syntax for integer partially closed ranges where `n` is a keyword
+  signifying the minimum or maximum range value e.g. `{{1..n}}` - 1 or greater values.
 - Use `{{integer}}` syntax for values where any integer is valid.
 - Use `{{float}}` syntax for values where any float is valid.
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Motivation: `infinity` can be misinterpreted and lead to confusion as all computer numbers are limited while infinity is not.
