### PR TITLE
style-guide: refresh page: describe ellipsis usage when options are expected too

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -171,6 +171,9 @@ All borders of integer and float ranges get included. If you want to exclude the
 It's up to the program to decide how to handle duplicating values, provided syntax
 tells no info about whether items are mutually exclusive or not.
 
+Note that if not just arguments are expected but options also use {{--option value1 --option value2 ...}}` like
+`{{--raw-field param1=value1 --raw-field param2=value2 ...}}` in `gh-workflow` page.
+
 ### Special cases
 
 - If a command performs irreversible changes to a file system or devices,


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Nested placeholders are not supported by our client specification, so it's impossible to nest them like this: `{{--raw-field {{param1}}={{value1}} --raw-field {{param2}}={{value2}} ...}}`. So mentioning how exactly to write duplicating options with arguments is useful.