### PR TITLE
pages.es/git-*: update Spanish pages with the term "commit"

### DIFF
--- a/pages.es/common/git-bisect.md
+++ b/pages.es/common/git-bisect.md
@@ -1,21 +1,21 @@
 # git bisect
 
-> Utiliza la búsqueda binaria para encontrar el commit que introdujo un error.
-> Git salta de un lado a otro del gráfico de commits para hasta alcanzar progresivamente el commit defectuoso.
+> Utiliza la búsqueda binaria para encontrar la confirmación que introdujo un error.
+> Git salta de un lado a otro del gráfico de confirmaciones para hasta alcanzar progresivamente la confirmación defectuosa.
 > Más información: <https://git-scm.com/docs/git-bisect>.
 
-- Comienza un sesión de bisecado en un rango de commits delimitada por un commit erróneo conocido y por uno sano conocido (normalmente más antiguo):
+- Comienza una sesión de bisecado en un rango de confirmaciones delimitado por una confirmación errónea conocida y por una sana conocida (normalmente más antigua):
 
 `git bisect start {{commit_erroneo}} {{commit_bueno}}`
 
-- Para cada commit que `git bisect` selecciona, marcarlo como "malo" o "bueno" después de probarlo para el problema:
+- Para cada confirmación que `git bisect` seleccione, marcala como "mala" o "buena" después de probarla para el problema:
 
 `git bisect {{bueno|malo}}`
 
-- Después de que `git bisect` determine con precisión el commit defectuoso, termina la sesión de bisecado y vuelve a la rama anterior:
+- Termina la sesión de bisecado y vuelve a la rama anterior después de que `git-bisect` determine con precisión la confirmación defectuosa:
 
 `git bisect reset`
 
-- Salta un commit durante una sesión de bisecado (p. ej., uno que falla las pruebas debido a un problema diferente):
+- Salta una confirmación durante una sesión de bisecado (p. ej. una que falla las pruebas debido a un problema diferente):
 
 `git bisect skip`

--- a/pages.es/common/git-bisect.md
+++ b/pages.es/common/git-bisect.md
@@ -6,7 +6,7 @@
 
 - Comienza una sesión de bisecado en un rango de confirmaciones delimitado por una confirmación errónea conocida y por una sana conocida (normalmente más antigua):
 
-`git bisect start {{commit_erroneo}} {{commit_bueno}}`
+`git bisect start {{confirmación_errónea}} {{confirmación_buena}}`
 
 - Para cada confirmación que `git bisect` seleccione, marcala como "mala" o "buena" después de probarla para el problema:
 

--- a/pages.es/common/git-blame.md
+++ b/pages.es/common/git-blame.md
@@ -1,12 +1,12 @@
 # git blame
 
-> Muestra el hash del commit y el último autor de cada línea de un archivo.
+> Muestra el hash de la confirmación y el último autor de cada línea de un archivo.
 > Más información: <https://git-scm.com/docs/git-blame>.
 
-- Muestra el archivo con el nombre del autor y el hash del commit en cada línea:
+- Muestra el archivo con el nombre del autor y el hash de la confirmación en cada línea:
 
 `git blame {{archivo}}`
 
-- Muestra el archivo con correo electrónico del autor y hash del commit en cada línea:
+- Muestra el archivo con correo electrónico del autor y hash de la confirmación en cada línea:
 
 `git blame -e {{archivo}}`

--- a/pages.es/common/git-branch.md
+++ b/pages.es/common/git-branch.md
@@ -9,7 +9,7 @@
 
 - Lista las ramas que incluyen una confirmación específica en su historial:
 
-`git branch --all --contains {{commit_hash}}`
+`git branch --all --contains {{hash_de_la_confirmación}}`
 
 - Muestra el nombre de la rama actual:
 
@@ -21,7 +21,7 @@
 
 - Crea una nueva rama basada en una confirmación específica:
 
-`git branch {{nombre_de_rama}} {{commit_hash}}`
+`git branch {{nombre_de_rama}} {{hash_de_la_confirmación}}`
 
 - Renombra una rama (para ello no debes tenerla controlada):
 

--- a/pages.es/common/git-branch.md
+++ b/pages.es/common/git-branch.md
@@ -7,7 +7,7 @@
 
 `git branch --all`
 
