### PR TITLE
dig: remove inaccurate description of ANY

### DIFF
--- a/pages.es/common/dig.md
+++ b/pages.es/common/dig.md
@@ -15,10 +15,6 @@
 
 `dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
-- Obtiene todos los tipos de registros para un dominio determinado:
-
-`dig {{example.com}} ANY`
-
 - Especifica un servidor DNS alterno a consultar:
 
 `dig @{{8.8.8.8}} {{example.com}}`

--- a/pages.it/common/dig.md
+++ b/pages.it/common/dig.md
@@ -11,10 +11,6 @@
 
 `dig +short {{esempio.com}} MX`
 
-- Richiedi tutti i tipi di record per un dato dominio:
-
-`dig {{esempio.com}} ANY`
-
 - Specifica un server DNS alternativo a cui fare richiesta:
 
 `dig @{{8.8.8.8}} {{esempio.com}}`

--- a/pages.ja/common/dig.md
+++ b/pages.ja/common/dig.md
@@ -15,10 +15,6 @@
 
 `dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
-- 指定したドメイン名のすべてのタイプのレコードを取得する:
-
-`dig {{example.com}} ANY`
-
 - 問い合わせる別の DNS サーバーを指定する:
 
 `dig @{{8.8.8.8}} {{example.com}}`

--- a/pages.ko/common/dig.md
+++ b/pages.ko/common/dig.md
@@ -11,10 +11,6 @@
 
 `dig +short {{example.com}} MX`
 
-- 주어진 도메인 이름에 대한 모든 유형의 레코드들 가져오기:
-
-`dig {{example.com}} ANY`
-
 - 쿼리할 대체 DNS 서버를 지정하기:
 
 `dig @{{8.8.8.8}} {{example.com}}`

--- a/pages.pt_BR/common/dig.md
+++ b/pages.pt_BR/common/dig.md
@@ -15,10 +15,6 @@
 
 `dig +short {{exemplo.com}} {{A|MX|TXT|CNAME|NS}}`
 
-- Obtém todos os tipos de registros para um nome de domínio fornecido:
-
-`dig {{exemplo.com}} ANY`
-
 - Especifica um servidor DNS alternativo para consultar:
 
 `dig @{{8.8.8.8}} {{exemplo.com}}`

--- a/pages/common/dig.md
+++ b/pages/common/dig.md
@@ -15,10 +15,6 @@
 
 `dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
-- Get all types of records for a given domain name:
-
-`dig {{example.com}} ANY`
-
 - Specify an alternate DNS server to query:
 
 `dig @{{8.8.8.8}} {{example.com}}`


### PR DESCRIPTION
The tldr page on dig lists `dig example.com ANY` for "Get all types of records for a given domain name"

This is not accurate. For example,  I've included the output `dig example.com ANY`, which just returns an error. What's happening here is pretty typical -- `example.com` does not implement `ANY`, so it doesn't return any results. It returns a `NOTIMP` aka "not implemented" error code instead.

See also the blog post [Saying goodbye to ANY](https://blog.cloudflare.com/rfc8482-saying-goodbye-to-any) for some more context around this.

dig sadly doesn't really have any reliable way to get all types of records for a given domain name so I don't think it makes sense to include at all.

```
; <<>> DiG 9.18.19 <<>> +all example.com ANY
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOTIMP, id: 32535
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;example.com.			IN	ANY

;; Query time: 33 msec
;; SERVER: 192.168.1.1#53(192.168.1.1) (TCP)
;; WHEN: Tue Dec 19 09:40:15 EST 2023
;; MSG SIZE  rcvd: 40
```