### PR TITLE
macchina: add page

### DIFF
--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -1,0 +1,24 @@
+# macchina
+
+> Macchina is a tool which fetches and displays information about your computer.
+> More information: <https://github.com/Macchina-CLI/macchina>.
+
+- List out system information, with either default settings or those specified in your configuration file:
+
+`macchina`
+
+- Specify a custom configuration file path:
+
+`macchina --config {{path/to/configuration/file}}`
+
+- List out system information, but lengthen uptime, shell and kernel output:
+
+`macchina --long-uptime --long-shell --long-kernel`
+
+- Check for any errors / system failures encountered when trying to fetch system information:
+
+`macchina --doctor`
+
+- List out original artists of all the ASCII art used by macchina:
+
+`macchina --ascii-artists`

--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -9,7 +9,7 @@
 
 - Specify a custom configuration file path:
 
-`macchina --config {{path/to/configuration/file}}`
+`macchina --config {{path/to/configuration_file}}`
 
 - List out system information, but lengthen uptime, shell and kernel output:
 

--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -1,6 +1,6 @@
 # macchina
 
-> Macchina is a tool which fetches and displays information about your computer.
+> Display information about your computer.
 > More information: <https://github.com/Macchina-CLI/macchina>.
 
 - List out system information, with either default settings or those specified in your configuration file:

--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -19,6 +19,6 @@
 
 `macchina --doctor`
 
-- List out original artists of all the ASCII art used by macchina:
+- List out original artists of all the ASCII art:
 
 `macchina --ascii-artists`

--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -15,7 +15,7 @@
 
 `macchina --long-uptime --long-shell --long-kernel`
 
-- Check for any errors / system failures encountered when trying to fetch system information:
+- Check for any errors/system failures encountered when trying to fetch system information:
 
 `macchina --doctor`
 

--- a/pages/common/macchina.md
+++ b/pages/common/macchina.md
@@ -11,7 +11,7 @@
 
 `macchina --config {{path/to/configuration_file}}`
 
-- List out system information, but lengthen uptime, shell and kernel output:
+- List system information, but lengthen uptime, shell and kernel output:
 
 `macchina --long-uptime --long-shell --long-kernel`
 
@@ -19,6 +19,6 @@
 
 `macchina --doctor`
 
-- List out original artists of all the ASCII art:
+- List original artists of all the ASCII art:
 
 `macchina --ascii-artists`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 6.1.8

Adding page for [macchina](https://github.com/Macchina-CLI/macchina) which is a tool similar to `neofetch` for displaying system info.
