### PR TITLE
expand: fix short option `-t` argument separator

### DIFF
--- a/pages.it/common/expand.md
+++ b/pages.it/common/expand.md
@@ -17,8 +17,8 @@
 
 - Sostituisci i tab con un determinato numero di spazi, non 8 (default):
 
-`expand -t={{numero_spazi}} {{file}}`
+`expand -t {{numero_spazi}} {{file}}`
 
 - Utilizza una lista separata da virgole di posizioni esplicite di tab:
 
-`expand -t={{1,4,6}}`
+`expand -t {{1,4,6}}`

--- a/pages/common/expand.md
+++ b/pages/common/expand.md
@@ -17,8 +17,8 @@
 
 - Have tabs a certain number of characters apart, not 8:
 
-`expand -t={{number}} {{path/to/file}}`
+`expand -t {{number}} {{path/to/file}}`
 
 - Use a comma separated list of explicit tab positions:
 
-`expand -t={{1,4,6}}`
+`expand -t {{1,4,6}}`


### PR DESCRIPTION
The `expand` command doesn't accept the equal sign '=' as a separator between the short option `-t` and its arguments. Below are illustrations of the error the user faces in case the equal sign is used:

  $ expand -t=2 path/to/file
    expand: tab size contains invalid character(s): ‘=2’
  $ expand -t=1,4,6
    expand: tab size contains invalid character(s): ‘=1,4,6’

For the short option `-t`, the correct separator is space, so fix this in the examples.