### PR TITLE
pages.fr: fix descriptions missing a space before the semicolon

### DIFF
--- a/pages.fr/common/age.md
+++ b/pages.fr/common/age.md
@@ -3,7 +3,7 @@
 > Un outil de cryptage de fichiers simple, moderne et sécurisé.
 > Plus d'informations : <https://github.com/FiloSottile/age>.
 
-- Générez un fichier crypté qui peut être décrypté avec une mot de passe:
+- Générez un fichier crypté qui peut être décrypté avec une mot de passe :
 
 `age --passphrase --output {{chemin/vers/fichier_crypté}} {{chemin/vers/fichier_non_crypté}}`
 
@@ -11,18 +11,18 @@
 
 `age-keygen --output {{chemin/vers/fichier}}`
 
-- Cryptage d'un fichier avec une ou plusieurs clés publiques qui sont entrées comme des littéraux:
+- Cryptage d'un fichier avec une ou plusieurs clés publiques qui sont entrées comme des littéraux :
 
 `age --recipient {{clé_publique_1}} --recipient {{clé_publique_2}} {{chemin/vers/fichier_non_crypté}} --output {{chemin/vers/fichier_crypté}}`
 
-- Cryptez un fichier avec une ou plusieurs clés publiques spécifiées dans un fichier de destinataires:
+- Cryptez un fichier avec une ou plusieurs clés publiques spécifiées dans un fichier de destinataires :
 
 `age --recipients-file {{chemin/vers/fichier_destinataire}} {{chemin/vers/fichier_non_crypté}} --output {{chemin/vers/fichier_crypté}}`
 
-- Déchiffrer un fichier avec un mot de passe:
+- Déchiffrer un fichier avec un mot de passe :
 
 `age --decrypt --output {{chemin/vers/fichier_décrypté}} {{chemin/vers/fichier_crypté}}`
 
-- Decrypt a file with a private key file:
+- Decrypt a file with a private key file :
 
 `age --decrypt --identity {{chemin/vers/fichier_clé_privée}} --output {{chemin/vers/fichier_décrypté}} {{chemin/vers/fichier_crypté}}`

--- a/pages.fr/common/anki.md
+++ b/pages.fr/common/anki.md
@@ -11,7 +11,7 @@
 
 `anki -p {{nom_de_profile}}`
 
-- Lancer `anki` dans une langue spécifique:
+- Lancer `anki` dans une langue spécifique :
 
 `anki -l {{langue}}`
 

--- a/pages.fr/common/aria2c.md
+++ b/pages.fr/common/aria2c.md
@@ -20,7 +20,7 @@
 
 `aria2c {{url_1}} {{url_2}}`
 
-- Télécharge les URIs listées dans un fichier avec un nombre limité de téléchargements en parallèle:
+- Télécharge les URIs listées dans un fichier avec un nombre limité de téléchargements en parallèle :
 
 `aria2c --input-file={{nom_de_fichier}} --max-concurrent-downloads={{nombre_de_téléchargements}}`
 

--- a/pages.fr/common/aria2c.md
+++ b/pages.fr/common/aria2c.md
@@ -6,19 +6,19 @@
 
 - Télécharge depuis une URI vers un fichier :
 
-`aria2c {{url}}`
+`aria2c "{{url}}"`
 
 - Télécharge un fichier via l'url spécifié en choisissant le nom de ce dernier :
 
-`aria2c --out={{nom_de_fichier}} {{url}}`
+`aria2c --out={{nom_de_fichier}} "{{url}}"`
 
 - Télécharge plusieurs fichiers (différents) en parallèle :
 
-`aria2c --force-sequential {{false}} {{url_1}} {{url_2}}`
+`aria2c --force-sequential {{false}} "{{url1 url2 ...}}"`
 
 - Télécharge depuis plusieurs sources avec chaque URI pointant vers le même fichier :
 
-`aria2c {{url_1}} {{url_2}}`
+`aria2c "{{url1 url2 ...}}"`
 
 - Télécharge les URIs listées dans un fichier avec un nombre limité de téléchargements en parallèle :
 
@@ -26,12 +26,12 @@
 
 - Télécharge avec plusieurs connections :
 
-`aria2c --split={{nombre_de_connections}} {{url}}`
+`aria2c --split={{nombre_de_connections}} "{{url}}"`
 
 - Téléchargement FTP avec nom d'utilisateur et mot de passe :
 
-`aria2c --ftp-user={{nom_d_utilisateur}} --ftp-passwd={{mot_de_passe}} {{url}}`
+`aria2c --ftp-user={{nom_d_utilisateur}} --ftp-passwd={{mot_de_passe}} "{{url}}"`
 
 - Limite la vitesse de téléchargement en octets/s :
 
-`aria2c --max-download-limit={{vitesse}} {{url}}`
+`aria2c --max-download-limit={{vitesse}} "{{url}}"`

--- a/pages.fr/common/arp.md
+++ b/pages.fr/common/arp.md
@@ -11,6 +11,6 @@
 
 `arp -d {{adresse}}`
 
-- Crée une entré dans la table ARP:
+- Crée une entré dans la table ARP :
 
 `arp -s {{adresse}} {{adresse_mac}}`

--- a/pages.fr/common/aws-quicksight.md
+++ b/pages.fr/common/aws-quicksight.md
@@ -4,7 +4,7 @@
 > Accès aux entrées QuickSight.
 > Plus d'informations : <https://docs.aws.amazon.com/cli/latest/reference/quicksight/>.
 
