### PR TITLE
scripts: use `[[` instead of `[`, fix literal shell globs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,11 +5,11 @@
 set -ex
 
 function initialize {
-  if [ -z "$TLDRHOME" ]; then
+  if [[ -z $TLDRHOME ]]; then
     export TLDRHOME=${GITHUB_WORKSPACE:-$(pwd)}
   fi
 
-  if [ -z "$TLDR_LANG_ARCHIVES_DIRECTORY" ]; then
+  if [[ -z $TLDR_LANG_ARCHIVES_DIRECTORY ]]; then
     export TLDR_LANG_ARCHIVES_DIRECTORY="${GITHUB_WORKSPACE:-$(pwd)}/language_archives"
   fi
 
@@ -36,7 +36,7 @@ function build_translation_archives {
 
   for lang_dir in "$source_directory"/pages*; do
     # Skip symlinks (pages.en) and things that are not directories
-    if [ ! -d "$lang_dir" ] || [ -h "$lang_dir" ]; then
+    if [[ ! -d $lang_dir || -h $lang_dir ]]; then
       continue
     fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,7 @@ function build_translation_archives {
   local source_directory="$TLDRHOME"
   local target_directory="$TLDR_LANG_ARCHIVES_DIRECTORY"
   mkdir -p "$target_directory"
-  rm -f "$target_directory/*"
+  rm -f "$target_directory"/*
 
   for lang_dir in "$source_directory"/pages*; do
     # Skip symlinks (pages.en) and things that are not directories

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -30,14 +30,14 @@ function check_duplicates {
   case "$platform" in
     common) # check if page already exists in other platforms
       for other in ${PLATFORMS/common/}; do
-        if [ -f "pages/$other/$file" ]; then
+        if [[ -f "pages/$other/$file" ]]; then
           printf "\x2d $MSG_EXISTS" "$page" "$other"
         fi
       done
       ;;
 
     *) # check if page already exists under common
-      if [ -f "pages/common/$file" ]; then
+      if [[ -f "pages/common/$file" ]]; then
         printf "\x2d $MSG_EXISTS" "$page" 'common'
       fi
       ;;
@@ -52,7 +52,7 @@ function check_diff {
 
   git_diff=$(git diff --name-status --find-copies-harder --diff-filter=AC --relative=pages/ remotes/origin/main)
 
-  if [ -n "$git_diff" ]; then
+  if [[ -n $git_diff ]]; then
     echo -e "Check PR: git diff:\n$git_diff" >&2
   else
     echo 'Check PR: git diff looks fine, no interesting changes detected.' >&2
@@ -85,13 +85,13 @@ function check_diff {
 # Recursively check the pages/ folder for anomalies.
 function check_structure {
   for platform in $PLATFORMS; do
-    if [ ! -d "pages/$platform" ]; then
+    if [[ ! -d "pages/$platform" ]]; then
       printf "\x2d $MSG_NOT_DIR" "pages/$platform"
     else
       for page in "pages/$platform"/*; do
-        if [ ! -f "$page" ]; then
+        if [[ ! -f $page ]]; then
           printf "\x2d $MSG_NOT_FILE" "$page"
-        elif [ "${page:(-3)}" != ".md" ]; then
+        elif [[ ${page:(-3)} != ".md" ]]; then
           printf "\x2d $MSG_NOT_MD" "$page"
         fi
       done
@@ -111,7 +111,7 @@ MSG_NOT_MD='The file `%s` does not have a `.md` extension.\n'
 
 PLATFORMS=$(ls pages/)
 
-if [ "$CI" = "true" ] && [ "$GITHUB_REPOSITORY" = "tldr-pages/tldr" ] && [ "$PULL_REQUEST_ID" != "" ]; then
+if [[ $CI == true && $GITHUB_REPOSITORY == "tldr-pages/tldr" && $PULL_REQUEST_ID != "" ]]; then
   check_diff
   check_structure
 else

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@
 set -ex
 
 function initialize {
-  if [ -z "$TLDRHOME" ]; then
+  if [[ -z $TLDRHOME ]]; then
     export TLDRHOME=${GITHUB_WORKSPACE:-$(pwd)}
   fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,9 +24,9 @@ function run_black {
     errs=$(python3 -m black scripts --check --required-version ${target_black_version} 2>&1 || true)
   fi
 
-  if [ -z "${errs}" ]; then
+  if [[ -z $errs ]]; then
     # skip black check if command is not available in the system.
-    if [ "$CI" != "true" ] && ! exists black; then
+    if [[ $CI != true ]] && ! exists black; then
       echo "Skipping black check, command not available."
       return 0
     fi
@@ -49,7 +49,7 @@ function run_black {
 
 function run_flake8 {
   # skip flake8 check if command is not available in the system.
-  if [ "$CI" != "true" ] && ! exists flake8; then
+  if [[ $CI != true ]] && ! exists flake8; then
     echo "Skipping flake8 check, command not available."
     return 0
   fi
@@ -73,7 +73,7 @@ function run_tests {
 function run_tests_pr {
   errs=$(run_tests 2>&1)
 
-  if [ -n "$errs" ]; then
+  if [[ -n $errs ]]; then
     echo -e "Test failed!\n$errs\n" >&2
     echo 'Sending errors to tldr-bot.' >&2
     echo -n "$errs" | python3 scripts/send-to-bot.py report-errors
@@ -86,7 +86,7 @@ function run_tests_pr {
 function run_checks_pr {
   msgs=$(bash scripts/check-pr.sh)
 
-  if [ -n "$msgs" ]; then
+  if [[ -n $msgs ]]; then
     echo -e "\nCheck PR reported the following message(s):\n$msgs\n" >&2
     echo 'Sending check results to tldr-bot.' >&2
     echo -n "$msgs" | python3 scripts/send-to-bot.py report-check-results
@@ -97,7 +97,7 @@ function run_checks_pr {
 # MAIN
 ###################################
 
-if [ "$CI" = "true" ] && [ "$GITHUB_REPOSITORY" = "tldr-pages/tldr" ] && [ "$PULL_REQUEST_ID" != "" ]; then
+if [[ $CI == true && $GITHUB_REPOSITORY == "tldr-pages/tldr" && $PULL_REQUEST_ID != "" ]]; then
   run_checks_pr
   run_tests_pr
 else


### PR DESCRIPTION
Since all shell scripts are run in Bash, we can use `[[` in if statements.
This allows to chain multiple conditions inside a single set of brackets.
```bash
if [ condition1 ] && [ condition2 ] && [ condition3 ]
```
can be written as
```bash
if [[ condition1 && condition2 && condition3 ]]
```

Quoting variables inside if statements is no longer needed, since Bash does not do `$IFS` splitting or glob expansion inside `[[`.