### PR TITLE
style-guide: document use of POSIX-compliant shell syntax

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -390,6 +390,42 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ## Example commands
 
+- The examples of pages in the subdirectory `common` for UNIX-like operating systems (e.g. `pages/common/tar.md`), preferably, should be written with the shell syntax specified by the [latest POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18).
+  However, if you believe the example is hard to read, has little to no use, or is impossible to write in POSIX-compliant syntax, use non-POSIX syntax and add a note or warning indicating it and some or all of its consequences concisely and specifically. For example:
+
+  ```md
+  # IFS
+
+  > IFS (Internal Field Separator) is a special environment variable that defines the delimiter used for word splitting in Unix shells.
+  > The default value of IFS is a space, tab, and newline. The three characters serve as delimiters.
+  > Note: Not all shells suport ANSI C quoted strings (i.e., $'...' and $"..."), the dollar sign could be included in the string.
+  > More information: <https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html>.
+  ```
+
+  To help you decide using POSIX-compliant syntax, ask yourself this:
+
+  - Is the example too long (i.e. [exceeds the maximum line length](https://github.com/tldr-pages/tldr/blob/main/.markdownlint.json#L5))?
+  - Does the example utilize any [risky](https://unix.stackexchange.com/a/278439) or [inefficient](https://unix.stackexchange.com/a/169765) commands?
+  - Does the example return the correct output?
+
+  **Bad example**:
+
+  *Fails with pathnames ending with trailing slashes*
+
+  ```markdown
+  - Get basename of UNIX pathname:
+
+  `echo "${{{pathname}}##*/}"`
+  ```
+
+  **Good example**:
+
+  ```md
+  - Get basename of UNIX pathname:
+
+  `basename "${{{pathname}}}"`
+  ```
+
 ### Option syntax
 
 - For commonly/frequently used commands (e.g. `grep`, `tar`, `etc`), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [N/A] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [N/A] The page(s) have at most 8 examples.
- [N/A] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A
 
Closes #12694.

I decided to suggest rather than obliging users to write command examples with POSIX-compliant shell syntax because I  and probably other reviewers will agree that some pages could become less useful in the long run. 
