### PR TITLE
fix/scripts: remove unnecessary `-r` from `cp`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ function build_translation_archives {
   done
 
   cd "$target_directory"
-  cp -r tldr-pages.zip tldr-pages.en.zip
+  cp tldr-pages.zip tldr-pages.en.zip
 }
 
 ###################################


### PR DESCRIPTION
#11205

> Seems like symlinking ZIP files are supported only in a handful of file systems

The filesystem has nothing to do with it; once you download the symlink it becomes a plain text file with the string `tldr-pages.zip` in it.

> This PR updates the command to recursively copy the ZIP's contents of `tldr-pages.zip` to `tldr-pages.en.zip`

No, it copies the zip file itself, no extracting, no recursive copying needed.