### PR TITLE
pages.*: standardize capitalization in note term

### DIFF
--- a/pages.ko/common/virsh.md
+++ b/pages.ko/common/virsh.md
@@ -1,6 +1,6 @@
 # virsh
 
-> virsh 게스트 도메인을 관리합니다. (NOTE: 'guest_id'는 게스트의 아이디, 이름 또는 UUID일 수 있습니다).
+> virsh 게스트 도메인을 관리합니다. (Note: 'guest_id'는 게스트의 아이디, 이름 또는 UUID일 수 있습니다).
 > `virsh list`와 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
 > 더 많은 정보: <https://libvirt.org/virshcmdref.html>.
 

--- a/pages/common/cupsaccept.md
+++ b/pages/common/cupsaccept.md
@@ -1,7 +1,7 @@
 # cupsaccept
 
 > Accept jobs sent to destinations.
-> NOTE: destination is referred as a printer or a class of printers.
+> Note: destination is referred as a printer or a class of printers.
 > See also: `cupsreject`, `cupsenable`, `cupsdisable`, `lpstat`.
 > More information: <https://www.cups.org/doc/man-cupsaccept.html>.
 

--- a/pages/common/cupsdisable.md
+++ b/pages/common/cupsdisable.md
@@ -1,7 +1,7 @@
 # cupsdisable
 
 > Stop printers and classes.
-> NOTE: destination is referred as a printer or a class of printers.
+> Note: destination is referred as a printer or a class of printers.
 > See also: `cupsenable`, `cupsaccept`, `cupsreject`, `lpstat`.
 > More information: <https://openprinting.github.io/cups/doc/man-cupsenable.html>.
 

--- a/pages/common/cupsreject.md
+++ b/pages/common/cupsreject.md
@@ -1,7 +1,7 @@
 # cupsreject
 
 > Reject jobs sent to printers.
-> NOTE: destination is referred as a printer or a class of printers.
+> Note: destination is referred as a printer or a class of printers.
 > See also: `cupsaccept`, `cupsenable`, `cupsdisable`, `lpstat`.
 > More information: <https://www.cups.org/doc/man-cupsaccept.html>.
 

--- a/pages/common/cupstestppd.md
+++ b/pages/common/cupstestppd.md
@@ -2,7 +2,7 @@
 
 > Test conformance of PPD files to the version 4.3 of the specification.
 > Error codes (1, 2, 3 and 4, respectively): bad CLI arguments, unable to open file, unskippable format errors and non-conformance with PPD specification.
-> NOTE: this command is deprecated.
+> Note: this command is deprecated.
 > See also: `lpadmin`.
 > More information: <https://openprinting.github.io/cups/doc/man-cupstestppd.html>.
 

--- a/pages/common/flex.md
+++ b/pages/common/flex.md
@@ -2,7 +2,7 @@
 
 > Lexical analyzer generator. A rewrite of `lex` with extensions to the POSIX specification.
 > Given the specification for a lexical analyzer, generates C code implementing it.
-> NOTE: long options don't work on OpenBSD.
+> Note: long options don't work on OpenBSD.
 > More information: <https://manned.org/flex>.
 
 - Generate an analyzer from a flex file, storing it to the file `lex.yy.c`:

--- a/pages/common/kosmorro.md
+++ b/pages/common/kosmorro.md
@@ -15,6 +15,6 @@
 
 `kosmorro --latitude={{48.7996}} --longitude={{2.3511}} --date={{2020-06-09}}`
 
-- Generate a PDF (note: TeXLive must be installed):
+- Generate a PDF (Note: TeXLive must be installed):
 
 `kosmorro --format={{pdf}} --output={{path/to/file.pdf}}`

--- a/pages/common/lex.md
+++ b/pages/common/lex.md
@@ -2,7 +2,7 @@
 
 > Lexical analyzer generator.
 > Given the specification for a lexical analyzer, generates C code implementing it.
-> NOTE: on most major OSes, this command is an alias for `flex`.
+> Note: on most major OSes, this command is an alias for `flex`.
 > More information: <https://manned.org/lex.1>.
 
 - Generate an analyzer from a Lex file, storing it to the file `lex.yy.c`:

--- a/pages/common/look.md
+++ b/pages/common/look.md
@@ -1,7 +1,7 @@
 # look
 
 > Display lines beginning with a prefix in a sorted file.
-> NOTE: the lines in the file must be sorted.
+> Note: the lines in the file must be sorted.
 > See also: `grep`, `sort`.
 > More information: <https://man.openbsd.org/look>.
 

--- a/pages/common/prosodyctl.md
+++ b/pages/common/prosodyctl.md
@@ -1,7 +1,7 @@
 # prosodyctl
 
 > The control tool for the Prosody XMPP server.
-> NOTE: process management through `prosodyctl` is discouraged. Instead, use the tools provided by your system (e.g. `systemctl`).
+> Note: process management through `prosodyctl` is discouraged. Instead, use the tools provided by your system (e.g. `systemctl`).
 > More information: <https://prosody.im/doc/prosodyctl>.
 
 - Show the status of the Prosody server:

