### PR TITLE
npm: favor 'package' over 'module'

### DIFF
--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -14,24 +14,24 @@
 
 - Download a specific version of a package and add it to the list of dependencies in `package.json`:
 
-`npm install {{module_name}}@{{version}}`
+`npm install {{package_name}}@{{version}}`
 
 - Download a package and add it to the list of dev dependencies in `package.json`:
 
-`npm install {{module_name}} --save-dev`
+`npm install {{package_name}} --save-dev`
 
 - Download a package and install it globally:
 
-`npm install --global {{module_name}}`
+`npm install --global {{package_name}}`
 
 - Uninstall a package and remove it from the list of dependencies in `package.json`:
 
-`npm uninstall {{module_name}}`
+`npm uninstall {{package_name}}`
 
 - Print a tree of locally installed dependencies:
 
 `npm list`
 
-- List top-level globally installed modules:
+- List top-level globally installed packages:
 
 `npm list --global --depth={{0}}`


### PR DESCRIPTION
Favor `package` over `module` for clarity and consistency. 😇 

As I understand the documentation, `module` is more specific: https://docs.npmjs.com/about-packages-and-modules

Note that the `package` term is used in the CLI help:

	$ npm install --help
	Install a package

	Usage:
	npm install [<package-spec> ...]

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
