### PR TITLE
docs: use the new `[!NOTE]` syntax

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -194,7 +194,8 @@ It is also RECOMMENDED to make the language configurable, to not only rely on th
 
 The [`LC_MESSAGES` environment variable](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html) MAY be present. If the client itself is localized and this environment variable is present, it MUST use its value to determine the language in which interface text is shown (separately from the language used for pages). In the absence of `LC_MESSAGES`, then `LANG` and `LANGUAGE` MUST be used for this purpose instead.
 
-**Note that** for page lookup it is highly RECOMMENDED to give precedence to the platform over the language. In other words, look for a platform under each language, before checking the next preferred language. This ensures a meaningful and correct page resolution.
+> [!IMPORTANT]
+> For page lookup it is highly RECOMMENDED to give precedence to the platform over the language. In other words, look for a platform under each language, before checking the next preferred language. This ensures a meaningful and correct page resolution.
 
 Here's an example of how the lookup should be done on `linux` having set `LANG=it` and `LANGUAGE="it:fr:en"`:
 

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -46,8 +46,9 @@ exceptions can always be considered, via open community discussion.)
   This means they will be able to
   push commits to all of the organization's repositories,
   merge PRs, label and close issues, among other things.
-  _Note_: All members of the tldr-pages organization
-  must make their membership public.
+  > [!NOTE]
+  > All members of the tldr-pages organization
+  > must make their membership public.
 
 - **Organization members who remain active for a while should become organization owners.**
   Specifically: members of the tldr-pages organization
@@ -78,8 +79,9 @@ exceptions can always be considered, via open community discussion.)
 
 ## How to change roles
 
