### PR TITLE
dd: remove checking progress example

### DIFF
--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -26,7 +26,3 @@
 - Restore a drive from an IMG file:
 
 `dd if={{path/to/file.img}} of={{/dev/drive_device}}`
-
-- Check the progress of an ongoing dd operation (run this command from another shell):
-
-`kill -USR1 $(pgrep ^dd)`


### PR DESCRIPTION
`pgrep` does not exist and `kill` needs `-s`.
But most importantly, `dd` doesn't have any "showing progress" functionality.

- **Version of the command being documented (if known):** The Open Group Standard: Base Specifications, Issue 7, 2018 Edition
