### PR TITLE
ffprobe: fix invalid command

### DIFF
--- a/pages/common/ffprobe.md
+++ b/pages/common/ffprobe.md
@@ -5,7 +5,7 @@
 
 - Display all available stream info for a media file:
 
-`ffprobe -v error -show_entries {{input.mp4}}`
+`ffprobe -v error -show_streams {{input.mp4}}`
 
 - Display media duration:
 


### PR DESCRIPTION
command does not work. show streams shows information corresponding with the description

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
