### PR TITLE
feat/ci: add support for attesting release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on: ['push', 'pull_request']
 
-permissions:
-  contents: write # to upload assets to releases
-
 jobs:
   ci:
-    runs-on: ubuntu-latest
-
     name: CI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload assets to releases
+      attestations: write # to upload assets attestation for build provenance
+      id-token: write # grant additional permission to attestation action to mint the OIDC token permission
 
     steps:
     - uses: actions/checkout@v4
@@ -53,3 +53,35 @@ jobs:
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check for generated files
+      id: check-files
+      run: |
+        echo "zip_exists=$(if [[ $(find language_archives -name '*.zip' | wc -l) -gt 0 ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
+        echo "pdf_exists=$(if [[ $(find scripts/pdf -name '*.pdf' | wc -l) -gt 0 ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
+        echo "checksums_exists=$(if [[ -f 'tldr.sha256sums' ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
+
+    - name: Construct subject-path for attest action
+      id: construct-subject-path
+      run: |
+        subject_path=""
+        if [[ ${{ env.zip_exists }} == 'true' ]]; then
+          zip_files=$(find language_archives -name '*.zip' -printf '%p,')
+          subject_path+="${zip_files::-1}"
+        fi
+        if [[ ${{ env.pdf_exists }} == 'true' ]]; then
+          if [[ -n $subject_path ]]; then subject_path+=","; fi
+          pdf_files=$(find scripts/pdf -name '*.pdf' -printf '%p,')
+          subject_path+="${pdf_files::-1}"
+        fi
+        if [[ ${{ env.checksums_exists }} == 'true' ]]; then
+          if [[ -n $subject_path ]]; then subject_path+=","; fi
+          subject_path+='tldr.sha256sums'
+        fi
+        echo "subject_path=$subject_path" >> $GITHUB_ENV
+
+    - name: Attest generated files
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true # prevent failing when no pages are modified
+      with:
+        subject-path: ${{ env.subject_path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,23 @@ jobs:
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: check-files
       run: |
-        echo "zip_exists=$(if [[ $(find language_archives -name '*.zip' | wc -l) -gt 0 ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
-        echo "pdf_exists=$(if [[ $(find scripts/pdf -name '*.pdf' | wc -l) -gt 0 ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
-        echo "checksums_exists=$(if [[ -f 'tldr.sha256sums' ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
+if [[ -n $(find language_archives -name "*.zip" -print -quit) ]]; then
+    echo "zip_exists=true" >> $GITHUB_ENV
+else
+    echo "zip_exists=false" >> $GITHUB_ENV
+fi
+
+if [[ -n $(find scripts/pdf -name "*.pdf" -print -quit) ]]; then
+    echo "pdf_exists=true" >> $GITHUB_ENV
+else
+    echo "pdf_exists=false" >> $GITHUB_ENV
+fi
+
+if [[ -f tldr.sha256sums ]]; then
+    echo "checksums_exist=true" >> $GITHUB_ENV
+else
+    echo "checksums_exist=false" >> $GITHUB_ENV
+fi
 
     - name: Construct subject-path for attest action
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
@@ -76,7 +90,7 @@ jobs:
           pdf_files=$(find scripts/pdf -name '*.pdf' -printf '%p,')
           subject_path+="${pdf_files::-1}"
         fi
-        if [[ ${{ env.checksums_exists }} == 'true' ]]; then
+        if [[ ${{ env.checksums_exist }} == 'true' ]]; then
           if [[ -n $subject_path ]]; then subject_path+=","; fi
           subject_path+='tldr.sha256sums'
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,23 +58,23 @@ jobs:
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: check-files
       run: |
-if [[ -n $(find language_archives -name "*.zip" -print -quit) ]]; then
-    echo "zip_exists=true" >> $GITHUB_ENV
-else
-    echo "zip_exists=false" >> $GITHUB_ENV
-fi
+        if [[ -n $(find language_archives -name "*.zip" -print -quit) ]]; then
+            echo "zip_exists=true" >> $GITHUB_ENV
+        else
+            echo "zip_exists=false" >> $GITHUB_ENV
+        fi
 
-if [[ -n $(find scripts/pdf -name "*.pdf" -print -quit) ]]; then
-    echo "pdf_exists=true" >> $GITHUB_ENV
-else
-    echo "pdf_exists=false" >> $GITHUB_ENV
-fi
+        if [[ -n $(find scripts/pdf -name "*.pdf" -print -quit) ]]; then
+            echo "pdf_exists=true" >> $GITHUB_ENV
+        else
+            echo "pdf_exists=false" >> $GITHUB_ENV
+        fi
 
-if [[ -f tldr.sha256sums ]]; then
-    echo "checksums_exist=true" >> $GITHUB_ENV
-else
-    echo "checksums_exist=false" >> $GITHUB_ENV
-fi
+        if [[ -f tldr.sha256sums ]]; then
+            echo "checksums_exist=true" >> $GITHUB_ENV
+        else
+            echo "checksums_exist=false" >> $GITHUB_ENV
+        fi
 
     - name: Construct subject-path for attest action
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             echo "checksums_exist=false" >> $GITHUB_ENV
         fi
 
-    - name: Construct subject-path for attest action
+    - name: Construct subject-path for attest
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: construct-subject-path
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check for generated files
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: check-files
       run: |
         echo "zip_exists=$(if [[ $(find language_archives -name '*.zip' | wc -l) -gt 0 ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
@@ -62,6 +63,7 @@ jobs:
         echo "checksums_exists=$(if [[ -f 'tldr.sha256sums' ]]; then echo true; else echo false; fi)" >> $GITHUB_ENV
 
     - name: Construct subject-path for attest action
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: construct-subject-path
       run: |
         subject_path=""
@@ -81,6 +83,8 @@ jobs:
         echo "subject_path=$subject_path" >> $GITHUB_ENV
 
     - name: Attest generated files
+      if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
+      id: attest
       uses: actions/attest-build-provenance@v1
       continue-on-error: true # prevent failing when no pages are modified
       with:

--- a/.github/workflows/copy-release-assets.yml
+++ b/.github/workflows/copy-release-assets.yml
@@ -4,28 +4,46 @@ on:
   release:
     types: published
 
-permissions:
-  contents: write
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   release:
-    name: Copy assets to the new release
+    name: copy-release-assets
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload assets to releases
+      attestations: write # to upload assets attestation for build provenance
+      id-token: write # grant additional permission to attestation action to mint the OIDC token permission
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download and upload
+      - name: Set tag names
         run: |
-          LATEST="$(git describe --tags --abbrev=0)"
-          PREVIOUS="$(git describe --tags --abbrev=0 "$LATEST"^)"
+          echo "LATEST=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          echo "PREVIOUS=$(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)" >> $GITHUB_ENV
 
+      - name: Download assets
+        run: |
           mkdir release-assets && cd release-assets
-
           gh release download "$PREVIOUS"
-          gh release upload "$LATEST" -- *
+
+      - name: Construct subject-path for attest action
+        id: construct-subject-path
+        run: |
+          zip_files=$(find release-assets -name '*.zip' -printf '%p,')
+          pdf_files=$(find release-assets -name '*.pdf' -printf '%p,')
+          subject_path="${zip_files::-1},${pdf_files::-1},release-assets/tldr.sha256sums"
+          echo "subject_path=$subject_path" >> $GITHUB_ENV
+
+      - name: Attest copied assets
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ env.subject_path }}
+
+      - name: Upload assets
+        working-directory: release-assets
+        run: gh release upload "$LATEST" -- *

