### PR TITLE
*: standardize "command-line"

### DIFF
--- a/pages/common/clifm.md
+++ b/pages/common/clifm.md
@@ -1,6 +1,6 @@
 # clifm
 
-> The command line file manager.
+> The command-line file manager.
 > More information: <https://github.com/leo-arch/clifm>.
 
 - Start CliFM:

--- a/pages/common/cs-complete-dep.md
+++ b/pages/common/cs-complete-dep.md
@@ -1,6 +1,6 @@
 # cs complete dep
 
-> Allows the developer to search for libraries without searching directly on the web but from the command line.
+> Allows the developer to search for libraries without searching directly on the web but from the command-line.
 > More information: <https://get-coursier.io/docs/cli-complete>.
 
 - Print which artifacts are published under a specific Maven group identifier:

--- a/pages/common/ern.md
+++ b/pages/common/ern.md
@@ -1,6 +1,6 @@
 # ern
 
-> Electrode Native platform command line client.
+> Electrode Native platform command-line client.
 > More information: <https://native.electrode.io/reference/index-6>.
 
 - Create a new `ern` application (`MiniApp`):

--- a/pages/common/gh-secret-set.md
+++ b/pages/common/gh-secret-set.md
@@ -1,6 +1,6 @@
 # gh secret set
 
-> Create or update GitHub secrets from the command line.
+> Create or update GitHub secrets from the command-line.
 > More information: <https://cli.github.com/manual/gh_secret_set>.
 
 - Set a secret for the current repository (user will be prompted for the value):

--- a/pages/common/gnatprep.md
+++ b/pages/common/gnatprep.md
@@ -7,6 +7,6 @@
 
 `gnatprep {{source_file}} {{target_file}} {{definitions_file}}`
 
-- Specify symbol values in the command line:
+- Specify symbol values in the command-line:
 
 `gnatprep -D{{name}}={{value}} {{source_file}} {{target_file}}`

--- a/pages/common/gsutil.md
+++ b/pages/common/gsutil.md
@@ -1,6 +1,6 @@
 # gsutil
 
-> The gsutil CLI lets you access Google Cloud Storage from the command line.
+> The gsutil CLI lets you access Google Cloud Storage from the command-line.
 > You can use gsutil to do a wide range of bucket and object management tasks.
 > More information: <https://cloud.google.com/storage/docs/gsutil>.
 

--- a/pages/common/lli.md
+++ b/pages/common/lli.md
@@ -7,7 +7,7 @@
 
 `lli {{path/to/file.ll}}`
 
-- Execute with command line arguments:
+- Execute with command-line arguments:
 
 `lli {{path/to/file.ll}} {{argument1 argument2 ...}}`
 

--- a/pages/common/neomutt.md
+++ b/pages/common/neomutt.md
@@ -1,6 +1,6 @@
 # neomutt
 
-> NeoMutt command line email client.
+> NeoMutt command-line email client.
 > More information: <https://neomutt.org>.
 
 - Open the specified mailbox:

--- a/pages/common/railway.md
+++ b/pages/common/railway.md
@@ -1,6 +1,6 @@
 # railway
 
-> Connect code to a Railway project from the command line.
+> Connect code to a Railway project from the command-line.
 > More information: <https://railway.app/>.
 
 - Login to a Railway account:
@@ -11,7 +11,7 @@
 
 `railway link {{projectId}}`
 
-- Create a new project directly from the command line:
+- Create a new project directly from the command-line:
 
 `railway init`
 

--- a/pages/common/tailscale-up.md
+++ b/pages/common/tailscale-up.md
@@ -1,7 +1,7 @@
 # tailscale up
 
 > Connects the client to the Tailscale network.
-> In version 1.8 and above, command line arguments are stored and reused until they're overwritten or `--reset` is called.
+> In version 1.8 and above, command-line arguments are stored and reused until they're overwritten or `--reset` is called.
 > More information: <https://tailscale.com/kb/admin/>.
 
 - Connect to Tailscale:

--- a/pages/common/tcc.md
+++ b/pages/common/tcc.md
@@ -1,6 +1,6 @@
 # tcc
 
-> A tiny C compiler that can run C source files as scripts and otherwise has command line options similar to `gcc`.
+> A tiny C compiler that can run C source files as scripts and otherwise has command-line options similar to `gcc`.
 > More information: <https://bellard.org/tcc/tcc-doc.html>.
 
 - Compile and link 2 source files to generate an executable:

--- a/pages/common/tcsh.md
+++ b/pages/common/tcsh.md
@@ -1,6 +1,6 @@
 # tcsh
 
-> C shell with file name completion and command line editing.
+> C shell with file name completion and command-line editing.
 > See also: `csh`.
 > More information: <https://manned.org/tcsh>.
 

--- a/pages/common/tts.md
+++ b/pages/common/tts.md
@@ -1,6 +1,6 @@
 # tts
 
-> Synthesize speech on the command line.
+> Synthesize speech on the command-line.
 > More information: <https://github.com/coqui-ai/TTS#command-line-tts>.
 
 - Run text-to-speech with the default models, writing the output to "tts_output.wav":

--- a/pages/common/u3d.md
+++ b/pages/common/u3d.md
@@ -1,6 +1,6 @@
 # u3d
 
-> Set of tools to interact with Unity from command line.
+> Set of tools to interact with Unity from command-line.
 > More information: <https://github.com/DragonBox/u3d>.
 
 - Open project from the current directory in correct Unity version:

--- a/pages/common/vifm.md
+++ b/pages/common/vifm.md
@@ -1,6 +1,6 @@
 # vifm
 
-> Vifm (VI File Manager) is a command line file manager.
+> Vifm (VI File Manager) is a command-line file manager.
 > More information: <https://github.com/vifm/vifm>.
 
 - Open the current directory:

--- a/pages/common/xmlstarlet.md
+++ b/pages/common/xmlstarlet.md
@@ -1,6 +1,6 @@
 # xmlstarlet
 
-> A commandline XML/XSLT toolkit.
+> A command-line XML/XSLT toolkit.
 > Note: You will likely need to know XPath: <https://developer.mozilla.org/en-US/docs/Web/XPath>.
 > More information: <https://xmlstar.sourceforge.net/docs.php>.
 

--- a/pages/common/yolo.md
+++ b/pages/common/yolo.md
@@ -1,6 +1,6 @@
 # yolo
 
-> The YOLO command line interface lets you simply train, validate or infer models on various tasks and versions.
+> The YOLO command-line interface lets you simply train, validate or infer models on various tasks and versions.
 > More information: <https://docs.ultralytics.com/cli/>.
 
 - Create a copy of the default configuration in your current working directory:

--- a/pages/linux/getopt.md
+++ b/pages/linux/getopt.md
@@ -1,6 +1,6 @@
 # getopt
 
-> Parse command line arguments.
+> Parse command-line arguments.
 > More information: <https://www.gnu.org/software/libc/manual/html_node/Getopt.html>.
 
 - Parse optional `verbose`/`version` flags with shorthands:

--- a/pages/linux/goobook.md
+++ b/pages/linux/goobook.md
@@ -1,6 +1,6 @@
 # goobook
 
-> Access Google contacts from `mutt` or the command line.
+> Access Google contacts from `mutt` or the command-line.
 > More information: <https://manned.org/goobook>.
 
 - Allow `goobook` to access Google contacts using OAuth2:

--- a/pages/linux/mpicc.md
+++ b/pages/linux/mpicc.md
@@ -1,7 +1,7 @@
 # mpicc
 
 > Open MPI C wrapper compiler.
-> The wrappers are simply thin shells on top of a C compiler, they add the relevant compiler and linker flags to the command line that are necessary to compile/link Open MPI programs, and then invoke the underlying C compiler to actually perform the command.
+> The wrappers are simply thin shells on top of a C compiler, they add the relevant compiler and linker flags to the command-line that are necessary to compile/link Open MPI programs, and then invoke the underlying C compiler to actually perform the command.
 > More information: <https://www.mpich.org/static/docs/latest/www1/mpicc.html>.
 
 - Compile a source code file into an object file:

--- a/pages/linux/qm-showcmd.md
+++ b/pages/linux/qm-showcmd.md
@@ -1,9 +1,9 @@
 # qm showcmd
 
-> Show command line which is used to start the VM (debug info).
+> Show command-line which is used to start the VM (debug info).
 > More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
-- Show command line for a specific virtual machine:
+- Show command-line for a specific virtual machine:
 
 `qm showcmd {{vm_id}}`
 

--- a/pages/linux/toolbox.md
+++ b/pages/linux/toolbox.md
@@ -1,6 +1,6 @@
 # toolbox
 
-> Tool for containerized command line environments on Linux.
+> Tool for containerized command-line environments on Linux.
 > Some subcommands such as `toolbox create` have their own usage documentation.
 > More information: <https://manned.org/toolbox.1>.
 

--- a/pages/linux/ttyplot.md
+++ b/pages/linux/ttyplot.md
@@ -1,6 +1,6 @@
 # ttyplot
 
-> A realtime plotting utility for the command line with data input from `stdin`.
+> A realtime plotting utility for the command-line with data input from `stdin`.
 > More information: <https://github.com/tenox7/ttyplot>.
 
 - Plot the values `1`, `2` and `3` (`cat` prevents ttyplot to exit):

--- a/pages/linux/virt-xml.md
+++ b/pages/linux/virt-xml.md
@@ -1,6 +1,6 @@
 # virt-xml
 
-> Edit libvirt Domain XML files with explicit command line options.
+> Edit libvirt Domain XML files with explicit command-line options.
 > NOTE: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
 > More information: <https://github.com/virt-manager/virt-manager/blob/main/man/virt-xml.rst>.
 

--- a/pages/linux/zathura.md
+++ b/pages/linux/zathura.md
@@ -1,6 +1,6 @@
 # zathura
 
-> A vim-like modal document viewer, with an integrated command line.
+> A vim-like modal document viewer, with an integrated command-line.
 > Make sure a backend is installed (poppler, PostScript, or DjVu).
 > More information: <https://pwmt.org/projects/zathura/>.
 

--- a/pages/windows/diskpart.md
+++ b/pages/windows/diskpart.md
@@ -3,7 +3,7 @@
 > Disk, volume and partition manager.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/diskpart>.
 
-- Run diskpart by itself in an administrative command prompt to enter its command line:
+- Run diskpart by itself in an administrative command prompt to enter its command-line:
 
 `diskpart`
 

--- a/pages/windows/vcvarsall.md
+++ b/pages/windows/vcvarsall.md
@@ -1,6 +1,6 @@
 # vcvarsall
 
-> Setup the environment variables required for using the Microsoft Visual Studio tools from the command line.
+> Setup the environment variables required for using the Microsoft Visual Studio tools from the command-line.
 > The path of `vcvarsall` for a certain Visual Studio installation can be found using `vswhere`.
 > More information: <https://learn.microsoft.com/cpp/build/building-on-the-command-line>.
 


### PR DESCRIPTION
```sh
$ grep -R command-line pages | wc -l
249
$ grep -R 'command line' pages | wc -l
28
$ grep -R commandline pages | grep -v 'More info' | wc -l
2
```

```sh
# I hate the fact that I had to use `sed -i`, but `sh` sucks
fd -t f . pages | xe sed -i '' 's/command line/command-line/g'
```