### PR TITLE
duplicity: remove bad options

### DIFF
--- a/pages.it/common/duplicity.md
+++ b/pages.it/common/duplicity.md
@@ -26,4 +26,4 @@
 
 - Ripristina una sotto-directory da un backup locale cifrato con GnuPG in una posizione precisa:
 
-`PASSPHRASE={{password_chiave_gpg}} duplicity restore --encrypt-key {{id_chiave_gpg}} --file-to-restore {{percorso/relativo/sotto_directory}} file://{{percorso/assoluto/della/directory/di/backup}} {{percorso/della/directory/dove/ripristinare}}`
+`PASSPHRASE={{password_chiave_gpg}} duplicity restore --encrypt-key {{id_chiave_gpg}} --path-to-restore {{percorso/relativo/sotto_directory}} file://{{percorso/assoluto/della/directory/di/backup}} {{percorso/della/directory/dove/ripristinare}}`

--- a/pages.it/common/duplicity.md
+++ b/pages.it/common/duplicity.md
@@ -10,7 +10,7 @@
 
 - Esegui il backup di una directory in un server Amazon S3, facendo un backup completo ogni mese:
 
-`duplicity --full-if-older-than {{1M}} --use-new-style s3://{{nome_bucket[/prefisso]}}`
+`duplicity --full-if-older-than {{1M}} s3://{{nome_bucket[/prefisso]}}`
 
 - Elimina le versioni più vecchie di un anno da un backup salvato in un server WebDAV:
 

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -26,4 +26,4 @@
 
 - Restore a subdirectory from a GnuPG-encrypted local backup to a given location:
 
-`PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --file-to-restore {{relative/path/restoredirectory}} file://{{absolute/path/to/backup/directory}} {{path/to/directory/to/restore/to}}`
+`PASSPHRASE={{gpg_key_password}} duplicity restore --encrypt-key {{gpg_key_id}} --path-to-restore {{relative/path/restoredirectory}} file://{{absolute/path/to/backup/directory}} {{path/to/directory/to/restore/to}}`

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -10,7 +10,7 @@
 
 - Backup a directory to Amazon S3, doing a full backup every month:
 
-`duplicity --full-if-older-than {{1M}} --use-new-style s3://{{bucket_name[/prefix]}}`
+`duplicity --full-if-older-than {{1M}} s3://{{bucket_name[/prefix]}}`
 
 - Delete versions older than 1 year from a backup stored on a WebDAV share:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.1.4

When I attempted to restore a backup with the command `duplicity restore --file-to-restore <FILE> file:///<DIRECTORY>`, it returned the following output:

```
CommandLineError: Option '--file-to-restore was changed in 2.0.0.
    --file-to-restore to --path-to-restore
    --do-not-restore-ownership to --no-restore-ownership

Enter 'duplicity --help' for help screen.
```

Later on, I could not find the option `--use-new-style` in the man page for my version of the command. However, I did find a [similar option in the source code](https://gitlab.com/duplicity/duplicity/-/blob/dev/duplicity/cli_data.py?ref_type=heads#L831) and the [file `CHANGELOG`](https://gitlab.com/duplicity/duplicity/-/blob/31abc1bf10b5b2e18f654ffe114054c8aa6369f6/CHANGELOG.md#L132) which if used, the command returns the following output:

```
CommandLineError: Option '--s3-use-new-style' was removed in 2.0.0.
The following options were deprecated and removed in 2.0.0
    --exclude-filelist-stdin
    --exclude-globbing-filelist
    --gio
    --include-filelist-stdin
    --include-globbing-filelist
    --old-filenames
    --s3-european-buckets
    --s3-multipart-max-timeout
    --s3-use-multiprocessing
    --s3-use-new-style
    --short-filenames
Enter 'duplicity --help' for help screen.
```

I have never used Amazon S3 storage, so I do not know for certain if the descriptions of the second example remain accurate.

**NOTE**: The forced update was to change a commit message, other than that, the commits are identical.