### PR TITLE
cargo-*: update page

### DIFF
--- a/pages/common/cargo-add.md
+++ b/pages/common/cargo-add.md
@@ -1,6 +1,6 @@
 # cargo add
 
-> Add dependencies to a Rust project's `Cargo.toml` file.
+> Add dependencies to a Rust project's `Cargo.toml` manifest.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-add.html>.
 
 - Add the latest version of a dependency to the current project:
@@ -21,7 +21,7 @@
 
 - Add a local crate as a dependency:
 
-`cargo add --path {{path/to/crate}}`
+`cargo add --path {{path/to/crate_directory}}`
 
 - Add a development or build dependency:
 

--- a/pages/common/cargo-bench.md
+++ b/pages/common/cargo-bench.md
@@ -7,13 +7,13 @@
 
 `cargo bench`
 
+- Don't stop when a benchmark fails:
+
+`cargo bench --no-fail-fast`
+
 - Compile, but don’t run benchmarks:
 
 `cargo bench --no-run`
-
-- Benchmark only the specified packages:
-
-`cargo bench --package {{package}}`
 
 - Benchmark the specified benchmark:
 

--- a/pages/common/cargo-doc.md
+++ b/pages/common/cargo-doc.md
@@ -1,20 +1,20 @@
 # cargo doc
 
-> Build and view Rust package documentation offline.
+> Build the documentation of Rust packages.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-doc.html>.
 
-- Build and view the default package documentation in the browser:
+- Build the documentation for the current project and all dependencies:
+
+`cargo doc`
+
+- Do not build documentation for dependencies:
+
+`cargo doc --no-deps`
+
+- Build and open the documentation in a browser:
 
 `cargo doc --open`
 
-- Build documentation without accessing the network:
-
-`cargo doc --offline`
-
-- View a particular package's documentation:
+- Build and view the documentation of a particular package:
 
 `cargo doc --open --package {{package}}`
-
-- View a particular package's documentation offline:
-
-`cargo doc --open --offline --package {{package}}`

--- a/pages/common/cargo-fetch.md
+++ b/pages/common/cargo-fetch.md
@@ -3,30 +3,10 @@
 > Fetch dependencies of a package from the network.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-fetch.html>.
 
-- Fetch dependencies from the `Cargo.lock` file:
+- Fetch dependencies specified in `Cargo.lock` (for all targets):
 
-`cargo fetch {{options}}`
+`cargo fetch`
 
-- Display verbose output:
+- Fetch dependencies for the specified target:
 
-`cargo fetch --verbose`
-
-- Do not print Cargo log messages:
-
-`cargo fetch --quiet`
-
-- Control colored output:
-
-`cargo fetch --color {{auto|always|never}}`
-
-- Path to `Cargo.toml`:
-
-`cargo fetch --manifest-path {{path}}`
-
-- Prevent Cargo from accessing the network:
-
-`cargo fetch --offline`
-
-- Display help:
-
-`cargo fetch --help`
+`cargo fetch --target {{target_triple}}`

--- a/pages/common/cargo-fix.md
+++ b/pages/common/cargo-fix.md
@@ -11,6 +11,10 @@
 
 `cargo fix --allow-dirty`
 
+- Migrate a package to the next Rust edition:
+
+`cargo fix --edition`
+
 - Fix the package’s library:
 
 `cargo fix --lib`
@@ -22,15 +26,3 @@
 - Fix all members in the workspace:
 
 `cargo fix --workspace`
-
-- Set the directory for all generated artifacts and intermediate files:
-
-`cargo fix --target-dir {{path/to/directory}}`
-
-- Restrict Cargo from access to network for any reason:
-
-`cargo fix --offline`
-
-- Run `n` jobs in parallel (default: number of logical CPUs):
-
-`cargo fix --jobs {{n}}`

--- a/pages/common/cargo-generate-lockfile.md
+++ b/pages/common/cargo-generate-lockfile.md
@@ -1,25 +1,9 @@
 # cargo generate-lockfile
 
