### PR TITLE
osx/*.md: make placeholders more compatible with CLIP ones

### DIFF
--- a/pages/osx/csshx.md
+++ b/pages/osx/csshx.md
@@ -9,7 +9,7 @@
 
 - Connect to multiple hosts with a given SSH key:
 
-`csshX {{user@hostname1}} {{user@hostname2}} --ssh_args "-i {{path/to/ssh_key.pem}}"`
+`csshX {{user@hostname1}} {{user@hostname2}} --ssh_args "-i {{path/to/key_file.pem}}"`
 
 - Connect to a pre-defined cluster from `/etc/clusters`:
 

--- a/pages/osx/dd.md
+++ b/pages/osx/dd.md
@@ -5,11 +5,11 @@
 
 - Make a bootable USB drive from an isohybrid file (such like `archlinux-xxx.iso`) and show the progress:
 
-`dd if={{path/to/file.iso}} of={{/dev/usb_drive}} status=progress`
+`dd if={{path/to/file.iso}} of={{/dev/usb_device}} status=progress`
 
 - Clone a drive to another drive with 4 MB block, ignore error and show the progress:
 
-`dd if={{/dev/source_drive}} of={{/dev/dest_drive}} bs={{4m}} conv={{noerror}} status=progress`
+`dd if={{/dev/source_device}} of={{/dev/dest_device}} bs={{4}}m conv={{noerror}} status=progress`
 
 - Generate a file of 100 random bytes by using kernel random driver:
 
@@ -17,7 +17,7 @@
 
 - Benchmark the write performance of a disk:
 
-`dd if=/dev/zero of={{path/to/file_1GB}} bs={{1024}} count={{1000000}}`
+`dd if=/dev/zero of={{path/to/1GB_file}} bs={{1024}} count={{1000000}}`
 
 - Generate a system backup into an IMG file and show the progress:
 

--- a/pages/osx/dd.md
+++ b/pages/osx/dd.md
@@ -9,7 +9,7 @@
 
 - Clone a drive to another drive with 4 MB block, ignore error and show the progress:
 
-`dd if={{/dev/source_device}} of={{/dev/dest_device}} bs={{4}}m conv={{noerror}} status=progress`
+`dd if={{/dev/source_device}} of={{/dev/dest_device}} bs={{4m}} conv={{noerror}} status=progress`
 
 - Generate a file of 100 random bytes by using kernel random driver:
 

--- a/pages/osx/dhcp6d.md
+++ b/pages/osx/dhcp6d.md
@@ -10,4 +10,4 @@
 
 - Use a custom configuration:
 
-`dhcp6d {{path/to/config}}`
+`dhcp6d {{path/to/config_file}}`

--- a/pages/osx/diskutil.md
+++ b/pages/osx/diskutil.md
@@ -9,12 +9,12 @@
 
 - Repair the filesystem data structures of a volume:
 
-`diskutil repairVolume {{/dev/diskX}}`
+`diskutil repairVolume {{/dev/disk_device}}`
 
 - Unmount a volume:
 
-`diskutil unmountDisk {{/dev/diskX}}`
+`diskutil unmountDisk {{/dev/disk_device}}`
 
 - Eject a CD/DVD (unmount first):
 
-`diskutil eject {{/dev/disk1}}`
+`diskutil eject {{/dev/disk_device1}}`

--- a/pages/osx/ditto.md
+++ b/pages/osx/ditto.md
@@ -5,12 +5,12 @@
 
 - Overwrite contents of destination directory with contents of source directory:
 
-`ditto {{path/to/source}} {{path/to/destination}}`
+`ditto {{path/to/source_directory}} {{path/to/destination_directory}}`
 
 - Print a line to the Terminal window for every file that's being copied:
 
-`ditto -V {{path/to/source}} {{path/to/destination}}`
+`ditto -V {{path/to/source_directory}} {{path/to/destination_directory}}`
 
 - Copy a given file or directory, while retaining the original file permissions:
 
-`ditto -rsrc {{path/to/source}} {{path/to/destination}}`
+`ditto -rsrc {{path/to/source_directory}} {{path/to/destination_directory}}`

--- a/pages/osx/du.md
+++ b/pages/osx/du.md
@@ -21,7 +21,7 @@
 
 - List the human-readable sizes of a directory and any subdirectories, up to N levels deep:
 
-`du -h -d {{N}} {{path/to/directory}}`
+`du -h -d {{2}} {{path/to/directory}}`
 
 - List the human-readable size of all `.jpg` files in subdirectories of the current directory, and show a cumulative total at the end:
 

--- a/pages/osx/emond.md
+++ b/pages/osx/emond.md
@@ -14,4 +14,4 @@
 
 - Use a specific configuration file:
 
-`emond -c {{path/to/config}}`
+`emond -c {{path/to/config_file}}`

--- a/pages/osx/fileicon.md
+++ b/pages/osx/fileicon.md
@@ -5,7 +5,7 @@
 
 - Set a custom icon for a specific file or directory:
 
-`fileicon set {{path/to/file_or_directory}} {{path/to/icon.png}}`
+`fileicon set {{path/to/file_or_directory}} {{path/to/icon_file.png}}`
 
 - Remove a custom icon from a specific file or directory:
 

--- a/pages/osx/ftxdiff.md
+++ b/pages/osx/ftxdiff.md
@@ -5,7 +5,7 @@
 
 - Output differences to a specific text file:
 
-`ftxdiff --output {{path/to/fontdiff.txt}} {{path/to/font1.ttc}} {{path/to/font2.ttc}}`
+`ftxdiff --output {{path/to/fontdiff_file.txt}} {{path/to/font_file1.ttc}} {{path/to/font_file2.ttc}}`
 
 - Include glyph names in output:
 

--- a/pages/osx/hdiutil.md
+++ b/pages/osx/hdiutil.md
@@ -9,7 +9,7 @@
 
 - Unmount an image:
 
-`hdiutil detach /Volumes/{{volume_name}}`
+`hdiutil detach /Volumes/{{volume_file}}`
 
 - List mounted images:
 

--- a/pages/osx/head.md
+++ b/pages/osx/head.md
@@ -5,16 +5,16 @@
 
 - Output the first few lines of a file:
 
-`head --lines {{count}} {{path/to/file}}`
+`head --lines {{8}} {{path/to/file}}`
 
 - Output the first few bytes of a file:
 
-`head --bytes {{count}} {{path/to/file}}`
+`head --bytes {{8}} {{path/to/file}}`
 
 - Output everything but the last few lines of a file:
 
-`head --lines -{{count}} {{path/to/file}}`
+`head --lines -{{8}} {{path/to/file}}`
 
 - Output everything but the last few bytes of a file:
 
-`head --bytes -{{count}} {{path/to/file}}`
+`head --bytes -{{8}} {{path/to/file}}`

--- a/pages/osx/icalbuddy.md
+++ b/pages/osx/icalbuddy.md
@@ -17,7 +17,7 @@
 
 - Show tasks for a specified number of days:
 
-`icalBuddy --includeOnlyEventsFromNowOn "tasksDueBefore:today+{{days}}"`
+`icalBuddy --includeOnlyEventsFromNowOn "tasksDueBefore:today+{{8}}"`
 
 - Show events in a time range:
 

--- a/pages/osx/indent.md
+++ b/pages/osx/indent.md
@@ -5,8 +5,8 @@
 
 - Format C/C++ source according to the Berkeley style:
 
-`indent {{path/to/source.c}} {{path/to/indented_source.c}} -nbad -nbap -bc -br -c33 -cd33 -cdb -ce -ci4 -cli0 -di16 -fc1 -fcb -i4 -ip -l75 -lp -npcs -nprs -psl -sc -nsob -ts8`
+`indent {{path/to/source_file.c}} {{path/to/indented_file.c}} -nbad -nbap -bc -br -c33 -cd33 -cdb -ce -ci4 -cli0 -di16 -fc1 -fcb -i4 -ip -l75 -lp -npcs -nprs -psl -sc -nsob -ts8`
 
 - Format C/C++ source according to the style of Kernighan & Ritchie (K&R):
 
-`indent {{path/to/source.c}} {{path/to/indented_source.c}} -nbad -bap -nbc -br -c33 -cd33 -ncdb -ce -ci4 -cli0 -cs -d0 -di1 -nfc1 -nfcb -i4 -nip -l75 -lp -npcs -nprs -npsl -nsc -nsob`
+`indent {{path/to/source_file.c}} {{path/to/indented_file.c}} -nbad -bap -nbc -br -c33 -cd33 -ncdb -ce -ci4 -cli0 -cs -d0 -di1 -nfc1 -nfcb -i4 -nip -l75 -lp -npcs -nprs -npsl -nsc -nsob`

--- a/pages/osx/launchctl.md
+++ b/pages/osx/launchctl.md
@@ -26,8 +26,8 @@
 
 - Manually run a known (loaded) agent/daemon, even if it is not the right time (note: this command uses the agent's label, rather than the filename):
 
-`launchctl start {{my_script}}`
+`launchctl start {{script_file}}`
 
 - Manually kill the process associated with a known agent/daemon, if it is running:
 
-`launchctl stop {{my_script}}`
+`launchctl stop {{script_file}}`

--- a/pages/osx/lipo.md
+++ b/pages/osx/lipo.md
@@ -5,16 +5,16 @@
 
 - Create a universal file from two single-architecture files:
 
-`lipo {{path/to/binary.x86_64}} {{path/to/binary.arm64e}} -create -output {{path/to/binary}}`
+`lipo {{path/to/binary_file.x86_64}} {{path/to/binary_file.arm64e}} -create -output {{path/to/binary_file}}`
 
 - List all architectures contained in a universal file:
 
-`lipo {{path/to/binary}} -archs`
+`lipo {{path/to/binary_file}} -archs`
 
 - Display detailed information about a universal file:
 
-`lipo {{path/to/binary}} -detailed_info`
+`lipo {{path/to/binary_file}} -detailed_info`
 
 - Extract a single-architecture file from a universal file:
 
-`lipo {{path/to/binary}} -thin {{arm64e}} -output {{path/to/binary.arm64e}}`
+`lipo {{path/to/binary_file}} -thin {{arm64e}} -output {{path/to/binary_file.arm64e}}`

--- a/pages/osx/notifyd.md
+++ b/pages/osx/notifyd.md
@@ -14,4 +14,4 @@
 
 - Log debug messages to an alternate log file:
 
-`notifyd -d -log_file {{path/to/log}}`
+`notifyd -d -log_file {{path/to/log_file}}`

--- a/pages/osx/readlink.md
+++ b/pages/osx/readlink.md
@@ -5,4 +5,4 @@
 
 - Print the absolute path which the symlink points to:
 
-`readlink {{path/to/symlink}}`
+`readlink {{path/to/symlink_file}}`

--- a/pages/osx/security.md
+++ b/pages/osx/security.md
@@ -21,12 +21,12 @@
 
 - Add a certificate from file to a [k]eychain (if -k isn't specified, the default keychain is used):
 
-`security add-certificates -k {{file.keychain}} {{path/to/cert.pem}}`
+`security add-certificates -k {{file.keychain}} {{path/to/cert_file.pem}}`
 
 - Add a CA certificate to the per-user Trust Settings:
 
-`security add-trusted-cert -k {{path/to/user-keychain.keychain-db}} {{path/to/ca-cert.pem}}`
+`security add-trusted-cert -k {{path/to/user-keychain.keychain-db}} {{path/to/ca-cert_file.pem}}`
 
 - Remove a CA certificate from the per-user Trust Settings:
 
-`security remove-trusted-cert {{path/to/ca-cert.pem}}`
+`security remove-trusted-cert {{path/to/ca-cert_file.pem}}`

--- a/pages/osx/sed.md
+++ b/pages/osx/sed.md
@@ -10,7 +10,7 @@
 
 - Execute a specific script [f]ile and print the result to `stdout`:
 
-`{{command}} | sed -f {{path/to/script.sed}}`
+`{{command}} | sed -f {{path/to/script_file.sed}}`
 
 - Replace all `apple` (extended regex) occurrences with `APPLE` (extended regex) in all input lines and print the result to `stdout`:
 

--- a/pages/osx/sips.md
+++ b/pages/osx/sips.md
@@ -10,11 +10,11 @@
 
 - Resample image at specified size, Image aspect ratio may be altered:
 
-`sips --resampleHeightWidth {{1920}} {{300}} {{image.ext}}`
+`sips --resampleHeightWidth {{1920}} {{300}} {{image_file.ext}}`
 
 - Resample image so height and width aren't greater than specified size (notice the capital Z):
 
-`sips --resampleHeightWidthMax {{1920}} {{300}} {{image.ext}}`
+`sips --resampleHeightWidthMax {{1920}} {{300}} {{image_file.ext}}`
 
 - Resample all images in a directory to fit a width of 960px (honoring aspect ratio):
 
@@ -26,4 +26,4 @@
 
 - Remove ColorSync ICC profile from an image:
 
-`sips --deleteProperty profile --deleteColorManagementProperties {{path/to/image.ext}}`
+`sips --deleteProperty profile --deleteColorManagementProperties {{path/to/image_file.ext}}`

--- a/pages/osx/systemsetup.md
+++ b/pages/osx/systemsetup.md
@@ -21,4 +21,4 @@
 
 - Specify a new startup disk:
 
-`systemsetup -setstartupdisk {{path}}`
+`systemsetup -setstartupdisk {{path/to/directory}}`

--- a/pages/osx/tail.md
+++ b/pages/osx/tail.md
@@ -6,15 +6,15 @@
 
 - Show last 'count' lines in file:
 
-`tail -n {{count}} {{path/to/file}}`
+`tail -n {{8}} {{path/to/file}}`
 
 - Print a file from a specific line number:
 
-`tail -n +{{count}} {{path/to/file}}`
+`tail -n +{{8}} {{path/to/file}}`
 
 - Print a specific count of bytes from the end of a given file:
 
-`tail -c {{count}} {{path/to/file}}`
+`tail -c {{8}} {{path/to/file}}`
 
 - Print the last lines of a given file and keep reading file until `Ctrl + C`:
 
@@ -26,4 +26,4 @@
 
 - Show last 'count' lines in 'file' and refresh every 'seconds' seconds:
 
-`tail -n {{count}} -s {{seconds}} -f {{path/to/file}}`
+`tail -n {{8}} -s {{10}} -f {{path/to/file}}`

--- a/pages/osx/tart.md
+++ b/pages/osx/tart.md
@@ -33,4 +33,4 @@
 
 - Change a VM's display resolution:
 
-`tart set {{vm-name}} --display {{width}}x{{height}}`
+`tart set {{vm-name}} --display {{640}}x{{400}}`

--- a/pages/osx/textutil.md
+++ b/pages/osx/textutil.md
@@ -5,20 +5,20 @@
 
 - Display information about `foo.rtf`:
 
-`textutil -info {{foo.rtf}}`
+`textutil -info {{path/to/foo.rtf}}`
 
 - Convert `foo.rtf` into `foo.html`:
 
-`textutil -convert {{html}} {{foo.rtf}}`
+`textutil -convert {{html}} {{path/to/foo.rtf}}`
 
 - Convert rich text to normal text:
 
-`textutil {{foo.rtf}} -convert {{txt}}`
+`textutil {{path/to/foo.rtf}} -convert {{txt}}`
 
 - Convert `foo.txt` into `foo.rtf`, using Times 10 for the font:
 
-`textutil -convert {{rtf}} -font {{Times}} -fontsize {{10}} {{foo.txt}}`
+`textutil -convert {{rtf}} -font {{Times}} -fontsize {{10}} {{path/to/foo.txt}}`
 
 - Load all RTF files in the current directory, concatenates their contents, and writes the result out as `index.html` with the HTML title set to "Several Files":
 
-`textutil -cat {{html}} -title "Several Files" -output {{index.html}} *.rtf`
+`textutil -cat {{html}} -title "Several Files" -output {{path/to/index.html}} *.rtf`

--- a/pages/osx/wacaw.md
+++ b/pages/osx/wacaw.md
@@ -9,11 +9,11 @@
 
 - Record a video:
 
-`wacaw --video {{filename}} --duration {{duration_in_seconds}}`
+`wacaw --video {{filename}} --duration {{10}}`
 
 - Take a picture with custom resolution:
 
-`wacaw --width {{width}} --height {{height}} {{filename}}`
+`wacaw --width {{width}} --height {{100}} {{filename}}`
 
 - Copy image just taken to clipboard:
 

--- a/pages/osx/whatis.md
+++ b/pages/osx/whatis.md
@@ -9,4 +9,4 @@
 
 - Search for information about multiple keywords:
 
-`whatis {{first_keyword}} {{second_keyword}}`
+`whatis {{keyword1}} {{keyword2}}`

--- a/pages/osx/xcode-select.md
+++ b/pages/osx/xcode-select.md
@@ -14,7 +14,7 @@
 
 - Select a given Xcode instance and use its developer directory as the active one:
 
-`xcode-select --switch {{path/to/Xcode.app}}`
+`xcode-select --switch {{path/to/Xcode_file.app}}`
 
 - Print the currently selected developer directory:
 

--- a/pages/osx/xml2man.md
+++ b/pages/osx/xml2man.md
@@ -5,12 +5,12 @@
 
 - Compile an MPGL file to a viewable man page:
 
-`xml2man {{path/to/command.mxml}}`
+`xml2man {{path/to/command_file.mxml}}`
 
 - Compile an MPGL file to a specific output file:
 
-`xml2man {{path/to/service.mxml}} {{path/to/service.7}}`
+`xml2man {{path/to/service_file.mxml}} {{path/to/service_file.7}}`
 
 - Compile an MPGL file to a specific output file, overwriting if it already exists:
 
-`xml2man -f {{path/to/function.mxml}} {{path/to/function.3}}`
+`xml2man -f {{path/to/function_file.mxml}} {{path/to/function_file.3}}`

--- a/pages/osx/xsltproc.md
+++ b/pages/osx/xsltproc.md
@@ -5,7 +5,7 @@
 
 - Transform an XML file with a specific XSLT stylesheet:
 
-`xsltproc --output {{path/to/output_file.html}} {{path/to/stylesheet_file.xslt}} {{path/to/xmlfile_file.xml}}`
+`xsltproc --output {{path/to/output_file.html}} {{path/to/stylesheet_file.xslt}} {{path/to/file.xml}}`
 
 - Pass a value to a parameter in the stylesheet:
 

--- a/pages/osx/xsltproc.md
+++ b/pages/osx/xsltproc.md
@@ -5,8 +5,8 @@
 
 - Transform an XML file with a specific XSLT stylesheet:
 
-`xsltproc --output {{output.html}} {{stylesheet.xslt}} {{xmlfile.xml}}`
+`xsltproc --output {{path/to/output_file.html}} {{path/to/stylesheet_file.xslt}} {{path/to/xmlfile_file.xml}}`
 
 - Pass a value to a parameter in the stylesheet:
 
-`xsltproc --output {{output.html}} --stringparam "{{name}}" "{{value}}" {{stylesheet.xslt}} {{xmlfile.xml}}`
+`xsltproc --output {{path/to/output_file.html}} --stringparam "{{name}}" "{{value}}" {{path/to/stylesheet_file.xslt}} {{path/to/xml_file.xml}}`

--- a/pages/osx/yaa.md
+++ b/pages/osx/yaa.md
@@ -5,24 +5,24 @@
 
 - Create an archive from a directory:
 
-`yaa archive -d {{path/to/directory}} -o {{path/to/output.yaa}}`
+`yaa archive -d {{path/to/directory}} -o {{path/to/output_file.yaa}}`
 
 - Create an archive from a file:
 
-`yaa archive -i {{path/to/file}} -o {{path/to/output.yaa}}`
+`yaa archive -i {{path/to/file}} -o {{path/to/output_file.yaa}}`
 
 - Extract an archive to the current directory:
 
-`yaa extract -i {{path/to/archive.yaa}}`
+`yaa extract -i {{path/to/archive_file.yaa}}`
 
 - List the contents of an archive:
 
-`yaa list -i {{path/to/archive.yaa}}`
+`yaa list -i {{path/to/archive_file.yaa}}`
 
 - Create an archive with a specific compression algorithm:
 
-`yaa archive -a {{algorithm}} -d {{path/to/directory}} -o {{path/to/output.yaa}}`
+`yaa archive -a {{algorithm}} -d {{path/to/directory}} -o {{path/to/output_file.yaa}}`
 
 - Create an archive with an 8 MB block size:
 
-`yaa archive -b {{8m}} -d {{path/to/directory}} -o {{path/to/output.yaa}}`
+`yaa archive -b {{8m}} -d {{path/to/directory}} -o {{path/to/output_file.yaa}}`


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/prototypes/pull/32
- https://github.com/command-line-interface-pages/cli-pages/pull/26

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
