### PR TITLE
npm: describe implicit `latest` version

### DIFF
--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -16,11 +16,11 @@
 
 `npm install {{module_name}}@{{version}}`
 
-- Download a package and add it to the list of dev dependencies in `package.json`:
+- Download the latest version of a package and add it to the list of dev dependencies in `package.json`:
 
 `npm install {{module_name}} --save-dev`
 
-- Download a package and install it globally:
+- Download the latest version of a package and install it globally:
 
 `npm install --global {{module_name}}`
 


### PR DESCRIPTION
This existing example already explains how to install a specific version:

> - Download a specific version of a package and add it to the list of dependencies in `package.json`:
> 
>  `npm install {{module_name}}@{{version}}`

Let's be explicit about other examples that install the `latest` version! 🤓

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
