### PR TITLE
zipcloak: move to `common` and replace "zipfile"

### DIFF
--- a/pages/common/zipcloak.md
+++ b/pages/common/zipcloak.md
@@ -1,16 +1,16 @@
 # zipcloak
 
-> Encrypt the contents within a zipfile.
+> Encrypt the contents within a Zip archive.
 > More information: <https://manned.org/zipcloak>.
 
-- Encrypt the contents of a zipfile:
+- Encrypt the contents of a Zip archive:
 
 `zipcloak {{path/to/archive.zip}}`
 
-- [d]ecrypt the contents of a zipfile:
+- [d]ecrypt the contents of a Zip archive:
 
 `zipcloak -d {{path/to/archive.zip}}`
 
-- [O]utput the encrypted contents into a new zipfile:
+- [O]utput the encrypted contents into a new Zip archive:
 
 `zipcloak {{path/to/archive.zip}} -O {{path/to/encrypted.zip}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Changes

- Move `zipcloak` to common (I don't if it works on Windows, but it is also [available for macOS](https://keith.github.io/xcode-man-pages/zipcloak.1.html))
- Replace "zipfile" with "Zip archive"
