### PR TITLE
systemd-run: add page

### DIFF
--- a/pages/linux/systemd-run.md
+++ b/pages/linux/systemd-run.md
@@ -1,0 +1,24 @@
+# systemd-run
+
+> Run programs in transient units.
+> More information: <https://manned.org/systemd-run>.
+
+- Start a transient service:
+
+`sudo systemd-run {{command}} {{[args...]}}`
+
+- Start a transient service under the service manager of the current user (no privileges):
+
+`systemd-run --user {{command}} {{[args...]}}`
+
+- Start a transient service with a custom unit name and description:
+
+`sudo systemd-run --unit={{name}} --description={{desc}} {{command}} {{[args...]}}`
+
+- Start a transient service with a custom environment variable that does not get cleaned up after it terminates:
+
+`sudo systemd-run --set-env={{name}}={{val}} --remain-after-exit {{command}} {{[args...]}}`
+
+- Start a transient timer that periodically runs its transient service (see `man systemd.time` for calendar event format):
+
+`sudo systemd-run --on-calendar={{calender event}} {{command}} {{[args...]}}`

--- a/pages/linux/systemd-run.md
+++ b/pages/linux/systemd-run.md
@@ -15,9 +15,9 @@
 
 `sudo systemd-run --unit={{name}} --description={{desc}} {{command}} {{[args...]}}`
 
-- Start a transient service with a custom environment variable that does not get cleaned up after it terminates:
+- Start a transient service that does not get cleaned up after it terminates with a custom environment variable:
 
-`sudo systemd-run --set-env={{name}}={{val}} --remain-after-exit {{command}} {{[args...]}}`
+`sudo systemd-run --remain-after-exit --set-env={{name}}={{val}} {{command}} {{[args...]}}`
 
 - Start a transient timer that periodically runs its transient service (see `man systemd.time` for calendar event format):
 

--- a/pages/linux/systemd-run.md
+++ b/pages/linux/systemd-run.md
@@ -21,4 +21,4 @@
 
 - Start a transient timer that periodically runs its transient service (see `man systemd.time` for calendar event format):
 
-`sudo systemd-run --on-calendar={{calender event}} {{command}} {{[args...]}}`
+`sudo systemd-run --on-calendar={{calendar event}} {{command}} {{[args...]}}`

--- a/pages/linux/systemd-run.md
+++ b/pages/linux/systemd-run.md
@@ -5,20 +5,20 @@
 
 - Start a transient service:
 
-`sudo systemd-run {{command}} {{[args...]}}`
+`sudo systemd-run {{command}} {{argument1 argument2 ...}}`
 
 - Start a transient service under the service manager of the current user (no privileges):
 
-`systemd-run --user {{command}} {{[args...]}}`
+`systemd-run --user {{command}} {{argument1 argument2 ...}}`
 
 - Start a transient service with a custom unit name and description:
 
-`sudo systemd-run --unit={{name}} --description={{desc}} {{command}} {{[args...]}}`
+`sudo systemd-run --unit={{name}} --description={{string}} {{command}} {{argument1 argument2 ...}}`
 
 - Start a transient service that does not get cleaned up after it terminates with a custom environment variable:
 
-`sudo systemd-run --remain-after-exit --set-env={{name}}={{val}} {{command}} {{[args...]}}`
+`sudo systemd-run --remain-after-exit --set-env={{name}}={{value}} {{command}} {{argument1 argument2 ...}}`
 
 - Start a transient timer that periodically runs its transient service (see `man systemd.time` for calendar event format):
 
-`sudo systemd-run --on-calendar={{calendar event}} {{command}} {{[args...]}}`
+`sudo systemd-run --on-calendar={{calendar_event}} {{command}} {{argument1 argument2 ...}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** systemd-253
