### PR TITLE
CODEOWNERS: remove waldyrious from pt_BR line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /pages.ko/ @IMHOJEONG
 /pages.nl/ @sebastiaanspeck @leonvsc @Waples
 /pages.pl/ @acuteenvy
-/pages.pt_BR/ @waldyrious @isaacvicente
+/pages.pt_BR/ @isaacvicente
 /pages.pt_PT/ @waldyrious
 /pages.ta/ @kbdharun
 /pages.tr/ @yutyo


### PR DESCRIPTION
In #11833 I removed my name from one of the pt-BR entries in CODEOWNERS, since there's already another maintainer looking after them, and I don't currently have the bandwidth to review changes in a timely manner. I kept my name as code owner for the pt-PT entries.

However, I didn't notice that there were actually two pt-BR entries in that file, so this PR does the same change for the other one.

Btw, thank you @isaacvicente for stepping up to help the project with the pt-BR content!