### PR TITLE
udevadm: correct wrong commands & one more entry

### DIFF
--- a/pages/linux/udevadm.md
+++ b/pages/linux/udevadm.md
@@ -15,9 +15,9 @@
 
 `sudo udevadm monitor --udev`
 
-- List attributes of a device:
+- List [a]ttributes of device `/dev/sda`:
 
-`sudo udevadm info --attribute-walk --path {{/dev/sda1}}`
+`sudo udevadm info -a {{/dev/sda1}}`
 
 - Reload all `udev` rules:
 
@@ -26,3 +26,7 @@
 - Trigger all `udev` rules to run:
 
 `sudo udevadm trigger`
+
+- Test an event run:
+
+`sudo udevadm test {{/dev/sda1}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Note the original 20th line `udevadm info --attribute-walk --path /dev/sda` very likely will not work, as a `/sys/` path shall follow `--path` option.
