### PR TITLE
Community: Update Gitter links to Matrix, Update Badges, Remove editor extensions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Chatroom
+  - name: Chat room
     url: https://matrix.to/#/#tldr-pages:matrix.org
-    about: You can ask and answer questions here
+    about: Consider joining the chat room to discuss your issue, question or suggestion with the community before opening an issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Gitter chat
-    url: https://gitter.im/tldr-pages/tldr
+  - name: Chatroom
+    url: https://matrix.to/#/#tldr-pages:matrix.org
     about: You can ask and answer questions here
   - name: Matrix Space
-    url: https://matrix.to/#/#tldr-pages:matrix.org
-    about: Matrix view of our Gitter chat rooms
+    url: https://matrix.to/#/#tldr-pages-project:matrix.org
+    about: Matrix space of our chat rooms

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Chatroom
     url: https://matrix.to/#/#tldr-pages:matrix.org
     about: You can ask and answer questions here
-  - name: Matrix Space
-    url: https://matrix.to/#/#tldr-pages-project:matrix.org
-    about: Matrix space of our chat rooms

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -126,7 +126,7 @@ using one of the template messages below as a base.
    According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md), you've now met the thresholds to be effectively considered an active maintainer of the project.
    To publicly acknowledge that fact, we'd like to add you to the tldr-pages organization.
 
