### PR TITLE
pacman: update French translation

### DIFF
--- a/pages.fr/linux/pacman.md
+++ b/pages.fr/linux/pacman.md
@@ -16,9 +16,9 @@
 
 `sudo pacman -Rs {{nom_paquet}}`
 
-- Recherche dans la base de données des paquets une expression régulière ou mot clé :
+- Recherche dans la base de données des paquets contenant un certain fichier :
 
-`pacman -Ss "{{terme_recherche}}"`
+`pacman -F "{{nom_fichier}}"`
 
 - Liste les paquets installés et leurs versions :
 


### PR DESCRIPTION
pacman -F is far more useful than pacman -Ss as it allows you to query a package name from a command name. It's very useful when you are locking for dependencies. It's the pacman equivalent of the apt-file command.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
