### PR TITLE
COMMUNITY-ROLES: document CODEOWNERS file

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -214,3 +214,6 @@ Example uses include (but are not limited to):
 - Contributors who speak a specific language who want to assist with reviewing translations in specific languages
 - Contributors with specific expertise who wish to review pull requests for specific platforms
 - Contributors interested in reviewing [client specification](https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md) updates
+
+> [!NOTE]
+> This mechanism is purely for automatic review requests for PRs and doesn't grant collaborators additional copyright over the code-owned files. View the [LICENSE](https://github.com/tldr-pages/tldr/blob/main/LICENSE.md) file for more information.

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -206,8 +206,7 @@ can then perform the actual role changes.
 
 ## CODEOWNERS
 
-The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the
-[tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get automatic review request notifications for given files and directories.
+The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the [tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get automatic review request notifications for given files and directories.
 If they wish to, contributors can open a pull request to add themselves to this file as desired.
 
 Example uses include (but are not limited to):

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -203,3 +203,16 @@ Any member of the community can (and is encouraged to) propose role changes
 by following the process outlined [above](#how-to-change-roles).
 [Owners of the tldr-pages organization](MAINTAINERS.md#organization-owners)
 can then perform the actual role changes.
+
+## CODEOWNERS
+The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the
+[tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get
+automatic review request notifications for given files and directories.
+If they wish to, contributors can open a pull request to add themselves
+to this file as desired.
+
+Example uses include (but are not limited to):
+
+- Contributors who speak a specific language who want to assist with reviewing translations in specific languages
+- Contributors with specific expertise who wish to review pull requests for specific platforms
+- Contributors interested in reviewing [client specification](https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md) updates

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -211,9 +211,9 @@ If they wish to, contributors can open a pull request to add themselves to this 
 
 Example uses include (but are not limited to):
 
-- Contributors who speak a specific language who want to assist with reviewing translations in specific languages
-- Contributors with specific expertise who wish to review pull requests for specific platforms
-- Contributors interested in reviewing [client specification](https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md) updates
+- Contributors who speak a specific language and want to assist with reviewing translations in those specific languages.
+- Contributors with specific expertise who wish to review pull requests for specific platforms.
+- Contributors interested in reviewing [client specification](https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md) updates.
 
 > [!NOTE]
 > This mechanism is purely for automatic review requests for PRs and doesn't grant collaborators additional copyright over the code-owned files. View the [LICENSE](https://github.com/tldr-pages/tldr/blob/main/LICENSE.md) file for more information.

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -205,6 +205,7 @@ by following the process outlined [above](#how-to-change-roles).
 can then perform the actual role changes.
 
 ## CODEOWNERS
+
 The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the
 [tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get
 automatic review request notifications for given files and directories.

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -209,8 +209,7 @@ can then perform the actual role changes.
 The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the
 [tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get
 automatic review request notifications for given files and directories.
-If they wish to, contributors can open a pull request to add themselves
-to this file as desired.
+If they wish to, contributors can open a pull request to add themselves to this file as desired.
 
 Example uses include (but are not limited to):
 

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -207,8 +207,7 @@ can then perform the actual role changes.
 ## CODEOWNERS
 
 The [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) allows contributors with write access to the
-[tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get
-automatic review request notifications for given files and directories.
+[tldr-pages/tldr repository](https://github.com/tldr-pages/tldr) to get automatic review request notifications for given files and directories.
 If they wish to, contributors can open a pull request to add themselves to this file as desired.
 
 Example uses include (but are not limited to):


### PR DESCRIPTION
Ref https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$P2PB65z9pBYv7KXAcTVv8p4WK_v3r1mx5cMyw5sgF2o?via=gitter.im&via=matrix.org&via=one.ems.host, this PR documents the [`.github/CODEOWNERS` file](https://github.com/tldr-pages/tldr/blob/main/.github/CODEOWNERS) in COMMUNITY-ROLES.

It is of course completely everyones' choice as to whether they are in the CODEOWNERS file or not.