### PR TITLE
nala: fix usage of sudo

### DIFF
--- a/pages/linux/nala.md
+++ b/pages/linux/nala.md
@@ -6,7 +6,7 @@
 
 - Install a package, or update it to the latest available version:
 
-`nala install {{package}}`
+`sudo nala install {{package}}`
 
 - Remove a package:
 
@@ -18,19 +18,19 @@
 
 - Search package names and descriptions using a word, regex (default) or glob:
 
-`sudo nala search "{{pattern}}"`
+`nala search "{{pattern}}"`
 
 - Update the list of available packages and upgrade the system:
 
-`nala upgrade`
+`sudo nala upgrade`
 
 - Remove all unused packages and dependencies from your system:
 
-`nala autoremove`
+`sudo nala autoremove`
 
 - Fetch fast mirrors to improve download speeds:
 
-`nala fetch`
+`sudo nala fetch`
 
 - Display the history of all transactions:
 


### PR DESCRIPTION
This page mentions using sudo for searching where no root permissions are needed, but does not mention sudo for commands that need root permission.

This commit fixes the this by adding sudo to the commands that need root. Alternatively, sudo could be removed from all commands as users might also use another way to get privileges than sudo.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
