### PR TITLE
keepassxc-cli: replace invalid `lookup` command with `search`

### DIFF
--- a/pages/common/keepassxc-cli.md
+++ b/pages/common/keepassxc-cli.md
@@ -5,7 +5,7 @@
 
 - Search entries:
 
-`keepassxc-cli lookup {{path/to/database_file}} {{name}}`
+`keepassxc-cli search {{path/to/database_file}} {{name}}`
 
 - List the contents of a folder:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
