### PR TITLE
delpart: add page

### DIFF
--- a/pages/linux/delpart.md
+++ b/pages/linux/delpart.md
@@ -1,0 +1,8 @@
+# delpart
+
+> Asks the Linux kernel to forget about a specified partition on a device.
+> More information: <https://manned.org/delpart>.
+
+- Tell the kernel to forget about the partition:
+
+`sudo delpart {{device}} {{partition}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.38.1

For delpart command as part of util-linux in #2214 
Sudo is necessary to get correct permission level.

I think adding a concrete example like:
`sudo delpart /dev/sda 1`
would help provide more clarity on how to use the command.
I'm not sure whether this would fit into the tldr page structure though.