### PR TITLE
aws-*: rephrase page descriptions to avoid CLI when unnedeed

### DIFF
--- a/pages/common/aws-cognito-idp.md
+++ b/pages/common/aws-cognito-idp.md
@@ -1,6 +1,6 @@
 # aws cognito-idp
 
-> Manage Amazon Cognito user pool and its users and groups using the CLI.
+> Configure an Amazon Cognito user pool and its users and groups and authenticate them.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cognito-idp/index.html>.
 
 - Create a new Cognito user pool:

--- a/pages/common/aws-dynamodb.md
+++ b/pages/common/aws-dynamodb.md
@@ -1,6 +1,6 @@
 # aws dynamodb
 
-> CLI for AWS dynamodb.
+> Manipulate an AWS Dynamodb database, a fast NoSQL database with predictable performance and seamless scalability.
 > More information: <https://docs.aws.amazon.com/cli/latest/reference/dynamodb/>.
 
 - Create a table:

--- a/pages/common/aws-ec2.md
+++ b/pages/common/aws-ec2.md
@@ -1,7 +1,7 @@
 # aws ec2
 
-> CLI for AWS EC2.
-> Provides secure and resizable computing capacity in the AWS cloud to enable faster development and deployment of applications.
+> Manage AWS EC2 instances and volumes.
+> AWS EC2 provides secure and resizable computing capacity in the AWS cloud for faster development and deployment of applications.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html>.
 
 - Display information about a specific instance:

--- a/pages/common/aws-eks.md
+++ b/pages/common/aws-eks.md
@@ -1,6 +1,7 @@
 # aws eks
 
-> CLI for Amazon EKS (Elastic Kubernetes Service).
+> Manage Amazon Elastic Kubernetes Service (EKS) addons, clusters, and node groups.
+> Amazon EKS is a service for easily running Kubernetes on AWS.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/eks/index.html>.
 
 - Create an EKS Cluster:

--- a/pages/common/aws-iam.md
+++ b/pages/common/aws-iam.md
@@ -1,6 +1,6 @@
 # aws iam
 
-> CLI for AWS IAM.
+> Intecract with the Identity and Access Management (IAM), a web service for securely controlling access to AWS services.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/index.html>.
 
 - List users:

--- a/pages/common/aws-kinesis.md
+++ b/pages/common/aws-kinesis.md
@@ -1,6 +1,6 @@
 # aws kinesis
 
-> Official AWS CLI for Amazon Kinesis streaming data services.
+> Interact with the Amazon Kinesis Data Streams, a service that scales elastically for real-time processing of streaming big data.
 > More information: <https://docs.aws.amazon.com/cli/latest/reference/kinesis/index.html#cli-aws-kinesis>.
 
 - Show all streams in the account:

--- a/pages/common/aws-lambda.md
+++ b/pages/common/aws-lambda.md
@@ -1,6 +1,6 @@
 # aws lambda
 
-> CLI for AWS lambda.
+> Use AWS Lambda, a compute service for running code without provisioning or managing servers.
 > More information: <https://docs.aws.amazon.com/cli/latest/reference/lambda/>.
 
 - Run a function:

--- a/pages/common/aws-rds.md
+++ b/pages/common/aws-rds.md
@@ -1,7 +1,6 @@
 # aws rds
 
-> CLI for AWS Relational Database Service.
-> Create and manage relational databases.
+> Use AWS Relational Database Service, a web service for setting up, operating and scaling relational databases.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/index.html>.
 
 - Display help for a specific RDS subcommand:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR rephrases AWS subcommands pages to use less generic and more useful descriptions, avoiding "CLI" when it is not directly related to the purpose of the command as the case of `aws history`, for example.

Although these are ready for review, there are still 4 AWS subcommands that need to be fixed:
- aws glue
- aws route53
- aws s3
- aws ses