### PR TITLE
powershell, pwsh, windows/*: fix PowerShell conventions

### DIFF
--- a/pages.ar/windows/sls.md
+++ b/pages.ar/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> هذا الأمر هو اسم مستعار لـ `where-object`.
+> هذا الأمر هو اسم مستعار لـ `Select-String`.
 > لمزيد من التفاصيل: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - إعرض التوثيقات للأمر الأصلي:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.bs/windows/sls.md
+++ b/pages.bs/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Ova komanda je pseudonim za `where-object`.
+> Ova komanda je pseudonim za `Select-String`.
 > Više informacija: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Pogledaj dokumentaciju za izvornu komandu:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ca/windows/sls.md
+++ b/pages.ca/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Aquest comandament és un àlies de `where-object`.
+> Aquest comandament és un àlies de `Select-String`.
 > Més informació: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Veure documentació pel comandament original:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.da/windows/sls.md
+++ b/pages.da/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Denne kommando er et alias af `where-object`.
+> Denne kommando er et alias af `Select-String`.
 > Mere information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Se dokumentation for den oprindelige kommando:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.de/windows/sls.md
+++ b/pages.de/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Dieser Befehl ist ein Alias von `where-object`.
+> Dieser Befehl ist ein Alias von `Select-String`.
 > Weitere Informationen: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.es/windows/sls.md
+++ b/pages.es/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Este comando es un alias de `where-object`.
+> Este comando es un alias de `Select-String`.
 > Más información: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Ver documentación para el comando original:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.fr/windows/sls.md
+++ b/pages.fr/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Cette commande est un alias de `where-object`.
+> Cette commande est un alias de `Select-String`.
 > Plus d'informations : <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Voir la documentation de la commande originale :
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.hi/windows/add-appxpackage.md
+++ b/pages.hi/windows/add-appxpackage.md
@@ -1,20 +1,20 @@
-# add-appxpackage
+# Add-AppxPackage
 
 > उपयोगकर्ता खाते में एक हस्ताक्षरित ऐप पैकेज (`.appx`, `.msix`, `.appxbundle` और `.msixbundle`) जोड़ने के लिए एक PowerShell उपयोगिता।
-> अधिक जानकारी: <https://learn.microsoft.com/powershell/module/appx/add-appxpackage>।
+> अधिक जानकारी: <https://learn.microsoft.com/powershell/module/appx/Add-AppxPackage>।
 
 - एक ऐप पैकेज जोड़ें:
 
-`add-appxpackage -Path {{पैकेज.msix\का\पथ}}`
+`Add-AppxPackage -Path {{पैकेज.msix\का\पथ}}`
 
 - निर्भरता के साथ एक ऐप पैकेज जोड़ें:
 
-`add-appxpackage -Path {{पैकेज.msix\का\पथ}} -DependencyPath {{निर्भरता.msix\का\पथ}}`
+`Add-AppxPackage -Path {{पैकेज.msix\का\पथ}} -DependencyPath {{निर्भरता.msix\का\पथ}}`
 
 - ऐप इंस्टॉलर फ़ाइल का उपयोग करके एक ऐप इंस्टॉल करें:
 
-`add-appxpackage -AppInstallerFile {{ऐप_इंस्टॉलर.msix\का\पथ}}`
+`Add-AppxPackage -AppInstallerFile {{ऐप_इंस्टॉलर.msix\का\पथ}}`
 
 - एक अहस्ताक्षरित पैकेज जोड़ें:
 
-`add-appxpackage -Path {{पैकेज.msix\का\पथ}} -DependencyPath {{निर्भरता.msix\का\पथ}} -AllowUnsigned`
+`Add-AppxPackage -Path {{पैकेज.msix\का\पथ}} -DependencyPath {{निर्भरता.msix\का\पथ}} -AllowUnsigned`

--- a/pages.hi/windows/sls.md
+++ b/pages.hi/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> यह आदेश `where-object` का उपनाम है।
+> यह आदेश `Select-String` का उपनाम है।
 > अधिक जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>।
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.id/windows/sls.md
+++ b/pages.id/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Perintah ini merupakan alias dari `where-object`.
+> Perintah ini merupakan alias dari `Select-String`.
 > Informasi lebih lanjut: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Menampilkan dokumentasi untuk perintah asli:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.it/windows/sls.md
+++ b/pages.it/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Questo comando è un alias per `where-object`.
+> Questo comando è un alias per `Select-String`.
 > Maggiori informazioni: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Consulta la documentazione del comando originale:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ja/windows/sls.md
+++ b/pages.ja/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> このコマンドは `where-object` のエイリアスです。
+> このコマンドは `Select-String` のエイリアスです。
 > 詳しくはこちら: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>
 
 - オリジナルのコマンドのドキュメントを表示する:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ko/windows/sls.md
+++ b/pages.ko/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> 이 명령은 `where-object` 의 에일리어스 (별칭) 입니다.
+> 이 명령은 `Select-String` 의 에일리어스 (별칭) 입니다.
 > 더 많은 정보: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.lo/windows/sls.md
+++ b/pages.lo/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> ຄຳສັ່ງນີ້ເປັນອີກຊື່ໜຶ່ງຂອງຄຳສັ່ງ `where-object`.
+> ຄຳສັ່ງນີ້ເປັນອີກຊື່ໜຶ່ງຂອງຄຳສັ່ງ `Select-String`.
 > ຂໍ້ມູນເພີ່ມເຕີມ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ml/windows/sls.md
+++ b/pages.ml/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> ഈ കമാൻഡ് `where-object` എന്നത്തിന്റെ അപരനാമമാണ്.
+> ഈ കമാൻഡ് `Select-String` എന്നത്തിന്റെ അപരനാമമാണ്.
 > കൂടുതൽ വിവരങ്ങൾ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ne/windows/sls.md
+++ b/pages.ne/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> यो आदेश `where-object` को उपनाम हो |
+> यो आदेश `Select-String` को उपनाम हो |
 > थप जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>।
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.nl/windows/remove-item.md
+++ b/pages.nl/windows/remove-item.md
@@ -6,24 +6,24 @@
 
 - Verwijder specifieke bestanden of registersleutels (zonder subkeys):
 
-`Remove-Item {{pad\naar\bestand_of_key1 pad\naar\bestand_of_key2 ...}}`
+`Remove-Item {{pad\naar\bestand_of_key1 , pad\naar\bestand_of_key2 ...}}`
 
 - Verwijder verborgen of alleen-lezen bestanden:
 
-`Remove-Item -Force {{pad\naar\bestand1 pad\naar\bestand2 ...}}`
+`Remove-Item -Force {{pad\naar\bestand1 , pad\naar\bestand2 ...}}`
 
 - Verwijder specifieke bestanden of registersleutels interactief gevraagd vóór elke verwijdering:
 
-`Remove-Item -Confirm {{pad\naar\bestand_of_key1 pad\naar\bestand_of_key2 ...}}`
+`Remove-Item -Confirm {{pad\naar\bestand_of_key1 , pad\naar\bestand_of_key2 ...}}`
 
 - Verwijder specifieke bestanden en mappen recursief (Windows 10 versie 1909 of hoger):
 
-`Remove-Item -Recurse {{pad\naar\bestand_of_map1 pad\naar\bestand_of_map2 ...}}`
+`Remove-Item -Recurse {{pad\naar\bestand_of_map1 , pad\naar\bestand_of_map2 ...}}`
 
 - Verwijder specifieke Windows-registersleutels en al zijn subkeys:
 
-`Remove-Item -Recurse {{pad\naar\key1 pad\naar\key2 ...}}`
+`Remove-Item -Recurse {{pad\naar\key1 , pad\naar\key2 ...}}`
 
 - Voer een dry-run van het verwijderproces uit:
 
-`Remove-Item -WhatIf {{pad\naar\bestand1 pad\naar\bestand2 ...}}`
+`Remove-Item -WhatIf {{pad\naar\bestand1 , pad\naar\bestand2 ...}}`

--- a/pages.nl/windows/sls.md
+++ b/pages.nl/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Dit commando is een alias van `where-object`.
+> Dit commando is een alias van `Select-String`.
 > Meer informatie: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.no/windows/sls.md
+++ b/pages.no/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Denne kommandoen er et alias for `where-object`.
+> Denne kommandoen er et alias for `Select-String`.
 > Mer informasjon: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Vis dokumentasjonen for den opprinnelige kommandoen:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.pl/windows/sls.md
+++ b/pages.pl/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> To polecenie jest aliasem `where-object`.
+> To polecenie jest aliasem `Select-String`.
 > Więcej informacji: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.pt_BR/windows/sls.md
+++ b/pages.pt_BR/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Este comando é um pseudônimo de `where-object`.
+> Este comando é um pseudônimo de `Select-String`.
 > Mais informações: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Ver documentação sobre o comando original:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.pt_PT/windows/sls.md
+++ b/pages.pt_PT/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Este comando é um alias de `where-object`.
+> Este comando é um alias de `Select-String`.
 > Mais informações: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Ver documentação do comando original:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ru/windows/sls.md
+++ b/pages.ru/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Эта команда — псевдоним для `where-object`.
+> Эта команда — псевдоним для `Select-String`.
 > Больше информации: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Смотри документацию для оригинальной команды:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.sv/windows/sls.md
+++ b/pages.sv/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Det här kommandot är ett alias för `where-object`.
+> Det här kommandot är ett alias för `Select-String`.
 > Mer information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Se dokumentationen för orginalkommandot:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.ta/windows/sls.md
+++ b/pages.ta/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> இக்கட்டளை `where-object` கட்டளையின் மற்றொருப் பெயர்.
+> இக்கட்டளை `Select-String` கட்டளையின் மற்றொருப் பெயர்.
 > மேலும் விவரத்திற்கு: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - அக்கட்டளையின் விளக்கத்தைக் காண:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.th/windows/sls.md
+++ b/pages.th/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `where-object`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `Select-String`
 > ข้อมูลเพิ่มเติม: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.tr/windows/sls.md
+++ b/pages.tr/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Bu komut `where-object` için bir takma addır.
+> Bu komut `Select-String` için bir takma addır.
 > Daha fazla bilgi için: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.uk/windows/sls.md
+++ b/pages.uk/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> Ця команда є псевдонімом для `where-object`.
+> Ця команда є псевдонімом для `Select-String`.
 > Більше інформації: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Дивись документацію для оригінальної команди:
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.zh/windows/sls.md
+++ b/pages.zh/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> 这是 `where-object` 命令的一个别名。
+> 这是 `Select-String` 命令的一个别名。
 > 更多信息：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - 原命令的文档在：
 
-`tldr where-object`
+`tldr select-string`

--- a/pages.zh_TW/windows/sls.md
+++ b/pages.zh_TW/windows/sls.md
@@ -1,8 +1,8 @@
 # sls
 
-> 這是 `where-object` 命令的一個別名。
+> 這是 `Select-String` 命令的一個別名。
 > 更多資訊：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - 原命令的文件在：
 
-`tldr where-object`
+`tldr select-string`

--- a/pages/common/powershell.md
+++ b/pages/common/powershell.md
@@ -1,37 +1,17 @@
 # powershell
 
-> Command-line shell and scripting language designed especially for system administration.
-> See also: `pwsh`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/powershell>.
+> This command may be mistaken as the cross-platform version of PowerShell (formerly known as PowerShell Core), which uses `pwsh` instead of `powershell`.
+> The original `powershell` command in Windows is still available to use the legacy Windows version of PowerShell (version 5.1 and below).
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh>.
 
-- Start an interactive shell session:
+- View the documentation for the command referring to the latest, cross-platform version of PowerShell (version 6 and above):
 
-`powershell`
+`tldr pwsh`
 
-- Start an interactive shell session without loading startup configs:
+- View the documentation for the command referring to the legacy Windows PowerShell (version 5.1 and below):
 
-`powershell -NoProfile`
+`tldr powershell -p windows`
 
-- Execute specific commands:
+- View the documentation for the command referring to the legacy Windows PowerShell in older versions of `tldr` command-line client:
 
-`powershell -Command "{{echo 'powershell is executed'}}"`
-
-- Execute a specific script:
-
-`powershell -File {{path/to/script.ps1}}`
-
-- Start a session with a specific version of PowerShell:
-
-`powershell -Version {{version}}`
-
-- Prevent a shell from exit after running startup commands:
-
-`powershell -NoExit`
-
-- Describe the format of data sent to PowerShell:
-
-`powershell -InputFormat {{Text|XML}}`
-
-- Determine how an output from PowerShell is formatted:
-
-`powershell -OutputFormat {{Text|XML}}`
+`tldr powershell -o windows`

--- a/pages/common/pwsh.md
+++ b/pages/common/pwsh.md
@@ -1,7 +1,37 @@
 # pwsh
 
-> This command is an alias of `powershell`.
+> Command-line shell and scripting language designed especially for system administration.
+> This command refers to PowerShell version 6 and above (also known as PowerShell Core and cross-platform PowerShell). To use the original Windows version (5.1 and below, also known as the legacy Windows PowerShell), use `powershell` instead of `pwsh`.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh>.
 
-- View documentation for the original command:
+- Start an interactive shell session:
 
-`tldr powershell`
+`pwsh`
+
+- Start an interactive shell session without loading startup configs:
+
+`pwsh -NoProfile`
+
+- Execute specific commands:
+
+`pwsh -Command "{{echo 'powershell is executed'}}"`
+
+- Execute a specific script:
+
+`pwsh -File {{path/to/script.ps1}}`
+
+- Start a session with a specific version of PowerShell:
+
+`pwsh -Version {{version}}`
+
+- Prevent a shell from exit after running startup commands:
+
+`pwsh -NoExit`
+
+- Describe the format of data sent to PowerShell:
+
+`pwsh -InputFormat {{Text|XML}}`
+
+- Determine how an output from PowerShell is formatted:
+
+`pwsh -OutputFormat {{Text|XML}}`

--- a/pages/windows/add-appxpackage.md
+++ b/pages/windows/add-appxpackage.md
@@ -1,20 +1,20 @@
-# add-appxpackage
+# Add-AppxPackage
 
 > A PowerShell utility to add a signed app package (`.appx`, `.msix`, `.appxbundle` and `.msixbundle`) to a user account.
-> More information: <https://learn.microsoft.com/powershell/module/appx/add-appxpackage>.
+> More information: <https://learn.microsoft.com/powershell/module/appx/Add-AppxPackage>.
 
 - Add an app package:
 
-`add-appxpackage -Path {{path\to\package.msix}}`
+`Add-AppxPackage -Path {{path\to\package.msix}}`
 
 - Add an app package with dependencies:
 
-`add-appxpackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}}`
+`Add-AppxPackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}}`
 
 - Install an app using the app installer file:
 
-`add-appxpackage -AppInstallerFile {{path\to\app.appinstaller}}`
+`Add-AppxPackage -AppInstallerFile {{path\to\app.appinstaller}}`
 
 - Add an unsigned package:
 
-`add-appxpackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}} -AllowUnsigned`
+`Add-AppxPackage -Path {{path\to\package.msix}} -DependencyPath {{path\to\dependencies.msix}} -AllowUnsigned`

--- a/pages/windows/powershell.md
+++ b/pages/windows/powershell.md
@@ -1,0 +1,37 @@
+# powershell
+
+> Command-line shell and scripting language designed especially for system administration.
+> This command refers to PowerShell version 5.1 and below (also known as the legacy Windows PowerShell). To use the newer, cross-platform version of PowerShell (also known as PowerShell Core), use `pwsh` instead of `powershell`.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/powershell>.
+
+- Start an interactive shell session:
+
+`powershell`
+
+- Start an interactive shell session without loading startup configs:
+
+`powershell -NoProfile`
+
+- Execute specific commands:
+
+`powershell -Command "{{echo 'powershell is executed'}}"`
+
+- Execute a specific script:
+
+`powershell -File {{path/to/script.ps1}}`
+
+- Start a session with a specific version of PowerShell:
+
+`powershell -Version {{version}}`
+
+- Prevent a shell from exit after running startup commands:
+
+`powershell -NoExit`
+
+- Describe the format of data sent to PowerShell:
+
+`powershell -InputFormat {{Text|XML}}`
+
+- Determine how an output from PowerShell is formatted:
+
+`powershell -OutputFormat {{Text|XML}}`

--- a/pages/windows/remove-appxpackage.md
+++ b/pages/windows/remove-appxpackage.md
@@ -1,20 +1,20 @@
-# remove-appxpackage
+# Remove-AppxPackage
 
 > A PowerShell utility to remove an app package from one or more user accounts.
-> More information: <https://learn.microsoft.com/powershell/module/appx/remove-appxpackage>.
+> More information: <https://learn.microsoft.com/powershell/module/appx/Remove-AppxPackage>.
 
 - Remove an app package:
 
-`remove-appxpackage {{package}}`
+`Remove-AppxPackage {{package}}`
 
 - Remove an app package for a specific user:
 
-`remove-appxpackage {{package}} -User {{username}}`
+`Remove-AppxPackage {{package}} -User {{username}}`
 
 - Remove an app package for all users:
 
-`remove-appxpackage {{package}} -AllUsers`
+`Remove-AppxPackage {{package}} -AllUsers`
 
 - Remove an app package but preserve it's app data:
 
-`remove-appxpackage {{package}} -PreserveApplicationData`
+`Remove-AppxPackage {{package}} -PreserveApplicationData`

--- a/pages/windows/remove-item.md
+++ b/pages/windows/remove-item.md
@@ -6,24 +6,24 @@
 
 - Remove specific files or registry keys (without subkeys):
 
-`Remove-Item {{path\to\file_or_key1 path\to\file_or_key2 ...}}`
+`Remove-Item {{path\to\file_or_key1 , path\to\file_or_key2 ...}}`
 
 - Remove hidden or read-only files:
 
-`Remove-Item -Force {{path\to\file1 path\to\file2 ...}}`
+`Remove-Item -Force {{path\to\file1 , path\to\file2 ...}}`
 
 - Remove specific files or registry keys interactively prompting before each removal:
 
-`Remove-Item -Confirm {{path\to\file_or_key1 path\to\file_or_key2 ...}}`
+`Remove-Item -Confirm {{path\to\file_or_key1 , path\to\file_or_key2 ...}}`
 
 - Remove specific files and directories recursively (Windows 10 version 1909 or later):
 
-`Remove-Item -Recurse {{path\to\file_or_directory1 path\to\file_or_directory2 ...}}`
+`Remove-Item -Recurse {{path\to\file_or_directory1 , path\to\file_or_directory2 ...}}`
 
 - Remove specific Windows registry keys and all its subkeys:
 
-`Remove-Item -Recurse {{path\to\key1 path\to\key2 ...}}`
+`Remove-Item -Recurse {{path\to\key1 , path\to\key2 ...}}`
 
 - Perform a dry run of the deletion process:
 
-`Remove-Item -WhatIf {{path\to\file1 path\to\file2 ...}}`
+`Remove-Item -WhatIf {{path\to\file1 , path\to\file2 ...}}`

--- a/pages/windows/sls.md
+++ b/pages/windows/sls.md
@@ -5,4 +5,4 @@
 
 - View documentation for the original command:
 
-`tldr where-object`
+`tldr select-string`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR fixes the following PowerShell command documentation to match the current PowerShell conventions.

+ **Add-AppxPackage:** Use the original naming format (`Add-AppxPackage` instead of `add-appxpackage`), see similar naming concerns for [slmgr / slmgr.vbs](https://github.com/tldr-pages/tldr/pull/8201)
+ **Delete-Item:** Use commas for separating multiple files and directories, see discussion from https://github.com/tldr-pages/tldr/pull/11342#discussion_r1377320108
+ **powershell, pwsh:** Clarify the documentation that `powershell` refers to the original Windows version of PowerShell (version 5.1 and below), while `pwsh` refers to the PowerShell version 6 and above (formerly known as PowerShell Core, now known as "cross-platform PowerShell"); reverting changes on #7984 and #11264; see also https://stackoverflow.com/questions/60124810/what-is-the-difference-between-pwsh-and-powershell-integrated-console-on-vs#60132705
+ **Remove-AppxPackage:** Use the original naming format (`Remove-AppxPackage` instead of `remove-appxpackage`), see similar naming concerns for [slmgr / slmgr.vbs](https://github.com/tldr-pages/tldr/pull/8201)
+ **sls:** Fixed mistakes that this is an alias to `Where-Object`. The command is supposed to be an alias of `Select-String`.
