### PR TITLE
MAINTAINERS: add @kant as collaborator

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -58,8 +58,10 @@ If you are an owner of the organization, you can see an automated list
   [4 September 2023](https://github.com/tldr-pages/tldr/issues/10611) — present
 - **Lucas Schneider ([@schneiderl](https://github.com/schneiderl))**:
   [11 April 2019](https://github.com/tldr-pages/tldr/issues/2898) — [17 January 2020](https://github.com/tldr-pages/tldr/issues/3764), [7 February 2023](https://github.com/tldr-pages/tldr/issues/10674) — present
-- **Isaac Vicente ([@isaacvicente](https://github.com/isaacvicente/))**:
+- **Isaac Vicente ([@isaacvicente](https://github.com/isaacvicente))**:
   [20 September 2023](https://github.com/tldr-pages/tldr/issues/10737) — present
+- **Darío Hereñú ([@kant](https://github.com/kant))**:
+  [20 September 2023](https://github.com/tldr-pages/tldr/issues/10738) — present
 - Owen Voke ([@owenvoke](https://github.com/owenvoke))
   [11 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258)
 - Marco Bonelli ([@mebeim](https://github.com/mebeim)):


### PR DESCRIPTION
Closes #10738

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Generally, we would suggest the maintainer create a PR (with a few exceptions) to add themselves to `MAINTAINERS.md`. I created this PR as a part of the process of cleaning up the state issues (and labelling good first issues) as we prepare for Hacktoberfest next week.
