### PR TITLE
CI/codespell: remove changed-files action, use point release of action

### DIFF
--- a/.github/codespell-ignore
+++ b/.github/codespell-ignore
@@ -1,6 +1,1 @@
 crate
-ned
-tre
-[l]ist
-[s]earch
-[u]ser

--- a/.github/codespell-ignore
+++ b/.github/codespell-ignore
@@ -1,1 +1,6 @@
 crate
+ned
+tre
+[l]ist
+[s]earch
+[u]ser

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,19 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v39.0.0
-        with:
-          # Ignore all other languages except English
-          files_ignore: |
-            pages.*/*/*
-            package-lock.json
-
       - uses: codespell-project/actions-codespell@master
         with:
           ignore_words_file: .github/codespell-ignore
           # Exit with 0 regardless of typos.
           only_warn: 1
-          # Only check files in the PR
-          path: ${{ steps.changed-files.outputs.all_changed_files }}
+          # Only check files from English pages
+          path: pages/*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: codespell-project/actions-codespell@master
+      - uses: codespell-project/actions-codespell@v2
         with:
           ignore_words_file: .github/codespell-ignore
           # Exit with 0 regardless of typos.
           only_warn: 1
-          # Only check files from English pages
+          # Only check English files from the pages directory
           path: pages/*


### PR DESCRIPTION
Superseeds #10704

This change would make the CI run only on English pages by directly passing the path to Codespell to prevent false detections like https://github.com/tldr-pages/tldr/pull/10702/files for other languages, There still would be annotations made for other pages not in PR similar to now, but it won't prevent us from merging the PR as we have the only_warn parameter set to 1. We can alternatively add those entries to codespell-ignore file.

Edit. Bonus It will also reduce the CI action run time of the codespell action.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
