### PR TITLE
git-cherry-pick: spelled-out version of `-n`

### DIFF
--- a/pages.es/common/git-cherry-pick.md
+++ b/pages.es/common/git-cherry-pick.md
@@ -18,4 +18,4 @@
 
 - Añade los cambios de un commit al directorio de trabajo, sin crear un commit:
 
-`git cherry-pick -n {{commit}}`
+`git cherry-pick --no-commit {{commit}}`

--- a/pages.fr/common/git-cherry-pick.md
+++ b/pages.fr/common/git-cherry-pick.md
@@ -18,4 +18,4 @@
 
 - Appliquer les changements d'un commit à la branche courante sans créer de commit :
 
-`git cherry-pick -n {{commit}}`
+`git cherry-pick --no-commit {{commit}}`

--- a/pages.it/common/git-cherry-pick.md
+++ b/pages.it/common/git-cherry-pick.md
@@ -18,4 +18,4 @@
 
 - Aggiungi le modifiche introdotte da un commit alla directory di lavoro, ma senza creare un nuovo commit:
 
-`git cherry-pick -n {{commit}}`
+`git cherry-pick --no-commit {{commit}}`

--- a/pages.tr/common/git-cherry-pick.md
+++ b/pages.tr/common/git-cherry-pick.md
@@ -18,4 +18,4 @@
 
 - Bir commit'in değişikliklerini, herhangi bir yeni commit oluşturmadan çalışan dizine ekle:
 
-`git cherry-pick -n {{commit}}`
+`git cherry-pick --no-commit {{commit}}`

--- a/pages/common/git-cherry-pick.md
+++ b/pages/common/git-cherry-pick.md
@@ -18,4 +18,4 @@
 
 - Add the changes of a commit to the working directory, without creating a commit:
 
-`git cherry-pick -n {{commit}}`
+`git cherry-pick --no-commit {{commit}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.41.0
