### PR TITLE
adb-logcat, logcat: add --pid examples

### DIFF
--- a/pages.es/android/logcat.md
+++ b/pages.es/android/logcat.md
@@ -15,10 +15,10 @@
 
 `logcat --regex {{expresión_regular}}`
 
-- Muestra registros para un proceso específico:
+- Muestra registros de un proceso específico:
 
 `logcat --pid={{pid}}`
 
-- Muestra registros para el proceso de un paquete específico:
+- Muestra registros del proceso de un paquete específico:
 
 `logcat --pid=$(pidof -s {{paquete}})`

--- a/pages.es/android/logcat.md
+++ b/pages.es/android/logcat.md
@@ -11,6 +11,14 @@
 
 `logcat -f {{ruta/al/archivo}}`
 
-- Muestra líneas que coincidan con una expresión regular:
+- Muestra registros que coincidan con una expresión regular:
 
 `logcat --regex {{expresión_regular}}`
+
+- Muestra registros para un proceso específico:
+
+`logcat --pid={{pid}}`
+
+- Muestra registros para el proceso de un paquete específico:
+
+`logcat --pid=$(pidof -s {{paquete}})`

--- a/pages.es/common/adb-logcat.md
+++ b/pages.es/common/adb-logcat.md
@@ -23,7 +23,7 @@
 
 `adb logcat *:W`
 
-- Muestra los registros para un proceso específico:
+- Muestra los registros de un proceso específico:
 
 `adb logcat --pid={{pid}}`
 

--- a/pages.es/common/adb-logcat.md
+++ b/pages.es/common/adb-logcat.md
@@ -23,6 +23,14 @@
 
 `adb logcat *:W`
 
+- Muestra los registros para un proceso específico:
+
+`adb logcat --pid={{pid}}`
+
+- Muestra los registros del proceso de un paquete específico:
+
+`adb logcat --pid=$(adb shell pidof -s {{paquete}})`
+
 - Colorea el registro (normalmente se utiliza con filtros):
 
 `adb logcat -v color`

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -11,6 +11,10 @@
 
 `logcat -f {{path/to/file}}`
 
+- Display lines that match a regular expression:
+
+`logcat --regex {{regular_expression}}`
+
 - Display logs for a specific PID:
 
 `logcat --pid={{pid}}`
@@ -18,7 +22,3 @@
 - Display logs for the process of a specific package:
 
 `logcat --pid=$(pidof -s {{package}})`
-
-- Display lines that match a regular expression:
-
-`logcat --regex {{regular_expression}}`

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -11,6 +11,14 @@
 
 `logcat -f {{path/to/file}}`
 
+- Display logs for a specific PID:
+
+`logcat --pid={{pid}}`
+
+- Display logs for the process of a specific package:
+
+`logcat --pid=$(pidof -s {{package}})`
+
 - Display lines that match a regular expression:
 
 `logcat --regex {{regular_expression}}`

--- a/pages/common/adb-logcat.md
+++ b/pages/common/adb-logcat.md
@@ -23,6 +23,14 @@
 
 `adb logcat *:W`
 
+- Display logs for a specific PID:
+
+`adb logcat --pid={{pid}}`
+
+- Display logs for the process of a specific package:
+
+`adb logcat --pid=$(adb shell pidof -s {{package}})`
+
 - Color the log (usually use with filters):
 
 `adb logcat -v color`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
