### PR TITLE
scripts/deploy.sh: add deployment to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: ['push', 'pull_request']
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: write # to upload assets to releases
 
 jobs:
   ci:
@@ -52,3 +52,4 @@ jobs:
       run: bash scripts/deploy.sh
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copy-release-assets.yml
+++ b/.github/workflows/copy-release-assets.yml
@@ -1,0 +1,31 @@
+name: Copy assets to the new release
+
+on:
+  release:
+    types: published
+
+permissions:
+  contents: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    name: Copy assets to the new release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download and upload
+        run: |
+          LATEST="$(git describe --tags --abbrev=0)"
+          PREVIOUS="$(git describe --tags --abbrev=0 "$LATEST"^)"
+
+          mkdir release-assets && cd release-assets
+
+          gh release download "$PREVIOUS"
+          gh release upload "$LATEST" -- *

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,11 +12,12 @@ function initialize {
     exit 0
   fi
 
-  if [[ -z $TLDRHOME ]]; then
-    export TLDRHOME=${GITHUB_WORKSPACE:-$(pwd)}
-  fi
-
   export SITE_HOME="$HOME/site"
+  export LANG_ARCHIVES="$GITHUB_WORKSPACE/language_archives"
+  export PDFS="$GITHUB_WORKSPACE/scripts/pdf"
+  export INDEX="$GITHUB_WORKSPACE/index.json"
+  RELEASE_TAG="$(git describe --tags --abbrev=0)"
+  export RELEASE_TAG
 
   # Configure git.
   git config --global user.email "tldrbotgithub@gmail.com"
@@ -26,7 +27,7 @@ function initialize {
 
   # Decrypt and add deploy key.
   eval "$(ssh-agent -s)"
-  echo "$DEPLOY_KEY"> id_ed25519
+  echo "$DEPLOY_KEY" > id_ed25519
   chmod 600 id_ed25519
   ssh-add id_ed25519
 }
@@ -34,18 +35,27 @@ function initialize {
 function upload_assets {
   git clone --quiet --depth 1 "git@github.com:tldr-pages/tldr-pages.github.io.git" "$SITE_HOME"
 
-  mv -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
-  find "$TLDRHOME/language_archives" -maxdepth 1 -name '*.zip' -exec mv -f {} "$SITE_HOME/assets/" \;
-  cp -f "$TLDRHOME/index.json" "$SITE_HOME/assets/"
-  find "$TLDRHOME/scripts/pdf" -maxdepth 1 -name '*.pdf' -exec mv -f {} "$SITE_HOME/assets/" \;
+  cp -f "$TLDR_ARCHIVE" "$SITE_HOME/assets/"
+  find "$LANG_ARCHIVES" -maxdepth 1 -name "*.zip" -exec cp -f {} "$SITE_HOME/assets/" \;
+  cp -f "$INDEX" "$SITE_HOME/assets/"
+  find "$PDFS" -maxdepth 1 -name "*.pdf" -exec cp -f {} "$SITE_HOME/assets/" \;
 
   cd "$SITE_HOME/assets"
   sha256sum -- index.json *.zip > tldr.sha256sums
 
+  # Old way of distributing assets. This needs to be deleted later.
   git add -A
   git commit -m "[GitHub Actions] uploaded assets after commit tldr-pages/tldr@$GITHUB_SHA"
   git push -q
   echo "Assets (pages archive, index and checksums) deployed to the static site."
+
+  gh release --repo tldr-pages/tldr upload --clobber "$RELEASE_TAG" -- \
+    tldr.sha256sums \
+    "$TLDR_ARCHIVE" \
+    "$INDEX" \
+    "$LANG_ARCHIVES/"*.zip \
+    "$PDFS/"*.pdf
+  echo "Assets deployed to GitHub releases."
 }
 
 ###################################


### PR DESCRIPTION
This PR does not break anything; the old method of distributing assets is still there.

My proposal for fixing this issue is: we merge this PR, then announce that we are moving the assets from https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/main/assets (https://tldr.sh/assets) to https://github.com/tldr-pages/tldr/releases/latest/download (and I think we should not make redirects so that we only have one URL). After some time, we swap the website repositories as described in https://github.com/tldr-pages/tldr/issues/12048#issue-2072204810 and remove the old distribution method from `deploy.sh`.

If someone comes up with a better solution, I'll just close this PR.

Discussed in #12048.