### PR TITLE
age: fix argument ordering

### DIFF
--- a/pages/common/age.md
+++ b/pages/common/age.md
@@ -13,11 +13,11 @@
 
 - Encrypt a file with one or more public keys that are entered as literals:
 
-`age --recipient {{public_key_1}} --recipient {{public_key_2}} {{path/to/unencrypted_file}} --output {{path/to/encrypted_file}}`
+`age --recipient {{public_key_1}} --recipient {{public_key_2}} --output {{path/to/encrypted_file}} {{path/to/unencrypted_file}}`
 
 - Encrypt a file to one or more recipients with their public keys specified in a file (one per line):
 
-`age --recipients-file {{path/to/recipients_file}} {{path/to/unencrypted_file}} --output {{path/to/encrypted_file}}`
+`age --recipients-file {{path/to/recipients_file}} --output {{path/to/encrypted_file}} {{path/to/unencrypted_file}}`
 
 - Decrypt a file with a passphrase:
 


### PR DESCRIPTION
"Input file must be specified after all flags" as of age v1.1.1

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- v1.1.1
