### PR TITLE
tldr: fix update command

### DIFF
--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -17,4 +17,4 @@
 
 - [u]pdate the local cache of tldr pages:
 
-`tldr -u`
+`tldr --update`


### PR DESCRIPTION
The -u flag is not recognized, while the --update flag is. (on Ubuntu 20.04.05)
the --update flag is also more verbose, following the content guidelines

- [x] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
