### PR TITLE
vf: add page

### DIFF
--- a/pages/common/vf.md
+++ b/pages/common/vf.md
@@ -11,7 +11,7 @@
 
 `vf new --python {{/usr/local/bin/python3.8}} {{virtualenv_name}}`
 
-- Activate or use a different virtual environment:
+- Activate and use the specified virtual environment:
 
 `vf activate {{virtualenv_name}}`
 
@@ -31,6 +31,6 @@
 
 `vf rm {{virtualenv_name}}`
 
-- Get summary of all virtualfish commands:
+- Display help:
 
 `vf help`

--- a/pages/common/vf.md
+++ b/pages/common/vf.md
@@ -1,6 +1,6 @@
-# virtualfish
+# vf
 
-> Fish shell tool for managing Python virtual environments.
+> VirtualFish is a fish shell tool for managing Python virtual environments.
 > More information: <https://virtualfish.readthedocs.io/en/latest/>.
 
 - Create a virtual environment:

--- a/pages/common/virtualfish.md
+++ b/pages/common/virtualfish.md
@@ -1,0 +1,36 @@
+# virtualfish
+
+> Fish shell tool for managing Python virtual environments.
+> More information: <https://virtualfish.readthedocs.io/en/latest/>.
+
+- Create a virtual environment:
+
+`vf new {{virtualenv_name}}`
+
+- Create a virtual environment for a specific Python version:
+
+`vf new --python {{/usr/local/bin/python3.8}} {{virtualenv_name}}`
+
+- Activate or use a different virtual environment:
+
+`vf activate {{virtualenv_name}}`
+
+- Connect the current virtualenv to the current directory, so that it is activated automatically as soon as you enter it (and deactivated as soon as you leave):
+
+`vf connect`
+
+- Deactivate the current virtual environment:
+
+`vf deactivate`
+
+- List all virtual environments:
+
+`vf ls`
+
+- Remove a virtual environment:
+
+`vf rm {{virtualenv_name}}`
+
+- Get summary of all virtualfish commands:
+
+`vf help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented:** 2.5.5

This tool actually has a different command name to use in the terminal, i.e. `vf` not `virtualfish`. Should I need to create `vf.md` also? What is guidelines for this?
