### PR TITLE
devenv: add page

### DIFF
--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -19,7 +19,7 @@
 
 `devenv up --config /{{file}}/{{path}}/`
 
-- Clean environment variables and re-enter shell in offline mode:
+- Clean the environment variables and re-enter the shell in offline mode:
 
 `devenv --clean --offline`
 

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -23,6 +23,6 @@
 
 `devenv --clean --offline`
 
-- Delete previous shell generations:
+- Delete the previous shell generations:
 
 `devenv gc`

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -1,8 +1,7 @@
 # devenv
 
 > Fast, Declarative, Reproducible and Composable Developer Environments using Nix.
-> More information: <https://devenv.sh/>.
-> GitHub repository: <https://github.com/cachix/devenv>.
+> Website/Docs: <https://devenv.sh/>. GitHub repository: <https://github.com/cachix/devenv>.
 
 - Initialise environment
 `devenv init`

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -3,7 +3,7 @@
 > Fast, Declarative, Reproducible and Composable Developer Environments using Nix.
 > More information: <https://devenv.sh>.
 
-- Initialise environment:
+- Initialise the environment:
 
 `devenv init`
 

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -25,7 +25,3 @@
 - Delete previous shell generations
 
 `devenv gc`
-
-- Build, copy, or run a container
-
-`devenv container <build|copy|run> {{container_name}}`

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -15,7 +15,7 @@
 
 `devenv info --verbose`
 
-- Start processes with devenv CLI:
+- Start processes with `devenv`:
 
 `devenv up --config /{{file}}/{{path}}/`
 

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -7,7 +7,7 @@
 
 `devenv init`
 
-- Enter Development Environment with relaxed hermeticity:
+- Enter the Development Environment with relaxed hermeticity (state of being airtight):
 
 `devenv shell --impure`
 

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -1,0 +1,31 @@
+# devenv
+
+> Fast, Declarative, Reproducible and Composable Developer Environments using Nix.
+> More information: <https://devenv.sh/>.
+> GitHub repository: <https://github.com/cachix/devenv>.
+
+- Initialise environment
+`devenv init`
+
+- Enter Development Environment with relaxed hermeticity
+`devenv shell --impure`
+
+- Get detailed information about the current environment
+
+`devenv info --verbose`
+
+- Start processes with devenv CLI
+
+`devenv up --config /{{file}}/{{path}}/`
+
+- Clean environment variables and re-enter shell in offline mode
+
+`devenv --clean --offline`
+
+- Delete previous shell generations
+
+`devenv gc`
+
+- Build, copy, or run a container
+
+`devenv container <build|copy|run> {{container_name}}`

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -3,24 +3,26 @@
 > Fast, Declarative, Reproducible and Composable Developer Environments using Nix.
 > Website/Docs: <https://devenv.sh/>. GitHub repository: <https://github.com/cachix/devenv>.
 
-- Initialise environment
+- Initialise environment:
+
 `devenv init`
 
-- Enter Development Environment with relaxed hermeticity
+- Enter Development Environment with relaxed hermeticity:
+
 `devenv shell --impure`
 
-- Get detailed information about the current environment
+- Get detailed information about the current environment:
 
 `devenv info --verbose`
 
-- Start processes with devenv CLI
+- Start processes with devenv CLI:
 
 `devenv up --config /{{file}}/{{path}}/`
 
-- Clean environment variables and re-enter shell in offline mode
+- Clean environment variables and re-enter shell in offline mode:
 
 `devenv --clean --offline`
 
-- Delete previous shell generations
+- Delete previous shell generations:
 
 `devenv gc`

--- a/pages/common/devenv.md
+++ b/pages/common/devenv.md
@@ -1,7 +1,7 @@
 # devenv
 
 > Fast, Declarative, Reproducible and Composable Developer Environments using Nix.
-> Website/Docs: <https://devenv.sh/>. GitHub repository: <https://github.com/cachix/devenv>.
+> More information: <https://devenv.sh>.
 
 - Initialise environment:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** devenv 1.0.5 (x86_64-linux)

however devenv supports multiple architectures thus `common` is most suitable place for it.
