### PR TITLE
pw-config: add page

### DIFF
--- a/pages/linux/pw-config.md
+++ b/pages/linux/pw-config.md
@@ -3,27 +3,27 @@
 > Debug PipeWire configuration parsing.
 > More information: <https://docs.pipewire.org/page_man_pw-config_1.html>.
 
-- List all config files that will be used:
+- List all configuration files that will be used:
 
 `pw-config`
 
-- List all config files that will be used by the PipeWire pulseaudio server:
+- List all configuration files that will be used by the PipeWire PulseAudio server:
 
 `pw-config --name pipewire-pulse.conf`
 
-- List all config sections used by the PipeWire pulseaudio server:
+- List all configuration sections used by the PipeWire PulseAudio server:
 
 `pw-config --name pipewire-pulse.conf list`
 
-- List the context.properties fragments used by the JACK clients:
+- List the `context.properties` fragments used by the JACK clients:
 
 `pw-config --name jack.conf list context.properties`
 
-- List the merged context.properties used by the JACK clients:
+- List the merged `context.properties` used by the JACK clients:
 
 `pw-config --name jack.conf merge context.properties`
 
-- List the merged context.modules used by the PipeWire server and [r]eformat:
+- List the merged `context.modules` used by the PipeWire server and [r]eformat:
 
 `pw-config --name pipewire.conf --recurse merge context.modules`
 

--- a/pages/linux/pw-config.md
+++ b/pages/linux/pw-config.md
@@ -1,0 +1,32 @@
+# pw-config
+
+> Debug PipeWire config parsing.
+> More information: <https://docs.pipewire.org/page_man_pw-config_1.html>.
+
+- List all config files that will be used:
+
+`pw-config`
+
+- List all config files that will be used by the PipeWire pulseaudio server:
+
+`pw-config --name pipewire-pulse.conf`
+
+- List all config sections used by the PipeWire pulseaudio server:
+
+`pw-config --name pipewire-pulse.conf list`
+
+- List the context.properties fragments used by the JACK clients:
+
+`pw-config --name jack.conf list context.properties`
+
+- List the merged context.properties used by the JACK clients:
+
+`pw-config --name jack.conf merge context.properties`
+
+- List the merged context.modules used by the PipeWire server and [r]eformat:
+
+`pw-config --name pipewire.conf --recurse merge context.modules`
+
+- Display help:
+
+`pw-config --help`

--- a/pages/linux/pw-config.md
+++ b/pages/linux/pw-config.md
@@ -1,6 +1,6 @@
 # pw-config
 
-> Debug PipeWire config parsing.
+> Debug PipeWire configuration parsing.
 > More information: <https://docs.pipewire.org/page_man_pw-config_1.html>.
 
 - List all config files that will be used:

--- a/pages/linux/pw-config.md
+++ b/pages/linux/pw-config.md
@@ -1,6 +1,6 @@
 # pw-config
 
-> Debug PipeWire configuration parsing.
+> List configuration paths and sections that will be used by the PipeWire server and clients.
 > More information: <https://docs.pipewire.org/page_man_pw-config_1.html>.
 
 - List all configuration files that will be used:


### PR DESCRIPTION
Hi. This PR adds a page for `pw-config`, which is part of `pipewire`. 
Instead of using placeholders, I used specific examples because I think they show more of what the command is about, but I will add placeholders if needed.
#11747 
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Compiled with libpipewire 1.0.6
