### PR TITLE
style-guide: document not rendered syntax

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -334,7 +334,8 @@ For instance, instead of `Listing all files:`, `List all files:` can be used as 
 
 Any syntax not documented in this guide or the client specification will **not** be rendered in most of our clients. See common cases below.
 
-### Links and images
+### Links
+
 Use angled brackets (e.g. <https://example.org>) when including links in pages.
 
 ### Emphasis

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -335,9 +335,7 @@ For instance, instead of `Listing all files:`, `List all files:` can be used as 
 Any syntax not documented in this guide or the client specification will **not** be rendered in most of our clients. See common cases below.
 
 ### Links and images
-
-- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not part of the tldr client specification and thus not supported by most of our clients.
-- If you want to use a link in a page, enclose it within angled brackets (e.g. <https://example.org>).
+Use angled brackets (e.g. <https://example.org>) when including links in pages.
 
 ### Emphasis
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -332,11 +332,11 @@ For instance, instead of `Listing all files:`, `List all files:` can be used as 
 
 ## Not rendered syntax
 
-Any syntax not documented on this guide or in the client specification is not guaranteed to be rendered in our clients. See common cases below.
+Any syntax not documented in this guide or the client specification will **not** be rendered in most of our clients. See common cases below.
 
 ### Links and images
 
-- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not guaranteed to be supported by our clients.
+- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not part of the tldr client specification and thus not supported by most of our clients.
 - If you want to use a link in a page, enclose it within angled brackets (e.g. <https://example.org>).
 
 ### Emphasis

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -337,7 +337,7 @@ Any syntax not documented on this guide or in the client specification will **no
 ### Links and images
 
 - Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not supported by our clients.
-- If you want to use a link in a page, write it normally, either outside or inside parenthesis.
+- If you want to use a link in a page, enclose it within angled brackets (e.g. <https://example.org>).
 
 ### Emphasis
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -332,11 +332,11 @@ For instance, instead of `Listing all files:`, `List all files:` can be used as 
 
 ## Not rendered syntax
 
-Any syntax not documented on this guide or in the client specification will **not** be rendered in our clients. See common cases below.
+Any syntax not documented on this guide or in the client specification is not guaranteed to be rendered in our clients. See common cases below.
 
 ### Links and images
 
-- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not supported by our clients.
+- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not guaranteed to be supported by our clients.
 - If you want to use a link in a page, enclose it within angled brackets (e.g. <https://example.org>).
 
 ### Emphasis

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -330,7 +330,16 @@ For instance, instead of `Listing all files:`, `List all files:` can be used as 
  `ls`
 ```
 
-## Emphasis
+## Not rendered syntax
+
+Any syntax not documented on this guide or in the client specification will **not** be rendered in our clients. See common cases below.
+
+### Links and images
+
+- Do not use Markdown links (\[link text\](link url)) or images in the pages, they are not supported by our clients.
+- If you want to use a link in a page, write it normally, either outside or inside parenthesis.
+
+### Emphasis
 
 Do not use *italics*, **boldface** or any other text styling in the pages. These are reserved for client emphasis of placeholders.
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Sometimes new contributors don't know this, so I think it's good to emphasize this.
