### PR TITLE
aircrack-ng, airdecap-ng, aireplay-ng: add Dutch translation

### DIFF
--- a/pages.nl/common/aircrack-ng.md
+++ b/pages.nl/common/aircrack-ng.md
@@ -1,0 +1,17 @@
+# aircrack-ng
+
+> Kraak WEP- en WPA/WPA2-sleutels van handshake in vastgelegde pakketten.
+> Onderdeel van Aircrack-ng netwerksoftwaresuite.
+> Meer Informatie: <https://www.aircrack-ng.org/doku.php?id=aircrack-ng>.
+
+- Kraak-sleutel uit opnamebestand met behulp van woordenlijst:
+
+`aircrack-ng -w {{pad/naar/woordenlijst.txt}} {{pad/naar/pakketbestand.cap}}`
+
+- Kraak de sleutel uit het opnamebestand met behulp van de woordenlijst en de essid van het toegangspunt:
+
+`aircrack-ng -w {{pad/naar/woordenlijst.txt}} -e {{essid}} {{pad/naar/pakketbestand.cap}}`
+
+- Kraak de sleutel uit het opnamebestand met behulp van de woordenlijst en het MAC-adres van het toegangspunt:
+
+`aircrack-ng -w {{pad/naar/woordenlijst.txt}} --bssid {{mac}} {{pad/naar/pakketbestand.cap}}`

--- a/pages.nl/common/airdecap-ng.md
+++ b/pages.nl/common/airdecap-ng.md
@@ -1,0 +1,25 @@
+# airdecap-ng
+
+> Decodeer een WEP-, WPA- of WPA2-gecodeerd opnamebestand.
+> Onderdeel van Aircrack-ng netwerksoftwaresuite.
+> Meer Informatie: <https://www.aircrack-ng.org/doku.php?id=airdecap-ng>.
+
+- Verwijder draadloze headers uit een open netwerkopnamebestand en gebruik het MAC-adres van het toegangspunt om te filteren:
+
+`airdecap-ng -b {{ap_mac}} {{pad/naar/pakketbestand.cap}}`
+
+- Decodeer een met WEP gecodeerd opnamebestand met de sleutel in hex-indeling:
+
+`airdecap-ng -w {{hex_key}} {{pad/naar/pakketbestand.cap}}`
+
+- Decodeer een met WPA/WPA2 gecodeerd opnamebestand met behulp van de essid en het wachtwoord van het toegangspunt:
+
+`airdecap-ng -e {{essid}} -p {{wachtwoord}} {{pad/naar/pakketbestand.cap}}`
+
+- Decodeer een met WPA/WPA2 gecodeerd opnamebestand met behoud van de headers met behulp van de essid en het wachtwoord van het toegangspunt:
+
+`airdecap-ng -l -e {{essid}} -p {{wachtwoord}} {{pad/naar/pakketbestand.cap}}`
+
+- Decodeer een met WPA/WPA2 gecodeerd opnamebestand met behulp van de essid en het wachtwoord van het toegangspunt en gebruik het MAC-adres om te filteren:
+
+`airdecap-ng -b {{ap_mac}} -e {{essid}} -p {{wachtwoord}} {{pad/naar/pakketbestand.cap}}`

--- a/pages.nl/common/aireplay-ng.md
+++ b/pages.nl/common/aireplay-ng.md
@@ -1,0 +1,9 @@
+# aireplay-ng
+
+> Injecteer pakketten in een draadloos netwerk.
+> Deel van `aircrack-ng`.
+> Meer Informatie: <https://www.aircrack-ng.org/doku.php?id=aireplay-ng>.
+
+- Stuur een specifiek aantal losgekoppelde pakketten op basis van het MAC-adres van een toegangspunt, het MAC-adres van een cliënt en een interface:
+
+`sudo aireplay-ng --deauth {{nummer}} --bssid {{ap_mac}} --dmac {{cliënt_mac}} {{interface}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
