### PR TITLE
yt-dlp: Fix example command

### DIFF
--- a/pages.pt_PT/common/yt-dlp.md
+++ b/pages.pt_PT/common/yt-dlp.md
@@ -22,7 +22,7 @@
 
 - Descarrega todas as playlists de um canal ou utilizador do YouTube, mantendo cada playlist num diretório separado:
 
-`yt-dlp -o "{{%(uploader)s/%(playlist)s/%(indice_playlist)s - %(titulo)s.%(ext)s}}" "{{https://www.youtube.com/user/TheLinuxFoundation/playlists}}"`
+`yt-dlp -o "{{%(uploader)s/%(playlist)s/%(indice_playlist)s - %(titulo)s.%(ext)s}}" "{{https://www.youtube.com/@LinuxFoundationOrg/playlists}}"`
 
 - Descarrega um curso do Udemy, mantendo cada capítulo num diretório em separado, dentro do diretório "MyVideos" na home do utilizador:
 

--- a/pages/common/yt-dlp.md
+++ b/pages/common/yt-dlp.md
@@ -27,7 +27,7 @@
 
 - Download all playlists of a YouTube channel/user keeping each playlist in a separate directory:
 
-`yt-dlp -o "{{%(uploader)s/%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s}}" "{{https://www.youtube.com/user/TheLinuxFoundation/playlists}}"`
+`yt-dlp -o "{{%(uploader)s/%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s}}" "{{https://www.youtube.com/@LinuxFoundationOrg/playlists}}"`
 
 - Download a Udemy course keeping each chapter in a separate directory:
 


### PR DESCRIPTION
Fixes the broken example URL in the "Download all playlists of a youtube channel" example.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**
Correct as of `2024.05.27`
