### PR TITLE
lsusb: edit command for fetching details of single device

### DIFF
--- a/pages/linux/lsusb.md
+++ b/pages/linux/lsusb.md
@@ -17,7 +17,7 @@
 
 - List detailed information about a USB device:
 
-`lsusb -D {{device}}`
+`lsusb --verbose -s {{bus}}:{{device number}}`
 
 - List devices with a specified vendor and product ID only:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Hello!

I've edited the command for viewing details for a single device.
The reason for this is that the `-D` flag which was earlier used, doesn't explicitly say that it is looking for a path to a device, which was confusing. And unless you are doing something very specific with usb devices existing outside `/dev/bus/usb`, just specifying bus and device number is easier than writing out `-D /dev/bus/usb/{{bus}}/{{devnum}}`
 
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**