### PR TITLE
gzip: split unrelated options into multiple placeholders

### DIFF
--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -21,12 +21,12 @@
 
 - Decompress a `gzip` archive specifying the output filename:
 
-`gzip {{-c|--stdout -d|--decompress path/to/file.gz}} > {{path/to/uncompressed_file}}`
+`gzip {{-c|--stdout}} {{-d|--decompress}} {{path/to/file.gz}} > {{path/to/uncompressed_file}}`
 
 - Specify the compression level. 1 is the fastest (low compression), 9 is the slowest (high compression), 6 is the default:
 
-`gzip -{{1..9 -c|--stdout path/to/file}} > {{path/to/compressed_file.gz}}`
+`gzip -{{1..9}} {{-c|--stdout}} {{path/to/file}} > {{path/to/compressed_file.gz}}`
 
 - Display the name and reduction percentage for each file compressed or decompressed:
 
-`gzip {{-v|--verbose -d|--decompress path/to/file.gz}}`
+`gzip {{-v|--verbose}} {{-d|--decompress}} {{path/to/file.gz}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Too long; didn't read
While #12892 made the page much nicer introducing placeholders with both short and long options, it grouped consecutive, but, unrelated options into a single placeholder, a pattern which I wasn't able to find in any other page. This is not a problem on its own, as obviously we can change the other ones, but in my opinion it's better to split them because of interactive clients and for a better mantainance.

## Similar syntax in other pages
### Regex
Instead of `{{--option_a a}} {{--option_b b}}` the page was using `{{--option_a a --option_b b}}`, so for searching for similar "super-placeholders", I used the regex ^`.+\{\{-[^\{\}]+ [^\{\}]+\}\}, which means find all lines that:
- Are command examples (start with `.`)
- Have placeholders that:
    1. Start with "-" and then have multiple non-bracket characters
    2. Have a space in the middle
    3. End with multiple non-bracket characters

### Results
In all other 11 pages, except for rsync, the grouped placeholders were in some way related, for example:
- Single placeholders for multiple arguments, but these arguments are for a single option:

> - Pass `jadx` disassembler [a]rguments:
>
> `apkleaks --file {{path/to/file.apk}} --args "{{--threads-count 5 --deobf}}"`

> - Run a command with extra SSH arguments:
> 
> `pssh -i -h {{path/to/hosts_file}} -x "{{-O VisualHostKey=yes}}" {{hostname -i}}`

- An option that can be passed multiple times:

> - Run a manual workflow with parameters:
> 
> `gh workflow run {{id|workflow_name|filename.yml}} {{--raw-field param1=value1 --raw-field param2=value2 ...}}` 
> 

There are infinitely more pages that split consecutive placeholders into multiple ones.

## My opinion on the new approach
- Irrelevant for client code: it obviously doesn't require any change on the client side
- Irrelevant for "non-interactive" clients: consecutive placeholders are presented in the same way as a single bigger placeholder
- Worse for "interactive" clients:
    - With "interactive" clients I mean specifically (mostly CLI) clients that support running a command example and then prompting for filling the placeholders, one time for each placeholder. Example: [tldr++](https://github.com/isacikgoz/tldr).
    - Filling a big at a single time placeholder can be a bit overwhelming for the user
    - Such a client can make a simple "Enter" mean "choose the default option", which a big placeholder would make it harder to change a specific option
- A bit worse for us, mantainers: IMO small placeholders are better than big placeholders in the raw syntax because it's easier to visualize related options