### PR TITLE
vboxmanage: refactor, add-pages

### DIFF
--- a/pages/common/vboxmanage-controlvm.md
+++ b/pages/common/vboxmanage-controlvm.md
@@ -1,0 +1,36 @@
+# vboxmanage-controlvm
+
+> Change the state and the settings of a currently running virtual machine.
+> More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- Temporarly stops the execution of a virtual machine:
+
+`VBoxManage controlvm {{uuid|vmname}}  pause`
+
+- Resume the execution of a paused virtual machine:
+
+`VBoxManage controlvm {{uuid|vmname}} resume`
+
+- Perform a cold reset on the virtual machine:
+
+`VBoxManage controlvm {{uuid|vmname}} reset`
+
+- Poweroff a virtual machine with the same effect as pulling the power cable of a computer:
+
+`VBoxManage controlvm {{uuid|vmname}} poweroff`
+
+- Shutdown the virtual machine and save its current state:
+
+`VBoxManage controlvm {{uuid|vmname}} savestate`
+
+- Send an ACPI shutdown signal to the virtual machine:
+
+`VBoxManage controlvm {{uuid|vmname}} acpipowerbutton`
+
+- Send command to reboot itself to the guest OS:
+
+`VBoxManage controlvm {{uuid|vmname}} reboot`
+
+- Shutdown down the virtual machine without saving its state:
+
+`VBoxManage controlvm {{uuid|vmname}} shutdown`

--- a/pages/common/vboxmanage-extpack.md
+++ b/pages/common/vboxmanage-extpack.md
@@ -1,0 +1,24 @@
+# vboxmanage-extpack
+
+> Manage extension packs for Oracle VirtualBox.
+> More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- Install extension packs to VirtualBox:
+
+`VBoxManage extpack install {{VboxExtensionPackFileName}}`
+
+- Update VBox extension packs:
+
+`VBoxManage extpack install --replace {{VboxExtensionPackFileName}}`
+
+- Uninstall extension packs from VirtualBox:
+
+`VBoxManage extpack uninstall {{VboxExtensionPackFileName}}`
+
+- Uninstall extension packs and skip most uninstallation refusal:
+
+`VBoxManage extpack uninstall --force {{VboxExtensionPackFileName}}`
+
+- Clean up temporary file and directory left by extension packs:
+
+`VBoxManage extpack cleanup`

--- a/pages/common/vboxmanage-list.md
+++ b/pages/common/vboxmanage-list.md
@@ -1,0 +1,36 @@
+# vboxmanage-list
+
+> List information about the Oracle VM VirtualBox software and associated service.
+> More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- List all VirtualBox virtual machines:
+
+`VBoxManage list vms`
+
+- Show DHCP servers available on the host system:
+
+`VBoxManage list dhcpservers`
+
+- Show Oracle VM VirtualBox extension packs currently installed:
+
+`VBoxManage list extpacks`
+
+- Show all VM groups:
+
+`VBoxManage list groups`
+
+- Show virtual disk settings that are currently in use by VBOX:
+
+`VBoxManage list hdds`
+
+- Show host-only network interfaces available on host system:
+
+`VBoxManage list hostonlyifs`
+
+- Show the list of currently running VM:
+
+`VBoxManage list runningvms`
+
+- Show host system info:
+
+`VBoxManage list hostinfo`

--- a/pages/common/vboxmanage-showvminfo.md
+++ b/pages/common/vboxmanage-showvminfo.md
@@ -1,0 +1,28 @@
+# vboxmanage-showvminfo
+
+> Show information about registered virtual machine.
+> More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- Show information about a particular virtual machine:
+
+`VBoxManage showvminfo {{name|uuid}}`
+
+- Show more detailed information about a particular virtual machine:
+
+`VBoxManage showvminfo --details {{name|uuid}}`
+
+- Information is displayed in a machine readable format:
+
+`VBoxManage showvminfo --machinereadable {{name|uuid}}`
+
+- Specify password id if the virtual machine is encrypted:
+
+`VBoxManage showvminfo --password-id {{passwordid}} {{name|uuid}}`
+
+- Specify the password file if the virtual machine is encrypted:
+
+`VBoxManage showvminfo --password {{path/to/passwordfile}} {{name|uuid}}`
+
+- Show the logs of a specific virtual machine:
+
+`VBoxManage showvminfo --log {{name|uuid}}`

--- a/pages/common/vboxmanage-startvm.md
+++ b/pages/common/vboxmanage-startvm.md
@@ -1,0 +1,24 @@
+# vboxmanage-startvm
+
+> Start registered virtual machine with name or uuid.
+> More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- Start a virtual machine:
+
+`VBoxManage startvm {{name|uuid}}`
+
+- Start a virtual machine with the specified UI mode:
+
+`VBoxManage startvm {{name|uuid}} --type {{headless|gui|sdl|seperate}}`
+
+- Specify a password file to start an encrypted virtual machine:
+
+`VBoxManage startvm {{name|uuid}} --password {{path/to/passwordfile}}`
+
+- Specify a password id to start an encrypted virtual machine:
+
+`VBoxManage startvm  {{name|uuid}} --password-id {{passwordid}}`
+
+- Start a vm with an environment variable pair name value:
+
+`VBoxManage startvm  {{name|uuid}} --put-env={{name}}={{value}}`

--- a/pages/common/vboxmanage.md
+++ b/pages/common/vboxmanage.md
@@ -4,30 +4,18 @@
 > Includes all the functionality of the GUI and more.
 > More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-intro>.
 
-- List all VirtualBox virtual machines:
+- Check the VBoxManage version:
 
-`VBoxManage list vms`
+`VBoxManage --version`
 
-- Show information about a particular virtual machine:
+- Show general help:
 
-`VBoxManage showvminfo {{name|uuid}}`
+`VBoxManage --help`
 
-- Start a virtual machine:
+- Show help on a VBoxManage subcommand (like `starvm`, `clonevm`, `import`, `export`, etc.):
 
-`VBoxManage startvm {{name|uuid}}`
+`VBoxManage --help {{subcommand}}`
 
-- Start a virtual machine in headless mode:
+- Execute a VboxManage subcommand:
 
-`VBoxManage startvm {{name|uuid}} --type headless`
-
-- Shutdown the virtual machine and save its current state:
-
-`VBoxManage controlvm {{name|uuid}} savestate`
-
-- Shutdown down the virtual machine without saving its state:
-
-`VBoxManage controlvm {{name|uuid}} poweroff`
-
-- Update VBox extension packs:
-
-`VBoxManage extpack install --replace {{VboxExtensionPackFileName}}`
+`VBoxManage {{subcommand}}`


### PR DESCRIPTION
Refactor of the main vboxmanage.md file and add-pages for vboxmanage subcommands, controlvm, extpack, startvm, list, showvminfo.

contribute: #11431

- [ x ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ x ] The page(s) have at most 8 examples.
- [ x ] The page description(s) have links to documentation or a homepage.
- [ x ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ x ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).