### PR TITLE
kubectl-expose: add page

### DIFF
--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -7,7 +7,7 @@
 
 `kubectl expose {{resource_type}} {{resource_name}} --port={{node_port}} --target-port={{container_port}}`
 
-- Create a service for a resource identified by defination file, to serve from container port to node port:
+- Create a service for a resource identified by a file:
 
 `kubectl expose -f {{path/to/file.yml}} --port={{node_port}} --target-port={{container_port}}`
 

--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -1,0 +1,16 @@
+# kubectl edit
+
+> Expose a resource as a new Kubernetes service.
+> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
+
+- Create a service for a resource, to serve from container port to node port:
+
+`kubectl expose {{resource_type}} {{resource_name}} --port={{node_port}} --target-port={{container_port}}`
+
+- Create a service for a resource identified by defination file, to serve from container port to node port:
+
+`kubectl expose -f {{path/to/file.yml}} --port={{node_port}} --target-port={{container_port}}`
+
+- Create a service with a name, to serve to a node port which will be same for container port:
+
+`kubectl expose {{resource_type}} {{resource_name}} --port={{node_port}} --name={{service_name}}`

--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -3,7 +3,7 @@
 > Expose a resource as a new Kubernetes service.
 > More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
 
-- Create a service for a resource, to serve from container port to node port:
+- Create a service for a resource, which will be served from container port to node port:
 
 `kubectl expose {{resource_type}} {{resource_name}} --port={{node_port}} --target-port={{container_port}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
