### PR TITLE
aireplay-ng: fix typo in URL

### DIFF
--- a/pages.id/common/aireplay-ng.md
+++ b/pages.id/common/aireplay-ng.md
@@ -2,7 +2,7 @@
 
 > Masukkan paket jaringan kepada jaringan nirkabel/wireless.
 > Bagian dari paket perangkat lunak jaringan Aircrack-ng.
-> Informasi lebih lanjut: <https://www.aircrack-ng.org/doku.php?id=aireplat-ng>.
+> Informasi lebih lanjut: <https://www.aircrack-ng.org/doku.php?id=aireplay-ng>.
 
 - Kirim sejumlah paket terpisah berdasarkan alamat MAC titik akses, alamat MAC klien, dan antarmuka jaringan (interface):
 


### PR DESCRIPTION

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).