### PR TITLE
pw-dot: update page

### DIFF
--- a/pages/linux/pw-dot.md
+++ b/pages/linux/pw-dot.md
@@ -14,7 +14,7 @@
 
 - Specify an [o]utput file, showing [a]ll object types:
 
-`pw-dot --output {{path/to/file.dot}} --all`
+`pw-dot --output {{path/to/file.dot}} {{-a|--all}}`
 
 - Print `.dot` graph to `stdout`, showing all object properties:
 

--- a/pages/linux/pw-dot.md
+++ b/pages/linux/pw-dot.md
@@ -8,22 +8,30 @@
 
 `pw-dot`
 
-- Specify an output file, showing all object types:
+- Read objects from `pw-dump` JSON file:
+
+`pw-dot {{-j|--json}} {{path/to/file.json}}`
+
+- Specify an [o]utput file, showing [a]ll object types:
 
 `pw-dot --output {{path/to/file.dot}} --all`
 
 - Print `.dot` graph to `stdout`, showing all object properties:
 
-`pw-dot --output - --detail`
+`pw-dot --output - {{-d|--detail}}`
 
-- Generate a graph from a remote instance, showing only linked objects:
+- Generate a graph from a [r]emote instance, showing only linked objects:
 
-`pw-dot --remote {{remote_name}} --smart`
+`pw-dot --remote {{remote_name}} {{-s|--smart}}`
 
-- Lay the graph from left to right, instead of dot's default top to bottom:
+- Lay the graph from [l]eft to [r]ight, instead of dot's default top to bottom:
 
-`pw-dot --lr`
+`pw-dot {{-L|--lr}}`
 
 - Lay the graph using 90-degree angles in edges:
 
-`pw-dot --90`
+`pw-dot {{-9|--90}}`
+
+- Display help:
+
+`pw-dot --help`


### PR DESCRIPTION
Hi. I added the short options and short option mnemonics. I also added examples about `--help` and `--json`. The `--json` option seems to not be included in the manual page but is present in the help (Fedora 40).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `Compiled with libpipewire 1.0.6`
