### PR TITLE
common/*: add ps-nvm commands

### DIFF
--- a/pages/common/get-nodeinstalllocation.md
+++ b/pages/common/get-nodeinstalllocation.md
@@ -1,0 +1,9 @@
+# Get-NodeInstallLocation
+
+> Get the current Node.js installation directory for `ps-nvm`.
+> Part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- Get the current Node.js installation directory:
+
+`Get-NodeInstallLocation`

--- a/pages/common/get-nodeversions.md
+++ b/pages/common/get-nodeversions.md
@@ -1,0 +1,17 @@
+# Get-NodeVersions
+
+> List installed and available Node.js versions for `ps-nvm`.
+> Part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- List all installed Node.js versions:
+
+`Get-NodeVersions`
+
+- List all available Node.js versions:
+
+`Get-NodeVersions -Remote`
+
+- List all available Node.js 20.x versions:
+
+`Get-NodeVersions -Remote -Filter ">=20.0.0 <21.0.0"`

--- a/pages/common/install-nodeversion.md
+++ b/pages/common/install-nodeversion.md
@@ -16,7 +16,7 @@
 
 `Install-NodeVersion ^20`
 
-- Install the x86 (x86 32-bit) / x64 (x86 64-bit) / arm64 (ARM 64-bit) version of Node.js
+- Install the x86 (x86 32-bit) / x64 (x86 64-bit) / arm64 (ARM 64-bit) version of Node.js:
 
 `Install-NodeVersion {{node_version}} -Architecture {{x86|x64|arm64}}`
 

--- a/pages/common/install-nodeversion.md
+++ b/pages/common/install-nodeversion.md
@@ -1,0 +1,25 @@
+# Install-NodeVersion
+
+> Install Node.js runtime versions for `ps-nvm`.
+> This command is part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- Install a specific Node.js version:
+
+`Install-NodeVersion {{node_version}}`
+
+- Install multiple Node.js versions:
+
+`Install-NodeVersion {{node_version1 , node_version2 , ...}}`
+
+- Install latest available version of Node.js 20:
+
+`Install-NodeVersion ^20`
+
+- Install the x86 (x86 32-bit) / x64 (x86 64-bit) / arm64 (ARM 64-bit) version of Node.js
+
+`Install-NodeVersion {{node_version}} -Architecture {{x86|x64|arm64}}`
+
+- Use a HTTP proxy to download Node.js:
+
+`Install-NodeVersion {{node-version}} -Proxy {{http://example.com}}`

--- a/pages/common/ps-nvm.md
+++ b/pages/common/ps-nvm.md
@@ -1,0 +1,29 @@
+# ps-nvm
+
+> PowerShell-based utility to manage multiple Node.js versions, inspired by `nvm`.
+> This tool provides multiple commands that all can only be run through PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- View documentation for `Get-NodeInstallLocation`, a tool to get the current Node.js install location:
+
+`tldr get-nodeinstalllocation`
+
+- View documentation for `Get-NodeVersions`, a tool to list all available and currently-installed Node.js versions:
+
+`tldr get-nodeversions`
+
+- View documentation for `Install-NodeVersion`, a tool to install Node.js runtime versions:
+
+`tldr get-nodeversion`
+
+- View documentation for `Remove-NodeVersion`, a tool to uninstall an existing Node.js version:
+
+`tldr remove-nodeversion`
+
+- View documentation for `Set-NodeInstallLocation`, a tool to set the Node.js install location:
+
+`tldr set-nodeinstalllocation`
+
+- View documentation for `Set-NodeVersion`, a tool to set the default version of Node.js:
+
+`tldr set-nodeversion`

--- a/pages/common/remove-nodeversion.md
+++ b/pages/common/remove-nodeversion.md
@@ -1,0 +1,21 @@
+# Remove-NodeVersion
+
+> Uninstall Node.js runtime versions for `ps-nvm`.
+> This command is part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- Uninstall a given Node.js version:
+
+`Remove-NodeVersion {{node_version}}`
+
+- Uninstall multiple Node.js versions:
+
+`Remove-NodeVersion {{node_version1 , node_version2 , ...}}`
+
+- Uninstall all currently-installed versions of Node.js 20.x:
+
+`Get-NodeVersions -Filter ">=20.0.0 <21.0.0" | Remove-NodeVersion`
+
+- Uninstall all currently-installed versions of Node.js:
+
+`Get-NodeVersions | Remove-NodeVersion`

--- a/pages/common/set-nodeinstalllocation.md
+++ b/pages/common/set-nodeinstalllocation.md
@@ -1,0 +1,9 @@
+# Set-NodeInstallLocation
+
+> Set the default Node.js installation directory for `ps-nvm`.
+> This command is part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- Change the Node.js install location to a specified directory (`ps-nvm` will create a new `.nvm` subdirectory to install them):
+
+`Set-NodeInstallLocation {{path/to/directory}}`

--- a/pages/common/set-nodeversion.md
+++ b/pages/common/set-nodeversion.md
@@ -1,0 +1,21 @@
+# Set-NodeVersion
+
+> Set the default Node.js version for `ps-nvm`.
+> Part of `ps-nvm` and can only be run under PowerShell.
+> More information: <https://github.com/aaronpowell/ps-nvm>.
+
+- Use a specific version of Node.js in the current PowerShell session:
+
+`Set-NodeVersion {{node_version}}`
+
+- Use the latest installed Node.js version 20.x:
+
+`Set-NodeVersion ^20`
+
+- Set the default Node.js version for the current user (only applies to future PowerShell sessions):
+
+`Set-NodeVersion {{node_version}} -Persist User`
+
+- Set the default Node.js version for all users (must be run as Administrator/root and only applies to future PowerShell sessions):
+
+`Set-NodeVersion {{node_version}} -Persist Machine`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR adds [ps-nvm](https://github.com/aaronpowell/ps-nvm), a PowerShell utility to manage Node.js versions akin to `nvm`. It is placed in `common` (instead of `windows`—see #6621) as the authors of this tool explicitly claims the tool to support Windows, macOS, and Linux, though they still require PowerShell to use the install Node.js versions.