### PR TITLE
alacritty: update configs to .toml from deprecated .yml

### DIFF
--- a/pages.de/common/alacritty.md
+++ b/pages.de/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{befehl}}`
 
-- Gib eine alternative Konfigurations-Datei an (ist standardmäßig `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Gib eine alternative Konfigurations-Datei an (ist standardmäßig `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{pfad/zu/konfiguration.yml}}`
+`alacritty --config-file {{pfad/zu/konfiguration.toml}}`
 
-- Starte mit aktiviertem Live-Konfigurations-Neuladen (kann auch standardmäßig in `alacritty.yml` eingestellt werden):
+- Starte mit aktiviertem Live-Konfigurations-Neuladen (kann auch standardmäßig in `alacritty.toml` eingestellt werden):
 
-`alacritty --live-config-reload --config-file {{pfad/zu/konfiguration.yml}}`
+`alacritty --live-config-reload --config-file {{pfad/zu/konfiguration.toml}}`

--- a/pages.es/common/alacritty.md
+++ b/pages.es/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{comando}}`
 
-- Especifica un archivo de configuración alternativo (por defecto es `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Especifica un archivo de configuración alternativo (por defecto es `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{ruta/al/config.yml}}`
+`alacritty --config-file {{ruta/al/config.toml}}`
 
-- Ejecuta con recarga automática de la configuración activada (puede activarse por defecto en `alacritty.yml`):
+- Ejecuta con recarga automática de la configuración activada (puede activarse por defecto en `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{ruta/al/config.yml}}`
+`alacritty --live-config-reload --config-file {{ruta/al/config.toml}}`

--- a/pages.fr/common/alacritty.md
+++ b/pages.fr/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{commande}}`
 
-- Utilise un autre fichier de configuration (le fichier par défault étant `$XDG_CONFIG_HOME/alacritty/alacritty.yml`) :
+- Utilise un autre fichier de configuration (le fichier par défault étant `$XDG_CONFIG_HOME/alacritty/alacritty.toml`) :
 
-`alacritty --config-file {{chemin/vers/config.yml}}`
+`alacritty --config-file {{chemin/vers/config.toml}}`
 
-- Lance avec la mise à jour en live dès que la configuration est modifiée ( peu également être activé par défaut dans `alacritty.yml`) :
+- Lance avec la mise à jour en live dès que la configuration est modifiée ( peu également être activé par défaut dans `alacritty.toml`) :
 
-`alacritty --live-config-reload --config-file {{chemin/vers/config.yml}}`
+`alacritty --live-config-reload --config-file {{chemin/vers/config.toml}}`

--- a/pages.id/common/alacritty.md
+++ b/pages.id/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{perintah}}`
 
-- Menentukan berkas konfigurasi alternatif (nilai default `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Menentukan berkas konfigurasi alternatif (nilai default `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{alamat/ke/konfigurasi.yml}}`
+`alacritty --config-file {{alamat/ke/konfigurasi.toml}}`
 
-- Menjalankan dengan mengaktifkan pemuatan ulang konfigurasi secara langsung/otomatis (dapat juga diaktifkan secara default di `alacritty.yml`):
+- Menjalankan dengan mengaktifkan pemuatan ulang konfigurasi secara langsung/otomatis (dapat juga diaktifkan secara default di `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{alamat/ke/konfigurasi.yml}}`
+`alacritty --live-config-reload --config-file {{alamat/ke/konfigurasi.toml}}`

--- a/pages.it/common/alacritty.md
+++ b/pages.it/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{comando}}`
 
-- Specifica un file di configurazione alternativo (predefinito a `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Specifica un file di configurazione alternativo (predefinito a `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{percorso/di/config.yml}}`
+`alacritty --config-file {{percorso/di/config.toml}}`
 
-- Esegui con ricaricamento configurazione live (può anche essere acceso in `alacritty.yml`):
+- Esegui con ricaricamento configurazione live (può anche essere acceso in `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{percorsi/al/config.yml}}`
+`alacritty --live-config-reload --config-file {{percorsi/al/config.toml}}`

--- a/pages.ko/common/alacritty.md
+++ b/pages.ko/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{명령어}}`
 
