### PR TITLE
holehe: add page

### DIFF
--- a/pages/common/holehe.md
+++ b/pages/common/holehe.md
@@ -1,0 +1,12 @@
+# holehe
+
+> Holehe checks if an email is attached to an account on sites like Twitter, Instagram, Imgur and over 120 others.
+> More information: <https://github.com/megadose/holehe#-cli-example>.
+
+- Show status across all supported websites for the specified email address:
+
+`holehe {{username@example.org}}`
+
+- Show status for only sites where the specified email address is in use:
+
+`holehe {{username@example.org}} --only-used`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
holehe v1.61

Repo: https://github.com/megadose/holehe

A similar tool to [Sherlock](https://github.com/sherlock-project/sherlock), but for email addresses instead of usernames.

PS: While this basically is a cyberstalking tool, I see it as a tool to aid privacy-conscious users in discovering and erasing online accounts/personal data.