### PR TITLE
netstat: add osx page

### DIFF
--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -3,7 +3,7 @@
 > Display network-related information such as open connections, open socket ports, etc.
 > More information: <https://keith.github.io/xcode-man-pages/netstat.1.html>.
 
-- Displays the PID and program name listening on the given protocol listen:
+- Display the PID and program name listening on a specific protocol:
 
 `netstat -p {{protocol}}`
 

--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -1,7 +1,7 @@
 # netstat
 
 > Display network-related information such as open connections, open socket ports, etc.
-> More information: <https://man.freebsd.org/cgi/man.cgi?netstat(1)>.
+> More information: <https://keith.github.io/xcode-man-pages/netstat.1.html>.
 
 - Displays the PID and program name listening on the given protocol listen:
 

--- a/pages/osx/netstat.md
+++ b/pages/osx/netstat.md
@@ -1,0 +1,16 @@
+# netstat
+
+> Display network-related information such as open connections, open socket ports, etc.
+> More information: <https://man.freebsd.org/cgi/man.cgi?netstat(1)>.
+
+- Displays the PID and program name listening on the given protocol listen:
+
+`netstat -p {{protocol}}`
+
+- Print the routing table and do not resolve IP addresses to hostnames:
+
+`netstat -nr`
+
+- Print the routing table of IPv4 addresses:
+
+`netstat -nr -f inet`


### PR DESCRIPTION
The common version doesn't seem to work in osx.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
