### PR TITLE
getfileinfo, slmgr.vbs: fix documentation

### DIFF
--- a/pages/osx/getfileinfo.md
+++ b/pages/osx/getfileinfo.md
@@ -5,16 +5,16 @@
 
 - Display information about a given file:
 
-`GetFileInfo {{path/to/filename}}`
+`GetFileInfo {{path/to/file}}`
 
-- Display the date and time a given file was created:
+- Display the [d]ate and time a given file was created:
 
-`GetFileInfo -d {{path/to/filename}}`
+`GetFileInfo -d {{path/to/file}}`
 
-- Display the date and time a given file was last modified:
+- Display the date and time a given file was last [m]odified:
 
-`GetFileInfo -m {{path/to/filename}}`
+`GetFileInfo -m {{path/to/file}}`
 
-- Display the creator of a given file:
+- Display the [c]reator of a given file:
 
-`GetFileInfo -c {{path/to/filename}}`
+`GetFileInfo -c {{path/to/file}}`

--- a/pages/windows/slmgr.vbs.md
+++ b/pages/windows/slmgr.vbs.md
@@ -6,32 +6,32 @@
 
 - [d]isplay the current Windows [l]icense [i]nformation:
 
-`slmgr /dli`
+`slmgr.vbs /dli`
 
 - [d]isplay the ins[t]allation [i]D for the current device. Useful for offline license activation:
 
-`slmgr /dti`
+`slmgr.vbs /dti`
 
 - Display the current license's e[xp]i[r]ation date and time:
 
-`slmgr /xpr`
+`slmgr.vbs /xpr`
 
 - [i]nstall a new Windows license [p]roduct [k]ey. Requires Administrator privileges and will override the existing license:
 
-`slmgr /ipk {{product_key}}`
+`slmgr.vbs /ipk {{product_key}}`
 
 - [a]c[t]ivate the Windows product license [o]nline. Requires Administrator privileges to do so:
 
-`slmgr /ato`
+`slmgr.vbs /ato`
 
 - [a]c[t]ivate the Windows [p]roduct license offline. Requires Administrator privileges and an Confirmation ID provided by Microsoft Product Activation Center:
 
-`slmgr /atp {{confirmation_id}}`
+`slmgr.vbs /atp {{confirmation_id}}`
 
 - [c]lear the current license's [p]roduct [k]e[y] from the Windows Registry. This will not deactivate or uninstall the current license, but prevents the key from being stolen by malicious programs in the future:
 
-`slmgr /cpky`
+`slmgr.vbs /cpky`
 
 - [u]ninstall the current license (by its [p]roduct [k]ey):
 
-`slmgr /upk`
+`slmgr.vbs /upk`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR modifies the following:

+ **osx/getfileinfo:** Use standard `{{path/to/file}}` and add command mnemonics
+ **windows/slmgr.vbs:** Use `slmgr.vbs` instead of `slmgr` in the command examples to match command name