### PR TITLE
MAINTAINERS: update file, COMMUNITY-ROLES: add notice for 2FA

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -20,6 +20,9 @@ straightforward, transparent, predictable, and impartial,
 the metrics used are objective, easy to check, and explicitly described below. (That's not to say they're hard-set rules:
 exceptions can always be considered through open community discussion.)
 
+> [!IMPORTANT]
+> It is required to have [two factor authentication](https://github.com/settings/security) (2FA) enabled for your GitHub account to be added as a outside collaborator or a member to the tldr-pages organization.
+
 ## When to change roles
 
 - **Regular contributors should be added as collaborators in the repository.**
@@ -74,7 +77,6 @@ exceptions can always be considered through open community discussion.)
   Indeed, if they return to active participation in the project,
   they should be added back to the organization, to reflect that fact.
 
-
 ## How to change roles
 
 > [!NOTE]
@@ -91,7 +93,7 @@ using one of the template messages below as a base.
 
 1. Open an issue with the following message template (edit it as appropriate):
 
-   ```
+   ```md
    Hi, @username! You seem to be enjoying contributing to the tldr-pages project.
    You now have had five distinct pull requests [merged](<!-- REPLACE THIS WITH THE LINKS TO THE RELEVANT PRs -->)!
    That qualifies you to become a collaborator in this repository, as explained in our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md).
@@ -105,6 +107,9 @@ using one of the template messages below as a base.
    So, what do you say? Can we add you as a collaborator?
 
    Either way, thanks for all your work so far!
+
+   > [!NOTE]
+   > It is required to have [two factor authentication](https://github.com/settings/security) (2FA) enabled for your GitHub account to be added as a collaborator the tldr-pages/tldr repository.
    ```
 
 2. Once they acknowledge the message and if they accept the invitation,
@@ -120,7 +125,7 @@ using one of the template messages below as a base.
 
 1. Open an issue with the following message template (edit it as appropriate):
 
-   ```
+   ```md
    Hi, @username! After joining as a collaborator in the repository, you have been regularly performing [maintenance tasks](<!-- REPLACE THIS WITH THE LINKS TO THE RELEVANT ISSUES AND/OR PRs -->).
 
    Thank you for that!
@@ -152,7 +157,7 @@ using one of the template messages below as a base.
 
 1. Open an issue with the following message template (edit it as appropriate):
 
-   ```
+   ```md
    Hi, @username! You've been an active tldr-pages organization member for over 6 months.
 
    Thanks for sticking around this far and helping out!
@@ -180,7 +185,7 @@ using one of the template messages below as a base.
 
 1. Open an issue with the following message template (edit it as appropriate):
 
-   ```
+   ```md
    Hi, @username! As you know, our [community roles documentation](https://github.com/tldr-pages/tldr/blob/main/COMMUNITY-ROLES.md) defines processes for keeping the list of organization members in sync with the actual maintenance team.
    Since you haven't been active in the project for a while now, we'll be relieving you from the maintainer responsibilities.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -27,8 +27,6 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [8 May 2019](https://github.com/tldr-pages/tldr/issues/2988) — present
 - **Pierre Rudloff ([@Rudloff](https://github.com/Rudloff))**:
   [16 November 2019](https://github.com/tldr-pages/tldr/issues/3580) — present
-- **Proscream ([@Proscream](https://github.com/Proscream))**:
-  [19 November 2019](https://github.com/tldr-pages/tldr/issues/3592) — present
 - **Guido Lena Cota ([@glenacota](https://github.com/glenacota))**:
   [19 October 2020](https://github.com/tldr-pages/tldr/issues/4763) — present
 - **Sahil Dhiman ([@sahilister](https://github.com/sahilister))**:
@@ -59,8 +57,6 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [22 October 2023](https://github.com/tldr-pages/tldr/issues/11159) — present
 - **HoJeong Im ([@IMHOJEONG](https://github.com/IMHOJEONG))**:
   [24 October 2023](https://github.com/tldr-pages/tldr/issues/11200) — present
-- **Shashank Hebbar ([@quantumflo](https://github.com/quantumflo))**:
-  [13 November 2023](https://github.com/tldr-pages/tldr/issues/11460) — present
 - **Leon ([@leonvsc](https://github.com/leonvsc))**:
   [14 November 2023](https://github.com/tldr-pages/tldr/issues/11495) — present
 - **Matthew Peveler ([@MasterOdin](https://github.com/MasterOdin))**:
@@ -114,6 +110,11 @@ If you are an owner of the organization, you can see an automated list [here](ht
 - Isaac Vicente ([@isaacvicente](https://github.com/isaacvicente)):
   [20 September 2023](https://github.com/tldr-pages/tldr/issues/10737) — [29 December 2023](https://github.com/tldr-pages/tldr/issues/11918)
 - Vitor Henrique ([@vitorhcl](https://github.com/vitorhcl)): [18 December 2023](https://github.com/tldr-pages/tldr/issues/11771) — [21 January 2024](https://github.com/tldr-pages/tldr/issues/12094)
+- Geipro/Proscream ([@Geipro)](https://github.com/Geipro)):
+  [19 November 2019](https://github.com/tldr-pages/tldr/issues/3592) — [27 March 2024](https://github.com/tldr-pages/tldr/issues/12209) (Removed during 2FA enforcement)
+- Ruben Vereecken ([@rubenvereecken](https://github.com/rubenvereecken)): [18 January 2018](https://github.com/tldr-pages/tldr/issues/1878#issuecomment-358610454) — [27 March 2024](https://github.com/tldr-pages/tldr/issues/12209) (Removed during 2FA enforcement)
+- Shashank Hebbar ([@quantumflo](https://github.com/quantumflo)):
+  [13 November 2023](https://github.com/tldr-pages/tldr/issues/11460) — [27 March 2024](https://github.com/tldr-pages/tldr/issues/12209) (Removed during 2FA enforcement)
 
 ## Organization members
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Closes #12209

## Changes

- Update the `MAINTAINERS.md` file to reflect the users removed post-2FA enablement in org.
- Add a notice to the `COMMUNITY-ROLES.md` file and repository collaborator template regarding the same. (Note: I didn't add it to the Org member or Org owner template as they would have 2FA already enabled as a collaborator)
