### PR TITLE
semanage-fcontext, restorecon: add page

### DIFF
--- a/pages/linux/restorecon.md
+++ b/pages/linux/restorecon.md
@@ -1,0 +1,25 @@
+# restorecon
+
+> Restore SELinux security context on files/directories according to persistent rules.
+> See also: `semanage-fcontext`.
+> More information: <https://manned.org/restorecon>.
+
+- View the current security context of a file or directory:
+
+`ls -dlZ {{path/to/file_or_directory}}`
+
+- Restore the security context of a file or directory:
+
+`restorecon {{path/to/file_or_directory}}`
+
+- Restore the security context of a directory recursively, and show all changed labels:
+
+`restorecon -R -v {{path/to/directory}}`
+
+- Restore the security context of a directory recursively, using all available threads, and show progress:
+
+`restorecon -R -T {{0}} -p {{path/to/directory}}`
+
+- Preview the label changes that would happen without applying them:
+
+`restorecon -R -n -v {{path/to/directory}}`

--- a/pages/linux/semanage-fcontext.md
+++ b/pages/linux/semanage-fcontext.md
@@ -1,0 +1,25 @@
+# semanage fcontext
+
+> Manage persistent SELinux security context rules on files/directories.
+> See also: `semanage`, `restorecon`.
+> More information: <https://manned.org/semanage-fcontext>.
+
+- List all file labelling rules:
+
+`sudo semanage fcontext --list`
+
+- List all user-defined file labelling rules without headings:
+
+`sudo semanage fcontext --list --locallist --noheading`
+
+- Add a user-defined rule that labels any path which matches a PCRE regex:
+
+`sudo semanage fcontext --add --type {{samba_share_t}} {{'/mnt/share(/.*)?'}}`
+
+- Delete a user-defined rule using its PCRE regex:
+
+`sudo semanage fcontext --delete {{'/mnt/share(/.*)?'}}`
+
+- Relabel a directory recursively by applying the new rules:
+
+`restorecon -R -v {{path/to/directory}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** `policycoreutils-3.5`

Closes #7479. Fine, I'll do it myself 🙃.