### PR TITLE
pages*: remove mnemonics when highlighting both long and short options

### DIFF
--- a/pages.es/common/pydocstyle.md
+++ b/pages.es/common/pydocstyle.md
@@ -7,11 +7,11 @@
 
 `pydocstyle {{archivo.py|ruta/al/directorio}}`
 
-- Muestra una [e]xplicación de cada error:
+- Muestra una explicación de cada error:
 
 `pydocstyle {{-e|--explain}} {{archivo.py|ruta/al/directorio}}`
 
-- Muestra información de [d]epuración:
+- Muestra información de depuración:
 
 `pydocstyle {{-d|--debug}} {{archivo.py|ruta/al/directorio}}`
 

--- a/pages.es/linux/agetty.md
+++ b/pages.es/linux/agetty.md
@@ -9,7 +9,7 @@
 
 `agetty {{tty}} {{115200}}`
 
-- Asume que `stdin` ya está conectado a una `tty` y establece un [t]iempo de espera para el inicio de sesión:
+- Asume que `stdin` ya está conectado a una `tty` y establece un tiempo de espera para el inicio de sesión:
 
 `agetty {{-t|--timeout}} {{tiempo_de_espera_en_segundos}} -`
 
@@ -25,6 +25,6 @@
 
 `agetty {{-i|--noissue}} -`
 
-- Cambia el directorio [r]aíz y escribe un [H]ost falso en el archivo `utmp`:
+- Cambia el directorio raíz y escribe un host falso en el archivo `utmp`:
 
 `agetty {{-r|--chroot}} {{/ruta/a/raíz_directorio}} {{-H|--host}} {{host_falso}} -`

--- a/pages.es/linux/blkpr.md
+++ b/pages.es/linux/blkpr.md
@@ -3,22 +3,22 @@
 > Registra, reserva, libera, anticipa y borra reservas persistentes en un dispositivo de bloque que soporte "Persistent Reservations".
 > Más información: <https://manned.org/blkpr>.
 
-- Registra ([c]omando) una nueva reserva con una clave dada en un dispositivo determinado:
+- Registra (comando) una nueva reserva con una clave dada en un dispositivo determinado:
 
-`blkpr {{-c|--command}} register --key {{clave_de_reserva}} {{ruta/al/dispositivo}}`
+`blkpr {{-c|--command}} register {{-k|--key}} {{clave_de_reserva}} {{ruta/al/dispositivo}}`
 
-- Establece el [t]ipo de reserva existente en acceso exclusivo:
+- Establece el tipo de reserva existente en acceso exclusivo:
 
-`blkpr -c reserve -k {{clave_de_reserva}} {{-t|--type}} exclusive-access {{ruta/al/dispositivo}}`
+`blkpr -c reserve {{-k|--key}} {{clave_de_reserva}} {{-t|--type}} exclusive-access {{ruta/al/dispositivo}}`
 
 - Adelanta la reserva existente con una clave dada y la reemplaza por una nueva reserva:
 
-`blkpr -c preempt {{-K|--oldkey}} {{clave_antigua}} --key {{nueva_clave}} -t write-exclusive {{ruta/al/dispositivo}}`
+`blkpr -c preempt {{-K|--oldkey}} {{clave_antigua}} {{-k|--key}} {{nueva_clave}} {{-t|--type}} write-exclusive {{ruta/al/dispositivo}}`
 
 - Libera una reserva con una clave y [t]ipo dados en un dispositivo determinado:
 
-`blkpr -c release --key {{clave_de_reserva}} -t {{tipo_de_reserva}} {{ruta/al/dispositivo}}`
+`blkpr -c release {{-k|--key}} {{clave_de_reserva}} {{-t|--type}} {{tipo_de_reserva}} {{ruta/al/dispositivo}}`
 
 - Borra todas las reservas de un dispositivo determinado:
 
-`blkpr -c clear -k {{clave}} {{ruta/al/dispositivo}}`
+`blkpr -c clear {{-k|--key}} {{clave}} {{ruta/al/dispositivo}}`

--- a/pages.es/linux/showkey.md
+++ b/pages.es/linux/showkey.md
@@ -7,7 +7,7 @@
 
 `sudo showkey`
 
