### PR TITLE
softwareupdate: fix typo

### DIFF
--- a/pages/osx/softwareupdate.md
+++ b/pages/osx/softwareupdate.md
@@ -13,7 +13,7 @@
 
 - Download and install all recommended updates:
 
-`softwareupdate --install --req`
+`softwareupdate --install --recommended`
 
 - Download and install a specific app:
 


### PR DESCRIPTION
The command expects --recommended or -r instead of --req which was instructed.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
macOS Sonoma 14.2.1
