### PR TITLE
style-guide: refresh page: intrudoce one way to describe regex flavours

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -161,6 +161,13 @@ All borders of integer and float ranges get included. If you want to exclude the
   using `{{*.ext}}` explains the command without being unnecessarily specific;
   while in `wc -l {{path/to/file}}` using `{{path/to/file}}` (without extension) is sufficient.
 
+### Regular expressions
+
+- Use `{{basic_regex}}` and `{{extended_regex}}` placeholder for basic regular expressions and
+  extended ones respectively.
+- Always refer to `basic-regex` and `extended-regex` pages via `See also:` line at the
+  beginning of the page when such regular expression flavours are used.
+
 ### Grouping placeholders
 
 - If a command can take 0 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -163,10 +163,11 @@ All borders of integer and float ranges get included. If you want to exclude the
 
 ### Regular expressions
 
-- Use `{{basic_regex}}` and `{{extended_regex}}` placeholder for basic regular expressions and
-  extended ones respectively.
-- Always refer to `basic-regex` and `extended-regex` pages via `See also:` line at the
-  beginning of the page when such regular expression flavours are used.
+- Use `{{<flavor>_regex}}` placeholder for regex e.g. `{{basic_regex}}` and `{{extended_regex}}` placeholder
+  for basic regular expressions and extended ones respectively.
+- Always refer to {{<flavor>_regex}} pages via `See also:` line at the
+  beginning of the page when such regular expression flavors are used like
+  `See also: basic_regex.`.
 
 ### Grouping placeholders
 

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -17,7 +17,7 @@
 
 - Match any character from a specific set of characters:
 
-`[{{chars}}]`
+`[{{characters}}]`
 
 - Match one of two specific alternatives:
 

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -25,4 +25,4 @@
 
 - Group a specific pattern:
 
-`({{alternative}})`
+`\({{pattern}}\)`

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -5,28 +5,28 @@
 
 - Match 0 or more repetitions of previous character, class or group:
 
-`{{character|class|group}}*`
+`{{a|[abc]]|(abc)}}*`
 
 - Match 1 or more repetitions of previous character, class or group:
 
-`{{character|class|group}}\+`
+`{{a|[abc]]|(abc)}}\+`
 
 - Match 0 or 1 repetitions of previous character, class or group:
 
-`{{character|class|group}}\?`
+`{{a|[abc]]|(abc)}}\?`
 
 - Match any character from a specific set of characters:
 
-`[{{characters}}]`
+`[{{abc}}]`
 
 - Match any character not from a specific set of characters:
 
-`[^{{characters}}]`
+`[^{{abc}}]`
 
 - Match one of two specific alternatives:
 
-`{{alternative1}}\|{{alternative2}}`
+`{{abc}}\|{{def}}`
 
 - Group a specific pattern:
 
-`\({{pattern}}\)`
+`\({{abc}}\)`

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -5,15 +5,15 @@
 
 - Match 0 or more repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}*`
+`{{a|[abc]|(abc)}}*`
 
 - Match 1 or more repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}\+`
+`{{a|[abc]|(abc)}}\+`
 
 - Match 0 or 1 repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}\?`
+`{{a|[abc]|(abc)}}\?`
 
 - Match any character from a specific set of characters:
 

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -19,6 +19,10 @@
 
 `[{{characters}}]`
 
+- Match any character not from a specific set of characters:
+
+`[^{{characters}}]`
+
 - Match one of two specific alternatives:
 
 `{{alternative1}}\|{{alternative2}}`

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -1,0 +1,28 @@
+# basic regex
+
+> This page describes basic regex syntax.
+> More information: <https://linuxize.com/post/regular-expressions-in-grep/>.
+
+- Match 0 or more repetitions of previous character, class or group:
+
+`{{character|class|group}}*`
+
+- Match 1 or more repetitions of previous character, class or group:
+
+`{{character|class|group}}\+`
+
+- Match 0 or 1 repetitions of previous character, class or group:
+
+`{{character|class|group}}\?`
+
+- Match any character from a specific set of characters:
+
+`[{{chars}}]`
+
+- Match one of two specific alternatives:
+
+`{{alternative1}}|{{alternative2}}`
+
+- Group a specific pattern:
+
+`({{alternative}})`

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -3,15 +3,15 @@
 > This page describes basic regex syntax.
 > More information: <https://linuxize.com/post/regular-expressions-in-grep/>.
 
-- Match 0 or more repetitions of previous character, class or group:
+- Match 0 or more repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}*`
 
