### PR TITLE
alien: add debtap to see also section

### DIFF
--- a/pages/linux/alien.md
+++ b/pages/linux/alien.md
@@ -1,6 +1,7 @@
 # alien
 
 > Convert different installation packages to other formats.
+> See also: `debtap`.
 > More information: <https://manned.org/alien>.
 
 - Convert a specific installation file to Debian format (`.deb` extension):

--- a/pages/linux/alien.md
+++ b/pages/linux/alien.md
@@ -1,7 +1,7 @@
 # alien
 
 > Convert different installation packages to other formats.
-> See also: `debtap`, for .deb conversion on Arch Linux.
+> See also: `debtap`, for `.deb` conversion on Arch Linux.
 > More information: <https://manned.org/alien>.
 
 - Convert a specific installation file to Debian format (`.deb` extension):

--- a/pages/linux/alien.md
+++ b/pages/linux/alien.md
@@ -1,7 +1,7 @@
 # alien
 
 > Convert different installation packages to other formats.
-> See also: `debtap`.
+> See also: `debtap`, for .deb conversion on Arch Linux.
 > More information: <https://manned.org/alien>.
 
 - Convert a specific installation file to Debian format (`.deb` extension):


### PR DESCRIPTION
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

debtap is more accurate than alien and focus on .deb -> Arch Linux packages/PKGBUILD, so it is nice to mention it there for Arch users