### PR TITLE
btrfs-version: fix syntax

### DIFF
--- a/pages.pt_BR/linux/btrfs-version.md
+++ b/pages.pt_BR/linux/btrfs-version.md
@@ -3,10 +3,10 @@
 > Exibe a versão do btrfs-progs.
 > Mais informações: <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
-- Exibir a versão do btrfs-progs.
+- Exibir a versão do btrfs-progs:
 
 `btrfs version`
 
-- Exibir a ajuda.
+- Exibir a ajuda:
 
 `btrfs version --help`


### PR DESCRIPTION
Fix end-of line punctuation in two command descriptions from `.` to `:`. Not sure how this passed our tests in #<!-- -->22 —I mean, #10110 :smile:. Maybe we need to update them? :thinking:

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).