### PR TITLE
.gitattributes: specify eol as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,5 @@
-# This ensures that the line endings in any files added or modified are
-# normalized before being committed. On Windows they will automatically
-# be checked-out as CRLF, and re-converted to LF before check-in.
-# See https://git-scm.com/docs/gitattributes for more information.
-* text=auto
+# https://github.com/tldr-pages/tldr/issues/7097
+* text=auto eol=lf
 
 # GitHub linguist ignores markdown files by default, but tldr-pages
 # is mostly markdown, so we explicitly make the pages detectable

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -90,32 +90,3 @@ git push --force-with-lease
 ```
 
 [![asciicast](https://asciinema.org/a/fFMZzQOgJyfUf8HTnXyRj0v02.svg)](https://asciinema.org/a/fFMZzQOgJyfUf8HTnXyRj0v02)
-
-# Editorconfig and Windows
-
-There is an issue that could arise when you clone the repository under Windows and use an editor which honors the settings in the `.editorconfig` file. With the default configuration, when you initially clone the repository, Git checks out files converting line endings to `CRLF`. Later, when you edit some file, or just save it without any modifications, your editor converts line endings to `LF` as per configuration in the `.editorconfig`. This causes the confusion, making Git mark the files as modified whereas they are not and issue the following warnings on `git diff` and `git add`:
-
-```
-warning: LF will be replaced by CRLF in...
-```
-
-To handle this problem, you need to clone the repository using the command:
-
-```sh
-git clone --config core.eol=lf {{remote_repository_location}}
-```
-
-If you've already cloned the repository, and don't want to repeat the whole process (if, for example, you've already made some modifications), you can fix the issue using the following commands. Be careful as these commands are potentially dangerous and you can lose your unfinished work in the current repository!
-
-```sh
-# set line feed (LF) as end of line
-git config --local core.eol lf
-# stash any local changes (if the working tree is clean, skip this step and the last one)
-git stash push
-# remove all the files under version control from index
-git rm -rfq --cached .
-# update all the files in index and working tree without converting LF to CRLF, as per new option value
-git reset --hard HEAD
-# restore the previous state from stash
-git stash pop --index
-```


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

---

Above is N/A.

Replaces manual instructions with the .gitattributes config that should achieve the same thing. No manual commands or documentation necessary.

If we could just get someone on Windows to test if they can reproduce the original problem, and if this fixes it, we should be fine to merge this.

### Related

* https://github.com/tldr-pages/tldr/pull/9010