### PR TITLE
MAINTAINERS: add @acuteenvy as org owner; update dead links

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -133,8 +133,6 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [19 May 2021](https://github.com/tldr-pages/tldr/issues/5989) — present
 - **Seth Falco ([@SethFalco](https://github.com/SethFalco))**:
   [21 June 2021](https://github.com/tldr-pages/tldr/issues/6149) — present
-- **Lena ([@acuteenvy](https://github.com/acuteenvy))**:
-  [21 June 2023](https://github.com/tldr-pages/tldr/issues/10406) — present
 - **Juri ([@gutjuri](https://github.com/gutjuri))**:
   [24 October 2023](https://github.com/tldr-pages/tldr/issues/11201) — present
 - **Sebastiaan Speck ([@sebastiaanspeck](https://github.com/sebastiaanspeck))**:
@@ -167,6 +165,8 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [4 January 2023](https://github.com/tldr-pages/tldr/issues/9671) — [7 July 2023](https://github.com/tldr-pages/tldr/issues/10054)
 - Matthew Peveler ([@MasterOdin](https://github.com/MasterOdin)):
   [18 March 2021](https://github.com/tldr-pages/tldr/issues/5473) — [15 November 2023](https://github.com/tldr-pages/tldr/issues/11509)
+- Lena ([@acuteenvy](https://github.com/acuteenvy)):
+  [21 June 2023](https://github.com/tldr-pages/tldr/issues/10406) — [25 December 2023](https://github.com/tldr-pages/tldr/issues/11839)
 
 ## Organization owners
 
@@ -196,6 +196,8 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [19 June 2023](https://github.com/tldr-pages/tldr/issues/10057) — present
 - **Lin Cheng Chieh ([@blueskyson](https://github.com/blueskyson))**:
   [7 July 2023](https://github.com/tldr-pages/tldr/issues/10054) — present
+- **Lena ([@acuteenvy](https://github.com/acuteenvy))**:
+  [25 December 2023](https://github.com/tldr-pages/tldr/issues/11839) — present
 - Igor Shubovych ([@igorshubovych](https://github.com/igorshubovych)):
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
 - Ruben Vereecken ([@rubenvereecken](https://github.com/rubenvereecken)):

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -166,7 +166,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - Matthew Peveler ([@MasterOdin](https://github.com/MasterOdin)):
   [18 March 2021](https://github.com/tldr-pages/tldr/issues/5473) — [15 November 2023](https://github.com/tldr-pages/tldr/issues/11509)
 - Lena ([@acuteenvy](https://github.com/acuteenvy)):
-  [21 June 2023](https://github.com/tldr-pages/tldr/issues/10406) — [25 December 2023](https://github.com/tldr-pages/tldr/issues/11839)
+  [21 June 2023](https://github.com/tldr-pages/tldr/issues/10406) — [27 December 2023](https://github.com/tldr-pages/tldr/issues/11839)
 
 ## Organization owners
 
@@ -197,7 +197,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
 - **Lin Cheng Chieh ([@blueskyson](https://github.com/blueskyson))**:
   [7 July 2023](https://github.com/tldr-pages/tldr/issues/10054) — present
 - **Lena ([@acuteenvy](https://github.com/acuteenvy))**:
-  [25 December 2023](https://github.com/tldr-pages/tldr/issues/11839) — present
+  [27 December 2023](https://github.com/tldr-pages/tldr/issues/11839) — present
 - Igor Shubovych ([@igorshubovych](https://github.com/igorshubovych)):
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
 - Ruben Vereecken ([@rubenvereecken](https://github.com/rubenvereecken)):

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,7 @@ If you are an owner of the organization, you can see an automated list
   [19 May 2021](https://github.com/tldr-pages/tldr/issues/5993) - [21 June 2021](https://github.com/tldr-pages/tldr/issues/6149)
 - Pixel Häußler ([@pixelcmtd](https://github.com/pixelcmtd)):
   [27 August 2021](https://github.com/tldr-pages/tldr/issues/6415) — [16 October 2022](https://github.com/tldr-pages/tldr/pull/9072#issuecomment-1279847932)
-- Emily Grace Seville ([@EmilySeville7cfg](https://github.com/EmilySeville7cfg)):
+- Emily Grace Seville ([@EmilyGraceSeville7cf](https://github.com/EmilyGraceSeville7cf)):
   [19 January 2022](https://github.com/tldr-pages/tldr/issues/1209#issuecomment-285924778) — [24 April 2022](https://github.com/tldr-pages/tldr/issues/8053)
 - K.B.Dharun Krishna ([@kbdharun](https://github.com/kbdharun)):
   [06 August 2022](https://github.com/tldr-pages/tldr/issues/8309) — [14 December 2022](https://github.com/tldr-pages/tldr/issues/9625)
@@ -153,7 +153,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [14 June 2021](https://github.com/tldr-pages/tldr/issues/6123) — [14 December 2021](https://github.com/tldr-pages/tldr/issues/7541)
 - Marcher Simon ([@marchersimon](https://github.com/marchersimon)):
   [9 April 2021](https://github.com/tldr-pages/tldr/issues/5722) — [9 August 2022](https://github.com/tldr-pages/tldr/issues/7540)
-- Emily Grace Seville ([@EmilySeville7cfg](https://github.com/EmilySeville7cfg)):
+- Emily Grace Seville ([@EmilyGraceSeville7cf](https://github.com/EmilyGraceSeville7cf)):
   [25 April 2022](https://github.com/tldr-pages/tldr/issues/8053) — [12 January 2022](https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$n3Jk7mhIzG6edTVUv6MkAoX_1N5z5MPRj2hclyrfKBI)
 - Pixel Häußler ([@pixelcmtd](https://github.com/pixelcmtd)):
   [16 October 2022](https://github.com/tldr-pages/tldr/pull/9072#issuecomment-1279847932) — [10 May 2023](https://github.com/tldr-pages/tldr/pull/10056)
@@ -210,7 +210,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
 - Arvid Gerstmann ([@Leandros](https://github.com/Leandros)):
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
-- Leandro Ostera ([@ostera](https://github.com/ostera)):
+- Leandro Ostera ([@leostera](https://github.com/leostera)):
   until [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454)
 - Waldir Pimenta ([@waldyrious](https://github.com/waldyrious)):
   until [26 August 2018](https://github.com/tldr-pages/tldr/issues/2257)


### PR DESCRIPTION
It seems that 2 users have changed their usernames, so I've updated dead links to their accounts.

Closes #11839.