### PR TITLE
htop: add `--delay` example

### DIFF
--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -15,6 +15,10 @@
 
 `htop --sort {{sort_item}}`
 
+- Start `htop` with a delay between updates, in tenths of a second (i.e. 50 = 5 seconds):
+
+`htop -d 50`
+
 - See interactive commands while running htop:
 
 `?`

--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -15,9 +15,9 @@
 
 `htop --sort {{sort_item}}`
 
-- Start `htop` with a delay between updates, in tenths of a second (i.e. 50 = 5 seconds):
+- Start `htop` with the specified delay between updates, in tenths of a second (i.e. 50 = 5 seconds):
 
-`htop -d 50`
+`htop --delay 50`
 
 - See interactive commands while running htop:
 


### PR DESCRIPTION
Adds htop -d for delayed updates

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).