### PR TITLE
head: split POSIX, BSD and GNU

### DIFF
--- a/pages/common/head.md
+++ b/pages/common/head.md
@@ -5,16 +5,4 @@
 
 - Output the first few lines of a file:
 
-`head --lines {{count}} {{path/to/file}}`
-
-- Output the first few bytes of a file:
-
-`head --bytes {{count}} {{path/to/file}}`
-
-- Output everything but the last few lines of a file:
-
-`head --lines -{{count}} {{path/to/file}}`
-
-- Output everything but the last few bytes of a file:
-
-`head --bytes -{{count}} {{path/to/file}}`
+`head -n {{count}} {{path/to/file}}`

--- a/pages/linux/head.md
+++ b/pages/linux/head.md
@@ -1,0 +1,20 @@
+# head
+
+> Output the first part of files.
+> More information: <https://www.gnu.org/software/coreutils/head>.
+
+- Output the first few lines of a file:
+
+`head --lines {{count}} {{path/to/file}}`
+
+- Output the first few bytes of a file:
+
+`head --bytes {{count}} {{path/to/file}}`
+
+- Output everything but the last few lines of a file:
+
+`head --lines -{{count}} {{path/to/file}}`
+
+- Output everything but the last few bytes of a file:
+
+`head --bytes -{{count}} {{path/to/file}}`

--- a/pages/osx/head.md
+++ b/pages/osx/head.md
@@ -1,0 +1,20 @@
+# head
+
+> Output the first part of files.
+> More information: <https://keith.github.io/xcode-man-pages/head.1.html>.
+
+- Output the first few lines of a file:
+
+`head --lines {{count}} {{path/to/file}}`
+
+- Output the first few bytes of a file:
+
+`head --bytes {{count}} {{path/to/file}}`
+
+- Output everything but the last few lines of a file:
+
+`head --lines -{{count}} {{path/to/file}}`
+
+- Output everything but the last few bytes of a file:
+
+`head --bytes -{{count}} {{path/to/file}}`


### PR DESCRIPTION
- **Version of the command being documented (if known):** The Open Group Standard: Base Specifications, Issue 7, 2018 Edition; macOS 13.2, FreeBSD 13.1; GNU coreutils 9.1
