### PR TITLE
freebsd, netbsd: add directory; pkg, pkgin: add page

### DIFF
--- a/pages/freebsd/pkg.md
+++ b/pages/freebsd/pkg.md
@@ -1,0 +1,28 @@
+# pkg
+
+> FreeBSD package manager.
+> More information: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+
+- Upgrade all packages:
+
+`pkg upgrade`
+
+- Search for a package:
+
+`pkg search {{keyword}}`
+
+- Install a new package:
+
+`pkg install {{package}}`
+
+- Delete a package:
+
+`pkg delete {{package}}`
+
+- List installed packages:
+
+`pkg info`
+
+- Remove unneeded dependencies:
+
+`pkg autoremove`

--- a/pages/freebsd/pkg.md
+++ b/pages/freebsd/pkg.md
@@ -3,14 +3,6 @@
 > FreeBSD package manager.
 > More information: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
 
-- Upgrade all packages:
-
-`pkg upgrade`
-
-- Search for a package:
-
-`pkg search {{keyword}}`
-
 - Install a new package:
 
 `pkg install {{package}}`
@@ -18,6 +10,14 @@
 - Delete a package:
 
 `pkg delete {{package}}`
+
+- Upgrade all packages:
+
+`pkg upgrade`
+
+- Search for a package:
+
+`pkg search {{keyword}}`
 
 - List installed packages:
 

--- a/pages/netbsd/pkgin.md
+++ b/pages/netbsd/pkgin.md
@@ -1,6 +1,6 @@
 # pkgin
 
-> Manage pkgsrc binary packages on NetBSD.
+> Manage `pkgsrc` binary packages on NetBSD.
 > More information: <https://pkgin.net/#usage>.
 
 - Install a package:

--- a/pages/netbsd/pkgin.md
+++ b/pages/netbsd/pkgin.md
@@ -1,0 +1,28 @@
+# pkgin
+
+> Manage pkgsrc binary packages on NetBSD.
+> More information: <https://pkgin.net/#usage>.
+
+- Upgrade all packages:
+
+`pkgin full-upgrade`
+
+- Search for a package:
+
+`pkgin search {{keyword}}`
+
+- Install a package:
+
+`pkgin install {{package}}`
+
+- Remove a package and its dependencies:
+
+`pkgin remove {{package}}`
+
+- List installed packages:
+
+`pkgin list`
+
+- Remove unneeded dependencies:
+
+`pkgin autoremove`

--- a/pages/netbsd/pkgin.md
+++ b/pages/netbsd/pkgin.md
@@ -3,14 +3,6 @@
 > Manage pkgsrc binary packages on NetBSD.
 > More information: <https://pkgin.net/#usage>.
 
-- Upgrade all packages:
-
-`pkgin full-upgrade`
-
-- Search for a package:
-
-`pkgin search {{keyword}}`
-
 - Install a package:
 
 `pkgin install {{package}}`
@@ -18,6 +10,14 @@
 - Remove a package and its dependencies:
 
 `pkgin remove {{package}}`
+
+- Upgrade all packages:
+
+`pkgin full-upgrade`
+
+- Search for a package:
+
+`pkgin search {{keyword}}`
 
 - List installed packages:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

---

This PR adds the `freebsd` and `netbsd` directories and pages for their package managers.

We definitely don't want to add a big amount of platform directories. I'd like to hear everyone's opinion on adding more BSDs. I think those are the three most popular ones (+OpenBSD), and I wouldn't add any more myself after this.
Each platform addition requires updating all the clients, so adding them all in one go would be ideal.

Discussed in #10698.
Closes #7077.