### PR TITLE
toipe: add page

### DIFF
--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -16,6 +16,6 @@
 
 `toipe {{-f|--file}} {{path/to/file}}`
 
-- Specify number of words on each test:
+- Specify the number of words on each test:
 
 `toipe {{-n|--num}} {{number_of_words}}`

--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -1,0 +1,21 @@
+# toipe
+
+> Yet another typing test, but crab flavoured.
+> A trusty terminal typing tester.
+> More information: <https://github.com/Samyak2/toipe>.
+
+- Start typing test with default wordlist:
+
+`toipe`
+
+- Use a specific wordlist:
+
+`toipe -w/--wordlist {{wordlist_name}}`
+
+- Use a custom wordlist:
+
+`toipe -f/--file {{file_path}}`
+
+- Specify number of words on each test:
+
+`toipe -n/--num {{number_of_words}}`

--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -4,7 +4,7 @@
 > A trusty terminal typing tester.
 > More information: <https://github.com/Samyak2/toipe>.
 
-- Start typing test with default wordlist:
+- Start the typing test with the default wordlist:
 
 `toipe`
 
@@ -14,7 +14,7 @@
 
 - Use a custom wordlist:
 
-`toipe {{-f|--file}} {{file_path}}`
+`toipe {{-f|--file}} {{path/to/file}}`
 
 - Specify number of words on each test:
 

--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -10,12 +10,12 @@
 
 - Use a specific wordlist:
 
-`toipe -w/--wordlist {{wordlist_name}}`
+`toipe {{-w|--wordlist}} {{wordlist_name}}`
 
 - Use a custom wordlist:
 
-`toipe -f/--file {{file_path}}`
+`toipe {{-f|--file}} {{file_path}}`
 
 - Specify number of words on each test:
 
-`toipe -n/--num {{number_of_words}}`
+`toipe {{-n|--num}} {{number_of_words}}`


### PR DESCRIPTION
Toipe is a terminal typing test built in rust.

- [x] The page(s) are in the correct platform directories: `common`
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
