### PR TITLE
obabel: add page

### DIFF
--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -6,16 +6,16 @@
 
 - Convert a .mol file to XYZ coordinates:
 
-'obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}'
+`obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}`
 
 - Convert a SMILES string to a 500x500 picture:
 
-'obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500'
+`obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500`
 
 - Convert a file of SMILES string to separate 3D .mol files:
 
-'obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m'
+`obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m`
 
 - Render multiple inputs into one picture:
 
-'obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}'
+`obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}`

--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -4,18 +4,18 @@
 > 
 > More information: <https://openbabel.org/wiki/Main_Page>
 
-- Convert a .mol file to XYZ coordinates
+- Convert a .mol file to XYZ coordinates:
 
-obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}
+'obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}'
 
-- Convert a SMILES string to a 500x500 picture
+- Convert a SMILES string to a 500x500 picture:
 
-obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500
+'obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500'
 
-- Convert a file of SMILES string to separate 3D .mol files
+- Convert a file of SMILES string to separate 3D .mol files:
 
-obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m
+'obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m'
 
-- Render multiple inputs into one picture
+- Render multiple inputs into one picture:
 
-obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}
+'obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}'

--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -1,8 +1,7 @@
 # obabel
 
-> Tool to translate between chemistry-related files
-> 
-> More information: <https://openbabel.org/wiki/Main_Page>
+> Tool to translate between chemistry-related files.
+> More information: <https://openbabel.org/wiki/Main_Page>.
 
 - Convert a .mol file to XYZ coordinates:
 

--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -1,6 +1,6 @@
 # obabel
 
-> Tool to translate between chemistry-related files.
+> Translate chemistry-related data.
 > More information: <https://openbabel.org/wiki/Main_Page>.
 
 - Convert a .mol file to XYZ coordinates:

--- a/pages/linux/obabel.md
+++ b/pages/linux/obabel.md
@@ -1,0 +1,21 @@
+# obabel
+
+> Tool to translate between chemistry-related files
+> 
+> More information: <https://openbabel.org/wiki/Main_Page>
+
+- Convert a .mol file to XYZ coordinates
+
+obabel {{path/to/file.mol}} -O {{path/to/output_file.xyz}}
+
+- Convert a SMILES string to a 500x500 picture
+
+obabel -:"{{SMILES}} -O {{path/to/output_file.png}} -xp 500
+
+- Convert a file of SMILES string to separate 3D .mol files
+
+obabel {{path/to/file.smi}} -O {{path/to/output_file.mol}} --gen3D -m
+
+- Render multiple inputs into one picture
+
+obabel {{path/to/file1}} {{path/to/file2}} -O {{path/to/output_file.png}}


### PR DESCRIPTION
tool to convert between chemistry files

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **OpenBabel 3.1.1**
