### PR TITLE
windows/*: add more PowerShell commands

### DIFF
--- a/pages/windows/get-command.md
+++ b/pages/windows/get-command.md
@@ -24,6 +24,6 @@
 
 `Get-Command -Module {{module}}`
 
-- Get the command information (e.g. version number or module name) by its name
+- Get the command information (e.g. version number or module name) by its name:
 
 `Get-Command {{command}}`

--- a/pages/windows/get-command.md
+++ b/pages/windows/get-command.md
@@ -1,0 +1,29 @@
+# Get-Command
+
+> List and get available commands in the current PowerShell session.
+> This command can only be run through PowerShell.
+> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/get-command>.
+
+- List all available PowerShell commands (aliases, cmdlets, functions) in the current computer:
+
+`Get-Command`
+
+- List all available PowerShell commands in the current session:
+
+`Get-Command -ListImported`
+
+- List only PowerShell aliases/cmdlets/functions available in the computer:
+
+`Get-Command -Type {{Alias|Cmdlet|Function}}`
+
+- List only programs or commands available on PATH in the current session:
+
+`Get-Command -Type Application`
+
+- List only PowerShell commands by the module name, e.g. `Microsoft.PowerShell.Utility` for utility-related commands:
+
+`Get-Command -Module {{module}}`
+
+- Get the command information (e.g. version number or module name) by its name
+
+`Get-Command {{command}}`

--- a/pages/windows/get-help.md
+++ b/pages/windows/get-help.md
@@ -1,28 +1,28 @@
 # Get-Help
 
-> Display help information and documentation for PowerShell commands, aka. cmdlets.
+> Display help information and documentation for PowerShell commands (aliases, cmdlets, and functions).
 > This command can only be run through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/get-help>.
 
-- Display general help information for a specific cmdlet:
+- Display general help information for a specific PowerShell command:
 
-`Get-Help {{cmdlet}}`
+`Get-Help {{command}}`
 
-- Display a more detailed documentation for a specific cmdlet:
+- Display a more detailed documentation for a specific PowerShell command:
 
-`Get-Help {{cmdlet}} -Detailed`
+`Get-Help {{command}} -Detailed`
 
-- Display the full technical documentation for a specific cmdlet:
+- Display the full technical documentation for a specific PowerShell command:
 
-`Get-Help {{cmdlet}} -Full`
+`Get-Help {{command}} -Full`
 
-- Print only the documentation for a specific parameter of the cmdlet (use `*` to show all parameters), if available:
+- Print only the documentation for a specific parameter of the PowerShell command (use `*` to show all parameters), if available:
 
-`Get-Help {{cmdlet}} -Parameter {{parameter}}`
+`Get-Help {{command}} -Parameter {{parameter}}`
 
 - Print only the examples of the cmdlet, if available:
 
-`Get-Help {{cmdlet}} -Examples`
+`Get-Help {{command}} -Examples`
 
 - List all available cmdlet help pages:
 
@@ -32,6 +32,6 @@
 
 `Update-Help`
 
-- View an online version of cmdlet documentation in the default web browser:
+- View an online version of PowerShell command documentation in the default web browser:
 
-`Get-Help {{cmdlet}} -Online`
+`Get-Help {{command}} -Online`

--- a/pages/windows/get-wuapiversion.md
+++ b/pages/windows/get-wuapiversion.md
@@ -1,0 +1,13 @@
+# Get-WUApiVersion
+
+> Get the Windows Update Agent version. Part of external `PSWindowsUpdate` module.
+> This command can only be run under PowerShell.
+> More information: <https://github.com/mgajda83/PSWindowsUpdate>.
+
+- Get the currently-installed Windows Update Agent version:
+
+`Get-WUApiVersion`
+
+- Send the current configuration data via email (SMTP):
+
+`Get-WUApiVersion -SendReport -PSWUSettings @{SmtpServer="{{smtp_server}}"; Port={{smtp_port}} From="{{sender_email}}" To="{{receiver_email}}"}`

--- a/pages/windows/get-wuhistory.md
+++ b/pages/windows/get-wuhistory.md
@@ -1,0 +1,25 @@
+# Get-WUHistory
+
+> Get the history of installed updates from Windows Update. Part of external `PSWindowsUpdate` module.
+> This command can only be run under PowerShell.
+> More information: <https://github.com/mgajda83/PSWindowsUpdate>.
+
+- Get list of update history:
+
+`Get-WUHistory`
+
+- List the last 10 installed updates:
+
+`Get-WUHistory -Last {{10}}`
+
+- List all updates installed from a specific date to today:
+
+`Get-WUHistory -MaxDate {{date}}`
+
+- List all updates installed in the past 24 hours:
+
+`Get-WUHistory -MaxDate (Get-Date).AddDays(-1)`
+
+- Send the results via email (SMTP):
+
+`Get-WUHistory -SendReport -PSWUSettings @{SmtpServer="{{smtp_server}}"; Port={{smtp_port}} From="{{sender_email}}" To="{{receiver_email}}"}`

--- a/pages/windows/get-wusettings.md
+++ b/pages/windows/get-wusettings.md
@@ -1,0 +1,13 @@
+# Get-WUSettings
+
+> Get the current Windows Update Agent configuration. Part of external `PSWindowsUpdate` module.
+> This command can only be run under PowerShell.
+> More information: <https://github.com/mgajda83/PSWindowsUpdate>.
+
+- Get the current Windows Update Agent configuration:
+
+`Get-WUSettings`
+
+- Send the current configuration data via email (SMTP):
+
+`Get-WUSettings -SendReport -PSWUSettings @{SmtpServer="{{smtp_server}}"; Port={{smtp_port}} From="{{sender_email}}" To="{{receiver_email}}"}`

--- a/pages/windows/install-module.md
+++ b/pages/windows/install-module.md
@@ -1,7 +1,7 @@
 # Install-Module
 
 > Install PowerShell modules from PowerShell Gallery, NuGet, and other repositories.
-> More information: <https://learn.microsoft.com/powershell/module/powershellget/install-module>
+> More information: <https://learn.microsoft.com/powershell/module/powershellget/install-module>.
 
 - Install a module, or update it to the latest available version:
 

--- a/pages/windows/install-module.md
+++ b/pages/windows/install-module.md
@@ -1,0 +1,36 @@
+# Install-Module
+
+> Install PowerShell modules from PowerShell Gallery, NuGet, and other repositories.
+> More information: <https://learn.microsoft.com/powershell/module/powershellget/install-module>
+
+- Install a module, or update it to the latest available version:
+
+`Install-Module {{module}}`
+
+- Install a module with a specific version:
+
+`Install-Module {{module}} -RequiredVersion {{version}}`
+
+- Install a module no earlier than a specific version:
+
+`Install-Module {{module}} -MinimumVersion {{version}}`
+
+- Specify a range of supported versions (inclusive) of the required module:
+
+`Install-Module {{module}} -MinimumVersion {{minimum_version}} -MaximumVersion {{maximum_version}}`
+
+- Install module from a specific repository:
+
+`Install-Module {{module}} -Repository {{repository}}`
+
+- Install module from specific repositories:
+
+`Install-Module {{module}} -Repository {{repository1 , repository2 , ...}}`
+
+- Install the module for all/current user:
+
+`Install-Module {{module}} -Scope {{AllUsers|CurrentUser}}`
+
+- Perform a dry run to determine which modules will be installed, upgraded, or removed through `Install-Module`:
+
+`Install-Module {{module}} -WhatIf`

--- a/pages/windows/pswindowsupdate.md
+++ b/pages/windows/pswindowsupdate.md
@@ -1,0 +1,13 @@
+# PSWindowsUpdate
+
+> A PowerShell external module to manage Windows Update.
+> This tool provides multiple commands that all can only be run through PowerShell.
+> More information: <https://github.com/mgajda83/PSWindowsUpdate>.
+
+- Install the module using `Install-Module`:
+
+`Install-Module PSWindowsUpdate`
+
+- List all commands available under the module:
+
+`Get-Command -Module PSWindowsUpdate`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
  + PowerShell 5.1
  + PSWindowsUpdate 2.0.0.4

This PR adds and improves the following commands:

+ **Get-Command**
+ **Get-Help:** Clarify that the command may also be used for PowerShell aliases and functions
+ **Install-Module:** Part of PowerShell package management (PowerShellGet)
+ **PSWindowsUpdate:** Setup alias page for the following commands:
  - **Get-WUApiVersion:** Get the Windows Update Agent version
  - **Get-WUHistory:** Get the Windows Update history
  - **Get-WUSettings:** Get the current Windows Update configuration