### PR TITLE
xfreerdp: add /drive example

### DIFF
--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -23,6 +23,6 @@
 
 `xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /cert:ignore`
 
-- Connect to a FreeRDP server wtih shared drive mapped:
+- Connect to a FreeRDP server with shared drive mapped:
 
-`xfreerdp /v:ip_address /u:username /p:password /drive:{{share_path}},{{share_name}}` 
+`xfreerdp /v:ip_address /u:username /p:password /drive:{{share_path}},{{share_name}}`

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -23,6 +23,6 @@
 
 `xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /cert:ignore`
 
-- Connect to a FreeRDP server with shared drive mapped:
+- Connect to a FreeRDP server with a shared directory:
 
 `xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /drive:{{path/to/directory}},{{share_name}}`

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -25,4 +25,4 @@
 
 - Connect to a FreeRDP server with shared drive mapped:
 
-`xfreerdp /v:ip_address /u:username /p:password /drive:{{path/to/directory}},{{share_name}}`
+`xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /drive:{{path/to/directory}},{{share_name}}`

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -22,3 +22,7 @@
 - Connect to a FreeRDP server ignoring any certificate checks:
 
 `xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /cert:ignore`
+
+- Connect to a FreeRDP server wtih shared drive mapped:
+
+`xfreerdp /v:ip_address /u:username /p:password /drive:{{share_path}},{{share_name}}` 

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -25,4 +25,4 @@
 
 - Connect to a FreeRDP server with shared drive mapped:
 
-`xfreerdp /v:ip_address /u:username /p:password /drive:{{share_path}},{{share_name}}`
+`xfreerdp /v:ip_address /u:username /p:password /drive:{{path/to/directory}},{{share_name}}`


### PR DESCRIPTION
Added command to map a shared drive, enables upload or download of files between local and remote hosts.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
