### PR TITLE
feat: add reference to other PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ accessible through typing `tldr tar` instead of the standard `man tar`.
 If you don't want to install any software, check out the [PDF version](https://github.com/tldr-pages/tldr/releases/latest/download/tldr-book.pdf) instead.
 
 > [!NOTE]
-> PDFs for translations are available for some languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
+> PDFs for translations are available for most languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
 
 There are also **various other clients** provided by the community,
 both for the command-line and for other platforms.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ accessible through typing `tldr tar` instead of the standard `man tar`.
 If you don't want to install any software, check out the [PDF version](https://github.com/tldr-pages/tldr/releases/latest/download/tldr-book.pdf) instead.
 
 > [!NOTE]
-> PDFs for translations are available for a few languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
+> PDFs for translations are available for some languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
 
 There are also **various other clients** provided by the community,
 both for the command-line and for other platforms.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ brew install tlrc
 Then you have direct access to simplified, easy-to-read help for commands, such as `tar`,
 accessible through typing `tldr tar` instead of the standard `man tar`.
 
-If you don't want to install any software,
-check out the [PDF version](https://tldr.sh/assets/tldr-book.pdf).
+If you don't want to install any software, check out the [PDF version](https://github.com/tldr-pages/tldr/releases/latest/download/tldr-book.pdf) instead.
+
+> [!NOTE]
+> PDFs for translations are available for a few languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
 
 There are also **various other clients** provided by the community,
 both for the command-line and for other platforms.


### PR DESCRIPTION
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

I initially thought of adding a separate index for the PDF files, but on second thought I don't think it is necessary as the files already contain the relevant language codes. This PR adds a note to the README referencing the translated PDFs and also updates the existing link from the website -> release assets. Since we will be removing the assets from the website in future.
