### PR TITLE
tail: replace "the file" with "it"

### DIFF
--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -16,7 +16,7 @@
 
 `tail --bytes {{count}} {{path/to/file}}`
 
-- Print the last lines of a given file and keep reading file until `Ctrl + C`:
+- Print the last lines of a given file and keep reading the file until `Ctrl + C`:
 
 `tail --follow {{path/to/file}}`
 

--- a/pages/common/tail.md
+++ b/pages/common/tail.md
@@ -16,7 +16,7 @@
 
 `tail --bytes {{count}} {{path/to/file}}`
 
-- Print the last lines of a given file and keep reading the file until `Ctrl + C`:
+- Print the last lines of a given file and keep reading it until `Ctrl + C`:
 
 `tail --follow {{path/to/file}}`
 

--- a/pages/osx/tail.md
+++ b/pages/osx/tail.md
@@ -16,7 +16,7 @@
 
 `tail -c {{8}} {{path/to/file}}`
 
-- Print the last lines of a given file and keep reading the file until `Ctrl + C`:
+- Print the last lines of a given file and keep reading it until `Ctrl + C`:
 
 `tail -f {{path/to/file}}`
 

--- a/pages/osx/tail.md
+++ b/pages/osx/tail.md
@@ -16,7 +16,7 @@
 
 `tail -c {{8}} {{path/to/file}}`
 
-- Print the last lines of a given file and keep reading file until `Ctrl + C`:
+- Print the last lines of a given file and keep reading the file until `Ctrl + C`:
 
 `tail -f {{path/to/file}}`
 


### PR DESCRIPTION
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Add the missing article "a" in both common and osx pages as suggested by the change on the style guide by @kbdharun on #12304.