### PR TITLE
get-nodeinstalllocation: fix Dutch translation

### DIFF
--- a/pages.nl/common/get-nodeinstalllocation.md
+++ b/pages.nl/common/get-nodeinstalllocation.md
@@ -1,7 +1,7 @@
 # Get-NodeInstallLocation
 
 > Haal de huidige Node.js installatiemap voor `ps-nvm` op.
-> Part of `ps-nvm` and can only be run under PowerShell.
+> Onderdeel van `ps-nvm` en kan alleen uitgevoerd worden in PowerShell.
 > Meer informatie: <https://github.com/aaronpowell/ps-nvm>.
 
 - Haal de huidige Node.js installatiemap op:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).