### PR TITLE
warp-cli: improve page description, add "See also" and add example

### DIFF
--- a/pages/common/warp-cli.md
+++ b/pages/common/warp-cli.md
@@ -1,6 +1,8 @@
 # warp-cli
 
-> Official command-line client for Cloudflare's WARP service.
+> Connect, disconnect and switch modes of a connection to Cloudflare's WARP service.
+> WARP is a VPN that encrypts traffic for privacy, security, and speed.
+> See also: `fastd`, `ivpn`, `mozzilavpn`, `mullvad`.
 > More information: <https://developers.cloudflare.com/warp-client/>.
 
 - Register the current device to WARP (must be run before first connection):
@@ -18,6 +20,10 @@
 - Display the WARP connection status:
 
 `warp-cli status`
+
+- Switch to a specific mode:
+
+`warp-cli set-mode {{mode}}`
 
 - Display help:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

1. Improve a previously almost generic description ("CLI client for x service")
2. Add another VPNs services to "See also", improving the discoverability of pages for similar purposes
3. Add `set-mode` example