### PR TITLE
pages*: fix brand and technical names

### DIFF
--- a/pages.de/linux/anbox.md
+++ b/pages.de/linux/anbox.md
@@ -1,6 +1,6 @@
 # anbox
 
-> Führe Android-Anwendungen auf jedem GNU/Linux-Betriebssystem aus.
+> Führe Android-Anwendungen auf jedem Linux-Betriebssystem aus.
 > Weitere Informationen: <https://manned.org/anbox>.
 
 - Starte Anbox im App Manager:

--- a/pages.no/linux/anbox.md
+++ b/pages.no/linux/anbox.md
@@ -1,6 +1,6 @@
 # anbox
 
-> Kjør Android-applikasjoner på et hvilket som helst GNU/Linux-operativsystem.
+> Kjør Android-applikasjoner på et hvilket som helst Linux-operativsystem.
 > Mer informasjon: <https://manned.org/anbox>.
 
 - Start Anbox i appbehandleren:

--- a/pages.tr/linux/brightnessctl.md
+++ b/pages.tr/linux/brightnessctl.md
@@ -1,6 +1,6 @@
 # brightnessctl
 
-> GNU/Linux işletim sistemlerinde cihaz parlaklığını okumak ve kontrol etmek için yardımcı program.
+> Linux işletim sistemlerinde cihaz parlaklığını okumak ve kontrol etmek için yardımcı program.
 > Daha fazla bilgi için: <https://github.com/Hummer12007/brightnessctl>.
 
 - Değiştirilebilir parlaklığa sahip cihazları listele:

--- a/pages.zh/linux/anbox.md
+++ b/pages.zh/linux/anbox.md
@@ -1,6 +1,6 @@
 # anbox
 
-> 在任何 GNU/Linux 操作系统上运行安卓应用。
+> 在任何 Linux 操作系统上运行安卓应用。
 > 更多信息：<https://manned.org/anbox>.
 
 - 在应用管理器中运行 Anbox：

--- a/pages/common/bgpgrep.md
+++ b/pages/common/bgpgrep.md
@@ -1,7 +1,7 @@
 # bgpgrep
 
 > Filter and print BGP data within MRT dumps.
-> Can read files compressed with gzip, bzip2 and xz.
+> Can read files compressed with `gzip`, `bzip2` and `xz`.
 > More information: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Output all routes:

--- a/pages/common/blender.md
+++ b/pages/common/blender.md
@@ -28,6 +28,6 @@
 
 `blender --background {{path/to/file}}.blend --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' --render-anim`
 
-- Start an interactive Blender session in the terminal with a python console (do `import bpy` after starting):
+- Start an interactive Blender session in the terminal with a Python console (do `import bpy` after starting):
 
 `blender --background --python-console`

--- a/pages/common/bzegrep.md
+++ b/pages/common/bzegrep.md
@@ -1,6 +1,6 @@
 # bzegrep
 
