### PR TITLE
mutool: cleanup page

### DIFF
--- a/pages/common/mutool.md
+++ b/pages/common/mutool.md
@@ -1,15 +1,15 @@
 # mutool
 
-> Convert PDF files, query information and extract data.
+> Convert, query information and extract data from PDF files.
 > More information: <https://mupdf.readthedocs.io/en/latest/mupdf-command-line.html>.
 
-- Convert pages 1-10 into 10 PNGs (Note: `%nd` in the output placeholder must be replaced with a print modifier like `%d` or `%2d`):
+- Convert pages 1 to 10 into 10 PNGs (Note: `%nd` in the output placeholder must be replaced with a print modifier like `%d` or `%2d`):
 
-`mutool convert -o {{path/to/output%nd.png}} {{path/to/input.pdf}} {{1-10}}`
+`mutool convert -o {{path/to/output%nd.png}} {{path/to/input.pdf}} 1-10`
 
-- Convert pages 2, 3 and 5 of a PDF into text in `stdout`:
+- Convert one or more pages of a PDF into text in `stdout`:
 
-`mutool draw -F {{txt}} {{path/to/input.pdf}} {{2,3,5}}`
+`mutool draw -F txt {{path/to/input.pdf}} {{2,3,5,...}}`
 
 - Concatenate multiple PDF files:
 
@@ -19,10 +19,10 @@
 
 `mutool info {{path/to/input.pdf}}`
 
-- Extract all images, fonts and resources embedded in a PDF out into the current directory:
+- Extract all images, fonts and resources embedded in a PDF to the current directory:
 
 `mutool extract {{path/to/input.pdf}}`
 
-- Print the outline (table of contents) of a PDF:
+- Show the outline (table of contents) of a PDF:
 
 `mutool show {{path/to/input.pdf}} outline`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 1.24