### PR TITLE
setenforce, {get,set}sebool, semanage-{boolean,port,permissive}: add page

### DIFF
--- a/pages/linux/getenforce.md
+++ b/pages/linux/getenforce.md
@@ -1,6 +1,7 @@
 # getenforce
 
 > Get the current mode of SELinux (i.e. enforcing, permissive, or disabled).
+> See also: `setenforce`, `semanage-permissive`.
 > More information: <https://manned.org/man/getenforce>.
 
 - Display the current mode of SELinux:

--- a/pages/linux/getsebool.md
+++ b/pages/linux/getsebool.md
@@ -1,0 +1,17 @@
+# getsebool
+
+> Get SELinux boolean value.
+> See also: `semanage-boolean`, `setsebool`.
+> More information: <https://manned.org/man/getsebool>.
+
+- Show the current setting of a boolean:
+
+`getsebool {{httpd_can_connect_ftp}}`
+
+- Show the current setting of [a]ll booleans:
+
+`getsebool -a`
+
+- Show the current setting of all booleans with explanations:
+
+`sudo semanage boolean {{-l|--list}}`

--- a/pages/linux/semanage-boolean.md
+++ b/pages/linux/semanage-boolean.md
@@ -1,0 +1,21 @@
+# semanage boolean
+
+> Manage persistent SELinux boolean settings.
+> See also: `semanage`, `getsebool`, `setsebool`.
+> More information: <https://manned.org/man/semanage-boolean>.
+
+- List all booleans settings:
+
+`sudo semanage boolean {{-l|--list}}`
+
+- List all user-defined boolean settings without headings:
+
+`sudo semanage boolean {{-l|--list}} {{-C|--locallist}} {{-n|--noheading}}`
+
+- Set or unset a boolean temporarily (non-persistent across reboot):
+
+`sudo setsebool {{httpd_can_network_connect}} {{1|true|on|0|false|off}}`
+
+- Set or unset a boolean persistently:
+
+`sudo semanage boolean {{-m|--modify}} {{-1|--on|-0|--off}} {{haproxy_connect_any}}`

--- a/pages/linux/semanage-boolean.md
+++ b/pages/linux/semanage-boolean.md
@@ -1,7 +1,7 @@
 # semanage boolean
 
 > Manage persistent SELinux boolean settings.
-> See also: `semanage`, `getsebool`, `setsebool`.
+> See also: `semanage` for managing SELinux policies, `getsebool` for checking boolean values, and `setsebool` for applying non-persistent boolean settings.
 > More information: <https://manned.org/man/semanage-boolean>.
 
 - List all booleans settings:
@@ -11,10 +11,6 @@
 - List all user-defined boolean settings without headings:
 
 `sudo semanage boolean {{-l|--list}} {{-C|--locallist}} {{-n|--noheading}}`
-
-- Set or unset a boolean temporarily (non-persistent across reboot):
-
-`sudo setsebool {{httpd_can_network_connect}} {{1|true|on|0|false|off}}`
 
 - Set or unset a boolean persistently:
 

--- a/pages/linux/semanage-permissive.md
+++ b/pages/linux/semanage-permissive.md
@@ -1,0 +1,14 @@
+# semanage permissive
+
+> Manage persistent SELinux permissive domains.
+> Note that this effectively makes the process unconfined. For long-term use, it is recommended to configure SELiunx properly.
+> See also: `semanage`, `getenforce`, `setenforce`.
+> More information: <https://manned.org/man/semanage-permissive>.
+
+- List all process types (a.k.a domains) that are in permissive mode:
+
+`sudo semanage permissive {{-l|--list}}`
+
+- Set or unset permissive mode for a domain:
+
+`sudo semanage permissive {{-a|--add|-d|--delete}} {{httpd_t}}`

--- a/pages/linux/semanage-port.md
+++ b/pages/linux/semanage-port.md
@@ -1,0 +1,21 @@
+# semanage port
+
+> Manage persistent SELinux port definitions.
+> See also: `semanage`.
+> More information: <https://manned.org/man/semanage-port>.
+
+- List all port labeling rules:
+
+`sudo semanage port {{-l|--list}}`
+
+- List all user-defined port labeling rules without headings:
+
+`sudo semanage port {{-l|--list}} {{-C|--locallist}} {{-n|--noheading}}`
+
+- Add a user-defined rule that assigns a label to a protocol-port pair:
+
+`sudo semanage port {{-a|--add}} {{-t|--type}} {{ssh_port_t}} {{-p|--proto}} {{tcp}} {{22000}}`
+
+- Delete a user-defined rule using its protocol-port pair:
+
+`sudo semanage port {{-d|--delete}} {{-p|--proto}} {{udp}} {{11940}}`

--- a/pages/linux/semanage.md
+++ b/pages/linux/semanage.md
@@ -1,6 +1,7 @@
 # semanage
 
 > SELinux persistent policy management tool.
+> Some subcommands such as `boolean`, `fcontext`, `port`, etc. have their own usage documentation.
 > More information: <https://manned.org/semanage>.
 
 - Set or unset a SELinux boolean. Booleans allow the administrator to customize how policy rules affect confined process types (a.k.a domains):

--- a/pages/linux/setenforce.md
+++ b/pages/linux/setenforce.md
@@ -1,0 +1,14 @@
+# setenforce
+
+> Toggle SELinux between enforcing and permissive modes.
+> To enable or disable SELinux, edit `/etc/selinux/config` instead.
+> See also: `getenforce`, `semanage-permissive`.
+> More information: <https://manned.org/man/setenforce>.
+
+- Put SELinux in enforcing mode:
+
+`setenforce {{1|Enforcing}}`
+
+- Put SELiunx in permissive mode:
+
+`setenforce {{0|Permissive}}`

--- a/pages/linux/setsebool.md
+++ b/pages/linux/setsebool.md
@@ -1,0 +1,25 @@
+# setsebool
+
+> Set SELinux boolean value.
+> See also: `semanage-boolean`, `getsebool`.
+> More information: <https://manned.org/man/setsebool>.
+
+- Show the current setting of [a]ll booleans:
+
+`getsebool -a`
+
+- Set or unset a boolean temporarily (non-persistent across reboot):
+
+`sudo setsebool {{httpd_can_network_connect}} {{1|true|on|0|false|off}}`
+
+- Set or unset a boolean [p]ersistently:
+
+`sudo setsebool -P {{container_use_devices}} {{1|true|on|0|false|off}}`
+
+- Set or unset multiple booleans [p]ersistently at once:
+
+`sudo setsebool -P {{ftpd_use_fusefs=1 mount_anyfile=0 ...}}`
+
+- Set or unset a boolean persistently (alternative method using `semanage-boolean`):
+
+`sudo semanage boolean {{-m|--modify}} {{-1|--on|-0|--off}} {{haproxy_connect_any}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `policycoreutils-python-utils-3.6`

I also updated `semanage.md` and `getenforce.md` to reference these new pages.