### PR TITLE
ios/*: add WebSSH native commands

### DIFF
--- a/pages/ios/malte.md
+++ b/pages/ios/malte.md
@@ -1,0 +1,14 @@
+# malte
+
+> The mashREPL Little Text Editor, exclusive to WebSSH.
+> In mashREPL, common text editor commands including `nano`, `vi`, and `vim` are aliased to `malte`.
+> This command can be only run under mashREPL menu on the WebSSH app.
+> More information: <https://webssh.net/documentation/mashREPL/>.
+
+- Edit a text file in WebSSH's inbuilt text editor:
+
+`malte {{path/to/file}}`
+
+- Show help information:
+
+`malte --help`

--- a/pages/ios/webssh-import.md
+++ b/pages/ios/webssh-import.md
@@ -1,0 +1,18 @@
+# webssh import
+
+> Import SSH configuration on the WebSSH app through the mashREPL command-line.
+> You may import the `ssh_config` file from other SSH clients by copying its contents to a new file using `malte`, before importing with this utility.
+> This command can be only run under mashREPL menu on the WebSSH app.
+> More information: <https://webssh.net/documentation/mashREPL/>.
+
+- Apply a new SSH configuration from a `ssh_config` text file in the current directory (remove `--apply` for dry-run):
+
+`webssh import sshconfig --apply`
+
+- Apply a new SSH configuration from a specified text file (remove `--apply` for dry-run):
+
+`webssh import sshconfig --from-file {{path/to/file}} --apply`
+
+- Allow overwriting of current SSH connections configuration:
+
+`webssh import sshconfig --from-file {{path/to/file}} --apply --overwrite`

--- a/pages/ios/webssh.md
+++ b/pages/ios/webssh.md
@@ -1,6 +1,7 @@
 # webssh
 
 > Manage, import, and export SSH configuration on the WebSSH app through the mashREPL command-line.
+> Some subcommands such as `webssh import` have their own usage documentation.
 > This command can be only run under mashREPL menu on the WebSSH app.
 > More information: <https://webssh.net/documentation/mashREPL/>.
 
@@ -16,14 +17,10 @@
 
 `webssh export sshconfig --apply`
 
-- Apply a new SSH configuration from a `ssh_config` text file in the current directory (remove `--apply` for dry-run):
+- Restore WebSSH in-app purchases from the command-line:
 
-`webssh export sshconfig --apply`
+`webssh store sync`
 
-- Apply a new SSH configuration from a specified text file (remove `--apply` for dry-run):
+- Unregister WebSSH in-app purchases on the device (this does not constitute refunds):
 
-`webssh export sshconfig --from-file {{path/to/file}} --apply`
-
-- Allow overwriting of current SSH connections configuration:
-
-`webssh export sshconfig --from-file {{path/to/file}} --apply --overwrite`
+`webssh store unregister all`

--- a/pages/ios/webssh.md
+++ b/pages/ios/webssh.md
@@ -1,0 +1,29 @@
+# webssh
+
+> Manage, import, and export SSH configuration on the WebSSH app through the mashREPL command-line.
+> This command can be only run under mashREPL menu on the WebSSH app.
+> More information: <https://webssh.net/documentation/mashREPL/>.
+
+- Print the current version of WebSSH:
+
+`webssh version`
+
+- Print the current version of WebSSH in full format (for diagnostics):
+
+`webssh version full`
+
+- Export the current SSH configuration into a text file (remove `--apply` for dry-run):
+
+`webssh export sshconfig --apply`
+
+- Apply a new SSH configuration from a `ssh_config` text file in the current directory (remove `--apply` for dry-run):
+
+`webssh export sshconfig --apply`
+
+- Apply a new SSH configuration from a specified text file (remove `--apply` for dry-run):
+
+`webssh export sshconfig --from-file {{path/to/file}} --apply`
+
+- Allow overwriting of current SSH connections configuration:
+
+`webssh export sshconfig --from-file {{path/to/file}} --apply --overwrite`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** WebSSH 26.4

> [!NOTE]
> 
> Please hold this PR before we can settle down on updating the tldr spec for iOS-specific apps