### PR TITLE
ls: add the recursive option to the list of options

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -23,9 +23,9 @@
 
 `ls -lh`
 
-- Long format list sorted by size (descending):
+- Long format list sorted by size (descending) recursively:
 
-`ls -lS`
+`ls -lSR`
 
 - Long format list of all files, sorted by modification date (oldest first):
 


### PR DESCRIPTION
I feel it is an important option to be mentioned in the list. We are already at 8 examples.


- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
