### PR TITLE
conda: activate/deactivate are not args

### DIFF
--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -14,11 +14,11 @@
 
 - Load an environment:
 
-`conda {{activate environment_name}}`
+`conda activate {{environment_name}}`
 
 - Unload an environment:
 
-`conda {{deactivate}}`
+`conda deactivate`
 
 - Delete an environment (remove all packages):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** N/A

---

`activate` and `deactivate` are commands, not args

Looks like before we had the token syntax because it was an enum `{{activate|deactivate}}` but it was split up into 2 separate examples. Now that it's 2 examples though, it doesn't make sense to use the token syntax imo, they are no longer considered user-defined elements of the command they're documenting.

### Related
* https://github.com/tldr-pages/tldr/pull/6050/files