### PR TITLE
autoconf: add Korean translation

### DIFF
--- a/pages.ko/common/autoconf.md
+++ b/pages.ko/common/autoconf.md
@@ -1,0 +1,16 @@
+# autoconf
+
+> 소프트웨어 소스 코드 패키지를 자동으로 구성하는 구성 스크립트 생성.
+> 더 많은 정보: <https://www.gnu.org/software/autoconf>.
+
+- `configure.ac` (있는 경우) 또는 `configure.in` 에서 구성 스크립트를 생성하고 이 스크립트를 `configure`에 저장:
+
+`autoconf`
+
+- 지정된 템플릿에서 구성 스크립트를 생성; `stdout`으로 출력:
+
+`autoconf {{템플릿-파일}}`
+
+- 지정된 템플릿에서 구성 스크립트를 생성하고(입력 파일이 변경되지 않은 경우에도) 출력을 파일에 작성:
+
+`autoconf --force --output={{출력파일}} {{템플릿-파일}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
