### PR TITLE
sunos/*.md: make placeholders more compatible with CLIP

### DIFF
--- a/pages/sunos/prstat.md
+++ b/pages/sunos/prstat.md
@@ -21,4 +21,4 @@
 
 - Print out a list of top 5 CPU using processes every second:
 
-`prstat -c -n 5 -s cpu 1`
+`prstat -c -n {{5}} -s cpu {{1}}`

--- a/pages/sunos/snoop.md
+++ b/pages/sunos/snoop.md
@@ -10,11 +10,11 @@
 
 - Save captured packets in a file instead of displaying them:
 
-`snoop -o {{filename}}`
+`snoop -o {{path/to/file}}`
 
 - Display verbose protocol layer summary of packets from a file:
 
-`snoop -V -i {{filename}}`
+`snoop -V -i {{path/to/file}}`
 
 - Capture network packets that come from a hostname and go to a given port:
 
@@ -22,4 +22,4 @@
 
 - Capture and show a hex-dump of network packets exchanged between two IP addresses:
 
-`snoop -x0 -p4 {{ip_address_1}} {{ip_address_2}}`
+`snoop -x0 -p4 {{ip1}} {{ip2}}`

--- a/pages/sunos/svccfg.md
+++ b/pages/sunos/svccfg.md
@@ -5,12 +5,12 @@
 
 - Validate configuration file:
 
-`svccfg validate {{smf.xml}}`
+`svccfg validate {{path/to/smf_file.xml}}`
 
 - Export service configurations to file:
 
-`svccfg export {{servicename}} > {{smf.xml}}`
+`svccfg export {{servicename}} > {{path/to/smf_file.xml}}`
 
 - Import/update service configurations from file:
 
-`svccfg import {{smf.xml}}`
+`svccfg import {{path/to/smf_file.xml}}`


### PR DESCRIPTION
- use placeholders for numbers
- use "path/to" and "file": missing "file" suffix breaks placeholder conversion
- simplify ip placeholders: existing "_address" suffix breaks placeholder conversion

These changes are compatible with [this](https://github.com/command-line-interface-pages/prototypes/pull/32) version of TlDr -> CLIP converter and used [here](https://github.com/command-line-interface-pages/cli-pages/pull/27).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
