### PR TITLE
docker-cp: add missing placeholders

### DIFF
--- a/pages.fr/common/docker-cp.md
+++ b/pages.fr/common/docker-cp.md
@@ -5,11 +5,11 @@
 
 - Copier un fichier ou un répertoire de l'hôte vers un conteneur :
 
-`docker cp {{chemin/vers/le_fichier_ou_le_dossier_de_l_hote} {{nom_du_conteneur}}:{{chemin/vers/le_fichier_ou_le_dossier_de_conteneur}}`
+`docker cp {{chemin/vers/le_fichier_ou_le_dossier_de_l_hote}} {{nom_du_conteneur}}:{{chemin/vers/le_fichier_ou_le_dossier_de_conteneur}}`
 
 - Copier un fichier ou un répertoire d'un conteneur vers l'hôte :
 
-`docker cp {{nom_du_conteneur}}:{{chemin/vers/le_fichier_ou_le_dossier_de_conteneur}} {{chemin/vers/le_fichier_ou_le_dossier_de_l_hote}`
+`docker cp {{nom_du_conteneur}}:{{chemin/vers/le_fichier_ou_le_dossier_de_conteneur}} {{chemin/vers/le_fichier_ou_le_dossier_de_l_hote}}`
 
 - Copier un fichier ou un répertoire de l'hôte vers un conteneur, en suivant les liens symboliques (copie les fichiers liés directement, pas les liens symboliques eux-mêmes) :
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

**Notes**
In the previous version, 2 `}` were missing.