### PR TITLE
pages*: replace "Véase" with "Vea" on some Spanish pages

### DIFF
--- a/pages.es/common/figlet.md
+++ b/pages.es/common/figlet.md
@@ -1,7 +1,7 @@
 # figlet
 
 > Genera encabezados usando caracteres ASCII desde la entrada del usuario.
-> Véase también `showfigfonts`.
+> Vea también `showfigfonts`.
 > Más información: <http://www.figlet.org/figlet-man.html>.
 
 - Genera el encabezado directamente introduciendo el texto:

--- a/pages.es/common/git-am.md
+++ b/pages.es/common/git-am.md
@@ -1,12 +1,16 @@
 # git am
 
 > Aplica archivos de parche. Útil cuando se reciben commits por correo electrónico.
-> Véase también `git format-patch`, comando que genera archivo de parche.
+> Vea también `git format-patch`, comando que genera archivos de parche.
 > Más información: <https://git-scm.com/docs/git-am>.
 
 - Aplica un archivo de parche:
 
 `git am {{ruta/al/archivo.patch}}`
+
+- Aplica un archivo de parche remoto:
+
+`curl -L {{https://ejemplo.com/file.patch}} | git apply`
 
 - Aborta el proceso de aplicar un archivo de parche:
 

--- a/pages.es/common/git-checkout.md
+++ b/pages.es/common/git-checkout.md
@@ -23,7 +23,7 @@
 
 `git checkout --track {{nombre_remoto}}/{{nombre_de_la_rama}}`
 
-- Descarta todos los cambios sin marcar en el directorio actual (véase `git reset` para más comandos para deshacer):
+- Descarta todos los cambios sin marcar en el directorio actual (vea `git reset` para más comandos para deshacer):
 
 `git checkout .`
 

--- a/pages.es/common/git-cherry-pick.md
+++ b/pages.es/common/git-cherry-pick.md
@@ -8,13 +8,13 @@
 
 `git cherry-pick {{confirmación}}`
 
-- Aplica un rango de confirmaciones de la rama actual (véase también `git rebase --onto`):
+- Aplica un rango de confirmaciones de la rama actual (vea también `git rebase --onto`):
 
 `git cherry-pick {{confirmación_inicial}}~..{{confirmación_final}}`
 
 - Aplica múltiples confirmaciones no secuenciales a la rama actual:
 
-`git cherry-pick {{confirmación_1}} {{confirmación_2}}`
+`git cherry-pick {{confirmación_1 confirmación_2 ...}}`
 
 - Añade los cambios de una confirmación al directorio de trabajo, sin crear una confirmación:
 

--- a/pages.es/common/git-format-patch.md
+++ b/pages.es/common/git-format-patch.md
@@ -1,7 +1,7 @@
 # git format-patch
 
 > Prepara archivos .patch. Es útil cuando se envían commits por correo electrónico.
-> Véase también `git-am`, comando que puede aplicar los archivos .patch generados.
+> Vea también `git-am`, comando que puede aplicar los archivos .patch generados.
 > Más información: <https://git-scm.com/docs/git-format-patch>.
 
 - Crea un archivo `.patch` con nombre automático para todos los cambios que no están en el push:

--- a/pages.es/common/git-restore.md
+++ b/pages.es/common/git-restore.md
@@ -1,7 +1,7 @@
 # git restore
 
 > Restaura los archivos del árbol de trabajo. Requiere la version 2.23+ de Git.
-> Véase también `git checkout` y `git reset`.
+> Vea también `git checkout` y `git reset`.
 > Más información: <https://git-scm.com/docs/git-restore>.
 
 - Restaura un archivo sin marcar a la versión de la confirmación actual (HEAD):

--- a/pages.es/common/git-switch.md
+++ b/pages.es/common/git-switch.md
@@ -1,7 +1,7 @@
 # git switch
 
 > Alterna entre ramas Git. Requiere una versión 2.23+ de Git.
-> Véase también `git checkout`.
+> Vea también `git checkout`.
 > Más información: <https://git-scm.com/docs/git-switch>.
 
 - Cambia a una rama existente:

--- a/pages.es/common/showfigfonts.md
+++ b/pages.es/common/showfigfonts.md
@@ -1,7 +1,7 @@
 # showfigfonts
 
 > Muestra una lista de fuentes disponibles para figlet.
-> Véase también `figlet`.
+> Vea también `figlet`.
 > Más información: <https://manned.org/showfigfonts>.
 
 - Muestra las fuentes disponibles:

--- a/pages.es/common/xkill.md
+++ b/pages.es/common/xkill.md
@@ -1,9 +1,17 @@
 # xkill
 
 > Cierra de manera forzosa una ventana interactivamente en una sesión gráfica.
-> Véase también `kill` y `killall`.
+> Vea también `kill` y `killall`.
 > Más información: <https://www.x.org/releases/current/doc/man/man1/xkill.1.xhtml>.
 
 - Muestra un cursor para cerrar forzosamente una ventana presionando con el botón izquierdo (presiona cualquier otro botón del ratón para cancelar):
 
 `xkill`
+
+- Muestra un cursor para seleccionar una ventana para cerrarla forzosamente al presionar cualquier botón del ratón:
+
+`xkill -button any`
+
+- Cierra forzosamente una ventana con un ID específico (use `xwininfo` para obtener información acerca de las ventanas):
+
+`xkill -id {{id}}`

--- a/pages.es/common/zsh.md
+++ b/pages.es/common/zsh.md
@@ -1,10 +1,10 @@
 # zsh
 
-> Z SHell, un intérprete para la línea de comandos compatible con Bash.
-> Véase también `histexpand` para la expansión del historial.
+> Z SHell, un intérprete de línea de comandos compatible con Bash.
+> Vea también `histexpand` para la expansión del historial.
 > Más información: <https://www.zsh.org>.
 
-- Comienza una sesión interactiva en la shell:
+- Comienza una sesión interactiva en el intérprete de comandos:
 
 `zsh`
 
@@ -16,10 +16,22 @@
 
 `zsh {{ruta/al/script.zsh}}`
 
+- Comprueba si hay errores de sintaxis en un script sin ejecutarlo:
+
+`zsh --no-exec {{ruta/al/script.zsh}}`
+
+- Ejecuta comandos desde `stdin`:
+
+`{{comando}} | zsh`
+
 - Ejecuta un script, mostrando cada comando antes de ejecutarlo:
 
 `zsh --xtrace {{ruta/al/script.zsh}}`
 
-- Comienza una sesión interactiva en la shell en modo detallado, mostrando cada comando antes de ejecutarlo:
+- Comienza una sesión interactiva en el intérprete de comandos en modo detallado, mostrando cada comando antes de ejecutarlo:
 
 `zsh --verbose`
+
+- Ejecuta un comando dentro de `zsh` con patrones glob desactivados:
+
+`noglob {{command}}`

--- a/pages.es/osx/arch.md
+++ b/pages.es/osx/arch.md
@@ -1,7 +1,7 @@
 # arch
 
 > Muestra el nombre de la arquitectura del sistema, o ejecuta un comando bajo una arquitectura diferente.
-> Véase también: `uname`.
+> Vea también: `uname`.
 > Más información: <https://keith.github.io/xcode-man-pages/arch.1.html>.
 
 - Muestra la arquitectura del sistema:


### PR DESCRIPTION
I ended up completing the missing commands
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->
