### PR TITLE
pages.{en, pt_BR}: replace the previous dockerd URL with the new one

### DIFF
--- a/pages.ar/linux/dockerd.md
+++ b/pages.ar/linux/dockerd.md
@@ -1,7 +1,7 @@
 # dockerd
 
 > هي عملية مستمرة تعمل في الخلفية تبدأها لتتحكم في حاويات الدوكر.
-> لمزيد من التفاصيل: <https://docs.docker.com/engine/reference/commandline/dockerd/>.
+> لمزيد من التفاصيل: <https://docs.docker.com/reference/cli/dockerd/>.
 
 - قم بتشغيل دوكر في الخلفية:
 

--- a/pages.pt_BR/linux/dockerd.md
+++ b/pages.pt_BR/linux/dockerd.md
@@ -21,4 +21,4 @@
 
 - Executa e define um nível de log específico:
 
-`dockerd --log-level {debug|info|warn|error|fatal}}`
+`dockerd --log-level {{debug|info|warn|error|fatal}}`

--- a/pages.pt_BR/linux/dockerd.md
+++ b/pages.pt_BR/linux/dockerd.md
@@ -1,7 +1,7 @@
 # dockerd
 
 > Um processo persistente para iniciar e gerenciar contêineres Docker.
-> Mais informações: <https://docs.docker.com/engine/reference/commandline/dockerd/>.
+> Mais informações: <https://docs.docker.com/reference/cli/dockerd/>.
 
 - Executa o daemon do Docker:
 

--- a/pages/linux/dockerd.md
+++ b/pages/linux/dockerd.md
@@ -1,7 +1,7 @@
 # dockerd
 
 > A persistent process to start and manage Docker containers.
-> More information: <https://docs.docker.com/engine/reference/commandline/dockerd/>.
+> More information: <https://docs.docker.com/reference/cli/dockerd/>.
 
 - Run Docker daemon:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Edit: There was another page (`./pages.ar/linux/dockerd.md`) that has the old URL.. but it's in Arabic and I can't seem to able to edit it.