### PR TITLE
git-filter-repo : all commands use the same command "git filter-repo"…

### DIFF
--- a/pages/common/git-filter-repo.md
+++ b/pages/common/git-filter-repo.md
@@ -10,12 +10,12 @@
 
 - Extract a single folder, keeping history:
 
-`git-filter-repo --path {{path/to/folder}}`
+`git filter-repo --path {{path/to/folder}}`
 
 - Remove a single folder, keeping history:
 
-`git-filter-repo --path {{path/to/folder}} --invert-paths`
+`git filter-repo --path {{path/to/folder}} --invert-paths`
 
 - Move everything from sub-folder one level up:
 
-`git-filter-repo --path-rename {{path/to/folder/:}}`
+`git filter-repo --path-rename {{path/to/folder/:}}`


### PR DESCRIPTION
In git-filter-repo.md, all commands use the same command "git filter-repo" instead of sometimes "git-filter-repo"
