### PR TITLE
cmake: add generator flag, help example

### DIFF
--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -30,3 +30,7 @@
 - Run a custom build target:
 
 `cmake --build {{path/to/build_directory}} --target {{target_name}}`
+
+- Display help, obtain a list of generators:
+
+`cmake --help`

--- a/pages/common/cmake.md
+++ b/pages/common/cmake.md
@@ -11,6 +11,10 @@
 
 `cmake {{path/to/project_directory}} -D {{CMAKE_BUILD_TYPE=Release}}`
 
+- Generate a build recipe using `generator_name` as the underlying build system:
+
+`cmake -G {{generator_name}} {{path/to/project_directory}}`
+
 - Use a generated recipe in a given directory to build artifacts:
 
 `cmake --build {{path/to/build_directory}}`


### PR DESCRIPTION
Given that the selection of generator can significantly impact project build times, I think adding the `-G` flag to the CMake page would be useful. This PR adds a short example for using this flag.

PS: First time contributing so let me know if I missed any steps in your typical workflow 

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
