### PR TITLE
git-clean: add all mnemonics and improve wording

### DIFF
--- a/pages/common/git-clean.md
+++ b/pages/common/git-clean.md
@@ -1,28 +1,28 @@
 # git clean
 
-> Remove untracked files from the working tree.
+> Remove files not tracked by Git from the working tree.
 > More information: <https://git-scm.com/docs/git-clean>.
 
-- Delete files that are not tracked by Git:
+- Delete untracked files:
 
 `git clean`
 
-- Interactively delete files that are not tracked by Git:
+- [i]nteractively delete untracked files:
 
 `git clean -i`
 
-- Show what files would be deleted without actually deleting them:
+- Show which files would be deleted without actually deleting them:
 
 `git clean --dry-run`
 
-- Forcefully delete files that are not tracked by Git:
+- [f]orcefully delete untracked files:
 
 `git clean -f`
 
-- Forcefully delete directories that are not tracked by Git:
+- [f]orcefully [d]elete untracked directories:
 
 `git clean -fd`
 
-- Delete untracked files, including ignored files in `.gitignore` and `.git/info/exclude`:
+- Delete untracked files, including e[x]cluded files (files ignored in `.gitignore` and `.git/info/exclude`):
 
 `git clean -x`

--- a/pages/common/git-clean.md
+++ b/pages/common/git-clean.md
@@ -19,7 +19,7 @@
 
 `git clean -f`
 
-- [f]orcefully [d]elete untracked directories:
+- [f]orcefully delete untracked [d]irectories:
 
 `git clean -fd`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Changes

- Add mnemonics for all short options
- Make the page description a bit more verbose and the example descriptions a bit more concise, it was the opposite before