### PR TITLE
gnmic-get, silicon: fix typos

### DIFF
--- a/pages/common/gnmic-get.md
+++ b/pages/common/gnmic-get.md
@@ -15,6 +15,6 @@
 
 `gnmic -a {{ip:port}} get --prefix {{prefix}} --path {{path1}} --path {{path2}}`
 
-- Query the device state and specify reponse encoding (json_ietf):
+- Query the device state and specify response encoding (json_ietf):
 
 `gnmic -a {{ip:port}} get --path {{path}} --encoding json_ietf`

--- a/pages/common/silicon.md
+++ b/pages/common/silicon.md
@@ -7,7 +7,7 @@
 
 `silicon  {{path/to/source_file}} --output {{path/to/output_image}}`
 
-- Generate an image from a source file with a specific programing language syntax highlighting (e.g. `rust`, `py`, `js`, etc.):
+- Generate an image from a source file with a specific programming language syntax highlighting (e.g. `rust`, `py`, `js`, etc.):
 
 `silicon  {{path/to/source_file}} --output {{path/to/output_image}} --language {{language|extension}}`
 


### PR DESCRIPTION
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
