### PR TITLE
pylint: add package and module examples

### DIFF
--- a/pages/common/pylint.md
+++ b/pages/common/pylint.md
@@ -7,6 +7,14 @@
 
 `pylint {{path/to/file.py}}`
 
+- Lint a package or module (must be importable; no `.py` suffix):
+
+`pylint {{package_or_module}}`
+
+- Lint a package from a directory path (must contain an `__init__.py` file):
+
+`pylint {{path/to/directory}}`
+
 - Lint a file and use a configuration file (usually named `pylintrc`):
 
 `pylint --rcfile {{path/to/pylintrc}} {{path/to/file.py}}`


### PR DESCRIPTION
The provided examples do not provide examples on how to lint packages and modules which is a common use-case. The added examples follow the recommended usage according to pylint docs.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):3.2.2
