### PR TITLE
agetty: add page

### DIFF
--- a/pages/linux/agetty.md
+++ b/pages/linux/agetty.md
@@ -1,0 +1,29 @@
+# agetty
+
+> Alternative `getty`: Open a `tty` port, prompt for a login name, and invoke the `/bin/login` command.
+> It is normally invoked by `init`.
+> More information: <https://manned.org/agetty>.
+
+- Connect `stdin` to a port (relative to `/dev`) and optionally specify a baud rate (defaults to 9600):
+
+`agetty {{tty}} {{115200}}`
+
+- Assume `stdin` is already connected to a `tty` and set a [t]imeout for the login:
+
+`agetty {{-t|--timeout}} {{timeout_in_seconds}} -`
+
+- Assume the `tty` is [8]-bit, overriding the `TERM` environment variable set by `init`:
+
+`agetty -8 - {{term_var}}`
+
+- Skip the login ([n]o login) and invoke, as root, another [l]ogin program instead of `/bin/login`:
+
+`agetty {{n|--skip-login}} {{-l|--login-program}} {{login_program}} {{tty}}`
+
+- Do not display the pre-login ([i]ssue) file (`/etc/issue` by default) before writing the login prompt:
+
+`agetty {{-i|--noissue}} -`
+
+- Change the [r]oot directory and write a specific fake [H]ost into the `utmp` file:
+
+`agetty {{-r|--chroot}} {{/path/to/root_directory}} {{-H|--host}} {{fake_host}} -`

--- a/pages/linux/agetty.md
+++ b/pages/linux/agetty.md
@@ -1,6 +1,7 @@
 # agetty
 
 > Alternative `getty`: Open a `tty` port, prompt for a login name, and invoke the `/bin/login` command.
+> Note: The baud rate is the speed of data transfer between a terminal and a device over a serial connection.
 > It is normally invoked by `init`.
 > More information: <https://manned.org/agetty>.
 

--- a/pages/linux/agetty.md
+++ b/pages/linux/agetty.md
@@ -1,8 +1,8 @@
 # agetty
 
 > Alternative `getty`: Open a `tty` port, prompt for a login name, and invoke the `/bin/login` command.
-> Note: The baud rate is the speed of data transfer between a terminal and a device over a serial connection.
 > It is normally invoked by `init`.
+> Note: the baud rate is the speed of data transfer between a terminal and a device over a serial connection.
 > More information: <https://manned.org/agetty>.
 
 - Connect `stdin` to a port (relative to `/dev`) and optionally specify a baud rate (defaults to 9600):


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** util-linux 2.39.3
