### PR TITLE
jwt: escape placeholder

### DIFF
--- a/pages.pt_BR/common/jwt.md
+++ b/pages.pt_BR/common/jwt.md
@@ -18,4 +18,4 @@
 
 - Codifica dados (payload) de um par de chaves (key pair) em um JWT:
 
-`jwt encode --alg {{HS256}} --secret {{1234567890}} -P chave=valor`
+`jwt encode --alg {{HS256}} --secret {{1234567890}} -P {{chave=valor}}`

--- a/pages/common/jwt.md
+++ b/pages/common/jwt.md
@@ -18,4 +18,4 @@
 
 - Encode key pair payload to JWT:
 
-`jwt encode --alg {{HS256}} --secret {{1234567890}} -P key=value`
+`jwt encode --alg {{HS256}} --secret {{1234567890}} -P {{key=value}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).