### PR TITLE
airodump-ng: add German Translation

### DIFF
--- a/pages.de/common/airodump-ng.md
+++ b/pages.de/common/airodump-ng.md
@@ -4,7 +4,7 @@
 > Teil von `aircrack-ng`.
 > Weitere Informationen: <https://www.aircrack-ng.org/doku.php?id=airodump-ng>.
 
-- Erfassen von Paketen und Anzeigen von Informationen über ein drahtloses Netzwerk:
+- Erfasse Pakete und zeige Informationen über ein drahtloses Netzwerk an:
 
 `sudo airodump-ng {{interface}}`
 

--- a/pages.de/common/airodump-ng.md
+++ b/pages.de/common/airodump-ng.md
@@ -8,6 +8,6 @@
 
 `sudo airodump-ng {{interface}}`
 
-- Erfassen von Paketen und Anzeigen von Informationen über ein drahtloses Netzwerk anhand der MAC-Adresse und des Kanals und diese in eine Datei schreiben.  
+- Erfasse Pakete und zeige Informationen über ein drahtloses Netzwerk anhand der MAC-Adresse und des Kanals an, und schreibe diese in eine Datei:
 
 `sudo airodump-ng --channel {{kanal}} --write {{pfad/zu/datei}} --bssid {{mac}} {{interface}}`

--- a/pages.de/common/airodump-ng.md
+++ b/pages.de/common/airodump-ng.md
@@ -1,0 +1,13 @@
+# airodump-ng
+
+> Erfasst Pakete und zeigt Informationen über drahtlose Netzwerke an.
+> Teil von `aircrack-ng`.
+> Mehr Informationen: <https://www.aircrack-ng.org/doku.php?id=airodump-ng>.
+
+- Erfassen von Paketen und Anzeigen von Informationen über ein drahtloses Netzwerk:
+
+`sudo airodump-ng {{interface}}`
+
+- Erfassen von Paketen und Anzeigen von Informationen über ein drahtloses Netzwerk anhand der MAC-Adresse und des Kanals und diese in eine Datei schreiben.  
+
+`sudo airodump-ng --channel {{kanal}} --write {{pfad/zu/datei}} --bssid {{mac}} {{interface}}`

--- a/pages.de/common/airodump-ng.md
+++ b/pages.de/common/airodump-ng.md
@@ -2,7 +2,7 @@
 
 > Erfasst Pakete und zeigt Informationen über drahtlose Netzwerke an.
 > Teil von `aircrack-ng`.
-> Mehr Informationen: <https://www.aircrack-ng.org/doku.php?id=airodump-ng>.
+> Weitere Informationen: <https://www.aircrack-ng.org/doku.php?id=airodump-ng>.
 
 - Erfassen von Paketen und Anzeigen von Informationen über ein drahtloses Netzwerk:
 


### PR DESCRIPTION
Translated the current airodump-ng.md into German.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
