### PR TITLE
pages/*: prefer brand name and add backticks around commands

### DIFF
--- a/pages/common/babeld.md
+++ b/pages/common/babeld.md
@@ -3,22 +3,22 @@
 > Routing daemon for Babel which uses firewall-style filters.
 > More information: <https://www.irif.fr/~jch/software/babel/babeld.html>.
 
-- Start babeld with a specific configuration file:
+- Start `babeld` with a specific configuration file:
 
 `babeld -c {{path/to/babeld.conf}}`
 
-- Start babeld with multiple configuration files (read in order):
+- Start `babeld` with multiple configuration files (read in order):
 
 `babeld -c {{path/to/ports.conf}} -c {{path/to/filters.conf}} -c {{path/to/interfaces.conf}}`
 
-- Start babeld and daemonise afterwards:
+- Start `babeld` and daemonise afterwards:
 
 `babeld -D`
 
-- Start babeld and pass a configuration command:
+- Start `babeld` and pass a configuration command:
 
 `babeld -C {{'redistribute metric 256'}}`
 
-- Start babeld and specify on which interfaces to operate:
+- Start `babeld` and specify on which interfaces to operate:
 
 `babeld {{eth0}} {{eth1}} {{wlan0}}`

--- a/pages/common/beanstalkd.md
+++ b/pages/common/beanstalkd.md
@@ -3,11 +3,11 @@
 > A simple and generic work-queue server.
 > More information: <https://beanstalkd.github.io/>.
 
-- Start beanstalkd, listening on port 11300:
+- Start Beanstalk, listening on port 11300:
 
 `beanstalkd`
 
-- Start beanstalkd listening on a custom port and address:
+- Start Beanstalk listening on a custom port and address:
 
 `beanstalkd -l {{ip_address}} -p {{port_number}}`
 

--- a/pages/common/browser-sync.md
+++ b/pages/common/browser-sync.md
@@ -15,6 +15,6 @@
 
 `browser-sync init`
 
-- Start browser-sync from config file:
+- Start Browsersync from config file:
 
 `browser-sync start --config {{config_file}}`

--- a/pages/common/diskonaut.md
+++ b/pages/common/diskonaut.md
@@ -3,11 +3,11 @@
 > Terminal disk space navigator, written in Rust.
 > More information: <https://github.com/imsnif/diskonaut>.
 
-- Start diskonaut in the current directory:
+- Start `diskonaut` in the current directory:
 
 `diskonaut`
 
-- Start diskonaut in a specific directory:
+- Start `diskonaut` in a specific directory:
 
 `diskonaut {{path/to/directory}}`
 

--- a/pages/common/elinks.md
+++ b/pages/common/elinks.md
@@ -1,6 +1,6 @@
 # elinks
 
-> A text based browser similar to lynx.
+> A text based browser similar to `lynx`.
 > More information: <http://elinks.or.cz>.
 
 - Start ELinks:

--- a/pages/common/elinks.md
+++ b/pages/common/elinks.md
@@ -3,7 +3,7 @@
 > A text based browser similar to lynx.
 > More information: <http://elinks.or.cz>.
 
-- Start elinks:
+- Start ELinks:
 
 `elinks`
 

--- a/pages/common/fastd.md
+++ b/pages/common/fastd.md
@@ -4,7 +4,7 @@
 > Works on Layer 2 or Layer 3, supports different encryption methods, used by Freifunk.
 > More information: <https://fastd.readthedocs.io/en/stable/>.
 
-- Start fastd with a specific configuration file:
+- Start `fastd` with a specific configuration file:
 
 `fastd --config {{path/to/fastd.conf}}`
 

--- a/pages/common/fzf.md
+++ b/pages/common/fzf.md
@@ -4,11 +4,11 @@
 > Similar to `sk`.
 > More information: <https://github.com/junegunn/fzf>.
 
-- Start fzf on all files in the specified directory:
+- Start `fzf` on all files in the specified directory:
 
 `find {{path/to/directory}} -type f | fzf`
 
-- Start fzf for running processes:
+- Start `fzf` for running processes:
 
 `ps aux | fzf`
 
@@ -16,14 +16,14 @@
 
 `find {{path/to/directory}} -type f | fzf --multi > {{path/to/file}}`
 
-- Start fzf with a specified query:
+- Start `fzf` with a specified query:
 
 `fzf --query "{{query}}"`
 
-- Start fzf on entries that start with core and end with either go, rb, or py:
+- Start `fzf` on entries that start with core and end with either go, rb, or py:
 
 `fzf --query "^core go$ | rb$ | py$"`
 
-- Start fzf on entries that not match pyc and match exactly travis:
+- Start `fzf` on entries that not match pyc and match exactly travis:
 
 `fzf --query "!pyc 'travis"`

--- a/pages/common/gdb.md
+++ b/pages/common/gdb.md
@@ -19,6 +19,6 @@
 
 `gdb -ex "{{commands}}" {{executable}}`
 
-- Start gdb and pass arguments to the executable:
+- Start `gdb` and pass arguments to the executable:
 
 `gdb --args {{executable}} {{argument1}} {{argument2}}`

--- a/pages/common/hangups.md
+++ b/pages/common/hangups.md
@@ -3,7 +3,7 @@
 > Third party command-line client for Google Hangouts.
 > More information: <https://github.com/tdryer/hangups>.
 
-- Start hangups:
+- Start `hangups`:
 
 `hangups`
 

--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -3,11 +3,11 @@
 > Display dynamic real-time information about running processes. An enhanced version of `top`.
 > More information: <https://htop.dev/>.
 
-- Start htop:
+- Start `htop`:
 
 `htop`
 
-- Start htop displaying processes owned by a specific user:
+- Start `htop` displaying processes owned by a specific user:
 
 `htop --user {{username}}`
 

--- a/pages/common/khal.md
+++ b/pages/common/khal.md
@@ -3,7 +3,7 @@
 > A text-based calendar and scheduling application for the command-line.
 > More information: <https://lostpackets.de/khal>.
 
-- Start khal on interactive mode:
+- Start Khal on interactive mode:
 
 `ikhal`
 

--- a/pages/common/locust.md
+++ b/pages/common/locust.md
@@ -15,14 +15,14 @@
 
 `locust --no-web --clients={{100}} --hatch-rate={{1}} --host={{http://example.com}}`
 
-- Start locust in master mode:
+- Start Locust in master mode:
 
 `locust --master --host={{http://example.com}}`
 
-- Connect locust slave to master:
+- Connect Locust slave to master:
 
 `locust --slave --host={{http://example.com}}`
 
-- Connect locust slave to master on a different machine:
+- Connect Locust slave to master on a different machine:
 
 `locust --slave --master-host={{master_hostname}} --host={{http://example.com}}`

--- a/pages/common/meld.md
+++ b/pages/common/meld.md
@@ -3,7 +3,7 @@
 > Graphical diffing and merging tool.
 > More information: <https://meldmerge.org/>.
 
-- Start meld:
+- Start `meld`:
 
 `meld`
 

--- a/pages/common/mosquitto.md
+++ b/pages/common/mosquitto.md
@@ -3,7 +3,7 @@
 > An MQTT broker.
 > More information: <https://mosquitto.org/>.
 
-- Start mosquitto:
+- Start Mosquitto:
 
 `mosquitto`
 

--- a/pages/common/mytop.md
+++ b/pages/common/mytop.md
@@ -3,7 +3,7 @@
 > Display MySQL server performance info like `top`.
 > More information: <http://jeremy.zawodny.com/mysql/mytop/mytop.html>.
 
-- Start mytop:
+- Start `mytop`:
 
 `mytop`
 

--- a/pages/common/newsboat.md
+++ b/pages/common/newsboat.md
@@ -11,7 +11,7 @@
 
 `echo {{http://example.com/path/to/feed}} >> "${HOME}/.newsboat/urls"`
 
-- Start newsboat and refresh all feeds on startup:
+- Start Newsboat and refresh all feeds on startup:
 
 `newsboat -r`
 

--- a/pages/common/peco.md
+++ b/pages/common/peco.md
@@ -3,14 +3,14 @@
 > Interactive filtering tool.
 > More information: <https://github.com/peco/peco>.
 
-- Start peco on all files in the specified directory:
+- Start `peco` on all files in the specified directory:
 
 `find {{path/to/directory}} -type f | peco`
 
-- Start peco for running processes:
+- Start `peco` for running processes:
 
 `ps aux | peco`
 
-- Start peco with a specified query:
+- Start `peco` with a specified query:
 
 `peco --query "{{query}}"`

--- a/pages/common/screenfetch.md
+++ b/pages/common/screenfetch.md
@@ -3,7 +3,7 @@
 > Display system information.
 > More information: <https://github.com/KittyKatt/screenFetch>.
 
-- Start screenfetch:
+- Start `screenfetch`:
 
 `screenfetch`
 

--- a/pages/common/sdcv.md
+++ b/pages/common/sdcv.md
@@ -4,7 +4,7 @@
 > Dictionaries are provided separately from the client.
 > More information: <https://manned.org/sdcv>.
 
-- Start sdcv interactively:
+- Start `sdcv` interactively:
 
 `sdcv`
 

--- a/pages/common/sk.md
+++ b/pages/common/sk.md
@@ -4,15 +4,15 @@
 > Similar to `fzf`.
 > More information: <https://github.com/lotabout/skim>.
 
-- Start skim on all files in the specified directory:
+- Start `skim` on all files in the specified directory:
 
 `find {{path/to/directory}} -type f | sk`
 
-- Start skim for running processes:
+- Start `skim` for running processes:
 
 `ps aux | sk`
 
-- Start skim with a specified query:
+- Start `skim` with a specified query:
 
 `sk --query "{{query}}"`
 

--- a/pages/common/speedcrunch.md
+++ b/pages/common/speedcrunch.md
@@ -3,7 +3,7 @@
 > A high-precision scientific calculator.
 > More information: <https://www.speedcrunch.org>.
 
-- Start speedcrunch:
+- Start SpeedCrunch:
 
 `speedcrunch`
 

--- a/pages/common/supervisord.md
+++ b/pages/common/supervisord.md
@@ -4,7 +4,7 @@
 > Supervisord is the server part of supervisor; it is primarily managed via a configuration file.
 > More information: <http://supervisord.org>.
 
-- Start supervisord with specified configuration file:
+- Start `supervisord` with specified configuration file:
 
 `supervisord -c {{path/to/file}}`
 

--- a/pages/common/telnet.md
+++ b/pages/common/telnet.md
@@ -19,7 +19,7 @@
 
 `Ctrl + ]`
 
-- Start telnet with "x" as the session termination character:
+- Start `telnet` with "x" as the session termination character:
 
 `telnet -e {{x}} {{ip_address}} {{port}}`
 

--- a/pages/common/wordgrinder.md
+++ b/pages/common/wordgrinder.md
@@ -3,7 +3,7 @@
 > Command-line word processor.
 > More information: <https://cowlark.com/wordgrinder>.
 
-- Start wordgrinder (loads a blank document by default):
+- Start WordGrinder (loads a blank document by default):
 
 `wordgrinder`
 

--- a/pages/common/wpm.md
+++ b/pages/common/wpm.md
@@ -3,15 +3,15 @@
 > Typeracer-like console app for measuring your WPM.
 > More information: <https://github.com/cslarsen/wpm>.
 
-- Start the program:
+- Start `wpm`:
 
 `wpm`
 
-- Start wpm with short texts:
+- Start `wpm` with short texts:
 
 `wpm --short`
 
-- Start wpm using a specific text file:
+- Start `wpm` using a specific text file:
 
 `wpm --load {{path/to/file.txt}}`
 
@@ -23,6 +23,6 @@
 
 `wpm --stats`
 
-- Start wpm with monochrome colors:
+- Start `wpm` with monochrome colors:
 
 `wpm --monochrome`

--- a/pages/common/wuzz.md
+++ b/pages/common/wuzz.md
@@ -3,7 +3,7 @@
 > Tool to interactively inspect HTTP requests and responses.
 > More information: <https://github.com/asciimoo/wuzz>.
 
-- Start wuzz:
+- Start `wuzz`:
 
 `wuzz`
 

--- a/pages/linux/bpytop.md
+++ b/pages/linux/bpytop.md
@@ -3,7 +3,7 @@
 > Display dynamic real-time information about running processes with graphs. Similar to `gtop` and `htop`.
 > More information: <https://github.com/aristocratos/bpytop>.
 
-- Start bpytop:
+- Start `bpytop`:
 
 `bpytop`
 

--- a/pages/linux/calcurse.md
+++ b/pages/linux/calcurse.md
@@ -3,7 +3,7 @@
 > A text-based calendar and scheduling application for the command-line.
 > More information: <https://calcurse.org>.
 
-- Start calcurse on interactive mode:
+- Start `calcurse` on interactive mode:
 
 `calcurse`
 

--- a/pages/linux/chronyc.md
+++ b/pages/linux/chronyc.md
@@ -3,7 +3,7 @@
 > Query the Chrony NTP daemon.
 > More information: <https://chrony.tuxfamily.org/doc/4.0/chronyc.html>.
 
-- Start chronyc in interactive mode:
+- Start `chronyc` in interactive mode:
 
 `chronyc`
 

--- a/pages/linux/collectd.md
+++ b/pages/linux/collectd.md
@@ -15,7 +15,7 @@
 
 `collectd -T`
 
-- Start collectd:
+- Start `collectd`:
 
 `collectd`
 

--- a/pages/linux/engrampa.md
+++ b/pages/linux/engrampa.md
@@ -4,7 +4,7 @@
 > See also: `zip`, `tar`.
 > More information: <https://github.com/mate-desktop/engrampa>.
 
-- Start engrampa:
+- Start Engrampa:
 
 `engrampa`
 

--- a/pages/linux/hardinfo.md
+++ b/pages/linux/hardinfo.md
@@ -3,7 +3,7 @@
 > Show hardware information in GUI window.
 > More information: <https://github.com/lpereira/hardinfo>.
 
-- Start hardinfo:
+- Start `hardinfo`:
 
 `hardinfo`
 

--- a/pages/linux/nethogs.md
+++ b/pages/linux/nethogs.md
@@ -3,7 +3,7 @@
 > Monitor bandwidth usage per process.
 > More information: <https://github.com/raboof/nethogs>.
 
-- Start nethogs as root (default device is eth0):
+- Start `nethogs` as root (default device is eth0):
 
 `sudo nethogs`
 

--- a/pages/linux/nethogs.md
+++ b/pages/linux/nethogs.md
@@ -3,7 +3,7 @@
 > Monitor bandwidth usage per process.
 > More information: <https://github.com/raboof/nethogs>.
 
-- Start `nethogs` as root (default device is eth0):
+- Start `nethogs` as root (default device is `eth0`):
 
 `sudo nethogs`
 

--- a/pages/linux/nethogs.md
+++ b/pages/linux/nethogs.md
@@ -3,7 +3,7 @@
 > Monitor bandwidth usage per process.
 > More information: <https://github.com/raboof/nethogs>.
 
-- Start `nethogs` as root (default device is `eth0`):
+- Start NetHogs as root (default device is `eth0`):
 
 `sudo nethogs`
 

--- a/pages/linux/nmon.md
+++ b/pages/linux/nmon.md
@@ -3,7 +3,7 @@
 > A system administrator, tuner, and benchmark tool.
 > More information: <https://manned.org/nmon>.
 
-- Start nmon:
+- Start `nmon`:
 
 `nmon`
 

--- a/pages/linux/raspi-config.md
+++ b/pages/linux/raspi-config.md
@@ -3,6 +3,6 @@
 > An `ncurses` terminal GUI to config a Raspberry Pi.
 > More information: <https://www.raspberrypi.org/documentation/computers/configuration.html>.
 
-- Start raspi-config:
+- Start `raspi-config`:
 
 `sudo raspi-config`

--- a/pages/linux/terminator.md
+++ b/pages/linux/terminator.md
@@ -3,7 +3,7 @@
 > Arrange multiple GNOME terminals in one window.
 > More information: <https://gnome-terminator.org/>.
 
-- Start terminator window:
+- Start `terminator` window:
 
 `terminator`
 

--- a/pages/linux/top.md
+++ b/pages/linux/top.md
@@ -3,7 +3,7 @@
 > Display dynamic real-time information about running processes.
 > More information: <https://manned.org/top>.
 
-- Start top:
+- Start `top`:
 
 `top`
 

--- a/pages/linux/xman.md
+++ b/pages/linux/xman.md
@@ -3,7 +3,7 @@
 > Manual page viewer for X Window System.
 > More information: <https://manned.org/xman>.
 
-- Start xman in three-button window:
+- Start `xman` in three-button window:
 
 `xman`
 

--- a/pages/osx/top.md
+++ b/pages/osx/top.md
@@ -3,19 +3,19 @@
 > Display dynamic real-time information about running processes.
 > More information: <https://ss64.com/osx/top.html>.
 
-- Start top, all options are available in the interface:
+- Start `top`, all options are available in the interface:
 
 `top`
 
-- Start top sorting processes by internal memory size (default order - process ID):
+- Start `top` sorting processes by internal memory size (default order - process ID):
 
 `top -o mem`
 
-- Start top sorting processes first by CPU, then by running time:
+- Start `top` sorting processes first by CPU, then by running time:
 
 `top -o cpu -O time`
 
-- Start top displaying only processes owned by given user:
+- Start `top` displaying only processes owned by given user:
 
 `top -user {{user_name}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Some commands have a capitalized name, for example weechat -> WeeChat
and if they don't: top -> \`top\`

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
N/A