### PR TITLE
MAINTAINERS Guide: remove minimum merge wait time requirement

### DIFF
--- a/contributing-guides/maintainers-guide.md
+++ b/contributing-guides/maintainers-guide.md
@@ -58,8 +58,7 @@ for the behavior expected of tldr-pages maintainers.
 - PRs should be merged once they
   (1) **pass the automated tests** (GitHub Actions, CLA signing, etc.),
   (2) have the **review comments addressed**,
-  (3) get **approved reviews by two maintainers**, (the second maintainer can merge immediately after approving) and
-  (4) have been open for at least **24 hours** unless the changes are trivial
+  (3) get **approved reviews by two maintainers**, (the second maintainer can merge immediately after approving)
 
 - If a PR fails to get a review from a second maintainer after a few days,
   the first maintainer should ping others for review. If it still lingers around


### PR DESCRIPTION
## Changes

- Removes the 24-hour minimum merge time requirement for PRs to be open. 

----

This requirement was made initially when we had a couple of active maintainers only and didn't have things like Codeowners to review translation PRs. So as the project grows with multiple active maintainers I don't think we need this rule anymore, given that we have merged a significant portion of our PRs within 24 hours in the last year for even non-trivial additions/modifications.