### PR TITLE
tor: remove duplicate and update link

### DIFF
--- a/pages/linux/tor.md
+++ b/pages/linux/tor.md
@@ -15,6 +15,10 @@
 
 `tor --status`
 
+- Run as client only:
+
+`tor --client`
+
 - Run as relay:
 
 `tor --relay`

--- a/pages/linux/tor.md
+++ b/pages/linux/tor.md
@@ -7,10 +7,6 @@
 
 `tor`
 
-- Start a Tor relay:
-
-`tor --relay`
-
 - View Tor configuration:
 
 `tor --config`

--- a/pages/linux/tor.md
+++ b/pages/linux/tor.md
@@ -1,7 +1,7 @@
 # tor
 
 > Enable anonymous communication through the Tor network.
-> More information: <https://manned.org/man/tor>.
+> More information: <https://manned.org/tor>.
 
 - Connect to the Tor network:
 
@@ -18,10 +18,6 @@
 - Check Tor status:
 
 `tor --status`
-
-- Run as client only:
-
-`tor --client`
 
 - Run as relay:
 


### PR DESCRIPTION
In this PR I removed the duplicate ( by default, tor acts as a client only). I also updated the link (removed the unnecessary `man/`).
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
