### PR TITLE
windows/*.md: make placeholders more compatible with CLIP ones

### DIFF
--- a/pages/windows/azcopy.md
+++ b/pages/windows/azcopy.md
@@ -9,11 +9,11 @@
 
 - Upload a local file:
 
-`azcopy copy '{{path/to/source/file}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}/{{blob_name}}'`
+`azcopy copy '{{path\to\source_file}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}/{{blob_name}}'`
 
 - Upload files with `.txt` and `.jpg` extensions:
 
-`azcopy copy '{{path/to/source}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}' --include-pattern '{{*.txt;*.jpg}}'`
+`azcopy copy '{{path\to\source_directory}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}' --include-pattern '{{*.txt;*.jpg}}'`
 
 - Copy a container directly between two Azure storage accounts:
 
@@ -21,7 +21,7 @@
 
 - Synchronize a local directory and delete files in the destination if they no longer exist in the source:
 
-`azcopy sync '{{path/to/source}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}' --recursive --delete-destination=true`
+`azcopy sync '{{path\to\source_directory}}' 'https://{{storage_account_name}}.blob.core.windows.net/{{container_name}}' --recursive --delete-destination=true`
 
 - Display detailed usage information:
 

--- a/pages/windows/choco-install.md
+++ b/pages/windows/choco-install.md
@@ -5,15 +5,15 @@
 
 - Install one or more space-separated packages:
 
-`choco install {{package(s)}}`
+`choco install {{package1 package2 ...}}`
 
 - Install packages from a custom configuration file:
 
-`choco install {{path/to/packages.config}}`
+`choco install {{path\to\packages_file.config}}`
 
 - Install a specific nuspec or nupkg file:
 
-`choco install {{path/to/file}}`
+`choco install {{path\to\file}}`
 
 - Install a specific version of a package:
 

--- a/pages/windows/choco-pack.md
+++ b/pages/windows/choco-pack.md
@@ -5,12 +5,12 @@
 
 - Package a NuGet specification to a nupkg file:
 
-`choco pack {{path/to/specification}}`
+`choco pack {{path\to\specification_file}}`
 
 - Package a NuGet specification specifying the version of the resulting file:
 
-`choco pack {{path/to/specification}} --version {{version}}`
+`choco pack {{path\to\specification_file}} --version {{version}}`
 
 - Package a NuGet specification to a specific directory:
 
-`choco pack {{path/to/specification}} --output-directory {{path/to/output_directory}}`
+`choco pack {{path\to\specification_file}} --output-directory {{path\to\output_directory}}`

--- a/pages/windows/choco-source.md
+++ b/pages/windows/choco-source.md
@@ -17,7 +17,7 @@
 
 - Add a new package source with a client certificate:
 
-`choco source add --name {{name}} --source {{url}} --cert {{path/to/certificate}}`
+`choco source add --name {{name}} --source {{url}} --cert {{path\to\certificate_file}}`
 
 - Enable a package source:
 

--- a/pages/windows/choco-uninstall.md
+++ b/pages/windows/choco-uninstall.md
@@ -5,7 +5,7 @@
 
 - Uninstall one or more space-separated packages:
 
-`choco uninstall {{package(s)}}`
+`choco uninstall {{package1 package2 ...}}`
 
 - Uninstall a specific version of a package:
 

--- a/pages/windows/choco-upgrade.md
+++ b/pages/windows/choco-upgrade.md
@@ -5,7 +5,7 @@
 
 - Upgrade one or more space-separated packages:
 
-`choco upgrade {{package(s)}}`
+`choco upgrade {{package1 package2 ...}}`
 
 - Upgrade to a specific version of a package:
 
@@ -17,7 +17,7 @@
 
 - Upgrade all except specified comma-separated packages:
 
-`choco upgrade all --except "{{package(s)}}"`
+`choco upgrade all --except "{{package1 package2 ...}}"`
 
 - Confirm all prompts automatically:
 

--- a/pages/windows/cipher.md
+++ b/pages/windows/cipher.md
@@ -5,16 +5,16 @@
 
 - Display information about a specific encrypted file or directory:
 
-`cipher /c:{{path/to/file_or_directory}}`
+`cipher /c:{{path\to\file_or_directory}}`
 
 - [e]ncrypt a file or directory (files added later to the directory are also encrypted as the directory is marked):
 
-`cipher /e:{{path/to/file_or_directory}}`
+`cipher /e:{{path\to\file_or_directory}}`
 
 - [d]ecrypt a file or directory:
 
-`cipher /d:{{path/to/file_or_directory}}`
+`cipher /d:{{path\to\file_or_directory}}`
 
 - Securely remove a file or directory:
 
-`cipher /w:{{path/to/file_or_directory}}`
+`cipher /w:{{path\to\file_or_directory}}`

--- a/pages/windows/clip.md
+++ b/pages/windows/clip.md
@@ -9,7 +9,7 @@
 
 - Copy the contents of a file to the Windows clipboard:
 
-`clip < {{path/to/file.ext}}`
+`clip < {{path\to\file.ext}}`
 
 - Copy text with a trailing newline to the Windows clipboard:
 

--- a/pages/windows/cmd.md
+++ b/pages/windows/cmd.md
@@ -13,7 +13,7 @@
 
 - Execute a specific script:
 
-`cmd {{path/to/script.bat}}`
+`cmd {{path\to\script.bat}}`
 
 - Execute specific commands and then enter an interactive shell:
 

--- a/pages/windows/cmstp.md
+++ b/pages/windows/cmstp.md
@@ -5,32 +5,32 @@
 
 - Install a specific profile:
 
-`cmstp "{{path/to/profile}}"`
+`cmstp "{{path\to\profile_file}}"`
 
 - Install without creating a desktop shortcut:
 
-`cmstp /ns "{{path/to/profile}}"`
+`cmstp /ns "{{path\to\profile_file}}"`
 
 - Install without checking for dependencies:
 
-`cmstp /nf "{{path/to/profile}}"`
+`cmstp /nf "{{path\to\profile_file}}"`
 
 - Only install for the current user:
 
-`cmstp /su "{{path/to/profile}}"`
+`cmstp /su "{{path\to\profile_file}}"`
 
 - Install for all users (requires administrator privileges):
 
-`cmstp /au "{{path/to/profile}}"`
+`cmstp /au "{{path\to\profile_file}}"`
 
 - Install silently without any prompts:
 
-`cmstp /s "{{path/to/profile}}"`
+`cmstp /s "{{path\to\profile_file}}"`
 
 - Uninstall a specific profile:
 
-`cmstp /u "{{path/to/profile}}"`
+`cmstp /u "{{path\to\profile_file}}"`
 
 - Uninstall silently without a confirmation prompt:
 
-`cmstp /u /s "{{path/to/profile}}"`
+`cmstp /u /s "{{path\to\profile_file}}"`

--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -10,28 +10,28 @@
 
 - Compare two specified files:
 
-`comp {{path/to/file_1}} {{path/to/file_2}}`
+`comp {{path\to\file1}} {{path\to\file2}}`
 
 - Compare two sets of files:
 
-`comp {{path/to/directory_1/*}} {{path/to/directory_2/*}}`
+`comp {{path\to\directory1}}\* {{path\to\directory2}}\*`
 
 - Display differences in decimal format:
 
-`comp /d {{path/to/file_1}} {{path/to/file_2}}`
+`comp /d {{path\to\file1}} {{path\to\file2}}`
 
 - Display differences in ASCII format:
 
-`comp /a {{path/to/file_1}} {{path/to/file_2}}`
+`comp /a {{path\to\file1}} {{path\to\file2}}`
 
 - Display line numbers for differences:
 
-`comp /l {{path/to/file_1}} {{path/to/file_2}}`
+`comp /l {{path\to\file1}} {{path\to\file2}}`
 
 - Compare files case-insensitively:
 
-`comp /c {{path/to/file_1}} {{path/to/file_2}}`
+`comp /c {{path\to\file1}} {{path\to\file2}}`
 
 - Compare only the first 5 lines of each file:
 
-`comp /n={{5}} {{path/to/file_1}} {{path/to/file_2}}`
+`comp /n={{5}} {{path\to\file1}} {{path\to\file2}}`

--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -9,7 +9,7 @@
 
 - Show the contents of a given directory:
 
-`dir {{path/to/directory}}`
+`dir {{path\to\directory}}`
 
 - Show the contents of the current directory, including hidden ones:
 
@@ -17,4 +17,4 @@
 
 - Show the contents of a given directory, including hidden ones:
 
-`dir {{path/to/directory}} /A`
+`dir {{path\to\directory}} /A`

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -25,8 +25,8 @@
 
 - Save macros to a file for portability:
 
-`doskey /macros > {{macinit}}`
+`doskey /macros > {{path/to/macinit_file}}`
 
 - Load macros from a file:
 
-`doskey /macrofile = {{macinit}}`
+`doskey /macrofile = {{path/to/macinit_file}}`

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -25,7 +25,7 @@
 
 - Save macros to a file for portability:
 
-`doskey /macros > {{path/to/macinit_file}}`
+`doskey /macros > {{path\to\macinit_file}}`
 
 - Load macros from a file:
 

--- a/pages/windows/doskey.md
+++ b/pages/windows/doskey.md
@@ -29,4 +29,4 @@
 
 - Load macros from a file:
 
-`doskey /macrofile = {{path/to/macinit_file}}`
+`doskey /macrofile = {{path\to\macinit_file}}`

--- a/pages/windows/exit.md
+++ b/pages/windows/exit.md
@@ -13,4 +13,4 @@
 
 - Quit using a specific exit code:
 
-`exit {{exit_code}}`
+`exit {{2}}`

--- a/pages/windows/expand.md
+++ b/pages/windows/expand.md
@@ -5,20 +5,20 @@
 
 - Uncompress a single-file Cabinet file to the specified directory:
 
-`expand {{path/to/file.cab}} {{path/to/directory}}`
+`expand {{path\to\file.cab}} {{path\to\directory}}`
 
 - Display the list of files in a source Cabinet file:
 
-`expand {{path/to/file.cab}} {{path/to/directory}} -d`
+`expand {{path\to\file.cab}} {{path\to\directory}} -d`
 
 - Uncompress all files from the Cabinet file:
 
-`expand {{path/to/file.cab}} {{path/to/directory}} -f:*`
+`expand {{path\to\file.cab}} {{path\to\directory}} -f:*`
 
 - Uncompress a specific file from a Cabinet file:
 
-`expand {{path/to/file.cab}} {{path/to/directory}} -f:{{file}}`
+`expand {{path\to\file.cab}} {{path\to\directory}} -f:{{path\to\file}}`
 
 - Ignore the directory structure when uncompressing, and add them to a single directory:
 
-`expand {{path/to/file.cab}} {{path/to/directory}} -i`
+`expand {{path\to\file.cab}} {{path\to\directory}} -i`

--- a/pages/windows/explorer.md
+++ b/pages/windows/explorer.md
@@ -13,4 +13,4 @@
 
 - Open Windows Explorer in a specific directory:
 
-`explorer {{path/to/directory}}`
+`explorer {{path\to\directory}}`

--- a/pages/windows/fc.md
+++ b/pages/windows/fc.md
@@ -6,28 +6,28 @@
 
 - Compare 2 specified files:
 
-`fc {{path/to/file_1}} {{path/to/file_2}}`
+`fc {{path\to\file1}} {{path\to\file2}}`
 
 - Perform a case-insensitive comparison:
 
-`fc /c {{path/to/file_1}} {{path/to/file_2}}`
+`fc /c {{path\to\file1}} {{path\to\file2}}`
 
 - Compare files as Unicode text:
 
-`fc /u {{path/to/file_1}} {{path/to/file_2}}`
+`fc /u {{path\to\file1}} {{path\to\file2}}`
 
 - Compare files as ASCII text:
 
-`fc /l {{path/to/file_1}} {{path/to/file_2}}`
+`fc /l {{path\to\file1}} {{path\to\file2}}`
 
 - Compare files as binary:
 
-`fc /b {{path/to/file_1}} {{path/to/file_2}}`
+`fc /b {{path\to\file1}} {{path\to\file2}}`
 
 - Disable tab-to-space expansion:
 
-`fc /t {{path/to/file_1}} {{path/to/file_2}}`
+`fc /t {{path\to\file1}} {{path\to\file2}}`
 
 - Compress whitespace (tabs and spaces) for comparisons:
 
-`fc /w {{path/to/file_1}} {{path/to/file_2}}`
+`fc /w {{path\to\file1}} {{path\to\file2}}`

--- a/pages/windows/find.md
+++ b/pages/windows/find.md
@@ -5,16 +5,16 @@
 
 - Find lines that contain a specified string:
 
-`find "{{string}}" {{path/to/file_or_directory}}`
+`find "{{string}}" {{path\to\file_or_directory}}`
 
 - Display lines that do not contain the specified string:
 
-`find "{{string}}" {{path/to/file_or_directory}} /v`
+`find "{{string}}" {{path\to\file_or_directory}} /v`
 
 - Display the count of lines that contain the specified string:
 
-`find "{{string}}" {{path/to/file_or_directory}} /c`
+`find "{{string}}" {{path\to\file_or_directory}} /c`
 
 - Display line numbers with the list of lines:
 
-`find "{{string}}" {{path/to/file_or_directory}} /n`
+`find "{{string}}" {{path\to\file_or_directory}} /n`

--- a/pages/windows/for.md
+++ b/pages/windows/for.md
@@ -13,11 +13,11 @@
 
 - Iterate over a given list of files:
 
-`for %{{variable}} in ({{file_a.ext file_b.ext file_c.ext}}) do ({{echo Loop is executed}})`
+`for %{{variable}} in ({{path\to\file1.ext path\to\file2.ext ...}}) do ({{echo Loop is executed}})`
 
 - Iterate over a given list of directories:
 
-`for /d %{{variable}} in ({{directory_a/ directory_b/ directory_c/}}) do ({{echo Loop is executed}})`
+`for /d %{{variable}} in ({{path\to\directory1.ext path\to\directory2.ext ...}}) do ({{echo Loop is executed}})`
 
 - Perform a given command in every directory:
 

--- a/pages/windows/forfiles.md
+++ b/pages/windows/forfiles.md
@@ -9,7 +9,7 @@
 
 - Search for files in a specific directory:
 
-`forfiles /p {{path/to/directory}}`
+`forfiles /p {{path\to\directory}}`
 
 - Run the specified command for each file:
 
@@ -25,4 +25,4 @@
 
 - Search for files older than 5 days:
 
-`forfiles /d {{+5}}`
+`forfiles /d +{{5}}`

--- a/pages/windows/ftp.md
+++ b/pages/windows/ftp.md
@@ -17,7 +17,7 @@
 
 - Run a file containing a list of FTP commands:
 
-`ftp -s:{{path/to/file}} {{host}}`
+`ftp -s:{{path\to\file}} {{host}}`
 
 - Download multiple files (glob expression):
 

--- a/pages/windows/ftype.md
+++ b/pages/windows/ftype.md
@@ -13,4 +13,4 @@
 
 - Set the associated program for a specific file type:
 
-`ftype {{file_type}}="{{path/to/executable_command}}"`
+`ftype {{file_type}}="{{path/to/executable_file}}"`

--- a/pages/windows/get-acl.md
+++ b/pages/windows/get-acl.md
@@ -6,7 +6,7 @@
 
 - Display the ACL for a specific directory:
 
-`Get-Acl {{path/to/directory}}`
+`Get-Acl {{path\to\directory}}`
 
 - Get an ACL for a registry key:
 

--- a/pages/windows/get-childitem.md
+++ b/pages/windows/get-childitem.md
@@ -22,4 +22,4 @@
 
 - List items in a directory other than the current one:
 
-`Get-ChildItem -Path {{path/to/directory}}`
+`Get-ChildItem -Path {{path\to\directory}}`

--- a/pages/windows/get-content.md
+++ b/pages/windows/get-content.md
@@ -6,12 +6,12 @@
 
 - Display the content of a file:
 
-`Get-Content -Path {{path/to/file}}`
+`Get-Content -Path {{path\to\file}}`
 
 - Display the first few lines of a file:
 
-`Get-Content -Path {{path/to/file}} -TotalCount {{count}}`
+`Get-Content -Path {{path\to\file}} -TotalCount {{10}}`
 
 - Display the content of the file and keep reading from it until `Ctrl + C` is pressed:
 
-`Get-Content -Path {{path/to/file}} -Wait`
+`Get-Content -Path {{path\to\file}} -Wait`

--- a/pages/windows/get-filehash.md
+++ b/pages/windows/get-filehash.md
@@ -6,8 +6,8 @@
 
 - Calculate a hash for a specified file using the SHA256 algorithm:
 
-`Get-FileHash {{path/to/file}}`
+`Get-FileHash {{path\to\file}}`
 
 - Calculate a hash for a specified file using a specified algorithm:
 
-`Get-FileHash {{path/to/file}} -Algorithm {{SHA1|SHA384|SHA256|SHA512|MD5}}`
+`Get-FileHash {{path\to\file}} -Algorithm {{SHA1|SHA384|SHA256|SHA512|MD5}}`

--- a/pages/windows/get-history.md
+++ b/pages/windows/get-history.md
@@ -14,4 +14,4 @@
 
 - Display the last N commands:
 
-`Get-History -Count {{count}}`
+`Get-History -Count {{10}}`

--- a/pages/windows/if.md
+++ b/pages/windows/if.md
@@ -17,7 +17,7 @@
 
 - Check whether `%errorlevel%` is greater than or equal to the specified exit code:
 
-`if errorlevel {{exit_code}} ({{echo Condition is true}})`
+`if errorlevel {{2}} ({{echo Condition is true}})`
 
 - Check whether two strings are equal:
 
@@ -29,4 +29,4 @@
 
 - Check whether a file exist:
 
-`if exist {{path/to/file}} ({{echo Condition is true}})`
+`if exist {{path\to\file}} ({{echo Condition is true}})`

--- a/pages/windows/invoke-item.md
+++ b/pages/windows/invoke-item.md
@@ -6,24 +6,24 @@
 
 - Open a file in its default program:
 
-`Invoke-Item -Path {{path/to/file}}`
+`Invoke-Item -Path {{path\to\file}}`
 
 - Open all files inside a directory:
 
-`Invoke-Item -Path {{path/to/directory/*}}`
+`Invoke-Item -Path {{path\to\directory}}\*`
 
 - Open all PNGs inside a directory:
 
-`Invoke-Item -Path {{path/to/directory/*.png}}`
+`Invoke-Item -Path {{path\to\directory}}\*.png`
 
 - Open all files inside a directory containing a specific keyword:
 
-`Invoke-Item -Path {{path/to/directory/*}} -Include {{*keyword*}}`
+`Invoke-Item -Path {{path\to\directory}}\* -Include {{*keyword*}}`
 
 - Open all files inside a directory except those containing a specific keyword:
 
-`Invoke-Item -Path {{path/to/directory/*}} -Exclude {{*keyword*}}`
+`Invoke-Item -Path {{path\to\directory}}\* -Exclude {{*keyword*}}`
 
 - Perform a dry run to determine which files will be opened inside a directory through `Invoke-Item`:
 
-`Invoke-Item -Path {{path/to/directory/*}} -WhatIf`
+`Invoke-Item -Path {{path\to\directory}}\* -WhatIf`

--- a/pages/windows/invoke-webrequest.md
+++ b/pages/windows/invoke-webrequest.md
@@ -6,7 +6,7 @@
 
 - Download the contents of a URL to a file:
 
-`Invoke-WebRequest {{http://example.com}} -OutFile {{filename}}`
+`Invoke-WebRequest {{http://example.com}} -OutFile {{path\to\file}}`
 
 - Send form-encoded data (POST request of type `application/x-www-form-urlencoded`):
 

--- a/pages/windows/iscc.md
+++ b/pages/windows/iscc.md
@@ -6,12 +6,12 @@
 
 - Compile an Inno Setup script:
 
-`iscc {{path/to/file.iss}}`
+`iscc {{path\to\file.iss}}`
 
 - Quietly compile an Inno Setup installer:
 
-`iscc /Q {{path/to/file.iss}}`
+`iscc /Q {{path\to\file.iss}}`
 
 - Compile a signed Inno Setup installer:
 
-`iscc /S={{name}}={{command}} {{path/to/file.iss}}`
+`iscc /S={{name}}={{command}} {{path\to\file.iss}}`

--- a/pages/windows/measure-object.md
+++ b/pages/windows/measure-object.md
@@ -10,4 +10,4 @@
 
 - Pipe input to Measure-Command (objects that are piped to `Measure-Command` are available to the script block that is passed to the Expression parameter):
 
-`"One", "Two", "Three", "Four" | Set-Content -Path "{{path/to/file}}"; Get-Content "{{path/to/file}}"; | Measure-Object -Character -Line -Word`
+`"One", "Two", "Three", "Four" | Set-Content -Path "{{path\to\file}}"; Get-Content "{{path\to\file}}"; | Measure-Object -Character -Line -Word`

--- a/pages/windows/mkdir.md
+++ b/pages/windows/mkdir.md
@@ -5,8 +5,8 @@
 
 - Create a directory:
 
-`mkdir {{path/to/directory}}`
+`mkdir {{path\to\directory}}`
 
 - Create a nested directory tree recursively:
 
-`mkdir {{path/to/sub_directory}}`
+`mkdir {{path\to\sub_directory}}`

--- a/pages/windows/mklink.md
+++ b/pages/windows/mklink.md
@@ -5,16 +5,16 @@
 
 - Create a symbolic link to a file:
 
-`mklink {{path/to/link}} {{path/to/source_file}}`
+`mklink {{path\to\link_file}} {{path\to\source_file}}`
 
 - Create a symbolic link to a directory:
 
-`mklink /d {{path/to/link}} {{path/to/source_directory}}`
+`mklink /d {{path\to\link_file}} {{path\to\source_directory}}`
 
 - Create a hard link to a file:
 
-`mklink /h {{path/to/link}} {{path/to/source_file}}`
+`mklink /h {{path\to\link_file}} {{path\to\source_file}}`
 
 - Create a directory junction:
 
-`mklink /j {{path/to/link}} {{path/to/source_file}}`
+`mklink /j {{path\to\link_file}} {{path\to\source_file}}`

--- a/pages/windows/more.md
+++ b/pages/windows/more.md
@@ -9,23 +9,23 @@
 
 - Display paginated output from one or more files:
 
-`more {{path/to/file}}`
+`more {{path\to\file}}`
 
 - Convert tabs to the specified number of spaces:
 
-`more {{path/to/file}} /t{{spaces}}`
+`more {{path\to\file}} /t{{spaces}}`
 
 - Clear the screen before displaying the page:
 
-`more {{path/to/file}} /c`
+`more {{path\to\file}} /c`
 
 - Display the output starting at line 5:
 
-`more {{path/to/file}} +{{5}}`
+`more {{path\to\file}} +{{5}}`
 
 - Enable extended interactive mode (see help for usage):
 
-`more {{path/to/file}} /e`
+`more {{path\to\file}} /e`
 
 - Display full usage information:
 

--- a/pages/windows/msg.md
+++ b/pages/windows/msg.md
@@ -21,4 +21,4 @@
 
 - Set a delay in seconds for a message:
 
-`msg /time:{{seconds}}`
+`msg /time:{{10}}`

--- a/pages/windows/msiexec.md
+++ b/pages/windows/msiexec.md
@@ -5,7 +5,7 @@
 
 - Install a program from its MSI package:
 
-`msiexec /package {{path/to/file.msi}}`
+`msiexec /package {{path\to\file.msi}}`
 
 - Install a MSI package from a website:
 
@@ -13,8 +13,8 @@
 
 - Install a MSP patch file:
 
-`msiexec /update {{path/to/file.msp}}`
+`msiexec /update {{path\to\file.msp}}`
 
 - Uninstall a program or patch using their respective MSI or MSP file:
 
-`msiexec /uninstall {{path/to/file}}`
+`msiexec /uninstall {{path\to\file}}`

--- a/pages/windows/pabcnetcclear.md
+++ b/pages/windows/pabcnetcclear.md
@@ -5,20 +5,20 @@
 
 - Compile the specified source file into an executable with the same name:
 
-`pabcnetcclear {{path/to/source_file.pas}}`
+`pabcnetcclear {{path\to\source_file.pas}}`
 
 - Compile the specified source file into an executable with the specified name:
 
-`pabcnetcclear /Output:{{path/to/file.exe}} {{path/to/source_file.pas}}`
+`pabcnetcclear /Output:{{path\to\_file.exe}} {{path\to\source_file.pas}}`
 
 - Compile the specified source file into an executable with the same name along with/without debug information:
 
-`pabcnetcclear /Debug:{{0|1}} {{path/to/source_file.pas}}`
+`pabcnetcclear /Debug:{{0|1}} {{path\to\source_file.pas}}`
 
 - Allow units to be searched in the specified path while compiling the source file into an executable with the same name:
 
-`pabcnetcclear /SearchDir:{{path/to/dir}} {{path/to/source_file.pas}}`
+`pabcnetcclear /SearchDir:{{path\to\directory}} {{path\to\source_file.pas}}`
 
 - Compile the specified source file into an executable, defining a symbol:
 
-`pabcnetcclear /Define:{{symbol}} {{path/to/source_file.pas}}`
+`pabcnetcclear /Define:{{symbol}} {{path\to\source_file.pas}}`

--- a/pages/windows/path.md
+++ b/pages/windows/path.md
@@ -9,11 +9,11 @@
 
 - Set the path to one or more semicolon-separated directories:
 
-`path {{path/to/directory(s)}}`
+`path {{path\to\directory1 path\to\directory2 ...}}`
 
 - Append a new directory to the original path:
 
-`path {{path/to/directory}};%path%`
+`path {{path\to\directory}};%path%`
 
 - Set command prompt to only search the current directory for executables:
 

--- a/pages/windows/pipwin.md
+++ b/pages/windows/pipwin.md
@@ -21,8 +21,8 @@
 
 - Download a package to a specific directory:
 
-`pipwin download --dest {{path/to/directory}} {{package_name}}`
+`pipwin download --dest {{path\to\directory}} {{package_name}}`
 
 - Install packages according to `requirements.txt`:
 
-`pipwin install --file {{path/to/requirements.txt}}`
+`pipwin install --file {{path\to\requirements.txt}}`

--- a/pages/windows/print.md
+++ b/pages/windows/print.md
@@ -5,8 +5,8 @@
 
 - Print a text file to the default printer:
 
-`print {{path/to/file}}`
+`print {{path\to\file}}`
 
 - Print a text file to a specific printer:
 
-`print /d:{{printer}} {{path/to/file}}`
+`print /d:{{printer}} {{path\to\file}}`

--- a/pages/windows/psexec.md
+++ b/pages/windows/psexec.md
@@ -14,7 +14,7 @@
 
 - Execute a command remotely and output the result to a file:
 
-`psexec \\{{remote_host}} cmd /c {{command}} -an ^>{{path/to/file.txt}}`
+`psexec \\{{remote_host}} cmd /c {{command}} -an ^>{{path\to\file.txt}}`
 
 - Execute a program to interact with users:
 

--- a/pages/windows/pushd.md
+++ b/pages/windows/pushd.md
@@ -6,4 +6,4 @@
 
 - Switch to directory and push it on the stack:
 
-`pushd {{path/to/directory}}`
+`pushd {{path\to\directory}}`

--- a/pages/windows/rdpsign.md
+++ b/pages/windows/rdpsign.md
@@ -5,20 +5,20 @@
 
 - Sign an RDP file:
 
-`rdpsign {{path/to/file.rdp}}`
+`rdpsign {{path\to\file.rdp}}`
 
 - Sign an RDP file using a specific sha256 hash:
 
-`rdpsign {{path/to/file.rdp}} /sha265 {{hash}}`
+`rdpsign {{path\to\file.rdp}} /sha265 {{hash}}`
 
 - Enable quiet output:
 
-`rdpsign {{path/to/file.rdp}} /q`
+`rdpsign {{path\to\file.rdp}} /q`
 
 - Display verbose warnings, messages and statuses:
 
-`rdpsign {{path/to/file.rdp}} /v`
+`rdpsign {{path\to\file.rdp}} /v`
 
 - Test the signing by displaying the output to `stdout` without updating the file:
 
-`rdpsign {{path/to/file.rdp}} /l`
+`rdpsign {{path\to\file.rdp}} /l`

--- a/pages/windows/reg-export.md
+++ b/pages/windows/reg-export.md
@@ -5,8 +5,8 @@
 
 - Export all sub keys and values of a specific key:
 
-`reg export {{key_name}} {{path/to/file.reg}}`
+`reg export {{key_name}} {{path\to\file.reg}}`
 
 - Force overwriting of an existing file without prompt:
 
-`reg export {{key_name}} {{path/to/file.reg}} /y`
+`reg export {{key_name}} {{path\to\file.reg}} /y`

--- a/pages/windows/reg-import.md
+++ b/pages/windows/reg-import.md
@@ -5,4 +5,4 @@
 
 - Import all keys, subkeys and values from a file:
 
-`reg import {{path/to/file.reg}}`
+`reg import {{path\to\file.reg}}`

--- a/pages/windows/reg-load.md
+++ b/pages/windows/reg-load.md
@@ -6,4 +6,4 @@
 
 - Load a backup file into the specified key:
 
-`reg load {{key_name}} {{path/to/file}}`
+`reg load {{key_name}} {{path\to\file}}`

--- a/pages/windows/reg-restore.md
+++ b/pages/windows/reg-restore.md
@@ -6,4 +6,4 @@
 
 - Overwrite a specified key with data from a backup file:
 
-`reg restore {{key_name}} {{path/to/file}}`
+`reg restore {{key_name}} {{path\to\file}}`

--- a/pages/windows/reg-save.md
+++ b/pages/windows/reg-save.md
@@ -5,8 +5,8 @@
 
 - Save a registry key, its sub keys and values to a specific file:
 
-`reg save {{key_name}} {{path/to/file}}`
+`reg save {{key_name}} {{path\to\file}}`
 
 - Forcefully overwrite an existing file without a prompt:
 
-`reg save {{key_name}} {{path/to/file}} /y`
+`reg save {{key_name}} {{path\to\file}} /y`

--- a/pages/windows/repair-bde.md
+++ b/pages/windows/repair-bde.md
@@ -13,7 +13,7 @@
 
 - Attempt to repair a specified volume using the provided recovery key file:
 
-`repair-bde {{C:}} -RecoveryKey {{path/to/file.bek}}`
+`repair-bde {{C:}} -RecoveryKey {{path\to\file.bek}}`
 
 - Attempt to repair a specified volume using the provided numerical recovery password:
 
@@ -25,11 +25,11 @@
 
 - Attempt to repair a specified volume using the provided key package:
 
-`repair-bde {{C:}} -KeyPackage {{path/to/directory}}`
+`repair-bde {{C:}} -KeyPackage {{path\to\directory}}`
 
 - Log all output to a specific file:
 
-`repair-bde {{C:}} -LogFile {{path/to/file}}`
+`repair-bde {{C:}} -LogFile {{path\to\file}}`
 
 - Display all available options:
 

--- a/pages/windows/replace.md
+++ b/pages/windows/replace.md
@@ -6,31 +6,31 @@
 
 - Replace the destination file with the one from the source directory:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}}`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}}`
 
 - Add files to the destination directory instead of replacing existing files:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /a`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /a`
 
 - Interactively copy multiple files, with a prompt before replacing or adding a destination file:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /p`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /p`
 
 - Replace even read only files:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /r`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /r`
 
 - Wait for you to insert a disk before it replaces files (originally to allow inserting a floppy disk):
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /w`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /w`
 
 - Replace all files in subdirectories of the destination:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /s`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /s`
 
 - Replace only files in the destination directory which are older than the files in the source directory:
 
-`replace {{path/to/file_or_directory}} {{path/to/destination}} /u`
+`replace {{path\to\file_or_directory}} {{path\to\destination_directory}} /u`
 
 - Display detailed usage information:
 

--- a/pages/windows/resolve-path.md
+++ b/pages/windows/resolve-path.md
@@ -10,8 +10,8 @@
 
 - Resolve a UNC path:
 
-`Resolve-Path -Path "\\{{hostname}}\{{path/to/file}}"`
+`Resolve-Path -Path "\\{{hostname}}\{{path\to\file}}"`
 
 - Get relative paths:
 
-`Resolve-Path -Path {{path/to/file_or_directory}} -Relative`
+`Resolve-Path -Path {{path\to\file_or_directory}} -Relative`

--- a/pages/windows/rmdir.md
+++ b/pages/windows/rmdir.md
@@ -5,12 +5,12 @@
 
 - Remove an empty directory:
 
-`rmdir {{path/to/directory}}`
+`rmdir {{path\to\directory}}`
 
 - Remove a directory and its contents recursively:
 
-`rmdir {{path/to/directory}} /s`
+`rmdir {{path\to\directory}} /s`
 
 - Remove a directory and its contents recursively without prompting:
 
-`rmdir {{path/to/directory}} /s /q`
+`rmdir {{path\to\directory}} /s /q`

--- a/pages/windows/robocopy.md
+++ b/pages/windows/robocopy.md
@@ -6,27 +6,27 @@
 
 - Copy all `.jpg` and `.bmp` files from one directory to another:
 
-`robocopy {{path/to/source}} {{path/to/destination}} {{*.jpg}} {{*.bmp}}`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} {{*.jpg}} {{*.bmp}}`
 
 - Copy all files and subdirectories, including empty ones:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /E`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} /E`
 
 - Mirror/Sync a directory, deleting anything not in source and include all attributes and permissions:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /MIR /COPYALL`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} /MIR /COPYALL`
 
 - Copy all files and subdirectories, excluding source files that are older than destination files:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /E /XO`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} /E /XO`
 
 - List all files 50 MB or larger instead of copying them:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /MIN:{{52428800}} /L`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} /MIN:{{52428800}} /L`
 
 - Allow resuming if network connection is lost and limit retries to 5 and wait time to 15 sec:
 
-`robocopy {{path/to/source}} {{path/to/destination}} /Z /R:5 /W:15`
+`robocopy {{path\to\source_directory}} {{path\to\destination_directory}} /Z /R:5 /W:15`
 
 - Display detailed usage information:
 

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -7,11 +7,11 @@
 
 - Search for a pattern within a file:
 
-`Select-String -Path "{{path/to/file}}" -Pattern '{{search_pattern}}'`
+`Select-String -Path "{{path\to\file}}" -Pattern '{{search_pattern}}'`
 
 - Search for an exact string (disables regular expressions):
 
-`Select-String -SimpleMatch "{{exact_string}}" {{path/to/file}}`
+`Select-String -SimpleMatch "{{exact_string}}" {{path\to\file}}`
 
 - Search for pattern in all `.ext` files in current dir:
 
@@ -19,8 +19,8 @@
 
 - Capture the specified number of lines before and after the line that matches the pattern:
 
-`Select-String --Context {{2,3}} "{{search_pattern}}" {{path/to/file}}`
+`Select-String --Context {{2,3}} "{{search_pattern}}" {{path\to\file}}`
 
 - Search stdin for lines that do not match a pattern:
 
-`Get-Content {{path/to/file}} | Select-String --NotMatch "{{search_pattern}}"`
+`Get-Content {{path\to\file}} | Select-String --NotMatch "{{search_pattern}}"`

--- a/pages/windows/set-acl.md
+++ b/pages/windows/set-acl.md
@@ -6,8 +6,8 @@
 
 - Copy a security descriptor from one file to another:
 
-`$OriginAcl = Get-Acl -Path {{path/to/file}}; Set-Acl -Path {{path/to/file}} -AclObject $OriginAcl`
+`$OriginAcl = Get-Acl -Path {{path\to\file}}; Set-Acl -Path {{path\to\file}} -AclObject $OriginAcl`
 
 - Use the pipeline operator to pass a descriptor:
 
-`Get-Acl -Path {{path/to/file}} | Set-Acl -Path {{path/to/file}}`
+`Get-Acl -Path {{path\to\file}} | Set-Acl -Path {{path\to\file}}`

--- a/pages/windows/sfc.md
+++ b/pages/windows/sfc.md
@@ -17,16 +17,16 @@
 
 - Scan a specific file and, if possible, repair any problems:
 
-`sfc /scanfile={{path/to/file}}`
+`sfc /scanfile={{path\to\file}}`
 
 - Scan a specific file without attempting to repair it:
 
-`sfc /verifyfile={{path/to/file}}`
+`sfc /verifyfile={{path\to\file}}`
 
 - When repairing offline, specify the boot directory:
 
-`sfc /offbootdir={{path/to/directory}}`
+`sfc /offbootdir={{path\to\directory}}`
 
 - When repairing offline, specify the Windows directory:
 
-`sfc /offwindir={{path/to/directory}}`
+`sfc /offwindir={{path\to\directory}}`

--- a/pages/windows/show-markdown.md
+++ b/pages/windows/show-markdown.md
@@ -6,7 +6,7 @@
 
 - Render markdown to console from a file:
 
-`Show-Markdown -Path {{path/to/file}}`
+`Show-Markdown -Path {{path\to\file}}`
 
 - Render markdown to console from string:
 
@@ -14,4 +14,4 @@
 
 - Open Markdown file in a browser:
 
-`Show-Markdown -Path {{path/to/file}} -UseBrowser`
+`Show-Markdown -Path {{path\to\file}} -UseBrowser`

--- a/pages/windows/shutdown.md
+++ b/pages/windows/shutdown.md
@@ -25,7 +25,7 @@
 
 - Specify a timeout in seconds to wait before shutting down:
 
-`shutdown /s /t {{seconds}}`
+`shutdown /s /t {{8}}`
 
 - Abort a shutdown sequence whose timeout is yet to expire:
 

--- a/pages/windows/takeown.md
+++ b/pages/windows/takeown.md
@@ -5,16 +5,16 @@
 
 - Take ownership of the specified file:
 
-`takeown /f {{path/to/file}}`
+`takeown /f {{path\to\file}}`
 
 - Take ownership of the specified directory:
 
-`takeown /d {{path/to/directory}}`
+`takeown /d {{path\to\directory}}`
 
 - Take ownership of the specified directory and all subdirectories:
 
-`takeown /r /d {{path/to/directory}}`
+`takeown /r /d {{path\to\directory}}`
 
 - Change ownership to the Administrator group instead of the current user:
 
-`takeown /a /f {{path/to/file}}`
+`takeown /a /f {{path\to\file}}`

--- a/pages/windows/tee-object.md
+++ b/pages/windows/tee-object.md
@@ -6,7 +6,7 @@
 
 - Output processes to a file and to the console:
 
-`Get-Process | Tee-Object -FilePath {{path/to/file}}`
+`Get-Process | Tee-Object -FilePath {{path\to\file}}`
 
 - Output processes to a variable and `Select-Object`:
 

--- a/pages/windows/test-json.md
+++ b/pages/windows/test-json.md
@@ -14,4 +14,4 @@
 
 - Test if a string from stdin matches a specific schema file:
 
-`'{{string}}' | Test-Json -SchemaFile {{path/to/schema.json}}`
+`'{{string}}' | Test-Json -SchemaFile {{path\to\schema_file.json}}`

--- a/pages/windows/tree.md
+++ b/pages/windows/tree.md
@@ -9,12 +9,12 @@
 
 - Display the tree for a specific directory:
 
-`tree {{path/to/directory}}`
+`tree {{path\to\directory}}`
 
 - Display the tree for a directory including files:
 
-`tree {{path/to/directory}} /f`
+`tree {{path\to\directory}} /f`
 
 - Display the tree using ASCII characters instead of extended characters:
 
-`tree {{path/to/directory}} /a`
+`tree {{path\to\directory}} /a`

--- a/pages/windows/type.md
+++ b/pages/windows/type.md
@@ -5,4 +5,4 @@
 
 - Display the contents of a specific file:
 
-`type {{path/to/file}}`
+`type {{path\to\file}}`

--- a/pages/windows/virtualboxvm.md
+++ b/pages/windows/virtualboxvm.md
@@ -13,7 +13,7 @@
 
 - Mount the specified DVD image file:
 
-`virtualboxvm --startvm {{name|uuid}} --dvd {{path/to/image_file}}`
+`virtualboxvm --startvm {{name|uuid}} --dvd {{path\to\image_file}}`
 
 - Display a command-line window with debug information:
 

--- a/pages/windows/vswhere.md
+++ b/pages/windows/vswhere.md
@@ -5,16 +5,16 @@
 
 - Find the path of vcvarsall.bat to set environment variables:
 
-`vswhere -products * -latest -prerelease -find **/VC/Auxiliary/Build/vcvarsall.bat`
+`vswhere -products * -latest -prerelease -find **\VC\Auxiliary\Build\vcvarsall.bat`
 
 - Find the directory of the x64 MSVC compiler (cl.exe, etc):
 
-`vswhere -products * -latest -prerelease -find **/Hostx64/x64/*`
+`vswhere -products * -latest -prerelease -find **\Hostx64\x64\*`
 
 - Find the directory of Clang bundled with Visual Studio bundled (clang-cl, clang-tidy, etc):
 
-`vswhere -products * -latest -prerelease -find **/Llvm/bin/*`
+`vswhere -products * -latest -prerelease -find **\Llvm\bin\*`
 
 - Find the path of `MSBuild.exe`:
 
-`vswhere -products * -latest -prerelease -find MSBuild/**/Bin/MSBuild.exe`
+`vswhere -products * -latest -prerelease -find MSBuild\**\Bin\MSBuild.exe`

--- a/pages/windows/where.md
+++ b/pages/windows/where.md
@@ -14,7 +14,7 @@
 
 - Recursively search for file pattern at specified path:
 
-`where /R {{path/to/directory}} {{file_pattern}}`
+`where /R {{path\to\directory}} {{file_pattern}}`
 
 - Silently return the error code for the location of the file pattern:
 

--- a/pages/windows/wsl-open.md
+++ b/pages/windows/wsl-open.md
@@ -13,7 +13,7 @@
 
 - Open a specific file in the user's default application in Windows:
 
-`wsl-open {{path/to/file}}`
+`wsl-open {{path\to\file}}`
 
 - Set `wsl-open` as the shell's web browser (open links with `wsl-open`):
 

--- a/pages/windows/wsl.md
+++ b/pages/windows/wsl.md
@@ -21,11 +21,11 @@
 
 - Export a distribution to a `.tar` file:
 
-`wsl --export {{distribution}} {{path/to/distro_fs.tar}}`
+`wsl --export {{distribution}} {{path\to\distro_file.tar}}`
 
 - Import a distribution from a `.tar` file:
 
-`wsl --import {{distribution}} {{path/to/install_location}} {{path/to/distro_fs.tar}}`
+`wsl --import {{distribution}} {{path\to\install_location}} {{path/to/distro_file.tar}}`
 
 - Change the version of wsl used for the specified distribution:
 

--- a/pages/windows/xcopy.md
+++ b/pages/windows/xcopy.md
@@ -5,31 +5,31 @@
 
 - Copy the file(s) to the specified destination:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}}`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}}`
 
 - List files that will be copied before copying:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /p`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /p`
 
 - Copy the directory structure only, excluding files:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /t`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /t`
 
 - Include empty directories when copying:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /e`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /e`
 
 - Keep the source ACL in the destination:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /o`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /o`
 
 - Allow resuming when network connection is lost:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /z`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /z`
 
 - Disable the prompt when the file exists in the destination:
 
-`xcopy {{path/to/file_or_directory}} {{path/to/destination}} /y`
+`xcopy {{path\to\file_or_directory}} {{path\to\destination_directory}} /y`
 
 - Display detailed usage information:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## ToDo

- [x] Missing `file` and `directory` prefixes added to make conversions possible to CLIP placeholders.
- [x] Some number placeholder descriptions replaced with numbers to make conversions possible to CLIP placeholders. Something like `{{height}}` is not convertible automatically as two things are unknown for converter:
  - semantic of this keyword
  - what is it: int or float or both are valid
- [x] Forward slashes used instead of backward ones. It makes render result better for clients those don't do special placeholder handling (for almost all), but also will be used for [this](https://github.com/command-line-interface-pages/prototypes/issues/40) feature in CLIP.

## Notes

[This](https://github.com/command-line-interface-pages/prototypes/pull/32) converter version was used to check it.

## Notes about CLIP

I am thinking about adding an ability to easily add new placeholder conversions without digging in converter source code via some YAML/JSON config as I often see unparsable placeholders in TlDr and I wanna other people to work on my project too, even without programming knowledge.

Update: [here](https://github.com/command-line-interface-pages/prototypes/pull/48) is a implementation for this feature (in progress).