### PR TITLE
rustdoc: add page

### DIFF
--- a/pages/common/rustdoc.md
+++ b/pages/common/rustdoc.md
@@ -1,0 +1,20 @@
+# rustdoc
+
+> Generate documentation for a Rust crate.
+> More information: <https://doc.rust-lang.org/stable/rustdoc/>
+
+- Generate documentation from the crate's root:
+
+`rustdoc {{src/lib.rs}}`
+
+- Pass a name for the project:
+
+`rustdoc {{src/lib.rs}} --crate-name {{name}}`
+
+- Generate documentation from Markdown files:
+
+`rustdoc {{file.md}}`
+
+- Specify the output directory:
+
+`rustdoc {{src/lib.rs}} --out-dir {{PATH}}`

--- a/pages/common/rustdoc.md
+++ b/pages/common/rustdoc.md
@@ -1,7 +1,7 @@
 # rustdoc
 
 > Generate documentation for a Rust crate.
-> More information: <https://doc.rust-lang.org/stable/rustdoc/>
+> More information: <https://doc.rust-lang.org/stable/rustdoc>.
 
 - Generate documentation from the crate's root:
 

--- a/pages/common/rustdoc.md
+++ b/pages/common/rustdoc.md
@@ -17,4 +17,4 @@
 
 - Specify the output directory:
 
-`rustdoc {{src/lib.rs}} --out-dir {{PATH}}`
+`rustdoc {{src/lib.rs}} --out-dir {{path/to/output_directory}}`

--- a/pages/common/rustdoc.md
+++ b/pages/common/rustdoc.md
@@ -13,7 +13,7 @@
 
 - Generate documentation from Markdown files:
 
-`rustdoc {{file.md}}`
+`rustdoc {{path/to/file.md}}`
 
 - Specify the output directory:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** rustdoc 1.72.0
