### PR TITLE
systemd-escape: add page

### DIFF
--- a/pages/linux/systemd-escape.md
+++ b/pages/linux/systemd-escape.md
@@ -1,0 +1,24 @@
+# systemd-escape
+
+> Escape strings for usage in systemd unit names.
+> More information: <https://www.freedesktop.org/software/systemd/man/systemd-escape.html>.
+
+- Escape the given text:
+
+`systemd-escape {{text}}`
+
+- Reverse the escaping process:
+
+`systemd-escape --unescape {{text}}`
+
+- Treat the given text as a path:
+
+`systemd-escape --path {{text}}`
+
+- Append the given suffix to the escaped text:
+
+`systemd-escape --suffix {{suffix}} {{text}}`
+
+- Use a template and inject the escaped text:
+
+`systemd-escape --template {{template}} {{text}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

see #10191