### PR TITLE
prosodyctl: discourage process management through prosodyctl

### DIFF
--- a/pages/common/prosodyctl.md
+++ b/pages/common/prosodyctl.md
@@ -1,7 +1,7 @@
 # prosodyctl
 
 > The control tool for the Prosody XMPP server.
-> NOTE: process management through prosodyctl is disencouraged. Instead, use the tools provided by your system e.g. `systemctl`.
+> NOTE: process management through `prosodyctl` is disencouraged. Instead, use the tools provided by your system e.g. `systemctl`.
 > More information: <https://prosody.im/doc/prosodyctl>.
 
 - Show the status of the Prosody server:

--- a/pages/common/prosodyctl.md
+++ b/pages/common/prosodyctl.md
@@ -1,6 +1,7 @@
 # prosodyctl
 
 > The control tool for the Prosody XMPP server.
+> NOTE: process management through prosodyctl is disencouraged. Instead, use the tools provided by your system e.g. `systemctl`.
 > More information: <https://prosody.im/doc/prosodyctl>.
 
 - Show the status of the Prosody server:

--- a/pages/common/prosodyctl.md
+++ b/pages/common/prosodyctl.md
@@ -1,7 +1,7 @@
 # prosodyctl
 
 > The control tool for the Prosody XMPP server.
-> NOTE: process management through `prosodyctl` is disencouraged. Instead, use the tools provided by your system e.g. `systemctl`.
+> NOTE: process management through `prosodyctl` is discouraged. Instead, use the tools provided by your system (e.g. `systemctl`).
 > More information: <https://prosody.im/doc/prosodyctl>.
 
 - Show the status of the Prosody server:


### PR DESCRIPTION
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

From the [official docs](https://prosody.im/doc/prosodyctl#process-management):
> Do not use these to start and stop Prosody unless you know what you are doing. Instead, use your distributions init system tools, e.g. systemctl.