-- Lista las ramas que incluyen un commit Git específico en su historial:
+- Lista las ramas que incluyen una confirmación específica en su historial:
 
 `git branch --all --contains {{commit_hash}}`
 
@@ -15,11 +15,11 @@
 
 `git branch --show-current`
 
-- Crea una nueva rama basada en el commit actual:
+- Crea una nueva rama basada en la confirmación actual:
 
 `git branch {{nombre_rama}}`
 
-- Crea una nueva rama basada en un commit específico:
+- Crea una nueva rama basada en una confirmación específica:
 
 `git branch {{nombre_de_rama}} {{commit_hash}}`
 

--- a/pages.es/common/git-checkout.md
+++ b/pages.es/common/git-checkout.md
@@ -31,6 +31,6 @@
 
 `git checkout {{nombre_del_archivo}}`
 
-- Reemplaza un archivo en el directorio actual con la versión de este en un commit de una rama específica:
+- Reemplaza un archivo en el directorio actual con la versión de este en la confirmación de una rama específica:
 
 `git checkout {{nombre_de_la_rama}} -- {{nombre_del_archivo}}`

--- a/pages.es/common/git-cherry-pick.md
+++ b/pages.es/common/git-cherry-pick.md
@@ -1,21 +1,21 @@
 # git cherry-pick
 
-> Aplica los cambios introducidos por commits existentes a la rama actual.
+> Aplica los cambios introducidos por confirmaciones existentes a la rama actual.
 > Para aplicar cambios a otra rama, primero utiliza `git checkout` para cambiar a la rama deseada.
 > Más información: <https://git-scm.com/docs/git-cherry-pick>.
 
-- Aplica un commit a la rama actual:
+- Aplica una confirmación a la rama actual:
 
 `git cherry-pick {{commit}}`
 
-- Aplica un rango de commits de la rama actual (véase también `git rebase --onto`):
+- Aplica un rango de confirmaciones de la rama actual (véase también `git rebase --onto`):
 
 `git cherry-pick {{commit_inicial}}~..{{commit_final}}`
 
-- Aplica múltiples commits no secuenciales a la rama actual:
+- Aplica múltiples confirmaciones no secuenciales a la rama actual:
 
 `git cherry-pick {{commit_1}} {{commit_2}}`
 
-- Añade los cambios de un commit al directorio de trabajo, sin crear un commit:
+- Añade los cambios de una confirmación al directorio de trabajo, sin crear una confirmación:
 
 `git cherry-pick --no-commit {{commit}}`

--- a/pages.es/common/git-cherry-pick.md
+++ b/pages.es/common/git-cherry-pick.md
@@ -6,16 +6,16 @@
 
 - Aplica una confirmación a la rama actual:
 
-`git cherry-pick {{commit}}`
+`git cherry-pick {{confirmación}}`
 
 - Aplica un rango de confirmaciones de la rama actual (véase también `git rebase --onto`):
 
-`git cherry-pick {{commit_inicial}}~..{{commit_final}}`
+`git cherry-pick {{confirmación_inicial}}~..{{confirmación_final}}`
 
 - Aplica múltiples confirmaciones no secuenciales a la rama actual:
 
-`git cherry-pick {{commit_1}} {{commit_2}}`
+`git cherry-pick {{confirmación_1}} {{confirmación_2}}`
 
 - Añade los cambios de una confirmación al directorio de trabajo, sin crear una confirmación:
 
-`git cherry-pick --no-commit {{commit}}`
+`git cherry-pick --no-commit {{confirmación}}`

--- a/pages.es/common/git-commit.md
+++ b/pages.es/common/git-commit.md
@@ -1,28 +1,28 @@
 # git commit
 
-> Realiza commits de los archivos al repositorio.
+> Realiza confirmaciones de los archivos al repositorio.
 > Más información: <https://git-scm.com/docs/git-commit>.
 
-- Realiza un commit de los archivos marcados al repositorio con un mensaje:
+- Realiza una confirmación de los archivos marcados al repositorio con un mensaje:
 
 `git commit -m "{{mensaje}}"`
 
