### PR TITLE
style-guide: add guidelines for standard streams; fix remaining pages

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -180,6 +180,7 @@ Use backticks on the following:
 - Paths, e.g. `package.json`, `/etc/package.json`.
 - Extensions, e.g. `.dll`.
 - Commands, e.g. `ls`.
+- Standard streams: `stdout`, `stdin`, `stderr`. **Do not** use the full names (e.g. standard output).
 
 ## Descriptions
 

--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -27,7 +27,7 @@
 
 `duckdb {{path/to/dbfile}} -init {{path/to/script.sql}}`
 
-- Read CSV from stdin and write CSV to stdout:
+- Read CSV from `stdin` and write CSV to `stdout`:
 
 `cat {{path/to/source.csv}} | duckdb -c "{{COPY (FROM read_csv_auto('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}"`
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -3,7 +3,7 @@
 > The Perl 5 language interpreter.
 > More information: <https://www.perl.org>.
 
-- Print lines from stdin [m/] matching regex1 and case insensitive [/i] regex2:
+- Print lines from `stdin` [m/] matching regex1 and case insensitive [/i] regex2:
 
 `perl -n -e 'print if m/{{regex1}}/ and m/{{regex2}}/i'`
 

--- a/pages/common/readonly.md
+++ b/pages/common/readonly.md
@@ -12,6 +12,6 @@
 
 `readonly {{existing_variable}}`
 
-- [p]rint to the standard output the names and values of all read-only variables:
+- [p]rint the names and values of all read-only variables to `stdout`:
 
 `readonly -p`

--- a/pages/linux/compress.md
+++ b/pages/linux/compress.md
@@ -15,7 +15,7 @@
 
 `compress -b {{bits}}`
 
-- Write to standard output (no files are changed):
+- Write to `stdout` (no files are changed):
 
 `compress -c {{path/to/file}}`
 

--- a/pages/linux/uncompress.md
+++ b/pages/linux/uncompress.md
@@ -11,10 +11,10 @@
 
 `uncompress -f {{path/to/file1.Z path/to/file2.Z ...}}`
 
-- Write to standard output (no files are changed and no `.Z` files are created):
+- Write to `stdout` (no files are changed and no `.Z` files are created):
 
 `uncompress -c {{path/to/file1.Z path/to/file2.Z ...}}`
 
-- Verbose mode (write to standard error about percentage reduction or expansion):
+- Verbose mode (write to `stderr` about percentage reduction or expansion):
 
 `uncompress -v {{path/to/file1.Z path/to/file2.Z ...}}`

--- a/pages/linux/zbarcam.md
+++ b/pages/linux/zbarcam.md
@@ -1,9 +1,9 @@
 # zbarcam
 
-> Scans and decodes barcodes (and QR codes) from a video device.
+> Scan and decode barcodes (and QR codes) from a video device.
 > More information: <https://manned.org/zbarcam>.
 
-- Continuously read barcodes and print them to standard output:
+- Continuously read barcodes and print them to `stdout`:
 
 `zbarcam`
 


### PR DESCRIPTION
Continuation of #10436, #10442 and probably something else I forgot about.
Fixes the remaining long versions that have gone unnoticed in reviews since the two PRs.