### PR TITLE
pages*: use "an SQL" instead of "a SQL"

### DIFF
--- a/pages/common/dolt-sql.md
+++ b/pages/common/dolt-sql.md
@@ -1,6 +1,6 @@
 # dolt sql
 
-> Run a SQL query. Multiple SQL statements must be separated by semicolons.
+> Run an SQL query. Multiple SQL statements must be separated by semicolons.
 > More information: <https://docs.dolthub.com/cli-reference/cli#dolt-sql>.
 
 - Run a single query:

--- a/pages/common/dotnet-ef.md
+++ b/pages/common/dotnet-ef.md
@@ -31,6 +31,6 @@
 
 `dotnet ef migrations list`
 
-- Generate a SQL script from migrations range:
+- Generate an SQL script from migrations range:
 
 `dotnet ef migrations script {{from_migration}} {{to_migration}}`

--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -15,7 +15,7 @@
 
 `duckdb -c "{{SELECT * FROM 'data_source.[csv|csv.gz|json|json.gz|parquet]'}}"`
 
-- Run a SQL script:
+- Run an SQL script:
 
 `duckdb -c ".read {{path/to/script.sql}}"`
 

--- a/pages/common/gcloud-sql-export-sql.md
+++ b/pages/common/gcloud-sql-export-sql.md
@@ -1,10 +1,10 @@
 # gcloud sql export sql
 
-> Export data from a Cloud SQL instance to a SQL file in Google Cloud Storage.
+> Export data from a Cloud SQL instance to an SQL file in Google Cloud Storage.
 > Useful for creating backups or migrating data. See also: `gcloud`.
 > More information: <https://cloud.google.com/sdk/gcloud/reference/sql/export/sql>.
 
-- Export data from a specific Cloud SQL instance to a Google Cloud Storage bucket as a SQL dump file:
+- Export data from a specific Cloud SQL instance to a Google Cloud Storage bucket as an SQL dump file:
 
 `gcloud sql export sql {{instance}} gs://{{bucket_name}}/{{file_name}}`
 

--- a/pages/common/mysqlsh.md
+++ b/pages/common/mysqlsh.md
@@ -12,7 +12,7 @@
 
 `mysqlsh --user {{username}} --host {{hostname}} --port {{port}}`
 
-- Execute a SQL statement on the server and exit:
+- Execute an SQL statement on the server and exit:
 
 `mysqlsh --user {{username}} --execute '{{sql_statement}}'`
 

--- a/pages/common/textql.md
+++ b/pages/common/textql.md
@@ -3,7 +3,7 @@
 > Execute SQL against structured text like csv or tsv files.
 > More information: <https://github.com/dinedal/textql>.
 
-- Print the lines in the specified `.csv` file that match a SQL query to `stdout`:
+- Print the lines in the specified `.csv` file that match an SQL query to `stdout`:
 
 `textql -sql "{{SELECT * FROM filename}}" {{path/to/filename.csv}}`
 

--- a/pages/linux/dnsrecon.md
+++ b/pages/linux/dnsrecon.md
@@ -3,7 +3,7 @@
 > DNS enumeration tool.
 > More information: <https://github.com/darkoperator/dnsrecon>.
 
-- Scan a domain and save the results to a SQLite database:
+- Scan a domain and save the results to an SQLite database:
 
 `dnsrecon --domain {{example.com}} --db {{path/to/database.sqlite}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This is all about the famous discussion about the pronunciation of SQL ("Ess-cue-ell" vs "Sequel"). If it is pronunciated like "Ess-cue-ell", the right wording is "an SQL", if it is pronunciated like "Sequel", the right wording is "a SQL".

I read [an article](https://www.dbvis.com/thetable/sql-or-sequel) and, in my opinion, "Ess-cue-ell" looks like the pronunciation more close to the "official" one.

Either way, the most important thing to me is keeping consistency through all pages.