### PR TITLE
watchexec: fix --restart example

### DIFF
--- a/pages/common/watchexec.md
+++ b/pages/common/watchexec.md
@@ -17,4 +17,4 @@
 
 - Call/restart `my_server` when any file in the current directory change, sending `SIGKILL` to stop the child process:
 
-`watchexec --restart --signal {{SIGKILL}} {{my_server}}`
+`watchexec --restart --stop-signal {{SIGKILL}} {{my_server}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.22.3

In the most recent watchexec version (1.22.3) to the date of this commit it is necessary to use the "--stop-signal" flag instead of "--signal". Otherwise an error message would show up telling the user that "--signal" and "--restart" cannot be used in combination

<details>
<summary>Attached is a screenshot showing the issue.</summary>
<img src="https://github.com/tldr-pages/tldr/assets/61627369/bed169bf-828f-4786-b889-13672071e9ee">
</details>