### PR TITLE
osx/as.md: make placeholders auto convertible to CLIP ones

### DIFF
--- a/pages/osx/as.md
+++ b/pages/osx/as.md
@@ -6,16 +6,16 @@
 
 - Assemble a file, writing the output to `a.out`:
 
-`as {{file.s}}`
+`as {{path/to/file.s}}`
 
 - Assemble the output to a given file:
 
-`as {{file.s}} -o {{out.o}}`
+`as {{path/to/file.s}} -o {{path/to/out.o}}`
 
 - Generate output faster by skipping whitespace and comment preprocessing. (Should only be used for trusted compilers):
 
-`as -f {{file.s}}`
+`as -f {{path/to/file.s}}`
 
 - Include a given path to the list of directories to search for files specified in `.include` directives:
 
-`as -I {{path/to/directory}} {{file.s}}`
+`as -I {{path/to/directory}} {{path/to/file.s}}`

--- a/pages/osx/as.md
+++ b/pages/osx/as.md
@@ -10,7 +10,7 @@
 
 - Assemble the output to a given file:
 
-`as {{path/to/file.s}} -o {{path/to/out.o}}`
+`as {{path/to/file.s}} -o {{path/to/output_file.o}}`
 
 - Generate output faster by skipping whitespace and comment preprocessing. (Should only be used for trusted compilers):
 


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/prototypes/pull/32

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Notes

- `{{out.o}}` is completely messed up placeholder as there is no `file` keyword inside it and `path/to` prefix, that's why it can't be automatically [recognized](https://github.com/command-line-interface-pages/prototypes/pull/32) as file
- other placeholders are broken but can be interpreted as file as contain `path/to`