### PR TITLE
magick-convert: fix typo

### DIFF
--- a/pages.nl/common/magick-convert.md
+++ b/pages.nl/common/magick-convert.md
@@ -20,7 +20,7 @@
 
 `magick convert {{pad/naar/invoer_afbeelding.png}} -define jpeg:extent=512kb {{pad/naar/uitvoer_afbeelding.jpg}}`
 
-- Verticaal/Horizontaal toevoegen van afbeeldingen:
+- Verticaal/horizontaal toevoegen van afbeeldingen:
 
 `magick convert {{pad/naar/afbeelding1.png pad/naar/afbeelding2.png ...}} {{-append|+append}} {{pad/naar/uitvoer_afbeelding.png}}`
 

--- a/pages/common/magick-convert.md
+++ b/pages/common/magick-convert.md
@@ -20,7 +20,7 @@
 
 `magick convert {{path/to/input_image.png}} -define jpeg:extent=512kb {{path/to/output_image.jpg}}`
 
-- Vertically/Horizontally append images:
+- Vertically/horizontally append images:
 
 `magick convert {{path/to/image1.png path/to/image2.png ...}} {{-append|+append}} {{path/to/output_image.png}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).