### PR TITLE
todo.sh: add page

### DIFF
--- a/pages/common/todo.sh.md
+++ b/pages/common/todo.sh.md
@@ -1,0 +1,28 @@
+# todo.sh
+
+> A simple and extensible shell script for managing your todo.txt file.
+> More information: <https://github.com/todotxt/todo.txt-cli>.
+
+- List every items:
+
+`todo.sh ls`
+
+- Add an item with project and context tags:
+
+`todo.sh add '{{description}} +{{project}} @{{context}}'`
+
+- Mark an item as [do]ne:
+
+`todo.sh do {{item_no}}`
+
+- Remove an item:
+
+`todo.sh rm {{item_no}}`
+
+- Set an item's [pri]ority (A-Z):
+
+`todo.sh pri {{item_no}} {{priority}}`
+
+- Replace an item:
+
+`todo.sh replace {{item_no}} '{{new_description}}'`

--- a/pages/common/todo.sh.md
+++ b/pages/common/todo.sh.md
@@ -1,9 +1,9 @@
 # todo.sh
 
-> A simple and extensible shell script for managing your todo.txt file.
+> Simple and extensible shell script for managing your `todo.txt` file.
 > More information: <https://github.com/todotxt/todo.txt-cli>.
 
-- List every items:
+- List every item:
 
 `todo.sh ls`
 


### PR DESCRIPTION
Document https://github.com/todotxt/todo.txt-cli, version 2.12.0

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): 2.12**
