### PR TITLE
ipcs: fix POSIX page; linux/ipcs, lsipc: add pages

### DIFF
--- a/pages/common/ipcs.md
+++ b/pages/common/ipcs.md
@@ -1,12 +1,32 @@
 # ipcs
 
-> Display information about resources used in IPC (Inter-process Communication).
-> More information: <https://manned.org/ipcs>.
+> Show information about the usage of XSI IPC facilities: shared memory segments, message queues, and semaphore arrays.
+> More information: <https://manned.org/ipcs.1p>.
 
-- Specific information about the Message Queue which has the ID 32768:
-
-`ipcs -qi 32768`
-
-- General information about all the IPC:
+- Show information about all the IPC:
 
 `ipcs -a`
+
+- Show information about active shared [m]emory segments, message [q]ueues or [s]empahore sets:
+
+`ipcs {{-m|-q|-s}}`
+
+- Show information on maximum allowable size in [b]ytes:
+
+`ipcs -b`
+
+- Show [c]reator’s user name and group name for all IPC facilities:
+
+`ipcs -c`
+
+- Show the [p]ID of the last operators for all IPC facilities:
+
+`ipcs -p`
+
+- Show access [t]imes for all IPC facilities:
+
+`ipcs -t`
+
+- Show [o]utstanding usage for active message queues, and shared memory segments.
+
+`ipcs -o`

--- a/pages/linux/ipcs.md
+++ b/pages/linux/ipcs.md
@@ -1,0 +1,37 @@
+# ipcs
+
+> Show information about the usage of System V IPC facilities: shared memory segments, message queues, and semaphore arrays.
+> See `lsipc` for a more flexible tool, `ipcmk` for creating IPC facilities, and `ipcrm` for deleting them.
+> More information: <https://manned.org/ipcs>.
+
+- Show information about all active IPC facilities:
+
+`ipcs`
+
+- Show information about active shared [m]emory segments, message [q]ueues or [s]empahore sets:
+
+`ipcs {{--shmems|--queues|--semaphores}}`
+
+- Show full details on the resource with a specific [i]D:
+
+`ipcs {{--shmems|--queues|--semaphores}} --id {{resource_id}}`
+
+- Show [l]imits in [b]ytes or in a human-readable format:
+
+`ipcs --limits {{--bytes|--human}}`
+
+- Show s[u]mmary about current usage:
+
+`ipcs --summary`
+
+- Show [c]reator's and owner's UIDs and PIDs for all IPC facilities:
+
+`ipcs --creator`
+
+- Show the [p]ID of the last operators for all IPC facilities:
+
+`ipcs --pid`
+
+- Show last access [t]imes for all IPC facilities:
+
+`ipcs --time`

--- a/pages/linux/lsipc.md
+++ b/pages/linux/lsipc.md
@@ -1,0 +1,29 @@
+# lsipc
+
+> Show information on System V IPC facilities currently employed in the system.
+> See `ipcs` for the older tool.
+> More information: <https://manned.org/lsipc>.
+
+- Show information about all active IPC facilities:
+
+`lsipc`
+
+- Show information about active shared [m]emory segments, message [q]ueues or [s]empahore sets:
+
+`lsipc {{--shmems|--queues|--semaphores}}`
+
+- Show full details on the resource with a specific [i]D:
+
+`lsipc {{--shmems|--queues|--semaphores}} --id {{resource_id}}`
+
+- Print the given [o]utput columns (see all supported columns with `--help`):
+
+`lsipc --output {{KEY,ID,PERMS,SEND,STATUS,NSEMS,RESOURCE,...}}`
+
+- Use [r]aw, [J]SON, [l]ist or [e]xport (key="value") format:
+
+`lsipc {{--raw|--json|--list|--export}}`
+
+- Don't truncate output:
+
+`lsipc --notruncate`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** POSIX.1-2017 and util-linux 2.40-rc2

See https://github.com/tldr-pages/tldr/pull/12354#discussion_r1501872389 details on the "See `command1` for _function1_, `command2` for _function2_" syntax proposal.