-   If you accept the invitation, we ask you to make your membership public, and (in case you don't already) start hanging out in our Matrix chat room.
+   If you accept the invitation, we ask you to make your membership public, and (in case you don't already) start hanging out in our [Matrix chat room](https://matrix.to/#/#tldr-pages:matrix.org).
    Additionally, consider subscribing to the notifications from the various repositories under the [tldr-pages organization](https://github.com/tldr-pages).
    As one of the public faces of the tldr-pages project, it's also especially important that you follow and encourage the [project
    governance principles](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md).

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -126,7 +126,7 @@ using one of the template messages below as a base.
    According to our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md), you've now met the thresholds to be effectively considered an active maintainer of the project.
    To publicly acknowledge that fact, we'd like to add you to the tldr-pages organization.
 
-   If you accept the invitation, we ask you to make your membership public, and (in case you don't already) start hanging out in our Gitter chat room.
+   If you accept the invitation, we ask you to make your membership public, and (in case you don't already) start hanging out in our Matrix chat room.
    Additionally, consider subscribing to the notifications from the various repositories under the [tldr-pages organization](https://github.com/tldr-pages).
    As one of the public faces of the tldr-pages project, it's also especially important that you follow and encourage the [project
    governance principles](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 [![license][license-image]][license-url]
 
 [matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
-[matrix-image]: https://img.shields.io/badge/chat-on_matrix-deeppink
+[matrix-image]: https://img.shields.io/badge/chat-on_matrix-lightseagreen
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,15 @@
 [![license][license-image]][license-url]
 
 [matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
-[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org
+[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org?label=Chat+on+Matrix
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
-[prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
+[prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=Merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
-[contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg
+[contributors-image]: https://img.shields.io/github/contributors/tldr-pages/tldr.svg?label=Contributors
 [cla-assistant-url]: https://cla-assistant.io/tldr-pages/tldr
 [cla-assistant-image]: https://cla-assistant.io/readme/badge/tldr-pages/tldr
 [license-url]: https://github.com/tldr-pages/tldr/blob/main/LICENSE.md
-[license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg
+[license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg?label=License
 
 Contributions to the tldr-pages project are [most welcome](GOVERNANCE.md)!
 All `tldr` pages are stored in Markdown right here on GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing
 
-[![Gitter chat][gitter-image]][gitter-url]
+[![Matrix chat][matrix-image]][matrix-url]
 [![Merged PRs][prs-merged-image]][prs-merged-url]
 [![GitHub contributors][contributors-image]][contributors-url]
 [![CLA assistant][cla-assistant-image]][cla-assistant-url]
 [![license][license-image]][license-url]
 
-[gitter-url]: https://gitter.im/tldr-pages/tldr
-[gitter-image]: https://img.shields.io/badge/chat-on_gitter-deeppink
+[matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
+[matrix-image]: https://img.shields.io/badge/chat-on_matrix-deeppink
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 [![license][license-image]][license-url]
 
 [matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
-[matrix-image]: https://img.shields.io/badge/chat-on_matrix-lightseagreen
+[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,7 +38,7 @@ Community members are asked to abide by the following principles:
    e.g. when setting up services that require passwords,
    but otherwise all communications that impact the project
    will either happen in issue and PR discussions,
-   or in the [Gitter chat room](https://gitter.im/tldr-pages/tldr)
+   or in the [Matrix chat room](https://matrix.to/#/#tldr-pages:matrix.org)
    (which is open to all, and publicly logged).
 
 4. **All decisions are made by community consensus**.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -131,13 +131,13 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - Axel Navarro ([@navarroaxel](https://github.com/navarroaxel)):
   [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504) — [7 April 2021](https://github.com/tldr-pages/tldr/issues/5703)
 - bl-ue ([@bl-ue](https://github.com/bl-ue)):
-  [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — [25 June 2021](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$qCyBANu8Ub_GKJgwh0zKlVSgWASLYxYJXBn4NDEEQPw?via=gitter.im&via=matrix.org&via=one.ems.host)
+  [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — [25 June 2021](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$qCyBANu8Ub_GKJgwh0zKlVSgWASLYxYJXBn4NDEEQPw)
 - CleanMachine1 ([@CleanMachine1](https://github.com/CleanMachine1)):
   [14 June 2021](https://github.com/tldr-pages/tldr/issues/6123) — [14 December 2021](https://github.com/tldr-pages/tldr/issues/7541)
 - Marcher Simon ([@marchersimon](https://github.com/marchersimon)):
   [9 April 2021](https://github.com/tldr-pages/tldr/issues/5722) — [9 August 2022](https://github.com/tldr-pages/tldr/issues/7540)
 - Emily Grace Seville ([@EmilySeville7cfg](https://github.com/EmilySeville7cfg)):
-  [25 April 2022](https://github.com/tldr-pages/tldr/issues/8053) — [12 January 2022](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$n3Jk7mhIzG6edTVUv6MkAoX_1N5z5MPRj2hclyrfKBI?via=gitter.im&via=matrix.org&via=one.ems.host)
+  [25 April 2022](https://github.com/tldr-pages/tldr/issues/8053) — [12 January 2022](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$n3Jk7mhIzG6edTVUv6MkAoX_1N5z5MPRj2hclyrfKBI)
 
 ## Organization owners
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -131,13 +131,13 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - Axel Navarro ([@navarroaxel](https://github.com/navarroaxel)):
   [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504) — [7 April 2021](https://github.com/tldr-pages/tldr/issues/5703)
 - bl-ue ([@bl-ue](https://github.com/bl-ue)):
-  [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — [25 June 2021](https://gitter.im/tldr-pages/tldr?at=60d615598a40b117282a96d7)
+  [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219) — [25 June 2021](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$qCyBANu8Ub_GKJgwh0zKlVSgWASLYxYJXBn4NDEEQPw?via=gitter.im&via=matrix.org&via=one.ems.host)
 - CleanMachine1 ([@CleanMachine1](https://github.com/CleanMachine1)):
   [14 June 2021](https://github.com/tldr-pages/tldr/issues/6123) — [14 December 2021](https://github.com/tldr-pages/tldr/issues/7541)
 - Marcher Simon ([@marchersimon](https://github.com/marchersimon)):
   [9 April 2021](https://github.com/tldr-pages/tldr/issues/5722) — [9 August 2022](https://github.com/tldr-pages/tldr/issues/7540)
 - Emily Grace Seville ([@EmilySeville7cfg](https://github.com/EmilySeville7cfg)):
-  [25 April 2022](https://github.com/tldr-pages/tldr/issues/8053) — [12 January 2022](https://gitter.im/tldr-pages/tldr?at=63bf282dd8678973f9aa90bb)
+  [25 April 2022](https://github.com/tldr-pages/tldr/issues/8053) — [12 January 2022](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$n3Jk7mhIzG6edTVUv6MkAoX_1N5z5MPRj2hclyrfKBI?via=gitter.im&via=matrix.org&via=one.ems.host)
 
 ## Organization owners
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -148,9 +148,9 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - **Romain Prieto ([@rprieto](https://github.com/rprieto))**:
   created the project on [8 December 2013](https://github.com/tldr-pages/tldr/commit/11264d9b19000734a2d35ecbdbdebc0b0b45aed9)
 - **Agniva De Sarker ([@agnivade](https://github.com/agnivade))**:
-  [27 September 2016](https://gitter.im/tldr-pages/tldr?at=57eaedefe4e41c6a4afc2f47) — present
+  [21 September 2016](https://github.com/tldr-pages/tldr/issues/9899) — present
 - **Starbeamrainbowlabs ([@sbrl](https://github.com/sbrl))**:
-  [23 April 2017](https://gitter.im/tldr-pages/tldr?at=58fc6fce3e27cac331b5c397) — present
+  [19 April 2017](https://github.com/tldr-pages/tldr/issues/9899) — present
 - **Owen Voke ([@owenvoke](https://github.com/owenvoke))**
   [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989) — present
 - **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 [![license][license-image]][license-url]
 
 [github-actions-url]: https://github.com/tldr-pages/tldr/actions
-[github-actions-image]: https://img.shields.io/github/actions/workflow/status/tldr-pages/tldr/ci.yml?branch=main
+[github-actions-image]: https://img.shields.io/github/actions/workflow/status/tldr-pages/tldr/ci.yml?branch=main&label=Build
 [matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
-[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org
+[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org?label=Chat+on+Matrix
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
-[prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
+[prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=Merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors
-[contributors-image]: https://img.shields.io/github/contributors-anon/tldr-pages/tldr.svg
+[contributors-image]: https://img.shields.io/github/contributors-anon/tldr-pages/tldr.svg?label=Contributors
 [license-url]: https://github.com/tldr-pages/tldr/blob/main/LICENSE.md
-[license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg
+[license-image]: https://img.shields.io/badge/license-CC_BY_4.0-blue.svg?label=License
 </div>
 
 ## What is tldr-pages?

--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ All `tldr` pages are written in markdown, so they can be edited quite easily and
 pull requests here using Git on the command-line or
 using the GitHub web interface.
 
-But we already have some plugins for different editors to enhance the tldr page editing experience:
-
-- [Emacs](https://github.com/tldr-pages/tldr-emacs-extension)
-
-For editors without a plugin system, we provide a set of configurations in a [separate repo](https://github.com/tldr-pages/tldr-editor-configs).
-
 We strive to maintain a [welcoming and collaborative](GOVERNANCE.md) community.
 If it's your first time contributing, have a look at the [contributing guidelines](CONTRIBUTING.md), and go ahead!
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [github-actions-url]: https://github.com/tldr-pages/tldr/actions
 [github-actions-image]: https://img.shields.io/github/actions/workflow/status/tldr-pages/tldr/ci.yml?branch=main
 [matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
-[matrix-image]: https://img.shields.io/badge/chat-on_matrix-deeppink
+[matrix-image]: https://img.shields.io/matrix/tldr-pages:matrix.org
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
   <h1><a href="https://tldr.sh/"><img alt="tldr-pages" src="images/banner.png" width=600/></a></h1>
 
 [![Build status][github-actions-image]][github-actions-url]
-[![Gitter chat][gitter-image]][gitter-url]
+[![Matrix chat][matrix-image]][matrix-url]
 [![Merged PRs][prs-merged-image]][prs-merged-url]
 [![GitHub contributors][contributors-image]][contributors-url]
 [![license][license-image]][license-url]
 
 [github-actions-url]: https://github.com/tldr-pages/tldr/actions
 [github-actions-image]: https://img.shields.io/github/actions/workflow/status/tldr-pages/tldr/ci.yml?branch=main
-[gitter-url]: https://gitter.im/tldr-pages/tldr
-[gitter-image]: https://img.shields.io/badge/chat-on_gitter-deeppink
+[matrix-url]: https://matrix.to/#/#tldr-pages:matrix.org
+[matrix-image]: https://img.shields.io/badge/chat-on_matrix-deeppink
 [prs-merged-url]: https://github.com/tldr-pages/tldr/pulls?q=is:pr+is:merged
 [prs-merged-image]: https://img.shields.io/github/issues-pr-closed-raw/tldr-pages/tldr.svg?label=merged+PRs&color=green
 [contributors-url]: https://github.com/tldr-pages/tldr/graphs/contributors

--- a/contributing-guides/maintainers-guide.md
+++ b/contributing-guides/maintainers-guide.md
@@ -25,7 +25,7 @@ as a guideline for current and future maintainers.
   You can respond yourself
   or ask other members to provide their thoughts/opinions.
   In addition, if possible, try to hang around in the
-  [Gitter chat room](https://gitter.im/tldr-pages/tldr)
+  [Matrix chat room](https://matrix.to/#/#tldr-pages:matrix.org)
   on a regular basis as well, or at least show up every now and then.
 
 - **Know when and how to say no**.


### PR DESCRIPTION
## Changes

- Update Gitter Links to Matrix.
- Discussion: [here](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$Fte7Zjp0XTMZnFac-B3aezKf206I--jMNh45AfYQnWk?via=gitter.im&via=matrix.org&via=one.ems.host)