### PR TITLE
git-annotate: add -L example

### DIFF
--- a/pages/common/git-annotate.md
+++ b/pages/common/git-annotate.md
@@ -12,3 +12,7 @@
 - Print a file with the author email and commit hash prepended to each line:
 
 `git annotate -e {{path/to/file}}`
+
+- Print only rows that match a regular expression:
+
+`git annotate -L :{{regexp}} {{path/to/file}}`


### PR DESCRIPTION
- [x] The page(s) have at most 8 examples.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.34.1
