### PR TITLE
iptables: update page

### DIFF
--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -5,32 +5,32 @@
 
 - View chains, rules, packet/byte counters and line numbers for the filter table:
 
-`sudo iptables -vnL --line-numbers`
+`sudo iptables --verbose --numeric --list --line-numbers`
 
-- Set chain policy rule:
+- Set chain [P]olicy rule:
 
-`sudo iptables -P {{chain}} {{rule}}`
+`sudo iptables --policy {{chain}} {{rule}}`
 
-- Append rule to chain policy for IP:
+- [A]ppend rule to chain policy for IP:
 
-`sudo iptables -A {{chain}} -s {{ip}} -j {{rule}}`
+`sudo iptables --append {{chain}} --source {{ip}} --jump {{rule}}`
 
-- Append rule to chain policy for IP considering protocol and port:
+- [A]ppend rule to chain policy for IP considering [p]rotocol and port:
 
-`sudo iptables -A {{chain}} -s {{ip}} -p {{protocol}} --dport {{port}} -j {{rule}}`
+`sudo iptables --append {{chain}} --source {{ip}} --protocol {{protocol}} --dport {{port}} --jump {{rule}}`
 
 - Add a NAT rule to translate all traffic from the `192.168.0.0/24` subnet to the host's public IP:
 
-`sudo iptables -t {{nat}} -A {{POSTROUTING}} -s {{192.168.0.0/24}} -j {{MASQUERADE}}`
+`sudo iptables --table {{nat}} --append {{POSTROUTING}} --source {{192.168.0.0/24}} --jump {{MASQUERADE}}`
 
-- Delete chain rule:
+- [D]elete chain rule:
 
-`sudo iptables -D {{chain}} {{rule_line_number}}`
+`sudo iptables --delete {{chain}} {{rule_line_number}}`
 
-- Save iptables configuration of a given table to a file:
+- Save `iptables` configuration of a given [t]able to a file:
 
-`sudo iptables-save -t {{tablename}} > {{path/to/iptables_file}}`
+`sudo iptables-save --table {{tablename}} > {{path/to/iptables_file}}`
 
-- Restore iptables configuration from a file:
+- Restore `iptables` configuration from a file:
 
 `sudo iptables-restore < {{path/to/iptables_file}}`

--- a/pages/linux/iptables.md
+++ b/pages/linux/iptables.md
@@ -3,9 +3,9 @@
 > Program that allows configuration of tables, chains and rules provided by the Linux kernel firewall.
 > More information: <https://www.netfilter.org/projects/iptables/>.
 
-- View chains, rules, and packet/byte counters for the filter table:
+- View chains, rules, packet/byte counters and line numbers for the filter table:
 
-`sudo iptables -vnL`
+`sudo iptables -vnL --line-numbers`
 
 - Set chain policy rule:
 


### PR DESCRIPTION
as line number is required to delete a rule (as seen in the examples for `iptables -D`), it is useful to see the numbers in the list command so adding `--line-numbers` in the list command example

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
