### PR TITLE
cal: improve util-linux page and split POSIX, osx and *BSD

### DIFF
--- a/pages/common/cal.md
+++ b/pages/common/cal.md
@@ -1,0 +1,16 @@
+# cal
+
+> Prints calendar information, with the current day highlighted.
+> More information: <https://manned.org/cal.1p>.
+
+- Display a calendar for the current month:
+
+`cal`
+
+- Display a calendar for a specific year (4 digits):
+
+`cal {{year}}`
+
+- Display a calendar for a specific month and year:
+
+`cal {{month}} {{year}}`

--- a/pages/freebsd/cal.md
+++ b/pages/freebsd/cal.md
@@ -1,0 +1,32 @@
+# cal
+
+> Prints calendar information, with the current day highlighted.
+> More information: <https://man.freebsd.org/cgi/man.cgi?cal>.
+
+- Display a calendar for the current month:
+
+`cal`
+
+- Display a calendar for a specific year (4 digits):
+
+`cal {{year}}`
+
+- Display a calendar for a specific month and year:
+
+`cal {{month}} {{year}}`
+
+- Display the whole calendar for the current year:
+
+`cal -y`
+
+- Don't [h]ighlight today and display [3] months spanning the date:
+
+`cal -h -3 {{month}} {{year}}`
+
+- Display the 2 months [B]efore and 3 [A]fter a specific [m]onth of the current year:
+
+`cal -A 3 -B 2 {{month}}`
+
+- Display [j]ulian days (one-based, numbered from January 1):
+
+`cal -j`

--- a/pages/linux/cal.md
+++ b/pages/linux/cal.md
@@ -7,9 +7,17 @@
 
 `cal`
 
-- Display previous, current and next month:
+- Display [3] months spanning the date:
 
 `cal -3`
+
+- Display the whole calendar for the current [y]ear:
+
+`cal --year`
+
+- Display the next twelve months:
+
+`cal --twelve`
 
 - Use Monday as the first day of the week:
 

--- a/pages/netbsd/cal.md
+++ b/pages/netbsd/cal.md
@@ -1,0 +1,36 @@
+# cal
+
+> Prints calendar information, with the current day highlighted.
+> More information: <https://man.freebsd.org/cgi/man.cgi?cal>.
+
+- Display a calendar for the current month:
+
+`cal`
+
+- Display a calendar for a specific year (4 digits):
+
+`cal {{year}}`
+
+- Display a calendar for a specific month and year:
+
+`cal {{month}} {{year}}`
+
+- Display the whole calendar for the current year using [j]ulian days (one-based, numbered from January 1):
+
+`cal -y -j`
+
+- Don't [h]ighlight today and display [3] months spanning the date:
+
+`cal -h -3 {{month}} {{year}}`
+
+- Display the 2 months [B]efore and 3 [A]fter a specific [m]onth of the current year:
+
+`cal -A 3 -B 2 {{month}}`
+
+- Display a specific number of months before and after ([C]ontext) the specified month:
+
+`cal -C {{months}} {{month}}`
+
+- Specify the starting [d]ay of the week (0: Sunday, 1: Monday, ..., 6: Saturday):
+
+`cal -d {{0..6}}`

--- a/pages/openbsd/cal.md
+++ b/pages/openbsd/cal.md
@@ -1,0 +1,32 @@
+# cal
+
+> Prints calendar information, with the current day highlighted.
+> More information: <https://man.openbsd.org/cal>.
+
+- Display a calendar for the current month:
+
+`cal`
+
+- Display a calendar for a specific year (4 digits):
+
+`cal {{year}}`
+
+- Display a calendar for a specific month and year:
+
+`cal {{month}} {{year}}`
+
+- Display a calendar for the current [y]ear:
+
+`cal -y`
+
+- Display [j]ulian days (one-based, numbered from January 1):
+
+`cal -j`
+
+- Use [m]onday as week start instead of Sunday:
+
+`cal -m`
+
+- Number [w]eek numbers (incompatible with `-j`):
+
+`cal -w`


### PR DESCRIPTION
For #9612 and #11827.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).