### PR TITLE
xz*: update pages

### DIFF
--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -1,31 +1,31 @@
 # xz
 
-> Compress or decompress .xz and .lzma files.
-> More information: <https://tukaani.org/xz/format.html>.
+> Compress or decompress `.xz` and `.lzma` files.
+> More information: <https://manned.org/xz>.
 
-- Compress a file to the xz file format:
+- Compress a file using xz:
 
 `xz {{path/to/file}}`
 
-- Decompress a xz file:
+- Decompress an xz file:
 
-`xz -d {{file.xz}}`
+`xz --decompress {{file.xz}}`
 
-- Compress a file to the LZMA file format:
+- Compress a file using lzma:
 
 `xz --format={{lzma}} {{path/to/file}}`
 
-- Decompress an LZMA file:
+- Decompress an lzma file:
 
-`xz -d --format={{lzma}} {{file.lzma}}`
+`xz --decompress --format={{lzma}} {{file.lzma}}`
 
-- Decompress a file and write to `stdout`:
+- Decompress a file and write to `stdout` (implies `--keep`):
 
-`xz -dc {{file.xz}}`
+`xz --decompress --stdout {{file.xz}}`
 
 - Compress a file, but don't delete the original:
 
-`xz -k {{path/to/file}}`
+`xz --keep {{path/to/file}}`
 
 - Compress a file using the fastest compression:
 

--- a/pages/common/xz.md
+++ b/pages/common/xz.md
@@ -9,7 +9,7 @@
 
 - Decompress an xz file:
 
-`xz --decompress {{file.xz}}`
+`xz --decompress {{path/to/file.xz}}`
 
 - Compress a file using lzma:
 
@@ -17,11 +17,11 @@
 
 - Decompress an lzma file:
 
-`xz --decompress --format={{lzma}} {{file.lzma}}`
+`xz --decompress --format={{lzma}} {{path/to/file.lzma}}`
 
 - Decompress a file and write to `stdout` (implies `--keep`):
 
-`xz --decompress --stdout {{file.xz}}`
+`xz --decompress --stdout {{path/to/file.xz}}`
 
 - Compress a file, but don't delete the original:
 

--- a/pages/common/xzcmp.md
+++ b/pages/common/xzcmp.md
@@ -1,6 +1,7 @@
 # xzcmp
 
-> Compare compressed files.
+> Invokes `cmp` on files compressed with `xz`, `lzma`, `gzip`, `bzip2`, `lzop`, or `zstd`.
+> All options specified are passed directly to `cmp`.
 > More information: <https://manned.org/xzcmp>.
 
 - Compare two specific files:

--- a/pages/common/xzdiff.md
+++ b/pages/common/xzdiff.md
@@ -1,7 +1,7 @@
 # xzdiff
 
-> Invokes the diff command on files compressed with xz, lzma, gzip, bzip2, lzop, or zstd.
-> All options specified are passed directly to diff.
+> Invokes `diff` on files compressed with `xz`, `lzma`, `gzip`, `bzip2`, `lzop`, or `zstd`.
+> All options specified are passed directly to `diff`.
 > More information: <https://manned.org/xzdiff>.
 
 - Compare files:
@@ -23,7 +23,3 @@
 - Compare files using paginated results:
 
 `xzdiff --paginate {{path/to/file1}} {{path/to/file2}}`
-
-- Compare directories recursively (shows names for differing files/directories as well as changes made to files):
-
-`diff --recursive {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/xzgrep.md
+++ b/pages/common/xzgrep.md
@@ -1,20 +1,20 @@
 # xzgrep
 
-> Search possibly compressed files with xz, lzma, gzip, bzip2, lzop, or zstd for regular expressions.
+> Search files possibly compressed with `xz`, `lzma`, `gzip`, `bzip2`, `lzop`, or `zstd` using regular expressions.
 > See also: `grep`.
-> More information: <https://manned.org/xzgrep.1>.
+> More information: <https://manned.org/xzgrep>.
 
 - Search for a pattern within a file:
 
-`xzgrep "{{search_pattern}}" {{path/to/compressed/file}}`
+`xzgrep "{{search_pattern}}" {{path/to/file}}`
 
 - Search for an exact string (disables regular expressions):
 
-`xzgrep --fixed-strings "{{exact_string}}" {{path/to/compressed/file}}`
+`xzgrep --fixed-strings "{{exact_string}}" {{path/to/file}}`
 
 - Search for a pattern in all files showing line numbers of matches:
 
-`xzgrep --line-number "{{search_pattern}}" {{path/to/compressed/file}}`
+`xzgrep --line-number "{{search_pattern}}" {{path/to/file}}`
 
 - Use extended regular expressions (supports `?`, `+`, `{}`, `()` and `|`), in case-insensitive mode:
 

--- a/pages/common/xzless.md
+++ b/pages/common/xzless.md
@@ -1,17 +1,17 @@
 # xzless
 
-> Display text from `.xz` and `.lzma` files.
+> Display text from `xz` and `lzma` compressed files.
 > See also: `less`.
 > More information: <https://manned.org/xzless>.
 
 - View a compressed file:
 
-`xzless {{path/to/archive}}`
+`xzless {{path/to/file}}`
 
 - View a compressed file and display line numbers:
 
-`xzless --LINE-NUMBERS {{path/to/archive}}`
+`xzless --LINE-NUMBERS {{path/to/file}}`
 
 - View a compressed file and quit if the entire file can be displayed on the first screen:
 
-`xzless --quit-if-one-screen {{path/to/archive}}`
+`xzless --quit-if-one-screen {{path/to/file}}`


### PR DESCRIPTION
Explanations of less obvious changes:
## `xz`
Change the documentation link (the old one pointed to the specification of the `xz` format, not the command).

## `xzdiff`
Remove the last example (it is copied directly from the `diff` page, and does not apply to `xzdiff` since it will not decompress files in directories recursively).

## `xzless`
Replace `path/to/archive` with `path/to/file` since the file cannot be an archive, it has to be a single compressed file.