### PR TITLE
pages.*: sync more info link

### DIFF
--- a/pages.de/common/exit.md
+++ b/pages.de/common/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > Verlasse die Shell.
-> Weitere Informationen: <https://manned.org/exit>.
+> Weitere Informationen: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>.
 
 - Beende die Shell mit dem Exitcode des zuletzt ausgeführten Befehls:
 

--- a/pages.de/common/export.md
+++ b/pages.de/common/export.md
@@ -1,7 +1,7 @@
 # export
 
 > Befehl zum Markieren von Shell-Variablen in der aktuellen Umgebung, die mit allen neu abgezweigten Unterprozessen exportiert werden sollen.
-> Weitere Informationen: <https://www.gnu.org/software/bash/manual/bash.html#index-export>.
+> Weitere Informationen: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export>.
 
 - Lege eine neue Umgebungsvariable fest:
 

--- a/pages.fa/common/export.md
+++ b/pages.fa/common/export.md
@@ -1,7 +1,7 @@
 # export
 
 > دستور تغییر متغییرهای محلی سیستم موجود برای پروسه های جدید.
-> اطلاعات بیشتر: <https://www.gnu.org/software/bash/manual/bash.html#index-export>.
+> اطلاعات بیشتر: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export>.
 
 - ایجاد و تعیین مقدار یک متغییر جدید:
 

--- a/pages.hi/common/exit.md
+++ b/pages.hi/common/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > शेल से बाहर निकलें।
-> अधिक जानकारी: <https://manned.org/exit>।
+> अधिक जानकारी: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>।
 
 - निष्पादित अंतिम कमांड के निकास कोड के साथ शेल से बाहर निकलें:
 

--- a/pages.it/common/exec.md
+++ b/pages.it/common/exec.md
@@ -1,7 +1,7 @@
 # exec
 
 > Sostituisci il processo corrente con un altro.
-> Maggiori informazioni: <https://linuxcommand.org/lc3_man_pages/exech.html>.
+> Maggiori informazioni: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exec>.
 
 - Sostituisci con il comando specificato utilizzando le variabili di ambiente correnti:
 

--- a/pages.pt_BR/common/cups-config.md
+++ b/pages.pt_BR/common/cups-config.md
@@ -1,7 +1,7 @@
 # cups-config
 
 > Mostra informação técnica sobre a instalação do seu servidor de impressão CUPS.
-> More information: <https://openprinting.github.io/cups/doc/man-cups-config.html>.
+> Mais informações: <https://openprinting.github.io/cups/doc/man-cups-config.html>.
 
 - Mostra a versão do CUPS instalada atualmente:
 

--- a/pages.pt_BR/common/cupsaccept.md
+++ b/pages.pt_BR/common/cupsaccept.md
@@ -3,7 +3,7 @@
 > Aceita trabalhos enviados para um ou mais destinos.
 > NOTA: destino se refere a uma impressora ou uma classe de impressoras.
 > Veja também: `cupsreject`, `cupsenable`, `cupsdisable`, `lpstat`.
-> Mais informações: <https://openprinting.github.io/cups/doc/man-cupsaccept.html>.
+> Mais informações: <https://www.cups.org/doc/man-cupsaccept.html>.
 
 - Aceita trabalhos de impressão para os destinos especificados:
 

--- a/pages.pt_BR/common/cupsenable.md
+++ b/pages.pt_BR/common/cupsenable.md
@@ -3,7 +3,7 @@
 > Inicia impressoras e classes.
 > NOTA: destino se refere a uma impressora ou uma classe de impressoras.
 > Veja também: `cupsdisable`, `cupsaccept`, `cupsreject`, `lpstat`.
-> Mais informações: <https://openprinting.github.io/cups/doc/man-cupsenable.html>.
+> Mais informações: <https://www.cups.org/doc/man-cupsenable.html>.
 
 - Inicia um ou mais destino(s):
 

--- a/pages.pt_BR/common/cupsreject.md
+++ b/pages.pt_BR/common/cupsreject.md
@@ -3,7 +3,7 @@
 > Rejeita trabalhos enviados para uma ou mais impressoras.
 > NOTA: destino se refere a uma impressora ou uma classe de impressoras.
 > Veja também: `cupsaccept`, `cupsenable`, `cupsdisable`, `lpstat`.
-> Mais informações: <https://openprinting.github.io/cups/doc/man-cupsaccept.html>.
+> Mais informações: <https://www.cups.org/doc/man-cupsaccept.html>.
 
 - Rejeita trabalhos para os destinos especificados:
 

--- a/pages.ru/common/exit.md
+++ b/pages.ru/common/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > Выйти из оболочки.
-> Больше информации: <https://manned.org/exit>.
+> Больше информации: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>.
 
 - Выход из оболочки с кодом выхода последней выполненной команды:
 

--- a/pages.sv/common/exit.md
+++ b/pages.sv/common/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > Avsluta shell.
-> Mer information: <https://manned.org/exit>.
+> Mer information: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>.
 
 - Avsluta shell med utgångskoden från det senast utförda kommandot:
 

--- a/pages.zh/common/eval.md
+++ b/pages.zh/common/eval.md
@@ -1,7 +1,7 @@
 # eval
 
 > 在当前 shell 中以单个命令的形式执行参数，并返回其结果。
-> 更多信息：<https://manned.org/eval>.
+> 更多信息：<https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#eval>.
 
 - 使用 'foo' 做为参数调用 `echo`：
 

--- a/pages.zh/common/exit.md
+++ b/pages.zh/common/exit.md
@@ -1,7 +1,7 @@
 # exit
 
 > 退出终端程序。
-> 更多信息：<https://manned.org/exit>.
+> 更多信息：<https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>.
 
 - 使用最后执行命令的退出代码，退出终端程序：
 

--- a/pages.zh/common/export.md
+++ b/pages.zh/common/export.md
@@ -1,7 +1,7 @@
 # export
 
 > 命令为当前 shell 中的子进程进行环境变量设置。
-> 更多信息：<https://www.gnu.org/software/bash/manual/bash.html#index-export>.
+> 更多信息：<https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export>.
 
 - 设置为新的环境变量：
 

--- a/pages.zh/common/trap.md
+++ b/pages.zh/common/trap.md
@@ -2,7 +2,7 @@
 
 > 在进程或操作系统接收到信号后自动执行命令。
 > 可用于对用户中断或其他操作执行清理。
-> 更多信息：<https://manned.org/trap>.
+> 更多信息：<https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#trap>.
 
 - 列出设置 trap 的可用信号：
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

We need to be more careful if a PR edits/updates the link or when a new page is added, if the more info line is reflecting the English page. I could add it to the `check-pr`-script if we want, but we don’t want to have the `tldr-bot` make too much noise in a PR.