### PR TITLE
sed: improve description of -i option

### DIFF
--- a/pages/linux/sed.md
+++ b/pages/linux/sed.md
@@ -20,6 +20,6 @@
 
 `{{command}} | sed -n '1p'`
 
-- Replace all `apple` (basic regex) occurrences with `mango` (basic regex) in all input lines and save modifications to a specific file:
+- Replace all `apple` (basic regex) occurrences with `mango` (basic regex) in the specific file and overwrite the original file in-place:
 
 `sed -i 's/apple/mango/g' {{path/to/file}}`

--- a/pages/linux/sed.md
+++ b/pages/linux/sed.md
@@ -20,6 +20,6 @@
 
 `{{command}} | sed -n '1p'`
 
-- Replace all `apple` (basic regex) occurrences with `mango` (basic regex) in the specific file and overwrite the original file in-place:
+- Replace all `apple` (basic regex) occurrences with `mango` (basic regex) in a specific file and overwrite the original file in place:
 
 `sed -i 's/apple/mango/g' {{path/to/file}}`


### PR DESCRIPTION
The original description makes it sound like sed would wait for additional input while it actually just modifies the specified file in-place.

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** GNU sed 4.8
