### PR TITLE
test: skip symlinked English folder and optimise the script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,19 +61,20 @@ function run_flake8 {
 function run_tests {
   find pages* -name '*.md' -exec markdownlint {} +
   tldr-lint ./pages
-  for dir in ./pages*/; do
-    echo "Running on $dir"
-    if [[ ! -d $dir || -L $dir ]]; then
+  for f in ./pages*; do
+    echo "Running on $f"
+    if [[ -L $f ]]; then
+        echo "skipping symlinked $f"
         continue
     fi
     
     checks="TLDR003,TLDR004,TLDR015,TLDR104"
-    if [[ $dir == *zh* || $dir == *zh_TW* ]]; then
+    if [[ $f == *zh* || $f == *zh_TW* ]]; then
         checks+=",TLDR005"
     fi
     
-    echo "executing 'tldr-lint --ignore $checks' on $dir"
-    tldr-lint --ignore $checks "${dir}"
+    echo "executing 'tldr-lint --ignore $checks' on $f"
+    tldr-lint --ignore $checks "${f}"
   done
   run_black
   run_flake8

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,12 +61,19 @@ function run_flake8 {
 function run_tests {
   find pages* -name '*.md' -exec markdownlint {} +
   tldr-lint ./pages
-  for f in ./pages.*; do
-    if [[ $f == *zh* || $f == *zh_TW* ]]; then
-      tldr-lint --ignore "TLDR003,TLDR004,TLDR005,TLDR015,TLDR104" "${f}"
-    else
-      tldr-lint --ignore "TLDR003,TLDR004,TLDR015,TLDR104" "${f}"
+  for dir in ./pages*/; do
+    echo "Running on $dir"
+    if [[ ! -dir $dir || -L $dir ]]; then
+        continue
     fi
+    
+    checks="TLDR003,TLDR004,TLDR104"
+    if [[ $dir == *zh* || $dir == *zh_TW* ]]; then
+        options+=",TLDR015"
+    fi
+    
+    echo "executing 'tldr-lint --ignore $options' on $dir"
+    tldr-lint --ignore $options "${dir}"
   done
   run_black
   run_flake8

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -62,18 +62,12 @@ function run_tests {
   find pages* -name '*.md' -exec markdownlint {} +
   tldr-lint ./pages
   for f in ./pages.*; do
-    echo "Running on $f"
-    if [[ -L $f ]]; then
-        echo "skipping symlinked $f"
-        continue
-    fi
-    
     checks="TLDR003,TLDR004,TLDR015,TLDR104"
-    if [[ $f == *zh* || $f == *zh_TW* ]]; then
+    if [[ -L $f ]]; then
+        continue
+    elif [[ $f == *zh* || $f == *zh_TW* ]]; then
         checks+=",TLDR005"
     fi
-    
-    echo "executing 'tldr-lint --ignore $checks' on $f"
     tldr-lint --ignore $checks "${f}"
   done
   run_black

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -67,9 +67,9 @@ function run_tests {
         continue
     fi
     
-    checks="TLDR003,TLDR004,TLDR104"
+    checks="TLDR003,TLDR004,TLDR015TLDR104"
     if [[ $dir == *zh* || $dir == *zh_TW* ]]; then
-        checks+=",TLDR015"
+        checks+=",TLDR005"
     fi
     
     echo "executing 'tldr-lint --ignore $checks' on $dir"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -69,11 +69,11 @@ function run_tests {
     
     checks="TLDR003,TLDR004,TLDR104"
     if [[ $dir == *zh* || $dir == *zh_TW* ]]; then
-        options+=",TLDR015"
+        checks+=",TLDR015"
     fi
     
-    echo "executing 'tldr-lint --ignore $options' on $dir"
-    tldr-lint --ignore $options "${dir}"
+    echo "executing 'tldr-lint --ignore $checks' on $dir"
+    tldr-lint --ignore $checks "${dir}"
   done
   run_black
   run_flake8

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -67,7 +67,7 @@ function run_tests {
         continue
     fi
     
-    checks="TLDR003,TLDR004,TLDR015TLDR104"
+    checks="TLDR003,TLDR004,TLDR015,TLDR104"
     if [[ $dir == *zh* || $dir == *zh_TW* ]]; then
         checks+=",TLDR005"
     fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,7 +61,7 @@ function run_flake8 {
 function run_tests {
   find pages* -name '*.md' -exec markdownlint {} +
   tldr-lint ./pages
-  for f in ./pages*; do
+  for f in ./pages.*; do
     echo "Running on $f"
     if [[ -L $f ]]; then
         echo "skipping symlinked $f"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -63,7 +63,7 @@ function run_tests {
   tldr-lint ./pages
   for dir in ./pages*/; do
     echo "Running on $dir"
-    if [[ ! -dir $dir || -L $dir ]]; then
+    if [[ ! -d $dir || -L $dir ]]; then
         continue
     fi
     


### PR DESCRIPTION
The reason for this PR are PR's which introduce/edit English pages. The tldr-lint runs on `./pages` and on `./ pages.en`. `./pages.en` is the symlinked version of `./pages`. This PR will fix this.

Ref: https://github.com/tldr-pages/tldr/pull/11535#issuecomment-1817189589