### PR TITLE
virt-qemu-run: add page

### DIFF
--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,8 +1,8 @@
 # virt-qemu-run
 
-Experimental tool to run a QEMU Guest VM independent of libvirtd.
+> Experimental tool to run a QEMU Guest VM independent of libvirtd.
 
-More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
+> More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
 
 - Run a QEMU virtual machine:
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,6 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of libvirtd.
->
 > More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
 
 - Run a QEMU virtual machine:

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,0 +1,21 @@
+# virt-qemu-run
+
+Experimental tool to run a QEMU Guest VM independent of libvirtd.
+
+More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
+
+- Run a QEMU virtual machine:
+
+`virt-qemu-run {{path/to/guest.xml}}`
+
+- Run a QEMU virtual machine and store the state in a specified directory:
+
+`virt-qemu-run --root={{path/to/directory}} {{path/to/guest.xml}}`
+
+- Run a QEMU virtual machine and display verbose information about startup:
+
+`virt-qemu-run --verbose {{path/to/guest.xml}}`
+
+- Display help:
+
+`virt-qemu-run --help`

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,7 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of libvirtd.
-> More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
+> More information: <https://manned.org/man/virt-qemu-run>
 
 - Run a QEMU virtual machine:
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -7,7 +7,7 @@
 
 `virt-qemu-run {{path/to/guest.xml}}`
 
-- Run a QEMU virtual machine and store the state in a specified directory:
+- Run a QEMU virtual machine and store the state in a specific directory:
 
 `virt-qemu-run --root={{path/to/directory}} {{path/to/guest.xml}}`
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,7 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of `libvirtd`.
-> More information: <https://manned.org/virt-qemu-run>.
+> More information: <https://libvirt.org/manpages/virt-qemu-run.html>.
 
 - Run a QEMU virtual machine:
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,7 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of libvirtd.
-> More information: <https://manned.org/man/virt-qemu-run>
+> More information: <https://manned.org/man/virt-qemu-run>.
 
 - Run a QEMU virtual machine:
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -11,7 +11,7 @@
 
 `virt-qemu-run --root={{path/to/directory}} {{path/to/guest.xml}}`
 
-- Run a QEMU virtual machine and display verbose information about startup:
+- Run a QEMU virtual machine and display verbose information about the startup:
 
 `virt-qemu-run --verbose {{path/to/guest.xml}}`
 

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,7 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of libvirtd.
-
+>
 > More information: [https://manned.org/man/virt-qemu-run](https://manned.org/man/virt-qemu-run)
 
 - Run a QEMU virtual machine:

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,6 +1,6 @@
 # virt-qemu-run
 
-> Experimental tool to run a QEMU Guest VM independent of libvirtd.
+> Experimental tool to run a QEMU Guest VM independent of `libvirtd`.
 > More information: <https://manned.org/virt-qemu-run>.
 
 - Run a QEMU virtual machine:

--- a/pages/common/virt-qemu-run.md
+++ b/pages/common/virt-qemu-run.md
@@ -1,7 +1,7 @@
 # virt-qemu-run
 
 > Experimental tool to run a QEMU Guest VM independent of libvirtd.
-> More information: <https://manned.org/man/virt-qemu-run>.
+> More information: <https://manned.org/virt-qemu-run>.
 
 - Run a QEMU virtual machine:
 


### PR DESCRIPTION
Added virt-qemu-run tldr page

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

For #5425 