### PR TITLE
ffmpeg: update syntax for the -codec switch

### DIFF
--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -25,12 +25,12 @@
 
 - Convert AVI video to MP4. AAC Audio @ 128kbit, h264 Video @ CRF 23:
 
-`ffmpeg -i {{input_video}}.avi -codec:audio aac -b:audio 128k -codec:video libx264 -crf 23 {{output_video}}.mp4`
+`ffmpeg -i {{input_video}}.avi -codec:a aac -b:a 128k -codec:v libx264 -crf 23 {{output_video}}.mp4`
 
 - Remux MKV video to MP4 without re-encoding audio or video streams:
 
 `ffmpeg -i {{input_video}}.mkv -codec copy {{output_video}}.mp4`
 
-- Convert MP4 video to VP9 codec. For the best quality, use a CRF value (recommended range 15-35) and -b:video MUST be 0:
+- Convert MP4 video to VP9 codec. For the best quality, use a CRF value (recommended range 15-35) and -b:v MUST be 0:
 
-`ffmpeg -i {{input_video}}.mp4 -codec:video libvpx-vp9 -crf {{30}} -b:video 0 -codec:audio libopus -vbr on -threads {{number_of_threads}} {{output_video}}.webm`
+`ffmpeg -i {{input_video}}.mp4 -codec:v libvpx-vp9 -crf {{30}} -b:v 0 -codec:a libopus -vbr on -threads {{number_of_threads}} {{output_video}}.webm`


### PR DESCRIPTION
[as far as i can tell](https://ffmpeg.org/ffmpeg.html#Stream-specifiers-1), the syntax does not use `:video` and `:audio` for the stream specifier, and instead uses `:v` and `:a`, respectively

these are the errors i received:

`Invalid stream specifier: video`, `Invalid stream specifier: audio`

i'm on version 4.4.2, on ubuntu

`ffmpeg is already the newest version (7:4.4.2-0ubuntu0.22.04.1)`

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory: `common`
- [x] The page has at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
- 4.4.2
