### PR TITLE
docker-images: Adding command to sort images by size

### DIFF
--- a/pages/common/docker-images.md
+++ b/pages/common/docker-images.md
@@ -22,3 +22,7 @@
 - List images that contain a substring in their name:
 
 `docker images "{{*name*}}"`
+
+- Sort images by size
+
+`docker images --format "{{.ID}}\t{{.Size}}\t{{.Repository}}:{{.Tag}}" | sort -k 2 -h`


### PR DESCRIPTION
From: https://stackoverflow.com/a/61091528/520275

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
