### PR TITLE
mktemp: fix `common` and standardize between variants

### DIFF
--- a/pages/common/mktemp.md
+++ b/pages/common/mktemp.md
@@ -1,16 +1,20 @@
 # mktemp
 
 > Create a temporary file or directory.
-> More information: <https://ss64.com/osx/mktemp.html>.
+> More information: <https://man.openbsd.org/mktemp.1>.
 
-- Create an empty temporary file and print the absolute path to it:
+- Create an empty temporary file and print its absolute path:
 
 `mktemp`
 
-- Create an empty temporary file with a given suffix and print the absolute path to file:
+- Use a custom path template (`X`s are replaced with random alphanumeric characters):
 
-`mktemp --suffix "{{.ext}}"`
+`mktemp {{/tmp/example.XXXXXXXX}}`
 
-- Create a temporary directory and print the absolute path to it:
+- Use a custom file name template:
+
+`mktemp -t {{example.XXXXXXXX}}`
+
+- Create an empty temporary directory and print its absolute path:
 
 `mktemp -d`

--- a/pages/common/mktemp.md
+++ b/pages/common/mktemp.md
@@ -7,6 +7,10 @@
 
 `mktemp`
 
+- Use a custom directory if `$TMPDIR` is not set (the default is platform-dependent, but usually `/tmp`):
+
+`mktemp -p {{/path/to/tempdir}}`
+
 - Use a custom path template (`X`s are replaced with random alphanumeric characters):
 
 `mktemp {{/tmp/example.XXXXXXXX}}`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -1,21 +1,24 @@
 # mktemp
 
 > Create a temporary file or directory.
-> Note that examples here all assume `$TMPDIR` is unset.
 > More information: <https://www.gnu.org/software/autogen/mktemp.html>.
 
-- Create an empty temporary file in `/tmp/` and print its absolute path:
+- Create an empty temporary file and print its absolute path:
 
 `mktemp`
 
-- Create a temporary directory in `/tmp/` and print its absolute path:
+- Use a custom path template (`X`s are replaced with random alphanumeric characters):
+
+`mktemp {{/tmp/example.XXXXXXXX}}`
+
+- Use a custom file name template:
+
+`mktemp -t {{example.XXXXXXXX}}`
+
+- Create an empty temporary file with the given suffix and print its absolute path:
+
+`mktemp --suffix {{.ext}}`
+
+- Create an empty temporary directory and print its absolute path:
 
 `mktemp --directory`
-
-- Create an empty temporary file at the specified path, with `X`s replaced with random alphanumeric characters, and print its path:
-
-`mktemp "{{path/to/file_XXXXX_name}}"`
-
-- Create an empty temporary file in `/tmp/` with the specified name, with `X`s replaced with random alphanumeric characters, and print its path:
-
-`mktemp -t "{{file_XXXXX_name}}"`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -1,7 +1,7 @@
 # mktemp
 
 > Create a temporary file or directory.
-> More information: <https://www.gnu.org/software/autogen/mktemp.html>.
+> More information: <https://www.gnu.org/software/coreutils/mktemp>.
 
 - Create an empty temporary file and print its absolute path:
 
@@ -9,7 +9,7 @@
 
 - Use a custom directory (defaults to `$TMPDIR` or `/tmp`):
 
-`mktemp --tmpdir {{/path/to/tempdir}}`
+`mktemp --tmpdir={{/path/to/tempdir}}`
 
 - Use a custom path template (`X`s are replaced with random alphanumeric characters):
 
@@ -17,7 +17,7 @@
 
 - Use a custom file name template:
 
-`mktemp --deprecated-tmpdir {{example.XXXXXXXX}}`
+`mktemp -t {{example.XXXXXXXX}}`
 
 - Create an empty temporary file with the given suffix and print its absolute path:
 

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -7,13 +7,17 @@
 
 `mktemp`
 
+- Use a custom directory (defaults to `/tmp`):
+
+`mktemp --tmpdir {{/path/to/tempdir}}`
+
 - Use a custom path template (`X`s are replaced with random alphanumeric characters):
 
 `mktemp {{/tmp/example.XXXXXXXX}}`
 
 - Use a custom file name template:
 
-`mktemp -t {{example.XXXXXXXX}}`
+`mktemp --deprecated-tmpdir {{example.XXXXXXXX}}`
 
 - Create an empty temporary file with the given suffix and print its absolute path:
 

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -7,7 +7,7 @@
 
 `mktemp`
 
-- Use a custom directory (defaults to `$TMPDIR` or `/tmp`):
+- Use a custom directory (defaults to `$TMPDIR`, or `/tmp`):
 
 `mktemp --tmpdir={{/path/to/tempdir}}`
 

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -7,7 +7,7 @@
 
 `mktemp`
 
-- Use a custom directory (defaults to `/tmp`):
+- Use a custom directory (defaults to `$TMPDIR` or `/tmp`):
 
 `mktemp --tmpdir {{/path/to/tempdir}}`
 

--- a/pages/osx/mktemp.md
+++ b/pages/osx/mktemp.md
@@ -1,0 +1,24 @@
+# mktemp
+
+> Create a temporary file or directory.
+> More information: <https://keith.github.io/xcode-man-pages/mktemp.1.html>.
+
+- Create an empty temporary file and print its absolute path:
+
+`mktemp`
+
+- Use a custom directory (defaults to the output of `getconf DARWIN_USER_TEMP_DIR`, or `/tmp`):
+
+`mktemp --tmpdir={{/path/to/tempdir}}`
+
+- Use a custom path template (`X`s are replaced with random alphanumeric characters):
+
+`mktemp {{/tmp/example.XXXXXXXX}}`
+
+- Use a custom file name prefix:
+
+`mktemp -t {{example}}`
+
+- Create an empty temporary directory and print its absolute path:
+
+`mktemp --directory`


### PR DESCRIPTION
As promised in https://github.com/tldr-pages/tldr/pull/10651#issuecomment-1703191336
There are many inconsistencies between the different platforms, but I checked everything multiple times against docs and implementations and this seems to be correct

Documented versions:
- `common`: OpenBSD-current
- `linux`: GNU coreutils 9.4
- `osx`: macOS 12-14