### PR TITLE
tsort: add example with a string

### DIFF
--- a/pages/common/tsort.md
+++ b/pages/common/tsort.md
@@ -7,3 +7,7 @@
 - Perform a topological sort consistent with a partial sort per line of input separated by blanks:
 
 `tsort {{path/to/file}}`
+
+- Perform a topological sort consistent on strings:
+
+`echo "UI Backend\nBackend Database\nDocs UI"|tsort`

--- a/pages/common/tsort.md
+++ b/pages/common/tsort.md
@@ -10,4 +10,4 @@
 
 - Perform a topological sort consistent on strings:
 
-`echo "UI Backend\nBackend Database\nDocs UI"|tsort`
+`echo "{{UI Backend\nBackend Database\nDocs UI}}"|tsort`

--- a/pages/common/tsort.md
+++ b/pages/common/tsort.md
@@ -10,4 +10,4 @@
 
 - Perform a topological sort consistent on strings:
 
-`echo "{{UI Backend\nBackend Database\nDocs UI}}"|tsort`
+`echo -e "{{UI Backend\nBackend Database\nDocs UI}}" | tsort`


### PR DESCRIPTION
The current example doesn't show what path/to/file should be like (or provide a concrete example)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- []  The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
