### PR TITLE
gitwatch: add page

### DIFF
--- a/pages/common/gitwatch.md
+++ b/pages/common/gitwatch.md
@@ -1,0 +1,16 @@
+# gitwatch
+
+> Automatically commit file or directory changes to a git repository
+> More information: <https://github.com/gitwatch/gitwatch>.
+
+- Automatically commit any changes made to a file or directory
+
+`gitwatch {{path/to/file_or_directory}}`
+
+- Automatically commit changes, and push these to git repository:
+
+`gitwatch -r {{remote_name}} {{path/to/file_or_directory}}`
+
+- Automatically commit changes, and push these to a specific branch of the git repository:
+
+`gitwatch -r {{remote_name}} -b {{branch_name}} {{path/to/file_or_directory}}`

--- a/pages/common/gitwatch.md
+++ b/pages/common/gitwatch.md
@@ -7,10 +7,10 @@
 
 `gitwatch {{path/to/file_or_directory}}`
 
-- Automatically commit changes, and push these to git repository:
+- Automatically commit changes and push them to a remote repository:
 
 `gitwatch -r {{remote_name}} {{path/to/file_or_directory}}`
 
-- Automatically commit changes, and push these to a specific branch of the git repository:
+- Automatically commit changes and push them to a specific branch of a remote repository:
 
 `gitwatch -r {{remote_name}} -b {{branch_name}} {{path/to/file_or_directory}}`

--- a/pages/common/gitwatch.md
+++ b/pages/common/gitwatch.md
@@ -1,9 +1,9 @@
 # gitwatch
 
-> Automatically commit file or directory changes to a git repository
+> Automatically commit file or directory changes to a git repository.
 > More information: <https://github.com/gitwatch/gitwatch>.
 
-- Automatically commit any changes made to a file or directory
+- Automatically commit any changes made to a file or directory:
 
 `gitwatch {{path/to/file_or_directory}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
  - I would like feedback on this. [gitwatch](https://github.com/gitwatch/gitwatch) is supported on osx and linux. Should the page therefore go in `common`, or should this PR add the gitwatch page only to `linux` and `osx` platform directories?
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 
