### PR TITLE
gotelemetry: add page

### DIFF
--- a/pages/common/gotelemetry.md
+++ b/pages/common/gotelemetry.md
@@ -1,0 +1,24 @@
+# gotelemetry
+
+> A tool for managing Go telemetry data and settings.
+> More information: <https://telemetry.go.dev/privacy#collection>.
+
+- Enable telemetry uploading:
+
+`gotelemetry on`
+
+- Disable telemetry uploading:
+
+`gotelemetry off`
+
+- Run a Web Viewer for local telemetry data:
+
+`gotelemetry view`
+
+- Print the current telemetry environment:
+
+`gotelemetry env`
+
+- Show details about any subcommand:
+
+`gotelemetry help {{subcommand}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** I installed latest but according to this https://pkg.go.dev/golang.org/x/telemetry/cmd/gotelemetry It would be `v0`

