### PR TITLE
kcat: fix typo

### DIFF
--- a/pages/common/kcat.md
+++ b/pages/common/kcat.md
@@ -17,7 +17,7 @@
 
 - Publish message by reading from `stdin`:
 
-` echo {{message}} | kcat -P -t {{topic}} -b {{brokers}}`
+`echo {{message}} | kcat -P -t {{topic}} -b {{brokers}}`
 
 - Publish messages by reading from a file:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).