### PR TITLE
aws-quicksight: improve page description

### DIFF
--- a/pages/common/aws-quicksight.md
+++ b/pages/common/aws-quicksight.md
@@ -1,7 +1,6 @@
 # aws quicksight
 
-> CLI for AWS QuickSight.
-> Access QuickSight entities.
+> Create, delete, list, search and update AWS QuickSight entities.
 > More information: <https://docs.aws.amazon.com/cli/latest/reference/quicksight/>.
 
 - List datasets:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.15.19

IMO the term "CLI" in page descriptions are unnecessary because most tldr pages document CLI programs, we should focus on making explicit that GUI programs are GUI programs.