### PR TITLE
archlinux-java: fix documentation link, update page

### DIFF
--- a/pages.de/linux/archlinux-java.md
+++ b/pages.de/linux/archlinux-java.md
@@ -1,7 +1,7 @@
 # archlinux-java
 
 > Ein Helfer Script das Funktionen für Java-Umgebungen bereitstellt.
-> Weitere Informationen: <https://github.com/michaellass/archlinux-java-run>.
+> Weitere Informationen: <https://wiki.archlinux.org/title/Java#Switching_between_JVM>.
 
 - Liste installierte Java-Umgebungen:
 

--- a/pages.zh/linux/archlinux-java.md
+++ b/pages.zh/linux/archlinux-java.md
@@ -1,7 +1,7 @@
 # archlinux-java
 
 > 提供 Java 环境设置功能的一个帮助脚本。
-> 更多信息：<https://github.com/michaellass/archlinux-java-run>.
+> 更多信息：<https://wiki.archlinux.org/title/Java#Switching_between_JVM>.
 
 - 列出已安装的 Java 环境：
 

--- a/pages/linux/archlinux-java.md
+++ b/pages/linux/archlinux-java.md
@@ -1,11 +1,15 @@
 # archlinux-java
 
-> A helper script that provides functionalities for Java environments.
-> More information: <https://github.com/michaellass/archlinux-java-run>.
+> Switch between installed Java environments.
+> More information: <https://wiki.archlinux.org/title/Java#Switching_between_JVM>.
 
 - List installed Java environments:
 
 `archlinux-java status`
+
+- Return the short name of the current default Java environment:
+
+`archlinux-java get`
 
 - Set the default Java environment:
 
@@ -15,6 +19,6 @@
 
 `archlinux-java unset`
 
-- Set the default Java environment automatically:
+- Fix an invalid/broken default Java environment configuration:
 
 `archlinux-java fix`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

---

https://github.com/michaellass/archlinux-java-run documents an entirely different program.