### PR TITLE
waybar: add page

### DIFF
--- a/pages/linux/waybar.md
+++ b/pages/linux/waybar.md
@@ -3,7 +3,7 @@
 > Highly customizable Wayland bar for Sway and Wlroots based compositors.
 > More information: <https://github.com/Alexays/Waybar>.
 
-- Start waybar with default configuration and stylesheet:
+- Start `waybar` with the default configuration and stylesheet:
 
 `waybar`
 
@@ -15,6 +15,6 @@
 
 `waybar {{-s|--style}} {{path/to/stylesheet}}`
 
-- Set the logging level for waybar:
+- Set the logging level:
 
 `waybar {{-l|--log-level}} {{trace|debug|info|warning|error|critical|off}}`

--- a/pages/linux/waybar.md
+++ b/pages/linux/waybar.md
@@ -1,0 +1,20 @@
+# waybar
+
+> Highly customizable Wayland bar for Sway and Wlroots based compositors.
+> More information: <https://github.com/Alexays/Waybar>.
+
+- Start waybar with default configuration and stylesheet:
+
+`waybar`
+
+- Use a different configuration file:
+
+`waybar {{-c|--config}} {{path/to/config}}`
+
+- Use a different stylesheet file:
+
+`waybar {{-s|--style}} {{path/to/stylesheet}}`
+
+- Set the logging level for waybar:
+
+`waybar {{-l|--log-level}} {{trace|debug|info|warning|error|critical|off}}`


### PR DESCRIPTION
Waybar is a highly customizable Wayland bar for Sway and Wlroots based compositors.

- [x] The page(s) are in the correct platform directories: `common`
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
