### PR TITLE
az, az-apim, az-group, az-storage, az-tag, az-upgrade: add Spanish translation

### DIFF
--- a/pages.es/common/az-apim.md
+++ b/pages.es/common/az-apim.md
@@ -1,0 +1,25 @@
+# az apim
+
+> Administra los servicios de Azure API Management.
+> Parte de `az`.
+> Más información: <https://docs.microsoft.com/cli/azure/apim>.
+
+- Enumera las instancias del servicio API Management:
+
+`az apim list --resource-group {{grupo_de_recursos}}`
+
+- Crear una instancia de servicio de API Management:
+
+`az apim create --name {{nombre}} --resource-group {{grupo_de_recursos}} --publisher-email {{email}} --publisher-name {{name}}`
+
+- Elimina una instancia de servicio de API Management:
+
+`az apim delete --name {{nombre}} --resource-group {{grupo_de_recursos}}`
+
+- Muestra detalles de una instancia de servicio de API Management:
+
+`az apim show --name {{nombre}} --resource-group {{grupo_de_recursos}}`
+
+- Actualiza una instancia del servicio API Management:
+
+`az apim update --name {{nombre}} --resource-group {{grupo_de_recursos}}`

--- a/pages.es/common/az-apim.md
+++ b/pages.es/common/az-apim.md
@@ -8,15 +8,15 @@
 
 `az apim list --resource-group {{grupo_de_recursos}}`
 
-- Crear una instancia de servicio de API Management:
+- Crea una instancia de servicio de API Management:
 
 `az apim create --name {{nombre}} --resource-group {{grupo_de_recursos}} --publisher-email {{email}} --publisher-name {{name}}`
 
-- Elimina una instancia de servicio de API Management:
+- Elimina una instancia del servicio de API Management:
 
 `az apim delete --name {{nombre}} --resource-group {{grupo_de_recursos}}`
 
-- Muestra detalles de una instancia de servicio de API Management:
+- Muestra detalles de una instancia del servicio de API Management:
 
 `az apim show --name {{nombre}} --resource-group {{grupo_de_recursos}}`
 

--- a/pages.es/common/az-group.md
+++ b/pages.es/common/az-group.md
@@ -1,0 +1,21 @@
+# az group
+
+> Administra grupos de recursos e implementaciones de plantillas.
+> Parte de `azure-cli`.
+> Más información: <https://docs.microsoft.com/cli/azure/group>.
+
+- Crea un nuevo grupo de recursos:
+
+`az group create --nombre {{nombre}} --ubicación {{ubicación}}`
+
+- Comprueba si existe un grupo de recursos:
+
+`az group exists --nombre {{nombre}}`
+
+- Elimina un grupo de recursos:
+
+`az group delete --nombre {{nombre}}`
+
+- Coloca un grupo de recursos en estado de espera hasta que se cumpla una condición:
+
+`az group wait --nombre {{nombre}} --{{created|deleted|exists|updated}}`

--- a/pages.es/common/az-storage.md
+++ b/pages.es/common/az-storage.md
@@ -1,0 +1,25 @@
+# az storage
+
+> Administra los recursos de Azure Cloud Storage.
+> Parte de `azure-cli`.
+> Más información: <https://learn.microsoft.com/cli/azure/storage>.
+
+- Crea una cuenta de almacenamiento:
+
+`az storage account create --resource-group  {{grupo_de_recursos}} --name {{nombre_de_cuenta}} -l {{ubicación}} --sku {{account_sku}}`
+
+- Enumera todas las cuentas de almacenamiento de un grupo de recursos:
+
+`az storage account list --resource-group  {{grupo_de_recursos}}`
+
+- Enumera las claves de acceso de una cuenta de almacenamiento:
+
+`az storage account keys list --resource-group  {{grupo_de_recursos}} --name {{nombre_de_cuenta}}`
+
+- Elimina una cuenta de almacenamiento:
+
+`az storage account delete --resource-group  {{grupo_de_recursos}} --name {{nombre_de_cuenta}}`
+
+- Actualiza la versión mínima de TLS para una cuenta de almacenamiento:
+
+`az storage account update --min-tls-version {TLS1_0|TLS1_1|TLS1_2} --name {{nombre_de_cuenta}} --resource-group  {{grupo_de_recursos}}`

--- a/pages.es/common/az-tag.md
+++ b/pages.es/common/az-tag.md
@@ -1,0 +1,25 @@
+# az tag
+
+> Administra etiquetas en un recurso de Azure.
+> Parte de `azure-cli`.
+> Más información: <https://learn.microsoft.com/cli/azure/tag>.
+
+- Crea un valor de etiqueta:
+
+`az tag add-value --name {{nombre_de_etiqueta}} --value {{valor_de_etiqueta}}`
+
+- Crea una etiqueta en la suscripción:
+
+`az tag create --name {{nombre_de_etiqueta}}`
+
+- Elimina una etiqueta de la suscripción:
+
+`az tag delete --name {{nombre_de_etiqueta}}`
+
+- Enumera todas las etiquetas de una suscripción:
+
+`az tag list --resource-id /subscriptions/{{subscription_id}}`
+
+- Elimina un valor de etiqueta para un nombre de etiqueta específico:
+
+`az tag remove-value --name {{nombre_de_etiqueta}} --value {{valor_de_etiqueta}}`

--- a/pages.es/common/az-upgrade.md
+++ b/pages.es/common/az-upgrade.md
@@ -1,0 +1,17 @@
+# az upgrade
+
+> Actualiza Azure CLI y sus extensiones.
+> Parte de `az`.
+> Más información: <https://learn.microsoft.com/es-mx/cli/azure/reference-index?view=azure-cli-latest#az-upgrade()>.
+
+- Actualiza Azure CLI:
+
+`az upgrade`
+
+- Actualiza Azure CLI y sus extensiones:
+
+`az upgrade --all`
+
+- Actualiza Azure CLI y sus extensiones sin solicitar confirmación:
+
+`az version --all --yes`

--- a/pages.es/common/az.md
+++ b/pages.es/common/az.md
@@ -1,0 +1,29 @@
+# az
+
+> La herramienta de línea de comandos de Azure.
+> Algunos subcomandos como `az login` tienen su propia documentación de uso.
+> Más información: <https://learn.microsoft.com/cli/azure>.
+
+- Inicia sesión en Azure:
+
+`az login`
+
+- Administra la información de la suscripción de Azure:
+
+`az account`
+
+- Enumera todos los discos administrados de Azure:
+
+`az disk list`
+
+- Enumera todas las máquinas virtuales de Azure:
+
+`az vm list`
+
+- Administra los servicios de Kubernetes de Azure:
+
+`az aks`
+
+- Administra los recursos de red de Azure:
+
+`az network`


### PR DESCRIPTION
Added Spanish translation for the following pages:

- az-apim
- az,
- az-storage
- az-group
- az-tag
- az-upgrade

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
