### PR TITLE
ncmpcpp, youtube-viewer, aplay: remove "command-line" from description

### DIFF
--- a/pages/common/ncmpcpp.md
+++ b/pages/common/ncmpcpp.md
@@ -1,6 +1,6 @@
 # ncmpcpp
 
-> A command-line music player client for the Music Player Daemon.
+> A music player client for the Music Player Daemon.
 > More information: <https://rybczak.net/ncmpcpp>.
 
 - Connect to a music player daemon on a given host and port:

--- a/pages/common/youtube-viewer.md
+++ b/pages/common/youtube-viewer.md
@@ -1,6 +1,6 @@
 # youtube-viewer
 
-> Command-line application for searching and playing videos from YouTube.
+> Search and play videos from YouTube.
 > More information: <https://github.com/trizen/youtube-viewer>.
 
 - Search for a video:

--- a/pages/linux/aplay.md
+++ b/pages/linux/aplay.md
@@ -1,6 +1,6 @@
 # aplay
 
-> Command-line sound player for ALSA soundcard driver.
+> Sound player for ALSA soundcard driver.
 > More information: <https://manned.org/aplay>.
 
 - Play a specific file (sampling rate, bit depth, etc. will be automatically determined for the file format):


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

We can follow this common approach for CLI music/audio players or specify CLI on the other pages too (e.g. aplay).