### PR TITLE
i3-scrot: fix select-to-clipboard parameter typo

### DIFF
--- a/pages/linux/i3-scrot.md
+++ b/pages/linux/i3-scrot.md
@@ -26,7 +26,7 @@
 
 - Capture a screenshot of a specific selection and copy it to the clipboard:
 
-`i3-scrot --select-to-clibpoard`
+`i3-scrot --select-to-clipboard`
 
 - Capture a screenshot of the active window after a delay of 5 seconds:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
