### PR TITLE
rustup-{set,self,completions.doc,override,component}: add page

### DIFF
--- a/pages/common/rustup-completions.md
+++ b/pages/common/rustup-completions.md
@@ -1,0 +1,8 @@
+# rustup completions
+
+> Generate shell completions for `rustup` and `cargo`.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Print the completion script to `stdout`:
+
+`rustup completions {{bash|elvish|fish|powershell|zsh}} {{rustup|cargo}}`

--- a/pages/common/rustup-component.md
+++ b/pages/common/rustup-component.md
@@ -1,0 +1,21 @@
+# rustup component
+
+> Modify a toolchain's installed components.
+> Without the `--toolchain` option `rustup` will use the default toolchain. See `rustup help toolchain` for more information about toolchains.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Add a component to a toolchain:
+
+`rustup component add --toolchain {{toolchain}} {{component}}`
+
+- Remove a component from a toolchain:
+
+`rustup component remove --toolchain {{toolchain}} {{component}}`
+
+- List installed and available components for a toolchain:
+
+`rustup component list --toolchain {{toolchain}}`
+
+- List installed components for a toolchain:
+
+`rustup component list --toolchain {{toolchain}} --installed`

--- a/pages/common/rustup-doc.md
+++ b/pages/common/rustup-doc.md
@@ -1,0 +1,25 @@
+# rustup doc
+
+> Open the offline Rust documentation for the current toolchain.
+> There are a lot more documentation pages not mentioned here. See `rustup help doc` for more information.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Open the main page:
+
+`rustup doc`
+
+- Open the documentation for a specific topic (a module in the standard library, a type, a keyword, etc.):
+
+`rustup doc {{std::fs|usize|fn|...}}`
+
+- Open the Rust Programming Language book:
+
+`rustup doc --book`
+
+- Open the Cargo book:
+
+`rustup doc --cargo`
+
+- Open the Rust Reference:
+
+`rustup doc --reference`

--- a/pages/common/rustup-override.md
+++ b/pages/common/rustup-override.md
@@ -1,0 +1,21 @@
+# rustup override
+
+> Modify directory toolchain overrides.
+> See `rustup help toolchain` for more information about toolchains.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- List directiory toolchain overrides:
+
+`rustup override list`
+
+- Set the override toolchain for the current directory (i.e. tell `rustup` to run `cargo`, `rustc`, etc. from a specific toolchain when in that directory):
+
+`rustup override set {{toolchain}}`
+
+- Remove the toolchain override for the current directory:
+
+`rustup override unset`
+
+- Remove all toolchain overrides for directories that no longer exist:
+
+`rustup override unset --nonexistent`

--- a/pages/common/rustup-self.md
+++ b/pages/common/rustup-self.md
@@ -1,0 +1,12 @@
+# rustup self
+
+> Modify the `rustup` installation.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Update `rustup`:
+
+`rustup self update`
+
+- Uninstall `rustup`:
+
+`rustup self uninstall`

--- a/pages/common/rustup-set.md
+++ b/pages/common/rustup-set.md
@@ -1,0 +1,16 @@
+# rustup set
+
+> Alter `rustup` settings.
+> More information: <https://rust-lang.github.io/rustup>.
+
+- Set the default host triple:
+
+`rustup set default-host {{host_triple}}`
+
+- Set the default profile (`minimal` includes only `rustc`, `rust-std` and `cargo`. `default` adds `rust-docs`, `rustfmt` and `clippy`):
+
+`rustup set profile {{minimal|default}}`
+
+- Set whether `rustup` should update itself when running `rustup update`:
+
+`rustup set auto-self-update {{enable|disable|check-only}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).