### PR TITLE
common: translate additional Git subcommands to Indonesian

### DIFF
--- a/pages.id/common/git-commit-tree.md
+++ b/pages.id/common/git-commit-tree.md
@@ -1,0 +1,21 @@
+# git commit-tree
+
+> Alat untuk membuat objek komit secara tingkat rendah (low-level).
+> Lihat juga: `git commit`.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-commit-tree>.
+
+- Buat objek komit baru dengan pesan tertentu:
+
+`git commit-tree {{tree}} -m "{{pesan}}"
+
+- Buat objek komit dengan pesan yang disimpan dalam suatu berkas (gunakan `-` untuk membaca dari `stdin`):
+
+`git commit-tree {{tree}} -F {{jalan/menuju/berkas}}`
+
+- Buat sebuah objek komit yang ditandatangani oleh kunci enkripsi GPG:
+
+`git commit-tree {{tree}} -m "{{pesan}}" --gpg-sign`
+
+- Buat sebuah objek komit dengan komit induk tertentu:
+
+`git commit-tree {{tree}} -m "{{message}}" -p {{kode_hash_sha_atas_komit_induk}}`

--- a/pages.id/common/git-commits-since.md
+++ b/pages.id/common/git-commits-since.md
@@ -1,0 +1,21 @@
+# git commits-since
+
+> Tampilkan daftar komit sejak waktu atau tanggal tertentu.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-commits-since>.
+
+- Tampilkan daftar komit yang dibentuk sejak kemarin (yesterday):
+
+`git commits-since {{yesterday}}`
+
+- Tampilkan daftar komit yang dibentuk sejak minggu lalu (last week):
+
+`git commits-since {{last week}}`
+
+- Tampilkan daftar komit yang dibentuk sejak bulan lalu (last month):
+
+`git commits-since {{last month}}`
+
+- Tampilkan daftar komit yang dibentuk sejak kemarin (yesterday), pada pukul 2 siang (2pm):
+
+`git commits-since {{yesterday 2pm}}`

--- a/pages.id/common/git-config.md
+++ b/pages.id/common/git-config.md
@@ -1,0 +1,37 @@
+# git config
+
+> Ubah pengaturan Git untuk repositori-repositori tertentu.
+> Konfigurasi ini dapat diatur hanya untuk repositori saat ini (lokal/local) atau untuk pengguna sistem operasi saat ini (global).
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-config>.
+
+- Tampilkan hanya daftar pengaturan Git untuk repositori saat ini (sebagaimana tersimpan dalam `.git/config` dalam pangkal direktori repositori):
+
+`git config --list --local`
+
+- Tampilkan hanya daftar pengaturan Git untuk pengguna saat ini (sebagaimana tersimpan dalam `~/.gitconfig` sebagai default, atau bila ada, `$XDG_CONFIG_HOME/git/config`):
+
+`git config --list --global`
+
+- Tampilkan hanya daftar pengaturan Git untuk keseluruhan sistem operasi (sebagaimana tersimpan dalam `/etc/gitconfig`), dan tampilkan lokasi berkas tersebut:
+
+`git config --list --system --show-origin`
+
+- Tampilkan nilai atas entri konfigurasi saat ini (contoh: `alias.unstage`):
+
+`git config alias.unstage`
+
+- Simpan baru atau ubah nilai entri konfigurasi tertentu secara global (untuk pengguna saat ini):
+
+`git config --global alias.unstage "reset HEAD --"`
+
+- Hapus atau kembalikan nilai dari entri konfigurasi tersebut menuju nilai default (bila ada):
+
+`git config --global --unset alias.unstage`
+
+- Sunting konfigurasi Git pada repositori saat ini dengan aplikasi pengolah teks default:
+
+`git config --edit`
+
+- Sunting konfigurasi Git pada pengguna saat ini dengan aplikasi pengolah teks default:
+
+`git config --global --edit`

--- a/pages.id/common/git-contrib.md
+++ b/pages.id/common/git-contrib.md
@@ -1,0 +1,9 @@
+# git contrib
+
+> Tampilkan daftar komit yang ditulis oleh penulis tertentu.
+> Bagian dari `git extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-contrib>.
+
+- Tampilkan daftar seluruh komit, beserta kode hash dan pesan, dari suatu penulis:
+
+`git contrib {{penulis}}`

--- a/pages.id/common/git-count-objects.md
+++ b/pages.id/common/git-count-objects.md
@@ -1,0 +1,20 @@
+# git count-objects
+
+> Hitung jumlah objek komit yang telah dibuka beserta pemakaian ruang penyimpanan dalam direktori repositori saat ini.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-count-objects>.
+
++ Hitung jumlah seluruh objek dan pemakaian ruang penyimpanan:
+
+`git count-objects`
+
+- Hitung jumlah seluruh objek dan pemakaian ruang penyimpanan, dalam format satuan yang lebih ramah dibaca manusia:
+
+`git count-objects --human-readable`
+
+- Tampilkan informasi perhitungan secara lebih mendalam:
+
+`git count-objects --verbose`
+
+- Tampilkan informasi perhitungan secara lebih mendalam, menggunakan format satuan yang lebih ramah dibaca manusia:
+
+`git count-objects --human-readable --verbose`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Continuing the work of #12679, this PR adds translations to `git-commit-tree`, `git-commits-since`, `git-config`, `git-contrib`, and `git-count-objects`.