### PR TITLE
fastfetch: add `--pipe` example

### DIFF
--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -7,7 +7,7 @@
 
 `fastfetch`
 
-- Display system information without a logo:
+- Display system information without a logo and escape sequences:
 
 `fastfetch --pipe`
 

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -11,7 +11,6 @@
 
 `fastfetch --pipe`
 
-
 - Fetch a specific structure:
 
 `fastfetch --structure {{structure}}`

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -7,6 +7,11 @@
 
 `fastfetch`
 
+- Display system information without a logo:
+
+`fastfetch --pipe`
+
+
 - Fetch a specific structure:
 
 `fastfetch --structure {{structure}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** fastfetch 2.9.1
