### PR TITLE
sox: fix trim example

### DIFF
--- a/pages/common/sox.md
+++ b/pages/common/sox.md
@@ -10,7 +10,7 @@
 
 - Trim an audio file to the specified times:
 
-`sox {{path/to/input_audio}} {{path/to/output_audio}} trim {{start}} {{end}}`
+`sox {{path/to/input_audio}} {{path/to/output_audio}} trim {{start}} {{duration}}`
 
 - Normalize an audio file (adjust volume to the maximum peak level, without clipping):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

I have verified empirically that this is how `sox`'s `trim` works.

A relevant section of `man sox`:

```
       position
              A  position  within the audio stream; the syntax is [=|+|-]timespec, where timespec is a time specification (see be‐
              low).  The optional first character indicates whether the timespec is to be interpreted relative to the start (=) or
              end (-) of audio, or to the previous position if the effect accepts multiple  position  arguments  (+).   The  audio
              length must be known for end-relative locations to work; some effects do accept -0 for end-of-audio, though, even if
              the  length  is unknown.  Which of =, +, - is the default depends on the effect and is shown in its syntax as, e.g.,
              position(+).
```
And `man sox` says that `trim` uses positions relative to the previous position (i.e. a duration):
```
trim {position(+)}
```
