### PR TITLE
id3v2: fix `--list` flag

### DIFF
--- a/pages/linux/id3v2.md
+++ b/pages/linux/id3v2.md
@@ -9,7 +9,7 @@
 
 - List all tags of specific files:
 
-`id3v2 --list-tags {{path/to/file1 path/to/file2 ...}}`
+`id3v2 --list {{path/to/file1 path/to/file2 ...}}`
 
 - Delete all `id3v2` or `id3v1` tags of specific files:
 


### PR DESCRIPTION
This is `id3v2`'s `--help`:

```
Usage: id3v2 [OPTION]... [FILE]...
Adds/Modifies/Removes/Views id3v2 tags, modifies/converts/lists id3v1 tags

  -h,  --help               Display this help and exit
  -f,  --list-frames        Display all possible frames for id3v2
  -L,  --list-genres        Lists all id3v1 genres
  -v,  --version            Display version information and exit
  -l,  --list               Lists the tag(s) on the file(s)
  -d,  --delete-v2          Deletes id3v2 tags
  -s,  --delete-v1          Deletes id3v1 tags
  -D,  --delete-all         Deletes both id3v1 and id3v2 tags
  -C,  --convert            Converts id3v1 tag to id3v2
  -1,  --id3v1-only         Writes only id3v1 tag
  -2,  --id3v2-only         Writes only id3v2 tag
  -r,  --remove-frame "FRAMEID"   Removes the specified id3v2 frame
  -a,  --artist       "ARTIST"    Set the artist information
  -A,  --album        "ALBUM"     Set the album title information
  -t,  --song         "SONG"      Set the song title information
  -c,  --comment      "DESCRIPTION":"COMMENT":"LANGUAGE"
                            Set the comment information (both
                            description and language optional)
  -g,  --genre   num        Set the genre number
  -y,  --year    num        Set the year
  -T,  --track   num/num    Set the track number/(optional) total tracks

You can set the value for any id3v2 frame by using '--' and then frame id
For example:
        id3v2 --TIT3 "Monkey!" file.mp3
would set the "Subtitle/Description" frame to "Monkey!".

```

This is using version

```
id3v2 0.1.12
Uses id3lib-3.8.3

This program adds/modifies/removes/views id3v2 tags,
and can convert from id3v1 tags
```

As you can see, there is no `--list-tags` flag, but there is a `--list` flag.