### PR TITLE
gitk, kitex, rclone, venv: edit pages

### DIFF
--- a/pages/common/gitk.md
+++ b/pages/common/gitk.md
@@ -21,4 +21,4 @@
 
 - Show at most 100 changes in all branches:
 
-` gitk --max-count={{100}} --all`
+`gitk --max-count={{100}} --all`

--- a/pages/common/gitk.md
+++ b/pages/common/gitk.md
@@ -21,4 +21,4 @@
 
 - Show at most 100 changes in all branches:
 
-`gitk --max-count={{100}} --all`
+`gitk --max-count=100 --all`

--- a/pages/common/kitex.md
+++ b/pages/common/kitex.md
@@ -10,7 +10,7 @@
 
 - Generate client codes when a project is not in `$GOPATH`:
 
-` kitex -module {{github.com/xx-org/xx-name}} {{path/to/IDL_file.thrift}}`
+`kitex -module {{github.com/xx-org/xx-name}} {{path/to/IDL_file.thrift}}`
 
 - Generate client codes with protobuf IDL:
 

--- a/pages/common/rclone.md
+++ b/pages/common/rclone.md
@@ -17,7 +17,7 @@
 
 - Copy files changed within the past 24 hours to a remote from the local machine, asking the user to confirm each file:
 
-`rclone copy --interactive --max-age 24h {{remote_name}}:{{path/to/directory}} {{path/to/local_directory}} `
+`rclone copy --interactive --max-age 24h {{remote_name}}:{{path/to/directory}} {{path/to/local_directory}}`
 
 - Mirror a specific file or directory (Note: Unlike copy, sync removes files from the remote if it does not exist locally):
 

--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -5,7 +5,7 @@
 
 - Create a Python virtual environment:
 
-` python -m venv {{path/to/virtual_environment}}`
+`python -m venv {{path/to/virtual_environment}}`
 
 - Activate the virtual environment (Linux and macOS):
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Discovered through the proposed new check TLDR021 in the linter (see https://github.com/tldr-pages/tldr-lint/pull/310).
