### PR TITLE
grub-set-default: add page

### DIFF
--- a/pages/linux/grub-set-default.md
+++ b/pages/linux/grub-set-default.md
@@ -1,0 +1,12 @@
+# grub-set-default
+
+> Set the default boot entry for GRUB.
+> More information: <https://manned.org/grub-set-default>.
+
+- Set the boot entry to a entry number, name or identifier:
+
+`sudo grub-set-default {{menu_entry}}`
+
+- Set the boot entry to a entry number, name or identifier for alternative boot directory:
+
+`sudo grub-set-default --boot-directory {{/path/to/directory}} {{menu_entry}}`

--- a/pages/linux/grub-set-default.md
+++ b/pages/linux/grub-set-default.md
@@ -3,10 +3,10 @@
 > Set the default boot entry for GRUB.
 > More information: <https://manned.org/grub-set-default>.
 
-- Set the boot entry to a entry number, name or identifier:
+- Set the default boot entry to an entry number, name or identifier:
 
-`sudo grub-set-default {{menu_entry}}`
+`sudo grub-set-default {{entry_number}}`
 
-- Set the boot entry to a entry number, name or identifier for alternative boot directory:
+- Set the default boot entry to an entry number, name or identifier for an alternative boot directory:
 
-`sudo grub-set-default --boot-directory {{/path/to/directory}} {{menu_entry}}`
+`sudo grub-set-default --boot-directory {{/path/to/boot_directory}} {{entry_number}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

It resolves part of issue #8080