### PR TITLE
CODEOWNERS: Remove @sbrl from pages/linux

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /pages.zh/ @blueskyson @einverne
 /pages.zh_TW/ @blueskyson
 
-/pages/linux/ @sbrl @cyqsimon
+/pages/linux/ @cyqsimon
 
 /*.md @sbrl @kbdharun
 /.github/workflows/* @sbrl @kbdharun @sebastiaanspeck


### PR DESCRIPTION
This is polluting my review requests such that I can't tell which ones have been explicitly requested of me and which ones are automatic.

Merging immediately as this only affects me.