### PR TITLE
pdftohtml: add page

### DIFF
--- a/pages/linux/pdftohtml.md
+++ b/pages/linux/pdftohtml.md
@@ -1,6 +1,6 @@
 # pdftohtml
 
-> Pdftohtml is a program to convert PDF files into HTML and XML and PNG images.
+> Pdftohtml is a program to convert PDF files into HTML, XML and PNG images.
 > More information: <https://linux.die.net/man/1/pdftohtml>.
 
 - Convert a pdf file to a html file:

--- a/pages/linux/pdftohtml.md
+++ b/pages/linux/pdftohtml.md
@@ -1,0 +1,20 @@
+# pdftohtml
+
+> Pdftohtml is a program to convert PDF files into HTML and XML and PNG images.
+> More information: <https://linux.die.net/man/1/pdftohtml>.
+
+- Convert a pdf file to a html file:
+
+`pdftohtml {{path/to/pdf}} {{path/to/html}}`
+
+- Ignore images in the pdf file:
+
+`pdftohtml -i {{path/to/pdf}} {{path/to/html}}`
+
+- Generate a single HTML that includes all pdf pages:
+
+`pdftohtml -s {{path/to/pdf}} {{path/to/html}}`
+
+- Convert a pdf file to a xml file:
+
+`pdftohtml -xml {{path/to/pdf}} {{path/to/html}}`

--- a/pages/linux/pdftohtml.md
+++ b/pages/linux/pdftohtml.md
@@ -1,7 +1,7 @@
 # pdftohtml
 
-> Pdftohtml is a program to convert PDF files into HTML, XML and PNG images.
-> More information: <https://linux.die.net/man/1/pdftohtml>.
+> Convert PDF files into HTML, XML and PNG images.
+> More information: <https://manned.org/pdftohtml.1>.
 
 - Convert a PDF file to an HTML file:
 

--- a/pages/linux/pdftohtml.md
+++ b/pages/linux/pdftohtml.md
@@ -1,7 +1,7 @@
 # pdftohtml
 
 > Convert PDF files into HTML, XML and PNG images.
-> More information: <https://manned.org/pdftohtml.1>.
+> More information: <https://manned.org/pdftohtml>.
 
 - Convert a PDF file to an HTML file:
 

--- a/pages/linux/pdftohtml.md
+++ b/pages/linux/pdftohtml.md
@@ -3,18 +3,18 @@
 > Pdftohtml is a program to convert PDF files into HTML, XML and PNG images.
 > More information: <https://linux.die.net/man/1/pdftohtml>.
 
-- Convert a pdf file to a html file:
+- Convert a PDF file to an HTML file:
 
-`pdftohtml {{path/to/pdf}} {{path/to/html}}`
+`pdftohtml {{path/to/file.pdf}} {{path/to/output_file.html}}`
 
-- Ignore images in the pdf file:
+- Ignore images in the PDF file:
 
-`pdftohtml -i {{path/to/pdf}} {{path/to/html}}`
+`pdftohtml -i {{path/to/file.pdf}} {{path/to/output_file.html}}`
 
-- Generate a single HTML that includes all pdf pages:
+- Generate a single HTML file that includes all PDF pages:
 
-`pdftohtml -s {{path/to/pdf}} {{path/to/html}}`
+`pdftohtml -s {{path/to/file.pdf}} {{path/to/output_file.html}}`
 
-- Convert a pdf file to a xml file:
+- Convert a PDF file to an XML file:
 
-`pdftohtml -xml {{path/to/pdf}} {{path/to/html}}`
+`pdftohtml -xml {{path/to/file.pdf}} {{path/to/output_file.xml}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 23.02.0
