### PR TITLE
objcopy: add page

### DIFF
--- a/pages/linux/objcopy.md
+++ b/pages/linux/objcopy.md
@@ -1,24 +1,24 @@
 # objcopy
 
 > The GNU objcopy utility copies the contents of an object file to another.
-> More Information at: <https://manned.org/objcopy>.
+> More Information: <https://manned.org/objcopy>.
 
-- Copy data to another file.
+- Copy data to another file:
 
 `objcopy {{/your/path/to/file/src}} {{/your/path/to/file/destination}}`
 
-- Translate object files from one format to another.
+- Translate object files from one format to another:
 
 `objcopy --input-target={{inputformat}} --output-target={{output_format}} {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Strip all symbol information from file.
+- Strip all symbol information from file:
 
 `objcopy --strip-all {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Strip debugging information from file.
+- Strip debugging information from file:
 
 `objcopy --strip-debug {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Copy a specific section from the source to destination.
+- Copy a specific section from the source to destination:
 
 `objcopy --only-section={{section}} {{/path/to/your/src}} {{path/to/your/destination}}`

--- a/pages/linux/objcopy.md
+++ b/pages/linux/objcopy.md
@@ -1,0 +1,24 @@
+# objcopy
+
+> The GNU objcopy utility copies the contents of an object file to another
+> More information at: https://manned.org/objcopy
+
+- Copying to another file
+
+`objcopy {{/your/path/to/file/src}} {{/your/path/to/file/destination}}`
+
+- Translate object files from one format to another
+
+`objcopy --input-target={{inputformat}} --output-target={{output_format}} {{/path/to/your/src}} {{path/to/your/destination}}`
+
+- Strips all symbol information from file
+
+`objcopy --strip-all {{/path/to/your/src}} {{path/to/your/destination}}`
+
+- Strips debugging information from file
+
+`objcopy --strip-debug {{/path/to/your/src}} {{path/to/your/destination}}`
+
+- Copy a specific section from the source to destination
+
+`objcopy --only-section={{section}} {{/path/to/your/src}} {{path/to/your/destination}}`

--- a/pages/linux/objcopy.md
+++ b/pages/linux/objcopy.md
@@ -1,7 +1,7 @@
 # objcopy
 
 > The GNU objcopy utility copies the contents of an object file to another.
-> More Information: <https://manned.org/objcopy>.
+> More information: <https://manned.org/objcopy>.
 
 - Copy data to another file:
 

--- a/pages/linux/objcopy.md
+++ b/pages/linux/objcopy.md
@@ -1,24 +1,24 @@
 # objcopy
 
-> The GNU objcopy utility copies the contents of an object file to another
-> More information at: https://manned.org/objcopy
+> The GNU objcopy utility copies the contents of an object file to another.
+> More Information at: <https://manned.org/objcopy>.
 
-- Copying to another file
+- Copy data to another file.
 
 `objcopy {{/your/path/to/file/src}} {{/your/path/to/file/destination}}`
 
-- Translate object files from one format to another
+- Translate object files from one format to another.
 
 `objcopy --input-target={{inputformat}} --output-target={{output_format}} {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Strips all symbol information from file
+- Strip all symbol information from file.
 
 `objcopy --strip-all {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Strips debugging information from file
+- Strip debugging information from file.
 
 `objcopy --strip-debug {{/path/to/your/src}} {{path/to/your/destination}}`
 
-- Copy a specific section from the source to destination
+- Copy a specific section from the source to destination.
 
 `objcopy --only-section={{section}} {{/path/to/your/src}} {{path/to/your/destination}}`

--- a/pages/linux/objcopy.md
+++ b/pages/linux/objcopy.md
@@ -1,24 +1,24 @@
 # objcopy
 
-> The GNU objcopy utility copies the contents of an object file to another.
+> Copy the contents of an object file to another.
 > More information: <https://manned.org/objcopy>.
 
-- Copy data to another file:
+- Copy all data from a specific file to another one:
 
-`objcopy {{/your/path/to/file/src}} {{/your/path/to/file/destination}}`
+`objcopy {{path/to/file/source_file}} {{path/to/file/target_file}}`
 
 - Translate object files from one format to another:
 
-`objcopy --input-target={{inputformat}} --output-target={{output_format}} {{/path/to/your/src}} {{path/to/your/destination}}`
+`objcopy --input-target={{inputformat}} --output-target={{output_format}} {{path/to/your/source_file}} {{path/to/your/target_file}}`
 
-- Strip all symbol information from file:
+- Strip all symbol information from a specific file:
 
-`objcopy --strip-all {{/path/to/your/src}} {{path/to/your/destination}}`
+`objcopy --strip-all {{path/to/your/source_file}} {{path/to/your/target_file}}`
 
 - Strip debugging information from file:
 
-`objcopy --strip-debug {{/path/to/your/src}} {{path/to/your/destination}}`
+`objcopy --strip-debug {{/path/to/your/source_file}} {{path/to/your/target_file}}`
 
-- Copy a specific section from the source to destination:
+- Copy a specific section of the source file to the destination file:
 
-`objcopy --only-section={{section}} {{/path/to/your/src}} {{path/to/your/destination}}`
+`objcopy --only-section={{section}} {{path/to/your/source_file}} {{path/to/your/target_file}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- GNU objcopy (GNU Binutils for Ubuntu) 2.38
