### PR TITLE
COMMUNITY-ROLES: fix note, remove broken link reference

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -35,7 +35,6 @@ exceptions can always be considered through open community discussion.)
   (Maintenance work means facilitating contributions by other people,
   which in this project typically consists of reviewing and/or merging PRs.)
   Specifically: once a repository collaborator has _merged at least 10 PRs_
-  (see `https://github.com/tldr-pages/tldr/commits?committer=<username>`)
   and submitted at least _5 non-trivial reviews to PRs_
   (see `https://github.com/tldr-pages/tldr/pulls?q=reviewed-by:<username>`),
   which can overlap with the 10 they merged themselves,
@@ -46,9 +45,8 @@ exceptions can always be considered through open community discussion.)
   push commits to all of the organization's repositories,
   merge PRs, label and close issues, among other things.
 
-  > [!NOTE]
-  > All members of the tldr-pages organization
-  > must make their membership public.
+> [!NOTE]
+> All members of the tldr-pages organization **must make their membership public**.
 
 - **Organization members who remain active for a while should become organization owners.**
   Specifically: members of the tldr-pages organization

--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -46,7 +46,7 @@ exceptions can always be considered through open community discussion.)
   merge PRs, label and close issues, among other things.
 
 > [!NOTE]
-> All members of the tldr-pages organization **must make their membership public**.
+> All members of the tldr-pages organization **must** make their membership public.
 
 - **Organization members who remain active for a while should become organization owners.**
   Specifically: members of the tldr-pages organization


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

## Changes

- Fix the broken note rendering.
- Remove the merged PR check URL (`https://github.com/tldr-pages/tldr/commits?committer=<username>`) as afaik GitHub no longer offers a direct way to check it. In future, we can continue manually checking the merged PRs (for this requirement).

> [!NOTE]
> As the wording signifies it is for checking merged commits by you, not to be confused with authored/coauthored commits `https://github.com/tldr-pages/tldr/commits?author=<username>`