-- Visualiza códigos de ra[s]treo en hexadecimal:
+- Visualiza códigos de rastreo en hexadecimal:
 
 `sudo showkey {{-s|--scancodes}}`
 
@@ -15,7 +15,7 @@
 
 `sudo showkey {{-k|--keycodes}}`
 
-- Muestra los códigos en [a]SCII, decimal y hexadecimal:
+- Muestra los códigos en ASCII, decimal y hexadecimal:
 
 `sudo showkey {{-a|--ascii}}`
 

--- a/pages/common/azurite.md
+++ b/pages/common/azurite.md
@@ -3,7 +3,7 @@
 > Azure Storage API compatible server (emulator) in local environment.
 > More information: <https://www.npmjs.com/package/azurite>.
 
-- Use an existing [l]ocation as workspace path:
+- Use an existing location as workspace path:
 
 `azurite {{-l|--location}} {{path/to/directory}}`
 
@@ -11,7 +11,7 @@
 
 `azurite {{-s|--silent}}`
 
-- Enable [d]ebug log by providing a file path as log destination:
+- Enable debug log by providing a file path as log destination:
 
 `azurite {{-d|--debug}} {{path/to/debug.log}}`
 

--- a/pages/common/diff.md
+++ b/pages/common/diff.md
@@ -7,7 +7,7 @@
 
 `diff {{old_file}} {{new_file}}`
 
-- Compare files, ignoring [w]hite spaces:
+- Compare files, ignoring white spaces:
 
 `diff {{-w|--ignore-all-space}} {{old_file}} {{new_file}}`
 
@@ -15,11 +15,11 @@
 
 `diff {{-y|--side-by-side}} {{old_file}} {{new_file}}`
 
-- Compare files, showing the differences in [u]nified format (as used by `git diff`):
+- Compare files, showing the differences in unified format (as used by `git diff`):
 
 `diff {{-u|--unified}} {{old_file}} {{new_file}}`
 
-- Compare directories [r]ecursively (shows names for differing files/directories as well as changes made to files):
+- Compare directories recursively (shows names for differing files/directories as well as changes made to files):
 
 `diff {{-r|--recursive}} {{old_directory}} {{new_directory}}`
 

--- a/pages/common/git-archive.md
+++ b/pages/common/git-archive.md
@@ -7,11 +7,11 @@
 
 `git archive --verbose HEAD`
 
-- Use the Zip format and report progress [v]erbosely:
+- Use the Zip format and report progress verbosely:
 
 `git archive {{-v|--verbose}} --format zip HEAD`
 
-- [o]utput the Zip archive to a specific file:
+- Output the Zip archive to a specific file:
 
 `git archive -v {{-o|--output}} {{path/to/file.zip}} HEAD`
 

--- a/pages/common/pydocstyle.md
+++ b/pages/common/pydocstyle.md
@@ -7,11 +7,11 @@
 
 `pydocstyle {{file.py|path/to/directory}}`
 
-- Show an [e]xplanation of each error:
+- Show an explanation of each error:
 
 `pydocstyle {{-e|--explain}} {{file.py|path/to/directory}}`
 
-- Show [d]ebug information:
+- Show debug information:
 
 `pydocstyle {{-d|--debug}} {{file.py|path/to/directory}}`
 

--- a/pages/linux/agetty.md
+++ b/pages/linux/agetty.md
@@ -9,7 +9,7 @@
 
 `agetty {{tty}} {{115200}}`
 
-- Assume `stdin` is already connected to a `tty` and set a [t]imeout for the login:
+- Assume `stdin` is already connected to a `tty` and set a timeout for the login:
 
 `agetty {{-t|--timeout}} {{timeout_in_seconds}} -`
 
@@ -17,14 +17,14 @@
 
 `agetty -8 - {{term_var}}`
 
-- Skip the login ([n]o login) and invoke, as root, another [l]ogin program instead of `/bin/login`:
+- Skip the login (no login) and invoke, as root, another login program instead of `/bin/login`:
 
 `agetty {{-n|--skip-login}} {{-l|--login-program}} {{login_program}} {{tty}}`
 
