### PR TITLE
pamtotiff, pbmtowbmp, pnmtotiff, pnmtotiffcmyk, tifftopnm, wbmptopbm: add pages

### DIFF
--- a/pages/common/pamtotiff.md
+++ b/pages/common/pamtotiff.md
@@ -1,0 +1,16 @@
+# pamtotiff
+
+> Convert a Netpbm image to a TIFF file.
+> More information: <https://netpbm.sourceforge.net/doc/pamtotiff.html>.
+
+- Convert a PAM image to a TIFF image:
+
+`pamtotiff {{path/to/input_file.pam}} > {{path/to/output_file.tiff}}`
+
+- Explicitly specify a compression method for the output file:
+
+`pamtotiff -{{none|packbits|lzw|g3|g4|flate|adobeflate}} {{path/to/input_file.pam}} > {{path/to/output_file.tiff}}`
+
+- Always produce a color TIFF image, even if the input image is greyscale:
+
+`pamtotiff -color {{path/to/input_file.pam}} > {{path/to/output_file.tiff}}`

--- a/pages/common/pbmtowbmp.md
+++ b/pages/common/pbmtowbmp.md
@@ -1,0 +1,8 @@
+# pbmtowbmp
+
+> Convert a PBM image to a wireless bitmap file.
+> More information: <https://netpbm.sourceforge.net/doc/pbmtowbmp.html>.
+
+- Convert a PBM image to a WBMP file:
+
+`pbmtowbmp {{path/to/input_file.pbm}} > {{path/to/output_file.wbmp}}`

--- a/pages/common/pnmtotiff.md
+++ b/pages/common/pnmtotiff.md
@@ -1,0 +1,8 @@
+# pnmtotiff
+
+> This command is superseded by `pamtotiff`.
+> More information: <https://netpbm.sourceforge.net/doc/pnmtotiff.html>.
+
+- View documentation for the current command:
+
+`tldr pamtotiff`

--- a/pages/common/pnmtotiffcmyk.md
+++ b/pages/common/pnmtotiffcmyk.md
@@ -1,0 +1,16 @@
+# pnmtotiffcmyk
+
+> Convert a Netpbm image to a CMYK encoded TIFF file.
+> More information: <https://netpbm.sourceforge.net/doc/pnmtotiffcmyk.html>.
+
+- Convert a PNM image to a CMYK encoded TIFF image:
+
+`pnmtotiffcmyk {{path/to/input_file.pnm}} > {{path/to/output_file.tiff}}`
+
+- Specify the TIFF compression method:
+
+`pnmtotiffcmyk -{{none|packbits|lzw}} {{path/to/input_file.pnm}} > {{path/to/output_file.tiff}}`
+
+- Control the fill order:
+
+`pnmtotiffcmyk -{{msb2lsb|lsb2msb}} {{path/to/input_file.pnm}} > {{path/to/output_file.tiff}}`

--- a/pages/common/tifftopnm.md
+++ b/pages/common/tifftopnm.md
@@ -1,0 +1,20 @@
+# tifftopnm
+
+> Convert a TIFF image to a PNM image.
+> More information: <https://netpbm.sourceforge.net/doc/tifftopnm.html>.
+
+- Convert a TIFF file to a PNM file:
+
+`tifftopnm {{path/to/input_file.tiff}} > {{path/to/output_file.pnm}}`
+
+- Create a PGM file containing the alpha channel of the input image:
+
+`tifftopnm -alphaout {{path/to/alpha_file.pgm}} {{path/to/input_file.tiff}} > {{path/to/output_file.pnm}}`
+
+- Respect the `fillorder` tag in the input TIFF image:
+
+`tifftopnm -respectfillorder {{path/to/input_file.tiff}} > {{path/to/output_file.pnm}}`
+
+- Print TIFF header information to `stderr`:
+
+`tifftopnm -headerdump {{path/to/input_file.tiff}} > {{path/to/output_file.pnm}}`

--- a/pages/common/wbmptopbm.md
+++ b/pages/common/wbmptopbm.md
@@ -1,0 +1,8 @@
+# wbmptopbm
+
+> Convert a wireless bitmap file to a PBM image.
+> More information: <https://netpbm.sourceforge.net/doc/wbmptopbm.html>.
+
+- Convert a WBMP file to a PBM image:
+
+`wbmptopbm {{path/to/input_file.wbpm}} > {{path/to/output_file.pbm}}`


### PR DESCRIPTION

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
