### PR TITLE
hub sub commands: add page

### DIFF
--- a/pages/common/hub-branch.md
+++ b/pages/common/hub-branch.md
@@ -1,0 +1,12 @@
+# hub branch
+
+> Create a branch or show current branch.
+> See also `git branch`.
+
+- Show the name of the currently active branch:
+
+`hub branch`
+
+- Create a new branch:
+
+`hub branch {{branch_name}}`

--- a/pages/common/hub-browse.md
+++ b/pages/common/hub-browse.md
@@ -1,0 +1,16 @@
+# hub browse
+
+> Open a GitHub repository in the browser or print the URL.
+> More information: <https://cli.github.com/manual/hub_browse>.
+
+- Open the homepage of the current repository in the default web browser:
+
+`hub browse`
+
+- Open the homepage of a specific repository in the default web browser:
+
+`hub browse {{owner}}/{{repository}}`
+
+- Open the subpage of a specific repository in the default web browser, subpage can be "wiki", "commits", "issues", or other (default: "tree"):
+
+`hub browse {{owner}}/{{repository}} {{subpage}}`

--- a/pages/common/hub-ci-status.md
+++ b/pages/common/hub-ci-status.md
@@ -1,0 +1,12 @@
+# hub ci-status
+
+> Display status of GitHub checks.
+> More information: <https://hub.github.com/hub-ci-status.1.html>.
+
+- Check the CI status for this branch:
+
+`hub ci-status --verbose`
+
+- Display status of GitHub checks for a commit:
+
+`hub ci-status --verbose {{commit_SHA}}`

--- a/pages/common/hub-clone.md
+++ b/pages/common/hub-clone.md
@@ -1,0 +1,8 @@
+# hub clone
+
+> Clone an existing repository.
+> More information: <https://hub.github.com/hub-clone.1.html>.
+
+- Clone an existing repository to current directory (If run into authentication problem, try full ssh path):
+
+`hub clone {{remote_repository_location}}`

--- a/pages/common/hub-create.md
+++ b/pages/common/hub-create.md
@@ -1,0 +1,12 @@
+# hub create
+
+> Create a new repository on GitHub.
+> More information: <https://hub.github.com/hub-create.1.html>.
+
+- Upload the current (local-only) repository to your GitHub account as public:
+
+`hub create`
+
+- Create a private repository and open the new repository in a web browser:
+
+`hub create --private --browse`

--- a/pages/common/hub-delete.md
+++ b/pages/common/hub-delete.md
@@ -1,0 +1,8 @@
+# hub delete
+
+> Delete an existing repository on GitHub.
+> More information: <https://hub.github.com/hub-delete.1.html>.
+
+- Delete personal repo on GitHub:
+
+`hub delete {{repo}}`

--- a/pages/common/hub-fork.md
+++ b/pages/common/hub-fork.md
@@ -1,0 +1,16 @@
+# hub fork
+
+> Fork the given GitHub repo. Like `git fork` from `git-extras`.
+> More information: <https://hub.github.com/hub-fork.1.html>.
+
+- Fork a GitHub repository by its slug:
+
+`hub fork {{tldr-pages/tldr}}`
+
+- Fork a GitHub repository by its URL:
+
+`hub fork {{https://github.com/tldr-pages/tldr}}`
+
+- Fork current GitHub repository, set remote name to origin:
+
+`hub fork --remote-name {{origin}}`

--- a/pages/common/hub-init.md
+++ b/pages/common/hub-init.md
@@ -1,0 +1,8 @@
+# hub init
+
+> Initializes a new local git repository.
+> More information: <https://hub.github.com/hub-init.1.html>.
+
+- Initialize a new local repository:
+
+`hub init`

--- a/pages/common/hub-issue.md
+++ b/pages/common/hub-issue.md
@@ -1,0 +1,16 @@
+# hub issue
+
+> Manage Github issues.
+> More information: <https://hub.github.com/hub-issue.1.html>.
+
+- List the last 10 issues with the `bug` label:
+
+`hub issue list --limit {{10}} --labels "{{bug}}" `
+
+- Display a specific issue:
+
+`hub issue show {{issue_number}}`
+
+- List 10 closed issues assigneed to a specific user:
+
+`hub issue --state {{closed}} --assignee {{username}} --limit {{10}}`


### PR DESCRIPTION
Added the following hub subcommands: branch, browse, ci-status, clone, create, init, issue, delete, fork

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):2.14.2**
