### PR TITLE
reg-query: add missing placeholder; iptables-save: fix typo

### DIFF
--- a/pages/linux/iptables-save.md
+++ b/pages/linux/iptables-save.md
@@ -1,7 +1,7 @@
 # iptables-save
 
 > Save the `iptables` IPv4 configuration.
-> Use `ip6tables-save` to the same for IPv6.
+> Use `ip6tables-save` to do the same for IPv6.
 > More information: <https://manned.org/iptables-save>.
 
 - Print the `iptables` configuration:

--- a/pages/windows/reg-query.md
+++ b/pages/windows/reg-query.md
@@ -29,7 +29,7 @@
 
 - Only search in [k]ey names:
 
-`reg query {{key_name}} /f /k`
+`reg query {{key_name}} /f "{{query_pattern}}" /k`
 
 - [c]ase-sensitively search for an [e]xact match:
 


### PR DESCRIPTION
- missing placeholder in #12301
- `iptables-save` had a typo ("to to" instead of "to do"). #12508 removed one word instead of fixing the typo.