-- Do not display the pre-login ([i]ssue) file (`/etc/issue` by default) before writing the login prompt:
+- Do not display the pre-login (issue) file (`/etc/issue` by default) before writing the login prompt:
 
 `agetty {{-i|--noissue}} -`
 
-- Change the [r]oot directory and write a specific fake [H]ost into the `utmp` file:
+- Change the root directory and write a specific fake host into the `utmp` file:
 
 `agetty {{-r|--chroot}} {{/path/to/root_directory}} {{-H|--host}} {{fake_host}} -`

--- a/pages/linux/blkpr.md
+++ b/pages/linux/blkpr.md
@@ -3,22 +3,22 @@
 > Register, reserve, release, preempt, and clear persistent reservations on a block device that supports Persistent Reservations.
 > More information: <https://manned.org/blkpr>.
 
-- Register ([c]ommand) a new reservation with a given [k]ey on a given device:
+- Register (command) a new reservation with a given key on a given device:
 
-`blkpr {{-c|--command}} register --key {{reservation_key}} {{path/to/device}}`
+`blkpr {{-c|--command}} register {{-k|--key}} {{reservation_key}} {{path/to/device}}`
 
-- Set the [t]ype of an existing reservation to exclusive access:
+- Set the type of an existing reservation to exclusive access:
 
-`blkpr -c reserve -k {{reservation_key}} {{-t|--type}} exclusive-access {{path/to/device}}`
+`blkpr -c reserve {{-k|--key}} {{reservation_key}} {{-t|--type}} exclusive-access {{path/to/device}}`
 
-- Preempt the existing reservation with a given [K]ey and replace it with a new reservation:
+- Preempt the existing reservation with a given key and replace it with a new reservation:
 
-`blkpr -c preempt {{-K|--oldkey}} {{old_key}} --key {{new_key}} -t write-exclusive {{path/to/device}}`
+`blkpr -c preempt {{-K|--oldkey}} {{old_key}} {{-k|--key}} {{new_key}} {{-t|--type}} write-exclusive {{path/to/device}}`
 
-- Release a reservation with a given [k]ey and [t]ype on a given device:
+- Release a reservation with a given key and type on a given device:
 
-`blkpr -c release --key {{reservation_key}} -t {{reservation_type}} {{path/to/device}}`
+`blkpr -c release {{-k|--key}} {{reservation_key}} {{-t|--type}} {{reservation_type}} {{path/to/device}}`
 
 - Clear all reservations from a given device:
 
-`blkpr -c clear -k {{key}} {{path/to/device}}`
+`blkpr -c clear {{-k|--key}} {{key}} {{path/to/device}}`

--- a/pages/linux/pw-dot.md
+++ b/pages/linux/pw-dot.md
@@ -12,7 +12,7 @@
 
 `pw-dot {{-j|--json}} {{path/to/file.json}}`
 
-- Specify an [o]utput file, showing [a]ll object types:
+- Specify an [o]utput file, showing all object types:
 
 `pw-dot --output {{path/to/file.dot}} {{-a|--all}}`
 
@@ -24,7 +24,7 @@
 
 `pw-dot --remote {{remote_name}} {{-s|--smart}}`
 
-- Lay the graph from [l]eft to [r]ight, instead of dot's default top to bottom:
+- Lay the graph from left to right, instead of dot's default top to bottom:
 
 `pw-dot {{-L|--lr}}`
 

--- a/pages/linux/showkey.md
+++ b/pages/linux/showkey.md
@@ -7,15 +7,15 @@
 
 `sudo showkey`
 
-- Display [s]cancodes in hexadecimal:
+- Display scancodes in hexadecimal:
 
 `sudo showkey {{-s|--scancodes}}`
 
-- Display [k]eycodes in decimal (default):
+- Display keycodes in decimal (default):
 
 `sudo showkey {{-k|--keycodes}}`
 
-- Display keycodes in [a]SCII, decimal, and hexadecimal:
+- Display keycodes in ASCII, decimal, and hexadecimal:
 
 `sudo showkey {{-a|--ascii}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).

<details>
<summary>Script</summary>

```python
#!/usr/bin/env python3
# SPDX-License-Identifier: MIT

