### PR TITLE
docs: suggest auto setup remote in contributing-guides/git-terminal

### DIFF
--- a/contributing-guides/git-terminal.md
+++ b/contributing-guides/git-terminal.md
@@ -26,6 +26,9 @@ The overall process should look somewhat like this:
 6. Push the commit(s) to your fork:
   `git push -u origin HEAD`
 
+7. If you want to avoid setting the upstream every time and just run `git push`:
+  `git config push.autoSetupRemote true`
+
 > [!WARNING]
 > Please avoid force-pushing since it makes the review process harder.
 


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).