### PR TITLE
nmap: add sudo to nmap -sn example

### DIFF
--- a/pages/common/nmap.md
+++ b/pages/common/nmap.md
@@ -8,9 +8,9 @@
 
 `nmap -O {{ip_or_hostname}}`
 
-- Try to determine whether the specified hosts are up (ping scan) and what their names are:
+- Try to determine whether the specified hosts are up (ping scan) and what their names and MAC adddresses are:
 
-`nmap -sn {{ip_or_hostname}} {{optional_another_address}}`
+`sudo nmap -sn {{ip_or_hostname}} {{optional_another_address}}`
 
 - Also enable scripts, service detection, OS fingerprinting and traceroute:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Nmap version 7.70

`nmap -sn` can run with or without sudo, but sudo allows access to low-level network discovery methods like ARP scanning, which provides more accurate and detailed results including MAC address.

Example:
``` 
# without sudo
nmap -sn 192.168.4.205
Starting Nmap 7.70 ( https://nmap.org ) at 2023-08-21 13:14 AEST
Nmap scan report for 192.168.4.205
Host is up (0.00061s latency).
Nmap done: 1 IP address (1 host up) scanned in 0.01 seconds

# with sudo
sudo nmap -sn 192.168.4.205
Starting Nmap 7.70 ( https://nmap.org ) at 2023-08-21 13:14 AEST
Nmap scan report for 192.168.4.205
Host is up (0.00048s latency).
MAC Address: 68:B5:99:41:B6:C6 (Hewlett Packard)       *************
Nmap done: 1 IP address (1 host up) scanned in 0.40 seconds
```

Although there is a general note in the description:
> Some features only activate when Nmap is run with root privileges.

But this makes sense to the commands where root privileges are mandatory to run with.
```
 $ nmap -O 192.168.4.205
TCP/IP fingerprinting (for OS scan) requires root privileges.
QUITTING!
```
For `nmap -sn` command, since it can run without root privileges, users won't bother adding sudo while trying and miss the detailed information which could be helpful to them, especially for scanning ip for a target device with known a MAC address in a subnet , e.g., `sudo nmap -sn 192.168.0.1/24`.