### PR TITLE
b3sum: add page

### DIFF
--- a/pages/common/b3sum.md
+++ b/pages/common/b3sum.md
@@ -16,7 +16,7 @@
 
 `{{some_command}} | b3sum`
 
-- Create a file of BLAKE3 sums:
+- Create a file of BLAKE3 checksums:
 
 `b3sum {{path/to/file}} > {{path/to/file.b3}}`
 

--- a/pages/common/b3sum.md
+++ b/pages/common/b3sum.md
@@ -1,6 +1,7 @@
 # b3sum
 
-> A command line utility for calculating BLAKE3 hashes, similar to Coreutils tools like b2sum or md5sum.
+> Command line utility for calculating BLAKE3 hashes.
+> It is similar to Coreutils tools like b2sum or md5sum.
 > More information: <https://github.com/BLAKE3-team/BLAKE3/tree/master/b3sum>.
 
 - Calculate the BLAKE3 checksum for a file:

--- a/pages/common/b3sum.md
+++ b/pages/common/b3sum.md
@@ -1,0 +1,24 @@
+# b3sum
+
+> A command line utility for calculating BLAKE3 hashes, similar to Coreutils tools like b2sum or md5sum.
+> More information: <https://github.com/BLAKE3-team/BLAKE3/tree/master/b3sum>.
+
+- Calculate the BLAKE3 checksum for a file:
+
+`b3sum {{path/to/file}}`
+
+- Calculate BLAKE3 checksums for multiple files:
+
+`b3sum {{path/to/file1}} {{path/to/file2}}`
+
+- Calculate the BLAKE3 checksum from `stdin`:
+
+`{{some_command}} | b3sum`
+
+- Create a file of BLAKE3 sums:
+
+`b3sum {{path/to/file}} > {{path/to/file.b3}}`
+
+- Read and verify a file of BLAKE3 sums:
+
+`b3sum --check {{path/to/file.b3}}`

--- a/pages/common/b3sum.md
+++ b/pages/common/b3sum.md
@@ -20,6 +20,6 @@
 
 `b3sum {{path/to/file}} > {{path/to/file.b3}}`
 
-- Read and verify a file of BLAKE3 sums:
+- Read and verify a file of BLAKE3 checksums:
 
 `b3sum --check {{path/to/file.b3}}`


### PR DESCRIPTION
I like b3sum and use tldr pages. So I thought I would start contributing with writing the missing tldr page for b3sum. If anything is wrong please tell me/suggest changes.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** b3sum 1.3.3
