### PR TITLE
scc: remove erroneous spacings

### DIFF
--- a/pages/common/scc.md
+++ b/pages/common/scc.md
@@ -21,7 +21,7 @@
 
 - Only count files with specific file extensions:
 
-`scc --include-ext {{go, java, js}}`
+`scc --include-ext {{go,java,js}}`
 
 - Exclude directories from being counted:
 


### PR DESCRIPTION
fix --include-ext example

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- version: **3.2.0:**
