### PR TITLE
openvpn: update command

### DIFF
--- a/pages/common/openvpn.md
+++ b/pages/common/openvpn.md
@@ -17,7 +17,7 @@
 
 - Create a cryptographic key and save it to file:
 
-`openvpn --genkey --secret {{path/to/key}}`
+`openvpn --genkey secret {{path/to/key}}`
 
 - Try to set up a peer-to-peer tunnel on bob.example.com host with a static key:
 


### PR DESCRIPTION
Usage of `openvpn --genkey --secret` is deprecated. One should use `openvpn --genkey secret` instead.

`openvpn --genkey --secret [file]` results in `WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead.`

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.5.1
