### PR TITLE
bgpgrep, peerindex: update links

### DIFF
--- a/pages.de/common/bgpgrep.md
+++ b/pages.de/common/bgpgrep.md
@@ -2,7 +2,7 @@
 
 > Filtert und gibt BGP-Daten in einem MRT-Dump aus.
 > Kann mit gzip, bzip2 und xz komprimierte Dateien lesen.
-> Weitere Informationen: <https://gitea.it/1414codeforge/ubgpsuite>.
+> Weitere Informationen: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Gib alle Routen aus:
 

--- a/pages.de/common/peerindex.md
+++ b/pages.de/common/peerindex.md
@@ -2,7 +2,7 @@
 
 > Liest MRT TABLE_DUMPV2 Peer Index Table aus.
 > Kann mit gzip, bzip2 und xz komprimierte Dateien lesen.
-> Weitere Informationen: <https://gitea.it/1414codeforge/ubgpsuite>.
+> Weitere Informationen: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Gib alle Peers aus:
 

--- a/pages/common/bgpgrep.md
+++ b/pages/common/bgpgrep.md
@@ -2,7 +2,7 @@
 
 > Filter and print BGP data within MRT dumps.
 > Can read files compressed with gzip, bzip2 and xz.
-> More information: <https://gitea.it/1414codeforge/ubgpsuite>.
+> More information: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Output all routes:
 

--- a/pages/common/peerindex.md
+++ b/pages/common/peerindex.md
@@ -2,7 +2,7 @@
 
 > Inspect MRT TABLE_DUMPV2 Peer Index Table.
 > Can read files compressed with gzip, bzip2 and xz.
-> More information: <https://gitea.it/1414codeforge/ubgpsuite>.
+> More information: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Output all peers:
 


### PR DESCRIPTION
Since gitea.it no longer allows registrations, neither issues nor PRs can be created. Therefore the main repo was moved from to Codeberg.

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
