### PR TITLE
docker-exec: fix typo

### DIFF
--- a/pages.de/common/docker-exec.md
+++ b/pages.de/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Bestimme das Arbeitsverzeichnis, in dem der Befehl ausgeführt werden soll:
 
-`docker exec --interactive -tty --workdir {{pfad/zum/verzeichnis}} {{container_name}} {{befehl}}`
+`docker exec --interactive --tty --workdir {{pfad/zum/verzeichnis}} {{container_name}} {{befehl}}`
 
 - Führe einen Befehl im Hintergrund in einem laufenden Container aus, aber lies von der Standardeingabe:
 

--- a/pages.fr/common/docker-exec.md
+++ b/pages.fr/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Sélectionner le répertoire de travail pour une commande donnée à exécuter :
 
-`docker exec --interactive -tty --workdir {{chemin/vers/le/répertoire}} {{nom_du_conteneur}} {{commande}}`
+`docker exec --interactive --tty --workdir {{chemin/vers/le/répertoire}} {{nom_du_conteneur}} {{commande}}`
 
 - Exécuter une commande en arrière-plan sur un conteneur existant mais garder `stdin` ouvert :
 

--- a/pages.it/common/docker-exec.md
+++ b/pages.it/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Seleziona la directory di lavoro in cui eseguire un dato comando:
 
-`docker exec --interactive -tty --workdir {{percorso/della/directory}} {{nome_container}} {{comando}}`
+`docker exec --interactive --tty --workdir {{percorso/della/directory}} {{nome_container}} {{comando}}`
 
 - Esegui un comando in background su un container esistente, mantenendo aperto `stdin`:
 

--- a/pages.tr/common/docker-exec.md
+++ b/pages.tr/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Belirtilen bir komutu üstünde çalıştırmak adına çalışan dizini seç:
 
-`docker exec --interactive -tty --workdir {{örnek/dizin}} {{konteyner_ismi}} {{komut}}`
+`docker exec --interactive --tty --workdir {{örnek/dizin}} {{konteyner_ismi}} {{komut}}`
 
 - Varolan konteyner üstünde arkaplanda çalışmak üzere bir komut çalıştır ancak `stdin`'i açık tut:
 

--- a/pages/common/docker-exec.md
+++ b/pages/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Select the working directory for a given command to execute into:
 
-`docker exec --interactive -tty --workdir {{path/to/directory}} {{container_name}} {{command}}`
+`docker exec --interactive --tty --workdir {{path/to/directory}} {{container_name}} {{command}}`
 
 - Run a command in background on existing container but keep `stdin` open:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).