### PR TITLE
xclip: add Spanish translation

### DIFF
--- a/pages.es/linux/xclip.md
+++ b/pages.es/linux/xclip.md
@@ -1,0 +1,37 @@
+# xclip
+
+> Herramienta para manipular el portapapeles de X11, similar a `xsel`.
+> Maneja la selección primaria y secundaria de X y el portapapeles (`Ctrl + C`/`Ctrl + V`).
+> Más información: <https://manned.org/xclip>.
+
+- Copia la salida de un comando a la selección primaria de X11:
+
+`echo 123 | xclip`
+
+- Copia la salida de un commando a una selección de X11:
+
+`echo 123 | xclip -selection {{primary|secondary|clipboard}}`
+
+- Copia la salida de un commando al portapapeles, usando notación corta:
+
+`echo 123 | xclip -sel clip`
+
+- Copia el contenido de un fichero al portapapeles:
+
+`xclip -sel clip {{archivo.txt}}`
+
+- Copia el contenido de un fichero con formato PNG al portapapeles:
+
+`xclip -sel clip -t image/png {{archivo.png}}`
+
+- Copia la entrada del usuario al portapapeles:
+
+`xclip -i`
+
+- Imprime el contenido de la selección primaria de X11:
+
+`xclip -o`
+
+- Imprime el contenido del portapapeles:
+
+`xclip -o -sel clip`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 0.13

I did not translate the string `(clipboard)` from the [original page](/tldr-pages/tldr/blob/main/pages/linux/xclip.md) because I think users could confuse the system clipboard with the X11 primary selection.

Also, as far as I know there is no such term as "short notation" regarding the command line option style of `xclip`. Maybe it means the shorter form of an option (e.g. `-sel`)?