### PR TITLE
style-guide: clarify available man pages on manned.org

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -371,7 +371,7 @@ This can be resolved by inserting a comma before the "and" or "or" in the final 
 ``See also: `date`, for Unix information; `umount`, for unmounting partitions.``
 ## More information links
 
-- On the `More information` link line, we prefer linking to the author's provided documentation of the command line reference or the man page. When not available, use <https://manned.org> as the default fallback for all platforms (except `osx` and some BSD platforms). Alternatively, you can link to the author's website or a tutorial page if the command doesn't have a documentation page.
+- On the `More information` link line, we prefer linking to the author's provided documentation of the command line reference or the man page. When not available, use <https://manned.org> as the default fallback for all platforms (except `osx` and BSD platforms other than FreeBSD). Alternatively, you can link to the author's website or a tutorial page if the command doesn't have a documentation page.
 
 - **All links must be enclosed inside angular brackets (`<` and `>`) for proper rendering in clients.**
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

Currently, manned.org only supports Alpine Linux, Arch Linux, CentOS, Debian, Fedora, FreeBSD and Ubuntu, so we can be more specific on the style guide.