### PR TITLE
common/*, osx/arch: add Indonesian translation

### DIFF
--- a/pages.id/common/ansiweather.md
+++ b/pages.id/common/ansiweather.md
@@ -1,0 +1,16 @@
+# ansiweather
+
+> Tampilkan kondisi cuaca saat ini ke dalam terminal.
+> Informasi lebih lanjut: <https://github.com/fcambus/ansiweather>.
+
+- Tampilkan ramalan cuaca ([f]orecast) selama tujuh hari ke depan bagi suatu [l]okasi, dengan satuan [u]nit ukur metrik:
+
+`ansiweather -u metric -f 7 -l {{Rzeszow,PL}}`
+
+- Tampilkan ramalan cuaca ([F]orecast) selama lima hari ke depan bagi lokasi saat ini, dengan tampilan [s]imbol serta informasi waktu matahari terbit dan terbenam ([d]aylight):
+
+`ansiweather -F -s true -d true`
+
+- Tampilkan informasi kecepatan angin ([w]ind) dan kelembapan udara ([h]umidity) bagi waktu dan lokasi saat ini:
+
+`ansiweather -w true -h true`

--- a/pages.id/common/ant.md
+++ b/pages.id/common/ant.md
@@ -1,0 +1,24 @@
+# ant
+
+> Apache Ant: bangun dan atur proyek pengembangan piranti lunak berbasis Java.
+> Informasi lebih lanjut: <https://ant.apache.org>.
+
+- Bangun suatu proyek Java dengan pengaturan yang didefinisikan dalam `build.xml` (lokasi default):
+
+`ant`
+
+- Bangun proyek menggunakan berkas/[f]ile pengaturan selain `build.xml`:
+
+`ant -f {{buildfile.xml}}`
+
+- Tampilkan informasi mengenai daftar target pembangunan piranti lunak yang memungkinkan bagi proyek ini:
+
+`ant -p`
+
+- Tampilkan informasi pendukung awakutu ([d]ebugging):
+
+`ant -d`
+
+- Jalankan pembangunan bagi seluruh target pembangunan yang tidak bergantung kepada target-target yang gagal dibangun:
+
+`ant -k`

--- a/pages.id/common/antibody.md
+++ b/pages.id/common/antibody.md
@@ -1,0 +1,16 @@
+# antibody
+
+> Program manajemen plugin syel "si paling cepat".
+> Informasi lebih lanjut: <https://getantibody.github.io>.
+
+- Gabungkan semua plugin untuk dimuat dalam syel secara statis:
+
+`antibody bundle < {{~/.zsh_plugins.txt}} > {{~/.zsh_plugins.sh}}`
+
+- Mutakhirkan seluruh bundel:
+
+`antibody update`
+
+- Tampilkan seluruh plugin yang terpasang:
+
+`antibody list`

--- a/pages.id/common/anytopnm.md
+++ b/pages.id/common/anytopnm.md
@@ -1,0 +1,12 @@
+# anytopnm
+
+> Ubah format gambar apapun menuju format gambar umum.
+> More information: <https://netpbm.sourceforge.net/doc/anytopnm.html>.
+
+- Ubah suatu gambar dari format apapun menuju format PBM, PGM, atau PPM:
+
+`anytopnm {{jalan/menuju/input}} > {{jalan/menuju/output.pnm}}`
+
+- Tampilkan informasi versi:
+
+`anytopnm --version`

--- a/pages.id/common/apg.md
+++ b/pages.id/common/apg.md
@@ -1,0 +1,24 @@
+# apg
+
+> Buat kata sandi secara acak dan kompleks.
+> Informasi lebih lanjut: <https://manned.org/apg>.
+
+- Buat sebuah kata sandi secara acak (panjang default bagi kata sandi adalah 8):
+
+`apg`
+
+- Buat sebuah kata sandi dengan minimum 1 simbol (S), 1 nomor (N), 1 huruf kapital (C), dan 1 huruf kecil (L):
+
+`apg -M SNCL`
+
+- Buat kata sandi dengan panjang 16 karakter:
+
+`apg -m {{16}}`
+
+- Buat kata sandi dengan panjang ma[x]imum 16 karakter:
+
+`apg -x {{16}}`
+
+- Buat sebuah kata sandi yang tidak mengandung kata yang terkandung di dalam suatu berkas kamus:
+
+`apg -r {{jalan/menuju/berkas_kamus}}`

--- a/pages.id/common/apkleaks.md
+++ b/pages.id/common/apkleaks.md
@@ -1,0 +1,13 @@
+# apkleaks
+
+> Pindai berkas APK (aplikasi Android) untuk mencari URI, alur pemanggilan (endpoint), dan konfigurasi rahasia.
+> Catatan: APKLeaks menggunakan `jadx` untuk membongkar kode aplikasi Android.
+> Informasi lebih lanjut: <https://github.com/dwisiswant0/apkleaks>.
+
+- Pindai berkas ([f]ile) APK untuk mencari daftar endpoint dan kode konfigurasi rahasia:
+
+`apkleaks --file {{jalan/menuju/berkas.apk}}`
+
+- Pindai dan simpan luaran ([o]utput) ke dalam suatu berkas:
+
+`apkleaks --file {{jalan/menuju/berkas.apk}} --output {{jalan/menuju/berkas_output.txt}}`

--- a/pages.id/common/apm.md
+++ b/pages.id/common/apm.md
@@ -1,0 +1,17 @@
+# apm
+
+> Manajer paket untuk aplikasi pengolah teks Atom.
+> Lihat juga: `atom`.
+> Informasi lebih lanjut: <https://github.com/atom/apm>.
+
+- Pasang suatu paket dari <http://atom.io/packages> atau tema dari <http://atom.io/themes>:
+
+`apm install {{nama_paket}}`
+
+- Hapus pemasangan suatu paket atau tema:
+
+`apm remove {{nama_paket}}`
+
+- Mutakhirkan paket atau tema menuju versi terbaru:
+
+`apm upgrade {{nama_paket}}`

--- a/pages.id/common/apropos.md
+++ b/pages.id/common/apropos.md
@@ -1,0 +1,16 @@
+# apropos
+
+> Lakukan pencarian nama dan deskripsi perintah dalam buku panduan program baris perintah (`manpages`).
+> Informasi lebih lanjut: <https://manned.org/apropos>.
+
+- Cari daftar dokumentasi perintah yang mengandung kata dengan format kata kunci ekspresi reguler (regex):
+
+`apropos {{ekspresi_reguler}}`
+
+- Jangan pangkas tampilan teks hasil pencarian menurut panjang jendela terminal:
+
+`apropos -l {{ekspresi_reguler}}`
+
+- Cari daftar dokumentasi perintah yang mengandung seluruh ([a]ll) kriteria kata dalam bentuk ekspresi reguler (regex):
+
+`apropos {{ekspresi_reguler_1}} -a {{ekspresi_reguler_2}} -a {{ekspresi_reguler_3}}`

--- a/pages.id/common/ar.md
+++ b/pages.id/common/ar.md
@@ -1,0 +1,25 @@
+# ar
+
+> Buat, olah, dan ekstrak berkas dalam format arsip Unix. Biasanya dimanfaatkan untuk pustaka statis (`.a`) dan paket piranti lunak Debian (`.deb`).
+> Lihat juga: `tar`.
+> Informasi lebih lanjut: <https://manned.org/ar>.
+
+- E[x]trak seluruh berkas dalam suatu arsip:
+
+`ar x {{jalan/menuju/berkas.a}}`
+
+- Lihat daf[t]ar isi dari suatu arsip:
+
+`ar t {{jalan/menuju/berkas.ar}}`
+
+- Gantikan ([r]eplace) atau tambahkan suatu berkas ke dalam arsip:
+
+`ar r {{jalan/menuju/berkas.deb}} {{jalan/menuju/debian-binary jalan/menuju/control.tar.gz jalan/menuju/data.tar.xz ...}}`
+
+- Ma[s]ukkan suatu berkas objek (setara dengan penggunaan `ranlib`):
+
+`ar s {{jalan/menuju/berkas.a}}`
+
+- Buat suatu arsip berisikan kumpulan berkas tertentu, dan suatu berkas daftar indeks para objek:
+
+`ar rs {{jalan/menuju/berkas.a}} {{jalan/menuju/berkas1.o jalan/menuju/berkas2.o ...}}`

--- a/pages.id/common/arc.md
+++ b/pages.id/common/arc.md
@@ -1,0 +1,20 @@
+# arc
+
+> Arcanist: program CLI untuk Phabricator.
+> Informasi lebih lanjut: <https://secure.phabricator.com/book/phabricator/article/arcanist>.
+
+- Kirim semua perubahan untuk ditinjau melalui alat Differential:
+
+`arc diff`
+
+- Tampilkan daftar revisi yang masih menunggu persetujuan (pending):
+
+`arc list`
+
+- Mutakhirkan pesan-pesan Git seusai peninjauan:
+
+`arc amend`
+
+- Simpan (land/push) perubahan yang disetujui menuju repositori Git:
+
+`arc land`

--- a/pages.id/common/arch.md
+++ b/pages.id/common/arch.md
@@ -1,0 +1,9 @@
+# arch
+
+> Tampilkan nama arsitektur sistem saat ini.
+> Lihat juga: `uname`.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/arch>.
+
+- Tampilkan informasi arsitektur sistem saat ini:
+
+`arch`

--- a/pages.id/common/archwiki-rs.md
+++ b/pages.id/common/archwiki-rs.md
@@ -1,0 +1,20 @@
+# archwiki-rs
+
+> Baca, cari, dan unduh artikel dari situs ArchWiki.
+> Informasi lebih lanjut: <https://gitlab.com/lucifayr/archwiki-rs>.
+
+- Baca suatu artikel dari situs ArchWiki:
+
+`archwiki-rs read-page {{judul_artikel}}`
+
+- Baca suatu artikel dari ArchWiki dengan format tertentu:
+
+`archwiki-rs read-page {{judul_artikel}} --format {{plain-text|markdown|html}}`
+
+- Cari artikel dalam ArchWiki yang mengandung teks tertentu:
+
+`archwiki-rs search "{{teks_yang_dicari}}" --text-search`
+
+- Unduh seluruh artikel dari situs ArchWiki ke dalam suatu direktori:
+
+`archwiki-rs local-wiki {{/jalan/menuju/wiki_lokal}} --format {{plain-text|markdown|html}}`

--- a/pages.id/osx/arch.md
+++ b/pages.id/osx/arch.md
@@ -1,0 +1,17 @@
+# arch
+
+> Tampilkan nama arsitektur sistem saat ini, atau jalankan suatu perintah menggunakan arsitektur yang berbeda.
+> Lihat juga: `uname`.
+> Informasi lebih lanjut:  <https://keith.github.io/xcode-man-pages/arch.1.html>.
+
+- Tampilkan informasi arsitektur sistem saat ini:
+
+`arch`
+
+- Jalankan suatu perintah menggunakan arsitektur x86_64:
+
+`arch -x86_64 "{{command}}"`
+
+- Jalankan suatu perintah menggunakan arsitektur arm:
+
+`arch -arm64 "{{command}}"`

--- a/pages/common/rkdeveloptool.md
+++ b/pages/common/rkdeveloptool.md
@@ -1,0 +1,30 @@
+# rkdeveloptool
+
+> Flash, dump, and manage boot firmware for Rockchip-based computer devices.
+> You will need to turn on the device into Maskrom/Bootrom mode before connecting it through USB.
+> Some subcommands may require to run as root.
+> More information: <https://github.com/rockchip-linux/rkdeveloptool>.
+
+- [l]ist all connected Rockchip-based flash [d]evices:
+
+`rkdeveloptool ld`
+
+- Initialize the device by forcing it to [d]ownload and install the [b]ootloader from the specified file:
+
+`rkdeveloptool db {{path/to/bootloader.bin}}`
+
+- [u]pdate the boot[l]oader software with a new one:
+
+`rkdeveloptool ul {{path/to/bootloader.bin}}`
+
+- Write an image to a GPT-formatted flash partition, specifying the initial storage sector (usually `0x0` alias `0`):
+
+`rkdeveloptool wl {{initial_sector}} {{path/to/image.img}}`
+
+- Write to the flash partition by its user-friendly name:
+
+`rkdeveloptool wlx {{partition_name}} {{path/to/image.img}}`
+
+- [r]eset/reboot the [d]evice, exit from the Maskrom/Bootrom mode to boot into the selected flash partition:
+
+`rkdeveloptool rd`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
