### PR TITLE
reg*: improve pages

### DIFF
--- a/pages/windows/reg-add.md
+++ b/pages/windows/reg-add.md
@@ -7,18 +7,18 @@
 
 `reg add {{key_name}}`
 
-- Add a new value under a specific key:
+- Add a new [v]alue under a specific key:
 
 `reg add {{key_name}} /v {{value}}`
 
-- Add a new value with specific data:
+- Add a new value with specific [d]ata:
 
 `reg add {{key_name}} /d {{data}}`
 
-- Add a new value to a key with a specific data type:
+- Add a new value to a key with a specific data [t]ype:
 
-`reg add {{key_name}} /t {{type}}`
+`reg add {{key_name}} /t REG_{{SZ|MULTI_SZ|DWORD_BIG_ENDIAN|DWORD|BINARY|DWORD_LITTLE_ENDIAN|LINK|FULL_RESOURCE_DESCRIPTOR|EXPAND_SZ}}`
 
-- Forcefully overwrite the existing registry value without a prompt:
+- [f]orcefully (without a prompt) overwrite the existing registry value:
 
 `reg add {{key_name}} /f`

--- a/pages/windows/reg-compare.md
+++ b/pages/windows/reg-compare.md
@@ -23,6 +23,6 @@
 
 `reg compare {{key_name1}} {{key_name2}} /oa`
 
-- Compare [o]utputting [n]othing:
+- Compare two keys, [o]utputting [n]othing:
 
 `reg compare {{key_name1}} {{key_name2}} /on`

--- a/pages/windows/reg-compare.md
+++ b/pages/windows/reg-compare.md
@@ -3,22 +3,22 @@
 > Compare keys and their values in the registry.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-compare>.
 
-- Compare all values under a specific key with a second key:
+- Compare all values under a specific key with another key:
 
-`reg compare {{first_key_name}} {{second_key_name}}`
+`reg compare {{key_name1}} {{key_name2}}`
 
 - Compare a specific value under two keys:
 
-`reg compare {{first_key_name}} {{second_key_name}} /v {{value}}`
+`reg compare {{key_name1}} {{key_name2}} /v {{value}}`
 
 - Compare all sub keys and values for two keys:
 
-`reg compare {{first_key_name}} {{second_key_name}} /s`
+`reg compare {{key_name1}} {{key_name2}} /s`
 
 - Only output the matches between the specified keys:
 
-`reg compare {{first_key_name}} {{second_key_name}} /os`
+`reg compare {{key_name1}} {{key_name2}} /os`
 
 - Output the differences and matches between the specified keys:
 
-`reg compare {{first_key_name}} {{second_key_name}} /oa`
+`reg compare {{key_name1}} {{key_name2}} /oa`

--- a/pages/windows/reg-compare.md
+++ b/pages/windows/reg-compare.md
@@ -7,18 +7,22 @@
 
 `reg compare {{key_name1}} {{key_name2}}`
 
-- Compare a specific value under two keys:
+- Compare a specific [v]alue under two keys:
 
 `reg compare {{key_name1}} {{key_name2}} /v {{value}}`
 
-- Compare all sub keys and values for two keys:
+- Compare all [s]ubkeys and values for two keys:
 
 `reg compare {{key_name1}} {{key_name2}} /s`
 
-- Only output the matches between the specified keys:
+- Only [o]utput the matches ([s]ame) between the specified keys:
 
 `reg compare {{key_name1}} {{key_name2}} /os`
 
-- Output the differences and matches between the specified keys:
+- [o]utput the differences and matches ([a]ll) between the specified keys:
 
 `reg compare {{key_name1}} {{key_name2}} /oa`
+
+- Compare [o]utputting [n]othing:
+
+`reg compare {{key_name1}} {{key_name2}} /on`

--- a/pages/windows/reg-copy.md
+++ b/pages/windows/reg-copy.md
@@ -7,10 +7,10 @@
 
 `reg copy {{old_key_name}} {{new_key_name}}`
 
