### PR TITLE
flutter-pub: add page

### DIFF
--- a/pages/common/flutter-pub.md
+++ b/pages/common/flutter-pub.md
@@ -1,0 +1,21 @@
+# flutter
+
+> Flutter's own package manager. Packages are available on <https://flutter.dev>.
+> More information: <https://docs.flutter.dev/packages-and-plugins/using-packages>.
+
+
+- Download / Update all packages specified in `pubspec.yaml`:
+
+`flutter pub get`
+
+- Add a package dependency to an app:
+
+`flutter pub add {{package}}`
+
+- Remove a package dependency to an app:
+
+`flutter pub remove {{package}}`
+
+- Upgrade to the highest version of a package that is allowed by `pubspec.yaml`:
+
+`flutter pub upgrade {{package}}`

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -19,10 +19,6 @@
 
 `flutter run -d all`
 
-- Download all packages specified in `pubspec.yaml`:
-
-`flutter pub get`
-
 - Run tests in a terminal from the root of the project:
 
 `flutter test {{test/example_test.dart}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** Flutter 3.13.1
