### PR TITLE
chsh: add Spanish translation

### DIFF
--- a/pages.es/common/chsh.md
+++ b/pages.es/common/chsh.md
@@ -1,0 +1,20 @@
+# chsh
+
+> Cambia el intérprete de comandos de inicio de sesión.
+> Más información: <https://manned.org/chsh>.
+
+- Cambia interactivamente el intérprete del usuario actual:
+
+`chsh`
+
+- Cambia el intérprete del usuario actual por otro en específico:
+
+`chsh -s {{ruta/al/intérprete}}`
+
+- Cambia el intérprete de otro usuario:
+
+`chsh -s {{ruta/al/intérprete}} {{nombre_de_usuario}}`
+
+- En[l]ista los intérpretes disponibles:
+
+`chsh -l`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.38.1

I noticed some pages (e.g., `adb-shell`, `autossh`, `history`, `nix-classic`, `zsh`, `abroot`, `useradd`, `dd`, `whence`, `cmd`) in Spanish did not translate the term *shell*, so I am not sure if I should as well because I had to remove option mnemonics.
