### PR TITLE
cavif: improve page

### DIFF
--- a/pages/common/cavif.md
+++ b/pages/common/cavif.md
@@ -1,21 +1,21 @@
 # cavif
 
-> PNG/JPEG to AVIF converter. Written in Rust.
+> Convert PNG/JPEG images to AVIF. Written in Rust.
 > See also: `convert`.
 > More information: <https://github.com/kornelski/cavif-rs>.
 
 - Convert a JPEG file to AVIF, saving it to `file.avif`:
 
-`cavif {{path/to/file.jpg}}`
+`cavif {{path/to/image.jpg}}`
 
-- Adjust the image quality (1-100) and convert a PNG file to AVIF:
+- Adjust the image quality and convert a PNG file to AVIF:
 
-`cavif --quality {{60}} {{path/to/file.png}}`
+`cavif --quality {{1..100}} {{path/to/image.png}}`
 
 - Specify the output location:
 
-`cavif {{path/to/file.jpg}} --output {{path/to/file.avif}}`
+`cavif {{path/to/image.jpg}} --output {{path/to/output.avif}}`
 
 - Overwrite the destination file if it already exists:
 
-`cavif --overwrite {{path/to/file.jpg}}`
+`cavif --overwrite {{path/to/image.jpg}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

1. Use imperative in page description
2. Use path/to/image.{jpg,png} instead of path/to/file.{jpg,png}
3. Use range placeholders