### PR TITLE
ifmetric: add page

### DIFF
--- a/pages/linux/ifmetric.md
+++ b/pages/linux/ifmetric.md
@@ -3,7 +3,7 @@
 > An IPv4 route metrics manipulation tool.
 > More information: <https://0pointer.de/lennart/projects/ifmetric/>.
 
-- Set the priority of the specified network interface, a higher number indicates lower priority:
+- Set the priority of the specified network interface (a higher number indicates lower priority):
 
 `sudo ifmetric {{interface}} {{value}}`
 

--- a/pages/linux/ifmetric.md
+++ b/pages/linux/ifmetric.md
@@ -1,0 +1,12 @@
+# ifmetric
+
+> An IPv4 route metrics manipulation tool.
+> More information: <https://0pointer.de/lennart/projects/ifmetric/>.
+
+- Set the priority of the specified network interface, a higher number indicates lower priority:
+
+`sudo ifmetric {{interface}} {{value}}`
+
+- Reset the priority of the specified network interface:
+
+`sudo ifmetric {{interface}} {{0}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Not known

---

For those of you with more than one network adapter, sometimes you might be connected to more than one network, right? i.e. on Wi-Fi + Ethernet for laptop users.

I noticed that some of my traffic was going over Wi-Fi for some reason even though I'm connected via Ethernet. (They both ultimately hit the same router, so there's no benefit to this.) :thinking: 

This lets you configure the priority interfaces should have when you're connected to multiple, so you can indicate which is fastest or should handle traffic first if available.

i.e. If you want to stay connected to Wi-Fi as a fallback, but don't want to use `wlo1` unless `enp6s0` is down:

```sh
sudo ifmetric wlo1 1
```