### PR TITLE
agetty: add missing hyphen in placeholder

### DIFF
--- a/pages/linux/agetty.md
+++ b/pages/linux/agetty.md
@@ -19,7 +19,7 @@
 
 - Skip the login ([n]o login) and invoke, as root, another [l]ogin program instead of `/bin/login`:
 
-`agetty {{n|--skip-login}} {{-l|--login-program}} {{login_program}} {{tty}}`
+`agetty {{-n|--skip-login}} {{-l|--login-program}} {{login_program}} {{tty}}`
 
 - Do not display the pre-login ([i]ssue) file (`/etc/issue` by default) before writing the login prompt:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** According to the output of `agetty --version`, `util-linux 2.39.3` 

As discussed in a comment of #12552, this adds the missing hyphen to indicate the option `-n`.
