### PR TITLE
select: move to common, fix placeholders

### DIFF
--- a/pages/common/select.md
+++ b/pages/common/select.md
@@ -5,7 +5,7 @@
 
 - Create a menu out of individual words:
 
-`select {{word}} in {{apple}} {{orange}} {{pear}} {{banana}}; do echo ${{word}}; done`
+`select {{word}} in {{apple orange pear banana}}; do echo ${{word}}; done`
 
 - Create a menu from the output of another command:
 
@@ -17,4 +17,4 @@
 
 - Create a menu from a Bash array:
 
-`{{fruits}}=({{apple}} {{orange}} {{pear}} {{banana}}); select {{word}} in ${{{fruits}}[@]}; do echo ${{word}}; done`
+`{{fruits}}=({{apple orange pear banana}}); select {{word}} in ${{{fruits[@]}}}; do echo ${{word}}; done`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR implements the fix from #12445 (`${{{fruits[@]}}}` will be rendered as $**{fruits[@]}** ), removes redundant braces (`{{x}} {{y}}` is rendered exactly the same as `{{x y}}`) and moves `select` to `common`, because Bash is not Linux-specific.

Closes #12445.