### PR TITLE
locate: wrap glob with quotes

### DIFF
--- a/pages/linux/locate.md
+++ b/pages/linux/locate.md
@@ -9,7 +9,7 @@
 
 - Look for a file by its exact filename (a pattern containing no globbing characters is interpreted as `*pattern*`):
 
-`locate */{{filename}}`
+`locate '*/{{filename}}'`
 
 - Recompute the database. You need to do it if you want to find recently added files:
 


### PR DESCRIPTION
Put arg with  `*` in singe quotes to prevent expanding in non-empty directories.