### PR TITLE
git, git-*: add and improve Indonesian translation (Part 1)

### DIFF
--- a/pages.id/common/git-abort.md
+++ b/pages.id/common/git-abort.md
@@ -1,0 +1,9 @@
+# git abort
+
+> Batalkan proses penyatuan melalui rebase, merge, atau cherry-pick yang sedang berlangsung.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
+
+- Batalkan proses penyatuan (rebase, merge, atau cherry-pick) yang sedang berlangsung:
+
+`git abort`

--- a/pages.id/common/git-add.md
+++ b/pages.id/common/git-add.md
@@ -1,6 +1,6 @@
 # git add
 
-> Menambahkan file yang diubah ke indeks.
+> Tambahkan file yang diubah ke indeks.
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-add>.
 
 - Tambahkan file ke indeks:

--- a/pages.id/common/git-am.md
+++ b/pages.id/common/git-am.md
@@ -1,0 +1,22 @@
+# git am
+
+> Gunakan perubahan dari file deskripsi perubahan (patch) untuk melakukan sebuah komit. Dapat digunakan untuk menerima komit melalui surel/email.
+> Lihat juga `git format-patch` untuk membuat file deskripsi perubahan/patch.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-am>.
+
+- Gunakan dan komit perubahan dari file patch dalam direktori lokal:
+
+`git am {{jalan/menuju/file.patch}}`
+
+- Gunakan dan komit perubahan dari file patch dari sumber dalam jaringan (online):
+
+`curl -L {{https://example.com/file.patch}} | git apply`
+
+- Batalkan proses perubahan yang dilakukan:
+
+`git am --abort`
+
+- Lakukan perubahan-perubahan dari file patch sebisa mungkin, dan tolak file patch jika proses tersebut gagal:
+
+`git am --reject {{jalan/menuju/file.patch}}`
+

--- a/pages.id/common/git-annex.md
+++ b/pages.id/common/git-annex.md
@@ -1,0 +1,29 @@
+# git annex
+
+> Kelola file dengan Git, tanpa memeriksa isi kontennya.
+> Saat file dianeksasi, kontennya dipindahkan ke penyimpanan key-value, dan symlink dibuat yang mengarah ke konten tersebut.
+> Informasi lebih lanjut: <https://git-annex.branchable.com>.
+
+- Inisialisasi sebuah repositori dengan Git annex:
+
+`git annex init`
+
+- Tambahkan file ke dalam repositori:
+
+`git annex add {{jalan/menuju/file_atau_direktori}}`
+
+- Tampilkan status file atau direktori saat ini:
+
+`git annex status {{jalan/menuju/file_atau_direktori}}`
+
+- Sinkronisasikan repositori lokal dengan sumber remote:
+
+`git annex {{remote}}`
+
+- Dapatkan isi file atau direktori:
+
+`git annex get {{jalan/menuju/file_atau_direktori}}`
+
+- Tampilkan informasi bantuan:
+
+`git annex help`

--- a/pages.id/common/git-annotate.md
+++ b/pages.id/common/git-annotate.md
@@ -1,0 +1,18 @@
+# git annotate
+
+> Tampilkan kode hash serta pelaku komit terakhir pada setiap baris suatu file teks.
+> Lihat juga `git blame`, yang lebih disarankan daripada `git annotate`.
+> Perintah `git annotate` disediakan bagi pengguna yang telah familiar pada sistem manajemen versi lainnya.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-annotate>.
+
+- Tampilkan file teks beserta informasi nama pelaku dan kode hash komit terakhir pada akhir setiap baris teks:
+
+`git annotate {{jalan/menuju/file}}`
+
+- Tampilkan file dengan informasi komit menggunakan alamat surel/[e]mail daripada nama pelaku:
+
+`git annotate -e {{jalan/menuju/file}}`
+
+- Tampilkan hanya baris-baris teks yang memenuhi kriteria ekspresi reguler:
+
+`git annotate -L :{{ekspresi_reguler}} {{jalan/menuju/file}}`

--- a/pages.id/common/git-apply.md
+++ b/pages.id/common/git-apply.md
@@ -1,0 +1,29 @@
+# git apply
+
+> Gunakan perubahan dari file deskripsi perubahan (patch) kepada indeks perubahan tanpa mencatat sebuah komit.
+> Lihat juga `git am`, yang sama-sama menggunakan perubahan dari file patch namun juga mencatatnya ke dalam sebuah komit baru.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-apply>.
+
+- Tampilkan informasi lengkap (mode verbose) atas proses perubahan yang sedang dilakukan:
+
+`git apply --verbose {{jalan/menuju/file}}`
+
+- Gunakan patch dan tambahkan file yang diubah ke dalam indeks perubahan:
+
+`git apply --index {{jalan/menuju/file}}`
+
+- Gunakan perubahan dari file patch dari sumber dalam jaringan (online):
+
+`curl -L {{https://example.com/file.patch}} | git apply`
+
+- Tampilkan informasi statistik perbedaan (diffstat) setelah melakukan perubahan menurut file patch:
+
+`git apply --stat --apply {{jalan/menuju/file}}`
+
+- Batalkan perubahan yang dilakukan melalui file patch:
+
+`git apply --reverse {{jalan/menuju/file}}`
+
+- Simpan hasil perubahan ke dalam indeks perubahan tanpa merubah susunan file/direktori dalam direktori kerja saat ini:
+
+`git apply --cache {{jalan/menuju/file}}`

