### PR TITLE
choco, latex: fix wrong term translation in zh_TW

### DIFF
--- a/pages.zh_TW/common/latex.md
+++ b/pages.zh_TW/common/latex.md
@@ -7,10 +7,10 @@
 
 `latex {{tex 檔案}}`
 
-- 編譯 DVI 文檔，指定輸出位置：
+- 編譯 DVI 文件，指定輸出位置：
 
 `latex -output-directory={{輸出目錄位置}} {{tex 檔案}}`
 
-- 編譯 DVI 文檔，出錯時退出：
+- 編譯 DVI 文件，出錯時退出：
 
 `latex -halt-on-error {{tex 檔案}}`

--- a/pages.zh_TW/windows/choco.md
+++ b/pages.zh_TW/windows/choco.md
@@ -1,18 +1,18 @@
 # choco
 
 > 「Chocolatey package manager」軟體套件管理器。
-> 執行命令由兩個單字「組合」成，例如 `choco install`，請參考使用文檔。
+> 執行命令由兩個單字「組合」成，例如 `choco install`，請參考使用文件。
 > 更多資訊：<https://chocolatey.org>.
 
 - 執行「組合」命令：
 
 `choco {{命令}}`
 
-- 顯示 `choco` 幫助文檔：
+- 顯示 `choco` 幫助文件：
 
 `choco -?`
 
-- 顯示「組合」命令幫助文檔：
+- 顯示「組合」命令幫助文件：
 
 `choco {{命令}} -?`
 


### PR DESCRIPTION
"文檔" is used in zh_CN, for zh_TW, that is "文件".

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
