### PR TITLE
7zr: fix pt_PT translation

### DIFF
--- a/pages.pt_PT/common/7zr.md
+++ b/pages.pt_PT/common/7zr.md
@@ -1,4 +1,4 @@
-# 7z
+# 7zr
 
 > Compactador de arquivos com uma alta taxa de compressão.
 > Semelhante ao '7z', com a diferença que suporta apenas ficheiros '.7z'.
@@ -6,28 +6,28 @@
 
 - Adicionar um ficheiro ou diretório a um novo ou existente arquivo:
 
-`7z a {{diretório/arquivo_compactado.7z}} {{diretório/ficheiro_ou_diretório}}`
+`7zr a {{diretório/arquivo_compactado.7z}} {{diretório/ficheiro_ou_diretório}}`
 
 - Encripa um arquivo existente (incluindo filenames):
 
-`7z a {{diretório/ficheiro_encriptado.7z}} -p{{palavra-passe}} -mhe=on {{diretório/arquivo_compactado.7z}}`
+`7zr a {{diretório/ficheiro_encriptado.7z}} -p{{palavra-passe}} -mhe=on {{diretório/arquivo_compactado.7z}}`
 
 - Descompactar um arquivo mantendo a estrutura de diretórios original:
 
-`7z x {{diretório/arquivo_compactado.7z}}`
+`7zr x {{diretório/arquivo_compactado.7z}}`
 
 - Descompactar um arquivo para um diretório especificado pelo utilizador:
 
-`7z x {{diretório/arquivo_compactado.7z}} -o{{localização/do/directório}}`
+`7zr x {{diretório/arquivo_compactado.7z}} -o{{localização/do/directório}}`
 
 - Descompactar um arquivo para a saída padrão (stdout):
 
-`7z x {{diretório/arquivo_compactado.7z}} -so`
+`7zr x {{diretório/arquivo_compactado.7z}} -so`
 
 - Listar os conteúdos de um arquivo:
 
-`7z l {{diretório/arquivo_compactado.7z}}`
+`7zr l {{diretório/arquivo_compactado.7z}}`
 
 - Listar todos os tipos de arquivamento/compressão disponíveis:
 
-`7z i`
+`7zr i`


### PR DESCRIPTION
The page said "7z" when it should have said "7zr".
