### PR TITLE
obabel: add page

### DIFF
--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -1,0 +1,21 @@
+# obabel
+
+> Tool to translate between chemistry-related files
+> 
+> More information: <https://openbabel.org/wiki/Main_Page>
+
+- Convert a .mol file to XYZ coordinates
+
+'obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}
+
+- Convert a SMILES string to a 500x500 picture
+
+'obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500
+
+- Convert a file of SMILES string to seperate 3D .mol files
+
+obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m
+
+- Render multiple inputs into one picture
+
+obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}


### PR DESCRIPTION
tool to convert chemistry files

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Open Babel 3.1.1**
