### PR TITLE
jf: add page for JFrog CLI

### DIFF
--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -1,16 +1,16 @@
 # jf
 
-> Interface with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control.
+> Interact with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control.
 > More information: <https://jfrog.com/help/r/jfrog-cli/usage>.
 
-- Add new configuration:
+- Add a new configuration:
 
 `jf config add`
 
-- Show current configuration:
+- Show the current configuration:
 
 `jf config show`
 
-- Search artifacts within the given repository and directory:
+- Search for artifacts within the given repository and directory:
 
 `jf rt search --recursive {{repostiory_name}}/{{path}}/`

--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -5,7 +5,7 @@
 
 - Add new configuration:
 
-`jf config add `
+`jf config add`
 
 - Show current configuration:
 

--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -1,7 +1,7 @@
 # jf
 
-> Use JF CLI for interfacing with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control
-> More information: <https://jfrog.com/help/r/jfrog-cli/usage>
+> Use JF CLI for interfacing with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control.
+> More information: <https://jfrog.com/help/r/jfrog-cli/usage>.
 
 - Add new configuration:
 

--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -1,0 +1,16 @@
+# jf
+
+> Use JF CLI for interfacing with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control
+> More information: <https://jfrog.com/help/r/jfrog-cli/usage>
+
+- Add new configuration:
+
+`jf config add `
+
+- Show current configuration:
+
+`jf config show`
+
+- Artifactory: Search artifacts within given repository and directory:
+
+`jf rt search --recursive {{repostiory_name}}/{{path}}/`

--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -11,6 +11,6 @@
 
 `jf config show`
 
-- Artifactory: Search artifacts within given repository and directory:
+- Search artifacts within the given repository and directory:
 
 `jf rt search --recursive {{repostiory_name}}/{{path}}/`

--- a/pages/common/jf.md
+++ b/pages/common/jf.md
@@ -1,6 +1,6 @@
 # jf
 
-> Use JF CLI for interfacing with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control.
+> Interface with JFrog products like Artifactory, Xray, Distribution, Pipelines and Mission Control.
 > More information: <https://jfrog.com/help/r/jfrog-cli/usage>.
 
 - Add new configuration:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
```
> jf --version
jf version 2.41.0
```
