### PR TITLE
chore(ci): bump `actions/setup-python` to v5, set version to 3.12; fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /pages/linux/ @sbrl
 
 /*.md @sbrl @kbdharun
-/.github/* @sbrl @kbdharun @sebastiaanspeck
+/.github/workflows/* @sbrl @kbdharun @sebastiaanspeck
 /scripts/* @sebastiaanspeck
 
 /contributing-guides/maintainers-guide.md @sbrl @kbdharun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: 'pip'
 
     - uses: actions/setup-node@v4


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [x] I have tested the changes [^1] 

## Changes

- Bump `actions/setup-python` to `v5`.
- Set the Python version to 3.12.
- Fix the CODEOWNERS glob pattern for the `.github` directory by specifying the `workflows` subdirectory.

[^1]: I have tested the changes in my fork and the action run can be found [here](https://github.com/kbdharun/tldr/actions/runs/7182439409/job/19558953916).