### PR TITLE
a2disconf: add Polish translation

### DIFF
--- a/pages.pl/linux/a2disconf.md
+++ b/pages.pl/linux/a2disconf.md
@@ -1,6 +1,6 @@
 # a2disconf
 
-> Wyłącz plik konfiguracyjny Apache w systemach opartych o Debian.
+> Wyłącz plik konfiguracyjny Apache w systemach opartych na Debianie.
 > Więcej informacji: <https://manpages.debian.org/latest/apache2/a2disconf.8.en.html>.
 
 - Wyłącz plik konfiguracyjny:

--- a/pages.pl/linux/a2disconf.md
+++ b/pages.pl/linux/a2disconf.md
@@ -1,0 +1,12 @@
+# a2disconf
+
+> Wyłącz plik konfiguracyjny Apache w systemach opartych o Debian.
+> Więcej informacji: <https://manpages.debian.org/latest/apache2/a2disconf.8.en.html>.
+
+- Wyłącz plik konfiguracyjny:
+
+`sudo a2disconf {{plik_konfiguracyjny}}`
+
+- Nie pokazuj wiadomości informacyjnych:
+
+`sudo a2disconf --quiet {{plik_konfiguracyjny}}`


### PR DESCRIPTION
This PR adds Polish translation for `a2disconf` (`linux`).
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