-> Find extended regular expression patterns in `bzip2` compressed files using egrep.
+> Find extended regular expression patterns in `bzip2` compressed files using `egrep`.
 > More information: <https://manned.org/bzegrep>.
 
 - Search for extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`) in a compressed file (case-sensitive):

--- a/pages/common/bzegrep.md
+++ b/pages/common/bzegrep.md
@@ -1,6 +1,6 @@
 # bzegrep
 
-> Find extended regular expression patterns in bzip2 compressed files using egrep.
+> Find extended regular expression patterns in `bzip2` compressed files using egrep.
 > More information: <https://manned.org/bzegrep>.
 
 - Search for extended regular expressions (supporting `?`, `+`, `{}`, `()` and `|`) in a compressed file (case-sensitive):
@@ -23,6 +23,6 @@
 
 `bzegrep --only-matching "{{search_pattern}}" {{path/to/file}}`
 
-- Recursively search files in a bzip2 compressed tar archive for a pattern:
+- Recursively search files in a `bzip2` compressed `tar` archive for a pattern:
 
 `bzegrep --recursive "{{search_pattern}}" {{path/to/file}}`

--- a/pages/common/bzfgrep.md
+++ b/pages/common/bzfgrep.md
@@ -1,6 +1,6 @@
 # bzfgrep
 
-> Find any fixed strings separated by new lines in bzip2 compressed files using fgrep.
+> Find any fixed strings separated by new lines in `bzip2` compressed files using fgrep.
 > More information: <https://manned.org/bzfgrep>.
 
 - Search for lines matching the list of search strings separated by new lines in a compressed file (case-sensitive):
@@ -23,6 +23,6 @@
 
 `bzfgrep --only-matching "{{search_string}}" {{path/to/file}}`
 
-- Recursively search files in a bzip2 compressed tar archive for the given list of strings:
+- Recursively search files in a `bzip2` compressed `tar` archive for the given list of strings:
 
 `bzfgrep --recursive "{{search_string}}" {{path/to/file}}`

--- a/pages/common/bzfgrep.md
+++ b/pages/common/bzfgrep.md
@@ -1,6 +1,6 @@
 # bzfgrep
 
-> Find any fixed strings separated by new lines in `bzip2` compressed files using fgrep.
+> Find any fixed strings separated by new lines in `bzip2` compressed files using `fgrep`.
 > More information: <https://manned.org/bzfgrep>.
 
 - Search for lines matching the list of search strings separated by new lines in a compressed file (case-sensitive):

--- a/pages/common/bzgrep.md
+++ b/pages/common/bzgrep.md
@@ -1,6 +1,6 @@
 # bzgrep
 
-> Find patterns in bzip2 compressed files using grep.
+> Find patterns in `bzip2` compressed files using grep.
 > More information: <https://manned.org/bzgrep>.
 
 - Search for a pattern within a compressed file:
@@ -23,7 +23,7 @@
 
 `bzgrep --only-matching "{{search_pattern}}" {{path/to/file}}`
 
-- Recursively search files in a bzip2 compressed tar archive for a pattern:
+- Recursively search files in a `bzip2` compressed `tar` archive for a pattern:
 
 `bzgrep --recursive "{{search_pattern}}" {{path/to/tar/file}}`
 

--- a/pages/common/bzgrep.md
+++ b/pages/common/bzgrep.md
@@ -1,6 +1,6 @@
 # bzgrep
 
-> Find patterns in `bzip2` compressed files using grep.
+> Find patterns in `bzip2` compressed files using `grep`.
 > More information: <https://manned.org/bzgrep>.
 
 - Search for a pattern within a compressed file:

--- a/pages/common/colorls.md
+++ b/pages/common/colorls.md
@@ -1,6 +1,6 @@
 # colorls
 
-> A Ruby gem that beautifies the terminal's ls command, with color and font-awesome icons.
+> A Ruby gem that beautifies the terminal's `ls` command, with color and font-awesome icons.
 > More information: <https://github.com/athityakumar/colorls>.
 
 - List files one per line:

--- a/pages/common/cs-install.md
+++ b/pages/common/cs-install.md
@@ -31,6 +31,6 @@
 
 `cs list`
 
-- Pass specific java options to an installed application:
+- Pass specific Java options to an installed application:
 
 `{{application_name}} {{-Jjava_option_name1=value1 -Jjava_option_name2=value2 ...}}`

--- a/pages/common/cs-java.md
+++ b/pages/common/cs-java.md
@@ -1,6 +1,6 @@
 # cs java
 
-> The `java` and `java-home` commands fetch and install JVMs. The java command runs them too.
+> The `java` and `java-home` commands fetch and install JVMs. The `java` command runs them too.
 > More information: <https://get-coursier.io/docs/cli-java>.
 
 - Display Java version by using coursier:

--- a/pages/common/cs-java.md
+++ b/pages/common/cs-java.md
@@ -1,13 +1,13 @@
 # cs java
 
-> The java and java-home commands fetch and install JVMs. The java command runs them too.
+> The `java` and `java-home` commands fetch and install JVMs. The java command runs them too.
 > More information: <https://get-coursier.io/docs/cli-java>.
 
-- Call the java version by using coursier:
+- Display Java version by using coursier:
 
 `cs java -version`
 
-- Call a specific java version with custom properties using coursier:
+- Call a specific Java version with custom properties using coursier:
 
 `cs java --jvm {{jvm_name}}:{{jvm_version}} -Xmx32m -X{{another_jvm_opt}} -jar {{path/to/jar_name.jar}}`
 

--- a/pages/common/cs-launch.md
+++ b/pages/common/cs-launch.md
@@ -15,6 +15,6 @@
 
 `cs launch {{group_id}}:{{artifact_id}}:{{artifact_version}} --main-class {{path/to/main_class_file}}`
 
-- Launch an application with specific java options and a jvm memory ones:
+- Launch an application with specific Java options and a jvm memory ones:
 
 `cs launch --java-opt {{-Doption_name1:option_value1 -Doption_name2:option_value2 ...}} --java-opt {{-Xjvm_option1 -Xjvm_option2 ...}} {{application_name}}`

--- a/pages/common/cs-launch.md
+++ b/pages/common/cs-launch.md
@@ -15,6 +15,6 @@
 
 `cs launch {{group_id}}:{{artifact_id}}:{{artifact_version}} --main-class {{path/to/main_class_file}}`
 
-- Launch an application with specific Java options and a jvm memory ones:
+- Launch an application with specific Java options and JVM memory ones:
 
 `cs launch --java-opt {{-Doption_name1:option_value1 -Doption_name2:option_value2 ...}} --java-opt {{-Xjvm_option1 -Xjvm_option2 ...}} {{application_name}}`

--- a/pages/common/docker-container.md
+++ b/pages/common/docker-container.md
@@ -27,7 +27,7 @@
 
 `docker container inspect {{container_name}}`
 
-- Export a container's filesystem as a tar archive:
+- Export a container's filesystem as a `tar` archive:
 
 `docker container export {{container_name}}`
 

--- a/pages/common/docker-save.md
+++ b/pages/common/docker-save.md
@@ -3,11 +3,11 @@
 > Export Docker images to archive.
 > More information: <https://docs.docker.com/engine/reference/commandline/save/>.
 
-- Save an image by redirecting `stdout` to a tar archive:
+- Save an image by redirecting `stdout` to a `tar` archive:
 
 `docker save {{image}}:{{tag}} > {{path/to/file.tar}}`
 
-- Save an image to a tar archive:
+- Save an image to a `tar` archive:
 
 `docker save --output {{path/to/file.tar}} {{image}}:{{tag}}`
 

--- a/pages/common/eget.md
+++ b/pages/common/eget.md
@@ -15,7 +15,7 @@
 
 `eget {{zyedidia/micro}} --to={{path/to/directory}}`
 
-- Specify a `git` tag instead of using the latest version:
+- Specify a Git tag instead of using the latest version:
 
 `eget {{zyedidia/micro}} --tag={{v2.0.10}}`
 

--- a/pages/common/fluxctl.md
+++ b/pages/common/fluxctl.md
@@ -11,7 +11,7 @@
 
 `fluxctl list-images`
 
-- Synchronize the cluster with the git repository:
+- Synchronize the cluster with the `git` repository:
 
 `fluxctl sync`
 

--- a/pages/common/fluxctl.md
+++ b/pages/common/fluxctl.md
@@ -11,7 +11,7 @@
 
 `fluxctl list-images`
 
-- Synchronize the cluster with the `git` repository:
+- Synchronize the cluster with the Git repository:
 
 `fluxctl sync`
 

--- a/pages/common/git-archive-file.md
+++ b/pages/common/git-archive-file.md
@@ -1,9 +1,9 @@
 # git archive-file
 
-> Export all the files of the current Git branch into a zip archive.
+> Export all the files of the current Git branch into a `zip` archive.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-archive-file>.
 
-- Pack the currently checked out commit into a zip archive:
+- Pack the currently checked out commit into a `zip` archive:
 
 `git archive-file`

--- a/pages/common/git-bug.md
+++ b/pages/common/git-bug.md
@@ -1,6 +1,6 @@
 # git bug
 
-> A distributed bug tracker that uses `git`'s internal storage, so no files are added in your project.
+> A distributed bug tracker that uses Git's internal storage, so no files are added in your project.
 > You may submit your problems to the same `git` remote you use to interact with others, much like commits and branches.
 > More information: <https://github.com/MichaelMure/git-bug/blob/master/doc/md/git-bug.md>.
 

--- a/pages/common/git-bug.md
+++ b/pages/common/git-bug.md
@@ -1,7 +1,7 @@
 # git bug
 
 > A distributed bug tracker that uses Git's internal storage, so no files are added in your project.
-> You may submit your problems to the same `git` remote you use to interact with others, much like commits and branches.
+> You may submit your problems to the same Git remote you use to interact with others, much like commits and branches.
 > More information: <https://github.com/MichaelMure/git-bug/blob/master/doc/md/git-bug.md>.
 
 - Create a new identity:

--- a/pages/common/git-bug.md
+++ b/pages/common/git-bug.md
@@ -1,7 +1,7 @@
 # git bug
 
-> A distributed bug tracker that uses git's internal storage, so no files are added in your project.
-> You may submit your problems to the same git remote you use to interact with others, much like commits and branches.
+> A distributed bug tracker that uses `git`'s internal storage, so no files are added in your project.
+> You may submit your problems to the same `git` remote you use to interact with others, much like commits and branches.
 > More information: <https://github.com/MichaelMure/git-bug/blob/master/doc/md/git-bug.md>.
 
 - Create a new identity:

--- a/pages/common/git-cola.md
+++ b/pages/common/git-cola.md
@@ -3,11 +3,11 @@
 > A powerful Git GUI with a slick and intuitive user interface.
 > More information: <https://git-cola.readthedocs.io>.
 
-- Start git cola:
+- Start the GUI:
 
 `git cola`
 
-- Start git cola in amend mode:
+- Start the GUI in amend mode:
 
 `git cola --amend`
 

--- a/pages/common/git-force-clone.md
+++ b/pages/common/git-force-clone.md
@@ -1,6 +1,6 @@
 # git force-clone
 
-> Provides the basic functionality of `git clone`, but if the destination `git` repository already exists it will force-reset it to resemble a clone of the remote.
+> Provides the basic functionality of `git clone`, but if the destination Git repository already exists it will force-reset it to resemble a clone of the remote.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-force-clone>.
 

--- a/pages/common/git-force-clone.md
+++ b/pages/common/git-force-clone.md
@@ -1,6 +1,6 @@
 # git force-clone
 
-> Provides the basic functionality of `git clone`, but if the destination git repository already exists it will force-reset it to resemble a clone of the remote.
+> Provides the basic functionality of `git clone`, but if the destination `git` repository already exists it will force-reset it to resemble a clone of the remote.
 > Part of `git-extras`.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-force-clone>.
 

--- a/pages/common/gitmoji.md
+++ b/pages/common/gitmoji.md
@@ -7,11 +7,11 @@
 
 `gitmoji --commit`
 
-- Initialize the git hook (so `gitmoji` will be run every time `git commit` is run):
+- Initialize the `git` hook (so `gitmoji` will be run every time `git commit` is run):
 
 `gitmoji --init`
 
-- Remove the git hook:
+- Remove the `git` hook:
 
 `gitmoji --remove`
 

--- a/pages/common/gitmoji.md
+++ b/pages/common/gitmoji.md
@@ -7,11 +7,11 @@
 
 `gitmoji --commit`
 
-- Initialize the `git` hook (so `gitmoji` will be run every time `git commit` is run):
+- Initialize the Git hook (so `gitmoji` will be run every time `git commit` is run):
 
 `gitmoji --init`
 
-- Remove the `git` hook:
+- Remove the Git hook:
 
 `gitmoji --remove`
 

--- a/pages/common/gitwatch.md
+++ b/pages/common/gitwatch.md
@@ -1,6 +1,6 @@
 # gitwatch
 
-> Automatically commit file or directory changes to a `git` repository.
+> Automatically commit file or directory changes to a Git repository.
 > More information: <https://github.com/gitwatch/gitwatch>.
 
 - Automatically commit any changes made to a file or directory:

--- a/pages/common/gitwatch.md
+++ b/pages/common/gitwatch.md
@@ -1,6 +1,6 @@
 # gitwatch
 
-> Automatically commit file or directory changes to a git repository.
+> Automatically commit file or directory changes to a `git` repository.
 > More information: <https://github.com/gitwatch/gitwatch>.
 
 - Automatically commit any changes made to a file or directory:

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -1,6 +1,6 @@
 # gunzip
 
-> Extract file(s) from a `gzip` (.gz) archive.
+> Extract file(s) from a `gzip` (`.gz`) archive.
 > More information: <https://manned.org/gunzip>.
 
 - Extract a file from an archive, replacing the original file if it exists:

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -1,6 +1,6 @@
 # gunzip
 
-> Extract file(s) from a gzip (.gz) archive.
+> Extract file(s) from a `gzip` (.gz) archive.
 > More information: <https://manned.org/gunzip>.
 
 - Extract a file from an archive, replacing the original file if it exists:

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -1,9 +1,9 @@
 # gzip
 
-> Compress/uncompress files with gzip compression (LZ77).
+> Compress/uncompress files with `gzip` compression (LZ77).
 > More information: <https://www.gnu.org/software/gzip/manual/gzip.html>.
 
-- Compress a file, replacing it with a gzipped compressed version:
+- Compress a file, replacing it with a `gzip` archive:
 
 `gzip {{file.ext}}`
 
@@ -19,7 +19,7 @@
 
 `gzip -c {{file.ext}} > {{compressed_file.ext.gz}}`
 
-- Decompress a gzipped file specifying the output filename:
+- Decompress a `gzip` archive specifying the output filename:
 
 `gzip -c -d {{file.ext}}.gz > {{uncompressed_file.ext}}`
 

--- a/pages/common/helm.md
+++ b/pages/common/helm.md
@@ -28,7 +28,7 @@
 
 `helm install {{name}} {{repository_name}}/{{chart_name}}`
 
-- Download helm chart as a tar archive:
+- Download helm chart as a `tar` archive:
 
 `helm get {{chart_release_name}}`
 

--- a/pages/common/hub-init.md
+++ b/pages/common/hub-init.md
@@ -1,6 +1,6 @@
 # hub init
 
-> Initializes a new local git repository.
+> Initializes a new local `git` repository.
 > More information: <https://hub.github.com/hub-init.1.html>.
 
 - Initialize a new local repository:

--- a/pages/common/hub-init.md
+++ b/pages/common/hub-init.md
@@ -1,6 +1,6 @@
 # hub init
 
-> Initializes a new local `git` repository.
+> Initializes a new local Git repository.
 > More information: <https://hub.github.com/hub-init.1.html>.
 
 - Initialize a new local repository:

--- a/pages/common/in-toto-run.md
+++ b/pages/common/in-toto-run.md
@@ -3,7 +3,7 @@
 > Generating link metadata while carrying out a supply chain step.
 > More information: <https://in-toto.readthedocs.io/en/latest/command-line-tools/in-toto-run.html>.
 
-- Tag a git repo and signing the resulting link file:
+- Tag a `git` repo and signing the resulting link file:
 
 `in-toto-run -n {{tag}} --products {{.}} -k {{key_file}} -- {{git tag v1.0}}`
 

--- a/pages/common/in-toto-run.md
+++ b/pages/common/in-toto-run.md
@@ -3,7 +3,7 @@
 > Generating link metadata while carrying out a supply chain step.
 > More information: <https://in-toto.readthedocs.io/en/latest/command-line-tools/in-toto-run.html>.
 
-- Tag a `git` repo and signing the resulting link file:
+- Tag a Git repo and signing the resulting link file:
 
 `in-toto-run -n {{tag}} --products {{.}} -k {{key_file}} -- {{git tag v1.0}}`
 

--- a/pages/common/java.md
+++ b/pages/common/java.md
@@ -3,11 +3,11 @@
 > Java application launcher.
 > More information: <https://docs.oracle.com/en/java/javase/20/docs/specs/man/java.html>.
 
-- Execute a java `.class` file that contains a main method by using just the class name:
+- Execute a Java `.class` file that contains a main method by using just the class name:
 
 `java {{classname}}`
 
-- Execute a java program and use additional third-party or user-defined classes:
+- Execute a Java program and use additional third-party or user-defined classes:
 
 `java -classpath {{path/to/classes1}}:{{path/to/classes2}}:. {{classname}}`
 

--- a/pages/common/jmeter.md
+++ b/pages/common/jmeter.md
@@ -1,6 +1,6 @@
 # jmeter
 
-> Open source java application designed for load testing functional behavior and measure performance.
+> Open source Java application designed for load testing functional behavior and measure performance.
 > More information: <https://jmeter.apache.org>.
 
 - Run a specific test plan in nongui mode:

--- a/pages/common/mocha.md
+++ b/pages/common/mocha.md
@@ -11,7 +11,7 @@
 
 `mocha {{directory/with/tests}}`
 
-- Run tests that match a specific grep pattern:
+- Run tests that match a specific `grep` pattern:
 
 `mocha --grep {{regular_expression}}`
 

--- a/pages/common/noti.md
+++ b/pages/common/noti.md
@@ -3,7 +3,7 @@
 > Monitor a process and trigger a banner notification.
 > More information: <https://github.com/variadico/noti>.
 
-- Display a notification when tar finishes compressing files:
+- Display a notification when `tar` finishes compressing files:
 
 `noti {{tar -cjf example.tar.bz2 example/}}`
 

--- a/pages/common/osv-scanner.md
+++ b/pages/common/osv-scanner.md
@@ -19,7 +19,7 @@
 
 `osv-scanner -r {{directory1 directory2 ...}}`
 
-- Skip scanning `git` repositories:
+- Skip scanning Git repositories:
 
 `osv-scanner --skip-git {{-r|-D}} {{target}}`
 

--- a/pages/common/osv-scanner.md
+++ b/pages/common/osv-scanner.md
@@ -19,7 +19,7 @@
 
 `osv-scanner -r {{directory1 directory2 ...}}`
 
-- Skip scanning git repositories:
+- Skip scanning `git` repositories:
 
 `osv-scanner --skip-git {{-r|-D}} {{target}}`
 

--- a/pages/common/pax.md
+++ b/pages/common/pax.md
@@ -7,7 +7,7 @@
 
 `pax -f {{archive.tar}}`
 
-- List the contents of a gzipped archive:
+- List the contents of a `gzip` archive:
 
 `pax -zf {{archive.tar.gz}}`
 

--- a/pages/common/peerindex.md
+++ b/pages/common/peerindex.md
@@ -1,7 +1,7 @@
 # peerindex
 
 > Inspect MRT TABLE_DUMPV2 Peer Index Table.
-> Can read files compressed with gzip, bzip2 and xz.
+> Can read files compressed with `gzip`, `bzip2` and `xz`.
 > More information: <https://codeberg.org/1414codeforge/ubgpsuite>.
 
 - Output all peers:

--- a/pages/common/ptargrep.md
+++ b/pages/common/ptargrep.md
@@ -3,7 +3,7 @@
 > Find regular expression patterns in tar archive files.
 > More information: <https://manned.org/ptargrep>.
 
-- Search for a pattern within a tar file:
+- Search for a pattern within a `tar` archive:
 
 `ptargrep "{{search_pattern}}" {{path/to/file}}`
 
@@ -15,6 +15,6 @@
 
 `ptargrep --basename "{{search_pattern}}" {{path/to/file}}`
 
-- Search for a case-insensitive pattern matching within a tar file:
+- Search for a case-insensitive pattern matching within a `tar` archive:
 
 `ptargrep --ignore-case "{{search_pattern}}" {{path/to/file}}`

--- a/pages/common/rarcrack.md
+++ b/pages/common/rarcrack.md
@@ -1,6 +1,6 @@
 # rarcrack
 
-> Password cracker for rar, zip and 7z archives.
+> Password cracker for `rar`, `zip` and `7zip` archives.
 
 - Brute force the password for an archive (tries to guess the archive type):
 

--- a/pages/common/rarcrack.md
+++ b/pages/common/rarcrack.md
@@ -1,6 +1,6 @@
 # rarcrack
 
-> Password cracker for `rar`, `zip` and `7zip` archives.
+> Password cracker for `rar`, `zip` and `7z` archives.
 
 - Brute force the password for an archive (tries to guess the archive type):
 

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -1,7 +1,7 @@
 # tar
 
 > Archiving utility.
-> Often combined with a compression method, such as gzip or bzip2.
+> Often combined with a compression method, such as `gzip` or `bzip2`.
 > More information: <https://www.gnu.org/software/tar>.
 
 - [c]reate an archive and write it to a [f]ile:
@@ -28,7 +28,7 @@
 
 `tar caf {{path/to/target.tar.xz}} {{path/to/file1 path/to/file2 ...}}`
 
-- Lis[t] the contents of a tar [f]ile [v]erbosely:
+- Lis[t] the contents of a `tar` [f]ile [v]erbosely:
 
 `tar tvf {{path/to/source.tar}}`
 

--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -3,7 +3,7 @@
 > Create lightweight virtual environments in python.
 > More information: <https://docs.python.org/3/library/venv.html>.
 
-- Create a python virtual environment:
+- Create a Python virtual environment:
 
 ` python -m venv {{path/to/virtual_environment}}`
 

--- a/pages/common/warp-diag.md
+++ b/pages/common/warp-diag.md
@@ -4,11 +4,11 @@
 > See also: `warp-cli`.
 > More information: <https://developers.cloudflare.com/warp-client/>.
 
-- Generate a zip file with information about the system configuration and the WARP connection:
+- Generate a `zip` file with information about the system configuration and the WARP connection:
 
 `warp-diag`
 
-- Generate a zip file with debug information including a timestamp to the output filename:
+- Generate a `zip` file with debug information including a timestamp to the output filename:
 
 `warp-diag --add-ts`
 

--- a/pages/common/zcat.md
+++ b/pages/common/zcat.md
@@ -1,12 +1,12 @@
 # zcat
 
-> Print data from gzip compressed files.
+> Print data from `gzip` compressed files.
 > More information: <https://www.gnu.org/software/gzip/manual/gzip.html>.
 
-- Print the uncompressed contents of a gzipped file to `stdout`:
+- Print the uncompressed contents of a `gzip` archive to `stdout`:
 
 `zcat {{file.txt.gz}}`
 
-- Print compression details of a gzipped file to `stdout`:
+- Print compression details of a `gzip` archive to `stdout`:
 
 `zcat -l {{file.txt.gz}}`

--- a/pages/common/zdiff.md
+++ b/pages/common/zdiff.md
@@ -1,12 +1,12 @@
 # zdiff
 
-> Invoke `diff` on gzipped files.
+> Invoke `diff` on `gzip` archives.
 > More information: <https://manned.org/zdiff>.
 
 - Compare two files, uncompressing them if necessary:
 
 `zdiff {{path/to/file1.gz}} {{path/to/file2.gz}}`
 
-- Compare a file to a gzipped archive with the same name:
+- Compare a file to a `gzip` archive with the same name:
 
 `zdiff {{path/to/file}}`

--- a/pages/common/zgrep.md
+++ b/pages/common/zgrep.md
@@ -1,6 +1,6 @@
 # zgrep
 
-> Grep text patterns from files within compressed file (equivalent to grep -Z).
+> Grep text patterns from files within compressed file (equivalent to `grep -Z`).
 > More information: <https://manned.org/zgrep>.
 
 - Grep a pattern in a compressed file (case-sensitive):

--- a/pages/common/zip.md
+++ b/pages/common/zip.md
@@ -1,6 +1,6 @@
 # zip
 
-> Package and compress (archive) files into zip file.
+> Package and compress (archive) files into `zip` archive.
 > See also: `unzip`.
 > More information: <https://manned.org/zip>.
 
@@ -24,7 +24,7 @@
 
 `zip -r -e {{path/to/compressed.zip}} {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
 
-- Archive files/directories to a multi-part [s]plit zip file (e.g. 3 GB parts):
+- Archive files/directories to a multi-part [s]plit `zip` archive (e.g. 3 GB parts):
 
 `zip -r -s {{3g}} {{path/to/compressed.zip}} {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
 

--- a/pages/common/zip2john.md
+++ b/pages/common/zip2john.md
@@ -1,6 +1,6 @@
 # zip2john
 
-> A tool to extract password hashes from zip files for use with John the Ripper password cracker.
+> A tool to extract password hashes from `zip` archives for use with John the Ripper password cracker.
 > This is a utility tool usually installed as part of the John the Ripper installation.
 > More information: <https://www.openwall.com/john/>.
 

--- a/pages/common/zipnote.md
+++ b/pages/common/zipnote.md
@@ -1,17 +1,17 @@
 # zipnote
 
-> View, add, or edit a zip archive's comments.
-> Files can also be renamed in the zip archive.
+> View, add, or edit a `zip` archive's comments.
+> Files can also be renamed in the `zip` archive.
 > More information: <https://manned.org/zipnote>.
 
-- View the comments on a zip archive:
+- View the comments on a `zip` archive:
 
 `zipnote {{path/to/file.zip}}`
 
-- Extract the comments on a zip archive to a file:
+- Extract the comments on a `zip` archive to a file:
 
 `zipnote {{path/to/file.zip}} > {{path/to/file.txt}}`
 
-- Add/Update comments in a zip archive from a file:
+- Add/Update comments in a `zip` archive from a file:
 
 `zipnote -w {{path/to/file.zip}} < {{path/to/file.txt}}`

--- a/pages/common/zmore.md
+++ b/pages/common/zmore.md
@@ -1,6 +1,6 @@
 # zmore
 
-> View gzip compressed files with `more`.
+> View `gzip` compressed files with `more`.
 > More information: <https://manned.org/zmore>.
 
 - Open a compressed file:

--- a/pages/linux/add-apt-repository.md
+++ b/pages/linux/add-apt-repository.md
@@ -1,13 +1,13 @@
 # add-apt-repository
 
-> Manages apt repository definitions.
+> Manages `apt` repository definitions.
 > More information: <https://manned.org/apt-add-repository>.
 
-- Add a new apt repository:
+- Add a new `apt` repository:
 
 `add-apt-repository {{repository_spec}}`
 
-- Remove an apt repository:
+- Remove an `apt` repository:
 
 `add-apt-repository --remove {{repository_spec}}`
 

--- a/pages/linux/anbox.md
+++ b/pages/linux/anbox.md
@@ -1,6 +1,6 @@
 # anbox
 
-> Run Android applications on any GNU/Linux operating system.
+> Run Android applications on any Linux operating system.
 > More information: <https://manned.org/anbox>.
 
 - Launch Anbox into the app manager:

--- a/pages/linux/apt-add-repository.md
+++ b/pages/linux/apt-add-repository.md
@@ -1,13 +1,13 @@
 # apt-add-repository
 
-> Manages apt repository definitions.
+> Manages `apt` repository definitions.
 > More information: <https://manpages.debian.org/latest/software-properties-common/apt-add-repository.1.html>.
 
-- Add a new apt repository:
+- Add a new `apt` repository:
 
 `apt-add-repository {{repository_spec}}`
 
-- Remove an apt repository:
+- Remove an `apt` repository:
 
 `apt-add-repository --remove {{repository_spec}}`
 

--- a/pages/linux/apt-file.md
+++ b/pages/linux/apt-file.md
@@ -1,6 +1,6 @@
 # apt-file
 
-> Search for files in apt packages, including ones not yet installed.
+> Search for files in `apt` packages, including ones not yet installed.
 > More information: <https://manpages.debian.org/latest/apt-file/apt-file.1.html>.
 
 - Update the metadata database:

--- a/pages/linux/atool.md
+++ b/pages/linux/atool.md
@@ -3,7 +3,7 @@
 > Manage archives of various formats.
 > More information: <https://www.nongnu.org/atool/>.
 
-- List files in a zip archive:
+- List files in a `zip` archive:
 
 `atool --list {{path/to/archive.zip}}`
 
@@ -11,10 +11,10 @@
 
 `atool --extract {{path/to/archive.tar.gz}}`
 
-- Create a new 7zip archive with two files:
+- Create a new `7zip` archive with two files:
 
 `atool --add {{path/to/archive.7z}} {{path/to/file1 path/to/file2 ...}}`
 
-- Extract all zip and rar archives in the current directory:
+- Extract all `zip` and rar archives in the current directory:
 
 `atool --each --extract {{*.zip *.rar}}`

--- a/pages/linux/atool.md
+++ b/pages/linux/atool.md
@@ -11,7 +11,7 @@
 
 `atool --extract {{path/to/archive.tar.gz}}`
 
-- Create a new `7zip` archive with two files:
+- Create a new `7z` archive with two files:
 
 `atool --add {{path/to/archive.7z}} {{path/to/file1 path/to/file2 ...}}`
 

--- a/pages/linux/brightnessctl.md
+++ b/pages/linux/brightnessctl.md
@@ -1,6 +1,6 @@
 # brightnessctl
 
-> Utility for reading and controlling device brightness for GNU/Linux operating systems.
+> Utility for reading and controlling device brightness for Linux operating systems.
 > More information: <https://github.com/Hummer12007/brightnessctl>.
 
 - List devices with changeable brightness:

--- a/pages/linux/checkupdates.md
+++ b/pages/linux/checkupdates.md
@@ -7,11 +7,11 @@
 
 `checkupdates`
 
-- List pending updates and download the packages to the pacman cache:
+- List pending updates and download the packages to the `pacman` cache:
 
 `checkupdates --download`
 
-- List pending updates using a specific pacman database:
+- List pending updates using a specific `pacman` database:
 
 `CHECKUPDATES_DB={{path/to/directory}} checkupdates`
 

--- a/pages/linux/getconf.md
+++ b/pages/linux/getconf.md
@@ -19,6 +19,6 @@
 
 `getconf CHILD_MAX`
 
-- List every configuration value and then find patterns with the grep command (i.e every value with MAX in it):
+- List every configuration value and then find patterns with the `grep` command (i.e every value with MAX in it):
 
 `getconf -a | grep MAX`

--- a/pages/linux/ostree.md
+++ b/pages/linux/ostree.md
@@ -1,6 +1,6 @@
 # ostree
 
-> Version control for binary files similar to git but optimized for operating system root filesystems.
+> Version control for binary files similar to `git` but optimized for operating system root filesystems.
 > OSTree is the foundation for immutable image-based operating systems such as Fedora Silverblue, Fedora IoT or Fedora CoreOS.
 > More information: <https://ostreedev.github.io/ostree>.
 

--- a/pages/linux/paccache.md
+++ b/pages/linux/paccache.md
@@ -1,9 +1,9 @@
 # paccache
 
-> A pacman cache cleaning utility.
+> A `pacman` cache cleaning utility.
 > More information: <https://manned.org/paccache>.
 
-- Remove all but the 3 most recent package versions from the pacman cache:
+- Remove all but the 3 most recent package versions from the `pacman` cache:
 
 `paccache -r`
 

--- a/pages/linux/pacdiff.md
+++ b/pages/linux/pacdiff.md
@@ -19,7 +19,7 @@
 
 `DIFFPROG={{editor}} pacdiff`
 
-- Scan for configuration files with `locate` instead of using pacman database:
+- Scan for configuration files with `locate` instead of using `pacman` database:
 
 `pacdiff --locate`
 

--- a/pages/linux/pacman-key.md
+++ b/pages/linux/pacman-key.md
@@ -4,7 +4,7 @@
 > See also: `pacman`.
 > More information: <https://man.archlinux.org/man/pacman-key>.
 
-- Initialize the pacman keyring:
+- Initialize the `pacman` keyring:
 
 `sudo pacman-key --init`
 

--- a/pages/linux/pacman-mirrors.md
+++ b/pages/linux/pacman-mirrors.md
@@ -1,7 +1,7 @@
 # pacman-mirrors
 
-> Generate a pacman mirrorlist for Manjaro Linux.
-> Every run of pacman-mirrors requires you to synchronize your database and update your system using `sudo pacman -Syyu`.
+> Generate a `pacman` mirrorlist for Manjaro Linux.
+> Every run of `pacman-mirrors` requires you to synchronize your database and update your system using `sudo pacman -Syyu`.
 > See also: `pacman`.
 > More information: <https://wiki.manjaro.org/index.php?title=Pacman-mirrors>.
 

--- a/pages/linux/pacman.md
+++ b/pages/linux/pacman.md
@@ -33,6 +33,6 @@
 
 `pacman -Qtdq`
 
-- Empty the entire pacman cache:
+- Empty the entire `pacman` cache:
 
 `sudo pacman -Scc`

--- a/pages/linux/pacstrap.md
+++ b/pages/linux/pacstrap.md
@@ -23,7 +23,7 @@
 
 `pacstrap -c {{path/to/new/root}} {{packages}}`
 
-- Install packages without copy the host's pacman keyring to the target:
+- Install packages without copy the host's `pacman` keyring to the target:
 
 `pacstrap -G {{path/to/new/root}} {{packages}}`
 

--- a/pages/linux/pkgctl-db-update.md
+++ b/pages/linux/pkgctl-db-update.md
@@ -1,6 +1,6 @@
 # pkgctl db update
 
-> Update the pacman database as final release step for packages that have been transfered and staged on <https://repos.archlinux.org>.
+> Update the `pacman` database as final release step for packages that have been transfered and staged on <https://repos.archlinux.org>.
 > More information: <https://man.archlinux.org/man/pkgctl-db-update.1>.
 
 - Update the binary repository as final release step:

--- a/pages/linux/rpmspec.md
+++ b/pages/linux/rpmspec.md
@@ -3,7 +3,7 @@
 > Query a RPM spec file.
 > More information: <https://manned.org/rpmspec>.
 
-- List binary packages which would be generated from a rpm spec file:
+- List binary packages which would be generated from a RPM spec file:
 
 `rpmspec --query {{path/to/rpm.spec}}`
 
@@ -11,14 +11,14 @@
 
 `rpmspec --querytags`
 
-- Get summary information for single binary packages generated from a rpm spec file:
+- Get summary information for single binary packages generated from a RPM spec file:
 
 `rpmspec --query --queryformat "{{%{name}: %{summary}\n}}" {{path/to/rpm.spec}}`
 
-- Get the source package which would be generated from a rpm spec file:
+- Get the source package which would be generated from a RPM spec file:
 
 `rpmspec --query --srpm {{path/to/rpm.spec}}`
 
-- Parse a rpm spec file to `stdout`:
+- Parse a RPM spec file to `stdout`:
 
 `rpmspec --parse {{path/to/rpm.spec}}`

--- a/pages/linux/shiny-mirrors.md
+++ b/pages/linux/shiny-mirrors.md
@@ -1,6 +1,6 @@
 # shiny-mirrors
 
-> Generate a pacman mirror list for Manjaro Linux.
+> Generate a `pacman` mirror list for Manjaro Linux.
 > Every run of shiny-mirrors requires you to synchronize your database and update your system using `sudo pacman -Syyu`.
 > More information: <https://gitlab.com/Arisa_Snowbell/shiny-mirrors/-/blob/domina/shiny-mirrors/man/shiny-mirrors.md>.
 

--- a/pages/linux/slapt-get.md
+++ b/pages/linux/slapt-get.md
@@ -1,6 +1,6 @@
 # slapt-get
 
-> An apt like system for Slackware package management.
+> An `apt` like system for Slackware package management.
 > Package sources need to be configured in the slapt-getrc file.
 > More information: <https://software.jaos.org>.
 

--- a/pages/linux/sqfstar.md
+++ b/pages/linux/sqfstar.md
@@ -3,22 +3,22 @@
 > Create a squashfs filesystem from a tar archive.
 > More information: <https://manned.org/sqfstar>.
 
-- Create a squashfs filesystem (compressed using `gzip` by default) from an uncompressed tar archive:
+- Create a squashfs filesystem (compressed using `gzip` by default) from an uncompressed `tar` archive:
 
 `sqfstar {{filesystem.squashfs}} < {{archive.tar}}`
 
-- Create a squashfs filesystem from a tar archive compressed with `gzip`, and [comp]ress the filesystem using a specific algorithm:
+- Create a squashfs filesystem from a `tar` archive compressed with `gzip`, and [comp]ress the filesystem using a specific algorithm:
 
 `zcat {{archive.tar.gz}} | sqfstar -comp {{gzip|lzo|lz4|xz|zstd|lzma}} {{filesystem.squashfs}}`
 
-- Create a squashfs filesystem from a tar archive compressed with `xz`, excluding some of the files:
+- Create a squashfs filesystem from a `tar` archive compressed with `xz`, excluding some of the files:
 
 `xzcat {{archive.tar.xz}} | sqfstar {{filesystem.squashfs}} {{file1 file2 ...}}`
 
-- Create a squashfs filesystem from a tar archive compressed with `zstd`, excluding files ending with `.gz`:
+- Create a squashfs filesystem from a `tar` archive compressed with `zstd`, excluding files ending with `.gz`:
 
 `zstdcat {{archive.tar.zst}} | sqfstar {{filesystem.squashfs}} "{{*.gz}}"`
 
-- Create a squashfs filesystem from a tar archive compressed with `lz4`, excluding files matching a regular expression:
+- Create a squashfs filesystem from a `tar` archive compressed with `lz4`, excluding files matching a regular expression:
 
 `lz4cat {{archive.tar.lz4}} | sqfstar {{filesystem.squashfs}} -regex "{{regular_expression}}"`

--- a/pages/linux/waydroid.md
+++ b/pages/linux/waydroid.md
@@ -1,6 +1,6 @@
 # waydroid
 
-> A container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu.
+> A container-based approach to boot a full Android system on a regular Linux system like Ubuntu.
 > More information: <https://docs.waydro.id>.
 
 - Start Waydroid:

--- a/pages/linux/zip.md
+++ b/pages/linux/zip.md
@@ -1,6 +1,6 @@
 # zip
 
-> Package and compress (archive) files into zip file.
+> Package and compress (archive) files into `zip` archive.
 > See also: `unzip`.
 > More information: <https://manned.org/zip>.
 
@@ -24,7 +24,7 @@
 
 `zip -r --encrypt {{path/to/compressed.zip}} {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
 
-- Archive files/directories to a multi-part [s]plit zip file (e.g. 3 GB parts):
+- Archive files/directories to a multi-part [s]plit `zip` archive (e.g. 3 GB parts):
 
 `zip -r -s {{3g}} {{path/to/compressed.zip}} {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
 

--- a/pages/osx/dtrace.md
+++ b/pages/osx/dtrace.md
@@ -28,7 +28,7 @@
 
 `dtrace -f {{function}}`
 
-- Grad the specified  [p]rocess ID, cache its symbol table, and exit upon completion:
+- Grad the specified [p]rocess ID, cache its symbol table, and exit upon completion:
 
 `dtrace -p {{pid}}`
 

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -2,7 +2,7 @@
 
 > Finds text in strings and files in PowerShell.
 > This command can only be used through PowerShell.
-> You can use `Select-String` similar to grep in UNIX or findstr.exe in Windows.
+> You can use `Select-String` similar to `grep` in UNIX or findstr.exe in Windows.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Search for a pattern within a file:

--- a/pages/windows/select-string.md
+++ b/pages/windows/select-string.md
@@ -2,7 +2,7 @@
 
 > Finds text in strings and files in PowerShell.
 > This command can only be used through PowerShell.
-> You can use `Select-String` similar to `grep` in UNIX or findstr.exe in Windows.
+> You can use `Select-String` similar to `grep` in UNIX or `findstr.exe` in Windows.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - Search for a pattern within a file:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

I kept some of them because they are already covered by #4362 (git-archive), #12107 (java) and #12132 (cs-java):
```sh
$ grep -RE '^[>-].+ java |^[>-].+ zip ' *
common/git-archive.md:- Create a zip archive from the current HEAD and print it to `stdout`:
common/git-archive.md:- Same as above, but write the zip archive to file:
common/java.md:- Display usage information for the java command:
common/cs-java.md:> The `java` and `java-home` commands fetch and install JVMs. The java command runs them too.
```