### PR TITLE
rg: Add example for searching filenames

### DIFF
--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -24,6 +24,10 @@
 
 `rg {{regular_expression}} --glob {{glob}}`
 
+- Search for filenames that match a regular expression:
+
+`rg --files | rg {{regular_expression}}`
+
 - Only list matched files (useful when piping to other commands):
 
 `rg --files-with-matches {{regular_expression}}`

--- a/pages/common/rg.md
+++ b/pages/common/rg.md
@@ -12,10 +12,6 @@
 
 `rg --no-ignore --hidden {{regular_expression}}`
 
-- Search for a regular expression only in a certain filetype (e.g. HTML, CSS, etc.):
-
-`rg --type {{filetype}} {{regular_expression}}`
-
 - Search for a regular expression only in a subset of directories:
 
 `rg {{regular_expression}} {{set_of_subdirs}}`


### PR DESCRIPTION
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Removed the --type flag as that command needs one to go through `man rg` to figure out which arguments work for the filetype