### PR TITLE
julia: switch example from parallel to threaded

### DIFF
--- a/pages/common/julia.md
+++ b/pages/common/julia.md
@@ -27,6 +27,6 @@
 
 `julia -E '{{(1 - cos(pi/4))/2}}'`
 
-- Start Julia in parallel mode, using N worker processes:
+- Start Julia in multithreaded mode, using N threads:
 
-`julia -p {{N}}`
+`julia -t {{N}}`


### PR DESCRIPTION
Switch example startup from parallel mode (-p) to multithreaded mode (-t) to align with the latest practices, which should lead to better performance.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** all
