### PR TITLE
ruby: add http server example

### DIFF
--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -19,10 +19,10 @@
 
 `ruby -c {{script.rb}}`
 
-- Show the version of Ruby you are using:
-
-`ruby -v`
-
 - Start the built-in HTTP server on port 8080 in the current directory:
 
 `ruby -run -e httpd`
+
+- Show the version of Ruby you are using:
+
+`ruby -v`

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -22,3 +22,7 @@
 - Show the version of Ruby you are using:
 
 `ruby -v`
+
+- Start the built-in HTTP server on port 8080 in the current directory:
+
+`ruby -run -e httpd`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): Every ruby that is not EOL (3.0 to 3.2)**
