### PR TITLE
ppmflash: add page

### DIFF
--- a/pages/common/ppmflash.md
+++ b/pages/common/ppmflash.md
@@ -3,7 +3,7 @@
 > Brighten a PPM image file.
 > More information: <https://netpbm.sourceforge.net/doc/ppmflash.html>.
 
-- Brighten a PPM image by the fraction `falshfactor`:
+- Brighten a PPM image by the fraction `flashfactor`:
 
 `ppmflash {{flashfactor}} {{path/to/file.ppm}}`
 

--- a/pages/common/ppmflash.md
+++ b/pages/common/ppmflash.md
@@ -1,0 +1,12 @@
+# ppmflash
+
+> Brighten a PPM image file.
+> More information: <https://netpbm.sourceforge.net/doc/ppmflash.html>.
+
+- Brighten a PPM image by the fraction `falshfactor`:
+
+`ppmflash {{flashfactor}} {{path/to/file.ppm}}`
+
+- Display version:
+
+`ppmflash -version`

--- a/pages/common/ppmflash.md
+++ b/pages/common/ppmflash.md
@@ -3,9 +3,9 @@
 > Brighten a PPM image file.
 > More information: <https://netpbm.sourceforge.net/doc/ppmflash.html>.
 
-- Brighten a PPM image by the fraction `flashfactor`:
+- Generate a PPM image as output that is `flashfactor` times brighter than the input PPM image:
 
-`ppmflash {{flashfactor}} {{path/to/file.ppm}}`
+`ppmflash {{flashfactor}} {{path/to/file.ppm}} > {{path/to/file.ppm}}`
 
 - Display version:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Issue #10887 

This adds ppmflash page documentation.