### PR TITLE
rsync: update page, link to the official documentation instead of manned.org

### DIFF
--- a/pages.fr/common/rsync.md
+++ b/pages.fr/common/rsync.md
@@ -2,7 +2,7 @@
 
 > Transférer des fichiers vers ou depuis un hôte distant (pas entre deux hôtes distants).
 > Peut transférer un ou plusieurs fichiers correspondant à un motif.
-> Plus d'informations : <https://manned.org/rsync>.
+> Plus d'informations : <https://download.samba.org/pub/rsync/rsync.1>.
 
 - Transférer un fichier local vers un serveur distant :
 

--- a/pages.id/common/rsync.md
+++ b/pages.id/common/rsync.md
@@ -2,7 +2,7 @@
 
 > Transfer file ke atau dari sebuah _remote host_ (bukan di antara 2 _remote host_).
 > Bisa transfer satuan file, maupun beberapa file yang sesuai dengan pola tertentu.
-> Informasi lebih lanjut: <https://manned.org/rsync>.
+> Informasi lebih lanjut: <https://download.samba.org/pub/rsync/rsync.1>.
 
 - Transfer file dari lokal ke _remote host_:
 

--- a/pages.pl/common/rsync.md
+++ b/pages.pl/common/rsync.md
@@ -1,37 +1,37 @@
 # rsync
 
-> Przesyłaj pliki do lub ze zdalnego hosta (ale nie pomiędzy dwoma zdalnymi hostami).
-> Może przesyłać pojedyncze pliki lub wiele plików pasujących do wzorca.
+> Przesyłaj pliki do lub ze zdalnego hosta (ale nie pomiędzy dwoma zdalnymi hostami), domyślnie używając SSH.
+> Aby wskazać na ścieżkę zdalną, użyj `host:ścieżka/do/pliku_lub_katalogu`.
 > Więcej informacji: <https://download.samba.org/pub/rsync/rsync.1>.
 
-- Prześlij plik z lokalnego do zdalnego hosta:
+- Prześlij plik:
 
