### PR TITLE
flatpak: changed one example to use --app

### DIFF
--- a/pages/linux/flatpak.md
+++ b/pages/linux/flatpak.md
@@ -11,9 +11,9 @@
 
 `flatpak install {{remote}} {{name}}`
 
-- List all installed applications and runtimes:
+- List installed applications (ignores runtimes):
 
-`flatpak list`
+`flatpak list --app`
 
 - Update all installed applications and runtimes:
 


### PR DESCRIPTION
To let users know that they can ignore runtimes.

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.15.6