### PR TITLE
mktemp(linux): improve examples

### DIFF
--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -2,15 +2,16 @@
 
 > Create a temporary file or directory.
 > More information: <https://www.gnu.org/software/autogen/mktemp.html>.
+> Note that examples here all assume `$TMPDIR` is unset.
 
-- Create an empty temporary file and print the absolute path to it:
+- Create an empty temporary file in `/tmp/` and print its absolute path:
 
 `mktemp`
 
-- Create an empty temporary file with a given suffix and print the absolute path to file:
-
-`mktemp --suffix "{{.ext}}"`
-
-- Create a temporary directory and print the absolute path to it:
+- Create a temporary directory in `/tmp/` and print its absolute path:
 
 `mktemp --directory`
+
+- Create an empty temporary file at the specified path, with `X`s replaced with random alphanumeric characeters, and print its path:
+
+`mktemp "{{path/to/file-XXXXX-name}}"`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -12,6 +12,6 @@
 
 `mktemp --directory`
 
-- Create an empty temporary file at the specified path, with `X`s replaced with random alphanumeric characeters, and print its path:
+- Create an empty temporary file at the specified path, with `X`s replaced with random alphanumeric characters, and print its path:
 
 `mktemp "{{path/to/file-XXXXX-name}}"`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -1,8 +1,8 @@
 # mktemp
 
 > Create a temporary file or directory.
-> More information: <https://www.gnu.org/software/autogen/mktemp.html>.
 > Note that examples here all assume `$TMPDIR` is unset.
+> More information: <https://www.gnu.org/software/autogen/mktemp.html>.
 
 - Create an empty temporary file in `/tmp/` and print its absolute path:
 

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -14,4 +14,8 @@
 
 - Create an empty temporary file at the specified path, with `X`s replaced with random alphanumeric characters, and print its path:
 
-`mktemp "{{path/to/file-XXXXX-name}}"`
+`mktemp "{{path/to/file_XXXXX_name}}"`
+
+- Create an empty temporary file in `/tmp/` with the specified name, with `X`s replaced with random alphanumeric characters, and print its path:
+
+`mktemp -t "{{file_XXXXX_name}}"`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** GNU coreutils 9.3