### PR TITLE
swaybg: add page

### DIFF
--- a/pages/linux/swaybg.md
+++ b/pages/linux/swaybg.md
@@ -5,11 +5,11 @@
 
 - Set an image as wallpaper:
 
-`swaybg -i "{{path/to/image}}"`
+`swaybg -i {{path/to/image}}`
 
 - Set the wallpaper mode:
 
-`swaybg -i "{{path/to/image}}" -m {{stretch | fit | fill | center | tile | solid_color}}`
+`swaybg -i {{path/to/image}} -m {{stretch|fit|fill|center|tile|solid_color}}`
 
 - Set a static color as a wallpaper:
 

--- a/pages/linux/swaybg.md
+++ b/pages/linux/swaybg.md
@@ -1,0 +1,16 @@
+# swaybg
+
+> Wallpaper tool for Wayland compositors.
+> More information: <https://github.com/swaywm/swaybg>.
+
+- Set an image as wallpaper:
+
+`swaybg -i "{{path/to/image}}"`
+
+- Set the wallpaper mode:
+
+`swaybg -i "{{path/to/image}}" -m {{stretch | fit | fill | center | tile | solid_color}}`
+
+- Set a static color as a wallpaper:
+
+`swaybg -c {{"#rrggbb"}}`

--- a/pages/linux/swaybg.md
+++ b/pages/linux/swaybg.md
@@ -3,14 +3,14 @@
 > Wallpaper tool for Wayland compositors.
 > More information: <https://github.com/swaywm/swaybg>.
 
-- Set an image as wallpaper:
+- Set an [i]mage as wallpaper:
 
-`swaybg -i {{path/to/image}}`
+`swaybg --image {{path/to/image}}`
 
-- Set the wallpaper mode:
+- Set the wallpaper [m]ode:
 
-`swaybg -i {{path/to/image}} -m {{stretch|fit|fill|center|tile|solid_color}}`
+`swaybg --image {{path/to/image}} --mode {{stretch|fit|fill|center|tile|solid_color}}`
 
-- Set a static color as a wallpaper:
+- Set a static [c]olor as a wallpaper:
 
-`swaybg -c {{"#rrggbb"}}`
+`swaybg --color {{"#rrggbb"}}`

--- a/pages/linux/swaybg.md
+++ b/pages/linux/swaybg.md
@@ -1,9 +1,9 @@
 # swaybg
 
 > Wallpaper tool for Wayland compositors.
-> More information: <https://github.com/swaywm/swaybg>.
+> More information: <https://github.com/swaywm/swaybg/blob/master/swaybg.1.scd>.
 
-- Set an [i]mage as wallpaper:
+- Set the wallpaper to an [i]mage:
 
 `swaybg --image {{path/to/image}}`
 
@@ -11,6 +11,6 @@
 
 `swaybg --image {{path/to/image}} --mode {{stretch|fit|fill|center|tile|solid_color}}`
 
-- Set a static [c]olor as a wallpaper:
+- Set the wallpaper to a static [c]olor:
 
 `swaybg --color {{"#rrggbb"}}`


### PR DESCRIPTION

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

 swaybg version 1.2.0
