### PR TITLE
cd, chdir, set-location, sl: Add PowerShell alias and standardize page

### DIFF
--- a/pages/windows/cd.md
+++ b/pages/windows/cd.md
@@ -1,19 +1,12 @@
 # cd
 
 > Display the current working directory or move to a different directory.
+> In PowerShell, this command is an alias of `Set-Location`. This documentation only applies to the Command Prompt (`cmd`) version of `cd`.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/cd>.
 
 - Display the path of the current directory:
 
 `cd`
-
-- Go to root of current drive:
-
-`cd \`
-
-- Go up to the parent of the current directory:
-
-`cd ..`
 
 - Go to a specific directory in the same drive:
 
@@ -22,3 +15,15 @@
 - Go to a specific directory in a different [d]rive:
 
 `cd /d {{C}}:{{path\to\directory}}`
+
+- Go up to the parent of the current directory:
+
+`cd ..`
+
+- Go to the home directory of the current user:
+
+`cd %userprofile%`
+
+- Go to root of current drive:
+
+`cd \`

--- a/pages/windows/chdir.md
+++ b/pages/windows/chdir.md
@@ -1,0 +1,12 @@
+# slmgr
+
+> This command is an alias of `cd` in Command Prompt, and subsequently `Set-Location` in PowerShell.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/chdir>.
+
+- View documentation for the original Command Prompt command:
+
+`tldr cd`
+
+- View documentation for the original PowerShell command:
+
+`tldr set-location`

--- a/pages/windows/set-location.md
+++ b/pages/windows/set-location.md
@@ -1,0 +1,33 @@
+# Set-Location
+
+> Display the current working directory or move to a different directory.
+> This command can only be used through PowerShell.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-location>.
+
+- Go to the specified directory:
+
+`Set-Location {{path\to\directory}}`
+
+- Go to a specific directory in a different drive:
+
+`Set-Location {{C}}:{{path\to\directory}}`
+
+- Go and display the location of specified directory:
+
+`Set-Location {{path\to\directory}} -PassThru`
+
+- Go up to the parent of the current directory:
+
+`Set-Location ..`
+
+- Go to the home directory of the current user:
+
+`cd ~`
+
+- Go back/forward to the previously chosen directory:
+
+`Set-Location {{-|+}}`
+
+- Go to root of current drive:
+
+`Set-Location \`

--- a/pages/windows/sl.md
+++ b/pages/windows/sl.md
@@ -1,0 +1,8 @@
+# sl
+
+> In PowerShell, this command is an alias of `Set-Location`.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-location>.
+
+- View documentation for the original command:
+
+`tldr set-location`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
  + Command Prompt: 10.0.22621.1702 (Windows 11)
  + PowerShell: 5.1.22621.963 ([not the cross-platform version of PowerShell / PowerShell Core](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.3))

This PR adds the PowerShell version (as hinted by @tayopi on https://github.com/tldr-pages/tldr/issues/6621#issuecomment-1739796760) of the `cd` command, `Set-Location`, with some significant differences from the original Command Prompt version. Additionally, this PR also rearranges the command examples of `windows/cd` to be similar to `common/cd`.