### PR TITLE
pwsh: refresh page

### DIFF
--- a/pages/common/pwsh.md
+++ b/pages/common/pwsh.md
@@ -1,25 +1,7 @@
 # pwsh
 
-> PowerShell Core is a cross-platform automation and configuration tool/framework.
-> See also: `powershell`.
-> More information: <https://learn.microsoft.com/powershell/>.
+> This command is an alias of `powershell`.
 
-- Start an interactive shell session:
+- View documentation for the original command:
 
-`pwsh`
-
-- Start an interactive shell session without loading startup configs:
-
-`pwsh -NoProfile`
-
-- Execute specific commands:
-
-`pwsh -Command "{{string}}"`
-
-- Execute a specific script:
-
-`pwsh {{path/to/script.ps1}}`
-
-- Start an interactive shell session with a specific execution policy:
-
-`pwsh -ExecutionPolicy {{AllSigned|Bypass|Default|RemoteSigned|Restricted|...}}`
+`tldr powershell`


### PR DESCRIPTION
Since #7984, `powershell` is in `common`. This makes `pwsh` an alias of it, as AFAIK it should be.
Closes #7194.