### PR TITLE
w32tm: add page

### DIFF
--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -1,6 +1,6 @@
 # w32tm
 
-> Query and control w32time time synchronization service on Windows from the command-line.
+> Query and control the w32time time synchronization service.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
 
 - Show the current status of the time synchronization:

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -13,15 +13,15 @@
 
 - run with elevated privileges:
 
-`w32tm /debug /enable /file:C:\Windows\w32time.log /size:10000000 /entries:0-300`
+`w32tm /debug /enable /file:{{path\to\debug.log}} /size:{{10000000}} /entries:{{0-300}}`
 
 - Get packet info:
 
-`w32tm /stripchart /packetinfo /samples:1 /computer:$computer`
+`w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
 
 - 2 seconds:
 
-`w32tm /stripchart /computer:time.windows.com`
+`w32tm /stripchart /computer:{{time_server}}`
 
 - run with elevated privileges:
 

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -3,30 +3,30 @@
 > Query and control w32time time synchronization service on Windows from the command-line.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
 
-- Get packet info:
+- Get a NTP reply from a time server:
 
 `w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
 
-- 2 seconds:
+- Show a time offset graph against a time server:
 
 `w32tm /stripchart /computer:{{time_server}}`
 
-- State of the time syncronization:
+- Show the current status of the time synchronization:
 
 `w32tm /query /status /verbose`
 
-- Peer statistics:
+- Show state of the currently used time servers:
 
 `w32tm /query /peers`
 
-- (run in elevated console):
+- Show configuration of the w32time service (run in elevated console):
 
 `w32tm /query /configuration`
 
-- (run in elevated console):
+- Force time resynchronization immediatelly (run in elevated console):
 
 `w32tm /resync /force`
 
-- (run in elevated console):
+- Write w32time debug logs into a file (run in elevated console):
 
 `w32tm /debug /enable /file:{{path\to\debug.log}} /size:{{10000000}} /entries:{{0-300}}`

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -23,7 +23,7 @@
 
 `w32tm /query /configuration`
 
-- Force time resynchronization immediatelly (run in elevated console):
+- Force time resynchronization immediately (run in elevated console):
 
 `w32tm /resync /force`
 

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -3,7 +3,7 @@
 > Query and control the w32time time synchronization service.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
 
-- Show the current status of the time synchronization:
+- Show the current status of time synchronization:
 
 `w32tm /query /status /verbose`
 

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -1,0 +1,32 @@
+# w32tm
+
+> Query and control w32time time synchronization service on Windows from the command-line.
+> More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
+
+- run with elevated privileges:
+
+`w32tm /query /configuration`
+
+- State of the time syncronization:
+
+`w32tm /query /status /verbose`
+
+- run with elevated privileges:
+
+`w32tm /debug /enable /file:C:\Windows\w32time.log /size:10000000 /entries:0-300`
+
+- Get packet info:
+
+`w32tm /stripchart /packetinfo /samples:1 /computer:$computer`
+
+- 2 seconds:
+
+`w32tm /stripchart /computer:time.windows.com`
+
+- run with elevated privileges:
+
+`w32tm /resync /force`
+
+- Peer statistics:
+
+`w32tm /query /peers`

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -15,7 +15,7 @@
 
 `w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
 
-- Show state of the currently used time servers:
+- Show the state of the currently used time servers:
 
 `w32tm /query /peers`
 

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -3,17 +3,17 @@
 > Query and control w32time time synchronization service on Windows from the command-line.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
 
-- Get a NTP reply from a time server:
+- Show the current status of the time synchronization:
 
-`w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
+`w32tm /query /status /verbose`
 
 - Show a time offset graph against a time server:
 
 `w32tm /stripchart /computer:{{time_server}}`
 
-- Show the current status of the time synchronization:
+- Show an NTP reply from a time server:
 
-`w32tm /query /status /verbose`
+`w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
 
 - Show state of the currently used time servers:
 

--- a/pages/windows/w32tm.md
+++ b/pages/windows/w32tm.md
@@ -3,18 +3,6 @@
 > Query and control w32time time synchronization service on Windows from the command-line.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
 
-- run with elevated privileges:
-
-`w32tm /query /configuration`
-
-- State of the time syncronization:
-
-`w32tm /query /status /verbose`
-
-- run with elevated privileges:
-
-`w32tm /debug /enable /file:{{path\to\debug.log}} /size:{{10000000}} /entries:{{0-300}}`
-
 - Get packet info:
 
 `w32tm /stripchart /packetinfo /samples:1 /computer:{{time_server}}`
@@ -23,10 +11,22 @@
 
 `w32tm /stripchart /computer:{{time_server}}`
 
-- run with elevated privileges:
+- State of the time syncronization:
 
-`w32tm /resync /force`
+`w32tm /query /status /verbose`
 
 - Peer statistics:
 
 `w32tm /query /peers`
+
+- (run in elevated console):
+
+`w32tm /query /configuration`
+
+- (run in elevated console):
+
+`w32tm /resync /force`
+
+- (run in elevated console):
+
+`w32tm /debug /enable /file:{{path\to\debug.log}} /size:{{10000000}} /entries:{{0-300}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** versions implicitly follow Windows OS version, but these commands should work in any windows from WS2012 up until now
