### PR TITLE
windows/*: add PowerShell pwd and mv equivalents

### DIFF
--- a/pages/windows/get-location.md
+++ b/pages/windows/get-location.md
@@ -1,6 +1,7 @@
 # Get-Location
 
 > Print name of current/working directory.
+> This command can only be run through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
 
 - Print the current directory:

--- a/pages/windows/get-location.md
+++ b/pages/windows/get-location.md
@@ -1,0 +1,8 @@
+# Get-Location
+
+> Print name of current/working directory.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
+
+- Print the current directory:
+
+`Get-Location`

--- a/pages/windows/gl.md
+++ b/pages/windows/gl.md
@@ -1,0 +1,8 @@
+# gl
+
+> In PowerShell, this command is an alias of `Get-Location`.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
+
+- View documentation for the original command:
+
+`tldr get-location`

--- a/pages/windows/mi.md
+++ b/pages/windows/mi.md
@@ -1,0 +1,8 @@
+# mi
+
+> In PowerShell, this command is an alias of `Move-Item`.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
+
+- View documentation for the original command:
+
+`tldr move-item`

--- a/pages/windows/move-item.md
+++ b/pages/windows/move-item.md
@@ -1,0 +1,40 @@
+# Move-Item
+
+> Move or rename files and directories.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
+
+- Rename a file or directory when the target is not an existing directory:
+
+`Move-Item {{path\to\source}} {{path\to\target}}`
+
+- Move a file or directory into an existing directory:
+
+`Move-Item {{path\to\source}} {{path\to\existing_directory}}`
+
+- Rename or move file(s) with specific name (do not treat special characters inside strings):
+
+`Move-Item -LiteralPath "{{path\to\source}}" {{path\to\file_or_directory}}`
+
+- Move multiple files into an existing directory, keeping the filenames unchanged:
+
+`Move-Item {{path\to\source1 , path\to\source2 ...}} {{path\to\existing_directory}}`
+
+- Move or rename a registry key:
+
+`Move-Item {{path\to\source_key}} {{path\to\new_or_existing_key}}`
+
+- Move multiple registry keys:
+
+`Move-Item {{path\to\source_key1 , path\to\source_key1 ...}} {{path\to\new_or_existing_key}}`
+
+- Do not prompt for confirmation before overwriting existing files or registry keys:
+
+`mv -Force {{path\to\source}} {{path\to\target}}`
+
+- Prompt for confirmation before overwriting existing files, regardless of file permissions:
+
+`mv -Confirm {{path\to\source}} {{path\to\target}}`
+
+- Move files in dry-run mode, showing files and directories which could be moved without executing them:
+
+`mv -WhatIf {{path\to\source}} {{path\to\target}}`

--- a/pages/windows/move-item.md
+++ b/pages/windows/move-item.md
@@ -21,7 +21,7 @@
 
 - Move or rename registry key(s):
 
-`Move-Item {{path\to\source_key1 , path\to\source_key1 ...}} {{path\to\new_or_existing_key}}`
+`Move-Item {{path\to\source_key1 , path\to\source_key2 ...}} {{path\to\new_or_existing_key}}`
 
 - Do not prompt for confirmation before overwriting existing files or registry keys:
 

--- a/pages/windows/move-item.md
+++ b/pages/windows/move-item.md
@@ -1,6 +1,7 @@
 # Move-Item
 
-> Move or rename files and directories.
+> Move or rename files, directories, registry keys, and other PowerShell data items.
+> This command can only be run through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
 
 - Rename a file or directory when the target is not an existing directory:

--- a/pages/windows/move-item.md
+++ b/pages/windows/move-item.md
@@ -19,11 +19,7 @@
 
 `Move-Item {{path\to\source1 , path\to\source2 ...}} {{path\to\existing_directory}}`
 
-- Move or rename a registry key:
-
-`Move-Item {{path\to\source_key}} {{path\to\new_or_existing_key}}`
-
-- Move multiple registry keys:
+- Move or rename registry key(s):
 
 `Move-Item {{path\to\source_key1 , path\to\source_key1 ...}} {{path\to\new_or_existing_key}}`
 

--- a/pages/windows/move.md
+++ b/pages/windows/move.md
@@ -1,0 +1,29 @@
+# move
+
+> Move or rename files and directories.
+> In PowerShell, this command is an alias of `Move-Item`. This documentation is based on the Command Prompt (`cmd`) version of `move`.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/move>.
+
+- View documentation of the equivalent PowerShell command:
+
+`tldr move-item`
+
+- Rename a file or directory when the target is not an existing directory:
+
+`move {{path\to\source}} {{path\to\target}}`
+
+- Move a file or directory into an existing directory:
+
+`move {{path\to\source}} {{path\to\existing_directory}}`
+
+- Move a file or directory across drives:
+
+`move {{C:\path\to\source}} {{D:\path\to\target}}`
+
+- Do not prompt for confirmation before overwriting existing files:
+
+`move /Y {{path\to\source}} {{path\to\existing_directory}}`
+
+- Prompt for confirmation before overwriting existing files, regardless of file permissions:
+
+`move /-Y {{path\to\source}} {{path\to\existing_directory}}`

--- a/pages/windows/mv.md
+++ b/pages/windows/mv.md
@@ -1,0 +1,13 @@
+# mv
+
+> In PowerShell, this command is an alias of `Move-Item`.
+> However, this command is not available on the Command Prompt (`cmd`). Use `move` instead for similar functionality.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
+
+- View documentation for the equivalent Command Prompt command:
+
+`tldr move`
+
+- View documentation for the original PowerShell command:
+
+`tldr move-item`

--- a/pages/windows/pwd.md
+++ b/pages/windows/pwd.md
@@ -1,0 +1,13 @@
+# pwd
+
+> In PowerShell, this command is an alias of `Get-Location`.
+> However, this command is not available on the Command Prompt (`cmd`). Use `cd` instead for similar functionality.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
+
+- View documentation for the equivalent Command Prompt command:
+
+`tldr cd`
+
+- View documentation for the original PowerShell command:
+
+`tldr get-location`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR adds `Get-Location` and `Move-Item`, as well as their aliases: `gl`, `move`, `mi`, `mv`, and `pwd`. Additionally, the `move` documentation for Command Prompt is also added.