### PR TITLE
scripts/deploy.sh: remove redundant paths from the sumfile

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,12 +37,9 @@ function upload_assets {
   find "$TLDR_PDF_FILES_DIRECTORY" -maxdepth 1 -name "*.pdf" -exec mv -f {} "$SITE_HOME/assets/" \;
   rm -rf "$TLDR_PDF_FILES_DIRECTORY"
 
-  sha256sum \
-    "${SITE_HOME}/assets/index.json" \
-    "${SITE_HOME}/assets/"*.zip \
-    > "${SITE_HOME}/assets/tldr.sha256sums"
+  cd "$SITE_HOME/assets"
+  sha256sum -- index.json *.zip > tldr.sha256sums
 
-  cd "$SITE_HOME"
   git add -A
   git commit -m "[GitHub Actions] uploaded assets after commit tldr-pages/tldr@${GITHUB_SHA}"
   git push -q


### PR DESCRIPTION
Currently, `tldr.sha256sums` looks like this:
```
<sha256sum>    /home/runner/site/assets/tldr-pages.lang.zip
```

Clients only need the filename.
```
<sha256sum>    tldr-pages.lang.zip
```