### PR TITLE
feat/scripts: support generating PDFs for platforms

### DIFF
--- a/scripts/pdf/README.md
+++ b/scripts/pdf/README.md
@@ -19,7 +19,7 @@ Make sure OS specific dependencies for WeasyPrint are installed by following the
 
 Generating the PDF is as simple as running:
 
-    python3 render.py <path-to-pages-directory> [--color <color-scheme>] [--output <filename>]
+    python3 render.py <path-to-pages-directory> [--color <color-scheme>] [--output <filename>] [--platform <platform-name>]
 
 Complete information about the arguments can be viewed by running:
 

--- a/scripts/pdf/render.py
+++ b/scripts/pdf/render.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from weasyprint import HTML
 
 
-def main(loc, colorscheme, output_filename, platform=None):
+def main(loc, colorscheme, output_filename, platform):
     # Checking correctness of path
     if not os.path.isdir(loc):
         print("Invalid directory. Please try again!", file=sys.stderr)

--- a/scripts/pdf/render.py
+++ b/scripts/pdf/render.py
@@ -46,12 +46,6 @@ def main(loc, colorscheme, output_filename, platform=None):
         if platform and operating_sys not in platform:
             continue
 
-        # Check if the platform directory exists
-        platform_dir = os.path.join(loc, operating_sys)
-        if not os.path.isdir(platform_dir):
-            print(f"Platform directory '{platform_dir}' doesn't exist. Skipping.")
-            continue
-
         # Required string to create directory title pages
         html += (
             "<h1 class=title-dir>"
@@ -62,7 +56,7 @@ def main(loc, colorscheme, output_filename, platform=None):
 
         # Conversion of Markdown to HTML string
         for page_number, md in enumerate(
-            sorted(glob.glob(os.path.join(platform_dir, "*.md"))), start=1
+            sorted(glob.glob(os.path.join(loc, operating_sys, "*.md"))), start=1
         ):
             with open(md, "r") as inp:
                 text = inp.readlines()
@@ -76,23 +70,17 @@ def main(loc, colorscheme, output_filename, platform=None):
             html += '<p style="page-break-before: always" ></p>'
             print(f"Rendered page {page_number} of the directory {operating_sys}")
 
-    output_filename_with_platform = output_filename
-    if platform:
-        output_filename_with_platform = (
-            f"{output_filename[:-4]}-{'+'.join(platform)}.pdf"
-        )
-
     html += "</body></html>"
 
     # Writing the PDF to disk
-    if not html.count("<h2"):
-        print(f"No pages found for platform {', '.join(platform)}. Skipping.")
-        return
-    print("\nConverting all pages to PDF...")
-    HTML(string=html).write_pdf(output_filename_with_platform, stylesheets=csslist)
+    if platform:
+        output_filename = f"{output_filename[:-4]}-{'+'.join(platform)}.pdf"
 
-    if os.path.exists(output_filename_with_platform):
-        print(f"\nCreated {output_filename_with_platform} in the current directory!\n")
+    print("\nConverting all pages to PDF...")
+    HTML(string=html).write_pdf(output_filename, stylesheets=csslist)
+
+    if os.path.exists(output_filename):
+        print(f"\nCreated {output_filename} in the current directory!\n")
 
 
 if __name__ == "__main__":
@@ -119,7 +107,7 @@ if __name__ == "__main__":
         "-p",
         "--platform",
         nargs="+",
-        help="Specify one or more platforms to generate PDFs for (e.g. common, linux, etc)",
+        help="Specify one or more platforms to generate PDFs for",
     )
     args = parser.parse_args()
 

--- a/scripts/pdf/render.py
+++ b/scripts/pdf/render.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         "-p",
         "--platform",
         nargs="+",
-        help="Specify one or more platforms to generate PDFs for",
+        help="Specify one or more platforms to generate PDFs for (e.g. common, linux, etc)",
     )
     args = parser.parse_args()
 

--- a/scripts/pdf/render.py
+++ b/scripts/pdf/render.py
@@ -16,6 +16,7 @@ from datetime import datetime
 
 from weasyprint import HTML
 
+
 def main(loc, colorscheme, output_filename, platform=None):
     # Checking correctness of path
     if not os.path.isdir(loc):
@@ -77,19 +78,22 @@ def main(loc, colorscheme, output_filename, platform=None):
 
     output_filename_with_platform = output_filename
     if platform:
