### PR TITLE
common: add Indonesian translations for Git subcommands

### DIFF
--- a/pages.id/common/git-clear-soft.md
+++ b/pages.id/common/git-clear-soft.md
@@ -1,0 +1,9 @@
+# git clear-soft
+
+> Hapus direktori kerja Git tidak termasuk file di `.gitignore`, seolah-olah baru saja dikloning dengan cabang saat ini.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-clear-soft>.
+
+- Reset semua file yang terlacak dan hapus semua file yang tidak terlacak:
+
+`git clear-soft`

--- a/pages.id/common/git-coauthor.md
+++ b/pages.id/common/git-coauthor.md
@@ -1,0 +1,9 @@
+# git coauthor
+
+> Tambahkan penulis komit baru dalam komit terkini. Perintah ini menulis ulang riwayat perubahan pada Git, karena itu opsi `--force` akan dibutuhkan saat melakukan pendorongan perubahan (push) di lain waktu.
+> Bagian dari `git extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-coauthor>.
+
+- Tambahkan penulis baru terkadap komit Git terakhir:
+
+`git coauthor {{nama}} {{nama@example.com}}`

--- a/pages.id/common/git-cola.md
+++ b/pages.id/common/git-cola.md
@@ -15,7 +15,7 @@
 
 `git cola --prompt`
 
--  Jalankan dengan membuka repositori Git dengan alamat yang ditentukan:
+- Jalankan dengan membuka repositori Git dengan alamat yang ditentukan:
 
 `git cola --repo {{jalan/menuju/repositori-git}}`
 

--- a/pages.id/common/git-cola.md
+++ b/pages.id/common/git-cola.md
@@ -1,0 +1,24 @@
+# git cola
+
+> Tampilan antarmuka grafis (GUI) untuk Git yang kuat, apik, dan intuitif.
+> Informasi lebih lanjut: <https://git-cola.readthedocs.io>.
+
+- Jalankan program GUI:
+
+`git cola`
+
+- Jalankan GUI pada mode perubahan (amend):
+
+`git cola --amend`
+
+- Jalankan dengan meminta program menanyakan repositori Git yang akan dilihat. Jika tidak didefinisikan, maka program ini akan melihat direktori saat ini:
+
+`git cola --prompt`
+
+-  Jalankan dengan membuka repositori Git dengan alamat yang ditentukan:
+
+`git cola --repo {{jalan/menuju/repositori-git}}`
+
+- Terapkan filter jalur ke dalam widget status:
+
+`git cola --status-filter {{filter}}`

--- a/pages.id/common/git-column.md
+++ b/pages.id/common/git-column.md
@@ -1,0 +1,16 @@
+# git column
+
+> Tampilkan data dalam bentuk kolom.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-column>.
+
+- Tampilkan `stdin` dalam bentuk beberapa kolom:
+
+`ls | git column --mode={{column}}`
+
+- Tampilkan `stdin` sebagai beberapa kolom dengan lebar maksimum sebesar `100`:
+
+`ls | git column --mode=column --width={{100}}`
+
+- Tampilkan `stdin` sebagai beberapa kolom dengan padding maksimum sebesar `30`:
+
+`ls | git column --mode=column --padding={{30}}`

--- a/pages.id/common/git-commit-graph.md
+++ b/pages.id/common/git-commit-graph.md
@@ -1,4 +1,4 @@
-# git komit-grafik
+# git commit-graph
 
 > Tulis dan verifikasi file grafik komit Git.
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-commit-graph>.

--- a/pages.id/common/git-commit-graph.md
+++ b/pages.id/common/git-commit-graph.md
@@ -1,0 +1,16 @@
+# git komit-grafik
+
+> Tulis dan verifikasi file grafik komit Git.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-commit-graph>.
+
+- Tulis file grafik komit untuk komit yang dikemas di dalam direktori `.git` pada lokal repositori:
+
+`git commit-graph write`
+
+- Tulis file grafik komit yang berisi semua komit yang dapat dijangkau:
+
+`git show-ref --hash | git commit-graph write --stdin-commits`
+
+- Tulis file grafik komit yang berisi semua komit dalam file grafik komit saat ini beserta yang dapat dijangkau dari `HEAD`:
+
+`git rev-parse {{HEAD}} | git commit-graph write --stdin-commits --append`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Subcommands are `git-clear-soft`, `git-coauthor`, `git-cola`, `git-column`, and `git-commit-graph`.
