### PR TITLE
git-am, git-apply: add and tweak remote patch examples

### DIFF
--- a/pages/common/git-am.md
+++ b/pages/common/git-am.md
@@ -1,12 +1,16 @@
 # git am
 
-> Apply patch files. Useful when receiving commits via email.
+> Apply patch files and create a commit. Useful when receiving commits via email.
 > See also `git format-patch`, which can generate patch files.
 > More information: <https://git-scm.com/docs/git-am>.
 
-- Apply a patch file:
+- Apply and commit changes following a local patch file:
 
 `git am {{path/to/file.patch}}`
+
+- Apply and commit changes following a remote patch file:
+
+`curl -L {{https://example.com/file.patch}} | git apply`
 
 - Abort the process of applying a patch file:
 

--- a/pages/common/git-apply.md
+++ b/pages/common/git-apply.md
@@ -1,6 +1,7 @@
 # git apply
 
-> Apply a patch to files and/or to the index.
+> Apply a patch to files and/or to the index without creating a commit.
+> See also `git am`, which applies a patch and also creates a commit.
 > More information: <https://git-scm.com/docs/git-apply>.
 
 - Print messages about the patched files:
@@ -13,7 +14,7 @@
 
 - Apply a remote patch file:
 
-`curl {{https://example.com/file.patch}} | git apply`
+`curl -L {{https://example.com/file.patch}} | git apply`
 
 - Output diffstat for the input and apply the patch:
 


### PR DESCRIPTION
`curl` now uses the `-L` option to follow redirects, which is required
when applying patch files from GitHub URLs. The example was also added
to `git-am` where it works too.

The difference between `git-am` and `git-apply` was also clarified in each
command's description.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Git 2.39.2, curl 7.85.0 (Linux). `curl -L` has been around for a long time, so even very old curl versions support it.
