### PR TITLE
auditctl: add page

### DIFF
--- a/pages/linux/auditctl.md
+++ b/pages/linux/auditctl.md
@@ -1,4 +1,5 @@
 # auditctl
+
 > Utility to control the behavior, get status and manage rules of the Linux Auditing System.
 > More information: <https://manned.org/auditctl>.
 

--- a/pages/linux/auditctl.md
+++ b/pages/linux/auditctl.md
@@ -4,27 +4,27 @@
 
 - Display the [s]tatus of the audit system:
 
-`auditctl -s`
+`sudo auditctl -s`
 
 - [l]ist all currently loaded audit rules:
 
-`auditctl -l`
+`sudo auditctl -l`
 
 - [D]elete all audit rules:
 
-`auditctl -D`
+`sudo auditctl -D`
 
 - [e]nable/disable the audit system:
 
-`auditctl -e {{1|0}}`
+`sudo auditctl -e {{1|0}}`
 
 - Watch a file for changes:
 
-`auditctl -a always,exit -F arch=b64 -F path={{/path/to/file}} -F perm=wa`
+`sudo auditctl -a always,exit -F arch=b64 -F path={{/path/to/file}} -F perm=wa`
 
 - Recursively watch a directory for changes:
 
-`auditctl -a always,exit -F arch=b64 -F dir={{/path/to/directory/}} -F perm=wa`
+`sudo auditctl -a always,exit -F arch=b64 -F dir={{/path/to/directory/}} -F perm=wa`
 
 - Display [h]elp:
 

--- a/pages/linux/auditctl.md
+++ b/pages/linux/auditctl.md
@@ -1,0 +1,31 @@
+# auditctl
+> Utility to control the behavior, get status and manage rules of the Linux Auditing System.
+> More information: <https://manned.org/auditctl>.
+
+- Display the [s]tatus of the audit system:
+
+`auditctl -s`
+
+- [l]ist all currently loaded audit rules:
+
+`auditctl -l`
+
+- [D]elete all audit rules:
+
+`auditctl -D`
+
+- [e]nable/disable the audit system:
+
+`auditctl -e {{1|0}}`
+
+- Watch a file for changes:
+
+`auditctl -a always,exit -F arch=b64 -F path={{/path/to/file}} -F perm=wa`
+
+- Recursively watch a directory for changes:
+
+`auditctl -a always,exit -F arch=b64 -F dir={{/path/to/directory/}} -F perm=wa`
+
+- Display [h]elp:
+
+`auditctl -h`


### PR DESCRIPTION
Hi. This PR adds a page for `auditctl` under `linux` directory.
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 4.0.1
