### PR TITLE
eza: fix Polish translation

### DIFF
--- a/pages.pl/common/eza.md
+++ b/pages.pl/common/eza.md
@@ -1,36 +1,36 @@
-# exa
+# eza
 
 > Nowoczesny odpowiednik `ls`, fork `exa`.
 > Więcej informacji: <https://github.com/eza-community/eza>.
 
 - Wyświetl listę plików, po jednym w linii:
 
-`exa --oneline`
+`eza --oneline`
 
 - Wyświetl wszystkie pliki, łącznie z ukrytymi:
 
-`exa --all`
+`eza --all`
 
 - Wyświetl listę wszystkich plików ze szczegółami (uprawnienia, właściciel, wielkość i data zmiany):
 
-`exa --long --all`
+`eza --long --all`
 
 - Wyświetl listę plików posortowaną względem wielkości pliku, od największego:
 
-`exa --reverse --sort={{size}}`
+`eza --reverse --sort={{size}}`
 
 - Wyświetl drzewko plików (trzy poziomy):
 
-`exa --long --tree --level={{3}}`
+`eza --long --tree --level={{3}}`
 
 - Wyświetl listę plików posortowaną względem daty zmiany, od najstarszego:
 
-`exa --long --sort={{modified}}`
+`eza --long --sort={{modified}}`
 
 - Wyświetl listę plików wraz z nagłówkiem, ikoną i statusem Git:
 
-`exa --long --header --icons --git`
+`eza --long --header --icons --git`
 
 - Wyświetl listę plików, ignorując pliki z `.gitignore`:
 
-`exa --git-ignore`
+`eza --git-ignore`


### PR DESCRIPTION
I forgot to change `exa` to `eza` after copying the page (#10867).