### PR TITLE
journalctl: add "logs from last unit start" example

### DIFF
--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -34,3 +34,7 @@
 - Show all messages by a specific executable:
 
 `journalctl {{path/to/executable}}`
+
+- Show logs from last unit start:
+
+`journalctl _SYSTEMD_INVOCATION_ID=$(systemctl show --value --property=InvocationID {{unit}})`


### PR DESCRIPTION
I find it very useful

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
