### PR TITLE
ps: clarify grep example

### DIFF
--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -11,7 +11,7 @@
 
 `ps auxww`
 
-- Search for a process that matches a string:
+- Search for a process that matches a string (Note: This will also match the `grep` process itself when using a simple string.):
 
 `ps aux | grep {{string}}`
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -13,7 +13,7 @@
 
 - Search for a process that matches a string (the brackets filter out `grep` itself):
 
-`ps aux | grep [s]tring`
+`ps aux | grep {{[s]tring}}`
 
 - List all processes of the current user in extra full format:
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -11,7 +11,7 @@
 
 `ps auxww`
 
-- Search for a process that matches a string (Note: This will also match the `grep` process itself when using a simple string.):
+- Search for a process that matches a string (the brackets filter out `grep` itself):
 
 `ps aux | grep {{string}}`
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -13,7 +13,7 @@
 
 - Search for a process that matches a string (the brackets filter out `grep` itself):
 
-`ps aux | grep {{string}}`
+`ps aux | grep [s]tring`
 
 - List all processes of the current user in extra full format:
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -11,7 +11,7 @@
 
 `ps auxww`
 
-- Search for a process that matches a string (the brackets filter out `grep` itself):
+- Search for a process that matches a string (the brackets will prevent `grep` from matching itself):
 
 `ps aux | grep {{[s]tring}}`
 


### PR DESCRIPTION
Added a note that `ps aux | grep {{string}}` will match the grep process itself unless using a regex with grep. This is something that actively confused me as a newbie.

---

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
`ps from procps-ng 4.0.3`
`grep (GNU grep) 3.11`

