### PR TITLE
adb, adb-install, adb-reverse, adb-shell: use imperative mood on Indonesian translation

### DIFF
--- a/pages.id/common/adb-install.md
+++ b/pages.id/common/adb-install.md
@@ -3,18 +3,18 @@
 > Android Debug Bridge Install: Menginstal paket ke emulator Android atau perangkat Android terhubung.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/adb>.
 
-- Menginstal aplikasi Android ke emulator/perangkat:
+- Instal aplikasi Android ke emulator/perangkat:
 
 `adb install {{alamat/ke/berkas.apk}}`
 
-- Menginstal ulang aplikasi yang sudah ada, menjaga datanya:
+- Instal ulang aplikasi yang sudah ada, menjaga datanya:
 
 `adb install -r {{alamat/ke/berkas.apk}}`
 
-- Memberikan semua izin yang terdaftar di manifest aplikasi:
+- Berikan semua izin yang terdaftar di manifest aplikasi:
 
 `adb install -g {{alamat/ke/berkas.apk}}`
 
-- Memperbarui langsung paket terinstal dengan hanya memperbarui bagian dari APK yang berubah:
+- Perbarui langsung paket terinstal dengan hanya memperbarui bagian dari APK yang berubah:
 
 `Adb install --fastdeploy {{alamat/ke/berkas.apk}}`

--- a/pages.id/common/adb-reverse.md
+++ b/pages.id/common/adb-reverse.md
@@ -7,14 +7,14 @@
 
 `adb reverse --list`
 
-- Membalik port TCP dari emulator/perangkat ke localhost:
+- Balikkan port TCP dari emulator/perangkat ke localhost:
 
 `adb reverse tcp:{{port_jarak_jauh}} tcp:{{port_lokal}}`
 
-- Melepas koneksi socket terbalik dari emulator/perangkat:
+- Lepaskan koneksi socket terbalik dari emulator/perangkat:
 
 `adb reverse --remove tcp:{{port_jarak_jauh}}`
 
-- Melepas semua koneksi socket terbalik dari semua emulator dan perangkat:
+- Lepaskan semua koneksi socket terbalik dari semua emulator dan perangkat:
 
 `adb reverse --remove-all`

--- a/pages.id/common/adb-shell.md
+++ b/pages.id/common/adb-shell.md
@@ -3,34 +3,34 @@
 > Android Debug Bridge Shell: Menjalankan perintah shell jarak jauh pada emulator Android atau perangkat Android terhubung.
 > Informasi lebih lanjut: <https://developer.android.com/studio/command-line/adb>.
 
-- Memulai shell interaktif jarak jauh di emulator/perangkat:
+- Mulaikan shell interaktif jarak jauh di emulator/perangkat:
 
 `adb shell`
 
-- Mendapatkan semua properti dari emulator/perangkat:
+- Dapatkan semua properti dari emulator/perangkat:
 
 `adb shell getprop`
 
-- Mengembalikan semua izin runtime ke default:
+- Kembalikan semua izin runtime ke default:
 
 `adb shell pm reset-permissions`
 
-- Mencabut izin berbahaya dari sebuah aplikasi:
+- Cabut izin berbahaya dari sebuah aplikasi:
 
 `adb shell pm revoke {{paket}} {{izin}}`
 
-- Memicu sebuah peristiwa penting:
+- Picukan sebuah peristiwa penting:
 
 `adb shell input keyevent {{keycode}}`
 
-- Mengosongkan data aplikasi pada emulator/perangkat:
+- Kosongkan data aplikasi pada emulator/perangkat:
 
 `adb shell pm clear {{paket}}`
 
-- Memulai aktivitas pada emulator/perangkat:
+- Mulaikan aktivitas pada emulator/perangkat:
 
 `adb shell am start -n {{paket}}/{{aktivitas}}`
 
-- Memulai aktivitas beranda pada emulator/perangkat:
+- Mulaikan aktivitas beranda pada emulator/perangkat:
 
 `adb shell am start -W -c android.intent.category.HOME -a android.intent.action.MAIN`

--- a/pages.id/common/adb.md
+++ b/pages.id/common/adb.md
@@ -8,26 +8,26 @@
 
 `adb start-server`
 
-- Menghentikan proses server adb:
+- Hentikan proses server adb:
 
 `adb kill-server`
 
-- Memulai shell jarak jauh pada emulator/perangkat tujuan:
+- Mulai shell jarak jauh pada emulator/perangkat tujuan:
 
 `adb shell`
 
-- Menginstal aplikasi Android ke emulator/perangkat tujuan:
+- Instal aplikasi Android ke emulator/perangkat tujuan:
 
 `adb install -r {{alamat/ke/berkas.apk}}`
 
-- Menyalin berkas/direktori dari perangkat tujuan:
+- Salin berkas/direktori dari perangkat tujuan:
 
 `adb pull {{alamat/ke/berkas_atau_direktori_perangkat}} {{alamat/ke/direktori_lokal_tujuan}}`
 
-- Menyalin berkas/direktori ke perangkat tujuan:
+- Salin berkas/direktori ke perangkat tujuan:
 
 `adb push {{alamat/ke/berkas_atau_direktori_lokal}} {{alamat/ke/direktori_perangkat_tujuan}}`
 
-- Mendapatkan daftar perangkat yang terhubung:
+- Dapatkan daftar perangkat yang terhubung:
 
 `adb devices`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

See #8576.