### PR TITLE
style-guide: modify page

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -263,7 +263,7 @@ Keep the following guidelines in mind when choosing placeholders:
 - If a command can take 0 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
   For instance, if multiple paths are expected `{{path/to/directory1 path/to/directory2 ...}}` can be used.
 - If a command can take 0 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
-  If there are more than 5 possible values use `|...` after the last item.
+  If there are more than 5 possible values, you can use `|...` after the last item.
 - It's impossible to restrict the minimum or (and) maximum placeholder count via `ellipsis`.
 
 It's up to the program to decide how to handle duplicating values, provided syntax


### PR DESCRIPTION
We have multiple pages where more than 5 possible argument values are separated with `|`. (e.g. [here](https://github.com/tldr-pages/tldr/blob/main/pages/common/%5B.md))
However, the style-guide currently states that if there are more than 5 possible values, we should use `...` after the last (5th?) item.
As this is 1. not how we do things in practice and 2. too restrictive (e.g. if there are 6 possible values, you'd be forced to write `...` INSTEAD of the last value), I propose to change this from a hard rule to a recommendation.