### PR TITLE
adb: fix verb tense in pt_BR

### DIFF
--- a/pages.pt_BR/common/adb.md
+++ b/pages.pt_BR/common/adb.md
@@ -4,7 +4,7 @@
 > Alguns subcomandos tais como `adb shell` possuem sua própria documentação de uso.
 > Mais informações: <https://developer.android.com/studio/command-line/adb>.
 
-- Checa se o servidor adb está em execução e o iniciar:
+- Checa se o servidor adb está em execução e o inicia:
 
 `adb start-server`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Continues #11792. The verb "inicia" now is in the same verbal tense that "checa", in the start of the period.