### PR TITLE
apt-get: add recommendation for apt

### DIFF
--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -2,7 +2,7 @@
 
 > Debian and Ubuntu package management utility.
 > Search for packages using `apt-cache`.
-> Recommended to use apt when used interactively in Ubuntu versions 16.04 and later.
+> Recommended to use `apt` when used interactively in Ubuntu versions 16.04 and later.
 > More information: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `apt-get` commands):

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -2,7 +2,7 @@
 
 > Debian and Ubuntu package management utility.
 > Search for packages using `apt-cache`.
-> Recommended to use `apt` when used interactively in Ubuntu versions 16.04 and later.
+> It is recommended to use `apt` when used interactively in Ubuntu versions 16.04 and later.
 > More information: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `apt-get` commands):

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -2,7 +2,7 @@
 
 > Debian and Ubuntu package management utility.
 > Search for packages using `apt-cache`.
-> Recommended to use apt when used interactively in Ubuntu versions 16.04 and later. 
+> Recommended to use apt when used interactively in Ubuntu versions 16.04 and later.
 > More information: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `apt-get` commands):

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -2,6 +2,7 @@
 
 > Debian and Ubuntu package management utility.
 > Search for packages using `apt-cache`.
+> Recommended to use apt when used interactively in Ubuntu versions 16.04 and later. 
 > More information: <https://manpages.debian.org/latest/apt/apt-get.8.html>.
 
 - Update the list of available packages and versions (it's recommended to run this before other `apt-get` commands):


### PR DESCRIPTION
Copied from line 4 of [apt.md](https://github.com/tldr-pages/tldr/blob/main/pages/linux/apt.md) to recommend users to use `apt` instead of `apt-get` in Ubuntu versions 16.04 and later.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
Latest/All