### PR TITLE
id3tag: update --title argument

### DIFF
--- a/pages/common/id3tag.md
+++ b/pages/common/id3tag.md
@@ -5,7 +5,7 @@
 
 - Set artist and title tag of an MP3 file:
 
-`id3tag --artist={{artist}} --song={{title}} {{path/to/file.mp3}}`
+`id3tag --artist {{artist}} --song {{title}} {{path/to/file.mp3}}`
 
 - Set album title of all MP3 files in the current directory:
 

--- a/pages/common/id3tag.md
+++ b/pages/common/id3tag.md
@@ -5,7 +5,7 @@
 
 - Set artist and song title tag of an MP3 file:
 
-`id3tag --artist {{artist}} --song {{title}} {{path/to/file.mp3}}`
+`id3tag --artist {{artist}} --song {{song_title}} {{path/to/file.mp3}}`
 
 - Set album title of all MP3 files in the current directory:
 

--- a/pages/common/id3tag.md
+++ b/pages/common/id3tag.md
@@ -3,7 +3,7 @@
 > Tool for reading, writing, and manipulating ID3v1 and ID3v2 tags of MP3 files.
 > More information: <https://manned.org/id3tag>.
 
-- Set artist and title tag of an MP3 file:
+- Set artist and song title tag of an MP3 file:
 
 `id3tag --artist {{artist}} --song {{title}} {{path/to/file.mp3}}`
 

--- a/pages/common/id3tag.md
+++ b/pages/common/id3tag.md
@@ -5,7 +5,7 @@
 
 - Set artist and title tag of an MP3 file:
 
-`id3tag --artist={{artist}} --title={{title}} {{path/to/file.mp3}}`
+`id3tag --artist={{artist}} --song={{title}} {{path/to/file.mp3}}`
 
 - Set album title of all MP3 files in the current directory:
 


### PR DESCRIPTION
The `--title` parameter is now named `--song` ([man](https://manned.org/id3tag) reference).

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** id3lib 3.8.3
