### PR TITLE
common/open, open.fish: add page

### DIFF
--- a/pages/common/open.fish.md
+++ b/pages/common/open.fish.md
@@ -1,7 +1,7 @@
 # open
 
-> Opens files, directories and applications.
-> This command is available on `fish` on operating system without built-in `open` command (e.g. Haiku and macOS).
+> Opens files, directories, and URIs with default applications.
+> This command is available through `fish` on operating systems without the built-in `open` command (e.g. Haiku and macOS).
 > More information: <https://fishshell.com/docs/current/cmds/open.html>.
 
 - Open a file with the associated application:

--- a/pages/common/open.fish.md
+++ b/pages/common/open.fish.md
@@ -1,0 +1,25 @@
+# open
+
+> Opens files, directories and applications.
+> This command is available on `fish` on operating system without built-in `open` command (e.g. Haiku and macOS).
+> More information: <https://fishshell.com/docs/current/cmds/open.html>.
+
+- Open a file with the associated application:
+
+`open {{path/to/file.ext}}`
+
+- Open all the files of a given extension in the current directory with the associated application:
+
+`open {{*.ext}}`
+
+- Open a directory using the default file manager:
+
+`open {{path/to/directory}}`
+
+- Open a website using the default web browser:
+
+`open {{https://example.com}}`
+
+- Open a specific URI using the default application that can handle it:
+
+`open {{tel:123}}`

--- a/pages/common/open.md
+++ b/pages/common/open.md
@@ -1,0 +1,15 @@
+# open
+
+> `open` can refer to multiple commands with the same name.
+
+- View documentation for the command available in macOS:
+
+`tldr open -p osx`
+
+- View documentation for the macOS command in older versions of `tldr` command-line client:
+
+`tldr open -o osx`
+
+- View documentation for the command available through `fish`:
+
+`tldr open.fish`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**  fish, version 3.6.1

This PR adds a collision page for `open`, which may also be understood as a `fish`-specific command.