### PR TITLE
osx/csrutil.md: make placeholder convertible to CLIP one

### DIFF
--- a/pages/osx/csrutil.md
+++ b/pages/osx/csrutil.md
@@ -21,7 +21,7 @@
 
 - Add an IPv4 address to the list of allowed NetBoot sources:
 
-`csrutil netboot add {{ip_address}}`
+`csrutil netboot add {{ip}}`
 
 - Reset the System Integrity Protection status and clear the NetBoot list:
 


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/prototypes/pull/32

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**


## Note

`address` suffix is required to be omitted to make placeholder convertible.

## Result

Conversion result thanks to fixes:

```md
# csrutil

> Manage the System Integrity Protection configuration
> More information: https://ss64.com/osx/csrutil.html

- Display the System Integrity Protection status:

`csrutil status`

- Disable the System Integrity Protection:

`csrutil disable`

- Enable the System Integrity Protection:

`csrutil enable`

- Display the list of allowed NetBoot sources:

`csrutil netboot list`

- Add an IPv4 address to the list of allowed NetBoot sources:

`csrutil netboot add {string ip}`

- Reset the System Integrity Protection status and clear the NetBoot list:

`csrutil clear`

```