-- Realiza un commit de los archivos marcados con un mensaje leído desde un archivo:
+- Realiza una confirmación de los archivos marcados con un mensaje leído desde un archivo:
 
 `git commit --file {{ruta/al/archivo_del_mensaje_del_commit}}`
 
-- Marca automáticamente todos los archivos modificados y realiza un commit con un mensaje:
+- Marca automáticamente todos los archivos modificados y realiza una confirmación con un mensaje:
 
 `git commit -a -m "{{mensaje}}"`
 
-- Sustituye el último commit con los cambios marcados actualmente, cambiando el hash del commit:
+- Sustituye la última confirmación con los cambios marcados actualmente, cambiando el hash de la confirmación:
 
 `git commit --amend`
 
-- Realiza un commit para archivos específicos (marcados previamente):
+- Realiza una confirmación para archivos específicos (marcados previamente):
 
 `git commit {{ruta/al/archivo1}} {{ruta/al/archivo2}}`
 
-- Crea un commit, incluso si no hay archivos marcados:
+- Crea una confirmación, incluso si no hay archivos marcados:
 
 `git commit -m "{{mensaje}}" --allow-empty`

--- a/pages.es/common/git-commit.md
+++ b/pages.es/common/git-commit.md
@@ -9,7 +9,7 @@
 
 - Realiza una confirmación de los archivos marcados con un mensaje leído desde un archivo:
 
-`git commit --file {{ruta/al/archivo_del_mensaje_del_commit}}`
+`git commit --file {{ruta/al/archivo_con_mensaje_de_la_confirmación}}`
 
 - Marca automáticamente todos los archivos modificados y realiza una confirmación con un mensaje:
 

--- a/pages.es/common/git-diff.md
+++ b/pages.es/common/git-diff.md
@@ -3,31 +3,31 @@
 > Muestra los cambios de los archivos rastreados.
 > Más información: <https://git-scm.com/docs/git-diff>.
 
-- Muestra los cambios sin marcar ni commit:
+- Muestra los cambios sin marcar ni confirmación:
 
 `git diff`
 
-- Muestra todos los cambios sin commit, pero incluye los marcados:
+- Muestra todos los cambios sin confirmación, pero incluye los marcados:
 
 `git diff HEAD`
 
-- Muestra solo los cambios marcados pero que no tienen commit:
+- Muestra solo los cambios marcados pero que no tienen confirmación:
 
 `git diff --staged`
 
-- Muestra los cambios de todos los commits a partir de una fecha/tiempo específico (una expresión de fecha, por ej., "1 week 2 days" o una fecha ISO):
+- Muestra los cambios de todas las confirmaciones a partir de una fecha y/o tiempo específico (p. ej., `1 week 2 days` o una fecha ISO):
 
 `git diff 'HEAD@{3 months|weeks|days|hours|seconds ago}'`
 
-- Muestra solo los nombres de los archivos cambiados con un commit específico:
+- Muestra solo los nombres de los archivos cambiados en una confirmación específica:
 
 `git diff --name-only {{commit}}`
 
-- Muestra un resumen de la creación, renombre y modos de cambio con un commit específico:
+- Muestra un resumen de los cambios hecho en una confirmación (p. ej. permisos de un archivo):
 
 `git diff --summary {{commit}}`
 
-- Compara un único archivo entre dos ramas o commits:
+- Compara un único archivo entre dos ramas o confirmaciones:
 
 `git diff {{rama_1}}..{{rama_2}} [--] {{ruta/al/archivo}}`
 

--- a/pages.es/common/git-diff.md
+++ b/pages.es/common/git-diff.md
@@ -21,11 +21,11 @@
 
 - Muestra solo los nombres de los archivos cambiados en una confirmación específica:
 
-`git diff --name-only {{commit}}`
+`git diff --name-only {{confirmación}}`
 
 - Muestra un resumen de los cambios hecho en una confirmación (p. ej. permisos de un archivo):
 
-`git diff --summary {{commit}}`
+`git diff --summary {{confirmación}}`
 
 - Compara un único archivo entre dos ramas o confirmaciones:
 

--- a/pages.es/common/git-ls-tree.md
+++ b/pages.es/common/git-ls-tree.md
@@ -9,8 +9,8 @@
 
 - Muestra el contenido del árbol en una confirmación (recursivo en subárboles):
 