-> Generates the `Cargo.lock` file for the current package.
+> Generate the `Cargo.lock` file for the current package. Similar to `cargo update`, but has less options.
 > If the lockfile already exists it will be rebuilt with latest version of every package.
 > More information: <https://doc.rust-lang.org/stable/cargo/commands/cargo-generate-lockfile.html>.
 
 - Generate a `Cargo.lock` file with the latest version of every package:
 
 `cargo generate-lockfile`
-
-- Specify a custom path for the `Cargo.toml` file (Note: By default the file is present in the current directory):
-
-`cargo generate-lockfile --manifest-path {{path/to/file.toml}}`
-
-- Assert that the `Cargo.lock` file is up-to-date:
-
-`cargo generate-lockfile --locked`
-
-- Prevent Cargo from attempting to access the network to determine if it out-of-date:
-
-`cargo generate-lockfile --frozen`
-
-- Prevent Cargo from accessing the network. (Note: If Cargo requires internet to proceed and network is not available, it will stop with an error):
-
-`cargo generate-lockfile --offline`

--- a/pages/common/cargo-locate-project.md
+++ b/pages/common/cargo-locate-project.md
@@ -12,10 +12,6 @@
 
 `cargo locate-project --message-format {{plain|json}}`
 
-- Print the `Cargo.toml` manifest located at the given path:
-
-`cargo locate-project --manifest-path {{path/to/Cargo.toml}}`
-
 - Print the `Cargo.toml` manifest located at the root of the workspace as opposed to the current workspace member:
 
 `cargo locate-project --workspace`

--- a/pages/common/cargo-logout.md
+++ b/pages/common/cargo-logout.md
@@ -7,30 +7,6 @@
 
 `cargo logout`
 
-- Add the name of the registry to use:
+- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
 
-`cargo logout --registry {{registry}}`
-
-- Display verbose output:
-
-`cargo logout --verbose`
-
-- Do not print Cargo log message:
-
-`cargo logout --quiet`
-
-- Control when colored output is used:
-
-`cargo logout --color {{auto|always|never}}`
-
-- Override a Cargo configuration value:
-
-`cargo logout --config {{KEY=VALUE|PATH}}`
-
-- Change the current directory before executing any specified operation:
-
-`cargo logout -c {{PATH}}`
-
-- Display help:
-
-`cargo logout --help`
+`cargo logout --registry {{name}}`

--- a/pages/common/cargo-metadata.md
+++ b/pages/common/cargo-metadata.md
@@ -1,6 +1,6 @@
 # cargo metadata
 
-> Outputs the workspace members and resolved dependencies of current package.
+> Output the workspace members and resolved dependencies of current package as JSON.
 > Note: The output format is subject to change in future versions of Cargo.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-metadata.html>.
 

--- a/pages/common/cargo-remove.md
+++ b/pages/common/cargo-remove.md
@@ -1,36 +1,16 @@
 # cargo remove
 
-> Remove dependencies from a `Cargo.toml` manifest file.
+> Remove dependencies from a Rust project's `Cargo.toml` manifest.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-remove.html>.
 
-- Remove one or more dependencies from the `Cargo.toml` manifest:
+- Remove a dependency from the current project:
 
-`cargo remove {{dependency_name}}`
+`cargo remove {{dependency}}`
 
-- Remove a build dependency:
+- Remove a development or build dependency:
 
-`cargo remove --build {{dependency_name}}`
+`cargo remove --{{dev|build}} {{dependency}}`
 
-- Remove a dependency to the given target platform:
+- Remove a dependency of the given target platform:
 
-`cargo remove --target {{target}} {dependency_name}}`
-
-- Don't actually write to the manifest:
-
-`cargo remove --dry-run {{dependency_name}}`
-
-- Display verbose output:
-
-`cargo remove --verbose {{dependency_name}}`
-
-- Do not print Cargo log message:
-
-`cargo remove --quiet {{dependency_name}}`
-
-- Specify package to remove from:
-
-`cargo remove --package {{specification}} {dependency_name}}`
-
-- Display help:
-
-`cargo remove --help`
+`cargo remove --target {{target}} {{dependency}}`

