### PR TITLE
nc: edit page

### DIFF
--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -9,7 +9,7 @@
 
 - Connect to a target listener on the specified port and receive a file from it:
 
-`nc {{host}} {{port}} > {{received_file_name}}`
+`nc {{host}} {{port}} > {{received_filename}}`
 
 - Scan the open TCP ports of a specified host:
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -19,7 +19,7 @@
 
 `nc -l -p {{port}} -e {{shell_executable}}`
 
-- Connect to a target listener and provide your local shell access to the remote party (that is dangerous if abused):
+- Connect to a target listener and provide your local shell access to the remote party (this is dangerous and can be abused):
 
 `nc {{host}} {{port}} -e {{shell_executable}}`
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -5,7 +5,7 @@
 
 - Start a listener on the specified TCP port and send a file into it:
 
-`nc -l -p {{port}} < {{sent_file_name}}`
+`nc -l -p {{port}} < {{filename}}`
 
 - Connect to a target listener on the specified port and receive a file from it:
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -1,31 +1,27 @@
 # nc
 
-> A versatile utility for working with TCP or UDP data.
+> netcat is a versatile utility for redirecting IO into a network stream.
 > More information: <https://manned.org/man/nc.1>.
 
-- Establish a TCP connection:
+- Start a listener on the specified TCP port and send a file into it:
 
-`nc {{host}} {{port}}`
+`nc -l -p {{port}} < {{sent_file_name}}`
 
-- Set a timeout:
+- Connect to a target listener on the specified port and receive a file from it:
 
-`nc -w {{timeout_in_seconds}} {{host}} {{port}}`
+`nc {{host}} {{port}} > {{received_file_name}}`
 
 - Scan the open TCP ports of a specified host:
 
-`nc -v -z {{host}} {{port}}`
+`nc -v -z -w {{timeout_in_seconds}} {{host}} {{start_port}}-{{end_port}}`
 
-- Listen on a specified TCP port and print any data received:
+- Start a listener on the specified TCP port and provide your local shell access to the connected party (that is dangerous if abused):
 
-`nc -l -p {{port}}`
+`nc -l -p {{port}} -e {{shell_executable}}`
 
-- Keep the server up after the client detaches:
+- Connect to a target listener and provide your local shell access to the remote party (that is dangerous if abused):
 
-`nc -k -l -p {{port}}`
-
-- Listen on a specified UDP port and print connection details and any data received:
-
-`nc -u -l -p {{port}}`
+`nc {{host}} {{port}} -e {{shell_executable}}`
 
 - Act as a proxy and forward data from a local TCP port to the given remote host:
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -15,7 +15,7 @@
 
 `nc -v -z -w {{timeout_in_seconds}} {{host}} {{start_port}}-{{end_port}}`
 
-- Start a listener on the specified TCP port and provide your local shell access to the connected party (that is dangerous if abused):
+- Start a listener on the specified TCP port and provide your local shell access to the connected party (this is dangerous and can be abused):
 
 `nc -l -p {{port}} -e {{shell_executable}}`
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -17,19 +17,19 @@
 
 - Listen on a specified TCP port and print any data received:
 
-`nc -l {{port}}`
+`nc -l -p {{port}}`
 
 - Keep the server up after the client detaches:
 
-`nc -k -l {{port}}`
+`nc -k -l -p {{port}}`
 
 - Listen on a specified UDP port and print connection details and any data received:
 
-`nc -u -l {{port}}`
+`nc -u -l -p {{port}}`
 
 - Act as a proxy and forward data from a local TCP port to the given remote host:
 
-`nc -l {{local_port}} | nc {{hostname}} {{remote_port}}`
+`nc -l -p {{local_port}} | nc {{hostname}} {{remote_port}}`
 
 - Send an HTTP GET request:
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -5,15 +5,15 @@
 
 - Establish a TCP connection:
 
-`nc {{ip_address}} {{port}}`
+`nc {{host}} {{port}}`
 
 - Set a timeout:
 
-`nc -w {{timeout_in_seconds}} {{ipaddress}} {{port}}`
+`nc -w {{timeout_in_seconds}} {{host}} {{port}}`
 
 - Scan the open TCP ports of a specified host:
 
-`nc -v -z {{ip_address}} {{port}}`
+`nc -v -z {{host}} {{port}}`
 
 - Listen on a specified TCP port and print any data received:
 
@@ -29,8 +29,8 @@
 
 - Act as a proxy and forward data from a local TCP port to the given remote host:
 
-`nc -l -p {{local_port}} | nc {{hostname}} {{remote_port}}`
+`nc -l -p {{local_port}} | nc {{host}} {{remote_port}}`
 
 - Send an HTTP GET request:
 
-`echo -e "GET / HTTP/1.1\nHost: {{hostname}}\n\n" | nc {{hostname}} 80`
+`echo -e "GET / HTTP/1.1\nHost: {{host}}\n\n" | nc {{host}} 80`

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -1,6 +1,6 @@
 # nc
 
-> netcat is a versatile utility for redirecting IO into a network stream.
+> Netcat is a versatile utility for redirecting IO into a network stream.
 > More information: <https://manned.org/man/nc.1>.
 
 - Start a listener on the specified TCP port and send a file into it:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Changes

- Unified destination naming - it was unclear why it is hostname in one place vs ip_address in another.
- When ports are specified in listening mode (-l) -p parameter is mandatory, nc would not infer it as in the client mode.
- -k switch is not present in netcat
- More useful examples with file sending and shell access