### PR TITLE
apt-get, aptitude, adb, awk: fix typo in Spanish translation

### DIFF
--- a/pages.es/common/adb.md
+++ b/pages.es/common/adb.md
@@ -12,7 +12,7 @@
 
 `adb kill-server`
 
-- Inicia una terminal remota en la instance del emulador/dispositivo de destino:
+- Inicia una terminal remota en la instancia del emulador/dispositivo de destino:
 
 `adb shell`
 

--- a/pages.es/common/awk.md
+++ b/pages.es/common/awk.md
@@ -19,7 +19,7 @@
 
 `awk '{s+=$1} END {print s}' {{archivo}}`
 
-- Suma los valores en de la primera columna de un archivo e imprime el total de froma bonita:
+- Suma los valores en de la primera columna de un archivo e imprime el total de forma bonita:
 
 `awk '{s+=$1; print $1} END {print "--------"; print s}' {{archivo}}`
 

--- a/pages.es/linux/apt-get.md
+++ b/pages.es/linux/apt-get.md
@@ -28,6 +28,6 @@
 
 `apt-get autoremove`
 
-- Actualiza paquetes instalados (como `upgrade`), pero elimina paquete obsoletos e instala paquetes adiciones para satisfacer nuevas dependencias:
+- Actualiza paquetes instalados (como `upgrade`), pero elimina paquetes obsoletos e instala paquetes adiciones para satisfacer nuevas dependencias:
 
 `apt-get dist-upgrade`

--- a/pages.es/linux/aptitude.md
+++ b/pages.es/linux/aptitude.md
@@ -31,6 +31,6 @@
 
 `aptitude full-upgrade`
 
-- Mantiente un paquete instalado para que no sea actualizado automáticamente:
+- Mantiene un paquete instalado para que no sea actualizado automáticamente:
 
 `aptitude hold '?installed({{paquete}})'`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
