### PR TITLE
history: add command to display timestamp

### DIFF
--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -11,9 +11,9 @@
 
 `history {{20}}`
 
-- Display history with timestamps (Only available in Zsh. Use `-E` or `-f` for different time formats.):
+- Display history with timestamps in different formats (only available in Zsh):
 
-`history -i`
+`history -{{d|f|i|E}}`
 
 - Clear the commands history list (only for current Bash shell):
 

--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -11,6 +11,10 @@
 
 `history {{20}}`
 
+- Display history with timestamps (Only available in Zsh. Use `-E` or `-f` for different time formats.):
+
+`history -i`
+
 - Clear the commands history list (only for current Bash shell):
 
 `history -c`


### PR DESCRIPTION
Add command to display timestamp when printing history in Zsh

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
