### PR TITLE
ansible, ansible-*: add Indonesian translation

### DIFF
--- a/pages.id/common/ansible-doc.md
+++ b/pages.id/common/ansible-doc.md
@@ -1,0 +1,29 @@
+# ansible-doc
+
+> Tampilkan informasi mengenai modul-modul (action plugins) yang terpasang dalam pustaka pemasangan Ansible.
+> Tampilkan informasi singkat mengenai daftar plugin beserta deskripsi singkatnya.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/cli/ansible-doc.html>.
+
+- Tampilkan daftar modul/plugin yang tersedia:
+
+`ansible-doc --list`
+
+- Tampilkan daftar modul/plugin berdasarkan jenisnya:
+
+`ansible-doc --type {{become|cache|callback|cliconf|connection|...}} --list`
+
+- Tampilkan informasi mengenai suatu modul/plugin:
+
+`ansible-doc {{nama_plugin}}`
+
+- Tampilkan informasi mengenai suatu modul/plugin berdasarkan jenis spesifiknya:
+
+`ansible-doc --type {{become|cache|callback|cliconf|connection|...}} {{nama_plugin}}`
+
+- Lihat contoh cara penggunaan (dalam playbook) bagi suatu modul/plugin:
+
+`ansible-doc --snippet {{nama_plugin}}`
+
+- Tampilkan informasi mengenai suatu plugin/modul dalam format JSON:
+
+`ansible-doc --json {{nama_plugin}}`

--- a/pages.id/common/ansible-galaxy.md
+++ b/pages.id/common/ansible-galaxy.md
@@ -1,0 +1,32 @@
+# ansible-galaxy
+
+> Buat dan atur peran pengguna (role) Ansible.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+
+- Pasang sebuah peran kepada suatu pengguna:
+
+`ansible-galaxy install {{username}}.{{nama_peran}}`
+
+- Buang peran dari suatu pengguna:
+
+`ansible-galaxy remove {{username}}.{{nama_peran}}`
+
+- Tampilkan daftar peran yang tersedia:
+
+`ansible-galaxy list`
+
+- Cari peran berdasarkan nama:
+
+`ansible-galaxy search {{nama_peran}}`
+
+- Terbitkan sebuah peran baru:
+
+`ansible-galaxy init {{nama_peran}}`
+
+- Dapatkan informasi mengenai peran sebuah pengguna:
+
+`ansible-galaxy role info {{username}}.{{nama_peran}}`
+
+- Dapatkan informasi mengenai suatu koleksi:
+
+`ansible-galaxy collection info {{username}}.{{nama_koleksi}}`

--- a/pages.id/common/ansible-inventory.md
+++ b/pages.id/common/ansible-inventory.md
@@ -1,0 +1,21 @@
+# ansible-inventory
+
+> Tampilkan dan simpan informasi suatu inventaris Ansible (inventory).
+> Lihat juga: `ansible`.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/cli/ansible-inventory.html>.
+
+- Tampilkan informasi inventaris default:
+
+`ansible-inventory --list`
+
+- Tampilkan suatu inventaris kustom:
+
+`ansible-inventory --list --inventory {{jalan/menuju/berkas_atau_skrip_atau_direktori}}`
+
+- Tampilkan informasi inventaris default dalam format YAML:
+
+`ansible-inventory --list --yaml`
+
+- Simpan informasi inventaris default ke dalam suatu berkas teks:
+
+`ansible-inventory --list --output {{jalan/menuju/berkas}}`

--- a/pages.id/common/ansible-playbook.md
+++ b/pages.id/common/ansible-playbook.md
@@ -1,0 +1,32 @@
+# ansible-playbook
+
+> Jalankan kumpulan tugas yang didefinisikan di dalam buku aturan main (playbook), kepada para mesin secara jarak jauh melalui SSH.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+
+- Jalankan kumpulan tugas yang didefinisikan dalam buku aturan main (playbook):
+
+`ansible-playbook {{playbook}}`
+
+- Jalankan kumpulan tugas playbook dengan [i]nventaris mesin secara kustom:
+
+`ansible-playbook {{playbook}} -i {{berkas_inventaris}}`
+
+- Jalankan kumpulan tugas playbook dengan variabel [e]kstra sebagaimana didefinisikan dalam barisan perintah (command-line):
+
+`ansible-playbook {{playbook}} -e "{{variabel1}}={{nilai1}} {{variabel2}}={{nilai2}}"`
+
+- Jalankan kumpulan tugas playbook dengan variabel [e]kstra sebagaimana didefinisikan di dalam suatu berkas JSON:
+
+`ansible-playbook {{playbook}} -e "@{{daftar_variabel.json}}"`
+
+- Jalankan kumpulan tugas playbook dengan konfigurasi tag tertentu:
+
+`ansible-playbook {{playbook}} --tags {{tag1,tag2}}`
+
+- Jalankan kumpulan tugas playbook, dimulai dari nama tugas spesifik:
+
+`ansible-playbook {{playbook}} --start-at {{nama_tugas}}`
+
+- Jalankan kumpulan tugas playbook tanpa melakukan perubahan sebenarnya (dry-run):
+
+`ansible-playbook {{playbook}} --check --diff`

