### PR TITLE
Replace "Bash" with "Shell"

### DIFF
--- a/pages/common/shift.md
+++ b/pages/common/shift.md
@@ -1,6 +1,6 @@
 # shift
 
-> Bash built-in command that shifts the arguments passed to the calling function or script by a specified number of places.
+> Shell built-in command that shifts the arguments passed to the calling function or script by a specified number of places.
 > More information: <https://www.gnu.org/software/bash/manual/bash.html#index-shift>.
 
 - Move arguments by one place dropping the first argument:


### PR DESCRIPTION
The shift command is defined in the POSIX standard. It is not a Bash built-in command. Saying this implies that it's Bash-only, which is not true.

More info here:
https://manned.org/shift.1p