### PR TITLE
pages/common/*: replace command examples with unportable shell syntax

### DIFF
--- a/pages/common/comm.md
+++ b/pages/common/comm.md
@@ -21,4 +21,4 @@
 
 - Print lines only found in second file, when the files aren't sorted:
 
-`comm -13 <(sort {{file1}}) <(sort {{file2}})`
+`comm -13 {{path/to/sorted_file1}} {{path/to/sorted_file2}}`

--- a/pages/common/dnsx.md
+++ b/pages/common/dnsx.md
@@ -11,7 +11,7 @@
 
 - Query all the DNS records (A, AAAA, CNAME, NS, TXT, SRV, PTR, MX, SOA, AXFR, CAA):
 
-`dnsx -recon -re <<< {{example.com}}`
+`echo {{example.com}} | dnsx -recon -re`
 
 - Query a specific type of DNS record:
 

--- a/pages/common/for.md
+++ b/pages/common/for.md
@@ -9,7 +9,7 @@
 
 - Iterate over a given range of numbers:
 
-`for {{variable}} in {{{from}}..{{to}}..{{step}}}; do {{echo "Loop is executed"}}; done`
+`for {{variable}} in $(seq {from} {to} {step}); do {{echo "Loop is executed"}}; done`
 
 - Iterate over a given list of files:
 

--- a/pages/common/git-filter-repo.md
+++ b/pages/common/git-filter-repo.md
@@ -6,7 +6,7 @@
 
 - Replace a sensitive string in all files:
 
-`git filter-repo --replace-text <(echo '{{find}}==>{{replacement}}')`
+`git filter-repo --replace-text {{path/to/file_with_string}}`
 
 - Extract a single folder, keeping history:
 

--- a/pages/common/ifs.md
+++ b/pages/common/ifs.md
@@ -14,7 +14,7 @@
 
 - Reset IFS to default:
 
-`IFS=$' \t\n'`
+`IFS='<Space><Tab><Newline>'`
 
 - Temporarily change the IFS value in a subshell:
 

--- a/pages/common/md-to-clip.md
+++ b/pages/common/md-to-clip.md
@@ -14,7 +14,7 @@
 
 - Convert a tldr-page file to `stdout`:
 
-`md-to-clip --no-file-save <(echo '{{page-content}}')`
+`md-to-clip --no-file-save < {{path/to/page.md}}`
 
 - Convert tldr-pages files while recognizing additional placeholders from a specific config:
 

--- a/pages/common/sops.md
+++ b/pages/common/sops.md
@@ -29,4 +29,4 @@
 
 - Show the difference between two `sops` files:
 
-`diff <(sops -d {{path/to/secret1.enc.yaml}}) <(sops -d {{path/to/secret2.enc.yaml}})`
+`diff {{path/to/sops_file1}} {{path/to/sops_file2}}`

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -17,4 +17,4 @@
 
 - Create a directory called "example", count the number of characters in "example" and write "example" to the terminal:
 
-`echo "example" | tee >(xargs mkdir) >(wc -c)`
+`dir_name="{{example}}"; echo "${dir_name}"; mkdir -- "${dir_name}"; echo "${#dir_name}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

As proposed in #12694, I think the command examples of pages in the directory `common` must adhere to the latest POSIX standard to have some degree of certainty that the commands will function properly in many shells.

To find pages with unportable syntax, I used the following:

```shell
#!/usr/bin/env bash

codes=(SC{3000..4000})

for f in pages/common/*.md; do
    echo "Page: ${f}"
    grep -Ex '`.+`' -- "${f}" | sed 's/`//g' | shellcheck -i "$(echo "${codes[@]}" | tr " " ",")" -s sh -f gcc -
done
```

- Process substitution:

```shell
grep -FR --exclude-dir=pages.en '<(' pages*
```

- Extended globs:

```shell
grep -RE --exclude-dir=pages.en '[?*+@!]\(.*\)' pages*
```

- `function` keyword
 
```shell
grep -RE --exclude-dir=pages.en 'function [A-Za-z0-9_]+(\(\))?' pages*
```

- "File slurps" [^1]:

```shell
grep -RExl --exclude-dir=pages.en '`.*\$\(<.*\).*`' pages*
```   

It is worth noting that the `grep` commands and the script are nowhere near foolproof, I encountered many false positives, especially about brace expansions. Therefore, there are probably more pages out there with unportable shell syntax.

[^1]: https://mywiki.wooledge.org/Bashism#Syntax