### PR TITLE
fix/scripts: replace build assets symlink with copy

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ function build_translation_archives {
   done
 
   cd "$target_directory"
-  ln -s tldr-pages.zip tldr-pages.en.zip
+  cp -r tldr-pages.zip tldr-pages.en.zip
 }
 
 ###################################


### PR DESCRIPTION
Currently, the assets archive for `tldr-pages.en.zip` is [broken](https://github.com/tldr-pages/tldr-pages.github.io/blob/8cf584def37943d61d4573dfb057dfc0b2541487/assets/tldr-pages.en.zip) as symlink was used for generating this file from `tldr-pages.zip`. Seems like symlinking ZIP files are supported only in a handful of file systems, and the file results in an error like this:

![image](https://github.com/tldr-pages/tldr/assets/26346867/98b680c7-70fe-4a2a-be5e-9de3aaf8d030)

This PR updates the command to recursively copy the ZIP's contents of `tldr-pages.zip` to `tldr-pages.en.zip` under language archives.

Closes #11121