-        output_filename_with_platform = f"{output_filename[:-4]}-{'+'.join(platform)}.pdf"
+        output_filename_with_platform = (
+            f"{output_filename[:-4]}-{'+'.join(platform)}.pdf"
+        )
 
     html += "</body></html>"
 
     # Writing the PDF to disk
     if not html.count("<h2"):
-      print(f"No pages found for platform {', '.join(platform)}. Skipping.")
-      return
+        print(f"No pages found for platform {', '.join(platform)}. Skipping.")
+        return
     print("\nConverting all pages to PDF...")
     HTML(string=html).write_pdf(output_filename_with_platform, stylesheets=csslist)
 
     if os.path.exists(output_filename_with_platform):
         print(f"\nCreated {output_filename_with_platform} in the current directory!\n")
+
 
 if __name__ == "__main__":
     # Parsing the arguments
@@ -114,8 +118,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p",
         "--platform",
-        nargs='+',
-        help="Optionally, Specify one or more platforms to generate PDFs for.",
+        nargs="+",
+        help="Specify one or more platforms to generate PDFs for",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Changes

As discussed in [the chatroom](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$sS4To9n1vUpB5exkWW5Aa6wQ-ymqMhLIsl-i6FEeTwE?via=gitter.im&via=matrix.org&via=one.ems.host), this PR adds a way to generate custom PDFs for specific platforms manually. Currently, we use `python3 render.py <../../pages>` to generate PDFs (`tldr-book.pdf` by default) and there is a `-o` or `--output` flag to give a custom name to the PDF.

This PR adds a new optional flag `-p` or `--platform`, allowing pages to be generated for the specified platform alone. For example, `python3 render.py ../../pages -p android` will generate a PDF file named `tldr-book-android.pdf`.

You can pass multiple platforms as arguments, for example, `python3 render.py ../../pages -p android sunos` will generate a PDF file named `tldr-book-android+sunos.pdf`.

In the case of custom file names, the platform name is just appended behind the filename, for example `python3 render.py ../../pages -p android sunos -o tldr-book.pdf` will generate a file named `tldr-book-android+sunos.pdf`.

## Reference Outputs

```bash
(venv) kbdharun@homeserver:~/Downloads/tldr/scripts/pdf$ python3 render.py ../../pages -p android sunos
Rendered page 1 of the directory android
Rendered page 2 of the directory android
Rendered page 3 of the directory android
Rendered page 4 of the directory android
Rendered page 5 of the directory android
Rendered page 6 of the directory android
Rendered page 7 of the directory android
Rendered page 8 of the directory android
Rendered page 9 of the directory android
Rendered page 10 of the directory android
Rendered page 11 of the directory android
Rendered page 12 of the directory android
Rendered page 13 of the directory android
Rendered page 14 of the directory android
Rendered page 1 of the directory sunos
Rendered page 2 of the directory sunos
Rendered page 3 of the directory sunos
Rendered page 4 of the directory sunos
Rendered page 5 of the directory sunos
Rendered page 6 of the directory sunos
Rendered page 7 of the directory sunos
Rendered page 8 of the directory sunos
Rendered page 9 of the directory sunos

Converting all pages to PDF...

Created tldr-book-android+sunos.pdf in the current directory!
```

```bash
(venv) kbdharun@homeserver:~/Downloads/tldr/scripts/pdf$ python3 render.py ../../pages -p androi
No pages found for platform androi. Skipping.
```

```bash
(venv) kbdharun@homeserver:~/Downloads/tldr/scripts/pdf$ python3 render.py ../../pages -p android -o "tldr-books.pdf"
Rendered page 1 of the directory android
Rendered page 2 of the directory android
Rendered page 3 of the directory android
Rendered page 4 of the directory android
Rendered page 5 of the directory android
Rendered page 6 of the directory android
Rendered page 7 of the directory android
Rendered page 8 of the directory android
Rendered page 9 of the directory android
Rendered page 10 of the directory android
Rendered page 11 of the directory android
Rendered page 12 of the directory android
Rendered page 13 of the directory android
Rendered page 14 of the directory android

Converting all pages to PDF...

Created tldr-books-android.pdf in the current directory!
```

## Reference assets

Assets generated in the above steps:

[tldr-book-android+sunos.pdf](https://github.com/tldr-pages/tldr/files/13076974/tldr-book-android%2Bsunos.pdf)
[tldr-books-android.pdf](https://github.com/tldr-pages/tldr/files/13076983/tldr-books-android.pdf)

## Checklist

- [x] All changes have been tested and verified
- [x] The code has been formatted in black
- [x] README has been updated  