### PR TITLE
scripts/deploy.sh: exit immediately if there aren't any changes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,15 +5,18 @@
 set -ex
 
 function initialize {
+  export TLDR_ARCHIVE="tldr.zip"
+
+  if [[ ! -f $TLDR_ARCHIVE ]]; then
+    echo "No changes to deploy."
+    exit 0
+  fi
+
   if [[ -z $TLDRHOME ]]; then
     export TLDRHOME=${GITHUB_WORKSPACE:-$(pwd)}
   fi
 
-  export TLDR_LANG_ARCHIVES_DIRECTORY="$TLDRHOME/language_archives"
-  export TLDR_PDF_FILES_DIRECTORY="$TLDRHOME/scripts/pdf"
-  export TLDR_ARCHIVE="tldr.zip"
   export SITE_HOME="$HOME/site"
-  export SITE_REPO_SLUG="tldr-pages/tldr-pages.github.io"
 
   # Configure git.
   git config --global user.email "tldrbotgithub@gmail.com"
@@ -23,33 +26,26 @@ function initialize {
 
   # Decrypt and add deploy key.
   eval "$(ssh-agent -s)"
-  echo "${DEPLOY_KEY}"> id_ed25519
+  echo "$DEPLOY_KEY"> id_ed25519
   chmod 600 id_ed25519
   ssh-add id_ed25519
 }
 
 function upload_assets {
-  git clone --quiet --depth 1 git@github.com:${SITE_REPO_SLUG}.git "$SITE_HOME"
-  [[ -f "$TLDR_ARCHIVE" ]] && mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
-  find "$TLDR_LANG_ARCHIVES_DIRECTORY" -maxdepth 1 -name "*.zip" -exec mv -f {} "$SITE_HOME/assets/" \;
-  rm -rf "$TLDR_LANG_ARCHIVES_DIRECTORY"
-  [[ -f "$TLDRHOME/index.json" ]] && cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
-  find "$TLDR_PDF_FILES_DIRECTORY" -maxdepth 1 -name "*.pdf" -exec mv -f {} "$SITE_HOME/assets/" \;
-  rm -rf "$TLDR_PDF_FILES_DIRECTORY"
+  git clone --quiet --depth 1 "git@github.com:tldr-pages/tldr-pages.github.io.git" "$SITE_HOME"
+
+  mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
+  find "$TLDRHOME/language_archives" -maxdepth 1 -name "*.zip" -exec mv -f {} "$SITE_HOME/assets/" \;
+  cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
+  find "$TLDRHOME/scripts/pdf" -maxdepth 1 -name "*.pdf" -exec mv -f {} "$SITE_HOME/assets/" \;
 
   cd "$SITE_HOME/assets"
   sha256sum -- index.json *.zip > tldr.sha256sums
 
-  # Check if there are changes before committing and pushing.
-  if git diff --quiet; then
-    echo "No changes to deploy."
-    return
-  fi
-
   git add -A
-  git commit -m "[GitHub Actions] uploaded assets after commit tldr-pages/tldr@${GITHUB_SHA}"
+  git commit -m "[GitHub Actions] uploaded assets after commit tldr-pages/tldr@$GITHUB_SHA"
   git push -q
-  echo "Assets (pages archive, index and checksum) deployed to the static site."
+  echo "Assets (pages archive, index and checksums) deployed to the static site."
 }
 
 ###################################


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/pull/11825#issuecomment-1868687824 didn't work because it did the opposite - exit when there are changes, proceed if there aren't. I forgot to add a `!`.

---

I removed some of the variables used only once, because their contents were shorter than the variable name itself.

By the way, it would be great if we had some written conventions regarding the shell scripts.

- some scripts use `$var`, some `${var}`
- some quote every variable, some don't, etc.