### PR TITLE
pages*: fix names of operating systems

### DIFF
--- a/pages.es/osx/bless.md
+++ b/pages.es/osx/bless.md
@@ -7,7 +7,7 @@
 
 `bless --folder {{/Volumes/Mac OS X/System/Library/CoreServices}} --bootinfo --bootefi`
 
-- Configura un volumen que contenga Mac OS 9 y Mac OS X para que sea el volumen activo:
+- Configura un volumen que contenga macOS 9 y Mac OS X para que sea el volumen activo:
 
 `bless --mount {{Volumes/Mac OS}} --setBoot`
 

--- a/pages.pt_BR/osx/bless.md
+++ b/pages.pt_BR/osx/bless.md
@@ -3,11 +3,11 @@
 > Define a capacidade de inicialização por volume e as opções de disco de inicialização. Set volume boot capability and startup disk options.
 > Mais informações: <https://ss64.com/osx/bless.html>.
 
-- Define um volume somente com Mac OS X ou Darwin e cria os arquivos BootX e `boot.efi` se necessário:
+- Define um volume somente com macOS X ou Darwin e cria os arquivos BootX e `boot.efi` se necessário:
 
 `bless --folder {{/Volumes/Mac OS X/System/Library/CoreServices}} --bootinfo --bootefi`
 
-- Define um volume contendo Mac OS 9 ou Mac OS X como o volume ativo:
+- Define um volume contendo macOS 9 ou macOS X como o volume ativo:
 
 `bless --mount {{/Volumes/Mac OS}} --setBoot`
 

--- a/pages/common/mongod.md
+++ b/pages/common/mongod.md
@@ -3,7 +3,7 @@
 > The MongoDB database server.
 > More information: <https://docs.mongodb.com/manual/reference/program/mongod>.
 
-- Specify the storage directory (default: `/data/db` on Linux and MacOS, `C:\data\db` on Windows):
+- Specify the storage directory (default: `/data/db` on Linux and macOS, `C:\data\db` on Windows):
 
 `mongod --dbpath {{path/to/directory}}`
 

--- a/pages/common/perl.md
+++ b/pages/common/perl.md
@@ -15,6 +15,6 @@
 
 `perl -i'.bak' -p -e 's/{{regex}}/{{replacement}}/g' {{path/to/files}}`
 
-- Use perl's inline documentation, some pages also available via man on linux:
+- Use perl's inline documentation, some pages also available via man on Linux:
 
 `perldoc perlrun ; perldoc module ; perldoc -f splice; perldoc -q perlfaq1`

--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -7,7 +7,7 @@
 
 ` python -m venv {{path/to/virtual_environment}}`
 
-- Activate the virtual environment (Linux and Mac OS):
+- Activate the virtual environment (Linux and macOS):
 
 `source {{path/to/virtual_environment}}/bin/activate`
 

--- a/pages/linux/getconf.md
+++ b/pages/linux/getconf.md
@@ -11,7 +11,7 @@
 
 `getconf -a {{path/to/directory}}`
 
-- Check if your linux system is a 32-bit or 64-bit:
+- Check if the system is 32-bit or 64-bit:
 
 `getconf LONG_BIT`
 

--- a/pages/linux/grub-file.md
+++ b/pages/linux/grub-file.md
@@ -23,6 +23,6 @@
 
 `grub-file --is-x86-linux {{path/to/file}}`
 
-- Check if a file is an x86_64 XNU image (Mac OS X kernel):
+- Check if a file is an x86_64 XNU image (macOS kernel):
 
 `grub-file --is-x86_64-xnu {{path/to/file}}`

--- a/pages/osx/bless.md
+++ b/pages/osx/bless.md
@@ -3,11 +3,11 @@
 > Set volume boot capability and startup disk options.
 > More information: <https://ss64.com/osx/bless.html>.
 
-- Bless a volume with only Mac OS X or Darwin, and create the BootX and `boot.efi` files as needed:
+- Bless a volume with only macOS X or Darwin, and create the BootX and `boot.efi` files as needed:
 
 `bless --folder {{/Volumes/Mac OS X/System/Library/CoreServices}} --bootinfo --bootefi`
 
-- Set a volume containing either Mac OS 9 and Mac OS X to be the active volume:
+- Set a volume containing either macOS 9 and macOS X to be the active volume:
 
 `bless --mount {{/Volumes/Mac OS}} --setBoot`
 

--- a/pages/osx/signal.md
+++ b/pages/osx/signal.md
@@ -3,6 +3,6 @@
 > Simplified software signal facilities.
 > More information: <https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/signal.3.html>.
 
-- View documentation about signals in Mac OS:
+- View documentation about signals in macOS:
 
 `man signal`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I don't know if macOS name is right on the pages, given the name changes along its history:

March 24, 2001 - July 25, 2012:
Mac OS X 10.0, Mac OS X 10.1, Mac OS X 10.2, Mac OS X 10.3, Mac OS X 10.4, Mac OS X 10.5, Mac OS X 10.6, Mac OS X 10.7

July 25, 2012 - September 20, 2016:
OS X 10.8, OS X 10.9, OS X 10.10, OS X 10.11

September 20, 2016 - present:
macOS 10.12, macOS 10.13, macOS 10.14, macOS 10.15, macOS 11, macOS 12, macOS 13, macOS 14