### PR TITLE
docker, ollama, history, tldr: fix mnemonics

### DIFF
--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -24,7 +24,7 @@
 
 `docker images`
 
-- Open a shell inside a running container:
+- Open an [i]nteractive [t]ty with Bourne shell (`sh`) inside a running container:
 
 `docker exec -it {{container_name}} {{sh}}`
 

--- a/pages/common/history.md
+++ b/pages/common/history.md
@@ -15,14 +15,14 @@
 
 `history -{{d|f|i|E}}`
 
-- Clear the commands history list (only for current Bash shell):
+- [c]lear the commands history list (only for current Bash shell):
 
 `history -c`
 
-- Overwrite history file with history of current Bash shell (often combined with `history -c` to purge history):
+- Over[w]rite history file with history of current Bash shell (often combined with `history -c` to purge history):
 
 `history -w`
 
-- Delete the history entry at the specified offset:
+- [d]elete the history entry at the specified offset:
 
 `history -d {{offset}}`

--- a/pages/common/ollama.md
+++ b/pages/common/ollama.md
@@ -31,6 +31,6 @@
 
 `ollama rm {{model}}`
 
-- Create a model from a `Modelfile`:
+- Create a model from a `Model[f]ile`:
 
 `ollama create {{new_model_name}} -f {{path/to/Modelfile}}`

--- a/pages/common/ollama.md
+++ b/pages/common/ollama.md
@@ -31,6 +31,6 @@
 
 `ollama rm {{model}}`
 
-- Create a model from a `Model[f]ile`:
+- Create a model from a `Modelfile` ([f]):
 
 `ollama create {{new_model_name}} -f {{path/to/Modelfile}}`

--- a/pages/common/ollama.md
+++ b/pages/common/ollama.md
@@ -1,7 +1,7 @@
 # ollama
 
 > A large language model runner.
-> More information: <https://github.com/jmorganca/ollama>.
+> More information: <https://github.com/ollama/ollama>.
 
 - Start the daemon required to run other commands:
 

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -12,7 +12,7 @@
 
 `tldr {{command}} {{subcommand}}`
 
-- Print the tldr page for a command in the given [l]anguage (if available, otherwise fall back to English):
+- Print the tldr page for a command in the given [L]anguage (if available, otherwise fall back to English):
 
 `tldr --language {{language_code}} {{command}}`
 

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -12,7 +12,7 @@
 
 `tldr {{command}} {{subcommand}}`
 
-- Print the tldr page for a command in the given [L]anguage (if available, otherwise fall back to English):
+- Print the tldr page for a command in the given [l]anguage (if available, otherwise fall back to English):
 
 `tldr --language {{language_code}} {{command}}`
 
@@ -24,6 +24,6 @@
 
 `tldr --update`
 
-- List all pages for the current platform and `common`:
+- [l]ist all pages for the current platform and `common`:
 
 `tldr --list`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
