### PR TITLE
zellij: fix typo

### DIFF
--- a/pages/common/zellij.md
+++ b/pages/common/zellij.md
@@ -22,4 +22,4 @@
 
 - Detach from the current session (inside a zellij session):
 
-`Ctrl + N, D`
+`Ctrl + O, D`


### PR DESCRIPTION
fix typo in detach command, it's O not N.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
