### PR TITLE
xzless: add examples

### DIFF
--- a/pages/common/xzless.md
+++ b/pages/common/xzless.md
@@ -4,6 +4,18 @@
 > See also: `less`.
 > More information: <https://manned.org/xzless>.
 
-- Open a compressed file:
+- View a compressed file:
 
 `xzless {{path/to/archive.xz}}`
+
+- View a compressed file [r]ecursively page by page:
+
+`xzless -r {{path/to/archive.xz}}`
+
+- View a compressed file and display the line [n]umber:
+
+`xzless -N {{path/to/archive.xz}}`
+
+- View a compressed file and [f]ollow it:
+
+`xzless -F {{path/to/archive.xz}}`

--- a/pages/common/xzless.md
+++ b/pages/common/xzless.md
@@ -6,16 +6,12 @@
 
 - View a compressed file:
 
-`xzless {{path/to/archive.xz}}`
+`xzless {{path/to/archive}}`
 
-- View a compressed file [r]ecursively page by page:
+- View a compressed file and display line numbers:
 
-`xzless -r {{path/to/archive.xz}}`
+`xzless --LINE-NUMBERS {{path/to/archive}}`
 
-- View a compressed file and display the line [n]umber:
+- View a compressed file and quit if the entire file can be displayed on the first screen:
 
-`xzless -N {{path/to/archive.xz}}`
-
-- View a compressed file and [f]ollow it:
-
-`xzless -F {{path/to/archive.xz}}`
+`xzless --quit-if-one-screen {{path/to/archive}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** XZ Utils - 5.4.2
- **Issue:** https://github.com/tldr-pages/tldr/issues/8859
