### PR TITLE
rkdeveloptool: add new command

### DIFF
--- a/pages/common/rkdeveloptool.md
+++ b/pages/common/rkdeveloptool.md
@@ -1,0 +1,30 @@
+# rkdeveloptool
+
+> Flash, dump, and manage boot firmware for Rockchip-based computer devices.
+> You will need to turn on the device into Maskrom/Bootrom mode before connecting it through USB.
+> Some subcommands may require to run as root.
+> More information: <https://github.com/rockchip-linux/rkdeveloptool>.
+
+- [l]ist all connected Rockchip-based flash [d]evices:
+
+`rkdeveloptool ld`
+
+- Initialize the device by forcing it to [d]ownload and install the [b]ootloader from the specified file:
+
+`rkdeveloptool db {{path/to/bootloader.bin}}`
+
+- [u]pdate the boot[l]oader software with a new one:
+
+`rkdeveloptool ul {{path/to/bootloader.bin}}`
+
+- Write an image to a GPT-formatted flash partition, specifying the initial storage sector (usually `0x0` alias `0`):
+
+`rkdeveloptool wl {{initial_sector}} {{path/to/image.img}}`
+
+- Write to the flash partition by its user-friendly name:
+
+`rkdeveloptool wlx {{partition_name}} {{path/to/image.img}}`
+
+- [r]eset/reboot the [d]evice, exit from the Maskrom/Bootrom mode to boot into the selected flash partition:
+
+`rkdeveloptool rd`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.3

[rkdeveloptool](https://github.com/rockchip-linux/rkdeveloptool) is an arcane command-line utility developed by [Rockchip](http://www.rock-chips.com/), a Chinese semiconductor company, to configure the boot process and target bootable storage for computers featuring Rockchip SoCs. This tool has been extensively used to install and troubleshoot some Rockchip-based single-board computer (SBC) products, such as the [Orange Pi 5](http://www.orangepi.org/orangepiwiki/index.php/Orange_Pi_5) and [Radxa ROCK Pi 5](http://radxa.com/products/rock5/5a/) (both featuring the same Rockchip RK3588S SoC).

It's arcane because it has limited documentation about its subcommands and parameters, leaving several SBC users puzzled with these:

```
---------------------Tool Usage ---------------------
Help:			-h or --version
Version:		-v or --version
DownloadBoot:		db <Loader>
UpgradeLoader:		ul <Loader>
ReadLBA:		rl  <BeginSec> <SectorLen> <File>
WriteLBA:		wl  <BeginSec> <File>
WriteGPT:		gpt <gpt partition table>
EraseFlash:		ef 
TestDevice:		td
ResetDevice:		rd [subcode]
ReadFlashID:		rid
ReadFlashInfo:		rfi
ReadChipInfo:		rci
PackBootLoader:		pack
UnpackBootLoader:	unpack <boot loader>
TagSPL:			tagspl <tag> <U-Boot SPL>
-------------------------------------------------------
```

The following tldr-page documentation for `rkdeveloptool` has been carefully made by observing how the tool is actually used and recommended by SBC developers. In most cases, the common goal of this is to manage the device's installed eMMC or M.2 bootable storage space, and ensure that the SBC boots into them (instead from the SD card, e.g. in Orange Pi 5). The command examples has been personally used to flash an [Armbian](https://armbian.org) Linux image into an Orange Pi 5 Plus device.

+ Official documentation from Rockchip:
  - https://opensource.rock-chips.com/wiki_Rkdeveloptool
  - https://opensource.rock-chips.com/wiki_Boot_option
+ Official documentation from 96Boards (ROCK960 and ROCK960c):
  - https://www.96boards.org/documentation/consumer/rock/installation/linux-mac-rkdeveloptool.md.html
+ Official documentation from Radxa (ROCK Pi 3/4/5):
  - https://docs.radxa.com/en/rock3/rock3a/low-level-dev/rkdeveloptool
+ Official documentation from Xunlong (Orange Pi):
  - *The Orange Pi website [recommended](http://www.orangepi.org/orangepiwiki/index.php/Orange_Pi_5_Plus#How_to_use_RKDevTool_to_burn_Linux_image_into_eMMC) instead to use RkDevTool, the Windows-exclusive GUI version of `rkdeveloptool`, but its official firmware files do work with the command-line one.*
+ Community sources:
  - https://www.cnx-software.com/2018/07/10/rkdeveloptool-flash-linux-firmware-rockhip/
  - https://github.com/7Ji/orangepi5-archlinuxarm/issues/6
  - https://www.reddit.com/r/OrangePI/comments/15hw529/orange_pi_5_plus_rkdevtool/
