### PR TITLE
pages*: fix developer.android.com links

### DIFF
--- a/pages/android/am.md
+++ b/pages/android/am.md
@@ -1,7 +1,7 @@
 # am
 
 > Android activity manager.
-> More information: <https://developer.android.com/studio/command-line/adb#am>.
+> More information: <https://developer.android.com/tools/adb#am>.
 
 - Start a specific activity:
 

--- a/pages/android/dalvikvm.md
+++ b/pages/android/dalvikvm.md
@@ -1,7 +1,7 @@
 # dalvikvm
 
 > Android Java virtual machine.
-> More information: <https://source.android.com/devices/tech/dalvik>.
+> More information: <https://developer.android.com/tools/#art_and_dalvik>.
 
 - Start a specific Java program:
 

--- a/pages/android/dumpsys.md
+++ b/pages/android/dumpsys.md
@@ -2,7 +2,7 @@
 
 > Provide information about Android system services.
 > This command can only be used through `adb shell`.
-> More information: <https://developer.android.com/studio/command-line/dumpsys>.
+> More information: <https://developer.android.com/tools/dumpsys>.
 
 - Get diagnostic output for all system services:
 

--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -1,7 +1,7 @@
 # logcat
 
 > Dump a log of system messages, including stack traces when an error occurred, and information messages logged by applications.
-> More information: <https://developer.android.com/studio/command-line/logcat>.
+> More information: <https://developer.android.com/tools/logcat>.
 
 - Display system logs:
 

--- a/pages/android/pm.md
+++ b/pages/android/pm.md
@@ -1,7 +1,7 @@
 # pm
 
 > Display information about apps on an Android device.
-> More information: <https://developer.android.com/studio/command-line/adb#pm>.
+> More information: <https://developer.android.com/tools/adb#pm>.
 
 - List all installed apps:
 

--- a/pages/android/screencap.md
+++ b/pages/android/screencap.md
@@ -2,7 +2,7 @@
 
 > Take a screenshot of a mobile display.
 > This command can only be used through `adb shell`.
-> More information: <https://developer.android.com/studio/command-line/adb#screencap>.
+> More information: <https://developer.android.com/tools/adb#screencap>.
 
 - Take a screenshot:
 

--- a/pages/common/adb-install.md
+++ b/pages/common/adb-install.md
@@ -1,7 +1,7 @@
 # adb install
 
 > Android Debug Bridge Install: push packages to an Android emulator instance or connected Android devices.
-> More information: <https://developer.android.com/studio/command-line/adb>.
+> More information: <https://developer.android.com/tools/adb>.
 
 - Push an Android application to an emulator/device:
 

--- a/pages/common/adb-logcat.md
+++ b/pages/common/adb-logcat.md
@@ -1,7 +1,7 @@
 # adb logcat
 
 > Dump a log of system messages.
-> More information: <https://developer.android.com/studio/command-line/logcat>.
+> More information: <https://developer.android.com/tools/logcat>.
 
 - Display system logs:
 

--- a/pages/common/adb-reverse.md
+++ b/pages/common/adb-reverse.md
@@ -1,7 +1,7 @@
 # adb reverse
 
 > Android Debug Bridge Reverse: reverse socket connections from an Android emulator instance or connected Android devices.
-> More information: <https://developer.android.com/studio/command-line/adb>.
+> More information: <https://developer.android.com/tools/adb>.
 
 - List all reverse socket connections from emulators and devices:
 

--- a/pages/common/adb-shell.md
+++ b/pages/common/adb-shell.md
@@ -1,7 +1,7 @@
 # adb shell
 
 > Android Debug Bridge Shell: run remote shell commands on an Android emulator instance or connected Android devices.
-> More information: <https://developer.android.com/studio/command-line/adb>.
+> More information: <https://developer.android.com/tools/adb>.
 
 - Start a remote interactive shell on the emulator or device:
 

--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -2,7 +2,7 @@
 
 > Android Debug Bridge: communicate with an Android emulator instance or connected Android devices.
 > Some subcommands such as `adb shell` have their own usage documentation.
-> More information: <https://developer.android.com/studio/command-line/adb>.
+> More information: <https://developer.android.com/tools/adb>.
 
 - Check whether the adb server process is running and start it:
 

--- a/pages/common/bundletool-dump.md
+++ b/pages/common/bundletool-dump.md
@@ -1,7 +1,7 @@
 # bundletool dump
 
 > Manipulate Android Application Bundles.
-> More information: <https://developer.android.com/studio/command-line/bundletool>.
+> More information: <https://developer.android.com/tools/bundletool>.
 
 - Display the `AndroidManifest.xml` of the base module:
 

--- a/pages/common/bundletool-validate.md
+++ b/pages/common/bundletool-validate.md
@@ -1,7 +1,7 @@
 # bundletool validate
 
 > Manipulate Android Application Bundles.
-> More information: <https://developer.android.com/studio/command-line/bundletool>.
+> More information: <https://developer.android.com/tools/bundletool>.
 
 - Verify a bundle and display detailed information about it:
 

--- a/pages/common/bundletool.md
+++ b/pages/common/bundletool.md
@@ -2,7 +2,7 @@
 
 > Manipulate Android Application Bundles.
 > Some subcommands such as `bundletool validate` have their own usage documentation.
-> More information: <https://developer.android.com/studio/command-line/bundletool>.
+> More information: <https://developer.android.com/tools/bundletool>.
 
 - Display help for a subcommand:
 

--- a/pages/common/sdkmanager.md
+++ b/pages/common/sdkmanager.md
@@ -1,7 +1,7 @@
 # sdkmanager
 
 > Install packages for the Android SDK.
-> More information: <https://developer.android.com/studio/command-line/sdkmanager>.
+> More information: <https://developer.android.com/tools/sdkmanager>.
 
 - List available packages:
 

--- a/pages/common/zipalign.md
+++ b/pages/common/zipalign.md
@@ -2,7 +2,7 @@
 
 > Zip archive alignment tool.
 > Part of the Android SDK build tools.
-> More information: <https://developer.android.com/studio/command-line/zipalign>.
+> More information: <https://developer.android.com/tools/zipalign>.
 
 - Align the data of a ZIP file on 4-byte boundaries:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Some pages return 301 (page moved permanently), causing a redirection. This PR updates these links.