### PR TITLE
rustup-{install,run,which,help,man}: add page

### DIFF
--- a/pages/common/rustup-help.md
+++ b/pages/common/rustup-help.md
@@ -1,0 +1,12 @@
+# rustup help
+
+> Display help on `rustup` and its subcommands.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Display general help:
+
+`rustup help`
+
+- Display help for a subcommand:
+
+`rustup help {{subcommand}}`

--- a/pages/common/rustup-install.md
+++ b/pages/common/rustup-install.md
@@ -1,0 +1,9 @@
+# rustup install
+
+> Install or update Rust toolchains.
+> This command is an alias of `rustup update`, but can only install/update one toolchain at a time.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Install or update a specific toolchain (see `rustup help toolchain` for more information):
+
+`rustup install {{toolchain}}`

--- a/pages/common/rustup-man.md
+++ b/pages/common/rustup-man.md
@@ -1,0 +1,12 @@
+# rustup man
+
+> View the man page for a given command managed by `rustup`.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- View the man page for a given command from the default toolchain:
+
+`rustup man {{command}}`
+
+- View the man page for a given command from the specified toolchain:
+
+`rustup man --toolchain {{command}}`

--- a/pages/common/rustup-run.md
+++ b/pages/common/rustup-run.md
@@ -1,0 +1,9 @@
+# rustup run
+
+> Run a command with an environment configured for a given Rust toolchain.
+> Note: all commands managed by `rustup` have a shorthand for this: for example, `cargo +nightly build` is equivalent to `rustup run nightly cargo build`.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Run a command using a given Rust toolchain (see `rustup help toolchain` for more information):
+
+`rustup run {{toolchain}} {{command}}`

--- a/pages/common/rustup-which.md
+++ b/pages/common/rustup-which.md
@@ -1,0 +1,13 @@
+# rustup which
+
+> Display which binary will be run for a given command managed by `rustup`.
+> Like `which`, but searches a Rust toolchain instead of `$PATH`.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Display the path to the binary in the default toolchain:
+
+`rustup which {{command}}`
+
+- Display the path to the binary in the specified toolchain (see `rustup help toolchain` for more information):
+
+`rustup which --toolchain {{toolchain}} {{command}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).