### PR TITLE
vnstat*: fix flag, rename placeholder and add Spanish translation

### DIFF
--- a/pages.es/linux/vnstat.md
+++ b/pages.es/linux/vnstat.md
@@ -1,0 +1,24 @@
+# vnstat
+
+> Un monitor de tráfico de red basado en consola.
+> Más información: <https://manned.org/vnstat>.
+
+- Muestra resumen de tráfico para todas las interfaces:
+
+`vnstat`
+
+- Muestra resumen de tráfico para una interfaz de red específica:
+
+`vnstat -i {{interfaz_de_red}}`
+
+- Muestra estadísticas en vivo para una interfaz de red específica:
+
+`vnstat -l -i {{interfaz_de_red}}`
+
+- Muestra estadísticas de tráfico por hora durante las últimas 24 horas mediante un gráfico de barras:
+
+`vnstat -hg`
+
+- Mide y muestra el tráfico promedio por 30 segundos:
+
+`vnstat -tr {{30}}`

--- a/pages.es/linux/vnstat.md
+++ b/pages.es/linux/vnstat.md
@@ -11,7 +11,7 @@
 
 `vnstat -i {{interfaz_de_red}}`
 
-- Muestra estadísticas en vivo para una interfaz de red específica:
+- Muestra estadísticas en vivo de una interfaz de red específica:
 
 `vnstat -l -i {{interfaz_de_red}}`
 

--- a/pages.es/linux/vnstat.md
+++ b/pages.es/linux/vnstat.md
@@ -1,6 +1,6 @@
 # vnstat
 
-> Un monitor de tráfico de red basado en consola.
+> Monitor de tráfico de red de línea de comandos.
 > Más información: <https://manned.org/vnstat>.
 
 - Muestra un resumen de tráfico de todas las interfaces:

--- a/pages.es/linux/vnstat.md
+++ b/pages.es/linux/vnstat.md
@@ -3,7 +3,7 @@
 > Un monitor de tráfico de red basado en consola.
 > Más información: <https://manned.org/vnstat>.
 
-- Muestra resumen de tráfico para todas las interfaces:
+- Muestra un resumen de tráfico de todas las interfaces:
 
 `vnstat`
 

--- a/pages.es/linux/vnstat.md
+++ b/pages.es/linux/vnstat.md
@@ -7,7 +7,7 @@
 
 `vnstat`
 
-- Muestra resumen de tráfico para una interfaz de red específica:
+- Muestra un resumen de tráfico de una interfaz de red específica:
 
 `vnstat -i {{interfaz_de_red}}`
 

--- a/pages.es/linux/vnstati.md
+++ b/pages.es/linux/vnstati.md
@@ -9,7 +9,7 @@
 
 - Genera los 10 días con mayor tráfico de todos los tiempos:
 
-`vnstati --top {{10}} --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
+`vnstati --top 10 --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
 
 - Genera estadísticas de tráfico mensual de los últimos 12 meses:
 

--- a/pages.es/linux/vnstati.md
+++ b/pages.es/linux/vnstati.md
@@ -1,6 +1,6 @@
 # vnstati
 
-> Compatibilidad de salida a imagen PNG para vnStat.
+> Genera imágenes PNG compatibles con vnStat.
 > Más información: <https://manned.org/vnstati>.
 
 - Genera un resumen de los últimos dos meses, días, etc:

--- a/pages.es/linux/vnstati.md
+++ b/pages.es/linux/vnstati.md
@@ -1,0 +1,20 @@
+# vnstati
+
+> Compatibilidad de salida a imagen PNG para vnStat.
+> Más información: <https://manned.org/vnstati>.
+
+- Genera un resumen de los últimos 2: meses, días y todos los tiempos:
+
+`vnstati --summary --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
+
+- Genera los 10 días con mayor tráfico de todos los tiempos:
+
+`vnstati --top {{10}} --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
+
+- Genera estadísticas de tráfico mensual de los últimos 12 meses:
+
+`vnstati --months --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
+
+- Genera estadísticas de tráfico por hora de las últimas 24 horas:
+
+`vnstati --hours --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`

--- a/pages.es/linux/vnstati.md
+++ b/pages.es/linux/vnstati.md
@@ -3,7 +3,7 @@
 > Compatibilidad de salida a imagen PNG para vnStat.
 > Más información: <https://manned.org/vnstati>.
 
-- Genera un resumen de los últimos 2: meses, días y todos los tiempos:
+- Genera un resumen de los últimos dos meses, días, etc:
 
 `vnstati --summary --iface {{interfaz_de_red}} --output {{ruta/a/salida.png}}`
 

--- a/pages/linux/vnstat.md
+++ b/pages/linux/vnstat.md
@@ -9,11 +9,11 @@
 
 - Display traffic summary for a specific network interface:
 
-`vnstat -i {{eth0}}`
+`vnstat -i {{network_interface}}`
 
 - Display live stats for a specific network interface:
 
-`vnstat -l -i {{eth0}}`
+`vnstat -l -i {{network_interface}}`
 
 - Show traffic statistics on an hourly basis for the last 24 hours using a bar graph:
 

--- a/pages/linux/vnstati.md
+++ b/pages/linux/vnstati.md
@@ -9,7 +9,7 @@
 
 - Output the 10 most traffic-intensive days of all time:
 
-`vnstati --top10 --iface {{network_interface}} --output {{path/to/output.png}}`
+`vnstati --top {{10}} --iface {{network_interface}} --output {{path/to/output.png}}`
 
 - Output monthly traffic statistics from the last 12 months:
 

--- a/pages/linux/vnstati.md
+++ b/pages/linux/vnstati.md
@@ -9,7 +9,7 @@
 
 - Output the 10 most traffic-intensive days of all time:
 
-`vnstati --top {{10}} --iface {{network_interface}} --output {{path/to/output.png}}`
+`vnstati --top 10 --iface {{network_interface}} --output {{path/to/output.png}}`
 
 - Output monthly traffic statistics from the last 12 months:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

It seems before the flag was `--top10` but now the flag is `--top` and accepts an argument.
- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
