### PR TITLE
*: properly capitalize “Python”

### DIFF
--- a/pages.fr/common/2to3.md
+++ b/pages.fr/common/2to3.md
@@ -1,6 +1,6 @@
 # 2to3
 
-> Conversion automatisé de code python 2 vers 3.
+> Conversion automatisé de code Python 2 vers 3.
 > Plus d'informations : <https://docs.python.org/3/library/2to3.html>.
 
 - Afficher les changements qui seront effectués sans les effectuer (coup d'essai) :

--- a/pages.zh/common/androguard.md
+++ b/pages.zh/common/androguard.md
@@ -1,6 +1,6 @@
 # androguard
 
-> 使用 python 编写的一款针对安卓应用的逆向工程工具。
+> 使用 Python 编写的一款针对安卓应用的逆向工程工具。
 > 更多信息：<https://github.com/androguard/androguard>.
 
 - 展示 Android manifest 清单文件：

--- a/pages.zh/common/gunicorn.md
+++ b/pages.zh/common/gunicorn.md
@@ -3,7 +3,7 @@
 > Python 的 WSGI http 服务器。
 > 更多信息：<https://gunicorn.org/>.
 
-- 运行 python web 应用程序：
+- 运行 Python web 应用程序：
 
 `gunicorn {{导入路径：应用程序}}`
 

--- a/pages/common/chroma.md
+++ b/pages/common/chroma.md
@@ -3,7 +3,7 @@
 > Chroma is a general-purpose syntax highlighting library and corresponding command, for Go.
 > More information: <https://github.com/alecthomas/chroma>.
 
-- Highlight a source file with python lexer and output to terminal:
+- Highlight a source file with Python lexer and output to terminal:
 
 `chroma --lexer="{{python}}" {{source_file}}`
 

--- a/pages/common/gitlint.md
+++ b/pages/common/gitlint.md
@@ -11,7 +11,7 @@
 
 `gitlint --commits {{single_refspec_argument}}`
 
-- Path to a directory or python module with extra user-defined rules:
+- Path to a directory or Python module with extra user-defined rules:
 
 `gitlint --extra-path {{path/to/directory}}`
 

--- a/pages/common/meson.md
+++ b/pages/common/meson.md
@@ -1,6 +1,6 @@
 # meson
 
-> SCons-like build system that uses python as a front-end language and Ninja as a building backend.
+> SCons-like build system that uses Python as a front-end language and Ninja as a building backend.
 > More information: <https://mesonbuild.com>.
 
 - Generate a C project with a given name and version:

--- a/pages/common/pipx.md
+++ b/pages/common/pipx.md
@@ -1,6 +1,6 @@
 # pipx
 
-> Install and run python applications in isolated environments.
+> Install and run Python applications in isolated environments.
 > More information: <https://github.com/pypa/pipx>.
 
 - Run an app in a temporary virtual environment:

--- a/pages/common/pystun3.md
+++ b/pages/common/pystun3.md
@@ -1,6 +1,6 @@
 # pystun3
 
-> Classic STUN client written in python.
+> Classic STUN client written in Python.
 > More information: <https://github.com/talkiq/pystun3>.
 
 - Make a STUN request:

--- a/pages/common/tox.md
+++ b/pages/common/tox.md
@@ -16,7 +16,7 @@
 
 `tox --listenvs-all`
 
-- Run tests on a specific environment (e.g. python 3.6):
+- Run tests on a specific environment (e.g. Python 3.6):
 
 `tox -e {{py36}}`
 


### PR DESCRIPTION
```sh
grep -R python pages* | grep -vE '`|#|<' | tr ':' ' '
```