-`git ls-tree -r {{hash_del_commit}}`
+`git ls-tree -r {{hash_de_la_confirmación}}`
 
 - Muestra solo los nombres de archivos del árbol en una confirmación:
 
-`git ls-tree --name-only {{hash_del_commit}}`
+`git ls-tree --name-only {{hash_de_la_confirmación}}`

--- a/pages.es/common/git-ls-tree.md
+++ b/pages.es/common/git-ls-tree.md
@@ -7,10 +7,10 @@
 
 `git ls-tree {{nombre_de_la_rama}}`
 
-- Muestra el contenido del árbol en un commit (recursivo en subárboles):
+- Muestra el contenido del árbol en una confirmación (recursivo en subárboles):
 
 `git ls-tree -r {{hash_del_commit}}`
 
-- Muestra solo los nombres de archivos del árbol en un commit:
+- Muestra solo los nombres de archivos del árbol en una confirmación:
 
 `git ls-tree --name-only {{hash_del_commit}}`

--- a/pages.es/common/git-merge.md
+++ b/pages.es/common/git-merge.md
@@ -11,7 +11,7 @@
 
 `git merge -e {{nombre_de_la_rama}}`
 
-- Fusiona una rama y crea un commit para la fusión:
+- Fusiona una rama y crea una confirmación para la fusión:
 
 `git merge --no-ff {{nombre_de_la_rama}}`
 

--- a/pages.es/common/git-rebase.md
+++ b/pages.es/common/git-rebase.md
@@ -1,14 +1,14 @@
 # git rebase
 
-> Vuelve a aplicar commits de una rama en lo más alto de otra rama.
-> Se utiliza comúnmente para "mover" una rama entera a otra base, ya que crea copias de los commits en una nueva ubicación.
+> Vuelve a aplicar confirmaciones de una rama en lo más alto de otra rama.
+> Se utiliza comúnmente para "mover" una rama entera a otra base, ya que crea copias de las confirmaciones en una nueva ubicación.
 > Más información: <https://git-scm.com/docs/git-rebase>.
 
 - Reorganiza la rama actual en lo más alto de otra rama:
 
 `git rebase {{rama_de_reorganización}}`
 
-- Inicia un rebase interactivo que permite reordenar los commits, omitirlos, combinarlos o modificarlos:
+- Inicia un rebase interactivo que permite reordenar, omitir, combinar o modificar confirmaciones:
 
 `git rebase -i {{rama_base_objetivo_o_hash_del_commit}}`
 
@@ -16,7 +16,7 @@
 
 `git rebase --continue`
 
-- Continúa un rebase que fue pausado para fusionar conflictos saltando el commit conflictivo:
+- Continúa un rebase que fue pausado para fusionar conflictos saltando la confirmación conflictiva:
 
 `git rebase --skip`
 
@@ -28,7 +28,7 @@
 
 `git rebase --onto {{base_nueva}} {{base_antigua}}`
 
-- Reaplica los últimos 5 commits en su lugar, evita que puedan ser reordenados, omitidos, combinados o modificados:
+- Reaplica las últimas cinco confirmaciones en su lugar, evita que puedan ser reordenadas, omitidas, combinadas o modificadas:
 
 `git rebase -i {{HEAD~5}}`
 

--- a/pages.es/common/git-rebase.md
+++ b/pages.es/common/git-rebase.md
@@ -10,7 +10,7 @@
 
 - Inicia un rebase interactivo que permite reordenar, omitir, combinar o modificar confirmaciones:
 
-`git rebase -i {{rama_base_objetivo_o_hash_del_commit}}`
+`git rebase -i {{rama_base_objetivo_o_hash_de_la_confirmación}}`
 
 - Continúa un rebase que fue interrumpido por una fusión fallida después de editar los archivos con conflictos:
 

--- a/pages.es/common/git-reset.md
+++ b/pages.es/common/git-reset.md
@@ -1,7 +1,7 @@
 # git reset
 
-> Deshace commits o desmarca cambios mediante el restablecimiento del actual HEAD de Git al estado especificado.
-> Si se pasa una ruta, funciona como "desmarcar", si se pasa el hash de un commit o una rama, funciona como "deshacer" el commit.
+> Deshaz confirmaciones o desmarca cambios mediante el restablecimiento del actual HEAD de Git al estado especificado.
+> Si se pasa una ruta, funciona como "desmarcar", si se pasa el hash de una confirmación o una rama, funciona como "deshacer" la confirmación.
 > Más información: <https://git-scm.com/docs/git-reset>.
 
 - Desmarca todo:
