### PR TITLE
cli53: fix missing curly brace

### DIFF
--- a/pages/common/cli53.md
+++ b/pages/common/cli53.md
@@ -25,7 +25,7 @@
 
 - Create a `www` subdomain pointing to an IP address:
 
-`cli53 {{rc|rrcreate}} {{mydomain.com} {{'www 300 A 150.130.110.1'}}`
+`cli53 {{rc|rrcreate}} {{mydomain.com}} {{'www 300 A 150.130.110.1'}}`
 
 - Replace a `www` subdomain pointing to a different IP:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
cli53 version 0.8.22