### PR TITLE
ssh-keygen: small improvement and fix

### DIFF
--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -17,7 +17,7 @@
 
 - Generiere ein 4096 Bit langen RSA Schlüssel-Paar mit der E-Mail im Kommentarfeld:
 
-`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{kommentar|e-mail}}"`
+`ssh-keygen -t {{rsa}} -b {{4096}} -C "{{kommentar|e-mail}}"`
 
 - Entferne den Schlüssel eines Servers aus der `known_hosts` Datei (hilfreich wenn ein Server seinen Schlüssel aktualisiert hat und der alte somit nicht mehr gilt):
 

--- a/pages.de/common/ssh-keygen.md
+++ b/pages.de/common/ssh-keygen.md
@@ -11,9 +11,9 @@
 
 `ssh-keygen -f {{~/.ssh/datei}}`
 
-- Generiere ein ed25519 Schlüssel-Paar mit 100 Schlüssel-Ableitungs-Iterationen:
+- Generiere ein ed25519 Schlüssel-Paar mit 32 Schlüssel-Ableitungs-Iterationen:
 
-`ssh-keygen -t {{ed25519}} -a {{100}}`
+`ssh-keygen -t {{ed25519}} -a {{32}}`
 
 - Generiere ein 4096 Bit langen RSA Schlüssel-Paar mit der E-Mail im Kommentarfeld:
 

--- a/pages.fr/common/ssh-keygen.md
+++ b/pages.fr/common/ssh-keygen.md
@@ -17,7 +17,7 @@
 
 - Génère une clé RSA de 4096 bits, avec l'adresse électronique en commentaire:
 
-`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{commentaire|email}}"`
+`ssh-keygen -t {{rsa}} -b {{4096}} -C "{{commentaire|email}}"`
 
 - Retire les clés d'une machine donnée du fichier `known_hosts` des hôtes connus (utile lorsque un hôte déjà enregistré change de clé) :
 

--- a/pages.fr/common/ssh-keygen.md
+++ b/pages.fr/common/ssh-keygen.md
@@ -11,9 +11,9 @@
 
 `ssh-keygen -f {{~/.ssh/fichier}}`
 
-- Génère une clé ed25519, avec 100 passages de fonction de dérivation de clé:
+- Génère une clé ed25519, avec 32 passages de fonction de dérivation de clé:
 
-`ssh-keygen -t {{ed25519}} -a {{100}}`
+`ssh-keygen -t {{ed25519}} -a {{32}}`
 
 - Génère une clé RSA de 4096 bits, avec l'adresse électronique en commentaire:
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -13,7 +13,7 @@
 
 - Generate an RSA 4096-bit key with email as a comment:
 
-`ssh-keygen -t {{dsa|ecdsa|ed25519|rsa}} -b {{4096}} -C "{{comment|email}}"`
+`ssh-keygen -t {{rsa}} -b {{4096}} -C "{{comment|email}}"`
 
 - Remove the keys of a host from the known_hosts file (useful when a known host has a new key):
 

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -7,9 +7,9 @@
 
 `ssh-keygen`
 
-- Generate an ed25519 key with 100 key derivation function rounds and save the key to a specific file:
+- Generate an ed25519 key with 32 key derivation function rounds and save the key to a specific file:
 
-`ssh-keygen -t {{ed25519}} -a {{100}} -f {{~/.ssh/filename}}`
+`ssh-keygen -t {{ed25519}} -a {{32}} -f {{~/.ssh/filename}}`
 
 - Generate an RSA 4096-bit key with email as a comment:
 


### PR DESCRIPTION
Two changes:
1. The number of rounds in the ED25519 example has been changed to 32
  - Considering the default value of 16 is already considered "reasonable"<sup>[\[1\]](https://flak.tedunangst.com/post/new-openssh-key-format-and-bcrypt-pbkdf)</sup> safety-wise, there's really no good reason in most cases to go as high as 100. Using such a high value causes noticeably longer login times, especially for resource-constrained systems. Thus I think 32 is a more reasonable number to use as an example.
3. The RSA example now matches description.

---

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).