### PR TITLE
httpie: add osx page

### DIFF
--- a/pages/osx/httpie.md
+++ b/pages/osx/httpie.md
@@ -1,0 +1,36 @@
+# httpie
+
+> A user friendly HTTP tool.
+> More information: <https://github.com/httpie/httpie>.
+
+- Send a GET request (default method with no request data):
+
+`http {{https://example.com}}`
+
+- Send a POST request (default method with request data):
+
+`http {{https://example.com}} {{hello=World}}`
+
+- Send a POST request with redirected input:
+
+`http {{https://example.com}} < {{file.json}}`
+
+- Send a PUT request with a given JSON body:
+
+`http PUT {{https://example.com/todos/7}} {{hello=world}}`
+
+- Send a DELETE request with a given request header:
+
+`http DELETE {{https://example.com/todos/7}} {{API-Key:foo}}`
+
+- Show the whole HTTP exchange (both request and response):
+
+`http -v {{https://example.com}}`
+
+- Download a file:
+
+`http --download {{https://example.com}}`
+
+- Follow redirects and show intermediary requests and responses:
+
+`http --follow --all {{https://example.com}}`


### PR DESCRIPTION
I've used the same file from pages/linux/httpie.md since the functionality is the same.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

