### PR TITLE
farge: add page

### DIFF
--- a/pages/linux/farge.md
+++ b/pages/linux/farge.md
@@ -1,0 +1,24 @@
+# farge
+
+> Display the color of a specific pixel on the screen in either hexadecimal or RGB formats.
+> More information: <https://github.com/sdushantha/farge>.
+
+- Select a pixel interactively and display a small, square preview window of the color and it's hexadecimal value:
+
+`farge`
+
+- Select a pixel interactively and display a small, square preview window of the color, without displaying it's hexadecimal value:
+
+`farge --no-color-code`
+
+- Select a pixel interactively and output it's hexadecimal value to `stdout`:
+
+`farge --stdout`
+
+- Select a pixel interactively and output it's RGB value to `stdout`:
+
+`farge --rgb --stdout`
+
+- Select a pixel interactively and display it's hexadecimal value as a notification which expires in 5000 milliseconds:
+
+`farge --notify --expire-time 5000`

--- a/pages/linux/farge.md
+++ b/pages/linux/farge.md
@@ -3,22 +3,23 @@
 > Display the color of a specific pixel on the screen in either hexadecimal or RGB formats.
 > More information: <https://github.com/sdushantha/farge>.
 
-- Select a pixel interactively and display a small, square preview window of the color and it's hexadecimal value:
+- Display a small preview window of a pixel's color with it's hexadecimal value, and copy this value to the clipboard:
 
 `farge`
 
-- Select a pixel interactively and display a small, square preview window of the color, without displaying it's hexadecimal value:
+- Copy a pixel's hexadecimal value to the clipboard without displaying a preview window:
 
-`farge --no-color-code`
+`farge --no-preview`
 
-- Select a pixel interactively and output it's hexadecimal value to `stdout`:
+- Output a pixel's hexadecimal value to `stdout`, and copy this value to the clipboard:
 
 `farge --stdout`
 
-- Select a pixel interactively and output it's RGB value to `stdout`:
+
+- Output a pixel's RGB value to `stdout`, and copy this value to the clipboard:
 
 `farge --rgb --stdout`
 
-- Select a pixel interactively and display it's hexadecimal value as a notification which expires in 5000 milliseconds:
+- Display a pixel's hexadecimal value as a notification which expires in 5000 milliseconds, and copy this value to the clipboard:
 
 `farge --notify --expire-time 5000`

--- a/pages/linux/farge.md
+++ b/pages/linux/farge.md
@@ -15,7 +15,6 @@
 
 `farge --stdout`
 
-
 - Output a pixel's RGB value to `stdout`, and copy this value to the clipboard:
 
 `farge --rgb --stdout`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.0.9

Add page for the [farge](https://github.com/sdushantha/farge) tool, which is used for clicking on a pixel on the screen and getting it's colour value. It's similar to [xcolor](https://github.com/Soft/xcolor) if you have used that before.

This one was a bit tricky with the descriptions, as for example, every command first enters you into an interactive mode to select the pixel, and then every command also copies the output value to the clipboard so I was unsure whether to include that every time or what should be done in that scenario. I opted to talk about the clipboard, as that is not as obvious as having to enter interactive mode to select a pixel, and is not mentioned in the `--help` output. Let me know if there is a preferred way to handle this, and any other suggestions.