### PR TITLE
find: Markdown format tweaks, introduce the '+' operator for exec

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -25,11 +25,11 @@
 
 - Run a command for each file (use `{}` within the command to access the filename):
 
-`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {}}} \;`
+`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l}} {} \;`
 
 - Find all files modified today and pass the results to a single command as arguments:
 
-`find {{root_path}} -daystart -mtime {{-1}} -exec {{tar -cvf archive.tar {}}} \+`
+`find {{root_path}} -daystart -mtime {{-1}} -exec {{tar -cvf archive.tar}} {} \+`
 
 - Find empty (0 byte) files and delete them:
 

--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -25,11 +25,11 @@
 
 - Run a command for each file (use `{}` within the command to access the filename):
 
-`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {} }}\;`
+`find {{root_path}} -name '{{*.ext}}' -exec {{wc -l {}}} \;`
 
-- Find files modified in the last 7 days:
+- Find all files modified today and pass the results to a single command as arguments:
 
-`find {{root_path}} -daystart -mtime -{{7}}`
+`find {{root_path}} -daystart -mtime {{-1}} -exec {{tar -cvf archive.tar {}}} \+`
 
 - Find empty (0 byte) files and delete them:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known): findutils 4.9.0**