@@ -16,18 +16,18 @@
 
 `git reset --patch {{ruta/al/archivo}}`
 
-- Deshaz el último commit, manteniendo sus cambios, y cualquier otro cambio sin commit, en el sistema de archivo:
+- Deshaz la última confirmación, manteniendo sus cambios, y cualquier otro cambio sin confirmación, en el sistema de archivos:
 
 `git reset HEAD~`
 
-- Deshaz los últimos dos commits al añadir sus cambios al índice (por ej., marcado para commit):
+- Deshaz las últimas dos confirmaciones al añadir sus cambios al índice (p. ej. marcado para confirmación):
 
 `git reset --soft HEAD~2`
 
-- Descarta cualquier cambio sin commit, marcado o no (se puede `git checkout` solo para los cambios sin marcar):
+- Descarta cualquier cambio sin confirmación, marcado o no (se puede `git checkout` solo para los cambios sin marcar):
 
 `git reset --hard`
 
-- Restablece el repositorio a un commit específico y descarta a partir de este los cambios con y sin commit, y los marcados:
+- Restablece el repositorio a una confirmación específica y descarta a partir de esta los cambios con y sin confirmación, y los marcados:
 
 `git reset --hard {{commit}}`

--- a/pages.es/common/git-reset.md
+++ b/pages.es/common/git-reset.md
@@ -30,4 +30,4 @@
 
 - Restablece el repositorio a una confirmación específica y descarta a partir de esta los cambios con y sin confirmación, y los marcados:
 
-`git reset --hard {{commit}}`
+`git reset --hard {{confirmación}}`

--- a/pages.es/common/git-restore.md
+++ b/pages.es/common/git-restore.md
@@ -10,7 +10,7 @@
 
 - Restaura un archivo sin marcar a la versión de una confirmación específica:
 
-`git restore --source {{commit}} {{ruta/al/archivo}}`
+`git restore --source {{confirmación}} {{ruta/al/archivo}}`
 
 - Descarta los cambios sin confirmación para los archivos rastreados:
 

--- a/pages.es/common/git-restore.md
+++ b/pages.es/common/git-restore.md
@@ -4,15 +4,15 @@
 > Véase también `git checkout` y `git reset`.
 > Más información: <https://git-scm.com/docs/git-restore>.
 
-- Restaura un archivo sin marcar a la versión del commit actual (HEAD):
+- Restaura un archivo sin marcar a la versión de la confirmación actual (HEAD):
 
 `git restore {{ruta/al/archivo}}`
 
-- Restaura un archivo sin marcar a la versión de un commit específico:
+- Restaura un archivo sin marcar a la versión de una confirmación específica:
 
 `git restore --source {{commit}} {{ruta/al/archivo}}`
 
-- Descarta los cambios sin commit para los archivos rastreados:
+- Descarta los cambios sin confirmación para los archivos rastreados:
 
 `git restore :/`
 

--- a/pages.es/common/git-rev-list.md
+++ b/pages.es/common/git-rev-list.md
@@ -1,24 +1,24 @@
 # git rev-list
 
-> Muestra las revisiones (commits) en orden cronológico inverso.
+> Muestra las revisiones (confirmaciones) en orden cronológico inverso.
 > Más información: <https://git-scm.com/docs/git-rev-list>.
 
-- Muestra todos los commits de la rama actual:
+- Muestra todas las confirmaciones de la rama actual:
 
 `git rev-list {{HEAD}}`
 
-- Imprime el último commit que cambió (agregó/editó/eliminó) un archivo específico en la rama actual:
+- Imprime la última confirmación que cambió (agregó/editó/eliminó) un archivo específico en la rama actual:
 
 `git rev-list -n 1 HEAD -- {{ruta/al/archivo}}`
 
-- Muestra los commits más recientes a partir de una fecha y una rama específica:
+- Muestra las confirmaciones más recientes a partir de una fecha y una rama específica:
 
 `git rev-list --since={{'2019-12-01 00:00:00'}} {{nombre_de_rama}}`
 
