### PR TITLE
mesg: split util-linux and POSIX pages

### DIFF
--- a/pages/common/mesg.md
+++ b/pages/common/mesg.md
@@ -1,17 +1,17 @@
 # mesg
 
-> Check or set a terminal's ability to receive messages from other users, usually from the write command.
-> See also `write`.
-> More information: <https://manned.org/mesg>.
+> Check or set a terminal's ability to receive messages from other users, usually from the `write` command.
+> See also `write`, `talk`.
+> More information: <https://manned.org/mesg.1p>.
 
 - Check terminal's openness to write messages:
 
 `mesg`
 
-- Disable receiving messages from the write command:
+- Disallow receiving messages from the write command:
 
 `mesg n`
 
-- Enable receiving messages from the write command:
+- Allow receiving messages from the write command:
 
 `mesg y`

--- a/pages/linux/mesg.md
+++ b/pages/linux/mesg.md
@@ -1,0 +1,21 @@
+# mesg
+
+> Check or set a terminal's ability to receive messages from other users, usually from the `write` command.
+> See also `write`, `talk`.
+> More information: <https://manned.org/mesg.1>.
+
+- Check terminal's openness to write messages:
+
+`mesg`
+
+- Disallow receiving messages from other users:
+
+`mesg n`
+
+- Allow receiving messages from other users:
+
+`mesg y`
+
+- Enable [v]erbose mode, printing a warning if the command is not executed from a terminal:
+
+`mesg --verbose`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

For #11827 and #9612.