### PR TITLE
systemd-creds: add page

### DIFF
--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -1,0 +1,24 @@
+# systemd-creds
+
+> Lists, shows, encrypts and decrypts service credentials.
+> More information: <https://www.freedesktop.org/software/systemd/man/systemd-creds.html>.
+
+- Encrypt a file and set a specific name:
+
+`systemd-creds encrypt --name={{name}} {{input}} {{output}}`
+
+- Decrypt the file again:
+
+`systemd-creds decrypt {{input}} {{output}}`
+
+- Encrypt some text from `stdin`:
+
+`echo -n {{text}} | systemd-creds encrypt --name={{name}} - {{output}}`
+
+- Encrypt the text and append it to the service file (the credentials will be available in `$CREDENTIALS_DIRECTORY`):
+
+`echo -n {{text}} | systemd-creds encrypt --name={{name}} --pretty - - >> {{service}}`
+
+- Create a credential that is only valid until the given timestamp:
+
+`systemd-creds encrypt --not-after="{{timestamp}}" {{input}} {{output}}`

--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -1,6 +1,6 @@
 # systemd-creds
 
-> Lists, shows, encrypts and decrypts service credentials.
+> List, show, encrypt and decrypt service credentials.
 > More information: <https://www.freedesktop.org/software/systemd/man/systemd-creds.html>.
 
 - Encrypt a file and set a specific name:

--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -11,9 +11,9 @@
 
 `systemd-creds decrypt {{path/to/input_file}} {{path/to/output_file}}`
 
-- Encrypt some text from `stdin`:
+- Encrypt text from `stdin`:
 
-`echo -n {{text}} | systemd-creds encrypt --name={{name}} - {{output}}`
+`echo -n {{text}} | systemd-creds encrypt --name={{name}} - {{path/to/output}}`
 
 - Encrypt the text and append it to the service file (the credentials will be available in `$CREDENTIALS_DIRECTORY`):
 

--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -9,7 +9,7 @@
 
 - Decrypt the file again:
 
-`systemd-creds decrypt {{input}} {{output}}`
+`systemd-creds decrypt {{path/to/input_file}} {{path/to/output_file}}`
 
 - Encrypt some text from `stdin`:
 

--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -21,4 +21,4 @@
 
 - Create a credential that is only valid until the given timestamp:
 
-`systemd-creds encrypt --not-after="{{timestamp}}" {{input}} {{output}}`
+`systemd-creds encrypt --not-after="{{timestamp}}" {{path/to/input_file}} {{path/to/output_file}}`

--- a/pages/linux/systemd-creds.md
+++ b/pages/linux/systemd-creds.md
@@ -5,7 +5,7 @@
 
 - Encrypt a file and set a specific name:
 
-`systemd-creds encrypt --name={{name}} {{input}} {{output}}`
+`systemd-creds encrypt --name={{name}} {{path/to/input_file}} {{path/to/output}}`
 
 - Decrypt the file again:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

see #10191 