-- Muestra todos los commits fusionados en un commit específico:
+- Muestra todas las confirmaciones fusionadas en una confirmación específica:
 
 `git rev-list --merges {{commit}}`
 
-- Imprime el número de commits desde una etiqueta específica:
+- Imprime el número de confirmaciones desde una etiqueta específica:
 
 `git rev-list {{nombre_de_la_etiqueta}}..HEAD --count`

--- a/pages.es/common/git-rev-list.md
+++ b/pages.es/common/git-rev-list.md
@@ -17,7 +17,7 @@
 
 - Muestra todas las confirmaciones fusionadas en una confirmación específica:
 
-`git rev-list --merges {{commit}}`
+`git rev-list --merges {{confirmación}}`
 
 - Imprime el número de confirmaciones desde una etiqueta específica:
 

--- a/pages.es/common/git-rev-parse.md
+++ b/pages.es/common/git-rev-parse.md
@@ -3,7 +3,7 @@
 > Muestra metadatos relativos a revisiones específicas.
 > Más información: <https://git-scm.com/docs/git-rev-parse>.
 
-- Obtén el hash del commit de una rama:
+- Obtén el hash de la confirmación de una rama:
 
 `git rev-parse {{nombre_de_la_rama}}`
 

--- a/pages.es/common/git-revert.md
+++ b/pages.es/common/git-revert.md
@@ -1,20 +1,20 @@
 # git revert
 
-> Crea nuevos commits que revierten el efecto de los anteriores.
+> Crea nuevas confirmaciones que revierten el efecto de los anteriores.
 > Más información: <https://git-scm.com/docs/git-revert>.
 
-- Revierte el commit más reciente:
+- Revierte la confirmación más reciente:
 
 `git revert {{HEAD}}`
 
-- Revierte el quinto último commit:
+- Revierte la quinta confirmación más reciente:
 
 `git revert HEAD~{{4}}`
 
-- Revierte múltiples commits:
+- Revierte múltiples confirmaciones:
 
 `git revert {{rama~5..rama~2}}`
 
-- Revierte commits sin crear nuevos commits:
+- Revierte confirmaciones sin crear nuevas confirmaciones:
 
 `git revert -n {{0c01a9..9a1743}}`

--- a/pages.es/common/git-shortlog.md
+++ b/pages.es/common/git-shortlog.md
@@ -3,26 +3,26 @@
 > Resume la salida de `git log`.
 > Más información: <https://git-scm.com/docs/git-shortlog>.
 
-- Muestra un resumen de todos los commits realizados, agrupados alfabéticamente por autor:
+- Muestra un resumen de todas las confirmaciones realizadas, agrupadas alfabéticamente por autor:
 
 `git shortlog`
 
-- Muestra un resumen de todos los commits realizados, agrupados por el número de commits realizados:
+- Muestra un resumen de todas las confirmaciones realizadas, agrupadas por el número de confirmaciones realizadas:
 
 `git shortlog -n`
 
-- Muestra un resumen de todos los commits realizados, agrupados por la identidad de quien realiza el commit (usuario y correo electrónico):
+- Muestra un resumen de todas las confirmaciones realizadas, agrupadas por la identidad de quien realiza la confirmación (usuario y correo electrónico):
 
 `git shortlog -c`
 
-- Muestra un resumen de los últimos 5 commits (i. e., un rango de revisiones específico):
+- Muestra un resumen de las últimas cinco confirmaciones (i. e., un rango de revisiones específico):
 
 `git shortlog HEAD~{{5}}..HEAD`
 
-- Muestra todos los usuarios, correos electrónicos y número de commits en la rama actual:
+- Muestra todos los usuarios, correos electrónicos y número de confirmaciones en la rama actual:
 
 `git shortlog -sne`
 
-- Muestra todos los usuarios, correos electrónicos y número de commits en todas las ramas:
+- Muestra todos los usuarios, correos electrónicos y número de confirmaciones en todas las ramas:
 
 `git shortlog -sne --all`

--- a/pages.es/common/git-show.md
+++ b/pages.es/common/git-show.md
@@ -1,25 +1,25 @@
 # git show
 
