### PR TITLE
cut, tail: use keith.github.io for Dutch pages

### DIFF
--- a/pages.nl/osx/cut.md
+++ b/pages.nl/osx/cut.md
@@ -1,7 +1,7 @@
 # cut
 
 > Snij velden eruit vanuit `stdin` of bestanden.
-> Meer informatie: <https://manned.org/man/freebsd-13.0/cut.1>.
+> Meer informatie: <https://keith.github.io/xcode-man-pages/cut.1.html>.
 
 - Toon een specifiek karakter/veldbereik voor iedere regel:
 

--- a/pages.nl/osx/tail.md
+++ b/pages.nl/osx/tail.md
@@ -2,7 +2,7 @@
 
 > Toon het laatste deel van een bestand.
 > Bekijk ook: `head`.
-> Meer informatie: <https://manned.org/man/freebsd-13.0/tail.1>.
+> Meer informatie: <https://keith.github.io/tail.1.html>.
 
 - Toon laatste aantal regels in een bestand:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).