### PR TITLE
aircrack-ng: add German translation

### DIFF
--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -14,4 +14,4 @@
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der MAC-Adresse des Access Points:
 
-`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} --bssid {{mac}} {{Pfad/zu/Packetdatei.cap}}`
+`aircrack-ng -w {{pfad/zu/wortliste.txt}} --bssid {{mac}} {{pfad/zu/packetdatei.cap}}`

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -12,6 +12,6 @@
 
 `aircrack-ng -w {{pfad/zu/wortliste.txt}} -e {{essid}} {{pfad/zu/packetdatei.cap}}`
 
-- Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der MAC-Adresse des Access Points:
+- Knacke Schlüssel von abgefangenen Paketen mithilfe einer Wortliste und der MAC-Adresse des Access Points:
 
 `aircrack-ng -w {{pfad/zu/wortliste.txt}} --bssid {{mac}} {{pfad/zu/packetdatei.cap}}`

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -2,7 +2,6 @@
 
 > WEP und WPA/WPA2 Schlüssel im Kommunikationsaufbau knacken.
 > Teil des Aircrack-ng Softwarepakets.
-> Davor muss Packet abgefangen werden mit aircrack
 > Weitere Informationen: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng>.
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe von Wortlisten:

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -7,7 +7,7 @@
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe von Wortlisten:
 
-`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} {{Pfad/zu/Packetdatei.cap}}`
+`aircrack-ng -w {{pfad/zu/wortliste.txt}} {{pfad/zu/packetdatei.cap}}`
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der (E)SSID des Access Points:
 

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -8,7 +8,7 @@
 
 `aircrack-ng -w {{pfad/zu/wortliste.txt}} {{pfad/zu/packetdatei.cap}}`
 
-- Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der (E)SSID des Access Points:
+- Knacke Schlüssel von abgefangenen Paketen mithilfe einer Wortliste und der (E)SSID des Access Points:
 
 `aircrack-ng -w {{pfad/zu/wortliste.txt}} -e {{essid}} {{pfad/zu/packetdatei.cap}}`
 

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -1,0 +1,18 @@
+# aircrack-ng
+
+> WEP und WPA/WPA2 Schlüssel im Kommunikationsaufbau knacken.
+> Teil des Aircrack-ng Softwarepakets.
+> Davor muss Packet abgefangen werden mit aircrack
+> Mehr Informationen: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng> (auf Englisch)
+
+- Schlüssel knacken von abgefangenen Packeten mithilfe von Wortlisten:
+
+`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} {{Pfad/zu/Packetdatei.cap}}`
+
+- Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der (E)SSID des Access Points:
+
+`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} -e {{essid}} {{Pfad/zu/Packetdatei.cap}}`
+
+- Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der MAC-Adresse des Access Points:
+
+`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} --bssid {{mac}} {{Pfad/zu/Packetdatei.cap}}`

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -3,7 +3,7 @@
 > WEP und WPA/WPA2 Schlüssel im Kommunikationsaufbau knacken.
 > Teil des Aircrack-ng Softwarepakets.
 > Davor muss Packet abgefangen werden mit aircrack
-> Mehr Informationen: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng> (auf Englisch)
+> Weitere Informationen: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng>.
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe von Wortlisten:
 

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -10,7 +10,7 @@
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der (E)SSID des Access Points:
 
-`aircrack-ng -w {{Pfad/zu/Wortliste.txt}} -e {{essid}} {{Pfad/zu/Packetdatei.cap}}`
+`aircrack-ng -w {{pfad/zu/wortliste.txt}} -e {{essid}} {{pfad/zu/packetdatei.cap}}`
 
 - Schlüssel knacken von abgefangenen Packeten mithilfe einer Wortliste und der MAC-Adresse des Access Points:
 

--- a/pages.de/common/aircrack-ng.md
+++ b/pages.de/common/aircrack-ng.md
@@ -4,7 +4,7 @@
 > Teil des Aircrack-ng Softwarepakets.
 > Weitere Informationen: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng>.
 
-- Schlüssel knacken von abgefangenen Packeten mithilfe von Wortlisten:
+- Knacke Schlüssel von abgefangenen Paketen mithilfe von Wortlisten:
 
 `aircrack-ng -w {{pfad/zu/wortliste.txt}} {{pfad/zu/packetdatei.cap}}`
 


### PR DESCRIPTION
Translated the current aircrack-ng.md into german.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
