### PR TITLE
docs: use switch instead of checkout and fix header levels in contributing-guides/git-terminal

### DIFF
--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -51,7 +51,7 @@ There are two ways to update your fork.
 2. Using Git in the terminal:
 
 ```bash
-git checkout main
+git switch main
 git remote add upstream https://github.com/tldr-pages/tldr.git  # only run if you don't already have the upstream remote (check with "git remote -v")
 git fetch upstream main
 git rebase upstream/main     # in case you have any merge conflicts, click the link below to see how to resolve them

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -12,7 +12,7 @@ The overall process should look somewhat like this:
   `git clone https://github.com/{{your_username}}/tldr.git && cd tldr`
 
 3. Create a feature branch, e.g. named after the command you plan to edit:
-  `git checkout -b {{branch_name}}`
+  `git switch -c {{branch_name}}`
 
 > [!WARNING]
 > It is bad practice to submit a PR from the `main` branch of your forked repository. Please create pull requests from a well-named feature branch.
@@ -23,7 +23,7 @@ The overall process should look somewhat like this:
   `git commit --all -m "{{commit_message}}"`
 
 6. Push the commit(s) to your fork:
-  `git push origin {{branch_name}}`
+  `git push origin HEAD`
 
 > [!WARNING]
 > Please avoid force-pushing since it makes the review process harder.

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -24,7 +24,7 @@ The overall process should look somewhat like this:
   `git commit --all -m "{{commit_message}}"`
 
 6. Push the commit(s) to your fork:
-  `git push origin HEAD`
+  `git push -u origin HEAD`
 
 > [!WARNING]
 > Please avoid force-pushing since it makes the review process harder.

--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -1,4 +1,5 @@
-# Opening a Pull Request
+# Using Git
+## Opening a Pull Request
 
 Most people submit pull requests to the tldr-pages project
 [using GitHub's web interface][pr-howto].
@@ -38,7 +39,7 @@ Typically a pull request will include changes in a single file **unless the pull
 [commit-msg]: ../CONTRIBUTING.md#commit-message
 [mass-changes]: https://github.com/tldr-pages/tldr/pulls?&q=is:pr+is:merged+label:"mass+changes"
 
-# Updating your fork
+## Updating your fork
 
 Forks of GitHub repositories aren't updated automatically. You should update your fork regularly to keep it up-to-date with the latest changes and avoid merge conflicts.
 
@@ -59,7 +60,7 @@ git push --force-with-lease  # not needed if you only want to update your local 
 ```
 [How to resolve merge conflicts](https://docs.github.com/en/github/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)
 
-# Changing the email of your last commit
+## Changing the email of your last commit
 
 If the email that you used for the last commit isn't associated with your GitHub account, you can either add it [here](https://github.com/settings/emails) or change the email of the commit with the following commands:
 
@@ -68,7 +69,7 @@ git commit --amend --author="Your Name <new.email@example.com>"
 git push --force-with-lease
 ```
 
-# Changing the email of any commit(s)
+## Changing the email of any commit(s)
 
 1. Perform an [interactive rebase](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt--i), specifying the reference of the earliest commit to modify as the argument. For example, if the earliest commit with the wrong email address was 6 commits ago, you can specify the commit hash or just `HEAD~6`.
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

`git checkout` was split (even though it wasn't removed) into `git switch` and `git restore`, which provides a much cleaner separation of responsabilities.