-- 대체 구성파일 지정 (기본값 : `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- 대체 구성파일 지정 (기본값 : `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{경로/config.yml}}`
+`alacritty --config-file {{경로/config.toml}}`
 
-- 재배치가 가능한 라이브 구성 설정으로 실행 (기본적으로 `alacritty.yml` 에서도 활성화 가능):
+- 재배치가 가능한 라이브 구성 설정으로 실행 (기본적으로 `alacritty.toml` 에서도 활성화 가능):
 
-`alacritty --live-config-reload --config-file {{경로/config.yml}}`
+`alacritty --live-config-reload --config-file {{경로/config.toml}}`

--- a/pages.nl/common/alacritty.md
+++ b/pages.nl/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{bevel}}`
 
-- Geef een alternatief configuratiebestand op (standaard ingesteld op `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Geef een alternatief configuratiebestand op (standaard ingesteld op `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{pad/naar/config.yml}}`
+`alacritty --config-file {{pad/naar/config.toml}}`
 
-- Uitvoeren met live config reload ingeschakeld (kan ook standaard worden ingeschakeld in `alacritty.yml`):
+- Uitvoeren met live config reload ingeschakeld (kan ook standaard worden ingeschakeld in `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{pad/naar/config.yml}}`
+`alacritty --live-config-reload --config-file {{pad/naar/config.toml}}`

--- a/pages.pt_BR/common/alacritty.md
+++ b/pages.pt_BR/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{comando}}`
 
-- Especifica um arquivo de configuração alternativo (`$XDG_CONFIG_HOME/alacritty/alacritty.yml` por padrão):
+- Especifica um arquivo de configuração alternativo (`$XDG_CONFIG_HOME/alacritty/alacritty.toml` por padrão):
 
-`alacritty --config-file {{caminho/para/config.yml}}`
+`alacritty --config-file {{caminho/para/config.toml}}`
 
-- Executa com configuração ao vivo habilitada (pode também ser habilitada por padrão no `alacritty.yml`):
+- Executa com configuração ao vivo habilitada (pode também ser habilitada por padrão no `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{caminho/para/config.yml}}`
+`alacritty --live-config-reload --config-file {{caminho/para/config.toml}}`

--- a/pages.pt_PT/common/alacritty.md
+++ b/pages.pt_PT/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{comando}}`
 
-- Define um caminho alternativo para o ficheiro de configuração (por omissão `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Define um caminho alternativo para o ficheiro de configuração (por omissão `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{caminho/para/configuração.yml}}`
+`alacritty --config-file {{caminho/para/configuração.toml}}`
 
-- Executa com carregamento automático de configuração (pode ser definido por omissão em `alacritty.yml`):
+- Executa com carregamento automático de configuração (pode ser definido por omissão em `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{caminho/para/configuração.yml}}`
+`alacritty --live-config-reload --config-file {{caminho/para/configuração.toml}}`

--- a/pages.zh/common/alacritty.md
+++ b/pages.zh/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{命令}}`
 
-- 指定备用配置文件（默认在 `$XDG_CONFIG_HOME/alacritty/alacritty.yml`）：
+- 指定备用配置文件（默认在 `$XDG_CONFIG_HOME/alacritty/alacritty.toml`）：
 
-`alacritty --config-file {{路径/config.yml}}`
+`alacritty --config-file {{路径/config.toml}}`
 
-- 在启用实时配置重新加载的情况下运行（默认情况下也可以在 `alacritty.yml` 中启用）：
+- 在启用实时配置重新加载的情况下运行（默认情况下也可以在 `alacritty.toml` 中启用）：
 
-`alacritty --live-config-reload --config-file {{路径/config.yml}}`
+`alacritty --live-config-reload --config-file {{路径/config.toml}}`

--- a/pages/common/alacritty.md
+++ b/pages/common/alacritty.md
@@ -15,10 +15,10 @@
 
 `alacritty -e {{command}}`
 
-- Use an alternative configuration file (defaults to `$XDG_CONFIG_HOME/alacritty/alacritty.yml`):
+- Use an alternative configuration file (defaults to `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{path/to/config.yml}}`
+`alacritty --config-file {{path/to/config.toml}}`
 
-- Run with live configuration reload enabled (can also be enabled by default in `alacritty.yml`):
+- Run with live configuration reload enabled (can also be enabled by default in `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{path/to/config.yml}}`
+`alacritty --live-config-reload --config-file {{path/to/config.toml}}`


### PR DESCRIPTION
This PR updates the `alacritty` command page to use `.toml` as its config file extension, instead of the deprecated `.yml`.

See https://github.com/alacritty/alacritty/pull/7028/files for their deprecation warning :)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.13.2 (bb8ea18)