-*Note: This section is aimed at owners in the tldr-pages organization
-(i.e. the group of people who are able to perform these changes).*
+> [!NOTE]
+> This section is aimed at owners in the tldr-pages organization
+> (i.e. the group of people who are able to perform these changes).*
 
 If you notice a contributor being particularly active,
 review their recent contributions to check whether a role transition is due,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Just open an issue or send a pull request and we'll incorporate it as soon as po
 To get started, please [sign](https://cla-assistant.io/tldr-pages/tldr) the
 [Contributor License Agreement](https://gist.github.com/waldyrious/e50feec13683e565769fbd58ce503d4e).
 
-*Note*: when submitting a new command, please base your PR against the `main` branch, and check if there's already a pull request in progress for it.
+> [!NOTE]
+> When submitting a new command, please base your PR against the `main` branch, and check if there's already a pull request in progress for it.
 
 ## Guidelines
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,10 @@
 # Maintainers
 
 This file contains a list of the maintainers of the tldr-pages project.
-Note: only the people marked with **bold** are currently in the indicated role.
-The other entries are kept for historical record.
+
+> [!NOTE]
+> Only the people marked with **bold** are currently in the indicated role.
+> The other entries are kept for historical record.
 
 There are three types of maintainers, as described in
 [COMMUNITY-ROLES.md](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md#when-to-change-roles):
@@ -45,7 +47,7 @@ If you are an owner of the organization, you can see an automated list
 - **Patrice Denis ([@patricedenis](https://github.com/patricedenis))**:
   [10 May 2021](https://github.com/tldr-pages/tldr/issues/5919) — present
 - **Reinhart Previano Koentjoro ([@reinhart1010](https://github.com/reinhart1010))**:
-  [23 Nov 2021](https://github.com/tldr-pages/tldr/issues/7404) — present
+  [23 November 2021](https://github.com/tldr-pages/tldr/issues/7404) — present
 - **258204 ([@258204](https://github.com/258204))**:
   [10 December 2021](https://github.com/tldr-pages/tldr/issues/7522) — present
 - **Nicolas Hansse ([@Nico385412](https://github.com/Nico385412))**:
@@ -93,13 +95,13 @@ If you are an owner of the organization, you can see an automated list
 - Seth Falco ([@SethFalco](https://github.com/SethFalco)):
   [19 May 2021](https://github.com/tldr-pages/tldr/issues/5993) - [21 June 2021](https://github.com/tldr-pages/tldr/issues/6149)
 - Pixel Häußler ([@pixelcmtd](https://github.com/pixelcmtd)):
-  [27 Aug 2021](https://github.com/tldr-pages/tldr/issues/6415) — [16 October 2022](https://github.com/tldr-pages/tldr/pull/9072#issuecomment-1279847932)
+  [27 August 2021](https://github.com/tldr-pages/tldr/issues/6415) — [16 October 2022](https://github.com/tldr-pages/tldr/pull/9072#issuecomment-1279847932)
 - Emily Grace Seville ([@EmilySeville7cfg](https://github.com/EmilySeville7cfg)):
   [19 January 2022](https://github.com/tldr-pages/tldr/issues/1209#issuecomment-285924778) — [24 April 2022](https://github.com/tldr-pages/tldr/issues/8053)
 - K.B.Dharun Krishna ([@kbdharun](https://github.com/kbdharun)):
   [06 August 2022](https://github.com/tldr-pages/tldr/issues/8309) — [14 December 2022](https://github.com/tldr-pages/tldr/issues/9625)
 - Lin Cheng Chieh ([@blueskyson](https://github.com/blueskyson)):
-  [12 Aug 2021](https://github.com/tldr-pages/tldr/issues/6330) — [4 Jan 2023](https://github.com/tldr-pages/tldr/issues/9671)
+  [12 August 2021](https://github.com/tldr-pages/tldr/issues/6330) — [4 January 2023](https://github.com/tldr-pages/tldr/issues/9671)
 - Lena ([@acuteenvy](https://github.com/acuteenvy)):
   [13 May 2023](https://github.com/tldr-pages/tldr/issues/10187) — [21 June 2023](https://github.com/tldr-pages/tldr/issues/10406)
 
@@ -149,7 +151,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - K.B.Dharun Krishna ([@kbdharun](https://github.com/kbdharun)):
   [14 December 2022](https://github.com/tldr-pages/tldr/issues/9625) — [19 June 2023](https://github.com/tldr-pages/tldr/issues/10057)
 - Lin Cheng Chieh ([@blueskyson](https://github.com/blueskyson)):
-  [4 Jan 2023](https://github.com/tldr-pages/tldr/issues/9671) — [7 July 2023](https://github.com/tldr-pages/tldr/issues/10054)
+  [4 January 2023](https://github.com/tldr-pages/tldr/issues/9671) — [7 July 2023](https://github.com/tldr-pages/tldr/issues/10054)
 
 ## Organization owners
 

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -14,7 +14,8 @@ The overall process should look somewhat like this:
 3. Create a feature branch, e.g. named after the command you plan to edit:
   `git checkout -b {{branch_name}}`
 
-  > :warning: It is bad practice to submit a PR from the `main` branch of your forked repository. Please create pull requests from a well named feature branch.
+   > [!IMPORTANT]
+   > It is bad practice to submit a PR from the `main` branch of your forked repository. Please create pull requests from a well named feature branch.
 
 4. Make your changes (edit existing files or create new ones)
 
@@ -24,7 +25,8 @@ The overall process should look somewhat like this:
 6. Push the commit(s) to your fork:
   `git push origin {{branch_name}}`
 
-  > :warning: Please avoid force-pushing since it makes the review process harder.
+   > [!IMPORTANT]
+   > Please avoid force-pushing since it makes the review process harder.
 
 7. Go to the GitHub page for your fork and click the green "Compare & pull request" button.
 

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -14,7 +14,7 @@ The overall process should look somewhat like this:
 3. Create a feature branch, e.g. named after the command you plan to edit:
   `git checkout -b {{branch_name}}`
 
-   > [!IMPORTANT]
+   > [!WARNING]
    > It is bad practice to submit a PR from the `main` branch of your forked repository. Please create pull requests from a well named feature branch.
 
 4. Make your changes (edit existing files or create new ones)
@@ -25,7 +25,7 @@ The overall process should look somewhat like this:
 6. Push the commit(s) to your fork:
   `git push origin {{branch_name}}`
 
-   > [!IMPORTANT]
+   > [!WARNING]
    > Please avoid force-pushing since it makes the review process harder.
 
 7. Go to the GitHub page for your fork and click the green "Compare & pull request" button.

--- a/contributing-guides/maintainers-guide.md
+++ b/contributing-guides/maintainers-guide.md
@@ -3,14 +3,15 @@
 The following guidelines are meant to provide a general basis
 for the behavior expected of tldr-pages maintainers.
 
-*Note:* This text is a living standard;
-that is, it is meant to *describe* the project's maintenance practices,
-rather than *prescribe* them.
-As a maintainer, you're expected to refer to it for clarification
-about the collaborative workflows of the project,
-but also to propose changes to it
-that you feel would make it more useful
-as a guideline for current and future maintainers.
+> [!NOTE]
+> This text is a living standard;
+> that is, it is meant to *describe* the project's maintenance practices,
+> rather than *prescribe* them.
+> As a maintainer, you're expected to refer to it for clarification
+> about the collaborative workflows of the project,
+> but also to propose changes to it
+> that you feel would make it more useful
+> as a guideline for current and future maintainers.
 
 ## I. Responding to contributions
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -54,7 +54,8 @@ Example:
 `krita --fullscreen`
 ```
 
-> :bulb: The help page can be any documentation/project/tutorial page, not just a man page,
+> [!NOTE]
+> The help page can be any documentation/project/tutorial page, not just a man page,
 > but documentation pages are preferred.
 
 There is a linter that enforces the format above.


### PR DESCRIPTION
There's a [new GitHub markdown feature](https://github.com/orgs/community/discussions/16925) to emphasize information.

```markdown
> [!NOTE]
> This is a note.

> [!IMPORTANT]
> Important stuff.

> [!WARNING]
> This is a warning.
```
becomes
> [!NOTE]
> This is a note.

> [!IMPORTANT]
> Important stuff.

> [!WARNING]
> This is a warning.

I replaced all "***Note:***"s and similar things in the docs with the new syntax.