### PR TITLE
pages*: remove "one or more" from description when superfluous

### DIFF
--- a/pages/common/cs-fetch.md
+++ b/pages/common/cs-fetch.md
@@ -1,6 +1,6 @@
 # cs fetch
 
-> Fetch fetches the JARs of one or more dependencies.
+> Fetch fetches the JARs of dependencies.
 > More information: <https://get-coursier.io/docs/cli-fetch>.
 
 - Fetch a specific version of a jar:

--- a/pages/common/cs-launch.md
+++ b/pages/common/cs-launch.md
@@ -1,6 +1,6 @@
 # cs launch
 
-> Launch an application from the name directly from one or more Maven dependencies without the need of installing it.
+> Launch an application from the name directly from Maven dependencies without the need of installing it.
 > More information: <https://get-coursier.io/docs/cli-launch>.
 
 - Launch a specific application with arguments:

--- a/pages/common/cs-resolve.md
+++ b/pages/common/cs-resolve.md
@@ -1,6 +1,6 @@
 # cs resolve
 
-> Resolve lists the transitive dependencies of one or more other dependencies.
+> Resolve lists the transitive dependencies of other dependencies.
 > More information: <https://get-coursier.io/docs/cli-resolve>.
 
 - Resolve lists of transitive dependencies of two dependencies:

--- a/pages/common/cupsaccept.md
+++ b/pages/common/cupsaccept.md
@@ -1,6 +1,6 @@
 # cupsaccept
 
-> Accept jobs sent to one or more destinations.
+> Accept jobs sent to destinations.
 > NOTE: destination is referred as a printer or a class of printers.
 > See also: `cupsreject`, `cupsenable`, `cupsdisable`, `lpstat`.
 > More information: <https://www.cups.org/doc/man-cupsaccept.html>.

--- a/pages/common/cupsreject.md
+++ b/pages/common/cupsreject.md
@@ -1,6 +1,6 @@
 # cupsreject
 
-> Reject jobs sent to one or more printers.
+> Reject jobs sent to printers.
 > NOTE: destination is referred as a printer or a class of printers.
 > See also: `cupsaccept`, `cupsenable`, `cupsdisable`, `lpstat`.
 > More information: <https://www.cups.org/doc/man-cupsaccept.html>.

--- a/pages/common/docker-rm.md
+++ b/pages/common/docker-rm.md
@@ -1,6 +1,6 @@
 # docker rm
 
-> Remove one or more containers.
+> Remove containers.
 > More information: <https://docs.docker.com/engine/reference/commandline/rm>.
 
 - Remove containers:

--- a/pages/common/docker-rmi.md
+++ b/pages/common/docker-rmi.md
@@ -1,6 +1,6 @@
 # docker rmi
 
-> Remove one or more Docker images.
+> Remove Docker images.
 > More information: <https://docs.docker.com/engine/reference/commandline/rmi/>.
 
 - Display help:

--- a/pages/common/docker-save.md
+++ b/pages/common/docker-save.md
@@ -1,6 +1,6 @@
 # docker save
 
-> Export docker images to archive.
+> Export Docker images to archive.
 > More information: <https://docs.docker.com/engine/reference/commandline/save/>.
 
 - Save an image by redirecting `stdout` to a tar archive:

--- a/pages/common/docker-save.md
+++ b/pages/common/docker-save.md
@@ -1,6 +1,6 @@
 # docker save
 
-> Export one or more docker images to archive.
+> Export docker images to archive.
 > More information: <https://docs.docker.com/engine/reference/commandline/save/>.
 
 - Save an image by redirecting `stdout` to a tar archive:

--- a/pages/common/docker-start.md
+++ b/pages/common/docker-start.md
@@ -1,6 +1,6 @@
 # docker start
 
-> Start one or more stopped containers.
+> Start stopped containers.
 > More information: <https://docs.docker.com/engine/reference/commandline/start/>.
 
 - Display help:

--- a/pages/common/doctl-auth.md
+++ b/pages/common/doctl-auth.md
@@ -1,6 +1,6 @@
 # doctl auth
 
-> Authenticate doctl with API tokens.
+> Authenticate `doctl` with API tokens.
 > More information: <https://docs.digitalocean.com/reference/doctl/reference/auth/>.
 
 - Open a prompt to enter an API token and label its context:

--- a/pages/common/doctl-auth.md
+++ b/pages/common/doctl-auth.md
@@ -1,6 +1,6 @@
 # doctl auth
 
-> Authenticate doctl with one or more API tokens.
+> Authenticate doctl with API tokens.
 > More information: <https://docs.digitalocean.com/reference/doctl/reference/auth/>.
 
 - Open a prompt to enter an API token and label its context:

--- a/pages/common/identify.md
+++ b/pages/common/identify.md
@@ -1,6 +1,6 @@
 # identify
 
-> Describe the format and characteristics of one or more image files.
+> Describe the format and characteristics of image files.
 > Part of ImageMagick.
 > More information: <https://imagemagick.org/script/identify.php>.
 

--- a/pages/common/kubectl-taint.md
+++ b/pages/common/kubectl-taint.md
@@ -1,6 +1,6 @@
 # kubectl taint
 
-> Update the taints on one or more nodes.
+> Update the taints on nodes.
 > More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint>.
 
 - Apply taint to a node:

--- a/pages/common/mkfile.md
+++ b/pages/common/mkfile.md
@@ -1,6 +1,6 @@
 # mkfile
 
-> Create one or more empty files of any size.
+> Create empty files of any size.
 > More information: <https://manned.org/mkfile>.
 
 - Create an empty file of 15 kilobytes:

--- a/pages/common/pathchk.md
+++ b/pages/common/pathchk.md
@@ -1,6 +1,6 @@
 # pathchk
 
-> Check the validity and portability of one or more pathnames.
+> Check the validity and portability of pathnames.
 > More information: <https://www.gnu.org/software/coreutils/pathchk>.
 
 - Check pathnames for validity in the current system:

--- a/pages/common/podman-rmi.md
+++ b/pages/common/podman-rmi.md
@@ -1,6 +1,6 @@
 # podman rmi
 
-> Remove one or more Podman images.
+> Remove Podman images.
 > More information: <https://docs.podman.io/en/latest/markdown/podman-rmi.1.html>.
 
 - Remove one or more images given their names:

--- a/pages/common/ptargrep.md
+++ b/pages/common/ptargrep.md
@@ -1,6 +1,6 @@
 # ptargrep
 
-> Find regular expression patterns in one or more tar archive files.
+> Find regular expression patterns in tar archive files.
 > More information: <https://manned.org/ptargrep>.
 
 - Search for a pattern within a tar file:

--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -1,6 +1,6 @@
 # renice
 
-> Alter the scheduling priority/niceness of one or more running processes.
+> Alter the scheduling priority/niceness of running processes.
 > Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 > See also: `nice`.
 > More information: <https://manned.org/renice>.

--- a/pages/common/wondershaper.md
+++ b/pages/common/wondershaper.md
@@ -1,6 +1,6 @@
 # wondershaper
 
-> Allows the user to limit the bandwidth of one or more network adapters.
+> Allows the user to limit the bandwidth of network adapters.
 > More information: <https://github.com/magnific0/wondershaper#usage>.
 
 - Display [h]elp:

--- a/pages/linux/inotifywait.md
+++ b/pages/linux/inotifywait.md
@@ -1,6 +1,6 @@
 # inotifywait
 
-> Waits for changes to one or more files.
+> Waits for changes to files.
 > More information: <https://manned.org/inotifywait>.
 
 - Watch a specific file for events, exiting after the first one:

--- a/pages/linux/lvremove.md
+++ b/pages/linux/lvremove.md
@@ -1,6 +1,6 @@
 # lvremove
 
-> Remove one or more logical volumes.
+> Remove logical volumes.
 > See also: `lvm`.
 > More information: <https://man7.org/linux/man-pages/man8/lvremove.8.html>.
 

--- a/pages/linux/prlimit.md
+++ b/pages/linux/prlimit.md
@@ -10,7 +10,7 @@
 
 - Display limit values for all current resources of a specified process:
 
-`prlimit --pid {{pid number}}`
+`prlimit --pid {{pid_number}}`
 
 - Run a command with a custom number of open files limit:
 

--- a/pages/linux/ptx.md
+++ b/pages/linux/ptx.md
@@ -1,6 +1,6 @@
 # ptx
 
-> Generate a permuted index of words from one or more text files.
+> Generate a permuted index of words from text files.
 > More information: <https://www.gnu.org/software/coreutils/ptx>.
 
 - Generate a permuted index where the first field of each line is an index reference:

--- a/pages/linux/renice.md
+++ b/pages/linux/renice.md
@@ -1,6 +1,6 @@
 # renice
 
-> Alter the scheduling priority/niceness of one or more running processes.
+> Alter the scheduling priority/niceness of running processes.
 > Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 > See also: `nice`.
 > More information: <https://manned.org/renice>.

--- a/pages/linux/toolbox-rmi.md
+++ b/pages/linux/toolbox-rmi.md
@@ -1,12 +1,12 @@
 # toolbox rmi
 
-> Remove one or more `toolbox` images.
+> Remove `toolbox` images.
 > See also: `toolbox rm`.
 > More information: <https://manned.org/toolbox-rmi.1>.
 
-- Remove a `toolbox` image:
+- Remove one or more `toolbox` image:
 
-`toolbox rmi {{image_name}}`
+`toolbox rmi {{image_name1 image_name2 ...}}`
 
 - Remove all `toolbox` images:
 

--- a/pages/windows/choco-uninstall.md
+++ b/pages/windows/choco-uninstall.md
@@ -1,6 +1,6 @@
 # choco uninstall
 
-> Uninstall one or more packages with Chocolatey.
+> Uninstall packages with Chocolatey.
 > More information: <https://chocolatey.org/docs/commands-uninstall>.
 
 - Uninstall one or more space-separated packages:

--- a/pages/windows/expand.md
+++ b/pages/windows/expand.md
@@ -1,6 +1,6 @@
 # expand
 
-> Uncompress one or more Windows Cabinet files.
+> Uncompress Windows Cabinet files.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/expand>.
 
 - Uncompress a single-file Cabinet file to the specified directory:

--- a/pages/windows/find.md
+++ b/pages/windows/find.md
@@ -1,6 +1,6 @@
 # find
 
-> Find a specified string in one or more files.
+> Find a specified string in files.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/find>.
 
 - Find lines that contain a specified string:

--- a/pages/windows/finger.md
+++ b/pages/windows/finger.md
@@ -1,6 +1,6 @@
 # finger
 
-> Return information about one or more users on a specified system.
+> Return information about users on a specified system.
 > The remote system must be running the Finger service.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/finger>.
 

--- a/pages/windows/forfiles.md
+++ b/pages/windows/forfiles.md
@@ -1,6 +1,6 @@
 # forfiles
 
-> Select one or more files to execute a specified command on.
+> Select files to execute a specified command on.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/forfiles>.
 
 - Search for files in the current directory:

--- a/pages/windows/remove-appxpackage.md
+++ b/pages/windows/remove-appxpackage.md
@@ -1,6 +1,6 @@
 # Remove-AppxPackage
 
-> A PowerShell utility to remove an app package from one or more user accounts.
+> A PowerShell utility to remove an app package from user accounts.
 > More information: <https://learn.microsoft.com/powershell/module/appx/Remove-AppxPackage>.
 
 - Remove an app package:

--- a/pages/windows/start-service.md
+++ b/pages/windows/start-service.md
@@ -1,6 +1,6 @@
 # Start-Service
 
-> Starts one or more stopped services.
+> Starts stopped services.
 > This command can only be used through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/start-service>.
 

--- a/pages/windows/stop-service.md
+++ b/pages/windows/stop-service.md
@@ -1,6 +1,6 @@
 # Stop-Service
 
-> Stops one or more running services.
+> Stops running services.
 > This command can only be used through PowerShell.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-service>.
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I only left 7 of them, feel free to remove or add the expression again:

```sh
$ grep --recursive -E '^>.+one\sor\smore' pages/*
pages/common/javap.md:> Disassemble one or more class files and list them.
pages/linux/prlimit.md:> Given a process ID and one or more resources, prlimit tries to retrieve and/or modify the limits.
pages/linux/toolbox-rm.md:> Remove one or more `toolbox` containers.
pages/linux/salloc.md:> Start an interactive shell session or execute a command by allocating one or more nodes in a cluster.
pages/windows/choco-install.md:> Install one or more packages with Chocolatey.
pages/windows/choco-upgrade.md:> Upgrade one or more packages with Chocolatey.
pages/windows/del.md:> Delete one or more files.
pages/windows/findstr.md:> Find specified text within one or more files.
```
