### PR TITLE
common: add Indonesian translation for Calligra Office suite

### DIFF
--- a/pages.id/common/calligraflow.md
+++ b/pages.id/common/calligraflow.md
@@ -1,0 +1,17 @@
+# calligraflow
+
+> Aplikasi pengolah flowchart dan diagram, bagian dari Calligra.
+> Lihat juga:  `calligrastage`, `calligrawords`, `calligrasheets`.
+> Informasi lebih lanjut: <https://manned.org/calligraflow>.
+
+- Buka aplikasi pengolah flowchart dan diagram:
+
+`calligraflow`
+
+- Buka suatu berkas:
+
+`calligraflow {{jalan/menuju/berkas}}`
+
+- Tampilkan informasi bantuan atau versi aplikasi:
+
+`calligraflow --{{help|version}}`

--- a/pages.id/common/calligrasheets.md
+++ b/pages.id/common/calligrasheets.md
@@ -1,0 +1,17 @@
+# calligrasheets
+
+> Aplikasi pengolah lembar kerja (spreadsheet), bagian dari Calligra.
+> Lihat juga: `calligraflow`, `calligrastage`, `calligrawords`
+> Informasi lebih lanjut: <https://manned.org/calligrasheets>.
+
+- Buka aplikasi pengolah lembar kerja (spreadsheet):
+
+`calligrasheets`
+
+- Buka suatu berkas:
+
+`calligrasheets {{jalan/menuju/berkas}}`
+
+- Tampilkan informasi bantuan atau versi aplikasi:
+
+`calligrasheets --{{help|version}}`

--- a/pages.id/common/calligrastage.md
+++ b/pages.id/common/calligrastage.md
@@ -1,0 +1,17 @@
+# calligrastage
+
+> Aplikasi presentasi, bagian dari Calligra.
+> Lihat juga: `calligraflow`, `calligrawords`, `calligrasheets`.
+> Informasi lebih lanjut: <https://manned.org/calligrastage>.
+
+- Buka aplikasi presentasi:
+
+`calligrastage`
+
+- Buka suatu berkas:
+
+`calligrastage {{jalan/menuju/berkas}}`
+
+- Tampilkan informasi bantuan atau versi aplikasi:
+
+`calligrastage --{{help|version}}`

--- a/pages.id/common/calligrawords.md
+++ b/pages.id/common/calligrawords.md
@@ -1,0 +1,17 @@
+# calligrawords
+
+> Aplikasi pengolah dokumen teks, bagian dari Calligra.
+> Lihat juga: `calligraflow`, `calligrastage`, `calligrasheets`
+> Informasi lebih lanjut: <https://manned.org/calligrawords>.
+
+- Buka aplikasi pengolah dokumen teks:
+
+`calligrawords`
+
+- Buka suatu berkas:
+
+`calligrawords {{jalan/menuju/berkas}}`
+
+- Tampilkan informasi bantuan atau versi aplikasi:
+
+`calligrawords --{{help|version}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR adds translations to the four documented [Calligra Office](https://calligra.org/) commands on tldr-pages. They are simple and straightforward to translate, although there seems to be other undocumented commands related to KEXI and Karbon.