### PR TITLE
kubectl-create: add page

### DIFF
--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -1,6 +1,6 @@
 # kubectl create
 
-> Create a resource from a file or from stdin..
+> Create a resource from a file or from `stdin`.
 > More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
 
 - Create a resource using the resource definition file:

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -1,0 +1,28 @@
+# kubectl create
+
+> Create a resource from a file or from stdin..
+> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
+
+- Create a resource using the resource definition file:
+
+`kubectl create -f {{path/to/file.yml}}`
+
+- Create a resource from stdin:
+
+`kubectl create -f -`
+
+- Create a deployment:
+
+`kubectl create deployment {{deployment_name}} --image={{image}}`
+
+- Create a deployment with 3 replicas:
+
+`kubectl create deployment {{deployment_name}} --image={{image}} --replicas={{number_of_replicas}}`
+
+- Create a service named my-cs:
+
+`kubectl create service {{service_type}} {{service_name}} --tcp={{port}}:{{target_port}}`
+
+- Create a namespace:
+
+`kubectl create namespace {{namespace_name}}`

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -15,11 +15,11 @@
 
 `kubectl create deployment {{deployment_name}} --image={{image}}`
 
-- Create a deployment with 3 replicas:
+- Create a deployment with replicas:
 
 `kubectl create deployment {{deployment_name}} --image={{image}} --replicas={{number_of_replicas}}`
 
-- Create a service named my-cs:
+- Create a service:
 
 `kubectl create service {{service_type}} {{service_name}} --tcp={{port}}:{{target_port}}`
 

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -7,7 +7,7 @@
 
 `kubectl create -f {{path/to/file.yml}}`
 
-- Create a resource from stdin:
+- Create a resource from `stdin`:
 
 `kubectl create -f -`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