-`rsync {{ścieżka/do/lokalnego_pliku}} {{zdalny_host}}:{{ścieżka/do/zdalnego_katalogu}}`
+`rsync {{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij plik ze zdalnego do lokalnego hosta:
+- Użyj trybu archiwum (rekursywnie kopiuj katalogi, kopiuj dowiązania symboliczne bez rozwiązywania i zachowaj uprawnienia, własność i czasy modyfikacji):
 
-`rsync {{zdalny_host}}:{{ścieżka/do/zdalnego_pliku}} {{ścieżka/do/lokalnego_katalogu}}`
+`rsync --archive {{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij plik w trybie [a]rchiwum (aby zachować atrybuty) i skompresowanym ([z]ip) wyświetlając szczegółowy ([v]erbose) i czytelny dla człowieka ([h]uman-readable) [P]ostęp:
+- Kompresuj dane podczas gdy są wysyłane do miejsca docelowego, wyświetlaj szczegółowy i czytelny dla człowieka postęp i zachowaj częściowo przesłane pliki w przypadku przerwania:
 
-`rsync -azvhP {{ścieżka/do/lokalnego_pliku}} {{zdalny_host}}:{{ścieżka/do/zdalnego_katalogu}}`
+`rsync --compress --verbose --human-readable --partial --progress {{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij katalog i jego zawartość ze zdalnego do lokalnego hosta:
+- Rekursywnie kopiuj katalogi:
 
-`rsync -r {{zdalny_host}}:{{ścieżka/do/zdalnego_katalogu}} {{ścieżka/do/lokalnego_katalogu}}`
+`rsync --recursive {{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij zawartość katalogu (ale nie sam katalog) ze zdalnego do lokalnego hosta:
+- Prześlij zawartość katalogu, ale nie sam katalog:
 
-`rsync -r {{zdalny_host}}:{{ścieżka/do/zdalnego_katalogu}}/ {{ścieżka/do/lokalnego_katalogu}}`
+`rsync --recursive {{ścieżka/do/źródła}}/ {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij katalog [r]ekursywnie, w trybie [a]rchiwum (aby zachować atrybuty), rozwiązując zawarte dowiązania symbo[L]iczne, i ignorując już przesłane pliki o ile nie są nowsze ([u]nless):
+- Rekursywnie kopiuj katalogi, użyj trybu archiwum, rozwiąż dowiązania symboliczne i pomiń pliki, które są nowsze w miejscu docelowym:
 
-`rsync -rauL {{zdalny_host}}:{{ścieżka/do/zdalnego_katalogu}} {{ścieżka/do/lokalnego_katalogu}}`
+`rsync --recursive --archive --update --copy-links {{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij plik poprzez SSH i usuń pliki na zdalnym hoście, które nie istnieją na lokalnym:
+- Prześlij katalog do zdalnego hosta, na którym działa `rsyncd` i usuń pliki w miejscu docelowym które nie istnieją w źródle:
 
-`rsync -e ssh --delete {{zdalny_host}}:{{ścieżka/do/zdalnego_pliku}} {{ścieżka/do/lokalnego_pliku}}`
+`rsync --recursive --delete rsync://{{host}}:{{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`
 
-- Prześlij pliki poprzez SSH używając innego portu niż domyślny i wyświetlaj globalny postęp:
+- Prześlij plik poprzez SSH używając innego portu niż domyślny (22) i wyświetlaj globalny postęp:
 
-`rsync -e 'ssh -p {{port}}' --info=progress2 {{zdalny_host}}:{{ścieżka/do/zdalnego_pliku}} {{ścieżka/do/lokalnego_pliku}}`
+`rsync --rsh 'ssh -p {{port}}' --info=progress2 {{host}}:{{ścieżka/do/źródła}} {{ścieżka/do/miejsca_docelowego}}`

--- a/pages.pl/common/rsync.md
+++ b/pages.pl/common/rsync.md
@@ -2,7 +2,7 @@
 
 > Przesyłaj pliki do lub ze zdalnego hosta (ale nie pomiędzy dwoma zdalnymi hostami).
 > Może przesyłać pojedyncze pliki lub wiele plików pasujących do wzorca.
-> Więcej informacji: <https://manned.org/rsync>.
+> Więcej informacji: <https://download.samba.org/pub/rsync/rsync.1>.
 
 - Prześlij plik z lokalnego do zdalnego hosta:
 

--- a/pages.zh/common/rsync.md
+++ b/pages.zh/common/rsync.md
@@ -1,7 +1,7 @@
 # rsync
 
 > 一种快速，通用，远程（和本地）文件复制工具。
-> 更多信息：<https://manned.org/rsync>.
+> 更多信息：<https://download.samba.org/pub/rsync/rsync.1>.
 
 - 从本地传输文件到远程主机：
 

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -1,37 +1,37 @@
 # rsync
 
-> Transfer files either to or from a remote host (but not between two remote hosts).
-> Can transfer single files or multiple files matching a pattern.
+> Transfer files either to or from a remote host (but not between two remote hosts), by default using SSH.
+> To specify a remote path, use `host:path/to/file_or_directory`.
 > More information: <https://manned.org/rsync>.
 
-- Transfer a file from local to a remote host:
+- Transfer a file:
 
-`rsync {{path/to/local_file}} {{remote_host}}:{{path/to/remote_directory}}`
+`rsync {{path/to/source}} {{path/to/destination}}`
 
-- Transfer a file from a remote host to local:
+- Use archive mode (recursively copy directories, copy symlinks without resolving and preserve permissions, ownership and modification times):
 
-`rsync {{remote_host}}:{{path/to/remote_file}} {{path/to/local_directory}}`
+`rsync --archive {{path/to/source}} {{path/to/destination}}`
 
-- Transfer a file in [a]rchive (to preserve attributes) and compressed ([z]ipped) mode displaying [v]erbose and [h]uman-readable [P]rogress:
+- Compress the data as it is sent to the destination, display verbose and human-readable progress, and keep partially transferred files if interrupted:
 
-`rsync -azvhP {{path/to/local_file}} {{remote_host}}:{{path/to/remote_directory}}`
+`rsync --compress --verbose --human-readable --partial --progress {{path/to/source}} {{path/to/destination}}`
 
-- Transfer a directory and all its contents from a remote host to local:
+- Recursively copy directories:
 
-`rsync -r {{remote_host}}:{{path/to/remote_directory}} {{path/to/local_directory}}`
+`rsync --recursive {{path/to/source}} {{path/to/destination}}`
 
-- Transfer directory contents (but not the directory itself) from a remote host to local:
+- Transfer directory contents, but not the directory itself:
 
-`rsync -r {{remote_host}}:{{path/to/remote_directory}}/ {{path/to/local_directory}}`
+`rsync --recursive {{path/to/source}}/ {{path/to/destination}}`
 
-- Transfer a directory [r]ecursively, in [a]rchive (to preserve attributes), resolving contained sym[L]inks, and ignoring already transferred files [u]nless newer:
+- Recursively copy directories, use archive mode, resolve symlinks and skip files that are newer on the destination:
 
-`rsync -rauL {{remote_host}}:{{path/to/remote_directory}} {{path/to/local_directory}}`
+`rsync --recursive --archive --update --copy-links {{path/to/source}} {{path/to/destination}}`
 
-- Transfer a file over SSH and delete remote files that do not exist locally:
+- Transfer a directory to a remote host running `rsyncd` and delete files on the destination that do not exist on the source:
 
-`rsync -e ssh --delete {{remote_host}}:{{path/to/remote_file}} {{path/to/local_file}}`
+`rsync --recursive --delete rsync://{{host}}:{{path/to/source}} {{path/to/destination}}`
 
-- Transfer a file over SSH using a different port than the default and show global progress:
+- Transfer a file over SSH using a different port than the default (22) and show global progress:
 
-`rsync -e 'ssh -p {{port}}' --info=progress2 {{remote_host}}:{{path/to/remote_file}} {{path/to/local_file}}`
+`rsync --rsh 'ssh -p {{port}}' --info=progress2 {{host}}:{{path/to/source}} {{path/to/destination}}`

--- a/pages/common/rsync.md
+++ b/pages/common/rsync.md
@@ -2,7 +2,7 @@
 
 > Transfer files either to or from a remote host (but not between two remote hosts), by default using SSH.
 > To specify a remote path, use `host:path/to/file_or_directory`.
-> More information: <https://manned.org/rsync>.
+> More information: <https://download.samba.org/pub/rsync/rsync.1>.
 
 - Transfer a file:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

---

Closes #10586.