### PR TITLE
pages*/common/*: fix broken links

### DIFF
--- a/pages.es/common/tree.md
+++ b/pages.es/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Muestra los contenidos del directorio actual en forma de árbol.
-> Más información: <http://mama.indstate.edu/users/ice/tree/>.
+> Más información: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
 
 - Imprime archivos y directorios hasta `num` niveles de profundidad (donde 1 significa el directorio actual):
 

--- a/pages.es/common/tree.md
+++ b/pages.es/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Muestra los contenidos del directorio actual en forma de árbol.
-> Más información: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
+> Más información: <https://manned.org/man/tree>.
 
 - Imprime archivos y directorios hasta `num` niveles de profundidad (donde 1 significa el directorio actual):
 

--- a/pages.it/common/tree.md
+++ b/pages.it/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Mostra i contenuti della directory corrente come un albero.
-> Maggiori informazioni: <http://mama.indstate.edu/users/ice/tree/>.
+> Maggiori informazioni: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
 
 - Stampa file e directory fino al 'num'-esimo livello di profondità (dove 1 significa la directory corrente):
 

--- a/pages.it/common/tree.md
+++ b/pages.it/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Mostra i contenuti della directory corrente come un albero.
-> Maggiori informazioni: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
+> Maggiori informazioni: <https://manned.org/man/tree>.
 
 - Stampa file e directory fino al 'num'-esimo livello di profondità (dove 1 significa la directory corrente):
 

--- a/pages.ko/common/virsh.md
+++ b/pages.ko/common/virsh.md
@@ -2,7 +2,7 @@
 
 > virsh 게스트 도메인을 관리합니다. (Note: 'guest_id'는 게스트의 아이디, 이름 또는 UUID일 수 있습니다).
 > `virsh list`와 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
-> 더 많은 정보: <https://libvirt.org/virshcmdref.html>.
+> 더 많은 정보: <https://libvirt.org/manpages/virsh.html>.
 
 - 하이퍼아비저 세션에 연결:
 

--- a/pages.pt_BR/common/virsh.md
+++ b/pages.pt_BR/common/virsh.md
@@ -2,7 +2,7 @@
 
 > Gerenciar domínios de convidados do virsh. (NOTA: 'guest_id' pode ser o ID, nome ou UUID do convidado).
 > Alguns subcomandos, como `virsh list`, têm sua própria documentação de uso.
-> Mais informações: <https://libvirt.org/virshcmdref.html>.
+> Mais informações: <https://libvirt.org/manpages/virsh.html>.
 
 - Conecta a uma sessão do hipervisor:
 

--- a/pages.tr/common/tree.md
+++ b/pages.tr/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Mevcut dizinin içeriğini ağaç biçiminde göster.
-> Daha fazla bilgi için: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
+> Daha fazla bilgi için: <https://manned.org/man/tree>.
 
 - Dosya ve dizinleri `num` değeri kadar derinlikte göster (1 olması durumunda mevcut dizin gösterilir):
 

--- a/pages.tr/common/tree.md
+++ b/pages.tr/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Mevcut dizinin içeriğini ağaç biçiminde göster.
-> Daha fazla bilgi için: <http://mama.indstate.edu/users/ice/tree/>.
+> Daha fazla bilgi için: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
 
 - Dosya ve dizinleri `num` değeri kadar derinlikte göster (1 olması durumunda mevcut dizin gösterilir):
 

--- a/pages.zh/common/tree.md
+++ b/pages.zh/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > 以树的形式显示当前目录的内容。
-> 更多信息：<http://oldmanprogrammer.net/source.php?dir=projects/tree>.
+> 更多信息：<https://manned.org/man/tree>.
 
 - 显示深度达到 “级数” 级的文件和目录（其中 1 表示当前目录）：
 

--- a/pages.zh/common/tree.md
+++ b/pages.zh/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > 以树的形式显示当前目录的内容。
-> 更多信息：<http://mama.indstate.edu/users/ice/tree/>.
+> 更多信息：<http://oldmanprogrammer.net/source.php?dir=projects/tree>.
 
 - 显示深度达到 “级数” 级的文件和目录（其中 1 表示当前目录）：
 

--- a/pages/common/sam2p.md
+++ b/pages/common/sam2p.md
@@ -1,7 +1,7 @@
 # sam2p
 
 > Raster (bitmap) image converter with smart PDF and PostScript (EPS) output.
-> More information: <http://pts.50.hu/sam2p/>.
+> More information: <https://github.com/pts/sam2p>.
 
 - Concatenate all PDF files into one:
 

--- a/pages/common/secrethub.md
+++ b/pages/common/secrethub.md
@@ -1,7 +1,7 @@
 # secrethub
 
 > Keep secrets out of config files.
-> More information: <https://secrethub.io>.
+> More information: <https://github.com/secrethub/secrethub-cli>.
 
 - Print a secret to `stdout`:
 

--- a/pages/common/slimrb.md
+++ b/pages/common/slimrb.md
@@ -1,7 +1,7 @@
 # slimrb
 
 > Convert Slim files to HTML.
-> More information: <https://rdoc.info/gems/slim/frames#slim-command-slimrb>.
+> More information: <https://rubydoc.info/gems/slim/frames#slim-command-slimrb>.
 
 - Convert a Slim file to HTML:
 

--- a/pages/common/spfquery.md
+++ b/pages/common/spfquery.md
@@ -1,7 +1,7 @@
 # spfquery
 
 > Query Sender Policy Framework records to validate e-mail senders.
-> More information: <https://www.libspf2.org/>.
+> More information: <https://manned.org/spfquery>.
 
 - Check if an IP address is allowed to send an e-mail from the specified e-mail address:
 

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Show the contents of the current directory as a tree.
-> More information: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
+> More information: <https://manned.org/man/tree>.
 
 - Print files and directories up to 'num' levels of depth (where 1 means the current directory):
 

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Show the contents of the current directory as a tree.
-> More information: <http://mama.indstate.edu/users/ice/tree/>.
+> More information: <http://oldmanprogrammer.net/source.php?dir=projects/tree>.
 
 - Print files and directories up to 'num' levels of depth (where 1 means the current directory):
 

--- a/pages/common/unison.md
+++ b/pages/common/unison.md
@@ -1,7 +1,7 @@
 # unison
 
 > Bidirectional file synchronisation tool.
-> More information: <https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html>.
+> More information: <https://github.com/bcpierce00/unison>.
 
 - Sync two directories (creates log first time these two directories are synchronized):
 

--- a/pages/common/virsh.md
+++ b/pages/common/virsh.md
@@ -2,7 +2,7 @@
 
 > Manage virsh guest domains. (Note: 'guest_id' can be the ID, name or UUID of the guest).
 > Some subcommands such as `virsh list` have their own usage documentation.
-> More information: <https://libvirt.org/virshcmdref.html>.
+> More information: <https://libvirt.org/manpages/virsh.html>.
 
 - Connect to a hypervisor session:
 

--- a/pages/common/wireplumber.md
+++ b/pages/common/wireplumber.md
@@ -2,7 +2,7 @@
 
 > A modular session/policy manager for PipeWire and a GObject-based high-level library that wraps PipeWire’s API.
 > See also: `wpctl`, `pipewire`.
-> More information: <https://pipewire.pages.freedesktop.org/wireplumber/running-wireplumber-daemon.html>.
+> More information: <https://pipewire.pages.freedesktop.org/wireplumber/>.
 
 - Make WirePlumber start with the user session immediately (for systemd systems):
 

--- a/pages/common/wpexec.md
+++ b/pages/common/wpexec.md
@@ -2,7 +2,7 @@
 
 > Run WirePlumber Lua scripts.
 > See also: `wpctl`, `wireplumber`.
-> More information: <https://pipewire.pages.freedesktop.org/wireplumber/lua_api/lua_introduction.html>.
+> More information: <https://pipewire.pages.freedesktop.org/wireplumber/scripting/lua_api/lua_introduction.html>.
 
 - Run a WirePlumber script:
 

--- a/pages/common/xdelta.md
+++ b/pages/common/xdelta.md
@@ -2,7 +2,7 @@
 
 > Delta encoding utility.
 > Often used for applying patches to binary files.
-> More information: <http://xdelta.org>.
+> More information: <https://github.com/jmacd/xdelta>.
 
 - Apply a patch:
 


### PR DESCRIPTION
This PR is a continuation of #12821.
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
