### PR TITLE
curl: add ipv6 example ( EN and FR)

### DIFF
--- a/pages.fr/common/curl.md
+++ b/pages.fr/common/curl.md
@@ -4,6 +4,10 @@
 > Accepte la plupart des protocoles, notamment HTTP, FTP et POP3.
 > Plus d'informations : <https://curl.se/docs/manpage.html>.
 
+- Interroge une adresse IPv6 spécifique:
+
+`curl '{{http://[ipv6]:port}}'`
+
 - Télécharger le contenu d'une URL dans un fichier :
 
 `curl {{http://exemple.fr}} --output {{nom_fichier}}`

--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -4,6 +4,10 @@
 > Supports most protocols, including HTTP, FTP, and POP3.
 > More information: <https://curl.se/docs/manpage.html>.
 
+- Calls a specific IPv6 address:
+
+`curl '{{http://[ipv6]:port}}'`
+
 - Download the contents of a URL to a file:
 
 `curl {{http://example.com}} --output {{path/to/file}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