-- Copy a registry key recursively to a new registry location:
+- Copy a registry key recursively (with all [s]ubkeys) to a new registry location:
 
 `reg copy {{old_key_name}} {{new_key_name}} /s`
 
-- Forcefully copy a registry key without a prompt:
+- [f]orcefully (without a prompt) copy a registry key:
 
 `reg copy {{old_key_name}} {{new_key_name}} /f`

--- a/pages/windows/reg-delete.md
+++ b/pages/windows/reg-delete.md
@@ -15,6 +15,6 @@
 
 `reg delete {{key_name}} /va`
 
-- [f]orcefully delete [a]ll [v]alues recursively under a key without a prompt:
+- [f]orcefully (without a prompt) delete [a]ll [v]alues recursively under a key:
 
 `reg delete {{key_name}} /f /va`

--- a/pages/windows/reg-delete.md
+++ b/pages/windows/reg-delete.md
@@ -7,14 +7,14 @@
 
 `reg delete {{key_name}}`
 
-- Delete a value under a specific key:
+- Delete a [v]alue under a specific key:
 
 `reg delete {{key_name}} /v {{value}}`
 
-- Delete all values recursively under the specified key:
+- Delete [a]ll [v]alues recursively under the specified key:
 
 `reg delete {{key_name}} /va`
 
-- Forcefully delete all values recursively under a key without a prompt:
+- [f]orcefully delete [a]ll [v]alues recursively under a key without a prompt:
 
 `reg delete {{key_name}} /f /va`

--- a/pages/windows/reg-export.md
+++ b/pages/windows/reg-export.md
@@ -1,6 +1,6 @@
 # reg export
 
-> Export the specified sub keys and values into a file.
+> Export the specified sub keys and values into a `.reg` file.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-export>.
 
 - Export all sub keys and values of a specific key:

--- a/pages/windows/reg-export.md
+++ b/pages/windows/reg-export.md
@@ -1,12 +1,12 @@
 # reg export
 
-> Export the specified sub keys and values into a `.reg` file.
+> Export the specified subkeys and values to a `.reg` file.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-export>.
 
-- Export all sub keys and values of a specific key:
+- Export all subkeys and values of a specific key:
 
 `reg export {{key_name}} {{path\to\file.reg}}`
 
-- Force overwriting of an existing file without prompt:
+- Forcefully (assuming [y]es) overwrite of an existing file:
 
 `reg export {{key_name}} {{path\to\file.reg}} /y`

--- a/pages/windows/reg-flags.md
+++ b/pages/windows/reg-flags.md
@@ -11,6 +11,6 @@
 
 `reg flags {{key_name}} set {{flag_name1 flag_name2 ...}}`
 
-- Set one or more flags for a specific key and its [s]ub keys:
+- Set one or more flags for a specific key and its [s]ubkeys:
 
 `reg flags {{key_name}} set {{flag_name1 flag_name2 ...}} /s`

--- a/pages/windows/reg-import.md
+++ b/pages/windows/reg-import.md
@@ -1,6 +1,6 @@
 # reg import
 
-> Import all available keys, subkeys, and values from a file.
+> Import all available keys, subkeys, and values from a `.reg` file.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-import>.
 
 - Import all keys, subkeys and values from a file:

--- a/pages/windows/reg-load.md
+++ b/pages/windows/reg-load.md
@@ -1,9 +1,9 @@
 # reg load
 
-> Load saved sub keys into a different sub key in the registry.
-> This is intended for troubleshooting and temporary keys.
+> Load saved subkeys into a different subkey in the registry.
+> Note: this is intended for troubleshooting and temporary keys.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-load>.
 
 - Load a backup file into the specified key:
 
-`reg load {{key_name}} {{path\to\file}}`
+`reg load {{key_name}} {{path\to\file.hiv}}`

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -1,24 +1,36 @@
 # reg query
 
