### PR TITLE
resolvectl: add cache flushing and statistics, remove openpgp

### DIFF
--- a/pages/linux/resolvectl.md
+++ b/pages/linux/resolvectl.md
@@ -16,6 +16,14 @@
 
 `resolvectl query {{ip_address}}`
 
+- Flush all local DNS caches:
+
+`resolvectl flush-caches`
+
+- Display DNS statistics (transactions, cache, and DNSSEC):
+
+`resolvectl statistics`
+
 - Retrieve an MX record of a domain:
 
 `resolvectl --legend={{no}} --type={{MX}} query {{domain}}`

--- a/pages/linux/resolvectl.md
+++ b/pages/linux/resolvectl.md
@@ -32,10 +32,6 @@
 
 `resolvectl service _{{service}}._{{protocol}} {{name}}`
 
-- Retrieve the public key from an email address from an OPENPGPKEY DNS record:
-
-`resolvectl openpgp {{email}}`
-
 - Retrieve a TLS key:
 
 `resolvectl tlsa tcp {{domain}}:443`

--- a/pages/linux/resolvectl.md
+++ b/pages/linux/resolvectl.md
@@ -20,7 +20,7 @@
 
 `resolvectl flush-caches`
 
-- Display DNS statistics (transactions, cache, and DNSSEC):
+- Display DNS statistics (transactions, cache, and DNSSEC verdicts):
 
 `resolvectl statistics`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Getting the DNS statistics and clearing the DNS cache are some of the most common operations with resolvectl, hence it would make sense to have them in the tldr page.
I removed `resolvectl openpgp` from the tldr page, as it's rarely needed, and i needed to remove a command to go under the 8 example limit.