### PR TITLE
gh-repo: update command

### DIFF
--- a/pages/common/gh-repo.md
+++ b/pages/common/gh-repo.md
@@ -23,9 +23,9 @@
 
 `gh repo list {{owner}}`
 
-- List only non-forks repositories:
+- List only non-forks repositories, limit amount (default: 30):
 
-`gh repo list {{owner}} --non-forks`
+`gh repo list {{owner}} --source -L {{limit}}`
 
 - List repositories with a specific primary coding language:
 

--- a/pages/common/gh-repo.md
+++ b/pages/common/gh-repo.md
@@ -23,7 +23,7 @@
 
 `gh repo list {{owner}}`
 
-- List only non-forks repositories, limit amount (default: 30):
+- List only non-forks repositories and limit the number of repositories to list (default: 30):
 
 `gh repo list {{owner}} --source -L {{limit}}`
 


### PR DESCRIPTION
The flags changed around listing source repositories. This change reflects that.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** `gh version 2.35.0 (2023-09-19)`
