### PR TITLE
bootctl: move from common to linux, update page, add Polish translation

### DIFF
--- a/pages.pl/linux/bootctl.md
+++ b/pages.pl/linux/bootctl.md
@@ -1,0 +1,28 @@
+# bootctl
+
+> Kontroluj ustawienia oprogramowania układowego EFI i zarządzaj programem rozruchowym.
+> Więcej informacji: <https://manned.org/bootctl>.
+
+- Wyświetl informacje o oprogramowaniu układowym i programach rozruchowych:
+
+`bootctl status`
+
+- Wyświetl wszystkie dostępne wpisy programu rozruchowego:
+
+`bootctl list`
+
+- Ustaw opcję, aby uruchomić oprogramowanie układowe przy następnym rozruchu (podobne do `sudo systemctl reboot --firmware-setup`):
+
+`sudo bootctl reboot-to-firmware true`
+
+- Podaj ścieżkę do partycji systemowej EFI (domyślnie `/efi/`, `/boot/` lub `/boot/efi`):
+
+`bootctl --esp-path={{/ścieżka/do/partycji_systemowej_efi/}}`
+
+- Zainstaluj `systemd-boot` do partycji systemowej EFI:
+
+`sudo bootctl install`
+
+- Usuń wszystkie zainstalowane wersje `systemd-boot` z partycji systemowej EFI:
+
+`sudo bootctl remove`

--- a/pages/linux/bootctl.md
+++ b/pages/linux/bootctl.md
@@ -5,7 +5,11 @@
 
 - Show information about the system firmware and the bootloaders:
 
-`sudo bootctl status`
+`bootctl status`
+
+- Show all available bootloader entries:
+
+`bootctl list`
 
 - Set a flag to boot into the system firmware on the next boot (similar to `sudo systemctl reboot --firmware-setup`):
 
@@ -13,11 +17,7 @@
 
 - Specify the path to the EFI system partition (defaults to `/efi/`, `/boot/` or `/boot/efi`):
 
-`sudo bootctl --esp-path={{/path/to/efi_system_partition/}}`
-
-- Show all available bootloader entries:
-
-`sudo bootctl list`
+`bootctl --esp-path={{/path/to/efi_system_partition/}}`
 
 - Install `systemd-boot` into the EFI system partition:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I removed unnecessary `sudo`s from commands and moved `bootctl` to `linux`, since it's a part of systemd which runs only on linux.