"""
A Python script to generate or update alias pages.

Disclaimer: This script generates a lot of false positives so it isn't suggested to use the sync option. If used, only stage changes and commit verified changes for your language by using -l LANGUAGE.

Note: If the current directory or one of its parents is called "tldr", the script will assume it is the tldr root, i.e., the directory that contains a clone of https://github.com/tldr-pages/tldr
If you aren't, the script will use TLDR_ROOT as the tldr root. Also, ensure 'git' is available.

Usage:
    python3 scripts/set-alias-page.py [-p PAGE] [-S] [-l LANGUAGE] [-s] [-n]

Options:
    -p, --page PAGE
        Specify the alias page in the format "platform/alias_command.md".
    -S, --sync
        Synchronize each translation's alias page (if exists) with that of the English page.
    -l, --language LANGUAGE
        Specify the language, a POSIX Locale Name in the form of "ll" or "ll_CC" (e.g. "fr" or "pt_BR").
    -s, --stage
        Stage modified pages (requires 'git' on $PATH and TLDR_ROOT to be a Git repository).
    -n, --dry-run
        Show what changes would be made without actually modifying the page.
"""

import re
from pathlib import Path
from _common import (
    IGNORE_FILES,
    Colors,
    get_tldr_root,
    get_pages_dir,
    get_target_paths,
    get_locale,
    create_colored_line,
    create_argument_parser,
)


def check_page(path: Path, language_to_check: str = "") -> str:
    """
    Check a page.

    path (string): Path to a page.
    language_to_check (string): Optionally, the language of the translation to be checked.

    Returns:
    str: Execution status
         "" if the page matches the Style Guide"
         "\x1b[34mpage needs an update"
    """

    locale = get_locale(path)
    if language_to_check != "" and locale != language_to_check:
        # return empty status to indicate that the page is skipped
        return ""
    
    with path.open(encoding="utf-8") as f:
        lines = f.readlines()

        for i in range(1, len(lines)):
            command_match = re.search(r'\{\{-([a-z]{1})\|--\w+(-\w+)*\}\}', lines[i])
            if command_match:
                description_match = re.search(rf'\[({command_match[1]})]', lines[i-2])
                if description_match and command_match[1] == description_match[1]:
                    return create_colored_line(Colors.BLUE, "needs a manual check")
    
    return ""


def main():
    parser = create_argument_parser(
        "Checks all pages on some Style Guide conventions"
    )
    args = parser.parse_args()

    root = get_tldr_root()
    pages_dirs = get_pages_dir(root)

    en_path = root / "pages"
    platforms = [i.name for i in en_path.iterdir() if i.name not in IGNORE_FILES]
    for platform in platforms:
        platform_path = en_path / platform
        commands = [
            f"{platform}/{page.name}"
            for page in platform_path.iterdir()
            if page.name not in IGNORE_FILES
        ]
        for command in commands:
            for page_dir in pages_dirs:
                path = root / page_dir / command
                if path.exists():
                    status = check_page(path, args.language)
                    rel_path = "/".join(path.parts[-3:])
                    if status != "":
                        print(create_colored_line(Colors.GREEN, f"{rel_path} {status}"))


if __name__ == "__main__":
    main()
```
</details>

<details>
<summary>Output</summary>

```
pages.en/common/diff.md needs a manual check
pages/common/diff.md needs a manual check
pages.en/common/azurite.md needs a manual check
pages/common/azurite.md needs a manual check
pages.es/common/pydocstyle.md needs a manual check
pages.en/common/pydocstyle.md needs a manual check
pages/common/pydocstyle.md needs a manual check
pages.en/common/git-archive.md needs a manual check
pages/common/git-archive.md needs a manual check
pages.es/linux/showkey.md needs a manual check
pages.en/linux/showkey.md needs a manual check
pages/linux/showkey.md needs a manual check
pages.es/linux/agetty.md needs a manual check
pages.en/linux/agetty.md needs a manual check
pages/linux/agetty.md needs a manual check
pages.en/linux/pw-dot.md needs a manual check
pages/linux/pw-dot.md needs a manual check
pages.es/linux/blkpr.md needs a manual check
pages.en/linux/blkpr.md needs a manual check
pages/linux/blkpr.md needs a manual check
```
</details>