### PR TITLE
arping : fix typo in French translation

### DIFF
--- a/pages.fr/common/arping.md
+++ b/pages.fr/common/arping.md
@@ -20,7 +20,7 @@
 
 `arping -c {{nombre_d_appel}} {{ip_hôte}}`
 
-- Diffuse les paquets de requête ARP pour mettre à hour les caches ARP voisin :
+- Diffuse les paquets de requête ARP pour mettre à jour les caches ARP voisin :
 
 `arping -U {{ip_à_diffuser}}`
 


### PR DESCRIPTION
corrects a French mistake on the description of a command