-- Match 1 or more repetitions of previous character, class or group:
+- Match 1 or more repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}\+`
 
-- Match 0 or 1 repetitions of previous character, class or group:
+- Match 0 or 1 repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}\?`
 

--- a/pages/common/basic-regex.md
+++ b/pages/common/basic-regex.md
@@ -21,7 +21,7 @@
 
 - Match one of two specific alternatives:
 
-`{{alternative1}}|{{alternative2}}`
+`{{alternative1}}\|{{alternative2}}`
 
 - Group a specific pattern:
 

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -19,6 +19,10 @@
 
 `[{{characters}}]`
 
+- Match any character not from a specific set of characters:
+
+`[^{{characters}}]`
+
 - Match one of two specific alternatives:
 
 `{{alternative1}}|{{alternative2}}`

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -1,0 +1,28 @@
+# extended regex
+
+> This page describes extended regex syntax.
+> More information: <https://linuxize.com/post/regular-expressions-in-grep/>.
+
+- Match 0 or more repetitions of previous character, class or group:
+
+`{{character|class|group}}*`
+
+- Match 1 or more repetitions of previous character, class or group:
+
+`{{character|class|group}}+`
+
+- Match 0 or 1 repetitions of previous character, class or group:
+
+`{{character|class|group}}?`
+
+- Match any character from a specific set of characters:
+
+`[{{chars}}]`
+
+- Match one of two specific alternatives:
+
+`{{alternative1}}|{{alternative2}}`
+
+- Group a specific pattern:
+
+`({{pattern}})`

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -17,7 +17,7 @@
 
 - Match any character from a specific set of characters:
 
-`[{{chars}}]`
+`[{{characters}}]`
 
 - Match one of two specific alternatives:
 

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -5,15 +5,15 @@
 
 - Match 0 or more repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}*`
+`{{a|[abc]|(abc)}}*`
 
 - Match 1 or more repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}+`
+`{{a|[abc]|(abc)}}+`
 
 - Match 0 or 1 repetitions of previous character, class or group:
 
-`{{a|[abc]]|(abc)}}?`
+`{{a|[abc]|(abc)}}?`
 
 - Match any character from a specific set of characters:
 

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -5,28 +5,28 @@
 
 - Match 0 or more repetitions of previous character, class or group:
 
-`{{character|class|group}}*`
+`{{a|[abc]]|(abc)}}*`
 
 - Match 1 or more repetitions of previous character, class or group:
 
-`{{character|class|group}}+`
+`{{a|[abc]]|(abc)}}+`
 
 - Match 0 or 1 repetitions of previous character, class or group:
 
-`{{character|class|group}}?`
+`{{a|[abc]]|(abc)}}?`
 
 - Match any character from a specific set of characters:
 
-`[{{characters}}]`
+`[{{abc}}]`
 
 - Match any character not from a specific set of characters:
 
-`[^{{characters}}]`
+`[^{{abc}}]`
 
 - Match one of two specific alternatives:
 
-`{{alternative1}}|{{alternative2}}`
+`{{abc}}|{{def}}`
 
 - Group a specific pattern:
 
-`({{pattern}})`
+`({{abc}})`

--- a/pages/common/extended-regex.md
+++ b/pages/common/extended-regex.md
@@ -3,15 +3,15 @@
 > This page describes extended regex syntax.
 > More information: <https://linuxize.com/post/regular-expressions-in-grep/>.
 
-- Match 0 or more repetitions of previous character, class or group:
+- Match 0 or more repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}*`
 
-- Match 1 or more repetitions of previous character, class or group:
+- Match 1 or more repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}+`
 
-- Match 0 or 1 repetitions of previous character, class or group:
+- Match 0 or 1 repetitions of previous character, class, or group:
 
 `{{a|[abc]|(abc)}}?`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Instead of trying redescribe regex flavor syntax each time it's used we can refer to these two pages. This page set can be extended to describe python regex syntax, sed regex syntax, emacs one, etc.

Page naming convention: `{{flavor}}-regex.md`, like `python-regex.md`, `perl-regex.md`, etc.

closes #9756