### PR TITLE
aws-codeartifact: improve page description and examples

### DIFF
--- a/pages/common/aws-codeartifact.md
+++ b/pages/common/aws-codeartifact.md
@@ -1,25 +1,25 @@
 # aws codeartifact
 
-> CLI for AWS CodeArtifact.
-> CodeArtifact allows you to store artifacts using popular package managers and build tools like Maven, Gradle, npm, Yarn, Twine, pip, NuGet, and SwiftPM.
+> Manage CodeArtifact repositories, domains, packages, package versions and assets.
+> CodeArtifact is an artifact repository compatible with popular package managers and build tools like Maven, Gradle, npm, Yarn, Twine, pip, NuGet, and SwiftPM.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/codeartifact/index.html>.
 
 - List available domains for your AWS account:
 
 `aws codeartifact list-domains`
 
-- Generate credentials for a specific package manager (e.g.: npm, pip):
+- Generate credentials for a specific package manager:
 
-`aws codeartifact login --tool {{package_manager}} --domain {{your_domain}} --repository {{repository_name}}`
+`aws codeartifact login --tool {{npm|pip|twine}} --domain {{your_domain}} --repository {{repository_name}}`
 
 - Get the endpoint URL of a CodeArtifact repository:
 
 `aws codeartifact get-repository-endpoint --domain {{your_domain}} --repository {{repository_name}} --format {{npm|pypi|maven|nuget|generic}}`
 
-- Show list of all available CodeArtifact commands:
+- Display help:
 
 `aws codeartifact help`
 
-- Display help for specific EC2 subcommand:
+- Display help for a specific subcommand:
 
-`aws ec2 {{subcommand}} help`
+`aws codeartifact {{subcommand}} help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- **Version of the command being documented (if known):** 2.15.19

This PR has 3 changes:
1. Improve the page page description to a less generic one.
2. Improve the `--tool`'s argument placeholder of `aws codeartifact login` to show all possible options
3. Use generic wording for help commands