### PR TITLE
dotnet-add-reference: add examples for multiple references

### DIFF
--- a/pages/common/dotnet-add-reference.md
+++ b/pages/common/dotnet-add-reference.md
@@ -7,6 +7,14 @@
 
 `dotnet add reference {{path/to/reference.csproj}}`
 
+- Add multiple references to the project in the current directory:
+
+`dotnet add reference {{path/to/reference1.csproj path/to/reference2.csproj ...}}`
+
 - Add a reference to the specific project:
 
 `dotnet add {{path/to/project.csproj}} reference {{path/to/reference.csproj}}`
+
+- Add multiple references to the specific project:
+
+`dotnet add {{path/to/project.csproj}} reference {{path/to/reference1.csproj path/to/reference2.csproj ...}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): .NET Core 3.1 SDK and later versions**
