### PR TITLE
cargo-generate-lockfile: add page

### DIFF
--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -1,7 +1,7 @@
 # cargo generate-lockfile
 
 > Generates the `Cargo.lock` file for the current package.
-> If the lockfile already exsits it will be rebuilt with latest version of every package.
+> If the lockfile already exists it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 
 - Generate `Cargo.lock` file with the latest version of every package:

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -12,14 +12,14 @@
 
 `cargo generate-lockfile --manifest-path {{/path-to-toml-file}}`
 
-- Assert that the `Cargo.lock` file is up-to-date. 
+- Assert that the `Cargo.lock` file is up-to-date:
 
-`cargo generate-lockfile --locked` 
+`cargo generate-lockfile --locked`
 
-- Prevent the Cargo from attempting to access the network to determine if it out-of-date.
+- Prevent the Cargo from attempting to access the network to determine if it out-of-date:
 
 `cargo generate-lockfile --frozen`
 
-- Prevent Cargo from accessing the network. Cargo will attempt to proceed without network. If Cargo requires internet to proceed and network is not available Cargo will stop with an error.
+- Prevent Cargo from accessing the network. Cargo will attempt to proceed without network. If Cargo requires internet to proceed and network is not available Cargo will stop with an error:
  
 `cargo generate-lockfile --offline`

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -20,6 +20,6 @@
 
 `cargo generate-lockfile --frozen`
 
-- Prevent Cargo from accessing the network. Cargo will attempt to proceed without network. If Cargo requires internet to proceed and network is not available Cargo will stop with an error:
+- Prevent Cargo from accessing the network. (Note: If Cargo requires internet to proceed and network is not available, it will stop with an error):
 
 `cargo generate-lockfile --offline`

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -4,7 +4,7 @@
 > If the lockfile already exsits it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 
-- Generate Cargo.lock with latest version of every package:
+- Generate `Cargo.lock` file with the latest version of every package:
 
 `cargo generate-lockfile`
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -16,7 +16,7 @@
 
 `cargo generate-lockfile --locked`
 
-- Prevent the Cargo from attempting to access the network to determine if it out-of-date:
+- Prevent Cargo from attempting to access the network to determine if it out-of-date:
 
 `cargo generate-lockfile --frozen`
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -1,0 +1,25 @@
+# cargo generate-lockfile
+
+> Generates the Cargo.lock file for the current package.  
+> If the lockfile already exsits it will be rebuilt with latest version of every package.
+> More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
+
+- Generate Cargo.lock with latest version of every package:
+
+`cargo generate-lockfile`
+
+- Path for the `Cargo.toml` file. By default the file is present in the current directory:
+
+`cargo generate-lockfile --manifest-path {{/path-to-toml-file}}`
+
+- Assert that the `Cargo.lock` file is up-to-date. 
+
+`cargo generate-lockfile --locked` 
+
+- Prevent the Cargo from attempting to access the network to determine if it out-of-date.
+
+`cargo generate-lockfile --frozen`
+
+- Prevent Cargo from accessing the network. Cargo will attempt to proceed without network. If Cargo requires internet to proceed and network is not available Cargo will stop with an error.
+ 
+`cargo generate-lockfile --offline`

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -10,7 +10,7 @@
 
 - Path for the `Cargo.toml` file. By default the file is present in the current directory:
 
-`cargo generate-lockfile --manifest-path {{/path-to-toml-file}}`
+`cargo generate-lockfile --manifest-path {{path/to/toml/file}}`
 
 - Assert that the `Cargo.lock` file is up-to-date:
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -4,7 +4,7 @@
 > If the lockfile already exists it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 
-- Generate `Cargo.lock` file with the latest version of every package:
+- Generate a `Cargo.lock` file with the latest version of every package:
 
 `cargo generate-lockfile`
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -8,7 +8,7 @@
 
 `cargo generate-lockfile`
 
-- Path for the `Cargo.toml` file. By default the file is present in the current directory:
+- Specify a custom path for the `Cargo.toml` file (Note: By default the file is present in the current directory):
 
 `cargo generate-lockfile --manifest-path {{path/to/toml/file}}`
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -1,6 +1,6 @@
 # cargo generate-lockfile
 
-> Generates the Cargo.lock file for the current package.
+> Generates the `Cargo.lock` file for the current package.
 > If the lockfile already exsits it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -1,6 +1,6 @@
 # cargo generate-lockfile
 
-> Generates the Cargo.lock file for the current package.  
+> Generates the Cargo.lock file for the current package.
 > If the lockfile already exsits it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 
@@ -21,5 +21,5 @@
 `cargo generate-lockfile --frozen`
 
 - Prevent Cargo from accessing the network. Cargo will attempt to proceed without network. If Cargo requires internet to proceed and network is not available Cargo will stop with an error:
- 
+
 `cargo generate-lockfile --offline`

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -10,7 +10,7 @@
 
 - Specify a custom path for the `Cargo.toml` file (Note: By default the file is present in the current directory):
 
-`cargo generate-lockfile --manifest-path {{path/to/toml/file}}`
+`cargo generate-lockfile --manifest-path {{path/to/file.toml}}`
 
 - Assert that the `Cargo.lock` file is up-to-date:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Related issue (#10630)