--- a/pages.id/common/git-archive-file.md
+++ b/pages.id/common/git-archive-file.md
@@ -1,0 +1,9 @@
+# git archive-file
+
+> Ekspor seluruh file pada cabang Git saat ini menjadi sebuah file arsip zip.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-archive-file>.
+
+- Masukkan seluruh file pada komit yang sedang diperiksa ke dalam suatu file arsip zip:
+
+`git archive-file`

--- a/pages.id/common/git-archive.md
+++ b/pages.id/common/git-archive.md
@@ -1,0 +1,28 @@
+# git archive
+
+> Buat sebuah arsip direktori berdasarkan cabang/tree tertentu.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-archive>.
+
+- Buat sebuah arsip tar berisikan isi dari tree HEAD saat ini, kemudian tampilkan isi file arsip mentah menuju `stdout`:
+
+`git archive --verbose HEAD`
+
+- Buat sebuah arsip zip dari tree HEAD saat ini, kemudian tampilkan isi file arsip mentah menuju `stdout`:
+
+`git archive --verbose --format zip HEAD`
+
+- Lakukan hal yang sama, namun simpan arsip zip ke dalam suatu direktori:
+
+`git archive --verbose --output {{jalan/menuju/file.zip}} HEAD`
+
+- Buat arsip tar dari komit terakhir pada cabang tertentu:
+
+`git archive --output {{jalan/menuju/file.tar}} {{nama_cabang}}`
+
+- Buat arsip tar berdasaran subdirektori tertentu pada suatu repositori Git:
+
+`git archive --output={{jalan/menuju/file.tar}} HEAD:{{jalan/menuju/direktori}}`
+
+- Bubuhkan nama jalur pada awal nama setiap file, untuk diarsipkan di dalam direktori tertentu:
+
+`git archive --output={{jalan/menuju/file.tar}} --prefix={{jalan/untuk/dibubuhkan}}/ HEAD`

--- a/pages.id/common/git-authors.md
+++ b/pages.id/common/git-authors.md
@@ -1,0 +1,17 @@
+# git authors
+
+> Buat daftar pelaku komit pada suatu repositori Git.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+
+- Tampilkan daftar pelaku komit menuju `stdout` daripada menuju ke file `AUTHORS`:
+
+`git authors --list`
+
+- Masukkan daftar pelaku komit menuju file `AUTHORS`, kemudian buka file tersebut pada aplikasi penyunting file teks default:
+
+`git authors`
+
+- Masukkan daftar pelaku komit tanpa informasi alamat surel/email menuju file `AUTHORS`, kemudian buka file tersebut pada aplikasi penyunting file teks default:
+
+`git authors --no-email`

--- a/pages.id/common/git.md
+++ b/pages.id/common/git.md
@@ -1,29 +1,29 @@
 # git
 
 > Sistem kontrol versi terdistribusi.
-> Kami mempunyai dokumentasi terpisah untuk menggunakan subperintah seperti `git commit`.
+> Kami mempunyai dokumentasi terpisah untuk menggunakan subperintah seperti `commit`, `add`, `branch`, `checkout`, `push`, dsb.
 > Informasi lebih lanjut: <https://git-scm.com/>.
 
-- Memeriksa versi Git:
+- Periksa versi Git:
 
 `git --version`
 
-- Menunjukkan bantuan umum:
+- Tampilkan bantuan umum:
 
 `git --help`
 
-- Menampilkan bantuan pada sub perintah Git (seperti `commit`,` log`, dll.):
+- Tampilkan bantuan pada sub perintah Git (seperti `commit`,` log`, dll.):
 
 `git help {{subcommand}}`
 
-- Menjalankan subperintah Git:
+- Jalankan subperintah Git:
 
 `git {{subcommand}}`
 
-- Menjalankan subperintah Git di jalur root repositori kustom:
+- Jalankan subperintah Git di jalur root repositori kustom:
 
 `git -C {{alamat/ke/repositori}} {{subcommand}}`
 
-- Menjalankan subperintah Git dengan set konfigurasi yang diberikan:
+- Jalankan subperintah Git dengan set konfigurasi yang diberikan:
 
 `git -c '{{config.key}}={{value}}' {{subcommand}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR adds and improves many `git` and `git-extras` subcommands, as well as `git`-related tools. I decided to split this PR (unlike the original ["1 percent" PR](https://github.com/tldr-pages/tldr/pull/11640) by 10 files for easier review.