### PR TITLE
cupstestppd: add page

### DIFF
--- a/pages/common/cupstestppd.md
+++ b/pages/common/cupstestppd.md
@@ -2,6 +2,8 @@
 
 > Test conformance of PPD files to the version 4.3 of the specification.
 > Error codes (1, 2, 3 and 4, respectively): bad CLI arguments, unable to open file, unskippable format errors and non-conformance with PPD specification.
+> This command is deprecated.
+> See also: `lpadmin`.
 > More information: <https://openprinting.github.io/cups/doc/man-cupstestppd.html>.
 
 - Test the conformance of one or more files in quiet mode:

--- a/pages/common/cupstestppd.md
+++ b/pages/common/cupstestppd.md
@@ -1,0 +1,17 @@
+# cupstestppd
+
+> Test conformance of PPD files to the version 4.3 of the specification.
+> Error codes (1, 2, 3 and 4, respectively): bad CLI arguments, unable to open file, unskippable format errors and non-conformance with PPD specification.
+> More information: <https://openprinting.github.io/cups/doc/man-cupstestppd.html>.
+
+- Test the conformance of one or more files in quiet mode:
+
+`cupstestppd -q {path/to/file1.ppd path/to/file2.ppd ...}`
+
+- Get the PPD file from `stdin`, showing detailed conformance testing results:
+
+`cupstestppd -v - < path/to/file.ppd`
+
+- Test all PPD files under the current directory, printing the names of each file that does not conform:
+
+`find . -name \*.ppd \! -execdir cupstestppd -q '{}' \; -print`

--- a/pages/common/cupstestppd.md
+++ b/pages/common/cupstestppd.md
@@ -2,7 +2,7 @@
 
 > Test conformance of PPD files to the version 4.3 of the specification.
 > Error codes (1, 2, 3 and 4, respectively): bad CLI arguments, unable to open file, unskippable format errors and non-conformance with PPD specification.
-> This command is deprecated.
+> NOTE: this command is deprecated.
 > See also: `lpadmin`.
 > More information: <https://openprinting.github.io/cups/doc/man-cupstestppd.html>.
 

--- a/pages/common/cupstestppd.md
+++ b/pages/common/cupstestppd.md
@@ -8,11 +8,11 @@
 
 - Test the conformance of one or more files in quiet mode:
 
-`cupstestppd -q {path/to/file1.ppd path/to/file2.ppd ...}`
+`cupstestppd -q {{path/to/file1.ppd path/to/file2.ppd ...}}`
 
 - Get the PPD file from `stdin`, showing detailed conformance testing results:
 
-`cupstestppd -v - < path/to/file.ppd`
+`cupstestppd -v - < {{path/to/file.ppd}}`
 
 - Test all PPD files under the current directory, printing the names of each file that does not conform:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Partially fixes #6597. This command is deprecated in OpenPrinting CUPS. I'm only documenting this command because in Apple CUPS it is not deprecated yet.