### PR TITLE
netsh-interface-portproxy: add page

### DIFF
--- a/pages/windows/netsh-interface-portproxy.md
+++ b/pages/windows/netsh-interface-portproxy.md
@@ -17,4 +17,4 @@
 
 - Display help:
 
-`netsh /?`
+`netsh interface portproxy`

--- a/pages/windows/netsh-interface-portproxy.md
+++ b/pages/windows/netsh-interface-portproxy.md
@@ -1,11 +1,7 @@
-# netsh
+# netsh interface portproxy
 
-> Configure and display the status of various network components
-> More information: <https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh>.
-
-- Display help:
-
-`netsh /?`
+> Configure and display the status of various network components.
+> More information: <https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-interface-portproxy>.
 
 - Display current port forwarding setup:
 
@@ -18,3 +14,7 @@
 - Remove IPv4 port forwarding (run in elevated console):
 
 `netsh interface portproxy delete v4tov4 listenaddress={{192.168.0.1}} listenport={{8080}}`
+
+- Display help:
+
+`netsh /?`

--- a/pages/windows/netsh-interface-portproxy.md
+++ b/pages/windows/netsh-interface-portproxy.md
@@ -7,7 +7,7 @@
 
 `netsh interface portproxy show all`
 
-- Setup IPv4 port forwarding (run in elevated console):
+- Set up IPv4 port forwarding (run in elevated console):
 
 `netsh interface portproxy add v4tov4 listenaddress={{192.168.0.1}} listenport={{8080}}  connectaddress={{10.0.0.1}} connectport={{80}}`
 

--- a/pages/windows/netsh-interface-portproxy.md
+++ b/pages/windows/netsh-interface-portproxy.md
@@ -3,7 +3,7 @@
 > Configure and display the status of various network components.
 > More information: <https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-interface-portproxy>.
 
-- Display current port forwarding setup:
+- Display the current port forwarding setup:
 
 `netsh interface portproxy show all`
 

--- a/pages/windows/netsh.md
+++ b/pages/windows/netsh.md
@@ -1,0 +1,20 @@
+# netsh
+
+> Configure and display the status of various network components
+> More information: <https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh>.
+
+- Display help:
+
+`netsh /?`
+
+- Display current port forwarding setup:
+
+`netsh interface portproxy show all`
+
+- Setup IPv4 port forwarding (run in elevated console):
+
+`netsh interface portproxy add v4tov4 listenaddress={{192.168.0.1}} listenport={{8080}}  connectaddress={{10.0.0.1}} connectport={{80}}`
+
+- Remove IPv4 port forwarding (run in elevated console):
+
+`netsh interface portproxy delete v4tov4 listenaddress={{192.168.0.1}} listenport={{8080}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).