-> Muestra varios tipos de objetos Git (commits, etiquetas, etcétera).
+> Muestra varios tipos de objetos Git (confirmaciones, etiquetas, etcétera).
 > Más información: <https://git-scm.com/docs/git-show>.
 
-- Muestra información sobre el último commit (hash, mensaje, cambios y otros metadatos):
+- Muestra información sobre la última confirmación (hash, mensaje, cambios y otros metadatos):
 
 `git show`
 
-- Muestra información de un commit específico:
+- Muestra información de una confirmación específica:
 
 `git show {{commit}}`
 
-- Muestra información del commit asociado a una determinada etiqueta:
+- Muestra información de la confirmación asociada a una determinada etiqueta:
 
 `git show {{etiqueta}}`
 
-- Muestra información del tercer commit desde la punta de una rama:
+- Muestra información de la tercera confirmación desde la punta de una rama:
 
 `git show {{rama}}~{{3}}`
 
-- Muestra el mensaje de un commit en una única línea, eliminando el resultado de la diferencia:
+- Muestra el mensaje de una confirmación en una única línea, eliminando el resultado de la diferencia:
 
 `git show --oneline -s {{commit}}`
 
@@ -31,6 +31,6 @@
 
 `git show --summary {{commit}}`
 
-- Muestra el contenido de un archivo en una revisión específica (por ej., una rama, una etiqueta o un commit):
+- Muestra el contenido de un archivo en una revisión específica (por ej., una rama, una etiqueta o una confirmación):
 
 `git show {{revisión}}:{{ruta/al/archivo}}`

--- a/pages.es/common/git-show.md
+++ b/pages.es/common/git-show.md
@@ -9,7 +9,7 @@
 
 - Muestra información de una confirmación específica:
 
-`git show {{commit}}`
+`git show {{confirmación}}`
 
 - Muestra información de la confirmación asociada a una determinada etiqueta:
 
@@ -21,15 +21,15 @@
 
 - Muestra el mensaje de una confirmación en una única línea, eliminando el resultado de la diferencia:
 
-`git show --oneline -s {{commit}}`
+`git show --oneline -s {{confirmación}}`
 
 - Muestra solo estadísticas (caracteres agregados o removidos) de los archivos modificados:
 
-`git show --stat {{commit}}`
+`git show --stat {{confirmación}}`
 
 - Muestra solo la lista de archivos agregados, renombrados o eliminados:
 
-`git show --summary {{commit}}`
+`git show --summary {{confirmación}}`
 
 - Muestra el contenido de un archivo en una revisión específica (por ej., una rama, una etiqueta o una confirmación):
 

--- a/pages.es/common/git-stash.md
+++ b/pages.es/common/git-stash.md
@@ -25,7 +25,7 @@
 
 - Aplica un stash (por defecto es el último, llamado `stash@{0}`):
 
-`git stash apply {{nombre_opcional_del_stash_o_commit}}`
+`git stash apply {{nombre_opcional_del_stash_o_confirmación}}`
 
 - Suelta o aplica un stash (por defecto es `stash@{0}`) y lo elimina de la lista de stash si su aplicación no causa conflictos:
 

--- a/pages.es/common/git-stash.md
+++ b/pages.es/common/git-stash.md
@@ -19,15 +19,15 @@
 
 `git stash list`
 
-- Muestra los cambios como un parche entre el stash (por defecto es stash@{0}) y el commit de cuando se creó la entrada stash por primera vez:
+- Muestra los cambios como un parche entre el stash (por defecto es `stash@{0}`) y la confirmación de cuando se creó la entrada stash por primera vez:
 
 `git stash show -p {{stash@{0}}}`
 
-- Aplica un stash (por defecto es el último, llamado stash@{0}):
+- Aplica un stash (por defecto es el último, llamado `stash@{0}`):
 
 `git stash apply {{nombre_opcional_del_stash_o_commit}}`
 
-- Suelta o aplica un stash (por defecto es stash@{0}) y lo elimina de la lista de stash si su aplicación no causa conflictos:
+- Suelta o aplica un stash (por defecto es `stash@{0}`) y lo elimina de la lista de stash si su aplicación no causa conflictos:
 
 `git stash pop {{nombre_opcional_stash}}`
 

