### PR TITLE
gcc: fix typo

### DIFF
--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -3,7 +3,7 @@
 > Preprocess and compile C and C++ source files, then assemble and link them together.
 > More information: <https://gcc.gnu.org>.
 
-- Compile multiple source files into executable:
+- Compile multiple source files into an executable:
 
 `gcc {{path/to/source1.c path/to/source2.c ...}} -o {{path/to/output_executable}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):12.2.1**
