### PR TITLE
lstopo: add page

### DIFF
--- a/pages/common/lstopo.md
+++ b/pages/common/lstopo.md
@@ -1,4 +1,4 @@
-# lshw
+# lstopo
 
 > Show the hardware topology of the system.
 > More information: <https://manned.org/lstopo>.

--- a/pages/common/lstopo.md
+++ b/pages/common/lstopo.md
@@ -1,0 +1,24 @@
+# lshw
+
+> Show the hardware topology of the system.
+> More information: <https://manned.org/lstopo>.
+
+- Show the summarized system topology in a graphical window (or print to console if no graphical display is available):
+
+`lstopo`
+
+- Show the full system topology without summarizations:
+
+`lstopo --no-factorize`
+
+- Show the summarized system topology with only [p]hysical indices (i.e. as seen by the OS):
+
+`lstopo --physical`
+
+- Write the full system topology to a file in the specified format:
+
+`lstopo --no-factorize --output-format {{console|ascii|tex|fig|svg|pdf|ps|png|xml}} {{path/to/file}}`
+
+- Output in monochrome or greyscale:
+
+`lstopo --palette {{none|grey}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2.10.0
