### PR TITLE
gallery-dl: add --cookies-from-browser example and fix typo

### DIFF
--- a/pages/common/gallery-dl.md
+++ b/pages/common/gallery-dl.md
@@ -7,10 +7,14 @@
 
 `gallery-dl "{{url}}"`
 
+- Retrieve pre-existing cookies from your web browser (useful for sites that require login):
+
+`gallery-dl --cookies-from-browser {{browser}} "{{url}}"`
+
 - Get the direct URL of an image from a site supporting authentication with username and password:
 
 `gallery-dl --get-urls --username {{username}} --password {{password}} "{{url}}"`
 
 - Filter manga chapters by chapter number and language:
 
-`gallery-dl --chapter-filter "{{10 <= chapter < 20}}" --option "lang={{language_code}}" "{{url}}`
+`gallery-dl --chapter-filter "{{10 <= chapter < 20}}" --option "lang={{language_code}}" "{{url}}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) have at most 8 examples.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
1.25.7