### PR TITLE
id3v2: use hyphen minus (U+002D) instead of hyphen (U+2010)

### DIFF
--- a/pages/linux/id3v2.md
+++ b/pages/linux/id3v2.md
@@ -5,7 +5,7 @@
 
 - List all genres:
 
-`id3v2 ‐‐list‐genres`
+`id3v2 --list-genres`
 
 - List all tags of specific files:
 
@@ -13,7 +13,7 @@
 
 - Delete all `id3v2` or `id3v1` tags of specific files:
 
-`id3v2 {{--delete‐v2|--delete‐v1}} {{path/to/file1 path/to/file2 ...}}`
+`id3v2 {{--delete-v2|--delete-v1}} {{path/to/file1 path/to/file2 ...}}`
 
 - Display help:
 
@@ -21,4 +21,4 @@
 
 - Display version:
 
-`id3v2 ‐‐version`
+`id3v2 --version`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

The keyboard character is hyphen minus (‐, code point U+002D), while in the page the used character is hyphen (‐, code point U+2010).

This was causing an error with aiofile in my script (#12289).