### PR TITLE
zipsplit: improve page

### DIFF
--- a/pages/linux/zipsplit.md
+++ b/pages/linux/zipsplit.md
@@ -1,6 +1,6 @@
 # zipsplit
 
-> Read a Zip archive and split it into smaller Zip archives.
+> Split a Zip archive into smaller Zip archives.
 > More information: <https://manned.org/zipsplit>.
 
 - Split Zip archive into pieces that are no larger than 36000 bytes:

--- a/pages/linux/zipsplit.md
+++ b/pages/linux/zipsplit.md
@@ -15,6 +15,6 @@
 
 `zipsplit -p -n {{size}} {{path/to/archive.zip}}`
 
-- Output the split Zip archives into a given directory:
+- Output the smaller Zip archives into a given directory:
 
 `zipsplit -b {{path/to/output_directory}} -n {{size}} {{path/to/archive.zip}}`

--- a/pages/linux/zipsplit.md
+++ b/pages/linux/zipsplit.md
@@ -1,16 +1,20 @@
 # zipsplit
 
-> Read a zipfile and split it into smaller zipfiles.
+> Read a Zip archive and split it into smaller Zip archives.
 > More information: <https://manned.org/zipsplit>.
 
-- Split zipfile into pieces that are no larger than a particular size [n]:
+- Split Zip archive into pieces that are no larger than 36000 bytes:
+
+`zipsplit {{path/to/archive.zip}}`
+
+- Use a given [n]umber of bytes as the piece limit:
 
 `zipsplit -n {{size}} {{path/to/archive.zip}}`
 
-- [p]ause between the creation of each split zipfile:
+- [p]ause between the creation of each split Zip archive:
 
 `zipsplit -p -n {{size}} {{path/to/archive.zip}}`
 
-- Output the split zipfiles into the `archive` directory:
+- Output the split Zip archives into a given directory:
 
-`zipsplit -b {{archive}} -n {{size}} {{path/to/archive.zip}}`
+`zipsplit -b {{path/to/output_directory}} -n {{size}} {{path/to/archive.zip}}`

--- a/pages/linux/zipsplit.md
+++ b/pages/linux/zipsplit.md
@@ -3,15 +3,15 @@
 > Split a Zip archive into smaller Zip archives.
 > More information: <https://manned.org/zipsplit>.
 
-- Split Zip archive into pieces that are no larger than 36000 bytes:
+- Split Zip archive into parts that are no larger than 36000 bytes (36 MB):
 
 `zipsplit {{path/to/archive.zip}}`
 
-- Use a given [n]umber of bytes as the piece limit:
+- Use a given [n]umber of bytes as the part limit:
 
 `zipsplit -n {{size}} {{path/to/archive.zip}}`
 
-- [p]ause between the creation of each split Zip archive:
+- [p]ause between the creation of each part:
 
 `zipsplit -p -n {{size}} {{path/to/archive.zip}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Info-ZIP 3.00

## Changes

- Move zipcloak to common (it is not Linux-exclusive: https://keith.github.io/xcode-man-pages/zipsplit.1.html)
- Use standard path placeholder formatting
- Use "smaller Zip archives" instead of "split Zip archives" for clarity (IMO "split" is kinda confusing when used as the result)
- Add the simplest example usage (no flags, default piece size)
- Make the description more consise (splitting an archive implies it is being read)
