### PR TITLE
deb-get: remove sudo from search and show commands

### DIFF
--- a/pages/common/deb-get.md
+++ b/pages/common/deb-get.md
@@ -10,11 +10,11 @@
 
 - Search for a given package:
 
-`sudo deb-get search {{package}}`
+`deb-get search {{package}}`
 
 - Show information about a package:
 
-`sudo deb-get show {{package}}`
+`deb-get show {{package}}`
 
 - Install a package, or update it to the latest available version:
 


### PR DESCRIPTION
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).