### PR TITLE
virt-manager: edit page

### DIFF
--- a/pages/linux/virt-manager.md
+++ b/pages/linux/virt-manager.md
@@ -3,7 +3,7 @@
 > A desktop user interface for managing KVM and Xen virtual machines and LXC containers.
 > More information: <https://manpages.ubuntu.com/manpages/man1/virt-manager.1.html>.
 
-- Launch virt-manager:
+- Launch the GUI:
 
 `virt-manager`
 

--- a/pages/linux/virt-manager.md
+++ b/pages/linux/virt-manager.md
@@ -23,11 +23,11 @@
 
 `virt-manager --show-domain-creator`
 
-- Show domain details window:
+- Show domain details window for a specific virtual machine/container:
 
 `virt-manager --show-domain-editor {{name|id|uuid}}`
 
-- Show domain performance window:
+- Show domain performance window for a specific virtual machine/container:
 
 `virt-manager --show-domain-performance {{name|id|uuid}}`
 

--- a/pages/linux/virt-manager.md
+++ b/pages/linux/virt-manager.md
@@ -1,6 +1,6 @@
 # virt-manager
 
-> CLI launcher for virt-manager, a desktop user interface for managing KVM and Xen virtual machines and LXC containers.
+> A desktop user interface for managing KVM and Xen virtual machines and LXC containers.
 > More information: <https://manpages.ubuntu.com/manpages/man1/virt-manager.1.html>.
 
 - Launch virt-manager:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 4.1.0

## Changes

- Remove "CLI launcher for virt-manager" from the page description
- Use generic wording on the first example (no options)
- Clarify the purpose of the argument for the performance and detail windows