### PR TITLE
aws: update Korean translation; aws-{batch, cloud9},subcommand-mention: add Korean translation

### DIFF
--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -153,7 +153,9 @@ Alcuni comandi aggiuntivi, come `example command`, hanno la propria documentazio
 
 ### ko
 
-Not translated yet.
+```markdown
+`example command`와 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
+```
 
 ---
 

--- a/pages.ko/common/aws-batch.md
+++ b/pages.ko/common/aws-batch.md
@@ -1,0 +1,28 @@
+# aws batch
+
+> AWS Batch를 통해 배치 컴퓨팅 워크로드를 실행합니다.
+> 더 많은 정보: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/batch/index.html>.
+
+- 실행 중인 배치 작업 목록:
+
+`aws batch list-jobs --job-queue {{queue_name}}`
+
+- 컴퓨팅 환경 생성:
+
+`aws batch create-compute-environment --compute-environment-name {{compute_environment_name}} --type {{type}}`
+
+- 배치 작업 큐 생성:
+
+`aws batch create-job-queue --job-queue-name {{queue_name}} --priority {{priority}} --compute-environment-order {{compute_environment}}`
+
+- 작업 제출:
+
+`aws batch submit-job --job-name {{job_name}} --job-queue {{job_queue}} --job-definition {{job_definition}}`
+
+- 배치 작업 목록 설명:
+
+`aws batch describe-jobs --jobs {{jobs}}`
+
+- 작업 취소:
+
+`aws batch cancel-job --job-id {{job_id}} --reason {{reason}}`

--- a/pages.ko/common/aws-cloud9.md
+++ b/pages.ko/common/aws-cloud9.md
@@ -1,0 +1,32 @@
+# aws cloud9
+
+> AWS Cloud9은 클라우드에서 소프트웨어를 작성, 빌드, 실행, 테스트, 디버그 및 릴리스하는 도구 모음입니다.
+> 더 많은 정보: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloud9/index.html>.
+
+- Cloud9 개발 환경 식별자 목록 가져오기:
+
+`aws cloud9 list-environments`
+
+- Cloud9 개발 환경 만들기:
+
+`aws cloud9 create-environment-ec2 --name {{name}} --instance-type {{instance_type}}`
+
+- Cloud9 개발 환경에 대한 정보 표시:
+
+`aws cloud9 describe-environments --environment-ids {{environment_ids}}`
+
+- Cloud9 개발 환경에 환경 멤버 추가:
+
+`aws cloud9 create-environment-membership --environment-id {{environment_id}} --user-arn {{user_arn}} --permissions {{permissions}}`
+
+- Cloud9 개발 환경에 대한 상태 정보 표시:
+
+`aws cloud9 describe-environment-status --environment-id {{environment_id}}`
+
+- Cloud9 환경 삭제:
+
+`aws cloud9 delete-environment --environment-id {{environment_id}}`
+
+- 개발 환경에서 환경 멤버 삭제:
+
+`aws cloud9 delete-environment-membership --environment-id {{environment_id}} --user-arn {{user_arn}}`

--- a/pages.ko/common/aws.md
+++ b/pages.ko/common/aws.md
@@ -1,24 +1,37 @@
 # aws
 
 > Amazon Web Services의 공식 CLI tool입니다.
+> `aws s3`와 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
 > 더 많은 정보: <https://aws.amazon.com/cli>.
 
-- 모든 IAM 사용자 목록:
+- AWS Command-line 설정:
 
-`aws iam list-users`
+`aws configure wizard`
 
-- 특정 지역의 모든 ec2 인스턴스 나열:
+- SSO를 사용해 AWS Command-line 설정:
 
-`aws ec2 describe-instances --region {{us-east-1}}`
+`aws configure sso`
 
-- 특정 SQS 대기열에서 메시지 수신:
-
-`aws sqs receive-message --queue-url {{https://queue.amazonaws.com/546123/Test}}`
-
-- 특정 SNS 주제에 메시지 게시:
-
-`aws sns publish --topic-arn {{arn:aws:sns:us-east-1:54633:testTopic}} --message "Message"`
-
-- AWS 명령어에 대한 도움말을 보려면:
+- AWS 명령에 대한 도움말:
 
 `aws {{command}} help`
+
+- 호출자 ID 가져오기 (권한 문제 해결에 사용됨):
+
+`aws sts get-caller-identity`
+
+- 지역의 AWS 리소스 목록 및 YAML로 출력:
+
+`aws dynamodb list-tables --region {{us-east-1}} --output yaml`
+
+- 명령에 대한 자동 프롬프트 사용:
+
+`aws iam create-user --cli-auto-prompt`
+
+- AWS 리소스에 대한 대화형 마법사 사용:
+
+`aws dynamodb wizard {{new_table}}`
+
+- JSON CLI 스켈레톤 생성 (인프라를 코드로 사용하는 데 유용):
+
+`aws dynamodb update-table --generate-cli-skeleton`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