--- a/pages.es/common/git-svn.md
+++ b/pages.es/common/git-svn.md
@@ -19,6 +19,6 @@
 
 `git svn fetch`
 
-- Realiza un commit al repositorio SVN:
+- Realiza una confirmación en un repositorio SVN:
 
 `git svn commit`

--- a/pages.es/common/git-switch.md
+++ b/pages.es/common/git-switch.md
@@ -14,7 +14,7 @@
 
 - Crea y cambia a una nueva rama basada en una confirmación específica:
 
-`git switch --create {{nombre_de_la_rama}} {{commit}}`
+`git switch --create {{nombre_de_la_rama}} {{confirmación}}`
 
 - Cambia a la rama anterior:
 

--- a/pages.es/common/git-switch.md
+++ b/pages.es/common/git-switch.md
@@ -12,7 +12,7 @@
 
 `git switch --create {{nombre_de_la_rama}}`
 
-- Crea una nueva rama basada en un commit específico y se cambia a esta:
+- Crea y cambia a una nueva rama basada en una confirmación específica:
 
 `git switch --create {{nombre_de_la_rama}} {{commit}}`
 
@@ -24,6 +24,6 @@
 
 `git switch --recurse-submodules {{nombre_de_la_rama}}`
 
-- Cambia a una rama y automáticamente fusiona la rama actual y cualquier cambio sin commit en ella:
+- Cambia a una rama y automáticamente fusiona la rama actual y cualquier cambio sin confirmación en ella:
 
 `git switch --merge {{nombre_de_la_rama}}`

--- a/pages.es/common/git-tag.md
+++ b/pages.es/common/git-tag.md
@@ -14,7 +14,7 @@
 
 - Crea una etiqueta con el nombre especificado a partir de la confirmación señalada:
 
-`git tag {{nombre_de_la_etiqueta}} {{commit}}`
+`git tag {{nombre_de_la_etiqueta}} {{confirmación}}`
 
 - Crea una etiqueta anotada con el mensaje especificado:
 
@@ -30,4 +30,4 @@
 
 - Muestra todas las etiquetas cuyos ancestros incluyan una confirmación específica:
 
-`git tag --contains {{commit}}`
+`git tag --contains {{confirmación}}`

--- a/pages.es/common/git-tag.md
+++ b/pages.es/common/git-tag.md
@@ -1,18 +1,18 @@
 # git tag
 
 > Crea, muestra, borra o verifica etiquetas.
-> Una etiqueta es una referencia estática a un commit específico.
+> Una etiqueta es una referencia estática a una confirmación específica.
 > Más información: <https://git-scm.com/docs/git-tag>.
 
 - Muestra todas las etiquetas:
 
 `git tag`
 
-- Crea una etiqueta con el nombre especificado a partir del commit actual:
+- Crea una etiqueta con el nombre especificado a partir de la confirmación actual:
 
 `git tag {{nombre_de_la_etiqueta}}`
 
-- Crea una etiqueta con el nombre especificado a partir del commit señalado:
+- Crea una etiqueta con el nombre especificado a partir de la confirmación señalada:
 
 `git tag {{nombre_de_la_etiqueta}} {{commit}}`
 
@@ -28,6 +28,6 @@
 
 `git fetch --tags`
 
-- Muestra todas las etiquetas cuyos ancestros incluyan un commit específico:
+- Muestra todas las etiquetas cuyos ancestros incluyan una confirmación específica:
 
 `git tag --contains {{commit}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.43.0

The [Spanish documentation of GitHub](https://docs.github.com/es/search?query=confirmación) and the Spanish version of the book of Git use the term `confirmación` to refer to a commit.

I think it is worth mentioning that `tldr-lint` reported that the older [15th line of the page of `git bisect`](https://github.com/tldr-pages/tldr/commit/0e9c51ce14b242a395784662c5b92a2496b00659#diff-f59aaf1573c1cca31aa2f2bfc1631348805872cbdc7a45a2ff99a59c0847bd5dR15)  caused the error `TLDR104`.  After reading [a source file](https://github.com/tldr-pages/tldr-lint/blob/a871323935c3d83564d39c12f37f01b45ce81fd0/lib/tldr-parser.js#L756), apparently the word `Después` causes it. Is this a false positive?