### PR TITLE
jq: fix description and url

### DIFF
--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -23,7 +23,7 @@
 
 `{{cat path/to/file.json}} | jq '{{.[index1], .[index2], ...}}'`
 
-- Print all array items/object keys:
+- Print all array/object values:
 
 `{{cat path/to/file.json}} | jq '.[]'`
 

--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -1,7 +1,7 @@
 # jq
 
 > A command-line JSON processor that uses a domain-specific language (DSL).
-> More information: <https://stedolan.github.io/jq/manual/>.
+> More information: <https://jqlang.github.io/jq/manual/>.
 
 - Execute a specific expression (print a colored and formatted JSON output):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

I've found and fixed a small issue in the `jq` command page regarding the Array/Object Value Iterator `.[]`.

- cur: Print all array items/object keys:
- fix: Print all array/object values:

For reference, the official documentation (https://jqlang.github.io/jq/manual/) explains it as follows:

```
Array/Object Value Iterator: .[]
If you use the .[index] syntax, but omit the index entirely, it will return all of the elements of an array. Running .[] with the input [1,2,3] will produce the numbers as three separate results, rather than as a single array. A filter of the form .foo[] is equivalent to .foo | .[].

You can also use this on an object, and it will return all the values of the object.
```


Additionally, I've updated the documentation URL to the latest one, as the previous link was outdated.

