### PR TITLE
bc, dd, nc, sed, tree, yacc: update links

### DIFF
--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -2,7 +2,7 @@
 
 > An arbitrary precision calculator language.
 > See also: `dc`.
-> More information: <https://manned.org/man/bc.1>.
+> More information: <https://manned.org/bc.1>.
 
 - Start an interactive session:
 

--- a/pages/common/dd.md
+++ b/pages/common/dd.md
@@ -1,7 +1,7 @@
 # dd
 
 > Convert and copy a file.
-> More information: <https://manned.org/man/dd.1p>.
+> More information: <https://manned.org/dd.1p>.
 
 - Make a bootable USB drive from an isohybrid file (such as `archlinux-xxx.iso`):
 

--- a/pages/common/nc.md
+++ b/pages/common/nc.md
@@ -1,7 +1,7 @@
 # nc
 
 > Redirect I/O into a network stream through this versatile tool.
-> More information: <https://manned.org/man/nc.1>.
+> More information: <https://manned.org/nc.1>.
 
 - Start a listener on the specified TCP port and send a file into it:
 

--- a/pages/common/sed.md
+++ b/pages/common/sed.md
@@ -2,7 +2,7 @@
 
 > Edit text in a scriptable manner.
 > See also: `awk`, `ed`.
-> More information: <https://manned.org/man/sed.1posix>.
+> More information: <https://manned.org/sed.1posix>.
 
 - Replace all `apple` (basic regex) occurrences with `mango` (basic regex) in all input lines and print the result to `stdout`:
 

--- a/pages/common/tree.md
+++ b/pages/common/tree.md
@@ -1,7 +1,7 @@
 # tree
 
 > Show the contents of the current directory as a tree.
-> More information: <https://manned.org/man/tree>.
+> More information: <https://manned.org/tree>.
 
 - Print files and directories up to 'num' levels of depth (where 1 means the current directory):
 

--- a/pages/common/yacc.md
+++ b/pages/common/yacc.md
@@ -2,7 +2,7 @@
 
 > Generate an LALR parser (in C) with a formal grammar specification file.
 > See also: `bison`.
-> More information: <https://manned.org/man/yacc.1p>.
+> More information: <https://manned.org/yacc.1p>.
 
 - Create a file `y.tab.c` containing the C parser code and compile the grammar file with all necessary constant declarations for values. (Constant declarations file `y.tab.h` is created only when the `-d` flag is used):
 


### PR DESCRIPTION
This PR updates links from `manned.org/man/` to `manned.org/` in `common`.
I'll send another PR for the Linux ones. 

```sh
$ grep -r "https://manned.org/man" pages/ | wc -l
26
```

```sh
$ grep -r "https://manned.org/" pages/ | wc -l
752
```