### PR TITLE
chrt: fix argument order when changing the scheduling policy

### DIFF
--- a/pages/linux/chrt.md
+++ b/pages/linux/chrt.md
@@ -17,4 +17,4 @@
 
 - Set the scheduling policy for a process:
 
-`chrt --{{deadline|idle|batch|rr|fifo|other}} --pid {{PID}}`
+`chrt --{{deadline|idle|batch|rr|fifo|other}} --pid {{priority}} {{PID}}`

--- a/pages/linux/chrt.md
+++ b/pages/linux/chrt.md
@@ -17,4 +17,4 @@
 
 - Set the scheduling policy for a process:
 
-`chrt --pid {{PID}} --{{deadline|idle|batch|rr|fifo|other}}`
+`chrt --{{deadline|idle|batch|rr|fifo|other}} --pid {{PID}}`


### PR DESCRIPTION
Previous:
```
$ chrt --pid 3625066 --idle
chrt: invalid PID argument: '--idle'
```
(exit code 1)

With PR:
```
$ chrt --idle --pid 3625066  
pid 3625066's current scheduling policy: SCHED_OTHER
pid 3625066's current scheduling priority: 0
```
(exit code 0)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** chrt from util-linux 2.39.3
