### PR TITLE
md5sum: fix typo

### DIFF
--- a/pages/common/md5sum.md
+++ b/pages/common/md5sum.md
@@ -11,7 +11,7 @@
 
 `md5sum {{path/to/file1}} {{path/to/file2}}`
 
-- Calculate a MD5 checksum from `stdin`:
+- Calculate an MD5 checksum from `stdin`:
 
 `{{some_command}}" | md5sum`
 

--- a/pages/common/md5sum.md
+++ b/pages/common/md5sum.md
@@ -9,11 +9,11 @@
 
 - Calculate MD5 checksums for multiple files:
 
-`md5sum {{path/to/file1}} {{path/to/filen2}}`
+`md5sum {{path/to/file1}} {{path/to/file2}}`
 
-- Calculate a MD5 checksum from the standard input:
+- Calculate a MD5 checksum from `stdin`:
 
-`echo "{{text}}" | md5sum`
+`{{some_command}}" | md5sum`
 
 - Read a file of MD5SUMs and verify all files have matching checksums:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I updated the `stdin` example to be like in the [b2sum page](https://github.com/tldr-pages/tldr/blob/main/pages/common/b2sum.md?plain=1#L16).
This also affects translations ([Tamil](https://github.com/tldr-pages/tldr/blob/main/pages.ta/common/md5sum.md?plain=1#L16) and [Italian](https://github.com/tldr-pages/tldr/blob/main/pages.it/common/md5sum.md?plain=1#L20)), but I don't know the languages, so someone else has to fix those.
There's also [Chinese](https://github.com/tldr-pages/tldr/blob/main/pages.zh/common/md5sum.md?plain=1), but it hasn't been updated in a while and this example doesn't exist there.

Closes #9910.
