### PR TITLE
pages*: make "See also" conform to the new syntax (#12756)

### DIFF
--- a/pages/common/age-keygen.md
+++ b/pages/common/age-keygen.md
@@ -1,7 +1,7 @@
 # age-keygen
 
 > Generate `age` key pairs.
-> See `age` for how to encrypt/decrypt files.
+> See also: `age`, for encrypting/decrypting files.
 > More information: <https://manned.org/age-keygen>.
 
 - Generate a key pair, save it to an unencrypted file, and print the public key to `stdout`:

--- a/pages/common/age-keygen.md
+++ b/pages/common/age-keygen.md
@@ -1,7 +1,7 @@
 # age-keygen
 
 > Generate `age` key pairs.
-> See also: `age`, for encrypting/decrypting files.
+> See also: `age` for encrypting/decrypting files.
 > More information: <https://manned.org/age-keygen>.
 
 - Generate a key pair, save it to an unencrypted file, and print the public key to `stdout`:

--- a/pages/common/age.md
+++ b/pages/common/age.md
@@ -1,7 +1,7 @@
 # age
 
 > A simple, modern and secure file encryption tool.
-> See `age-keygen` for how to generate key pairs.
+> See also: `age-keygen`, for generating key pairs.
 > More information: <https://github.com/FiloSottile/age>.
 
 - Generate an encrypted file that can be decrypted with a passphrase:

--- a/pages/common/age.md
+++ b/pages/common/age.md
@@ -1,7 +1,7 @@
 # age
 
 > A simple, modern and secure file encryption tool.
-> See also: `age-keygen`, for generating key pairs.
+> See also: `age-keygen` for generating key pairs.
 > More information: <https://github.com/FiloSottile/age>.
 
 - Generate an encrypted file that can be decrypted with a passphrase:

--- a/pages/common/apm.md
+++ b/pages/common/apm.md
@@ -1,7 +1,7 @@
 # apm
 
 > Atom editor Package Manager.
-> See `atom`.
+> See also: `atom`.
 > More information: <https://github.com/atom/apm>.
 
 - Install a package from <http://atom.io/packages> or a theme from <http://atom.io/themes>:

--- a/pages/common/git-fsck.md
+++ b/pages/common/git-fsck.md
@@ -1,7 +1,8 @@
 # git fsck
 
 > Verify the validity and connectivity of nodes in a Git repository index.
-> Does not make any modifications. See `git gc` for cleaning up dangling blobs.
+> Does not make any modifications.
+> See also: `git gc`, for cleaning up dangling blobs.
 > More information: <https://git-scm.com/docs/git-fsck>.
 
 - Check the current repository:

--- a/pages/common/git-fsck.md
+++ b/pages/common/git-fsck.md
@@ -2,7 +2,7 @@
 
 > Verify the validity and connectivity of nodes in a Git repository index.
 > Does not make any modifications.
-> See also: `git gc`, for cleaning up dangling blobs.
+> See also: `git gc` for cleaning up dangling blobs.
 > More information: <https://git-scm.com/docs/git-fsck>.
 
 - Check the current repository:

--- a/pages/common/nix-build.md
+++ b/pages/common/nix-build.md
@@ -1,7 +1,7 @@
 # nix-build
 
 > Build a Nix expression.
-> See also: `tldr nix3 build`.
+> See also: `nix3 build`.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/nix-build.html>.
 
 - Build a Nix expression:

--- a/pages/common/nix-shell.md
+++ b/pages/common/nix-shell.md
@@ -1,7 +1,7 @@
 # nix-shell
 
 > Start an interactive shell based on a Nix expression.
-> See also: `tldr nix3 shell`.
+> See also: `nix3 shell`.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/nix-shell.html>.
 
 - Start with nix expression in `shell.nix` or `default.nix` in the current directory:

--- a/pages/common/nix-store.md
+++ b/pages/common/nix-store.md
@@ -1,7 +1,7 @@
 # nix-store
 
 > Manipulate or query the Nix store.
-> See also: `tldr nix3 store`.
+> See also: `nix3 store`.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/nix-store.html>.
 
 - Collect garbage, such as removing unused paths:

--- a/pages/common/nix3-build.md
+++ b/pages/common/nix3-build.md
@@ -1,7 +1,7 @@
 # nix build
 
 > Build a Nix expression (downloading from the cache when possible).
-> See also: `tldr nix-build`. See `tldr nix3 flake` for information about flakes.
+> See also: `nix-build`. See `tldr nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build.html>.
 
 - Build a package from nixpkgs, symlinking the result to `./result`:

--- a/pages/common/nix3-build.md
+++ b/pages/common/nix3-build.md
@@ -1,7 +1,7 @@
 # nix build
 
 > Build a Nix expression (downloading from the cache when possible).
-> See also: `nix-build`. See `tldr nix3 flake` for information about flakes.
+> See also: `nix-build`; `nix3 flake`, for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build.html>.
 
 - Build a package from nixpkgs, symlinking the result to `./result`:

--- a/pages/common/nix3-build.md
+++ b/pages/common/nix3-build.md
@@ -1,7 +1,7 @@
 # nix build
 
 > Build a Nix expression (downloading from the cache when possible).
-> See also: `nix-build`; `nix3 flake`, for information about flakes.
+> See also: `nix-build` for information about traditional Nix builds from expressions, `nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build.html>.
 
 - Build a package from nixpkgs, symlinking the result to `./result`:

--- a/pages/common/nix3-registry.md
+++ b/pages/common/nix3-registry.md
@@ -1,7 +1,7 @@
 # nix registry
 
 > Manage a Nix flake registry.
-> See `tldr nix3 flake` for information about flakes.
+> See also: `nix3 flake`, for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-registry.html>.
 
 - Pin the `nixpkgs` revision to the current version of the upstream repository:

--- a/pages/common/nix3-registry.md
+++ b/pages/common/nix3-registry.md
@@ -1,7 +1,7 @@
 # nix registry
 
 > Manage a Nix flake registry.
-> See also: `nix3 flake`, for information about flakes.
+> See also: `nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-registry.html>.
 
 - Pin the `nixpkgs` revision to the current version of the upstream repository:

--- a/pages/common/nix3-run.md
+++ b/pages/common/nix3-run.md
@@ -1,7 +1,7 @@
 # nix run
 
 > Run an application from a Nix flake.
-> See `tldr nix3 flake` for information about flakes.
+> See also: `nix3 flake`, for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html>.
 
 - Run the default application in the flake in the current directory:

--- a/pages/common/nix3-run.md
+++ b/pages/common/nix3-run.md
@@ -1,7 +1,7 @@
 # nix run
 
 > Run an application from a Nix flake.
-> See also: `nix3 flake`, for information about flakes.
+> See also: `nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html>.
 
 - Run the default application in the flake in the current directory:

--- a/pages/common/nix3-search.md
+++ b/pages/common/nix3-search.md
@@ -1,7 +1,7 @@
 # nix search
 
 > Search for packages in a Nix flake.
-> See `tldr nix3 flake` for information about flakes.
+> See also: `nix3 flake`, for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-search.html>.
 
 - Search `nixpkgs` for a package based on its name or description:

--- a/pages/common/nix3-search.md
+++ b/pages/common/nix3-search.md
@@ -1,7 +1,7 @@
 # nix search
 
 > Search for packages in a Nix flake.
-> See also: `nix3 flake`, for information about flakes.
+> See also: `nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-search.html>.
 
 - Search `nixpkgs` for a package based on its name or description:

--- a/pages/common/nix3-shell.md
+++ b/pages/common/nix3-shell.md
@@ -1,7 +1,7 @@
 # nix shell
 
 > Start a shell in which the specified packages are available.
-> See also: `nix-shell`. See `tldr nix3 flake` for information about flakes.
+> See also: `nix-shell`; `nix3 flake`, for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-shell.html>.
 
 - Start an interactive shell with some packages from `nixpkgs`:

--- a/pages/common/nix3-shell.md
+++ b/pages/common/nix3-shell.md
@@ -1,7 +1,7 @@
 # nix shell
 
 > Start a shell in which the specified packages are available.
-> See also: `tldr nix-shell`. See `tldr nix3 flake` for information about flakes.
+> See also: `nix-shell`. See `tldr nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-shell.html>.
 
 - Start an interactive shell with some packages from `nixpkgs`:

--- a/pages/common/nix3-shell.md
+++ b/pages/common/nix3-shell.md
@@ -1,7 +1,7 @@
 # nix shell
 
 > Start a shell in which the specified packages are available.
-> See also: `nix-shell`; `nix3 flake`, for information about flakes.
+> See also: `nix-shell` for setting up development environments, `nix3 flake` for information about flakes.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-shell.html>.
 
 - Start an interactive shell with some packages from `nixpkgs`:

--- a/pages/common/nix3-store.md
+++ b/pages/common/nix3-store.md
@@ -1,7 +1,7 @@
 # nix store
 
 > Manipulate the Nix store.
-> See also: `tldr nix-store`.
+> See also: `nix-store`.
 > More information: <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-store.html>.
 
 - Collect garbage, i.e. remove unused paths to reduce space usage:

--- a/pages/common/rustup-toolchain.md
+++ b/pages/common/rustup-toolchain.md
@@ -1,7 +1,6 @@
 # rustup toolchain
 
 > Manage Rust toolchains.
-> See `rustup help toolchain` for more information about toolchains.
 > More information: <https://rust-lang.github.io/rustup>.
 
 - Install or update a given toolchain:
@@ -19,3 +18,7 @@
 - Create a custom toolchain by symlinking to a directory:
 
 `rustup link {{custom_toolchain_name}} {{path/to/directory}}`
+
+- Display help:
+
+`rustup help toolchain`

--- a/pages/common/rustup-toolchain.md
+++ b/pages/common/rustup-toolchain.md
@@ -20,6 +20,3 @@
 
 `rustup link {{custom_toolchain_name}} {{path/to/directory}}`
 
-- Display help:
-
-`rustup help toolchain`

--- a/pages/common/rustup-toolchain.md
+++ b/pages/common/rustup-toolchain.md
@@ -1,6 +1,7 @@
 # rustup toolchain
 
 > Manage Rust toolchains.
+> See `rustup help toolchain` for more information about toolchains.
 > More information: <https://rust-lang.github.io/rustup>.
 
 - Install or update a given toolchain:

--- a/pages/common/rustup-toolchain.md
+++ b/pages/common/rustup-toolchain.md
@@ -19,4 +19,3 @@
 - Create a custom toolchain by symlinking to a directory:
 
 `rustup link {{custom_toolchain_name}} {{path/to/directory}}`
-

--- a/pages/linux/mount.ddi.md
+++ b/pages/linux/mount.ddi.md
@@ -1,7 +1,7 @@
 # mount.ddi
 
 > Mount Discoverable Disk Images.
-> See `tldr systemd-dissect` for other commands relevant to DDIs.
+> See also: `systemd-dissect`, for other commands relevant to DDIs.
 > More information: <https://www.freedesktop.org/software/systemd/man/latest/systemd-dissect.html>.
 
 - Mount an OS image:

--- a/pages/linux/mount.ddi.md
+++ b/pages/linux/mount.ddi.md
@@ -1,7 +1,7 @@
 # mount.ddi
 
 > Mount Discoverable Disk Images.
-> See also: `systemd-dissect`, for other commands relevant to DDIs.
+> See also: `systemd-dissect` for other commands relevant to DDIs.
 > More information: <https://www.freedesktop.org/software/systemd/man/latest/systemd-dissect.html>.
 
 - Mount an OS image:

--- a/pages/linux/setcap.md
+++ b/pages/linux/setcap.md
@@ -1,7 +1,7 @@
 # setcap
 
 > Set capabilities of specified file.
-> See also: `tldr getcap`.
+> See also: `getcap`.
 > More information: <https://manned.org/setcap>.
 
 - Set capability `cap_net_raw` (to use RAW and PACKET sockets) for a given file:


### PR DESCRIPTION
These pages are not following the "See also" standard ("See also: COMMAND_NAME").