### PR TITLE
mitmproxy : add the variable "SSLKEYLOGFILE"

### DIFF
--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -10,3 +10,7 @@
 - Start mitmproxy bound to custom address and port:
 
 `mitmproxy -b {{ip_address}} -p {{port}}`
+
+- Export the logs with SSL/TLS master keys, to external programs (wireshark,...)
+
+`SSLKEYLOGFILE="{{path/to/file}}" mitmproxy`


### PR DESCRIPTION
Hi

To mitmproxy, add the variable "SSLKEYLOGFILE". The explain is here : [https://docs.mitmproxy.org/stable/howto-wireshark-tls/](https://docs.mitmproxy.org/stable/howto-wireshark-tls/)



