### PR TITLE
pages/common: fix typos in placeholders

### DIFF
--- a/pages/common/git-stash.md
+++ b/pages/common/git-stash.md
@@ -19,9 +19,9 @@
 
 `git stash list`
 
-- Show the changes as a patch between the stash (default is stash@{0}) and the commit back when stash entry was first created:
+- Show the changes as a patch between the stash (default is `stash@{0}`) and the commit back when stash entry was first created:
 
-`git stash show -p {{stash@{0}}`
+`git stash show -p {{stash@{0}}}`
 
 - Apply a stash (default is the latest, named stash@{0}):
 

--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -25,4 +25,4 @@
 
 - Run a benchmark where a single parameter changes for each run:
 
-`hyperfine --prepare '{{make clean}}' --parameter-scan {{num_threads}} {{1}} {{10}} '{{make -j {num_threads}}'`
+`hyperfine --prepare '{{make clean}}' --parameter-scan {{num_threads}} {{1}} {{10}} '{{make -j {num_threads}}}'`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

Ref. #11850

Although this still will have a non-placeholder bracket it is much better than not being shown itself.

![image](https://github.com/tldr-pages/tldr/assets/26346867/dce0e1b7-21c8-4334-bb9e-240ae880ba99)
