### PR TITLE
kill: fix highlighting long and short options according to guideline

### DIFF
--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill -{{L|-table}}`
+`kill {{-L|--table}}`
 
 - Terminate a background job:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

> I used this regex to find these: `-\{\{([a-z]{1})\|-(\w+(-\w+)*)\}\}`. It is also an issue in the `look`-pages, but those get fixed in #12932 