### PR TITLE
byzanz-record: add page

### DIFF
--- a/pages/linux/byzanz-record.md
+++ b/pages/linux/byzanz-record.md
@@ -1,0 +1,20 @@
+# byzanz-record
+
+> Create media files from screen recordings.
+> More information: <https://linux.die.net/man/1/byzanz-record>.
+
+- Record the screen and write the recording to a file (by default, byzanz-record will only record for 10 seconds):
+
+`byzanz-record {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`
+
+- Send a desktop notification after recording:
+
+`byzanz-record {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}} && notify-send "Reminder" "Finished recording"`
+
+- Record the screen for a minute:
+
+`byzanz-record --duration 60 {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`
+
+- Delay recording for 10 seconds:
+
+`byzanz-record --delay 10 {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`

--- a/pages/linux/byzanz-record.md
+++ b/pages/linux/byzanz-record.md
@@ -7,9 +7,9 @@
 
 `byzanz-record {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`
 
-- Send a desktop notification after recording:
+- Show information while and after recording:
 
-`byzanz-record {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}} && notify-send "Reminder" "Finished recording"`
+`byzanz-record --verbose {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`
 
 - Record the screen for a minute:
 

--- a/pages/linux/byzanz-record.md
+++ b/pages/linux/byzanz-record.md
@@ -1,6 +1,6 @@
 # byzanz-record
 
-> Create media files from screen recordings.
+> Record the screen.
 > More information: <https://linux.die.net/man/1/byzanz-record>.
 
 - Record the screen and write the recording to a file (by default, byzanz-record will only record for 10 seconds):

--- a/pages/linux/byzanz-record.md
+++ b/pages/linux/byzanz-record.md
@@ -1,7 +1,7 @@
 # byzanz-record
 
 > Record the screen.
-> More information: <https://linux.die.net/man/1/byzanz-record>.
+> More information: <https://manned.org/byzanz-record>.
 
 - Record the screen and write the recording to a file (by default, `byzanz-record` will only record for 10 seconds):
 

--- a/pages/linux/byzanz-record.md
+++ b/pages/linux/byzanz-record.md
@@ -3,7 +3,7 @@
 > Record the screen.
 > More information: <https://linux.die.net/man/1/byzanz-record>.
 
-- Record the screen and write the recording to a file (by default, byzanz-record will only record for 10 seconds):
+- Record the screen and write the recording to a file (by default, `byzanz-record` will only record for 10 seconds):
 
 `byzanz-record {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 0.3

I did not check the first item in the list above because I am not completely sure if the `byzanz-record` command will execute properly in operating systems other than Linux. I cloned the repository of `byzanz-record` (i.e.  https://gitlab.gnome.org/Archive/byzanz) and noticed some source files read X11 and/or glib headers (e.g. https://gitlab.gnome.org/Archive/byzanz/-/blob/master/src/byzanzsession.c), which might mean that those are some or all of the dependencies. 

Also, I wanted to include the following example for recording the current window:

```shell
eval $(xdotool getwindowfocus getwindowgeometry --shell) && byzanz-record --x "${X}" --y "${Y}" --width "${WIDTH}" --height "${HEIGHT}" {{path/to/file.[byzanz|flv|gif|ogg|ogv|webm]}}
```

However, I feared it might be too long and complex.