### PR TITLE
kill: split POSIX and util-linux implementations

### DIFF
--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -2,15 +2,19 @@
 
 > Sends a signal to a process, usually related to stopping the process.
 > All signals except for SIGKILL and SIGSTOP can be intercepted by the process to perform a clean exit.
-> More information: <https://manned.org/kill.1posix>.
+> More information: <https://manned.org/kill>.
 
 - Terminate a program using the default SIGTERM (terminate) signal:
 
 `kill {{process_id}}`
 
-- List available signal names (to be used without the `SIG` prefix):
+- List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill -l`
+`kill -{{L|-table}}`
+
+- Terminate a background job:
+
+`kill %{{job_id}}`
 
 - Terminate a program using the SIGHUP (hang up) signal. Many daemons will reload instead of terminating:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

*BSD and macOS don't have any extensions to POSIX, so I didn't create a page for each one of them.

For #11827 and #9612.