### PR TITLE
[, [[: reword description

### DIFF
--- a/pages/common/[.md
+++ b/pages/common/[.md
@@ -1,7 +1,7 @@
 # [
 
 > Check file types and compare values.
-> Returns 0 if the condition evaluates to true, 1 if it evaluates to false.
+> Returns a status of 0 if the condition evaluates to true, 1 if it evaluates to false.
 > More information: <https://www.gnu.org/software/bash/manual/bash.html#index-test>.
 
 - Test if a given variable is equal/not equal to the specified string:

--- a/pages/common/[[.md
+++ b/pages/common/[[.md
@@ -1,7 +1,7 @@
 # [[
 
 > Check file types and compare values.
-> Returns 0 if the condition evaluates to true, 1 if it evaluates to false.
+> Returns a status of 0 if the condition evaluates to true, 1 if it evaluates to false.
 > More information: <https://www.gnu.org/software/bash/manual/bash.html#index-_005b_005b>.
 
 - Test if a given variable is equal/not equal to the specified string:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

---

The wording before gives the impression we're expecting to see `0` or `1` get logged to the terminal. But it exits with the respective status code, so it should state this clearly.

Wording borrowed from the help page for the command.

```
seth@seth-pc-tux:~$ help [[
[[ ... ]]: [[ expression ]]
    Execute conditional command.
    
    Returns a status of 0 or 1 depending on the evaluation of the conditional
    expression EXPRESSION.  Expressions are composed of the same primaries used
    by the `test' builtin, and may be combined using the following operators:
```

```
seth@seth-pc-tux:~$ [[ 1 == 1 ]]
seth@seth-pc-tux:~$ [[ 1 == 2 ]]
seth@seth-pc-tux:~$ [[ 1 == 1 ]]; echo $?
0
seth@seth-pc-tux:~$ [[ 1 == 2 ]]; echo $?
1
```
> Observe how `[[` has no output, rather to see anything we must echo the exit status of the previous command.