### PR TITLE
pw-cli: fix link to the documentation

### DIFF
--- a/pages/linux/pw-cli.md
+++ b/pages/linux/pw-cli.md
@@ -1,7 +1,7 @@
 # pw-cli
 
 > Manage a PipeWire instance's modules, objects, nodes, devices, links and much more.
-> More information: <https://docs.pipewire.org/page_man_pw_cli_1.html>.
+> More information: <https://docs.pipewire.org/page_man_pw-cli_1.html>.
 
 - Print all nodes (sinks and sources) along with their IDs:
 


### PR DESCRIPTION
This PR fixes the link to the documentation of the `pw-cli` command.
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).