### PR TITLE
docker-inspect: escape placeholders

### DIFF
--- a/pages.de/common/docker-inspect.md
+++ b/pages.de/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Zeige die IP Adresse eines Containers an:
 
-`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{container}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{container}}`
 
 - Zeige den Pfad zur Logdatei eines Containers:
 
-`docker inspect --format='{{.LogPath}}' {{container}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{container}}`
 
 - Zeige den Namen des Images eines Containers:
 
-`docker inspect --format='{{.Config.Image}}' {{container}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{container}}`
 
 - Zeige die Konfiguration als JSON an:
 
-`docker inspect --format='{{json .Config}}' {{container}}`
+`docker inspect --format='\{\{json .Config\}\}' {{container}}`
 
 - Zeige alle Port Bindings:
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{container}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{container}}`

--- a/pages.fr/common/docker-inspect.md
+++ b/pages.fr/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Afficher l'adresse IP d'un conteneur :
 
-`docker inspect --format='{{range .NetworkSettings.Networks}} {{.IPAddress}}{{end}}' {{conteneur}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{conteneur}}`
 
 - Afficher le chemin du fichier journal d'un conteneur :
 
-`docker inspect --format='{{.LogPath}}' {{conteneur}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{conteneur}}`
 
 - Afficher le nom de l'image d'un conteneur :
 
-`docker inspect --format='{{.Config.Image}}' {{conteneur}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{conteneur}}`
 
 - Afficher les informations de configuration en JSON :
 
-`docker inspect --format='{{json .Config}}' {{conteneur}}`
+`docker inspect --format='\{\{json .Config\}\}' {{conteneur}}`
 
 - Afficher toutes les liaisons de port :
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{conteneur}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{conteneur}}`

--- a/pages.it/common/docker-inspect.md
+++ b/pages.it/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Mostra l'indirizzo IP di un container:
 
-`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{nome_container}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{nome_container}}`
 
 - Mostra il percorso dei file di log di un container:
 
-`docker inspect --format='{{.LogPath}}' {{nome_container}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{nome_container}}`
 
 - Mostra il nome dell'immagine di un container:
 
-`docker inspect --format='{{.Config.Image}}' {{nome_container}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{nome_container}}`
 
 - Mostra le informazioni di configurazione in formato JSON:
 
-`docker inspect --format='{{json .Config}}' {{nome_container}}`
+`docker inspect --format='\{\{json .Config\}\}' {{nome_container}}`
 
 - Mostra il binding di tutte le porte:
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{nome_container}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{nome_container}}`

--- a/pages.pt_BR/common/docker-inspect.md
+++ b/pages.pt_BR/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Exibir o endereço IP de um contêiner:
 
-`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{contêiner}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{contêiner}}`
 
 - Exibir o caminho para o arquivo de log do contêiner:
 
-`docker inspect --format='{{.LogPath}}' {{contêiner}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{contêiner}}`
 
 - Exibir o nome da imagem do contêiner:
 
-`docker inspect --format='{{.Config.Image}}' {{contêiner}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{contêiner}}`
 
 - Exibir as informações de configuração como JSON:
 
-`docker inspect --format='{{json .Config}}' {{contêiner}}`
+`docker inspect --format='\{\{json .Config\}\}' {{contêiner}}`
 
 - Exibir todas as portas vinculadas:
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{contêiner}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{contêiner}}`

--- a/pages.tr/common/docker-inspect.md
+++ b/pages.tr/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Bir konteynerin IP adresini görüntüle:
 
-`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{konteyner}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{konteyner}}`
 
 - Konteynerin log dosyasının yolunu görüntüle:
 
-`docker inspect --format='{{.LogPath}}' {{konteyner}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{konteyner}}`
 
 - Konteynerin imge ismini görüntüle:
 
-`docker inspect --format='{{.Config.Image}}' {{konteyner}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{konteyner}}`
 
 - Konfigürasyon bilgisini JSON olarak görüntüle:
 
-`docker inspect --format='{{json .Config}}' {{konteyner}}`
+`docker inspect --format='\{\{json .Config\}\}' {{konteyner}}`
 
 - Tüm port limanlayıcıları görüntüle:
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{konteyner}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{konteyner}}`

--- a/pages/common/docker-inspect.md
+++ b/pages/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Display a container's IP address:
 
-`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{container}}`
+`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{container}}`
 
 - Display the path to the container's log file:
 
-`docker inspect --format='{{.LogPath}}' {{container}}`
+`docker inspect --format='\{\{.LogPath\}\}' {{container}}`
 
 - Display the image name of the container:
 
-`docker inspect --format='{{.Config.Image}}' {{container}}`
+`docker inspect --format='\{\{.Config.Image\}\}' {{container}}`
 
 - Display the configuration information as JSON:
 
-`docker inspect --format='{{json .Config}}' {{container}}`
+`docker inspect --format='\{\{json .Config\}\}' {{container}}`
 
 - Display all port bindings:
 
-`docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' {{container}}`
+`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{container}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Description

Addressing #10125, this PR adds placeholder escaping support to the format flag in `docker-inspect` pages to display the curly braces as it is.

The rendered pages will look like this (Note: I have taken this screenshot from `tlrc` as it is the only official client which has implemented the v2.1 specification till now):

![image](https://github.com/tldr-pages/tldr/assets/26346867/390d7e08-51bc-4e87-9d6f-09cc7e70c61b)

