### PR TITLE
terminal-notifier: add page

### DIFF
--- a/pages/osx/terminal-notifier.md
+++ b/pages/osx/terminal-notifier.md
@@ -1,0 +1,20 @@
+# terminal-notifier
+
+> Send macOS User Notifications.
+> More information: <https://github.com/julienXX/terminal-notifier>.
+
+- Send a notification:
+
+`terminal-notifier -message {{'TLDR rocks'}}`
+
+- Display piped data with a sound:
+
+`echo {{'Piped Message Data!'}} | terminal-notifier -sound {{default}}`
+
+- Open an URL when the notification is clicked:
+
+`terminal-notifier -message {{'💰 Check your Apple stock!'}} -open {{'http://finance.yahoo.com/q?s=AAPL'}}`
+
+- Open an app when the notification is clicked:
+
+`terminal-notifier -message {{'Imported 42 contacts.'}}  -activate {{'com.apple.AddressBook'}}`

--- a/pages/osx/terminal-notifier.md
+++ b/pages/osx/terminal-notifier.md
@@ -9,7 +9,7 @@
 
 - Display piped data with a sound:
 
-`echo {{'Piped Message Data!'}} | terminal-notifier -sound {{default}}`
+`echo '{{Piped Message Data!}}' | terminal-notifier -sound {{default}}`
 
 - Open a URL when the notification is clicked:
 

--- a/pages/osx/terminal-notifier.md
+++ b/pages/osx/terminal-notifier.md
@@ -3,18 +3,18 @@
 > Send macOS User Notifications.
 > More information: <https://github.com/julienXX/terminal-notifier>.
 
-- Send a notification:
+- Send a notification (message is mandatory):
 
-`terminal-notifier -message {{'TLDR rocks'}}`
+`terminal-notifier -group {{tldr-info}} -title {{TLDR}} -message {{'TLDR rocks'}}`
 
 - Display piped data with a sound:
 
 `echo {{'Piped Message Data!'}} | terminal-notifier -sound {{default}}`
 
-- Open an URL when the notification is clicked:
+- Open a URL when the notification is clicked:
 
-`terminal-notifier -message {{'💰 Check your Apple stock!'}} -open {{'http://finance.yahoo.com/q?s=AAPL'}}`
+`terminal-notifier -message {{'Check your Apple stock!'}} -open {{'http://finance.yahoo.com/q?s=AAPL'}}`
 
 - Open an app when the notification is clicked:
 
-`terminal-notifier -message {{'Imported 42 contacts.'}}  -activate {{'com.apple.AddressBook'}}`
+`terminal-notifier -message {{'Imported 42 contacts.'}}  -activate {{com.apple.AddressBook}}`

--- a/pages/osx/terminal-notifier.md
+++ b/pages/osx/terminal-notifier.md
@@ -3,7 +3,7 @@
 > Send macOS User Notifications.
 > More information: <https://github.com/julienXX/terminal-notifier>.
 
-- Send a notification (message is mandatory):
+- Send a notification (only the message is required):
 
 `terminal-notifier -group {{tldr-info}} -title {{TLDR}} -message '{{TLDR rocks}}'`
 

--- a/pages/osx/terminal-notifier.md
+++ b/pages/osx/terminal-notifier.md
@@ -5,7 +5,7 @@
 
 - Send a notification (message is mandatory):
 
-`terminal-notifier -group {{tldr-info}} -title {{TLDR}} -message {{'TLDR rocks'}}`
+`terminal-notifier -group {{tldr-info}} -title {{TLDR}} -message '{{TLDR rocks}}'`
 
 - Display piped data with a sound:
 
@@ -13,8 +13,8 @@
 
 - Open a URL when the notification is clicked:
 
-`terminal-notifier -message {{'Check your Apple stock!'}} -open {{'http://finance.yahoo.com/q?s=AAPL'}}`
+`terminal-notifier -message '{{Check your Apple stock!}}' -open '{{http://finance.yahoo.com/q?s=AAPL}}'`
 
 - Open an app when the notification is clicked:
 
-`terminal-notifier -message {{'Imported 42 contacts.'}}  -activate {{com.apple.AddressBook}}`
+`terminal-notifier -message '{{Imported 42 contacts.}}'  -activate {{com.apple.AddressBook}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): [2.0.0 the reboot](https://github.com/julienXX/terminal-notifier/releases/tag/2.0.0)**


Thank you for the great tool! Examples are inspired from the README page of this command, but simplified to go straight to the point.
