### PR TITLE
pacman: reference other pacman pages

### DIFF
--- a/pages.de/linux/pacman.md
+++ b/pages.de/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Arch Linux Paket Management Tool.
-> Manche Unterbefehle wie `pacman sync` sind separat dokumentiert.
+> Siehe auch: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Weitere Informationen: <https://man.archlinux.org/man/pacman.8>.
 
 - Synchronisiere und aktualisiere alle Pakete:

--- a/pages.fr/linux/pacman.md
+++ b/pages.fr/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Outil de gestion de paquets sur Arch Linux.
-> Certaines commandes comme `pacman sync` ont leur propre documentation.
+> Voir également: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Plus d'informations : <https://man.archlinux.org/man/pacman.8>.
 
 - Synchronise et mets à jour tous les paquets :

--- a/pages.id/linux/pacman.md
+++ b/pages.id/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Kegunaan manajer paket Arch Linux.
-> Kami mempunyai dokumentasi terpisah untuk menggunakan subperintah seperti `pacman sync`.
+> Guarda anche: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Informasi lebih lanjut: <https://man.archlinux.org/man/pacman.8>.
 
 - Sinkronkan dan perbarui semua paket:

--- a/pages.ml/linux/pacman.md
+++ b/pages.ml/linux/pacman.md
@@ -1,6 +1,7 @@
 # pacman
 
 > ആർച്ച് ലിന്ക്സിന്റെ പാക്കേജ് മാനേജുമെന്റ് യൂട്ടിലിറ്റി.
+> ഇതും കാണുക: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > കൂടുതൽ വിവരങ്ങൾ: <https://man.archlinux.org/man/pacman.8>.
 
 - ഇൻസ്റ്റാൾ ചെയ്‌ത എല്ലാ പാക്കേജും അപ്‌ഡേറ്റു ചെയ്യുക:

--- a/pages.pt_BR/linux/pacman.md
+++ b/pages.pt_BR/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Utilitário de Arch Linux para gerenciamento de pacotes.
-> Alguns subcomandos como `pacman sync` possuem sua própria documentação de uso.
+> Veja também: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Mais informações: <https://man.archlinux.org/man/pacman.8>.
 
 - Sincroniza e atualiza todos os pacotes:

--- a/pages.pt_PT/linux/pacman.md
+++ b/pages.pt_PT/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Utilitário para gerir pacotes Arch Linux.
-> Sub comandos como `pacman sync` tem a sua própria documentação.
+> Veja também: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Mais informações: <https://man.archlinux.org/man/pacman.8>.
 
 - Sincronizar e actualizar todos os pacotes:

--- a/pages.ta/linux/pacman.md
+++ b/pages.ta/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > ஆர்ச் லினக்ஸ் தொகுப்பு மேலாளர் பயன்பாடு.
-> `pacman sync` போன்ற சில துணைக் கட்டளைகள் அவற்றின் சொந்த பயன்பாட்டு ஆவணங்களைக் கொண்டுள்ளன.
+> இதையும் பார்க்கவும்: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`..
 > மேலும் விவரத்திற்கு: <https://man.archlinux.org/man/pacman.8>.
 
 - அனைத்து தொகுப்புகளையும் ஒத்திசைத்து புதுப்பிக்கவும்:

--- a/pages.tr/linux/pacman.md
+++ b/pages.tr/linux/pacman.md
@@ -1,6 +1,7 @@
 # pacman
 
 > Arch Linux paket yönetim aracı.
+> Ayrıca bakınız: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > Daha fazla bilgi için: <https://man.archlinux.org/man/pacman.8>.
 
 - Tüm paketleri senkronize et ve güncelle:

--- a/pages.zh/linux/pacman.md
+++ b/pages.zh/linux/pacman.md
@@ -1,6 +1,7 @@
 # pacman
 
 > Arch Linux 的软件包管理器工具。
+> 也可以看看：`pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > 更多信息：<https://man.archlinux.org/man/pacman.8>.
 
 - 同步并更新所有软件包：

--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -1,7 +1,7 @@
 # pacman
 
 > Arch Linux package manager utility.
-> Some subcommands such as `pacman sync` have their own usage documentation.
+> See also: `pacman-database`, `pacman-deptest`, `pacman-files`, `pacman-key`,  `pacman-mirrors`, `pacman-query`, `pacman-remove`, `pacman-sync`, `pacman-upgrade`.
 > For equivalent commands in other package managers, see <https://wiki.archlinux.org/title/Pacman/Rosetta>.
 > More information: <https://man.archlinux.org/man/pacman.8>.
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Changes

I have updated the description to highlight all the available pacman pages in `pacman.md` (in order for users to know that it exists too),  in the other pages we can just refer to this file instead of typing all the commands all over again (I will create PRs for it).

- Ref. #10119