--- a/.github/workflows/copy-release-assets.yml
+++ b/.github/workflows/copy-release-assets.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   release:
-    name: copy-release-assets
+    name: Copy release assets
     runs-on: ubuntu-latest
     permissions:
       contents: write # to upload assets to releases
@@ -32,6 +32,7 @@ jobs:
           gh release download "$PREVIOUS"
 
       - name: Construct subject-path for attest action
+        if: github.repository == 'tldr-pages/tldr'
         id: construct-subject-path
         run: |
           zip_files=$(find release-assets -name '*.zip' -printf '%p,')
@@ -40,10 +41,13 @@ jobs:
           echo "subject_path=$subject_path" >> $GITHUB_ENV
 
       - name: Attest copied assets
+        if: github.repository == 'tldr-pages/tldr'
+        id: attest
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: ${{ env.subject_path }}
 
       - name: Upload assets
+        if: github.repository == 'tldr-pages/tldr'
         working-directory: release-assets
         run: gh release upload "$LATEST" -- *

--- a/.github/workflows/copy-release-assets.yml
+++ b/.github/workflows/copy-release-assets.yml
@@ -31,7 +31,7 @@ jobs:
           mkdir release-assets && cd release-assets
           gh release download "$PREVIOUS"
 
-      - name: Construct subject-path for attest action
+      - name: Construct subject-path for attest
         if: github.repository == 'tldr-pages/tldr'
         id: construct-subject-path
         run: |


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Description (TLDR)

