### PR TITLE
contributing-guides: document preference of Spanish word in placeholders

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -602,3 +602,13 @@ For example, use `Lista os arquivos` instead of `Listar os arquivos`, `Listando 
 ```md
 - Crea un archivo en un directorio:
 ```
+
+- Preferably, use the word `identificador` in the placeholders of command examples. For example:
+
+```md
+{{identificador_de_usuario}}
+```
+
+*Writing prepositions is optional*
+
+  However, if the line of a command example exceeds the [maximum length](https://github.com/tldr-pages/tldr/blob/main/.markdownlint.json#L5), choose the word `identificador` or `id` and use it across all placeholders in the page.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -603,7 +603,7 @@ For example, use `Lista os arquivos` instead of `Listar os arquivos`, `Listando 
 - Crea un archivo en un directorio:
 ```
 
-- Preferably, use the word `identificador` in the placeholders of command examples. For example:
+- Preferably, use the word `identificador` instead of `id` in the placeholders of command examples. For example:
 
 ```md
 {{identificador_de_usuario}}


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [N/A] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [N/A] The page(s) have at most 8 examples.
- [N/A] The page description(s) have links to documentation or a homepage.
- [N/A] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A

When reviewing Spanish pages, I and other reviewers, often see the word `id` in placeholders to refer to an identifier (e.g. GPG key). I believe that is not correct. 

It is worth mentioning that this issue was suggested to be documented by @vitorhcl in a comment of #12675.

I have searched through the Spanish pages with the following command:

```shell
grep -REx '`.*\{\{id(_[[:alnum:]]+)+\}\}.*`' pages.es
```

And found just a handful of files with placeholders with the word `id` at the front, more specifically:

```shell
pages.es/common/az-account.md:1
pages.es/common/aws-ec2.md:3
pages.es/common/kill.md:7
pages.es/linux/apt-key.md:2
pages.es/linux/top.md:1
```

I think there are Spanish pages with the word `id` at the end, nonetheless, I can create another pull request modifying the pages to conform with the new documentation.