### PR TITLE
gitui, tig: improve page descriptions and add "See also"; tig: add example

### DIFF
--- a/pages/common/gitui.md
+++ b/pages/common/gitui.md
@@ -1,6 +1,7 @@
 # gitui
 
 > A lightweight keyboard-only TUI for Git.
+> See also: `tig`, `git-gui`.
 > More information: <https://github.com/extrawurst/gitui>.
 
 - Specify the color theme (defaults to `theme.ron`):

--- a/pages/common/gitui.md
+++ b/pages/common/gitui.md
@@ -1,6 +1,6 @@
 # gitui
 
-> Terminal UI for Git.
+> A lightweight keyboard-only TUI for Git.
 > More information: <https://github.com/extrawurst/gitui>.
 
 - Specify the color theme (defaults to `theme.ron`):

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -1,6 +1,6 @@
 # tig
 
-> A text-mode interface for Git.
+> A configurable `ncurses`-based TUI for Git.
 > See also: `gitui`, `git-gui`.
 > More information: <https://github.com/jonas/tig>.
 

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -1,6 +1,7 @@
 # tig
 
 > A text-mode interface for Git.
+> See also: `gitui`, `git-gui`.
 > More information: <https://github.com/jonas/tig>.
 
 - Show the sequence of commits starting from the current one in reverse chronological order:

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -2,7 +2,7 @@
 
 > A configurable `ncurses`-based TUI for Git.
 > See also: `gitui`, `git-gui`.
-> More information: <https://github.com/jonas/tig>.
+> More information: <https://jonas.github.io/tig/doc/manual.html>.
 
 - Show the sequence of commits starting from the current one in reverse chronological order:
 

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -27,3 +27,7 @@
 - Start in stash view, displaying all saved stashes:
 
 `tig stash`
+
+- Display help in TUI:
+
+`h`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Notes

- `tig` has mouse support, although it is disabled by default. It can be enabled adding the following line to `tigrc`:
```
set mouse = true
```

- `tig` has so many key bindings that allows changing the view, for example. The help in the TUI shows them.