### PR TITLE
caffeinate: add `-w` flag example

### DIFF
--- a/pages/osx/caffeinate.md
+++ b/pages/osx/caffeinate.md
@@ -11,7 +11,7 @@
 
 `caffeinate -s "{{command}}"`
 
-- Prevent from sleeping until a PID completes:
+- Prevent from sleeping until a process with the specified PID completes:
 
 `caffeinate -w {{pid}}`
 

--- a/pages/osx/caffeinate.md
+++ b/pages/osx/caffeinate.md
@@ -11,6 +11,10 @@
 
 `caffeinate -s "{{command}}"`
 
+- Prevent from sleeping until a PID completes:
+
+`caffeinate -w {{pid}}`
+
 - Prevent from sleeping (use `Ctrl + C` to exit):
 
 `caffeinate -i`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
