### PR TITLE
duckdb: add page

### DIFF
--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -9,23 +9,27 @@
 
 - Start an interactive shell on a database file. If the file does not exist, a new database is created:
 
-`duckdb {{path/to/dbfile.[db|duckdb]}}`
+`duckdb {{path/to/dbfile}}`
 
-- Load CSV or Parquet file to a table and quit:
+- Directly query a CSV, JSON, or Parquet file:
 
-`duckdb {{path/to/dbfile.[db|duckdb]}} -c "{{CREATE OR REPLACE TABLE tbl AS FROM 'data_source.[csv|parquet]'}}"`
+`duckdb -c "{{SELECT * FROM 'data_source.[csv|csv.gz|json|json.gz|parquet]'}}"`
 
-- Run query on database file and keep interactive shell open:
+- Run a SQL script:
 
-`duckdb {{path/to/dbfile.[db|duckdb]}} -cmd "{{SELECT DISTINCT * FROM tbl}}"`
+`duckdb -c ".read {{path/to/script.sql}}"`
 
-- Run SQL queries in file on database and keep interactive shell open:
+- Run query on database file and keep the interactive shell open:
 
-`duckdb {{path/to/dbfile.[db|duckdb]}} -init {{path/to/script.sql}}`
+`duckdb {{path/to/dbfile}} -cmd "{{SELECT DISTINCT * FROM tbl}}"`
 
-- Open database in read-only mode:
+- Run SQL queries in file on database and keep the interactive shell open:
 
-`duckdb -readonly {{path/to/dbfile.[db|duckdb]}}`
+`duckdb {{path/to/dbfile}} -init {{path/to/script.sql}}`
+
+- Read CSV from stdin and write CSV to stdout:
+
+`cat {{path/to/source.csv}} | duckdb -c "{{COPY (FROM read_csv_auto('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}"`
 
 - Display help:
 

--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -1,0 +1,32 @@
+# duckdb
+
+> Command-line client for DuckDB, an in-process analytical SQL engine.
+> More information: <https://duckdb.org>.
+
+- Start an interactive shell with a transient in-memory database:
+
+`duckdb`
+
+- Start an interactive shell on a database file. If the file does not exist, a new database is created:
+
+`duckdb {{path/to/dbfile.[db|duckdb]}}`
+
+- Load CSV or Parquet file to a table and quit:
+
+`duckdb {{path/to/dbfile.[db|duckdb]}} -c "{{CREATE OR REPLACE TABLE tbl AS FROM 'data_source.[csv|parquet]'}}"`
+
+- Run query on database file and keep interactive shell open:
+
+`duckdb {{path/to/dbfile.[db|duckdb]}} -cmd "{{SELECT DISTINCT * FROM tbl}}"`
+
+- Run SQL queries in file on database and keep interactive shell open:
+
+`duckdb {{path/to/dbfile.[db|duckdb]}} -init {{path/to/script.sql}}`
+
+- Open database in read-only mode:
+
+`duckdb -readonly {{path/to/dbfile.[db|duckdb]}}`
+
+- Display help:
+
+`duckdb -help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 0.8.1
