### PR TITLE
nu: fix log-level command instructions

### DIFF
--- a/pages/common/nu.md
+++ b/pages/common/nu.md
@@ -18,4 +18,4 @@
 
 - Execute a specific script with logging:
 
-`nu --loglevel {{error|warn|info|debug|trace}} {{path/to/script.nu}}`
+`nu --log-level {{error|warn|info|debug|trace}} {{path/to/script.nu}}`


### PR DESCRIPTION
This flag should be called `log-level`
```
> nu --loglevel info
× The `nu` command doesn't have flag `loglevel`.
   ╭─[source:1:1]
 1 │ nu --loglevel
   ·    ─────┬────
   ·         ╰── unknown flag
```
After:
```
> nu --log-level info
2023-01-28 07:57:42.536 PM [INFO ] nu: start logging src/main.rs:288:67
```

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