--- a/pages/common/q.md
+++ b/pages/common/q.md
@@ -23,6 +23,6 @@
 
 `q "SELECT * FROM {{path/to/file}} f1 JOIN {{path/to/other_file}} f2 ON (f1.c1 = f2.c1)"`
 
-- Format output using an output delimiter with an output header line (note: command will output column names based on the input file header or the column aliases overridden in the query):
+- Format output using an output delimiter with an output header line (Note: command will output column names based on the input file header or the column aliases overridden in the query):
 
 `q -D{{delimiter}} -O "SELECT {{column}} as {{alias}} from {{path/to/file}}"`

--- a/pages/common/tidy.md
+++ b/pages/common/tidy.md
@@ -1,7 +1,7 @@
 # tidy
 
 > Clean up and pretty print HTML, XHTML and XML files.
-> NOTE: `tidy` cannot preserve original indentation.
+> Note: `tidy` cannot preserve original indentation.
 > More information: <https://api.html-tidy.org/tidy/tidylib_api_5.2.0/tidy_cmd.html>.
 
 - Pretty print an HTML file:

--- a/pages/common/virsh.md
+++ b/pages/common/virsh.md
@@ -1,6 +1,6 @@
 # virsh
 
-> Manage virsh guest domains. (NOTE: 'guest_id' can be the id, name or UUID of the guest).
+> Manage virsh guest domains. (Note: 'guest_id' can be the id, name or UUID of the guest).
 > Some subcommands such as `virsh list` have their own usage documentation.
 > More information: <https://libvirt.org/virshcmdref.html>.
 

--- a/pages/common/virt-sparsify.md
+++ b/pages/common/virt-sparsify.md
@@ -1,7 +1,7 @@
 # virt-sparsify
 
 > Make virtual machine drive images thin-provisioned.
-> NOTE: Use only for offline machines to avoid data corruption.
+> Note: Use only for offline machines to avoid data corruption.
 > More information: <https://libguestfs.org>.
 
 - Create a sparsified compressed image without snapshots from an unsparsified one:

--- a/pages/linux/file-rename.md
+++ b/pages/linux/file-rename.md
@@ -1,7 +1,7 @@
 # rename
 
 > Rename multiple files.
-> NOTE: this page refers to the command from the `rename` Debian package.
+> Note: this page refers to the command from the `rename` Debian package.
 > More information: <https://manned.org/file-rename>.
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):

--- a/pages/linux/lid.md
+++ b/pages/linux/lid.md
@@ -1,6 +1,6 @@
 # lid
 
-> NOTE: This page is currently a redirection stub. If you are familiar with this program, please open a pull request.
+> Note: This page is currently a redirection stub. If you are familiar with this program, please open a pull request.
 > Query ID database and report results.
 > On Fedora and Arch Linux, the binary name `lid` is taken by another program. See `tldr libuser-lid`.
 > More information: <https://www.gnu.org/software/idutils/>.

--- a/pages/linux/look.md
+++ b/pages/linux/look.md
@@ -1,7 +1,7 @@
 # look
 
 > Display lines beginning with a prefix in a file.
-> NOTE: the lines in the file must be sorted.
+> Note: the lines in the file must be sorted.
 > See also: `grep`, `sort`.
 > More information: <https://manned.org/look>.
 

--- a/pages/linux/perl-rename.md
+++ b/pages/linux/perl-rename.md
@@ -1,7 +1,7 @@
 # rename
 
 > Rename multiple files.
-> NOTE: this page refers to the command from the `perl-rename` Arch Linux package.
+> Note: this page refers to the command from the `perl-rename` Arch Linux package.
 > More information: <https://manned.org/rename>.
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):

--- a/pages/linux/prename.md
+++ b/pages/linux/prename.md
@@ -1,7 +1,7 @@
 # rename
 
 > Rename multiple files.
-> NOTE: this page refers to the command from the `prename` Fedora package.
+> Note: this page refers to the command from the `prename` Fedora package.
 > More information: <https://manned.org/man/prename>.
 
 - Rename files using a Perl Common Regular Expression (substitute 'foo' with 'bar' wherever found):

--- a/pages/linux/quickget.md
+++ b/pages/linux/quickget.md
@@ -1,7 +1,7 @@
 # quickget
 
 > Download and prepare materials for building a Quickemu virtual machine.
-> NOTE: the parameter "edition" is always optional.
+> Note: the parameter "edition" is always optional.
 > See also: `quickemu`.
 > More information: <https://github.com/quickemu-project/quickemu>.
 

--- a/pages/linux/rename.md
+++ b/pages/linux/rename.md
@@ -1,7 +1,7 @@
 # rename
 
 > Rename multiple files.
-> NOTE: this page refers to the command from the `util-linux` package.
+> Note: this page refers to the command from the `util-linux` package.
 > For the Perl version, see `file-rename` or `perl-rename`.
 > Warning: This command has no safeguards and will overwrite files without prompting.
 > More information: <https://manned.org/rename>.

