### PR TITLE
lftp: add login parameter to connect to the server

### DIFF
--- a/pages/linux/lftp.md
+++ b/pages/linux/lftp.md
@@ -5,7 +5,7 @@
 
 - Connect to an FTP server:
 
-`lftp {{ftp.example.com}}`
+`lftp --user {{username}} {{ftp.example.com}}`
 
 - Download multiple files (glob expression):
 


### PR DESCRIPTION
Hi

**lftp** does not automatically ask for the username to connect to the ftp server.
Without the "--user" parameter, you must use the "login" command.
