### PR TITLE
ISSUE_TEMPLATES: add VCS link and add arrow for PR number for the commands list of lets-document

### DIFF
--- a/.github/ISSUE_TEMPLATE/lets-document.yml
+++ b/.github/ISSUE_TEMPLATE/lets-document.yml
@@ -33,6 +33,11 @@ body:
       required: true
   - type: textarea
     attributes:
+      label: VCS repository link (e.g. GitHub, GitLab)
+      description: Link to the Version Control System if the project is open source.
+      placeholder: https://github.com/user/repo
+  - type: textarea
+    attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.
   - type: textarea
@@ -40,7 +45,7 @@ body:
       label: Commands
       description: List out all the pages you want to create.
       placeholder: |
-        - [] command1
-        - [] command2
+        - [] command1 → <SPACE_FOR_PR_NUMBER>
+        - [] command2 → <SPACE_FOR_PR_NUMBER>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/page-modification-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-modification-request.yml
@@ -38,5 +38,10 @@ body:
       required: true
   - type: textarea
     attributes:
+      label: VCS repository link (e.g. GitHub, GitLab)
+      description: Link to the Version Control System if the project is open source.
+      placeholder: https://github.com/user/repo
+  - type: textarea
+    attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.

--- a/.github/ISSUE_TEMPLATE/page-request.yml
+++ b/.github/ISSUE_TEMPLATE/page-request.yml
@@ -38,5 +38,10 @@ body:
       required: true
   - type: textarea
     attributes:
+      label: VCS repository link (e.g. GitHub, GitLab)
+      description: Link to the Version Control System if the project is open source.
+      placeholder: https://github.com/user/repo
+  - type: textarea
+    attributes:
       label: Additional information
       description: Provide additional information if the command differs between platforms.


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

The VCS link can provide some useful information and we can inspect the code when the documentation is not that good.

The arrows in the Let's Document template suggests you can already put the arrows after each row.