### PR TITLE
fdroidcl, fastboot: update pages

### DIFF
--- a/pages/common/fastboot.md
+++ b/pages/common/fastboot.md
@@ -1,6 +1,6 @@
 # fastboot
 
-> Communicate with connected Android devices when in bootloader mode (the one place `adb` doesn't work).
+> Communicate with connected Android devices when in bootloader mode (the one place ADB doesn't work).
 > More information: <https://cs.android.com/android/platform/superproject/+/main:system/core/fastboot>.
 
 - Unlock the bootloader:
@@ -23,7 +23,7 @@
 
 `fastboot flash recovery {{path/to/file.img}}`
 
-- Display connected devices:
+- List connected devices:
 
 `fastboot devices`
 

--- a/pages/common/fdroidcl.md
+++ b/pages/common/fdroidcl.md
@@ -1,17 +1,17 @@
 # fdroidcl
 
-> F-Droid CLI client.
+> Manage F-Droid apps of devices connected via ADB.
 > More information: <https://github.com/mvdan/fdroidcl>.
 
 - Fetch the F-Droid index:
 
 `fdroidcl update`
 
-- Display info about an app:
+- Display information about an app:
 
 `fdroidcl show {{app_id}}`
 
-- Download an APK file:
+- Download the APK file of an app:
 
 `fdroidcl download {{app_id}}`
 
@@ -22,3 +22,11 @@
 - Install an app on a connected device:
 
 `fdroidcl install {{app_id}}`
+
+- Add a repository:
+
+`fdroidcl repo add {{repo_name}} {{url}}`
+
+- Remove, enable or disable a repository:
+
+`fdroidcl repo {{remove|enable|disable}} {{repo_name}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Changes

- Use ADB instead of `adb`
- fastboot: "Display connected devices" -> "List connected devices"
- fdroidcl: "info" -> "information"
- fdroidcl: Remove "CLI client" and use a more informative description
- fdroidcl: Document all `fdroidcl repo` subcommands