### PR TITLE
procs: add `--tree` example

### DIFF
--- a/pages/common/procs.md
+++ b/pages/common/procs.md
@@ -7,6 +7,10 @@
 
 `procs`
 
+- List all processes as a tree:
+
+`procs --tree`
+
 - List information about processes, if the commands which started them contain `zsh`:
 
 `procs {{zsh}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
