### PR TITLE
ac, afconvert, airshare: fix French typo

### DIFF
--- a/pages.fr/common/ac.md
+++ b/pages.fr/common/ac.md
@@ -1,7 +1,7 @@
 # ac
 
 > Imprime les statistiques sur combien de temps les utilisateurs ont été connectés
-> Plus d'information: <https://man.openbsd.org/ac>.
+> Plus d'informations: <https://man.openbsd.org/ac>.
 
 - Imprime combien de temps l'utilisateur actuel a été connecté en heures:
 

--- a/pages.fr/common/afconvert.md
+++ b/pages.fr/common/afconvert.md
@@ -1,7 +1,7 @@
 # afconvert
 
 > Convertir entre les formats de fichiers AFF et brut.
-> Plus d'information: <https://manned.org/afconvert.1>.
+> Plus d'informations: <https://manned.org/afconvert.1>.
 
 - Utiliser une extension spécifique (par défaut: `aff`):
 

--- a/pages.fr/common/airshare.md
+++ b/pages.fr/common/airshare.md
@@ -1,7 +1,7 @@
 # airshare
 
 > Transférer des données entre deux machines dans un réseau local.
-> Plus d'information: <https://airshare.rtfd.io/en/latest/cli.html>.
+> Plus d'informations: <https://airshare.rtfd.io/en/latest/cli.html>.
 
 - Partager des fichiers ou des dossiers:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
