### PR TITLE
gummy: add page

### DIFF
--- a/pages/linux/gummy.md
+++ b/pages/linux/gummy.md
@@ -1,0 +1,28 @@
+# gummy
+
+> Screen brightness/temperature manager for Linux/X11.
+> More information: <https://github.com/Fushko/gummy>.
+
+- Set the screen temperature to 3000K:
+
+`gummy --temperature {{3000}}`
+
+- Set the screen backlight to 50%:
+
+`gummy --backlight {{50}}`
+
+- Set the screen pixel brightness to 45%:
+
+`gummy --brightness {{45}}`
+
+- Increase current screen pixel brightness by 10%:
+
+`gummy --brightness {{+10}}`
+
+- Decrease current screen pixel brightness by 10%:
+
+`gummy --brightness {{-10}}`
+
+- Set the temperature and pixel brightness for the second screen:
+
+`gummy --screen {{1}} --temperature {{3800}} --brightness {{65}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): [0.4](https://github.com/Fushko/gummy/releases/tag/0.4)**

[Release 0.4](https://github.com/Fushko/gummy/releases/tag/0.4) for gummy split the single brightness flag into 2 different brightness controls - monitor backlight and pixel brightness. This tldr page addresses that and aims to make the separation clear for new and existing users. The relative value support was added in 0.4 which is also covered in the tldr page.