### PR TITLE
style-guide: document conjugation of descriptions in Spanish

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -527,3 +527,15 @@ To ensure that the sentence may not be confused with `start processing the web s
 Example descriptions on pages in Portuguese (for both European and Brazilian Portuguese) must start with verbs in the third person singular present indicative tense. This is because the descriptions must explain what the commands do, making this the correct form to express the intended meaning.
 
 For example, use `Lista os arquivos` instead of `Listar os arquivos`, `Listando os arquivos` or any other form.
+
+### Spanish-Specific Rules
+
+- The descriptions of commands and examples must be conjugated in the third person singular indicative tense. Here are a couple of examples:
+
+```markdown
+> Crea archivos.
+```
+
+```markdown
+- Crea un archivo en un directorio:
+```


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

As mentioned in the comments of the pull request #11981, this attempts to correct the inconsistent use of descriptions.

In addition, I think I have found  pages with this problem through the command `git grep -E '^[->] [[:alpha:]]+[aei]r ' pages.es`.
