### PR TITLE
coqui: add page

### DIFF
--- a/pages/common/tts.md
+++ b/pages/common/tts.md
@@ -1,0 +1,28 @@
+# tts
+
+> Synthesize speech on the command line.
+> More information: <https://github.com/coqui-ai/TTS#command-line-tts>.
+
+- Run text-to-speech with the default models, writing the output to "tts_output.wav":
+
+`tts --text "{{text}}"`
+
+- List provided models:
+
+`tts --list_models`
+
+- Query info for a model by idx:
+
+`tts --model_info_by_idx {{model_type/model_query_idx}}`
+
+- Query info for a model by name:
+
+`tts --model_info_by_name {{model_type/language/dataset/model_name}}`
+
+- Run a text-to-speech model with its default vocoder model:
+
+`tts --text "{{text}}" --model_name {{model_type/language/dataset/model_name}}`
+
+- Run your own text-to-speech model (using the Griffin-Lim vocoder):
+
+`tts --text "{{text}}" --model_path {{path/to/model.pth}} --config_path {{path/to/config.json}} --out_path {{path/to/file.wav}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**  
0.10.2

TTS is a CLI utility that comes with Coqui, a free and open-source engine for text-to-speech.

https://coqui.ai/

Not everything they do is open-source unfortunately, but the CLI tool and some of the models they use are. Overall seems pretty cool. :thinking: 

Seems like they're building an alternative to [VOCALOID](https://www.vocaloid.com/en/). :thinking: 

Most of the examples are derived from their help command, they use a TL;DR like syntax in the first place, so it just rewords things to make sense and sorts commands in what I think would be most relevant first.

![image](https://user-images.githubusercontent.com/22801583/213992461-2940825b-8b02-46fc-9e2d-d1233bc2c6e3.png)
> From their help command.