### PR TITLE
toipe: add example

### DIFF
--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -19,3 +19,7 @@
 - Specify the number of words on each test:
 
 `toipe {{-n|--num}} {{number_of_words}}`
+
+- Include punctuation:
+
+`toipe {{-p|--punctuation}}`


### PR DESCRIPTION
In [0.5.0](https://github.com/Samyak2/toipe/releases/tag/v0.5.0) update `--punctuation` option was added to `toipe` so I added an example for this option.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.5.0
