### PR TITLE
style-guide: refresh page: permit optional paths

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -149,6 +149,7 @@ All borders of integer and float ranges get included. If you want to exclude the
   but has to start at the root of the filesystem,
   prefix it with a slash,
   such as `get {{/path/to/remote_file}}`.
+- If a path is optional add `optional` at the beginning like `{{path/to/optional_file}}`.
 - In case of a possible reference both to a file or a directory,
   use `{{path/to/file_or_directory}}`.
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Instead of using `[` and `]` like man pages use I suggest to use `path/to/optional_*` syntax, where `*` is any string. Examples: `{{path/to/optional_file}}`, `{{path/to/optional_presentation}}`.

There are several PR authors who tried to use square brackets like this `[{{path/to/file}}]`, this PR aims to forbid such syntax.

Note that such syntax is impossible to be implemented for ranges as they don't accept arbitrary strings to be put in.