### PR TITLE
aws-s3-website: add page

### DIFF
--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -1,6 +1,7 @@
 # aws-s3-website
 
 > Set the website configuration for a bucket.
+> See also: `aws s3`.
 > More information: <https://docs.aws.amazon.com/cli/latest/reference/s3/website.html>.
 
 - Configure a bucket as a static website:

--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -1,4 +1,4 @@
-# aws-s3-website
+# aws s3 website
 
 > Set the website configuration for a bucket.
 > See also: `aws s3`.

--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -1,7 +1,7 @@
 # aws-s3-website
 
 > Set the website configuration for a bucket.
->  More information: <https://docs.aws.amazon.com/cli/latest/reference/s3/website.html>.
+> More information: <https://docs.aws.amazon.com/cli/latest/reference/s3/website.html>.
 
 - Configure a bucket as a static website:
 
@@ -10,9 +10,3 @@
 - Configure an error page for the website:
 
 `aws s3 website s3://bucket-name/ --index-document index.html --error-document error.html`
-
-
-
-
-
-  

--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -1,0 +1,18 @@
+# aws-s3-website
+
+> Set the website configuration for a bucket.
+>  More information: <https://docs.aws.amazon.com/cli/latest/reference/s3/website.html>.
+
+- Configure a bucket as a static website:
+
+`aws s3 website s3://bucket-name/ --index-document index.html`
+
+- Configure an error page for the website:
+
+`aws s3 website s3://bucket-name/ --index-document index.html --error-document error.html`
+
+
+
+
+
+  

--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -5,8 +5,8 @@
 
 - Configure a bucket as a static website:
 
-`aws s3 website s3://bucket-name/ --index-document index.html`
+`aws s3 website {{s3://bucket-name/}} --index-document {{index.html}}`
 
 - Configure an error page for the website:
 
-`aws s3 website s3://bucket-name/ --index-document index.html --error-document error.html`
+`aws s3 website {{s3://bucket-name/}} --index-document {{index.html}} --error-document {{error.html}}`

--- a/pages/common/aws-s3-website.md
+++ b/pages/common/aws-s3-website.md
@@ -6,8 +6,8 @@
 
 - Configure a bucket as a static website:
 
-`aws s3 website {{s3://bucket-name/}} --index-document {{index.html}}`
+`aws s3 website {{s3://bucket-name}} --index-document {{index.html}}`
 
 - Configure an error page for the website:
 
-`aws s3 website {{s3://bucket-name/}} --index-document {{index.html}} --error-document {{error.html}}`
+`aws s3 website {{s3://bucket-name}} --index-document {{index.html}} --error-document {{error.html}}`


### PR DESCRIPTION
Add an initial description of the local options for aws s3 website command.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** j
