### PR TITLE
systemd-cat: add page

### DIFF
--- a/pages/linux/systemd-cat.md
+++ b/pages/linux/systemd-cat.md
@@ -1,0 +1,12 @@
+# systemd-cat
+
+> Connect a pipeline or program's output streams with the systemd journal.
+> More information: <https://www.freedesktop.org/software/systemd/man/systemd-cat.html>.
+
+- Write the output of the specified command to the journal (both output streams are captured):
+
+`systemd-cat {{command}}`
+
+- Write the output of a pipeline to the journal (`stderr` stays connected to the terminal):
+
+`{{command}} | systemd-cat`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).