-- Liste les datasets:
+- Liste les datasets :
 
 `aws quicksight list-data-sets --aws-account-id {{id_compte_aws}}`
 

--- a/pages.fr/common/az.md
+++ b/pages.fr/common/az.md
@@ -20,7 +20,7 @@
 
 `az vm list`
 
-- Gère Azure Kubernetes Services:
+- Gère Azure Kubernetes Services :
 
 `az aks`
 

--- a/pages.fr/common/csh.md
+++ b/pages.fr/common/csh.md
@@ -4,18 +4,18 @@
 > Voir aussi : `tcsh`.
 > Plus d'informations : <https://www.mkssoftware.com/docs/man1/csh.1.asp>.
 
-- Démarrer une session interactive:
+- Démarrer une session interactive :
 
 `csh`
 
-- Démarrer une session interactive sans prendre en compte le fichier de configuration au démarrage:
+- Démarrer une session interactive sans prendre en compte le fichier de configuration au démarrage :
 
 `csh -f`
 
-- Exécuter une commande:
+- Exécuter une commande :
 
 `csh -c "{{echo 'Exécution de la commande echo par csh'}}"`
 
-- Exécuter un script:
+- Exécuter un script :
 
 `csh {{chemin/vers/script.csh}}`

--- a/pages.fr/common/docker-machine.md
+++ b/pages.fr/common/docker-machine.md
@@ -3,26 +3,26 @@
 > Créer et gérer des machines qui exécutent Docker.
 > Plus d'informations : <https://docs.docker.com/machine/reference/>.
 
-- Lister les machines Docker actuellement en cours d'exécution:
+- Lister les machines Docker actuellement en cours d'exécution :
 
 `docker-machine ls`
 
-- Créer une nouvelle machine Docker avec un nom spécifique:
+- Créer une nouvelle machine Docker avec un nom spécifique :
 
 `docker-machine create {{nom}}`
 
-- Récupérer les informations d'une machine Docker:
+- Récupérer les informations d'une machine Docker :
 
 `docker-machine status {{nom}}`
 
-- Démarrer une machine Docker:
+- Démarrer une machine Docker :
 
 `docker-machine start {{nom}}`
 
-- Arrêter une machine Docker:
+- Arrêter une machine Docker :
 
 `docker-machine stop {{nom}}`
 
-- Inspecter les informations d'une machine Docker:
+- Inspecter les informations d'une machine Docker :
 
 `docker-machine inspect {{nom}}`

--- a/pages.fr/common/docker-system.md
+++ b/pages.fr/common/docker-system.md
@@ -7,11 +7,11 @@
 
 `docker system`
 
-- Afficher l'utilisation du disque par docker:
+- Afficher l'utilisation du disque par docker :
 
 `docker system df`
 
-- Afficher des informations détaillées sur l'utilisation du disque par docker:
+- Afficher des informations détaillées sur l'utilisation du disque par docker :
 
 `docker system df --verbose`
 

--- a/pages.fr/common/gh.md
+++ b/pages.fr/common/gh.md
@@ -32,6 +32,6 @@
 
 `gh pr checkout {{numéro_de_la_PR}}`
 
-- Affiche le statut des pull requests du dépôt courant:
+- Affiche le statut des pull requests du dépôt courant :
 
 `gh pr status`

--- a/pages.fr/common/ssh-keygen.md
+++ b/pages.fr/common/ssh-keygen.md
@@ -11,11 +11,11 @@
 
 `ssh-keygen -f {{~/.ssh/fichier}}`
 
-- Génère une clé ed25519, avec 32 passages de fonction de dérivation de clé:
+- Génère une clé ed25519, avec 32 passages de fonction de dérivation de clé :
 
 `ssh-keygen -t {{ed25519}} -a {{32}}`
 
-- Génère une clé RSA de 4096 bits, avec l'adresse électronique en commentaire:
+- Génère une clé RSA de 4096 bits, avec l'adresse électronique en commentaire :
 
 `ssh-keygen -t {{rsa}} -b {{4096}} -C "{{commentaire|email}}"`
 

--- a/pages.fr/linux/cp.md
+++ b/pages.fr/linux/cp.md
@@ -3,7 +3,7 @@
 > Copier fichiers et répertoires.
 > Plus d'informations : <https://www.gnu.org/software/coreutils/cp>.
 
-- Copier un fichier vers un autre emplacement:
+- Copier un fichier vers un autre emplacement :
 
 `cp {{chemin/vers/fichier_original.ext}} {{chemin/vers/fichier_cible.ext}}`
 

--- a/pages.fr/sunos/svcadm.md
+++ b/pages.fr/sunos/svcadm.md
@@ -3,22 +3,22 @@
 > Manipuler les instances de service.
 > Plus d'informations : <https://www.unix.com/man-page/linux/1m/svcadm>.
 
-- Activer un service dans la base de données de service:
+- Activer un service dans la base de données de service :
 
 `svcadm enable {{nom_du_service}}`
 
-- Désactiver le service:
+- Désactiver le service :
 
 `svcadm disable {{nom_du_service}}`
 
-- Redémarrer un service en cours d'exécution:
+- Redémarrer un service en cours d'exécution :
 
 `svcadm restart {{nom_du_service}}`
 
-- Service de commande pour relire les fichiers de configuration:
+- Service de commande pour relire les fichiers de configuration :
 
 `svcadm refresh {{nom_du_service}}`
 
-- Effacer un service de l'état de maintenance et lui ordonner de démarrer:
+- Effacer un service de l'état de maintenance et lui ordonner de démarrer :
 
 `svcadm clear {{nom_du_service}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).