--- a/pages.id/common/ansible-pull.md
+++ b/pages.id/common/ansible-pull.md
@@ -1,0 +1,20 @@
+# ansible-pull
+
+> Tarik buku-buku aturan main (playbook) dari suatu repositori sistem manajemen versi (VCS), dan jalankan tugas-tugasnya bagi host lokal.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/cli/ansible-pull.html>.
+
+- Tarik suatu playbook dari repositori VCS, kemudian jalankan aturan default dari playbook local.yml:
+
+`ansible-pull -U {{url_repositori}}`
+
+- Tarik suatu playbook dari repositori VCS, kemudian jalankan aturan playbook dengan nama tertentu:
+
+`ansible-pull -U {{url_repositori}} {{playbook}}`
+
+- Tarik suatu playbook dari [C]abang tertentu pada repositori VCS, kemudian jalankan aturan playbook dengan nama tertentu:
+
+`ansible-pull -U {{url_repositori}} -C {{cabang}} {{playbook}}`
+
+- Tarik suatu playbook dari repositori VCS, kemudian definisikan daftar perangkat/host dari suatu berkas (hosts), kemudian jalankan aturan playbook dengan nama tertentu:
+
+`ansible-pull -U {{url_repositori}} -i {{berkas_hosts}} {{playbook}}`

--- a/pages.id/common/ansible-vault.md
+++ b/pages.id/common/ansible-vault.md
@@ -1,0 +1,28 @@
+# ansible-vault
+
+> Enkripsi dan dekripsi nilai, struktur data, dan file dalam proyek Ansible.
+> Informasi lebih lanjut: <https://docs.ansible.com/ansible/latest/user_guide/vault.html#id17>.
+
+- Buat suatu berkas brankas terenkripsi baru dengan permintaan kata sandi:
+
+`ansible-vault create {{nama_berkas_brankas}}`
+
+- Buat file brankas terenkripsi baru menggunakan berkas kunci (kata sandi) brankas untuk mengenkripsinya:
+
+`ansible-vault create --vault-password-file {{nama_berkas_kata_sandi}} {{nama_berkas_brankas}}`
+
+- Enkripsi file yang ada menggunakan berkas kata sandi opsional:
+
+`ansible-vault encrypt --vault-password-file {{nama_berkas_kata_sandi}} {{nama_berkas_brankas}}`
+
+- Enkripsi suatu teks string menggunakan format string terenkripsi standar Ansible, dan menampilkan petunjuk secara interaktif:
+
+`ansible-vault encrypt_string`
+
+- Lihat isi suatu brankas yang terenkripsi, menggunakan berkas kata sandi untuk mendekripsikannya:
+
+`ansible-vault view --vault-password-file {{nama_berkas_kata_sandi}} {{nama_berkas_brankas}}`
+
+- Ganti kunci (kata sandi) pada brankas terenkripsi dengan mendefinisikan berkas kata sandi baru:
+
+`ansible-vault rekey --vault-password-file {{nama_berkas_kata_sandi_lama}} --new-vault-password-file {{nama_berkas_kata_sandi_baru}} {{nama_berkas_brankas}}`

--- a/pages.id/common/ansible.md
+++ b/pages.id/common/ansible.md
@@ -1,0 +1,33 @@
+# ansible
+
+> Atur grup perangkat komputer yang secara jarak jauh melalui SSH. (Gunakan berkas `/etc/ansible/hosts` untuk menambahkan grup atau host baru).
+> Beberapa subperintah seperti `ansible galaxy` memiliki dokumentasi terpisah.
+> Informasi lebih lanjut: <https://www.ansible.com/>.
+
+- Tampilkan daftar host yang tergabung dalam suatu grup:
+
+`ansible {{grup}} --list-hosts`
+
+- Uji koneksi (ping) kepada grup perangkat tertentu dengan menggunakan [m]odul ping:
+
+`ansible {{grup}} -m ping`
+
+- Tampilkan informasi faktual tentang suatu grup perangkat dengan menggunakan [m]odul setup:
+
+`ansible {{grup}} -m setup`
+
+- Jalankan perintah pada suatu kelompok perangkat melalui [m]odul command dengan kumpulan [a]rgumen:
+
+`ansible {{grup}} -m command -a '{{perintah_saya}}'`
+
+- Jalankan perintah dengan hak akses administratif:
+
+`ansible {{grup}} --become --ask-become-pass -m command -a '{{perintah_saya}}'`
+
+- Jalankan perintah menggunakan berkas [i]nventaris tertentu:
+
+`ansible {{grup}} -i {{file_inventaris}} -m command -a '{{perintah_saya}}'`
+
+- Tampilkan daftar grup dalam sebuah inventaris:
+
+`ansible localhost -m debug -a '{{var=groups.keys()}}'`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR adds Indonesian translations to `ansible` and all of currently-documented subcommands.
