### PR TITLE
dart: add fix subcommand example

### DIFF
--- a/pages/common/dart.md
+++ b/pages/common/dart.md
@@ -26,3 +26,7 @@
 - Compile a Dart file to a native binary:
 
 `dart compile exe {{path/to/file.dart}}`
+
+- Apply automated fixes to the current project:
+
+`dart fix --apply`


### PR DESCRIPTION
In this PR, I added an example to the `dart` command about automatic code fixes using the `dart fix --apply` command. I think we should add this example because this subcommand is useful, especially for novice programmers.
Please review and merge these changes. 
Thank you!
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
