### PR TITLE
add-appxpackage: add page

### DIFF
--- a/pages/windows/add-appxpackage.md
+++ b/pages/windows/add-appxpackage.md
@@ -11,7 +11,7 @@
 
 `add-appxpackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}}`
 
-- Install an app using the App Installer file:
+- Install an app using the app installer file:
 
 `add-appxpackage -AppInstallerFile {{path\to\app.appinstaller}}`
 

--- a/pages/windows/add-appxpackage.md
+++ b/pages/windows/add-appxpackage.md
@@ -1,0 +1,20 @@
+# add-appxpackage
+
+> A PowerShell utility to add a signed app package (`.appx`, `.msix`, `.appxbundle` and `.msixbundle`) to a user account.
+> More information: <https://learn.microsoft.com/en-us/powershell/module/appx/add-appxpackage>.
+
+- Add an app package:
+
+`add-appxpackage -Path {{path\to\package.msix}}`
+
+- Add an app package with dependencies:
+
+`add-appxpackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}}`
+
+- Install an app using the App Installer file:
+
+`add-appxpackage -AppInstallerFile {{path\to\app.appinstaller}}`
+
+- Add an unsigned package:
+
+`add-appxpackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}} -AllowUnsigned`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

It's a very useful tool to add packages when you are using LTSC versions of windows 10 which do not contain the Windows App Store.