### PR TITLE
git ls-tree: print the filenames of the current branch head in a tree structure

### DIFF
--- a/pages/common/git-ls-tree.md
+++ b/pages/common/git-ls-tree.md
@@ -14,3 +14,7 @@
 - List only the filenames of the tree on a commit:
 
 `git ls-tree --name-only {{commit_hash}}`
+
+- Print the filenames of the current branch head in a tree structure:
+
+`git ls-tree -r --name-only HEAD | tree --fromfile`

--- a/pages/common/git-ls-tree.md
+++ b/pages/common/git-ls-tree.md
@@ -15,6 +15,6 @@
 
 `git ls-tree --name-only {{commit_hash}}`
 
-- Print the filenames of the current branch head in a tree structure:
+- Print the filenames of the current branch head in a tree structure (Note: `tree --fromfile` is not supported on Windows):
 
 `git ls-tree -r --name-only HEAD | tree --fromfile`

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -34,7 +34,3 @@
 - Print the tree ignoring the given directories:
 
 `tree -I '{{directory_name1|directory_name2}}'`
-
-- Print the current git repo tree:
-
-`git ls-tree -r --name-only HEAD | tree --fromfile`

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -34,3 +34,7 @@
 - Print the tree ignoring the given directories:
 
 `tree -I '{{directory_name1|directory_name2}}'`
+
+- Print the current git repo tree:
+
+`git ls-tree -r --name-only HEAD | tree --fromfile`


### PR DESCRIPTION
I'm not sure if it's allowed (since this command also uses `git` )

But it's pretty handy to print the git repo files tree, and also shows that you can pipe a list of files to the `tree` command.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
