### PR TITLE
xcodes-runtimes: update Indonesian translation

### DIFF
--- a/pages.id/osx/xcodes-runtimes.md
+++ b/pages.id/osx/xcodes-runtimes.md
@@ -17,12 +17,12 @@
 
 - Unduh/pasang runtime Simulator untuk iOS/watchOS/tvOS/visionOS versi spesifik (nama harus ditulis sebagai case-sensitive):
 
-`xcodes runtimes {{download|install}} "{{iOS|watchOS|tvOS|visionOS}} {{versi_runtime}}"`
+`xcodes runtimes {{download|install}} "{{iOS|watchOS|tvOS|visionOS}} {{nama_runtime}}"`
 
 - Atur lokasi penyimpanan arsip runtime yang akan diunduh (nilai default: `~/Downloads`):
 
-`xcodes runtimes {{download|install}} {{runtime_name}} --directory {{path/to/directory}}`
+`xcodes runtimes {{download|install}} {{nama_runtime}} --directory {{jalan/menuju/direktori}}`
 
 - Jangan hapus arsip runtime Simulator setelah pemasangan selesai:
 
-`xcodes runtimes install {{runtime_name}} --keep-archive`
+`xcodes runtimes install {{nama_runtime}} --keep-archive`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

## Changes

- Fixes the untranslated path placeholder (@Magrid0 You seem to have accidentally merged the PR #11296 before updating this)
- In some places, the runtime placeholder wasn't translated but in some places, it was but differently. I have updated it to `nama_runtime` throughout the page. (This error passed through my initial oversight too, sorry)