### PR TITLE
aws-cloud9: add page

### DIFF
--- a/pages/common/aws-cloud9.md
+++ b/pages/common/aws-cloud9.md
@@ -1,0 +1,32 @@
+# aws cloud9
+
+> Manage collection of tools to code, build, run, test, debug, and release software in the cloud.
+> More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloud9/index.html>.
+
+- Get a list of Cloud9 development environment identifiers:
+
+`aws cloud9 list-environments`
+
+- Create a Cloud9 development environment:
+
+`aws cloud9 create-environment-ec2 --name {{name}} --instance-type {{instance_type}}`
+
+- Display information about Cloud9 development environments:
+
+`aws cloud9 describe-environments --environment-ids {{environment_ids}}`
+
+- Adds an environment member to a Cloud9 development environment:
+
+`aws cloud9 create-environment-membership --environment-id {{environment_id}} --user-arn {{user_arn}} --permissions {{permissions}}`
+
+- Display status information for a Cloud9 development environment:
+
+`aws cloud9 describe-environment-status --environment-id {{environment_id}}`
+
+- Delete a Cloud9 environment:
+
+`aws cloud9 delete-environment --environment-id {{environment_id}}`
+
+- Delete an environment member from a development environment:
+
+`aws cloud9 delete-environment-membership --environment-id {{environment_id}} --user-arn {{user_arn}}`

--- a/pages/common/aws-cloud9.md
+++ b/pages/common/aws-cloud9.md
@@ -15,7 +15,7 @@
 
 `aws cloud9 describe-environments --environment-ids {{environment_ids}}`
 
-- Adds an environment member to a Cloud9 development environment:
+- Add an environment member to a Cloud9 development environment:
 
 `aws cloud9 create-environment-membership --environment-id {{environment_id}} --user-arn {{user_arn}} --permissions {{permissions}}`
 

--- a/pages/common/aws-cloud9.md
+++ b/pages/common/aws-cloud9.md
@@ -1,6 +1,6 @@
 # aws cloud9
 
-> Manage collection of tools to code, build, run, test, debug, and release software in the cloud.
+> Manage Cloud9 - a collection of tools to code, build, run, test, debug, and release software in the cloud.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloud9/index.html>.
 
 - Get a list of Cloud9 development environment identifiers:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
