### PR TITLE
chore: ignore venv recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ scripts/pdf/tldr-pages.pdf
 
 # Python venv for testing the PDF script
 # Create it with: python3 -m venv scripts/pdf/venv/
-scripts/pdf/venv/
+venv


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Mind if we ignore `venv` everywhere, so it doesn't matter where the contributor chooses to create their virtual environment? I prefer to keep it in the workspace root. ^-^'