### PR TITLE
git-rscp: update page

### DIFF
--- a/pages/common/git-rscp.md
+++ b/pages/common/git-rscp.md
@@ -1,9 +1,13 @@
 # git rscp
 
-> This command is an alias of `git scp`, to copy files from the current working tree to the working directory of a remote repository.
+> Reverse `git scp` - copy files from the working directory of a remote repository to the current working tree.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-scp>.
 
-- View documentation for the original command:
+- Copy specific files from a remote:
 
-`tldr git scp`
+`git rscp {{remote_name}} {{path/to/file1 path/to/file2 ...}}`
+
+- Copy a specific directory from a remote:
+
+`git rscp {{remote_name}} {{path/to/directory}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

---

https://github.com/tldr-pages/tldr/pull/10996#pullrequestreview-1678866133

I checked the code of `git scp`. `git-rscp` is indeed a symlink to `git-scp`, but it checks what command has been run:
https://github.com/tj/git-extras/blob/master/bin/git-scp#L172
```bash
case $(basename "$0") in
    git-scp)
        case $1 in
            ''|-h|'?'|help|--help) shift; _test_git_scp; _usage "$@";;
            *)                   scp_and_stage $@;;
        esac
    ;;
    git-rscp)                  reverse_scp $@;;
esac
```
and changes behavior appropriately.