### PR TITLE
pactl: add infodump example

### DIFF
--- a/pages/common/pactl.md
+++ b/pages/common/pactl.md
@@ -3,6 +3,10 @@
 > Control a running PulseAudio sound server.
 > More information: <https://manned.org/pactl>.
 
+- Show information about the sound server:
+
+`pactl info`
+
 - List all sinks (or other types - sinks are outputs and sink-inputs are active audio streams):
 
 `pactl list {{sinks}} short`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
17.0.0