### PR TITLE
tar.md: fix placeholders and make them convertible in the right way

### DIFF
--- a/pages/android/dumpsys.md
+++ b/pages/android/dumpsys.md
@@ -26,4 +26,4 @@
 
 - Specify a timeout period in seconds (defaults to 10s):
 
-`dumpsys -t {{seconds}}`
+`dumpsys -t {{8}}`

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -6,32 +6,32 @@
 
 - [c]reate an archive and write it to a [f]ile:
 
-`tar cf {{target.tar}} {{file1}} {{file2}} {{file3}}`
+`tar cf {{path/to/target.tar}} {{path/to/file1 path/to/file2 ...}}`
 
 - [c]reate a g[z]ipped archive and write it to a [f]ile:
 
-`tar czf {{target.tar.gz}} {{file1}} {{file2}} {{file3}}`
+`tar czf {{path/to/target.tar.gz}} {{path/to/file1 path/to/file2 ...}}`
 
 - [c]reate a g[z]ipped archive from a directory using relative paths:
 
-`tar czf {{target.tar.gz}} --directory={{path/to/directory}} .`
+`tar czf {{path/to/target.tar.gz}} --directory={{path/to/directory}} .`
 
 - E[x]tract a (compressed) archive [f]ile into the current directory [v]erbosely:
 
-`tar xvf {{source.tar[.gz|.bz2|.xz]}}`
+`tar xvf {{path/to/source.tar[.gz|.bz2|.xz]}}`
 
 - E[x]tract a (compressed) archive [f]ile into the target directory:
 
-`tar xf {{source.tar[.gz|.bz2|.xz]}} --directory={{path/to/directory}}`
+`tar xf {{path/to/source.tar[.gz|.bz2|.xz]}} --directory={{path/to/directory}}`
 
 - [c]reate a compressed archive and write it to a [f]ile, using [a]rchive suffix to determine the compression program:
 
-`tar caf {{target.tar.xz}} {{file1}} {{file2}} {{file3}}`
+`tar caf {{path/to/target.tar.xz}} {{path/to/file1 path/to/file2 ...}}`
 
 - Lis[t] the contents of a tar [f]ile [v]erbosely:
 
-`tar tvf {{source.tar}}`
+`tar tvf {{path/to/source.tar}}`
 
 - E[x]tract files matching a pattern from an archive [f]ile:
 
-`tar xf {{source.tar}} --wildcards "{{*.html}}"`
+`tar xf {{path/to/source.tar}} --wildcards "{{*.html}}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Notes

To make [TlDr -> CLIP](https://github.com/command-line-interface-pages/prototypes/tree/main/md-to-clip) converter correctly recognize 0..more files ellipsis should be used, separate placeholders are treated as disgustingly.