### PR TITLE
git-bug, git-bulk: fix English pages

### DIFF
--- a/pages/common/git-bug.md
+++ b/pages/common/git-bug.md
@@ -12,11 +12,11 @@
 
 `git bug add`
 
-- You can push your new entry to a remote:
+- Push a new bug entry to a remote:
 
 `git bug push`
 
-- You can pull for updates:
+- Pull for updates:
 
 `git bug pull`
 

--- a/pages/common/git-bulk.md
+++ b/pages/common/git-bulk.md
@@ -18,7 +18,7 @@
 
 - Clone repositories from a newline-separated list of remote locations then register them as workspaces:
 
-`git bulk --addworkspace {{workspace-name}} {{/path/to/root/directory}} --from {{/path/to/file}}`
+`git bulk --addworkspace {{workspace_name}} {{/path/to/root/directory}} --from {{/path/to/file}}`
 
 - List all registered workspaces:
 

--- a/pages/common/git-bulk.md
+++ b/pages/common/git-bulk.md
@@ -12,11 +12,11 @@
 
 `git bulk --addworkspace {{workspace_name}} {{/absolute/path/to/repository}}`
 
-- Clone a repository inside a specific directory then register the repository as a workspace:
+- Clone a repository inside a specific directory, then register the repository as a workspace:
 
 `git bulk --addworkspace {{workspace_name}} {{/absolute/path/to/parent_directory}} --from {{remote_repository_location}}`
 
-- Clone repositories from a newline-separated list of remote locations then register them as workspaces:
+- Clone repositories from a newline-separated list of remote locations, then register them as workspaces:
 
 `git bulk --addworkspace {{workspace_name}} {{/path/to/root/directory}} --from {{/path/to/file}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR brings two new changes:
+ git-bug: use imperative mood for command examples
+ git-bulk: fix placeholder naming convention