### PR TITLE
CI: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: CI
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: CI
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0.0
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: CI
 
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.0.0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

This PR bumps the `actions/checkout` version from `v3` (Node 16) to `v4` (Node 20) as Node 16 reaches eol on September 11.
