### PR TITLE
subcommand-mention: add Bengali, Bosnian and Romanian translation

### DIFF
--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -72,7 +72,6 @@ Some subcommands such as `example command` have their own usage documentation.
 
 ```markdown
 "Neki podkomandi, kao što je `example command`, imaju vlastitu dokumentaciju za upotrebu."
-
 ```
 
 ---

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -62,13 +62,18 @@ Some subcommands such as `example command` have their own usage documentation.
 
 ### bn
 
-Not translated yet.
+```markdown
+"কিছু সাবকমান্ড, উদাহরণস্বরূপ `example command`, তাদের নিজের ব্যবহার নির্দেশনা আছে।"
+```
 
 ---
 
 ### bs
 
-Not translated yet.
+```markdown
+"Neki podkomandi, kao što je `example command`, imaju vlastitu dokumentaciju za upotrebu."
+
+```
 
 ---
 
@@ -226,7 +231,9 @@ Alguns subcomandos, como `example command`, tem a sua própria documentação de
 
 ### ro
 
-Not translated yet.
+```markdown
+Unele subcomenzi, cum ar fi `example command`, au documentație proprie de utilizare.
+```
 
 ---
 


### PR DESCRIPTION
Added text for `ro`, `bn` and `bs`


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
