### PR TITLE
fix: omit Emacs extension and set of configs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ All `tldr` pages are written in markdown, so they can be edited quite easily and
 pull requests here using Git on the command-line or
 using the GitHub web interface.
 
-But we already have some plugins for different editors to enhance the tldr page editing experience:
-
-- [Emacs](https://github.com/tldr-pages/tldr-emacs-extension)
-
-For editors without a plugin system, we provide a set of configurations in a [separate repo](https://github.com/tldr-pages/tldr-editor-configs).
-
 We strive to maintain a [welcoming and collaborative](GOVERNANCE.md) community.
 If it's your first time contributing, have a look at the [contributing guidelines](CONTRIBUTING.md), and go ahead!
 


### PR DESCRIPTION

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Reason: they are not maintained.