### PR TITLE
mitmproxy : add the variable "SSLKEYLOGFILE"

### DIFF
--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -16,6 +16,6 @@
 
 `mitmproxy --scripts {{path/to/script.py}}`
 
-- Export the logs with SSL/TLS master keys, to external programs (wireshark,...)
+- Export the logs with SSL/TLS master keys, to external programs (wireshark,...):
 
 `SSLKEYLOGFILE="{{path/to/file}}" mitmproxy`

--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -16,6 +16,6 @@
 
 `mitmproxy --scripts {{path/to/script.py}}`
 
-- Export the logs with SSL/TLS master keys, to external programs (wireshark,...):
+- Export the logs with SSL/TLS master keys to external programs (wireshark, etc.):
 
 `SSLKEYLOGFILE="{{path/to/file}}" mitmproxy`

--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -15,3 +15,7 @@
 - Start `mitmproxy` using a script to process traffic:
 
 `mitmproxy --scripts {{path/to/script.py}}`
+
+- Export the logs with SSL/TLS master keys, to external programs (wireshark,...)
+
+`SSLKEYLOGFILE="{{path/to/file}}" mitmproxy`


### PR DESCRIPTION
Hi

To mitmproxy, add the variable "SSLKEYLOGFILE". The explain is here : https://docs.mitmproxy.org/stable/howto-wireshark-tls/