-> Display the values of keys and sub keys in the registry.
+> Display the values of keys and subkeys in the registry.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-query>.
 
 - Display all values of a key:
 
 `reg query {{key_name}}`
 
-- Display a specific value of a key:
+- Display a specific [v]alue of a key:
 
 `reg query {{key_name}} /v {{value}}`
 
-- Display all values of a key and its sub keys:
+- Display all values of a key and its [s]ubkeys:
 
 `reg query {{key_name}} /s`
 
-- Search for keys and values matching a specific pattern:
+- Search [f]or keys and values matching a specific pattern:
 
 `reg query {{key_name}} /f "{{query_pattern}}"`
 
 - Display a value of a key matching a specified data [t]ype:
 
-`reg query {{key_name}} /t {{type}}`
+`reg query {{key_name}} /t REG_{{SZ|MULTI_SZ|EXPAND_SZ|DWORD|BINARY|NONE}}`
+
+- Only search in [k]ey names or in [d]ata:
+
+`reg query {{key_name}} /{{k|d}}`
+
+- Search for an [e]xact match:
+
+`reg query {{key_name}} /e`
+
+- Search [c]ase-sensetively:
+
+`reg query {{key_name}} /c`

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -23,14 +23,14 @@
 
 `reg query {{key_name}} /t REG_{{SZ|MULTI_SZ|EXPAND_SZ|DWORD|BINARY|NONE}}`
 
-- Only search in [k]ey names or in [d]ata:
+- Only search in [d]ata:
 
-`reg query {{key_name}} /{{k|d}}`
+`reg query {{key_name}} /d`
 
-- Search for an [e]xact match:
+- Only search in [k]ey names:
 
-`reg query {{key_name}} /e`
+`reg query {{key_name}} /f /k`
 
-- Search [c]ase-sensitively:
+- [c]ase-sensitively search for an [e]xact match:
 
-`reg query {{key_name}} /c`
+`reg query {{key_name}} /c /e`

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -19,6 +19,6 @@
 
 `reg query {{key_name}} /f "{{query_pattern}}"`
 
-- Display a value of a key matching a specified data type:
+- Display a value of a key matching a specified data [t]ype:
 
 `reg query {{key_name}} /t {{type}}`

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -31,6 +31,6 @@
 
 `reg query {{key_name}} /e`
 
-- Search [c]ase-sensetively:
+- Search [c]ase-sensitively:
 
 `reg query {{key_name}} /c`

--- a/pages/windows/reg-restore.md
+++ b/pages/windows/reg-restore.md
@@ -1,9 +1,9 @@
 # reg restore
 
-> Restore a key and its values from a backup file.
+> Restore a key and its values from a `.hiv` file.
 > See `reg-save` for more information.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-restore>.
 
 - Overwrite a specified key with data from a backup file:
 
-`reg restore {{key_name}} {{path\to\file}}`
+`reg restore {{key_name}} {{path\to\file.hiv}}`

--- a/pages/windows/reg-restore.md
+++ b/pages/windows/reg-restore.md
@@ -1,6 +1,6 @@
 # reg restore
 
-> Restore a key and its values from a `.hiv` file.
+> Restore a key and its values from a native `.hiv` file.
 > See `reg-save` for more information.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-restore>.
 

--- a/pages/windows/reg-save.md
+++ b/pages/windows/reg-save.md
@@ -1,12 +1,12 @@
 # reg save
 
-> Save a registry key, its sub keys and values to a `.hiv` file.
+> Save a registry key, its subkeys and values to a native `.hiv` file.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-save>.
 
-- Save a registry key, its sub keys and values to a specific file:
+- Save a registry key, its subkeys and values to a specific file:
 
 `reg save {{key_name}} {{path\to\file.hiv}}`
 
-- Forcefully overwrite an existing file without a prompt:
+- Forcefully (assuming [y]es) overwrite an existing file:
 
 `reg save {{key_name}} {{path\to\file.hiv}} /y`

