### PR TITLE
cadaver: add page

### DIFF
--- a/pages/common/cadaver.md
+++ b/pages/common/cadaver.md
@@ -3,14 +3,14 @@
 > A command-line WebDAV client for Unix.
 > More information: <https://manned.org/cadaver>.
 
-- Connect to the server myserver.example.com, open the root collection:
+- Connect to the server dav.example.com, open the root collection:
 
 `cadaver http://dav.example.com/`
 
-- Connect to the server zope.example.com use port 8022, open the collection "/Users/fred/":
+- Connect to the server dav.example.com use port 8022 and open the collection "/foo/bar/":
 
-`cadaver http://zope.example.com:8022/Users/fred/`
+`cadaver http://dav.example.com:8022/foo/bar/`
 
-- Connect to a server called secure.example.com use SSL:
+- Connect to a server called davs.example.com use SSL:
 
-`cadaver https://secure.example.com/`
+`cadaver https://davs.example.com/`

--- a/pages/common/cadaver.md
+++ b/pages/common/cadaver.md
@@ -3,14 +3,14 @@
 > A command-line WebDAV client for Unix.
 > More information: <https://manned.org/cadaver>.
 
-- Connects to the server myserver.example.com, opening the root collection.
+- Connect to the server myserver.example.com, open the root collection.
 
 `cadaver http://dav.example.com/`
-    
-- Connects to the server zope.example.com using port 8022, opening the collection "/Users/fred/".
-  
+
+- Connect to the server zope.example.com use port 8022, open the collection "/Users/fred/".
+
 `cadaver http://zope.example.com:8022/Users/fred/`
-    
-- Connects to a server called secure.example.com using SSL.
-    
+
+- Connect to a server called secure.example.com use SSL.
+
 `cadaver https://secure.example.com/`

--- a/pages/common/cadaver.md
+++ b/pages/common/cadaver.md
@@ -1,16 +1,16 @@
 # cadaver
 
-> A command-line WebDAV client for Unix.
+> WebDAV client for Unix.
 > More information: <https://manned.org/cadaver>.
 
-- Connect to the server dav.example.com, open the root collection:
+- Connect to the server <dav.example.com>, open the root collection:
 
-`cadaver http://dav.example.com/`
+`cadaver {{http://dav.example.com/}}`
 
-- Connect to the server dav.example.com use port 8022 and open the collection "/foo/bar/":
+- Connect to a server using a specific port and open the collection `/foo/bar/`:
 
-`cadaver http://dav.example.com:8022/foo/bar/`
+`cadaver {{http://dav.example.com:8022/foo/bar/}}`
 
-- Connect to a server called davs.example.com use SSL:
+- Connect to a server using SSL:
 
-`cadaver https://davs.example.com/`
+`cadaver {{https://davs.example.com/}}`

--- a/pages/common/cadaver.md
+++ b/pages/common/cadaver.md
@@ -1,0 +1,16 @@
+# cadaver
+
+> A command-line WebDAV client for Unix.
+> More information: <https://manned.org/cadaver>.
+
+- Connects to the server myserver.example.com, opening the root collection.
+
+`cadaver http://dav.example.com/`
+    
+- Connects to the server zope.example.com using port 8022, opening the collection "/Users/fred/".
+  
+`cadaver http://zope.example.com:8022/Users/fred/`
+    
+- Connects to a server called secure.example.com using SSL.
+    
+`cadaver https://secure.example.com/`

--- a/pages/common/cadaver.md
+++ b/pages/common/cadaver.md
@@ -3,14 +3,14 @@
 > A command-line WebDAV client for Unix.
 > More information: <https://manned.org/cadaver>.
 
-- Connect to the server myserver.example.com, open the root collection.
+- Connect to the server myserver.example.com, open the root collection:
 
 `cadaver http://dav.example.com/`
 
-- Connect to the server zope.example.com use port 8022, open the collection "/Users/fred/".
+- Connect to the server zope.example.com use port 8022, open the collection "/Users/fred/":
 
 `cadaver http://zope.example.com:8022/Users/fred/`
 
-- Connect to a server called secure.example.com use SSL.
+- Connect to a server called secure.example.com use SSL:
 
 `cadaver https://secure.example.com/`


### PR DESCRIPTION
A command-line WebDAV client for Unix.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
