### PR TITLE
git-diff: clarify description of git diff

### DIFF
--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -3,7 +3,7 @@
 > Show changes to tracked files.
 > More information: <https://git-scm.com/docs/git-diff>.
 
-- Show unstaged, uncommitted changes:
+- Show unstaged changes:
 
 `git diff`
 


### PR DESCRIPTION
I'm currently learning Git, and when I looked up the command 'git diff,' I found the term 'uncommitted' quite confusing. It seemed more applicable to 'git diff HEAD' rather than to 'git diff.' I think it would be clearer to just use 'unstaged'.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
