### PR TITLE
grub-mkconfig: fix typos in Spanish translation

### DIFF
--- a/pages.es/linux/grub-mkconfig.md
+++ b/pages.es/linux/grub-mkconfig.md
@@ -1,16 +1,16 @@
 # grub-mkconfig
 
-> Generar un archivo de configuracion de GRUB.
+> Genera un archivo de configuracion de GRUB.
 > Más información: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dmkconfig.html>.
 
-- Ejecutar el comando solo e imprimir la salida a `stdout`:
+- Ejecuta el comando solo e imprime la salida a `stdout`:
 
 `sudo grub-mkconfig`
 
-- Generar el archivo de configuracion:
+- Genera el archivo de configuración:
 
 `sudo grub-mkconfig --output={{/boot/grub/grub.cfg}}`
 
-- Imprimir la pagina de ayuda:
+- Imprime la página de ayuda:
 
 `grub-mkconfig --help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
