### PR TITLE
build-pdf: only build changed folders since last commit

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,7 +40,6 @@ function upload_assets {
   sha256sum \
     "${SITE_HOME}/assets/index.json" \
     "${SITE_HOME}/assets/"*.zip \
-    "${SITE_HOME}/assets/"*.pdf \
     > "${SITE_HOME}/assets/tldr.sha256sums"
 
   cd "$SITE_HOME"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,10 +31,10 @@ function initialize {
 function upload_assets {
   git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git "$SITE_HOME"
   mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
-  mv -f "${TLDR_LANG_ARCHIVES_DIRECTORY}"/*.zip "$SITE_HOME/assets/"
+  find "$TLDR_LANG_ARCHIVES_DIRECTORY" -maxdepth 1 -name "*.zip" -exec mv -f {} "$SITE_HOME/assets/" \;
   rm -rf "$TLDR_LANG_ARCHIVES_DIRECTORY"
   cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
-  mv -f "${TLDR_PDF_FILES_DIRECTORY}"/*.pdf "${SITE_HOME}/assets/"
+  find "$TLDR_PDF_FILES_DIRECTORY" -maxdepth 1 -name "*.pdf" -exec mv -f {} "$SITE_HOME/assets/" \;
   rm -rf "$TLDR_PDF_FILES_DIRECTORY"
 
   sha256sum \

--- a/scripts/pdf/build-pdf.sh
+++ b/scripts/pdf/build-pdf.sh
@@ -7,7 +7,6 @@ set -ex
 function process_page {
   pageDir="$1"
   folder=$(basename "${pageDir}")
-  language="${folder##*.}"
   case $folder in
     pages.bn | pages.ja | pages.ko | pages.ml | pages.ta | pages.th | pages.zh | pages.zh_TW)
       ;;
@@ -15,6 +14,7 @@ function process_page {
       python3 render.py "${pageDir}" -c solarized-light
       ;;
     *)
+      language="${folder##*.}"
       python3 render.py "${pageDir}" -c basic -o "tldr-book-${language}.pdf"
       ;;
   esac

--- a/scripts/pdf/build-pdf.sh
+++ b/scripts/pdf/build-pdf.sh
@@ -32,11 +32,18 @@ function main {
     fi
   else
     case $languageId in
-      "all")
+      all)
         pageDirs=(../../pages*)
+        ;;
+      bn | ja | ko | ml | ta | th | zh | zh_TW)
+        echo "${languageId} is not supported to build a PDF"
+        ;;
+      en)
+        pageDirs=("pages")
         ;;
       *)
         pageDirs=("pages.${languageId}")
+        ;;
     esac
   fi
   

--- a/scripts/pdf/build-pdf.sh
+++ b/scripts/pdf/build-pdf.sh
@@ -21,22 +21,24 @@ function process_page {
 }
 
 function main {
-  type="$1"
-  case $type in
-    "all")
-      pageDirs=(../../pages*)
-      ;;
-    *)
-      changedFiles=$(git diff-tree --no-commit-id --name-only -r "$(git rev-parse HEAD)")
-      changedPageDirs=$(echo "$changedFiles" | awk -F/ '/^(pages[^\/]+|pages)\//{print $1}' | sort -u)
-      
-      if [ -z "$changedPageDirs" ]; then
-        pageDirs=()
-      else
-        mapfile -t pageDirs <<< "$changedPageDirs"
-      fi
-      ;;
-  esac
+  languageId="$1"
+  if [ -z "$languageId" ]; then
+    changedFiles=$(git diff-tree --no-commit-id --name-only -r "$(git rev-parse HEAD)")
+    changedPageDirs=$(echo "$changedFiles" | awk -F/ '/^(pages[^\/]+|pages)\//{print $1}' | sort -u)
+    if [ -z "$changedPageDirs" ]; then
+      pageDirs=()
+    else
+      mapfile -t pageDirs <<< "$changedPageDirs"
+    fi
+  else
+    case $languageId in
+      "all")
+        pageDirs=(../../pages*)
+        ;;
+      *)
+        pageDirs=("pages.${languageId}")
+    esac
+  fi
   
   for pageDir in "${pageDirs[@]}"; do
     process_page "../../${pageDir}"

--- a/scripts/pdf/build-pdf.sh
+++ b/scripts/pdf/build-pdf.sh
@@ -24,20 +24,23 @@ function main {
   type="$1"
   case $type in
     "all")
-      for pageDir in ../../pages*; do
-        process_page "${pageDir}"
-      done
+      pageDirs=(../../pages*)
       ;;
     *)
       changedFiles=$(git diff-tree --no-commit-id --name-only -r "$(git rev-parse HEAD)")
       changedPageDirs=$(echo "$changedFiles" | awk -F/ '/^(pages[^\/]+|pages)\//{print $1}' | sort -u)
-      mapfile -t pageDirs <<< "$changedPageDirs"
-
-      for pageDir in "${pageDirs[@]}"; do
-          process_page "../../${pageDir}"
-      done
+      
+      if [ -z "$changedPageDirs" ]; then
+        pageDirs=()
+      else
+        mapfile -t pageDirs <<< "$changedPageDirs"
+      fi
       ;;
   esac
+  
+  for pageDir in "${pageDirs[@]}"; do
+    process_page "../../${pageDir}"
+  done
 }
 
 ###################################

--- a/scripts/pdf/build-pdf.sh
+++ b/scripts/pdf/build-pdf.sh
@@ -21,13 +21,27 @@ function process_page {
 }
 
 function main {
-  for pageDir in ../../pages*; do
-    process_page "${pageDir}"
-  done
+  type="$1"
+  case $type in
+    "all")
+      for pageDir in ../../pages*; do
+        process_page "${pageDir}"
+      done
+      ;;
+    *)
+      changedFiles=$(git diff-tree --no-commit-id --name-only -r "$(git rev-parse HEAD)")
+      changedPageDirs=$(echo "$changedFiles" | awk -F/ '/^(pages[^\/]+|pages)\//{print $1}' | sort -u)
+      mapfile -t pageDirs <<< "$changedPageDirs"
+
+      for pageDir in "${pageDirs[@]}"; do
+          process_page "../../${pageDir}"
+      done
+      ;;
+  esac
 }
 
 ###################################
 # MAIN
 ###################################
 
-main
+main $1


### PR DESCRIPTION
I noticed the Build-step took very long. This was due to the fact that all pages-folders were build every commit, even if they didn't change. By adding the provided change in this PR, we will gather the pages-folders that were changed in the last commit and deploy those. I have tested this locally as far as I could test it locally.

This PR resolves this issue: https://github.com/tldr-pages/tldr/pull/11773#issuecomment-1862658871