### PR TITLE
kdeconnect-cli: expand description

### DIFF
--- a/pages/common/kdeconnect-cli.md
+++ b/pages/common/kdeconnect-cli.md
@@ -1,6 +1,6 @@
 # kdeconnect-cli
 
-> KDE's Connect CLI.
+> Use KDE Connect for sharing files or text to a device, ringing it, unlocking it, and much more.
 > More information: <https://kdeconnect.kde.org>.
 
 - List all devices:


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
