### PR TITLE
aws codeartifact: add page; pt_BR translation

### DIFF
--- a/pages.pt_BR/common/aws-codeartifact.md
+++ b/pages.pt_BR/common/aws-codeartifact.md
@@ -1,0 +1,25 @@
+# aws codeartifact
+
+> Interface de linha de comando para o AWS CodeArtifact.
+> O CodeArtifact permite armazenar artefatos usando gerenciadores de pacotes populares e criar ferramentas como Maven, Gradle, npm, Yarn, Twine, pip e NuGet.
+> Mais informações: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/codeartifact/index.html>.
+
+- Lista domínios disponíveis para a sua conta da AWS:
+
+`aws codeartifact list-domains`
+
+- Gera credenciais para um gerenciador de pacote específico (p.e.: npm, pip):
+
+`aws codeartifact login --tool {{gerenciador_de_pacotes}} --domain {{seu_domínio}} --repository {{nome_do_repositório}}`
+
+- Recupera a URL do endpoint de um repositório do CodeArtifact:
+
+`aws codeartifact get-repository-endpoint --domain {{seu_domínio}} --repository {{nome_do_repositório}} --format {{npm|pypi|maven|nuget|generic}}`
+
+- Lista todos os comandos disponíveis para o CodeArtifact:
+
+`aws codeartifact help`
+
+- Exibe ajuda específica para um subcomando do CodeArtifact:
+
+`aws ec2 {{subcommand}} help`

--- a/pages/common/aws-codeartifact.md
+++ b/pages/common/aws-codeartifact.md
@@ -1,0 +1,25 @@
+# aws codeartifact
+
+> CLI for AWS CodeArtifact.
+> CodeArtifact allows you to store artifacts using popular package managers and build tools like Maven, Gradle, npm, Yarn, Twine, pip, NuGet, and SwiftPM.
+> More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/codeartifact/index.html>.
+
+- List available domains for your AWS account:
+
+`aws codeartifact list-domains`
+
+- Generate credentials for a specific package manager (e.g.: npm, pip):
+
+`aws codeartifact login --tool {{package_manager}} --domain {{your_domain}} --repository {{repository_name}}`
+
+- Get the endpoint URL of a CodeArtifact repository:
+
+`aws codeartifact get-repository-endpoint --domain {{your_domain}} --repository {{repository_name}} --format {{npm|pypi|maven|nuget|generic}}`
+
+- Show list of all available CodeArtifact commands:
+
+`aws codeartifact help`
+
+- Show help for specific EC2 subcommand:
+
+`aws ec2 {{subcommand}} help`


### PR DESCRIPTION

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** `aws-cli/1.29.25 Python/3.11.5 Linux/6.1.59-1-lts botocore/1.31.25`
