### PR TITLE
dumpsys.md: make integer placeholder convertible to CLIP placeholder

### DIFF
--- a/pages/android/dumpsys.md
+++ b/pages/android/dumpsys.md
@@ -26,4 +26,4 @@
 
 - Specify a timeout period in seconds (defaults to 10s):
 
-`dumpsys -t {{seconds}}`
+`dumpsys -t {{8}}`


### PR DESCRIPTION
- `seconds` keyword is not recognized, but concrete integer value is

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