This PR adds support for attesting release artefacts both in our regular CI workflow and also for the copy assets workflow (which executes after we publish a release).

## Motive

Currently, at tldr, we are migrating to providing our assets only via GitHub releases (which allows us to update assets in a non-git way, dynamically).

 While this increases ease of use, it opens up a **glaring security issue** as it allows for any collaborator to update the assets (including the checksum) without a trace [and yep GitHub organization logs don't document Release assets modifications/uploads], causing us to have no idea which assets are tampered with (in case of a misuse/security incident).

Our current governance process facilitates inviting new collaborators/maintainers to this repository with write access (they are by default provided permission with modifying release assets). While we can't modify this workflow we can implement some safeguards by introducing a SLSA procedure.

> [!NOTE]
> SLSA (Supply chain Levels for Software Artifacts), is a security framework consisting of standards and controls that prevent tampering, improve integrity, and secure packages and infrastructure.

## Details

In this PR I am implementing support for GitHub attestations (using the `actions/attest-build-provenance` action) which allows maintaining a paper trail of the generated artefacts with detailed information on when the asset was generated/attested and who triggered it, etc. This information is stored in the form of Cosign bundles in Sigstore's public instance (Rekor IG, and the cert is from Fulcio). Feel free to check out <https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/> to know more about how it works.

Once this PR is merged, the generated attestations can be found at <https://github.com/tldr-pages/tldr/attestations>. You can see some sample attestations in [my fork](https://github.com/kbdkorg/tldr/attestations).

And this is how an [attestation generally](https://github.com/kbdkorg/tldr/attestations/928043) looks:

![image](https://github.com/tldr-pages/tldr/assets/26346867/ec8d84c7-41de-4894-b1c4-5659c3ab5b7b)

![image](https://github.com/tldr-pages/tldr/assets/26346867/3b5ce9ee-5365-433e-9b60-693e63507e6c)


> [!IMPORTANT]
> While atm, we can only validate the assets using `gh` (GitHub CLI), in future, we can implement a workflow to create an issue/alert the maintainers if we detect something is unverified.

## Changes

I have tested all the changes in my forks, this is the detailed changelog:

- In `ci.yml`:
  - Added new permissions for the attest action.
  - Added step for checking if files are generated.
  - Added a step to construct the file path, to generate paths for the available files to pass to the attest action.
  - Added a step to attest published release files (from CI) [**Note**: If no files are generated when modifying something like README, then the workflow will still pass, as I have configured continue on error.]

- In `copy-release-assets.yml`:
  - Added new permissions for the attest action.
  - Moved `LATEST` and `PREVIOUS` to a separate tag step and added them as GitHub Environment variables.
  - Added a step to construct the file path, to generate paths for the available files to pass to the attest action.
  - Added step to attest copied release files.
