### PR TITLE
style-guide: use "berkas" instead of "file" in Indonesian translations

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -478,7 +478,7 @@ Second, we recommend using the following forms of technical terms to make transl
 | Device | Perangkat | Preferred over [`peranti`](https://kbbi.kemdikbud.go.id/entri/peranti). |
 | Disc | Disc | Preferred over [`cakram`](https://kbbi.kemdikbud.go.id/entri/cakram) which is unfamiliar by some readers. Use specific words if possible (e.g. CD or DVD).  |
 | Execute / Run (a program...) | Jalankan | Preferred over [`eksekusikan`](https://kbbi.kemdikbud.go.id/entri/eksekusikan) which is longer to read and write. |
-| File | File | Preferred over [`berkas`](https://kbbi.kemdikbud.go.id/entri/berkas) which may be unfamiliar by some readers. |
+| File | Berkas | [`berkas`](https://kbbi.kemdikbud.go.id/entri/berkas) is an official term. Additionally, `jalan/menuju/file(_atau_direktori)` is deprecated in favor of `jalan/menuju/berkas(_atau_direktori)`. |
 | Generate | Buat | Preferred over [`hasilkan`](https://kbbi.kemdikbud.go.id/entri/hasilkan). Example context: `Buat laporan baru`. |
 | Hardware | Perangkat Keras | Preferred over [`peranti`](https://kbbi.kemdikbud.go.id/entri/peranti). |
 | Image (as picture or visual image) | Gambar | Do not confuse with `image` as a means of storage. |

--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -8,38 +8,38 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 > [!NOTE]
 > Placeholders in Arabian (`ar`) and Farsi (`fa`) pages shouldn't be translated to prevent flipped text when reading.
 
-| en    | path/to/file         | path/to/directory      | path/to/file_or_directory         | package   | username          |
-|:------|:---------------------|:-----------------------|:----------------------------------|:----------|:------------------|
-| bn    | পাথ/টু/ফাইল          | পাথ/টু/ডিরেক্টরি          | পথ/থেকে/ফাইল_অথবা_ডিরেক্টরি       | প্যাকেজ    | ইউজারনেম         |
-| bs    |                      |                        |                                   |           |                   |
-| ca    | camí/al/fitxer       | camí/al/directori      | camí/al/fitxer_o_directori        | paquet    | nom_usuari        |
-| cs    | cesta/k/souboru      | cesta/k/adresari       | cesta/k/souboru_ci_adresari       | balíček   | jmeno_uzivatele   |
-| da    | sti/til/fil          | sti/til/mappe          | sti/til/fil_eller_mappe           | pakke     | brugernavn        |
-| de    | pfad/zu/datei        | pfad/zu/verzeichnis    | pfad/zu/datei_oder_verzeichnis    | paket     | benutzername      |
-| es    | ruta/al/archivo      | ruta/al/directorio     | ruta/al/archivo_o_directorio      | paquete   | nombre_de_usuario |
-| fi    | polku/tiedostoon     | polku/hakemistoon      | polku/tiedostoon_vai_hakemistoon  | paketti   | tunnus            |
-| fr    | chemin/vers/fichier  | chemin/vers/dossier    | chemin/vers/fichier_ou_dossier    | paquet    | nom_d_utilisateur |
-| hi    | फ़ाइल/का/पथ            | निर्देशिका/का/पथ            | फ़ाइल_या_निर्देशिका/का/पथ                 | पैकेज      | उपयोगकर्ता_नाम         |
-| id    | jalan/menuju/file    | jalan/menuju/direktori | jalan/menuju/file_atau_direktori  | paket     | nama_pengguna     |
-| it    | percorso/del/file    | percorso/della/directory | percorso/del/file_o_directory     | pacchetto | nome_utente       |
-| ja    | ファイルパス         | ディレクトリパス         | ファイルパスまたはディレクトリパス | パッケージ  | ユーザー名        |
-| ko    | 경로/대상/파일        | 경로/대상/폴더          | 경로/대상/파일_또는_폴더           | 패키지    |  사용자 명        |
-| ml    | ഫയലിലേക്കുള്ള/പാത   | ഡയറക്ടറിയിലേക്കുള്ള/പാത    | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത  | പാക്കേജ്    | ഉപയോക്തൃനാമം |
-| ne    | फाइल/को/पथ            | निर्देशिका/को/पथ            | फाइल_वा_निर्देशिका/को/पथ                 | प्याकेज      | प्रयोगकर्ता_नाम        |
-| nl    | pad/naar/bestand     | pad/naar/map           | pad/naar/bestand_of_map           | pakket    | gebruikersnaam    |
-| no    |                      |                        |                                   |           |                   |
-| pl    | ścieżka/do/pliku     | ścieżka/do/katalogu    | ścieżka/do/pliku_lub_katalogu     | pakiet    | nazwa_użytkownika |
-| pt_BR | caminho/para/arquivo | caminho/para/diretorio | caminho/para/arquivo_ou_diretorio | pacote    | nome_do_usuario   |
-| pt_PT | caminho/para/ficheiro | caminho/para/diretório | caminho/para/ficheiro_ou_diretório | pacote  | nome_de_utilizador |
-| ro    |                      |                        |                                   |           |                   |
-| ru    | путь/до/файла        | путь/до/папки          | путь/до/файла_или_папки           | пакет     | имя_пользователя  |
-| sh    |                      |                        |                                   |           |                   |
-| sr    |                      |                        |                                   |           |                   |
-| sv    | sökväg/till/fil      | sökväg/till/katalog    | sökväg/till/fil_eller_katalog     | paket     | användarnamn      |
-| ta    | கோப்பு/பாதை      | அடைவிற்குப்/பாதை   | கோப்பு_அல்லது_அடைவு/பாதை | நிரல்தொகுப்பு | பயனர்ப்பெயர் |
-| th    | ทาง/ไป/ไฟล์         | ทาง/ไป/สารบบ             | ทาง/ไป/สารบบหรือไฟล์                 | แพคเกจ        | ชื่อผู้ใช้        |
-| tr    | dosya/yolu           | dizin/yolu             | dosya_veya_dizin/yolu             | paket     | kullanıcı_adı     |
-| uk    | шлях/до/файлу        | шлях/до/директорії     | шлях/до/файлу_чи_директорії       | пакунок   | ім'я_користувача  |
-| uz    |                      |                        |                                   |           |                   |
-| zh    | 路径/到/文件         | 路径/到/目录           | 路径/到/文件或目录                | 包        | 用户名            |
-| zh_TW | 檔案/完整/路徑       | 目錄/完整/路徑         | 檔案或目錄/完整/路徑              | 套件      | 使用者名稱        |
+| en    | path/to/file          | path/to/directory        | path/to/file_or_directory            | package       | username           |
+|-------|-----------------------|--------------------------|--------------------------------------|---------------|--------------------|
+| bn    | পাথ/টু/ফাইল           | পাথ/টু/ডিরেক্টরি         | পথ/থেকে/ফাইল_অথবা_ডিরেক্টরি          | প্যাকেজ       | ইউজারনেম           |
+| bs    |                       |                          |                                      |               |                    |
+| ca    | camí/al/fitxer        | camí/al/directori        | camí/al/fitxer_o_directori           | paquet        | nom_usuari         |
+| cs    | cesta/k/souboru       | cesta/k/adresari         | cesta/k/souboru_ci_adresari          | balíček       | jmeno_uzivatele    |
+| da    | sti/til/fil           | sti/til/mappe            | sti/til/fil_eller_mappe              | pakke         | brugernavn         |
+| de    | pfad/zu/datei         | pfad/zu/verzeichnis      | pfad/zu/datei_oder_verzeichnis       | paket         | benutzername       |
+| es    | ruta/al/archivo       | ruta/al/directorio       | ruta/al/archivo_o_directorio         | paquete       | nombre_de_usuario  |
+| fi    | polku/tiedostoon      | polku/hakemistoon        | polku/tiedostoon_vai_hakemistoon     | paketti       | tunnus             |
+| fr    | chemin/vers/fichier   | chemin/vers/dossier      | chemin/vers/fichier_ou_dossier       | paquet        | nom_d_utilisateur  |
+| hi    | फ़ाइल/का/पथ           | निर्देशिका/का/पथ         | फ़ाइल_या_निर्देशिका/का/पथ            | पैकेज         | उपयोगकर्ता_नाम     |
+| id    | jalan/menuju/berkas   | jalan/menuju/direktori   | jalan/menuju/berkas_atau_direktori   | paket         | nama_pengguna      |
+| it    | percorso/del/file     | percorso/della/directory | percorso/del/file_o_directory        | pacchetto     | nome_utente        |
+| ja    | ファイルパス                | ディレクトリパス                 | ファイルパスまたはディレクトリパス                    | パッケージ         | ユーザー名              |
+| ko    | 경로/대상/파일              | 경로/대상/폴더                 | 경로/대상/파일_또는_폴더                       | 패키지           | 사용자 명              |
+| ml    | ഫയലിലേക്കുള്ള/പാത     | ഡയറക്ടറിയിലേക്കുള്ള/പാത  | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത | പാക്കേജ്      | ഉപയോക്തൃനാമം       |
+| ne    | फाइल/को/पथ            | निर्देशिका/को/पथ         | फाइल_वा_निर्देशिका/को/पथ             | प्याकेज       | प्रयोगकर्ता_नाम    |
+| nl    | pad/naar/bestand      | pad/naar/map             | pad/naar/bestand_of_map              | pakket        | gebruikersnaam     |
+| no    |                       |                          |                                      |               |                    |
+| pl    | ścieżka/do/pliku      | ścieżka/do/katalogu      | ścieżka/do/pliku_lub_katalogu        | pakiet        | nazwa_użytkownika  |
+| pt_BR | caminho/para/arquivo  | caminho/para/diretorio   | caminho/para/arquivo_ou_diretorio    | pacote        | nome_do_usuario    |
+| pt_PT | caminho/para/ficheiro | caminho/para/diretório   | caminho/para/ficheiro_ou_diretório   | pacote        | nome_de_utilizador |
+| ro    |                       |                          |                                      |               |                    |
+| ru    | путь/до/файла         | путь/до/папки            | путь/до/файла_или_папки              | пакет         | имя_пользователя   |
+| sh    |                       |                          |                                      |               |                    |
+| sr    |                       |                          |                                      |               |                    |
+| sv    | sökväg/till/fil       | sökväg/till/katalog      | sökväg/till/fil_eller_katalog        | paket         | användarnamn       |
+| ta    | கோப்பு/பாதை           | அடைவிற்குப்/பாதை         | கோப்பு_அல்லது_அடைவு/பாதை             | நிரல்தொகுப்பு | பயனர்ப்பெயர்       |
+| th    | ทาง/ไป/ไฟล์           | ทาง/ไป/สารบบ             | ทาง/ไป/สารบบหรือไฟล์                 | แพคเกจ        | ชื่อผู้ใช้         |
+| tr    | dosya/yolu            | dizin/yolu               | dosya_veya_dizin/yolu                | paket         | kullanıcı_adı      |
+| uk    | шлях/до/файлу         | шлях/до/директорії       | шлях/до/файлу_чи_директорії          | пакунок       | ім'я_користувача   |
+| uz    |                       |                          |                                      |               |                    |
+| zh    | 路径/到/文件               | 路径/到/目录                  | 路径/到/文件或目录                           | 包             | 用户名                |
+| zh_TW | 檔案/完整/路徑              | 目錄/完整/路徑                 | 檔案或目錄/完整/路徑                          | 套件            | 使用者名稱              |


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**

This PR discorages the usage of `file` in Indonesian translations in favor `berkas`, which is a [standard word](https://kbbi.kemdikbud.go.id/entri/berkas) and already used in many software translations and local software (e.g. [BlankOn](https://dev.blankonlinux.or.id/TimPengembang/Dokumentasi/Panduan/PanduanWiki/KamusBlankOn/) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/indonesian-langpack/)).

As a consequence, the `jalan/menuju/file` placeholder should be replaced with `jalan/menuju/berkas`. This will be covered in another PR after this change is formally approved.