### PR TITLE
scrot: add two examples

### DIFF
--- a/pages/linux/scrot.md
+++ b/pages/linux/scrot.md
@@ -15,6 +15,14 @@
 
 `scrot --select`
 
+- Capture a screenshot interactively preventing accidental exits:
+
+`scrot --select --ignorekeyboard`
+
+- Capture a screenshot interactively delimiting the region with a colored line:
+
+`scrot --select --line color={{x11_color|rgb_color}}`
+
 - Capture a screenshot from the currently focused window:
 
 `scrot --focused`

--- a/pages/linux/scrot.md
+++ b/pages/linux/scrot.md
@@ -15,7 +15,7 @@
 
 `scrot --select`
 
-- Capture a screenshot interactively preventing accidental exits:
+- Capture a screenshot interactively without exiting on keyboard input, press `ESC` to exit:
 
 `scrot --select --ignorekeyboard`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.9

I personally use the `scrot` command with the examples I added, so I thought they might be useful to others.

One problem though, I am not sure what color names does `scrot` admit. I skimmed through [a source file](https://github.com/resurrecting-open-source-projects/scrot/blob/master/src/scrot_selection.c#L178) and guessed `scrot` accepts [X11 color names](https://en.wikipedia.org/wiki/X11_color_names). I have successfully tried the following commands:

- `scrot --select --line color="Dark Sea Green"`
- `scrot --select --line color="Dark Violet"`
- `scrot --select --line color="Goldenrod"`
