### PR TITLE
dhcpig: add page

### DIFF
--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -18,7 +18,7 @@
 
 - Enable color output:
 
-`sudo pig.py -c {{eth1}}`
+`sudo ./pig.py -c {{eth1}}`
 
 - Enable minimal verbosity and color output:
 

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -6,7 +6,7 @@
 
 - Exhaust all of the available DHCP addresses using the specified interface:
 
-`sudo pig.py {{eth0}}`
+`sudo ./pig.py {{eth0}}`
 
 - Exhaust IPv6 addresses using eth1 interface:
 

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -14,7 +14,7 @@
 
 - Send fuzzed/malformed data packets using the interface:
 
-`sudo pig.py --fuzz {{eth1}}`
+`sudo ./pig.py --fuzz {{eth1}}`
 
 - Enable color output:
 

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -1,0 +1,33 @@
+# dhcpig
+
+> Initiates an advanced DHCP exhaustion attack and stress test.
+> DHCPig need to be run with root privileges.
+> More information: <https://github.com/kamorin/DHCPig>.
+
+- Exhaust all of the available DHCP addresses using the specified interface:
+
+`sudo pig.py {{eth0}}`
+
+- Exhaust IPv6 addresses using eth1 interface:
+
+`sudo ./pig.py -6 {{eth1}}`
+
+- Send fuzzed/malformed data packets using the interface:
+
+`sudo pig.py --fuzz {{eth1}}`
+
+- Enable color output:
+
+`sudo pig.py -c {{eth1}}`
+
+- Enable minimal verbosity and color output:
+
+`sudo pig.py -c --verbosity=1 {{eth1}}`
+
+- Set debug verbosity and scan network of neighboring devices using ARP packets:
+
+`sudo pig.py -c --verbosity=100 --neighbors-scan-arp {{eth1}}`
+
+- Enable printing lease information,attempt to scan and release all neighbor IP addresses:
+
+`sudo ./pig.py --neighbors-scan-arp -r --show-options {{eth1}}`

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -26,7 +26,7 @@
 
 - Set debug verbosity and scan network of neighboring devices using ARP packets:
 
-`sudo pig.py -c --verbosity=100 --neighbors-scan-arp {{eth1}}`
+`sudo ./pig.py -c --verbosity=100 --neighbors-scan-arp {{eth1}}`
 
 - Enable printing lease information, attempt to scan and release all neighbor IP addresses:
 

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -1,7 +1,7 @@
 # dhcpig
 
 > Initiates an advanced DHCP exhaustion attack and stress test.
-> DHCPig need to be run with root privileges.
+> DHCPig needs to be run with root privileges.
 > More information: <https://github.com/kamorin/DHCPig>.
 
 - Exhaust all of the available DHCP addresses using the specified interface:
@@ -28,6 +28,6 @@
 
 `sudo pig.py -c --verbosity=100 --neighbors-scan-arp {{eth1}}`
 
-- Enable printing lease information,attempt to scan and release all neighbor IP addresses:
+- Enable printing lease information, attempt to scan and release all neighbor IP addresses:
 
 `sudo ./pig.py --neighbors-scan-arp -r --show-options {{eth1}}`

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -22,7 +22,7 @@
 
 - Enable minimal verbosity and color output:
 
-`sudo pig.py -c --verbosity=1 {{eth1}}`
+`sudo ./pig.py -c --verbosity=1 {{eth1}}`
 
 - Set debug verbosity and scan network of neighboring devices using ARP packets:
 


### PR DESCRIPTION
Add the dhcpig tool for IP resource exhaustion.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