--- a/pages/windows/reg-save.md
+++ b/pages/windows/reg-save.md
@@ -1,12 +1,12 @@
 # reg save
 
-> Save a registry key, its sub keys and values to a file.
+> Save a registry key, its sub keys and values to a `.hiv` file.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-save>.
 
 - Save a registry key, its sub keys and values to a specific file:
 
-`reg save {{key_name}} {{path\to\file}}`
+`reg save {{key_name}} {{path\to\file.hiv}}`
 
 - Forcefully overwrite an existing file without a prompt:
 
-`reg save {{key_name}} {{path\to\file}} /y`
+`reg save {{key_name}} {{path\to\file.hiv}} /y`

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -20,11 +20,11 @@
 
 `tldr reg {{compare|flags|query}}`
 
-- View documentation for exporting and importing registry keys preserving the key ownerships and ACLs:
+- View documentation for exporting and importing registry keys not preserving the key ownerships and ACLs:
 
 `tldr reg {{export|import}}`
 
-- View documentation for saving and restoring registry keys not preserving the key ownerships and ACLs:
+- View documentation for saving and restoring registry keys preserving the key ownerships and ACLs:
 
 `tldr reg {{save|restore}}`
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -20,7 +20,7 @@
 
 `tldr reg {{compare|flags|query}}`
 
-- View documentation for exporting and importing registry keys preserving the key ownerhips and ACL:
+- View documentation for exporting and importing registry keys preserving the key ownerships and ACLs:
 
 `tldr reg {{export|import}}`
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -8,7 +8,7 @@
 
 `reg {{command}}`
 
-- View documentation for adding existing and new keys and subkeys:
+- View documentation for adding and copying subkeys:
 
 `tldr reg {{add|copy}}`
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -10,7 +10,7 @@
 
 - View documentation for adding existing and new keys and subkeys:
 
-`tldr reg {{add|copy|load}}`
+`tldr reg {{add|copy}}`
 
 - View documentation for deleting keys and subkeys:
 
@@ -24,9 +24,9 @@
 
 `tldr reg {{export|import}}`
 
-- View documentation for saving and restoring registry keys preserving the key ownerships and ACLs:
+- View documentation for saving, restoring registry and unloading keys preserving the key ownerships and ACLs:
 
-`tldr reg {{save|restore}}`
+`tldr reg {{save|restore|load|unload}}`
 
 - Display help:
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -24,7 +24,7 @@
 
 `tldr reg {{export|import}}`
 
-- View documentation for saving and restoring registry keys not preserving the key ownerhips and ACL:
+- View documentation for saving and restoring registry keys not preserving the key ownerships and ACLs:
 
 `tldr reg {{save|restore}}`
 

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -8,7 +8,27 @@
 
 `reg {{command}}`
 
-- Display general information and list all available commands:
+- View documentation for adding existing and new keys and subkeys:
+
+`tldr reg {{add|copy|load}}`
+
+- View documentation for deleting keys and subkeys:
+
+`tldr reg {{delete|unload}}`
+
+- View documentation for searching, viewing, and comparing keys:
+
+`tldr reg {{compare|flags|query}}`
+
+- View documentation for exporting and importing registry keys preserving the key ownerhips and ACL:
+
+`tldr reg {{export|import}}`
+
+- View documentation for saving and restoring registry keys not preserving the key ownerhips and ACL:
+
+`tldr reg {{save|restore}}`
+
+- Display help:
 
 `reg /?`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x]  The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

- Add grouped examples of subcommands on reg.md to guide the reader through these pages rather than showing expected options first
- Distinguish save/restore and export/import on page descriptions, example path placeholders and reg.md
- "first_key_name" and "second_key_name" -> "key_name1" and "key_name2"
- Add mnemonics for all options
- Specify possible type arguments
- sub key -> subkey. This is the right spelling according to Microsoft's documentation
- Mark `reg load` note as such in the page description