### PR TITLE
mcfly: add page

### DIFF
--- a/pages/common/mcfly.md
+++ b/pages/common/mcfly.md
@@ -1,0 +1,29 @@
+# mcfly
+
+> A smart command history search and management tool.
+> Replaces your default shell history search (ctrl-r) with an intelligent search engine providing context and relevance to the commands.
+> More information: <https://github.com/cantino/mcfly>.
+
+- Print the mcfly integration code for the specified shell:
+
+`mcfly init {{bash|fish|zsh}}`
+
+- Search the history for a command, with 20 results:
+
+`mcfly search --results {{20}} "{{search_terms}}"`
+
+- Add a new command to the history:
+
+`mcfly add "{{command}}"`
+
+- Record that a directory has moved and transfer the history records from the old path to the new one:
+
+`mcfly move "{{path/to/old_directory}}" "{{path/to/new_directory}}"`
+
+- Train the suggestion engine (developer tool):
+
+`mcfly train`
+
+- Display help for a specific subcommand:
+
+`mcfly help {{subcommand}}`

--- a/pages/common/mcfly.md
+++ b/pages/common/mcfly.md
@@ -16,7 +16,7 @@
 
 `mcfly add "{{command}}"`
 
-- Record that a directory has moved and transfer the history records from the old path to the new one:
+- Record that a directory has moved and transfer the historical records from the old path to the new one:
 
 `mcfly move "{{path/to/old_directory}}" "{{path/to/new_directory}}"`
 


### PR DESCRIPTION
Creates a new page in common for [McFly](https://github.com/cantino/mcfly), a fast and intelligent
command history search engine.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page (if new), does not already exist in the repository.
- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page description includes a link to documentation or a homepage (if applicable).

**Version of the command being documented (if known):** 0.8.0
