### PR TITLE
git-clone: add --recurse-submodules

### DIFF
--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -15,13 +15,9 @@
 
 `git clone --no-checkout {{remote_repository_location}}`
 
-- Clone a local repository:
+- Clone a local repository quietly:
 
-`git clone --local {{path/to/local/repository}}`
-
-- Clone quietly:
-
-`git clone --quiet {{remote_repository_location}}`
+`git clone --local --quiet {{path/to/local/repository}}`
 
 - Clone an existing repository only fetching the 10 most recent commits on the default branch (useful to save time):
 

--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -31,6 +31,6 @@
 
 `git clone --config core.sshCommand="{{ssh -i path/to/private_ssh_key}}" {{remote_repository_location}}`
 
-- Automatically initialize and clone each submodule in the repository:
+- Automatically initialize and clone each submodule in the repository recursively:
 
 `git clone --recurse-submodules`

--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -31,6 +31,6 @@
 
 `git clone --config core.sshCommand="{{ssh -i path/to/private_ssh_key}}" {{remote_repository_location}}`
 
-- Automatically initialize and update each submodule in the repository:
+- Automatically initialize and clone each submodule in the repository:
 
 `git clone --recurse-submodules`

--- a/pages/common/git-clone.md
+++ b/pages/common/git-clone.md
@@ -34,3 +34,7 @@
 - Clone an existing repository using a specific SSH command:
 
 `git clone --config core.sshCommand="{{ssh -i path/to/private_ssh_key}}" {{remote_repository_location}}`
+
+- Automatically initialize and update each submodule in the repository:
+
+`git clone --recurse-submodules`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

page edited: `pages/common/git-clone.md` 