### PR TITLE
xcodes, xcodes-runtimes: fix placeholder style

### DIFF
--- a/pages/osx/xcodes-runtimes.md
+++ b/pages/osx/xcodes-runtimes.md
@@ -9,8 +9,8 @@
 
 - Download a Simulator runtime:
 
-`xcodes runtimes download {{runtime-name}}`
+`xcodes runtimes download {{runtime_name}}`
 
 - Download and install a Simulator runtime:
 
-`xcodes runtimes install {{runtime-name}}`
+`xcodes runtimes install {{runtime_name}}`

--- a/pages/osx/xcodes.md
+++ b/pages/osx/xcodes.md
@@ -14,11 +14,11 @@
 
 - Select an Xcode version by specifying a version number or a path:
 
-`xcodes select {{xcode-version|path/to/Xcode.app}}`
+`xcodes select {{xcode_version|path/to/Xcode.app}}`
 
 - Download and install a specific Xcode version:
 
-`xcodes install {{xcode-version}}`
+`xcodes install {{xcode_version}}`
 
 - Install the latest Xcode release and select it:
 
@@ -26,4 +26,4 @@
 
 - Download a specific Xcode version archive to a given directory without installing it:
 
-`xcodes download {{xcode-version}} --directory {{path/to/directory}}`
+`xcodes download {{xcode_version}} --directory {{path/to/directory}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.4.1

Our style guide mandates multi-word placeholders to be written in snake case.