### PR TITLE
git-lfs: update upstream link

### DIFF
--- a/pages.es/common/git-lfs.md
+++ b/pages.es/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Trabaja con archivos grandes en repositorios de Git.
-> Más información: <https://git-lfs.github.com>.
+> Más información: <https://git-lfs.com>.
 
 - Inicializa Git LFS:
 

--- a/pages.fr/common/git-lfs.md
+++ b/pages.fr/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Travailler dans un registre Git avec des fichiers volumineux.
-> Plus d'informations : <https://git-lfs.github.com>.
+> Plus d'informations : <https://git-lfs.com>.
 
 - Initialise le Git LFS :
 

--- a/pages.it/common/git-lfs.md
+++ b/pages.it/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Lavora con file di grandi dimensioni in repository Git.
-> Maggiori informazioni: <https://git-lfs.github.com>.
+> Maggiori informazioni: <https://git-lfs.com>.
 
 - Inizializza Git LFS:
 

--- a/pages.tr/common/git-lfs.md
+++ b/pages.tr/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Git depolarındaki büyük dosyalarla çalış.
-> Daha fazla bilgi için: <https://git-lfs.github.com>.
+> Daha fazla bilgi için: <https://git-lfs.com>.
 
 - Git LFS'i başlat:
 

--- a/pages/common/git-lfs.md
+++ b/pages/common/git-lfs.md
@@ -1,7 +1,7 @@
 # git lfs
 
 > Work with large files in Git repositories.
-> More information: <https://git-lfs.github.com>.
+> More information: <https://git-lfs.com>.
 
 - Initialize Git LFS:
 


### PR DESCRIPTION
https://git-lfs.github.com now redirects to https://git-lfs.com/.