### PR TITLE
tunelp: add page

### DIFF
--- a/pages/linux/tunelp.md
+++ b/pages/linux/tunelp.md
@@ -6,19 +6,19 @@
 
 - Check the [s]tatus of a parallel port device:
 
-`tunelp --status /dev/lp0`
+`tunelp --status {{/dev/lp0}}`
 
 - [r]eset a given parallel port:
 
-`tunelp --reset /dev/lp0`
+`tunelp --reset {{/dev/lp0}}`
 
 - Use a given [i]RQ for a device, each one representing an interrupt line:
 
-`tunelp -i 5 /dev/lp0`
+`tunelp -i 5 {{/dev/lp0}}`
 
 - Try a given number of times to output a [c]haracter to the printer before sleeping for a given [t]ime:
 
-`tunelp --chars {{times}} --time {{time_in_centiseconds}} /dev/lp0`
+`tunelp --chars {{times}} --time {{time_in_centiseconds}} {{/dev/lp0}}`
 
 - Enable or disable [a]borting on error (disabled by default):
 

--- a/pages/linux/tunelp.md
+++ b/pages/linux/tunelp.md
@@ -1,0 +1,25 @@
+# tunelp
+
+> Set various parameters for parallel port devices for troubleshooting or for better performance.
+> Part of `util-linux`.
+> More information: <https://manned.org/tunelp>.
+
+- Check the [s]tatus of a parallel port device:
+
+`tunelp --status /dev/lp0`
+
+- [r]eset a given parallel port:
+
+`tunelp --reset /dev/lp0`
+
+- Use a given [i]RQ for a device, each one representing an interrupt line:
+
+`tunelp -i 5 /dev/lp0`
+
+- Try a given number of times to output a [c]haracter to the printer before sleeping for a given [t]ime:
+
+`tunelp --chars {{times}} --time {{time_in_centiseconds}} /dev/lp0`
+
+- Enable or disable [a]borting on error (disabled by default):
+
+`tunelp --abort {{on|off}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** util-linux 2.39.3
