### PR TITLE
scripts/test.sh: only test added pages or scripts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm test
+COMMIT=true npm test


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

This PR modify test.sh so that, if $COMMIT == true, the tests are only ran on files that were added to commit. It also modify the pre-commit hook.

This greatly improves the commit test, only testing files that weren't tested yet, i.e., only files that will be in fact modified by the commit, and not the entire repository :tada:

You can still run npm test without environment variables to test all files, though.
