### PR TITLE
clido: add page

### DIFF
--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -27,7 +27,7 @@
 
 `clido edit {{texteditor}}`
 
-- Get your version number:
+- Show the version:
 
 `clido -v`
 

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -31,6 +31,6 @@
 
 `clido -v`
 
-- Get a list of commands:
+- Show a list of commands:
 
 `clido -h`

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -1,7 +1,7 @@
 # clido
 
 > Save-state TODO app for the terminal.
-> For more info, visit the Clido Wiki: <https://codeberg.org/Oglo12/clido/wiki>.
+> More information: <https://codeberg.org/Oglo12/clido/wiki>.
 
 - Create a list:
 

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -19,38 +19,6 @@
 
 `clido --lists`
 
-- Unload current list:
-
-`clido unload`
-
-- Add a task:
-
-`clido add {{task}}`
-
-- Remove a task:
-
-`clido rm {{tasknumber}}`
-
-- Mark a task as done:
-
-`clido check {{tasknumber}}`
-
-- Mark a task as not done:
-
-`clido uncheck {{tasknumber}}`
-
-- Mark a task as in progress:
-
-`clido inwork {{tasknumber}}`
-
-- List all tasks:
-
-`clido list`
-
-- Write pending changes:
-
-`clido write`
-
 - Toggle autowrite:
 
 `clido toggle-autowrite`

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -27,10 +27,10 @@
 
 `clido edit {{text_editor}}`
 
-- Show the version:
+- Display version:
 
 `clido -v`
 
-- Show a list of commands:
+- Display help:
 
 `clido -h`

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -1,0 +1,68 @@
+# clido
+
+> Save-state TODO app for the terminal.
+> For more info, visit the Clido Wiki: <https://codeberg.org/Oglo12/clido/wiki>
+
+- Create a list:
+
+`clido --new {{name}}`
+
+- Load a list:
+
+`clido --load {{name}}`
+
+- Delete a list:
+
+`clido --remove {{name}}`
+
+- List all lists:
+
+`clido --lists`
+
+- Unload current list:
+
+`clido unload`
+
+- Add a task:
+
+`clido add {{task}}`
+
+- Remove a task:
+
+`clido rm {{tasknumber}}`
+
+- Mark a task as done:
+
+`clido check {{tasknumber}}`
+
+- Mark a task as not done:
+
+`clido uncheck {{tasknumber}}`
+
+- Mark a task as in progress:
+
+`clido inwork {{tasknumber}}`
+
+- List all tasks:
+
+`clido list`
+
+- Write pending changes:
+
+`clido write`
+
+- Toggle autowrite:
+
+`clido toggle-autowrite`
+
+- Open a list in a text editor:
+
+`clido edit {{texteditor}}`
+
+- Get your version number:
+
+`clido -v`
+
+- Get a list of commands:
+
+`clido -h`

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -25,7 +25,7 @@
 
 - Open a list in a text editor:
 
-`clido edit {{texteditor}}`
+`clido edit {{text_editor}}`
 
 - Show the version:
 

--- a/pages/common/clido.md
+++ b/pages/common/clido.md
@@ -1,7 +1,7 @@
 # clido
 
 > Save-state TODO app for the terminal.
-> For more info, visit the Clido Wiki: <https://codeberg.org/Oglo12/clido/wiki>
+> For more info, visit the Clido Wiki: <https://codeberg.org/Oglo12/clido/wiki>.
 
 - Create a list:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
- Clido 1.4
