### PR TITLE
CI/codespell: ignore subfolders

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -24,6 +24,6 @@ jobs:
           # Exit with 0 regardless of typos.
           only_warn: 1
           # Skip non-English pages
-          skip: pages.*/*.md
+          skip: pages.*/*/*.md
           # Only check files in the PR
           path: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
In addition to #11430, forgot to include the platform-subfolders in the glob.