### PR TITLE
terminal-notifier: fix Spanish typo

### DIFF
--- a/pages.es/osx/terminal-notifier.md
+++ b/pages.es/osx/terminal-notifier.md
@@ -9,7 +9,7 @@
 
 - Muestra datos transmitidos con un sonido:
 
-`echo '{{Datos de mensajes transmitidos!}}'' | terminal-notifier -sound {{default}}`
+`echo '{{Datos de mensajes transmitidos!}}' | terminal-notifier -sound {{default}}`
 
 - Abre una URL al hacer clic en la notificación:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).