### PR TITLE
gfortran: add page

### DIFF
--- a/pages/common/gfortran.md
+++ b/pages/common/gfortran.md
@@ -1,0 +1,24 @@
+# gfortran
+
+> Preprocess and compile Fortran source files, then assemble and link them together.
+> More information: <https://gcc.gnu.org/wiki/GFortran>.
+
+- Compile multiple source files into executable:
+
+`gfortran {{path/to/source1.f90 path/to/source2.f90 ...}} -o {{path/to/output_executable}}`
+
+- Show common warnings, debug symbols in output, and optimize without affecting debugging:
+
+`gfortran {{path/to/source.f90}} -Wall -g -Og -o {{path/to/output_executable}}`
+
+- Include libraries from a different path:
+
+`gfortran {{path/to/source.f90}} -o {{path/to/output_executable}} -I{{path/to/mod_and_include}} -L{{path/to/library}} -l{{library_name}}`
+
+- Compile source code into Assembler instructions:
+
+`gfortran -S {{path/to/source.f90}}`
+
+- Compile source code into an object file without linking:
+
+`gfortran -c {{path/to/source.f90}}`

--- a/pages/common/gfortran.md
+++ b/pages/common/gfortran.md
@@ -3,7 +3,7 @@
 > Preprocess and compile Fortran source files, then assemble and link them together.
 > More information: <https://gcc.gnu.org/wiki/GFortran>.
 
-- Compile multiple source files into executable:
+- Compile multiple source files into an executable:
 
 `gfortran {{path/to/source1.f90 path/to/source2.f90 ...}} -o {{path/to/output_executable}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** GNU Fortran (GCC) 12.2.1 20230201

Since GCC and GFortran are very similar, I just copy&pasted the GCC page and adapted it.