### PR TITLE
gcloud-version: add page

### DIFF
--- a/pages/common/gcloud-version.md
+++ b/pages/common/gcloud-version.md
@@ -7,6 +7,6 @@
 
 `gcloud version`
 
-- For additional flags, run:
+- Display help:
 
 `gcloud version --help`

--- a/pages/common/gcloud-version.md
+++ b/pages/common/gcloud-version.md
@@ -3,7 +3,7 @@
 > Print version information for Google Cloud CLI components.
 > More information: <https://cloud.google.com/sdk/gcloud/reference/version>.
 
-- Print the version information for each CLI component:
+- Print the version information for all installed components, along with available updates to them:
 
 `gcloud version`
 

--- a/pages/common/gcloud-version.md
+++ b/pages/common/gcloud-version.md
@@ -1,0 +1,12 @@
+# gcloud-version
+
+> Print version information for CLI components.
+> More information: <https://cloud.google.com/sdk/gcloud/reference/version>.
+
+- Print the version information for each CLI component:
+
+`gcloud version`
+
+- For additional flags, run: 
+
+`gcloud version --help`

--- a/pages/common/gcloud-version.md
+++ b/pages/common/gcloud-version.md
@@ -1,6 +1,6 @@
 # gcloud-version
 
-> Print version information for CLI components.
+> Print version information for Google Cloud CLI components.
 > More information: <https://cloud.google.com/sdk/gcloud/reference/version>.
 
 - Print the version information for each CLI component:

--- a/pages/common/gcloud-version.md
+++ b/pages/common/gcloud-version.md
@@ -7,6 +7,6 @@
 
 `gcloud version`
 
-- For additional flags, run: 
+- For additional flags, run:
 
 `gcloud version --help`


### PR DESCRIPTION
Adding initial description of gcloud version command.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
