### PR TITLE
aws-secretsmanager: fix small Portuguese error in pt_BR

### DIFF
--- a/pages.pt_BR/common/aws-secretsmanager.md
+++ b/pages.pt_BR/common/aws-secretsmanager.md
@@ -19,7 +19,7 @@
 
 `aws secretsmanager describe-secret --secret-id {{nome_ou_arn}}`
 
-- Obtẽm o valor do secret (para pegar a última versão do secret não use `--version-stage`):
+- Obtém o valor do secret (para pegar a última versão do secret não use `--version-stage`):
 
 `aws secretsmanager get-secret-value --secret-id {{nome_ou_arn}} --version-stage {{versão_do_secret}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

The Portuguese specific rules on style guide says that verbs must be in the third person **singular** present indicative tense. In this page, there was a verb in the third person **plural** present indicative.
