### PR TITLE
eol: add page

### DIFF
--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -9,9 +9,9 @@
 
 `eol {{product}}`
 
-- Open product webpage on EOL:
+- Open the product webpage:
 
-`eol {{product}} -w`
+`eol {{product}} --web`
 
 - Get EOLs of multiple products all at once:
 

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -1,0 +1,36 @@
+# eol
+
+> CLI to show end-of-life dates (EoLs) for an (ever increasing) number of products (e.g. Programming Languages, Frameworks, Devices, Operating Systems, Desktop Applications, ...).
+> More information: <https://github.com/hugovk/norwegianblue>.
+
+- Get help:
+
+`eol -h`
+
+- List all available products:
+
+`eol`
+
+- Get eols of a given product:
+
+`eol {{product}}`
+
+- Open product webpage on endoflie.date:
+
+`eol {{product}} -w`
+
+- Get eols of multiple products all at once:
+
+`eol {{product1}} {{product2}} {{product3}}`
+
+- Get eols of a product as markdown:
+
+`eol {{product}} -f markdown`
+
+- Get eols of a product as csv:
+
+`eol {{product}} -f csv`
+
+- Get eols of a multiple products as a single markdown file:
+
+`eol {{product1}} {{product2}} {{product3}} -f markdown > eol_report.md`

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -13,10 +13,6 @@
 
 `eol {{product}} --web`
 
-- Get EOLs of multiple products all at once:
-
-`eol {{product1 product2 ...}}`
-
 - Get EOLs of a product in a specific format:
 
 `eol {{product}} -f {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -1,36 +1,30 @@
-# eol
-
-> CLI to show end-of-life dates (EoLs) for an (ever increasing) number of products (e.g. Programming Languages, Frameworks, Devices, Operating Systems, Desktop Applications, ...).
+> CLI to show end-of-life dates (EoLs) for a number of products.
 > More information: <https://github.com/hugovk/norwegianblue>.
-
-- Get help:
-
-`eol -h`
 
 - List all available products:
 
 `eol`
 
-- Get eols of a given product:
+- Get EOLs of a given product:
 
 `eol {{product}}`
 
-- Open product webpage on endoflie.date:
+- Open product webpage on EOL:
 
 `eol {{product}} -w`
 
-- Get eols of multiple products all at once:
+- Get EOLs of multiple products all at once:
 
-`eol {{product1}} {{product2}} {{product3}}`
+`eol {{product1 product2 ...}}`
 
-- Get eols of a product as markdown:
+- Get EOLs of a product in a specific format:
 
-`eol {{product}} -f markdown`
+`eol {{product}} -f {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`
 
-- Get eols of a product as csv:
+- Get EOLs of multiple products as a single markdown file:
 
-`eol {{product}} -f csv`
+`eol {{product1 product2 ...}} -f markdown > eol_report.md`
 
-- Get eols of a multiple products as a single markdown file:
+- Display help:
 
-`eol {{product1}} {{product2}} {{product3}} -f markdown > eol_report.md`
+`eol --help`

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -13,9 +13,9 @@
 
 `eol {{product}} --web`
 
-- Get EOLs of a product in a specific format:
+- Get EoLs of a one or more products in a specific format:
 
-`eol {{product}} -f {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`
+`eol {{product1 product2 ...}} --format {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`
 
 - Get EOLs of multiple products as a single markdown file:
 

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -17,9 +17,9 @@
 
 `eol {{product1 product2 ...}} --format {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`
 
-- Get EOLs of multiple products as a single markdown file:
+- Get EoLs of one or more products as a single markdown file:
 
-`eol {{product1 product2 ...}} -f markdown > eol_report.md`
+`eol {{product1 product2 ...}} --format {{markdown}} > {{eol_report.md}}`
 
 - Display help:
 

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -5,9 +5,9 @@
 
 `eol`
 
-- Get EOLs of a given product:
+- Get EoLs of one or more products:
 
-`eol {{product}}`
+`eol {{product1 product2 ...}}`
 
 - Open the product webpage:
 

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -1,3 +1,5 @@
+# eol
+
 > CLI to show end-of-life dates (EoLs) for a number of products.
 > More information: <https://github.com/hugovk/norwegianblue>.
 

--- a/pages/common/eol.md
+++ b/pages/common/eol.md
@@ -1,6 +1,6 @@
 # eol
 
-> CLI to show end-of-life dates (EoLs) for a number of products.
+> Show end-of-life dates (EoLs) for a number of products.
 > More information: <https://github.com/hugovk/norwegianblue>.
 
 - List all available products:


### PR DESCRIPTION
# :heavy_check_mark: Prerequisites

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] Version of the command being documented (if known):**

# :bookmark: Related resources

- [⌛ Manage EoLs like a boss with endoflife.date 🛑 ](https://dev.to/optnc/manage-eols-like-a-boss-with-endoflifedate-2ikf)