--- a/pages/common/cargo-run.md
+++ b/pages/common/cargo-run.md
@@ -1,7 +1,7 @@
 # cargo run
 
 > Run the current Cargo package.
-> Note: Set the working directory of the binary executed to the current working directory.
+> Note: the working directory of the executed binary will be set to the current working directory.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-run.html>.
 
 - Run the default binary target:
@@ -20,7 +20,7 @@
 
 `cargo run --features {{feature1 feature2 ...}}`
 
-- Disable the default feature:
+- Disable the default features:
 
 `cargo run --no-default-features`
 

--- a/pages/common/cargo-rustc.md
+++ b/pages/common/cargo-rustc.md
@@ -1,11 +1,12 @@
 # cargo rustc
 
-> Compile a Rust package, and pass extra options to the compiler.
+> Compile a Rust package. Similar to `cargo build`, but you can pass extra options to the compiler.
+> See `rustc --help` for all available options.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-rustc.html>.
 
-- Build the package or packages defined by the `Cargo.toml` manifest file in the current working directory:
+- Build the package and pass options to `rustc`:
 
-`cargo rustc`
+`cargo rustc -- {{rustc_options}}`
 
 - Build artifacts in release mode, with optimizations:
 
@@ -15,11 +16,11 @@
 
 `cargo rustc --release -- -C target-cpu=native`
 
-- Compile with speed optimization:
+- Compile with speed optimizations:
 
 `cargo rustc -- -C opt-level {{1|2|3}}`
 
-- Compile with [s]ize optimization (`z` also turns off loop vectorization):
+- Compile with [s]ize optimizations (`z` also turns off loop vectorization):
 
 `cargo rustc -- -C opt-level {{s|z}}`
 

--- a/pages/common/cargo-rustdoc.md
+++ b/pages/common/cargo-rustdoc.md
@@ -1,15 +1,20 @@
 # cargo rustdoc
 
-> Generate documentation for the Rust package.
+> Build the documentation of Rust packages.
+> Similar to `cargo doc`, but you can pass options to `rustdoc`. See `rustdoc --help` for all available options.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-rustdoc.html>.
 
-- Open the documentation in the browser:
+- Pass options to `rustdoc`:
 
-`cargo rustdoc --open`
+`cargo rustdoc -- {{rustdoc_options}}`
 
-- Specify the package to document:
+- Warn about a documentation lint:
 
-`cargo rustdoc --package {{spec}}`
+`cargo rustdoc -- --warn rustdoc::{{lint_name}}`
+
+- Ignore a documentation lint:
+
+`cargo rustdoc -- --allow rustdoc::{{lint_name}}`
 
 - Document the package's library:
 
@@ -26,7 +31,3 @@
 - Document the specified integration test:
 
 `cargo rustdoc --test {{name}}`
-
-- Display help:
-
-`cargo rustdoc --help`

--- a/pages/common/cargo-test.md
+++ b/pages/common/cargo-test.md
@@ -9,11 +9,7 @@
 
 - Set the number of simultaneous running test cases:
 
-`cargo test -- --test-threads={{count}}`
-
-- Require that `Cargo.lock` is up to date:
-
-`cargo test --locked`
+`cargo test -- --test-threads {{count}}`
 
 - Test artifacts in release mode, with optimizations:
 
@@ -23,7 +19,7 @@
 
 `cargo test --workspace`
 
-- Run tests for a package:
+- Run tests for a specific package:
 
 `cargo test --package {{package}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

A lot of the recently added `cargo` pages have some pointless examples in them. For example: specifying `--locked` (i.e do not touch the lockfile) for `cargo generate-lockfile` doesn't make sense, because the entire point of the command is to update the lockfile. Same goes for `--offline` in `cargo fetch`, which essentially tells Cargo to fetch dependencies from the network without using the network.

This PR removes those examples. I also tried to add some more useful ones.