### PR TITLE
docs: mention PR title in the commit message section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@ See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
 - [ ] The page(s) have at most 8 examples.
 - [ ] The page description(s) have links to documentation or a homepage.
 - [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
-- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-messagepr-title).
+- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
 - **Version of the command being documented (if known):**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@ See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
 - [ ] The page(s) have at most 8 examples.
 - [ ] The page description(s) have links to documentation or a homepage.
 - [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
-- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
+- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-messagepr-title).
 - **Version of the command being documented (if known):**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,7 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 
 For script changes, the commit message/PR title can be (but not limited to) one of the following examples:
 
+- For a new script addition: `scripts/{{script_name}}: add script`
 - For a script edit: `scripts/set-alias-page: fix performance issue`
 - For changes that affect multiple scripts: `scripts: replace insecure library`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ The latest version of [NodeJS](https://nodejs.org) is required to install `tldr-
 npm install --global tldr-lint
 ```
 
-Once its installed, you can test your page by running the following command:
+Once it is installed, you can test your page by running the following command:
 
 ```sh
 tldr-lint {{path/to/page.md}}
@@ -224,9 +224,9 @@ To commit a suggestion to your pull request, click on `Commit suggestion`:
 
 If you want to commit multiple suggestions, go to the "Files changed" tab and batch all suggestions. Now, click the `Commit suggestions` button and enter a commit message to create a single commit.
 
-### Commit message
+### Commit message/PR title
 
-For the commit message of page changes, use the following format:
+For the commit message and PR title of page changes, use the following format:
 
 `{{command}}: type of change`
 
@@ -236,11 +236,14 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 - For a page edit: `cat: fix typo`, `git-push: add --force example`
 - For a new translation of an existing page: `cp: add Tamil translation`
 - For a modification to the translation of an existing page: `cp: fix typo in Tamil translation`
-- For related changes to several pages: `grep, find, locate: synchronize format of wildcards`
+- For related changes to some pages: `grep, find, locate: synchronize format of wildcards`
+- For related changes to several unrelated pages: `pages*: fix Linux casing`
 - For multiple subcommand page additions: `git-{add, push, ...}: add page`
 - For modifying multiple pages in a language: `pages.<locale>/*: update pages`
 
-For other cases, its suggested to follow <https://www.conventionalcommits.org/> as much as possible.
+For script changes, use the format `scripts/{{script_name}}: type of change`.
+
+For other cases, it is suggested to follow <https://www.conventionalcommits.org/> as much as possible.
 
 ## Name collisions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,10 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 - For multiple subcommand page additions: `git-{add, push, ...}: add page`
 - For modifying multiple pages in a language: `pages.<locale>/*: update pages`
 
-For script changes, use the format `scripts/{{script_name}}: type of change`.
+For script changes, the commit message/PR title can be (but not limited to) one of the following examples:
+
+- For a script edit: `scripts/set-alias-page: fix performance issue`
+- For changes that affect multiple scripts: `scripts: replace insecure library`
 
 For other cases, it is suggested to follow <https://www.conventionalcommits.org/> as much as possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ To commit a suggestion to your pull request, click on `Commit suggestion`:
 
 If you want to commit multiple suggestions, go to the "Files changed" tab and batch all suggestions. Now, click the `Commit suggestions` button and enter a commit message to create a single commit.
 
-### Commit message/PR title
+### Commit message and PR title
 
 For the commit message and PR title of page changes, use the following format:
 
@@ -241,7 +241,7 @@ Where `{{command}}` is the name of the command being modified, and `type of chan
 - For multiple subcommand page additions: `git-{add, push, ...}: add page`
 - For modifying multiple pages in a language: `pages.<locale>/*: update pages`
 
-For script changes, the commit message/PR title can be (but not limited to) one of the following examples:
+For script changes, the commit message and the PR title can be (but not limited to) one of the following examples:
 
 - For a new script addition: `scripts/{{script_name}}: add script`
 - For a script edit: `scripts/set-alias-page: fix performance issue`


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

It can be a bit confusing to new contributors that the PR title is not mentioned in the link that they click on the PR template, they can think that the section only applies to commit messages.

This PR also contains some other changes:

1. Fix "its" vs. "it is"
2. Suggest "pages*" use for related changes that affect several unrelated pages
3. Define a standard for commit messages and PR titles of script changes