### PR TITLE
umount: split common and util-linux implementations

### DIFF
--- a/pages/common/umount.md
+++ b/pages/common/umount.md
@@ -2,7 +2,7 @@
 
 > Unlink a filesystem from its mount point, making it no longer accessible.
 > A filesystem cannot be unmounted when it is busy.
-> More information: <https://manned.org/umount.8>.
+> More information: <https://man.openbsd.org/umount>.
 
 - Unmount a filesystem, by passing the path to the source it is mounted from:
 

--- a/pages/linux/umount.md
+++ b/pages/linux/umount.md
@@ -23,5 +23,3 @@
 - Unmount all mounted filesystems (except the `proc` filesystem):
 
 `umount -a`
-
-

--- a/pages/linux/umount.md
+++ b/pages/linux/umount.md
@@ -1,0 +1,27 @@
+# umount
+
+> Unlink a filesystem from its mount point, making it no longer accessible.
+> A filesystem cannot be unmounted when it is busy.
+> More information: <https://manned.org/umount.8>.
+
+- Unmount a filesystem, by passing the path to the source it is mounted from:
+
+`umount {{path/to/device_file}}`
+
+- Unmount a filesystem, by passing the path to the target where it is mounted:
+
+`umount {{path/to/mounted_directory}}`
+
+- When an unmount fails, try to remount the filesystem read-only:
+
+`umount --read-only {{path/to/mounted_directory}}`
+
+- Recursively unmount each specified directory:
+
+`umount --recursive {{path/to/mounted_directory}}`
+
+- Unmount all mounted filesystems (except the `proc` filesystem):
+
+`umount -a`
+
+


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

It isn't a POSIX command, it first appeared on Version 1 AT&T UNIX and has some common options accross the implementation. I've used OpenBSD docs in common because it has less options and they are supported by FreeBSD, NetBSD and macOS.

For #11827.