### PR TITLE
cleanup: update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,6 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 - For multiple subcommand page additions: `git-{add, push, ...}: add page`
 - For modifying multiple pages in a language: `pages.<locale>/*: update pages`
 
----
-
 For other cases, its suggested to follow <https://www.conventionalcommits.org/> as much as possible.
 
 ## Name collisions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,14 +98,37 @@ To create a page for a subcommand, the program and subcommand need to be separat
 
 You should always add a base page (e.g. `git`) that describes the program and basic switches like `--version` or `--help`.
 
-To let others know about the subcommand, add a note saying ``Some subcommands such as `example command` have their own usage documentation`` to the base page.
+### Referencing subcommands
+
+The following methods can be used to reference subcommands:
+
+- To let others know about the subcommands, add a note saying ``Some subcommands such as `example command` have their own usage documentation`` to the main page. (See the [subcommand reference](/contributing-guides/translation-templates/subcommand-mention.md) page for translation templates.)
+- You can use "See also: `command1`, `command2`." template to reference similar commands, aliases and subcommands.
+- Alternatively, the whole page can be converted to reference the main subcommands.
+
+For example:
+
+```md
+# command
+
+> Short, snappy description.
+> Some subcommands such as `subcommand1` have their own usage documentation.
+> More information: <https://url-to-upstream.tld>.
+
+- View documentation for creating something:
+
+`tldr command-subcommand1`
+
+- View documentation for managing something:
+
+`tldr command-something2`
+```
 
 See these examples for reference:
 
 - [git](pages/common/git.md)
-- [git-commit](pages/common/git-commit.md)
-- [aws](pages/common/aws.md)
-- [aws-s3](pages/common/aws-s3.md)
+- [distrobox-create](pages/linux/distrobox-create.md)
+- [nmcli](pages/linux/nmcli.md)
 
 ## Translations
 
@@ -123,6 +146,9 @@ The `<country>` code is optional and should only be added when it is needed. In 
 
 > [!IMPORTANT]  
 > When adding a new language to `tldr`, it is suggested to add it to the [translation templates](contributing-guides/translation-templates) along with any page additions.
+
+> [!TIP]
+> When fixing errors in an existing translation, it is suggested to update the page to match with the latest version of the English page.
 
 To see the current progress of all translations, you can visit <https://lukwebsforge.github.io/tldri18n/>, which provides a dynamically updated table of all pages and their translations.
 
@@ -209,6 +235,14 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 ---
 
 For other cases, its suggested to follow <https://www.conventionalcommits.org/> as much as possible.
+
+## Name collisions
+
+When there are multiple commands sharing the same name, the existing page of the command and the new command can be renamed to `command.1` and so on following a numbering scheme or based on the programming language i.e. `command.js`. The base page can be updated to reference the newly renamed/created pages by following [this subcommand reference format](#subcommands).
+
+See the following page for reference:
+
+- [just](pages/common/just.md)
 
 ## Licensing
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Changes

- Document methods to reference subcommands (update examples).
- Add tip when fixing typos in translations the page must be updated to match with the English page.
- Document how to deal with name collisions. (I intentionally added it to the last section of the page as we wouldn't be referring to this frequently)