### PR TITLE
systemd-id128: fix typo; systemd-cryptenroll: update page

### DIFF
--- a/pages/linux/systemd-cryptenroll.md
+++ b/pages/linux/systemd-cryptenroll.md
@@ -1,37 +1,37 @@
 # systemd-cryptenroll
 
-> Interactively enroll or remove methods used to unlock LUKS2-encrypted partitions/block devices.
-> In order to allow a partition to be unlocked during system boot using something other than a Password, also update the crypttab file and initramfs.
+> Interactively enroll or remove methods used to unlock LUKS2-encrypted devices. Uses a password to unlock the device unless otherwise specified.
+> In order to allow a partition to be unlocked during system boot, update the `/etc/crypttab` file or the initramfs.
 > More information: <https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html>.
 
-- Unlock using Password, and enroll a new/additional Password:
+- Enroll a new password (similar to `cryptsetup luksAddKey`):
 
 `systemd-cryptenroll --password {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and enroll a new/additional Recovery Key:
+- Enroll a new recovery key (i.e. a randomly generated passphrase that can be used as a fallback):
 
 `systemd-cryptenroll --recovery-key {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and list available or enroll a new/additional PKCS#11 Token:
+- List available tokens, or enroll a new PKCS#11 token:
 
-`systemd-cryptenroll --pkcs11-token-uri={{list|auto|pkcs11_token_uri}} {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --pkcs11-token-uri {{list|auto|pkcs11_token_uri}} {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and list available or enroll a new FIDO2-Device (using PIN and Presence/Touch if available):
+- List available FIDO2 devices, or enroll a new FIDO2 device (`auto` can be used as the device name when there is only one token plugged in):
 
-`systemd-cryptenroll --fido2-device={{list|auto|path/to/fido2_hidraw_device}} {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --fido2-device {{list|auto|path/to/fido2_hidraw_device}} {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and enroll a new FIDO2-Device with User Verification (Biometrics):
+- Enroll a new FIDO2 device with user verification (biometrics):
 
-`systemd-cryptenroll --fido2-device={{auto|path/to/fido2_hidraw_device}} --fido2-with-user-verification=yes {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --fido2-device {{auto|path/to/fido2_hidraw_device}} --fido2-with-user-verification yes {{path/to/luks2_block_device}}`
 
-- Unlock using a FIDO2-Device, and enroll a new FIDO2-Device:
+- Unlock using a FIDO2 device, and enroll a new FIDO2 device:
 
-`systemd-cryptenroll --unlock-fido2-device={{path/to/fido2_hidraw_unlock_device}} --fido2-device={{path/to/fido2_hidraw_enroll_device}} {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --unlock-fido2-device {{path/to/fido2_hidraw_unlock_device}} --fido2-device {{path/to/fido2_hidraw_enroll_device}} {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and enroll a TPM2 Security Chip (only secure-boot-policy PCR) and require additional alphanumeric PIN:
+- Enroll a TPM2 security chip (only secure-boot-policy PCR) and require an additional alphanumeric PIN:
 
-`systemd-cryptenroll --tpm2-device={{auto|path/to/tpm2_block_device}} --tpm2-with-pin=yes {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --tpm2-device {{auto|path/to/tpm2_block_device}} --tpm2-with-pin yes {{path/to/luks2_block_device}}`
 
-- Unlock using Password, and remove all empty Passwords/all Passwords/all FIDO2-Devices/all PKCS#11 Tokens/all TMP2 Security Chips/all Recovery-Keys/all Methods:
+- Remove all empty passwords/all passwords/all FIDO2 devices/all PKCS#11 tokens/all TPM2 security chips/all recovery keys/all methods:
 
-`systemd-cryptenroll --wipe-slots={{empty|password|fido2|pkcs#11|tpm2|recovery|all}} {{path/to/luks2_block_device}}`
+`systemd-cryptenroll --wipe-slot {{empty|password|fido2|pkcs#11|tpm2|recovery|all}} {{path/to/luks2_block_device}}`

--- a/pages/linux/systemd-id128.md
+++ b/pages/linux/systemd-id128.md
@@ -19,6 +19,6 @@
 
 `systemd-id128 invocation-id`
 
-- Generate a new random identifier and print it as an UUID (five groups of digits separated by hyphens):
+- Generate a new random identifier and print it as a UUID (five groups of digits separated by hyphens):
 
 `systemd-id128 new --uuid`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).