### PR TITLE
opkg: remove upgrade command

### DIFF
--- a/pages/linux/opkg.md
+++ b/pages/linux/opkg.md
@@ -15,10 +15,6 @@
 
 `opkg update`
 
-- Upgrade all the installed packages:
-
-`opkg upgrade`
-
 - Upgrade one or more specific package(s):
 
 `opkg upgrade {{package(s)}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

According to the official wiki, running ```opkg upgrade``` is highly discouraged.

https://openwrt.org/meta/infobox/upgrade_packages_warning