### PR TITLE
pages*: avoid "specify" when it is superfluous

### DIFF
--- a/pages/common/cargo-login.md
+++ b/pages/common/cargo-login.md
@@ -8,6 +8,6 @@
 
 `cargo login`
 
-- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
+- Use the specified registry (registry names can be defined in the config - the default is <https://crates.io>):
 
 `cargo login --registry {{name}}`

--- a/pages/common/cargo-logout.md
+++ b/pages/common/cargo-logout.md
@@ -8,6 +8,6 @@
 
 `cargo logout`
 
-- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
+- Use the specified registry (registry names can be defined in the config - the default is <https://crates.io>):
 
 `cargo logout --registry {{name}}`

--- a/pages/common/cargo-owner.md
+++ b/pages/common/cargo-owner.md
@@ -15,6 +15,6 @@
 
 `cargo owner --list {{crate}}`
 
-- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
+- Use the specified registry (registry names can be defined in the config - the default is <https://crates.io>):
 
 `cargo owner --registry {{name}}`

--- a/pages/common/cargo-publish.md
+++ b/pages/common/cargo-publish.md
@@ -12,6 +12,6 @@
 
 `cargo publish --dry-run`
 
-- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
+- Use the specified registry (registry names can be defined in the config - the default is <https://crates.io>):
 
 `cargo publish --registry {{name}}`

--- a/pages/common/cargo-yank.md
+++ b/pages/common/cargo-yank.md
@@ -12,6 +12,6 @@
 
 `cargo yank --undo {{crate}}@{{version}}`
 
-- Specify the name of the registry to use (registry names can be defined in the config - the default is <https://crates.io>):
+- Use the specified registry (registry names can be defined in the config - the default is <https://crates.io>):
 
 `cargo yank --registry {{name}} {{crate}}@{{version}}`

--- a/pages/common/chroot.md
+++ b/pages/common/chroot.md
@@ -7,6 +7,6 @@
 
 `chroot {{path/to/new/root}} {{command}}`
 
-- Specify user and group (ID or name) to use:
+- Use a specific user and group:
 
-`chroot --userspec={{user:group}}`
+`chroot --userspec={{username_or_id:group_name_or_id}}`

--- a/pages/common/flite.md
+++ b/pages/common/flite.md
@@ -15,7 +15,7 @@
 
 `flite -f {{path/to/file.txt}}`
 
-- Specify which voice to use:
+- Use the specified voice:
 
 `flite -voice {{file://path/to/filename.flitevox|url}}`
 

--- a/pages/common/inkmake.md
+++ b/pages/common/inkmake.md
@@ -15,7 +15,7 @@
 
 `inkmake --svg {{path/to/file.svg}} --out {{path/to/output_image}} {{path/to/Inkfile}}`
 
-- Specify a custom Inkscape binary to use as the backend:
+- Use a custom Inkscape binary as the backend:
 
 `inkmake --inkscape {{/Applications/Inkscape.app/Contents/Resources/bin/inkscape}} {{path/to/Inkfile}}`
 

--- a/pages/common/minetestserver.md
+++ b/pages/common/minetestserver.md
@@ -12,7 +12,7 @@
 
 `minetestserver --world list`
 
-- Specify the world name to load:
+- Load the specified world:
 
 `minetestserver --world {{world_name}}`
 
@@ -20,7 +20,7 @@
 
 `minetestserver --gameid list`
 
-- Specify a game to use:
+- Use the specified game:
 
 `minetestserver --gameid {{game_id}}`
 

--- a/pages/common/phing.md
+++ b/pages/common/phing.md
@@ -23,7 +23,7 @@
 
 `phing -b {{path/to/log_file}} {{task_name}}`
 
-- Specify custom properties to use in the build:
+- Use custom properties in the build:
 
 `phing -D{{property}}={{value}} {{task_name}}`
 

--- a/pages/common/pnmtosgi.md
+++ b/pages/common/pnmtosgi.md
@@ -7,7 +7,7 @@
 
 `pnmtosgi {{path/to/input.pnm}} > {{path/to/output.sgi}}`
 
-- Specify whether or not compression should be used:
+- Disable or enable compression:
 
 `pnmtosgi -{{verbatim|rle}} {{path/to/input.pnm}} > {{path/to/output.sgi}}`
 

--- a/pages/common/ppmdist.md
+++ b/pages/common/ppmdist.md
@@ -7,6 +7,6 @@
 
 `ppmdist {{path/to/input.ppm}} > {{path/to/output.pgm}}`
 
-- Specify the method used to map colors to graylevels:
+- Use the specified method to map colors to graylevels:
 
 `ppmdist -{{frequency|intensity}} {{path/to/input.ppm}} > {{path/to/output.pgm}}`

--- a/pages/common/ppmtobmp.md
+++ b/pages/common/ppmtobmp.md
@@ -11,6 +11,6 @@
 
 `ppmtobmp -{{windows|os2}} {{path/to/file.ppm}} > {{path/to/file.bmp}}`
 
-- Specify the number of bits to use for each pixel:
+- Use a specific number of bits for each pixel:
 
 `ppmtobmp -bbp {{1|4|8|24}} {{path/to/file.ppm}} > {{path/to/file.bmp}}`

--- a/pages/common/streamlink.md
+++ b/pages/common/streamlink.md
@@ -15,7 +15,7 @@
 
 `streamlink {{example.com/stream}} {{best|worst}}`
 
-- Specify which player to use to feed stream data to (VLC is used by default if found):
+- Use a specific player to feed stream data to (VLC is used by default if found):
 
 `streamlink --player={{mpv}} {{example.com/stream}} {{best}}`
 

--- a/pages/linux/qrcp.md
+++ b/pages/linux/qrcp.md
@@ -15,11 +15,11 @@
 
 `qrcp send --zip {{path/to/file_or_directory}}`
 
-- Specify a [p]ort to use:
+- Use a specific [p]ort:
 
 `qrcp {{send|receive}} --port {{port_number}}`
 
-- Specify the network [i]nterface to use:
+- Use a specific network [i]nterface:
 
 `qrcp {{send|receive}} --interface interface`
 

--- a/pages/linux/uvcdynctrl.md
+++ b/pages/linux/uvcdynctrl.md
@@ -7,7 +7,7 @@
 
 `uvcdynctrl -l`
 
-- Specify the device to use (defaults to `video0`):
+- Use a specific device (defaults to `video0`):
 
 `uvcdynctrl -d {{device_name}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):**
