### PR TITLE
osx/cot.md: make placeholders auto convertible to CLIP ones

### DIFF
--- a/pages/osx/cot.md
+++ b/pages/osx/cot.md
@@ -21,4 +21,4 @@
 
 - Open a specific file with the cursor at a specific line and column:
 
-`cot --line {{line_number}} --column {{column_number}} {{path/to/file}}`
+`cot --line {{1}} --column {{80}} {{path/to/file}}`


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/prototypes/pull/32

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Notes

`line_number` and `column_number` are not automatically convertible, sample integer value is required to make them recognizable by [CLIP converter](https://github.com/command-line-interface-pages/prototypes/pull/32).

## Result

Conversion result thanks to fixes:

```md
# cot

> The Plain-Text Editor for macOS
> More information: https://coteditor.com/

- Start CotEditor:

`cot`

- Open specific files:

`cot {file* some description}`

- Open a new blank document:

`cot --new`

- Open a specific file and block the terminal until it is closed:

`cot --wait {file some description}`

- Open a specific file with the cursor at a specific line and column:

`cot --line {int some description: 1} --column {int some description: 80} {file some description}`

```