### PR TITLE
osx/asr.md: make placeholders auto convertible to CLIP ones

### DIFF
--- a/pages/osx/asr.md
+++ b/pages/osx/asr.md
@@ -10,7 +10,7 @@
 
 - Erase the target volume before restoring:
 
-`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}} --erase`
+`sudo asr restore --source {{image_file.dmg}} --target {{path/to/volume_file}} --erase`
 
 - Skip verification after restoring:
 

--- a/pages/osx/asr.md
+++ b/pages/osx/asr.md
@@ -14,7 +14,7 @@
 
 - Skip verification after restoring:
 
-`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}} --noverify`
+`sudo asr restore --source {{image_file.dmg}} --target {{path/to/volume_file}} --noverify`
 
 - Clone volumes without the use of an intermediate disk image:
 

--- a/pages/osx/asr.md
+++ b/pages/osx/asr.md
@@ -6,16 +6,16 @@
 
 - Restore a disk image to a target volume:
 
-`sudo asr restore --source {{image_name}}.dmg --target {{path/to/volume}}`
+`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}}`
 
 - Erase the target volume before restoring:
 
-`sudo asr restore --source {{image_name}}.dmg --target {{path/to/volume}} --erase`
+`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}} --erase`
 
 - Skip verification after restoring:
 
-`sudo asr restore --source {{image_name}}.dmg --target {{path/to/volume}} --noverify`
+`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}} --noverify`
 
 - Clone volumes without the use of an intermediate disk image:
 
-`sudo asr restore --source {{path/to/volume}} --target {{path/to/cloned_volume}}`
+`sudo asr restore --source {{path/to/volume}} --target {{path/to/volume_file}}`

--- a/pages/osx/asr.md
+++ b/pages/osx/asr.md
@@ -6,7 +6,7 @@
 
 - Restore a disk image to a target volume:
 
-`sudo asr restore --source {{image_filename.dmg}} --target {{path/to/volume_file}}`
+`sudo asr restore --source {{image_file.dmg}} --target {{path/to/volume_file}}`
 
 - Erase the target volume before restoring:
 

--- a/pages/osx/asr.md
+++ b/pages/osx/asr.md
@@ -18,4 +18,4 @@
 
 - Clone volumes without the use of an intermediate disk image:
 
-`sudo asr restore --source {{path/to/volume}} --target {{path/to/volume_file}}`
+`sudo asr restore --source {{path/to/volume_file}} --target {{path/to/volume_file}}`


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/prototypes/pull/32

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Note

`file` suffix is required to make placeholder convertible.

## Result

Conversion result thanks to fixes:

```md
# asr

> Restore (copy) a disk image onto a volume
> The command name stands for Apple Software Restore
> More information: https://www.unix.com/man-page/osx/8/asr/

- Restore a disk image to a target volume:

`sudo asr restore --source {file image file with mandatory .dmg extension} --target {file volume file}`

- Erase the target volume before restoring:

`sudo asr restore --source {file image file with mandatory .dmg extension} --target {file volume file} --erase`

- Skip verification after restoring:

`sudo asr restore --source {file image file with mandatory .dmg extension} --target {file volume file} --noverify`

- Clone volumes without the use of an intermediate disk image:

`sudo asr restore --source {file volume file} --target {file volume file}`

```