--- a/pages/linux/switch_root.md
+++ b/pages/linux/switch_root.md
@@ -1,7 +1,7 @@
 # switch_root
 
 > Use a different filesystem as the root of the mount tree.
-> NOTE: switch_root will fail to function if the new root is not the root of a mount. Use bind-mounting as a workaround.
+> Note: switch_root will fail to function if the new root is not the root of a mount. Use bind-mounting as a workaround.
 > See also: `chroot`, `mount`.
 > More information: <https://manned.org/switch_root.8>.
 

--- a/pages/linux/urpmi-addmedia.md
+++ b/pages/linux/urpmi-addmedia.md
@@ -1,7 +1,7 @@
 # urpmi.addmedia
 
 > Add media in Mageia.
-> NOTE: Mageia documentation uses medium and repository as synonymous.
+> Note: Mageia documentation uses medium and repository as synonymous.
 > See also: `urpmi`, `urpmi.update`, `urpme`, `urpmi.removemedia`, `urpmf`, `urpmq`.
 > More information: <https://wiki.mageia.org/en/URPMI#urpme>.
 

--- a/pages/linux/urpmi-removemedia.md
+++ b/pages/linux/urpmi-removemedia.md
@@ -1,7 +1,7 @@
 # urpmi.removemedia
 
 > Remove media in Mageia.
-> NOTE: Mageia documentation uses medium and repository as synonymous.
+> Note: Mageia documentation uses medium and repository as synonymous.
 > See also: `urpmi`, `urpme`, `urpmi.addmedia`, `urpmi.update`, `urpmf`, `urpmq`.
 > More information: <https://wiki.mageia.org/en/URPMI#urpmi.removemedia>.
 

--- a/pages/linux/urpmi-update.md
+++ b/pages/linux/urpmi-update.md
@@ -1,7 +1,7 @@
 # urpmi.update
 
 > Update the list of packages from a package repository in Mageia.
-> NOTE: Mageia documentation uses medium and repository as synonymous.
+> Note: Mageia documentation uses medium and repository as synonymous.
 > See also: `urpmi`, `urpme`, `urpmi.addmedia`, `urpmi.removemedia`, `urpmf`, `urpmq`.
 > More information: <https://wiki.mageia.org/en/URPMI#urpmi.update>.
 

--- a/pages/linux/virt-viewer.md
+++ b/pages/linux/virt-viewer.md
@@ -1,7 +1,7 @@
 # virt-viewer
 
 > Minimal graphical interface for a virtual machine (VM).
-> NOTE: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
+> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
 > More information: <https://manned.org/virt-viewer>.
 
 - Launch `virt-viewer` with a prompt to select running virtual machines:

--- a/pages/linux/virt-xml.md
+++ b/pages/linux/virt-xml.md
@@ -1,7 +1,7 @@
 # virt-xml
 
 > Edit libvirt Domain XML files with explicit command-line options.
-> NOTE: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
+> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
 > More information: <https://github.com/virt-manager/virt-manager/blob/main/man/virt-xml.rst>.
 
 - List all the suboptions for a specific option:

--- a/pages/osx/chpass.md
+++ b/pages/osx/chpass.md
@@ -1,7 +1,7 @@
 # chpass
 
 > Add or change user database information, including login shell and password.
-> NOTE: it's not possible to change the user's password on Open Directory systems, use `passwd` instead.
+> Note: it's not possible to change the user's password on Open Directory systems, use `passwd` instead.
 > See also: `passwd`.
 > More information: <https://man.freebsd.org/cgi/man.cgi?chpass>.
 

--- a/pages/osx/launchctl.md
+++ b/pages/osx/launchctl.md
@@ -20,11 +20,11 @@
 
 `launchctl list`
 
-- Unload a currently loaded agent, e.g. to make changes (note: the plist file is automatically loaded into `launchd` after a reboot and/or logging in):
+- Unload a currently loaded agent, e.g. to make changes (Note: the plist file is automatically loaded into `launchd` after a reboot and/or logging in):
 
 `launchctl unload ~/Library/LaunchAgents/{{my_script}}.plist`
 
-- Manually run a known (loaded) agent/daemon, even if it is not the right time (note: this command uses the agent's label, rather than the filename):
+- Manually run a known (loaded) agent/daemon, even if it is not the right time (Note: this command uses the agent's label, rather than the filename):
 
 `launchctl start {{script_file}}`
 

--- a/pages/windows/wget.md
+++ b/pages/windows/wget.md
@@ -1,7 +1,7 @@
 # wget
 
 > In PowerShell, this command may be an alias of `Invoke-WebRequest` when the original `wget` program (<https://www.gnu.org/software/wget>) is not properly installed.
-> NOTE: if version command returns an error, PowerShell may have substituted this command with `Invoke-WebRequest`.
+> Note: if version command returns an error, PowerShell may have substituted this command with `Invoke-WebRequest`.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
 
 - View documentation for the original `wget` command:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

This PR standardizes the capitalization of the "note" term in descriptions to use "Note:" instead of "NOTE:" or "note:".
