### PR TITLE
mktemp: add Dutch translation

### DIFF
--- a/pages.nl/common/mktemp.md
+++ b/pages.nl/common/mktemp.md
@@ -1,0 +1,24 @@
+# mktemp
+
+> Maak een tijdelijk bestand of een tijdelijke map aan.
+> Meer informatie: <https://man.openbsd.org/mktemp.1>.
+
+- Maak een leeg tijdelijk bestand en toon het absolute pad:
+
+`mktemp`
+
+- Gebruik een aangepaste map als `$TMPDIR` niet is ingesteld (de standaard is platformafhankelijk, maar meestal `/tmp`):
+
+`mktemp -p {{/pad/naar/tempdir}}`
+
+- Gebruik een aangepast pad-sjabloon (`X`en worden vervangen door willekeurige alfanumerieke tekens):
+
+`mktemp {{/tmp/voorbeeld.XXXXXXXX}}`
+
+- Gebruik een aangepast bestandsnaam-sjabloon:
+
+`mktemp -t {{voorbeeld.XXXXXXXX}}`
+
+- Maak een lege tijdelijke map aan en toon het absolute pad:
+
+`mktemp -d`

--- a/pages.nl/linux/mktemp.md
+++ b/pages.nl/linux/mktemp.md
@@ -1,0 +1,28 @@
+# mktemp
+
+> Maak een tijdelijk bestand of een tijdelijke map aan.
+> Meer informatie: <https://www.gnu.org/software/coreutils/mktemp>.
+
+- Maak een leeg tijdelijk bestand en toon het absolute pad:
+
+`mktemp`
+
+- Gebruik een aangepaste map (standaard is `$TMPDIR`, of `/tmp`):
+
+`mktemp --tmpdir={{/pad/naar/tempdir}}`
+
+- Gebruik een aangepast pad-sjabloon (`X`en worden vervangen door willekeurige alfanumerieke tekens):
+
+`mktemp {{/tmp/voorbeeld.XXXXXXXX}}`
+
+- Gebruik een aangepast bestandsnaam-sjabloon:
+
+`mktemp -t {{voorbeeld.XXXXXXXX}}`
+
+- Maak een leeg tijdelijk bestand met de opgegeven extensie en toon het absolute pad:
+
+`mktemp --suffix {{.ext}}`
+
+- Maak een lege tijdelijke map aan en toon het absolute pad:
+
+`mktemp --directory`

--- a/pages.nl/osx/mktemp.md
+++ b/pages.nl/osx/mktemp.md
@@ -1,0 +1,24 @@
+# mktemp
+
+> Maak een tijdelijk bestand of een tijdelijke map aan.
+> Meer informatie: <https://keith.github.io/xcode-man-pages/mktemp.1.html>.
+
+- Maak een leeg tijdelijk bestand en toon het absolute pad:
+
+`mktemp`
+
+- Gebruik een aangepaste map (standaard is de uitvoer van `getconf DARWIN_USER_TEMP_DIR`, of `/tmp`):
+
+`mktemp --tmpdir={{/pad/naar/tempdir}}`
+
+- Gebruik een aangepast pad-sjabloon (`X`en worden vervangen door willekeurige alfanumerieke tekens):
+
+`mktemp {{/tmp/voorbeeld.XXXXXXXX}}`
+
+- Gebruik een aangepaste bestandsnaam-prefix:
+
+`mktemp -t {{voorbeeld}}`
+
+- Maak een lege tijdelijke map aan en toon het absolute pad:
+
+`mktemp --directory`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 