### PR TITLE
ISSUE-TEMPLATES: add Let's document; update others

### DIFF
--- a/.github/ISSUE_TEMPLATE/lets-document.yml
+++ b/.github/ISSUE_TEMPLATE/lets-document.yml
@@ -1,7 +1,7 @@
 name: 📄 Let's document
 title: "Let's document: "
-description: Request creation of multiple related pages (e.g. a complicated command with multiple subcommands).
-labels: new command, help wanted, Let's document
+description: Request creation of multiple related pages (e.g. a utility with multiple subcommands).
+labels: new command, help wanted, let's document
 body:
   - type: textarea
     attributes:
@@ -18,19 +18,25 @@ body:
   - type: dropdown
     attributes:
       label: Platform
-      description: What OS does the program run on? (Select 'Common' if the program works on more than one OS)
+      description: What platform does the program run on? (Select "Common" if the program works on more than one platform)
       options:
+        - Android
+        - Common
+        - FreeBSD
         - Linux
         - macOS (OS X)
-        - Windows
-        - FreeBSD
-        - OpenBSD
         - NetBSD
-        - Android
+        - OpenBSD
         - SunOS
-        - Common
+        - Windows
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Provide additional information if the command differs between platforms.
+    validations:
+      required: false
   - type: textarea
     attributes:
       label: Commands

--- a/.github/ISSUE_TEMPLATE/lets-document.yml
+++ b/.github/ISSUE_TEMPLATE/lets-document.yml
@@ -35,8 +35,6 @@ body:
     attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.
-    validations:
-      required: false
   - type: textarea
     attributes:
       label: Commands

--- a/.github/ISSUE_TEMPLATE/lets-document.yml
+++ b/.github/ISSUE_TEMPLATE/lets-document.yml
@@ -1,20 +1,15 @@
-name: 📄 Page modification request
-title: "page modification request: "
-description: Request modification of a page.
-labels: page edit, help wanted
+name: 📄 Let's document
+title: "Let's document: "
+description: Request creation of multiple related pages (e.g. a complicated command with multiple subcommands).
+labels: new command, help wanted, Let's document
 body:
   - type: textarea
     attributes:
       label: Command description
-      description: Describe the command you want the page(s) to be modified.
-      placeholder: Tell us about the changes in the command!
+      description: Describe the commands you want to create.
+      placeholder: Tell us about the commands!
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Command details
-      description: Describe any details related to a command.
-      placeholder: e.g. command version
   - type: input
     attributes:
       label: Documentation
@@ -34,5 +29,14 @@ body:
         - Android
         - SunOS
         - Common
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Commands
+      description: List out all the pages you want to create.
+      placeholder: |
+        - [] command1
+        - [] command2
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/page-modification-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-modification-request.yml
@@ -1,5 +1,5 @@
 name: 📄 Page modification request
-title: "page modification request: "
+title: "Page modification request: "
 description: Request modification of a page.
 labels: page edit, help wanted
 body:
@@ -23,16 +23,22 @@ body:
   - type: dropdown
     attributes:
       label: Platform
-      description: What OS does the program run on? (Select 'Common' if the program works on more than one OS)
+      description: What platform does the program run on? (Select "Common" if the program works on more than one platform)
       options:
+        - Android
+        - Common
+        - FreeBSD
         - Linux
         - macOS (OS X)
-        - Windows
-        - FreeBSD
-        - OpenBSD
         - NetBSD
-        - Android
+        - OpenBSD
         - SunOS
-        - Common
+        - Windows
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Provide additional information if the command differs between platforms.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/page-modification-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-modification-request.yml
@@ -40,5 +40,3 @@ body:
     attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/page-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-request.yml
@@ -1,6 +1,6 @@
 name: 📄 Page request
 title: "page request: "
-description: Page request template.
+description: Request creation of a page.
 labels: new command, help wanted
 body:
   - type: textarea
@@ -8,19 +8,31 @@ body:
       label: Command description
       description: Describe a command you want to be summarized.
       placeholder: Tell us about the command!
+    validations:
+      required: true
   - type: input
     attributes:
       label: Command details
       description: Describe any details related to a command.
       placeholder: e.g. command version
-  - type: checkboxes
+  - type: input
     attributes:
-      label: OS
-      description: Select which operating system(s) this command works with.
+      label: Documentation
+      description: Link to the official documentation.
+      placeholder: https://example.com
+  - type: dropdown
+    attributes:
+      label: Platform
+      description: What OS does the program run on? (Select 'Common' if the program works on more than one OS)
       options:
-        - label: Android
-        - label: Linux
-        - label: macOS (osx)
-        - label: sunOS
-        - label: Windows
-
+        - Linux
+        - macOS (OS X)
+        - Windows
+        - FreeBSD
+        - OpenBSD
+        - NetBSD
+        - Android
+        - SunOS
+        - Common
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/page-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-request.yml
@@ -40,5 +40,3 @@ body:
     attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/page-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-request.yml
@@ -23,16 +23,22 @@ body:
   - type: dropdown
     attributes:
       label: Platform
-      description: What OS does the program run on? (Select 'Common' if the program works on more than one OS)
+      description: What platform does the program run on? (Select "Common" if the program works on more than one platform)
       options:
+        - Android
+        - Common
+        - FreeBSD
         - Linux
         - macOS (OS X)
-        - Windows
-        - FreeBSD
-        - OpenBSD
         - NetBSD
-        - Android
+        - OpenBSD
         - SunOS
-        - Common
+        - Windows
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Provide additional information if the command differs between platforms.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/page-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-request.yml
@@ -1,5 +1,5 @@
 name: 📄 Page request
-title: "page request: "
+title: "Page request: "
 description: Request creation of a page.
 labels: new command, help wanted
 body:

--- a/.github/ISSUE_TEMPLATE/page-translation.yml
+++ b/.github/ISSUE_TEMPLATE/page-translation.yml
@@ -1,12 +1,12 @@
 name: 📄 Page translation request
-title: "page translation request: "
+title: "Page translation request: "
 description: Request translation of a page.
-labels: translation
+labels: translation, help wanted
 body:
   - type: textarea
     attributes:
       label: Command description
-      description: Describe a command you want to be translated.
+      description: Describe the command to get translated for your language.
       placeholder: Tell us what TLDR page you want to see in your language!
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/page-translation.yml
+++ b/.github/ISSUE_TEMPLATE/page-translation.yml
@@ -1,6 +1,6 @@
 name: 📄 Page translation request
-title: "page translation: "
-description: Page translation request template.
+title: "page translation request: "
+description: Request translation of a page.
 labels: translation
 body:
   - type: textarea
@@ -10,31 +10,3 @@ body:
       placeholder: Tell us what TLDR page you want to see in your language!
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Command details
-      description: Describe any details related to a command.
-      placeholder: e.g. command version
-  - type: dropdown
-    attributes:
-      label: OS
-      description: Select an operating system category which this command falls into.
-      multiple: false
-      options:
-        - Linux
-        - Android
-        - macOS
-        - Windows
-        - General
-        - Other
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: OS details
-      description: Describe any details related to an operating system.
-      placeholder: |
-        e.g. OS version obtained via:
-        `uname -a` for Linux
-        `sw_vers` for macOS
-        `ver` for Windows


### PR DESCRIPTION
### Changes to existing templates
- Set some fields as required
- Change OS selection from checkboxes to dropdown, because we only need to know the directory name anyway
- Add a field for documentation
- Remove most fields from the translation template, because if a page already exists we only need to know its name


#### NOTE: merge this after #11313 because this adds BSDs to the platform dropdown.