### PR TITLE
pages.nl: fix typos

### DIFF
--- a/pages.nl/common/a2ping.md
+++ b/pages.nl/common/a2ping.md
@@ -3,7 +3,7 @@
 > Converteer afbeeldingen in EPS- of PDF-bestanden.
 > Meer informatie: <https://manned.org/a2ping>.
 
-- Converteer een afbeelding naar PDF (Opmerking: het opgeven van een uitvoerbestandsnaam is optioneel):
+- Converteer een afbeelding naar PDF (Let op: het opgeven van een uitvoerbestandsnaam is optioneel):
 
 `a2ping {{pad/naar/afbeelding.ext}} {{pad/naar/uitvoer.pdf}}`
 
@@ -11,11 +11,11 @@
 
 `a2ping --nocompress {{none|zip|best|flate}} {{pad/naar/bestand}}`
 
-- Scan HiResBoundingBox indien aanwezig (Opmerking: de standaard is yes):
+- Scan HiResBoundingBox indien aanwezig (Let op: de standaard is yes):
 
 `a2ping --nohires {{pad/naar/bestand}}`
 
-- Sta pagina-inhoud onder en links van de oorsprong toe (Opmerking: de standaard is no):
+- Sta pagina-inhoud onder en links van de oorsprong toe (Let op: de standaard is no):
 
 `a2ping --below {{pad/naar/bestand}}`
 

--- a/pages.nl/common/ac.md
+++ b/pages.nl/common/ac.md
@@ -1,20 +1,20 @@
 # ac
 
-> Druk statistieken af over hoe lang gebruikers verbonden zijn geweest.
+> Toon statistieken over hoe lang gebruikers verbonden zijn geweest.
 > Meer informatie: <https://man.openbsd.org/ac>.
 
-- Druk af hoe lang de huidige gebruiker verbonden is in uren:
+- Toon hoe lang de huidige gebruiker verbonden is in uren:
 
 `ac`
 
-- Druk af hoe lang gebruikers verbonden zijn in uren:
+- Toon hoe lang gebruikers verbonden zijn in uren:
 
 `ac -p`
 
-- Druk af hoe lang een bepaalde gebruiker verbonden is in uren:
+- Toon hoe lang een bepaalde gebruiker verbonden is in uren:
 
 `ac -p {{gebruikersnaam}}`
 
-- Print hoe lang een bepaalde gebruiker verbonden is in uren per dag (met totaal):
+- Toon hoe lang een bepaalde gebruiker verbonden is in uren per dag (met totaal):
 
 `ac -dp {{gebruikersnaam}}`

--- a/pages.nl/common/accelerate.md
+++ b/pages.nl/common/accelerate.md
@@ -11,7 +11,7 @@
 
 `accelerate config`
 
-- Druk de geschatte GPU-geheugenkosten af van het uitvoeren van een Hugging Face model met verschillende gegevenstypen:
+- Toon de geschatte GPU-geheugenkosten van het uitvoeren van een Hugging Face model met verschillende gegevenstypen:
 
 `accelerate estimate-memory {{name/model}}`
 

--- a/pages.nl/common/ack.md
+++ b/pages.nl/common/ack.md
@@ -1,7 +1,7 @@
 # ack
 
 > Een zoektool zoals grep, geoptimaliseerd voor ontwikkelaars.
-> Zie ook: `rg`, dat is veel sneller.
+> Bekijk ook: `rg`, dat is veel sneller.
 > Meer informatie: <https://beyondgrep.com/documentation>.
 
 - Zoek recursief naar bestanden met een tekenreeks of reguliere expressie in de huidige map:
@@ -28,7 +28,7 @@
 
 `ack --count --no-filename "{{zoekpatroon}}"`
 
-- Druk alleen voor elk bestand de bestandsnamen en het aantal overeenkomsten af:
+- Toon alleen voor elk bestand de bestandsnamen en het aantal overeenkomsten:
 
 `ack --count --files-with-matches "{{zoekpatroon}}"`
 

--- a/pages.nl/common/acme.sh.md
+++ b/pages.nl/common/acme.sh.md
@@ -1,7 +1,7 @@
 # acme.sh
 
 > Shell-script dat het ACME-clientprotocol implementeert, een alternatief voor `certbot`.
-> Zie ook `acme.sh dns`.
+> Bekijk ook `acme.sh dns`.
 > Meer informatie: <https://github.com/acmesh-official/acme.sh>.
 
 - Geef een certificaat uit met behulp van de webroot-modus:

--- a/pages.nl/common/arch.md
+++ b/pages.nl/common/arch.md
@@ -1,7 +1,7 @@
 # arch
 
 > Geef de naam van de systeemarchitectuur weer.
-> Zie ook `uname`.
+> Bekijk ook `uname`.
 > Meer informatie: <https://www.gnu.org/software/coreutils/arch>.
 
 - Geef de architectuur van het systeem weer:

--- a/pages.nl/common/cksum.md
+++ b/pages.nl/common/cksum.md
@@ -1,7 +1,7 @@
 # cksum
 
 > Bereken de CRC checksums en het aantal bytes van een bestand.
-> Opmerking: op oudere UNIX systemen kan de CRC implementatie verschillen.
+> Let op: op oudere UNIX systemen kan de CRC implementatie verschillen.
 > Meer informatie: <https://www.gnu.org/software/coreutils/cksum>.
 
 - Toon een 32-bit checksum, grootte in bytes en bestandsnaam:

--- a/pages.nl/common/echo.md
+++ b/pages.nl/common/echo.md
@@ -1,17 +1,17 @@
 # echo
 
-> Drukt gegeven argumenten af.
+> Toont gegeven argumenten.
 > Meer informatie: <https://www.gnu.org/software/coreutils/echo>.
 
-- Druk een tekstbericht af. Let op: aanhalingstekens zijn optimaal:
+- Toon een tekstbericht. Let op: aanhalingstekens zijn optioneel:
 
 `echo "{{Hallo Wereld}}"`
 
-- Druk een bericht af met omgevingsvariabelen:
+- Toon een bericht met omgevingsvariabelen:
 
 `echo "{{Mijn pad is $PATH}}"`
 
-- Drukt een bericht af zonder te volgen met een nieuwe regel:
+- Toont een bericht zonder te volgen met een nieuwe regel:
 
 `echo -n "{{Hallo Wereld}}"`
 
@@ -23,6 +23,6 @@
 
 `echo -e "{{kolom 1\kolom 2}}"`
 
-- Druk de afsluitstatus van de laatst uitgevoerde opdracht af (Opmerking: in Windows Command Prompt en PowerShell zijn de equivalente opdrachten respectievelijk `echo %errorlevel%` en `$lastexitcode`):
+- Toon de afsluitstatus van de laatst uitgevoerde opdracht (Let op: in Windows Command Prompt en PowerShell zijn de equivalente opdrachten respectievelijk `echo %errorlevel%` en `$lastexitcode`):
 
 `echo $?`

--- a/pages.nl/common/fossil-init.md
+++ b/pages.nl/common/fossil-init.md
@@ -1,7 +1,7 @@
 # fossil init
 
 > Initialiseer een nieuwe repository voor een project.
-> Zie ook: `fossil clone`.
+> Bekijk ook: `fossil clone`.
 > Meer informatie: <https://fossil-scm.org/home/help/init>.
 
 - Maak een nieuwe repository in een opgegeven bestand:

--- a/pages.nl/common/fossil-rm.md
+++ b/pages.nl/common/fossil-rm.md
@@ -1,7 +1,7 @@
 # fossil rm
 
 > Verwijder bestanden of mappen uit Fossil versiebeheer.
-> Zie ook: `fossil forget`.
+> Bekijk ook: `fossil forget`.
 > Meer informatie: <https://fossil-scm.org/home/help/rm>.
 
 - Verwijder een bestand of map uit Fossil versiebeheer:

--- a/pages.nl/common/just.1.md
+++ b/pages.nl/common/just.1.md
@@ -19,6 +19,6 @@
 
 `just -l`
 
-- Print de justfile:
+- Toon de justfile:
 
 `just --dump`

--- a/pages.nl/common/linode-cli-nodebalancers.md
+++ b/pages.nl/common/linode-cli-nodebalancers.md
@@ -10,7 +10,7 @@
 
 - Maak een nieuwe NodeBalancer:
 
-`linode-cli nodebalancers create --region {{region}}`
+`linode-cli nodebalancers create --region {{regio}}`
 
 - Toon details van een specifieke NodeBalancer:
 
@@ -18,7 +18,7 @@
 
 - Update een bestaande NodeBalancer:
 
-`linode-cli nodebalancers update {{nodebalancer_id}} --label {{new_label}}`
+`linode-cli nodebalancers update {{nodebalancer_id}} --label {{nieuw_label}}`
 
 - Verwijder een NodeBalancer:
 
@@ -30,4 +30,4 @@
 
 - Voeg een nieuwe configuratie toe aan een NodeBalancer:
 
-`linode-cli nodebalancers configs create {{nodebalancer_id}} --port {{port}} --protocol {{protocol}}`
+`linode-cli nodebalancers configs create {{nodebalancer_id}} --port {{poort}} --protocol {{protocol}}`

--- a/pages.nl/common/lp.md
+++ b/pages.nl/common/lp.md
@@ -3,23 +3,23 @@
 > Print bestanden.
 > Meer informatie: <https://manned.org/lp>.
 
-- Print de output van een commando met de standaard printer (bekijk het `lpstat` commando):
+- Toon de output van een commando met de standaard printer (bekijk het `lpstat` commando):
 
 `echo "test" | lp`
 
-- Print een bestand met de standaard printer:
+- Toon een bestand met de standaard printer:
 
 `lp {{pad/naar/bestandsnaam}}`
 
-- Print een bestand met een printer met naam (bekijk het `lpstat` commando):
+- Toon een bestand met een printer met naam (bekijk het `lpstat` commando):
 
 `lp -d {{printer_naam}} {{pad/naar/bestandsnaam}}`
 
-- Print N kopieën van een bestand met de standaard printer (vervang N met het gewenste aantal kopieën):
+- Toon N kopieën van een bestand met de standaard printer (vervang N met het gewenste aantal kopieën):
 
 `lp -n {{N}} {{pad/naar/bestandsnaam}}`
 
-- Print alleen specifieke pagina's met de standaard printer (print pagina's 1, 3-5, and 16):
+- Toon alleen specifieke pagina's met de standaard printer (print pagina's 1, 3-5, and 16):
 
 `lp -P 1,3-5,16 {{pad/naar/bestandsnaam}}`
 

--- a/pages.nl/common/rm.md
+++ b/pages.nl/common/rm.md
@@ -1,7 +1,7 @@
 # rm
 
 > Verwijder bestanden of mappen.
-> Zie ook: `rmdir`.
+> Bekijk ook: `rmdir`.
 > Meer informatie: <https://www.gnu.org/software/coreutils/rm>.
 
 - Verwijder specifieke bestanden:

--- a/pages.nl/common/strings.md
+++ b/pages.nl/common/strings.md
@@ -3,7 +3,7 @@
 > Vind printbare strings in een object bestand of binary.
 > Meer informatie: <https://manned.org/strings>.
 
-- Print alle strings in een binary:
+- Toon alle strings in een binary:
 
 `strings {{pad/naar/bestand}}`
 

--- a/pages.nl/common/time.md
+++ b/pages.nl/common/time.md
@@ -1,7 +1,7 @@
 # time
 
 > Meet hoe lang het uitvoeren van een commando duurt.
-> Opmerking: `time` kan ofwel bestaan als een shell builtin, een op zichzelf staand programma of beide.
+> Let op: `time` kan ofwel bestaan als een shell builtin, een op zichzelf staand programma of beide.
 > Meer informatie: <https://manned.org/time>.
 
 - Voer het `commando` uit en print de tijdmetingen naar `stdout`::

--- a/pages.nl/common/transmission-cli.md
+++ b/pages.nl/common/transmission-cli.md
@@ -14,7 +14,7 @@
 
 - Maak een torrent bestand van een specifiek bestand of map:
 
-`transmission-cli --new {{pad/naar/bron_bestand_of_map}}`
+`transmission-cli --new {{pad/naar/bronbestand_of_map}}`
 
 - Zet de download snelheid limiet naar 50 KB/s:
 

--- a/pages.nl/common/tty.md
+++ b/pages.nl/common/tty.md
@@ -3,6 +3,6 @@
 > Geeft de naam van de terminal terug.
 > Meer informatie: <https://www.gnu.org/software/coreutils/tty>.
 
-- Druk de bestandsnaam van deze terminal af:
+- Toon de bestandsnaam van deze terminal:
 
 `tty`

--- a/pages.nl/common/vim.md
+++ b/pages.nl/common/vim.md
@@ -11,7 +11,7 @@
 
 - Open een bestand bij een bepaald regelnummer:
 
-`vim +{{regel_nummer}} {{pad/naar/bestand}}`
+`vim +{{regelnummer}} {{pad/naar/bestand}}`
 
 - Bekijk de handleiding van Vim:
 

--- a/pages.nl/common/xzgrep.md
+++ b/pages.nl/common/xzgrep.md
@@ -1,7 +1,7 @@
 # xzgrep
 
 > Zoek bestanden die mogelijk worden gecomprimeerd met `xz`, `lzma`, `gzip`, `bzip2`, `lzop`, of `zstd` met behulp van reguliere expressies.
-> Zie ook: `grep`.
+> Bekijk ook: `grep`.
 > Meer informatie: <https://manned.org/xzgrep>.
 
 - Zoek naar een patroon in een bestand:

--- a/pages.nl/common/xzless.md
+++ b/pages.nl/common/xzless.md
@@ -1,7 +1,7 @@
 # xzless
 
 > Tekst weergeven van `xz` en `lzma` gecomprimeerde bestanden.
-> Zie ook: `less`.
+> Bekijk ook: `less`.
 > Meer informatie: <https://manned.org/xzless>.
 
 - Bekijk een gecomprimeerd bestand:

--- a/pages.nl/common/yapf.md
+++ b/pages.nl/common/yapf.md
@@ -3,11 +3,11 @@
 > Python stijlgidschecker.
 > Meer informatie: <https://github.com/google/yapf>.
 
-- Print de geformateerde diff die zal optreden uit:
+- Toon de geformateerde diff die zal optreden uit:
 
 `yapf --diff {{pad/naar/bestand}}`
 
-- Print de geformateerde diff uit en breng de wijzigingen aan in het bestand:
+- Toon de geformateerde diff uit en breng de wijzigingen aan in het bestand:
 
 `yapf --diff --in-place {{pad/naar/bestand}}`
 

--- a/pages.nl/common/yes.md
+++ b/pages.nl/common/yes.md
@@ -4,11 +4,11 @@
 > Deze opdracht wordt vaak gebruikt om ja te beantwoorden op elke prompt door installatieopdrachten (zoals apt-get).
 > Meer informatie: <https://www.gnu.org/software/coreutils/yes>.
 
-- Print herhaaldelijk "bericht":
+- Toon herhaaldelijk "bericht":
 
 `yes {{bericht}}`
 
-- Print herhaaldelijk "y":
+- Toon herhaaldelijk "y":
 
 `yes`
 
@@ -16,6 +16,6 @@
 
 `yes | sudo apt-get install {{programma}}`
 
-- Print herhaaldelijk een nieuwe regel om altijd de standaard optie van een vraag te accepteren:
+- Toon herhaaldelijk een nieuwe regel om altijd de standaard optie van een vraag te accepteren:
 
 `yes ''`

--- a/pages.nl/common/ykman-config.md
+++ b/pages.nl/common/ykman-config.md
@@ -1,7 +1,7 @@
 # ykman config
 
 > In- of uitschakelen van YubiKey applicaties.
-> Opmerking: je kan `ykman info` gebruiken om de huidige ingeschakelde applicaties te zien.
+> Let op: je kan `ykman info` gebruiken om de huidige ingeschakelde applicaties te zien.
 > Meer informatie: <https://docs.yubico.com/software/yubikey/tools/ykman/Base_Commands.html#ykman-config-options-command-args>.
 
 - Schakel een applicatie in via USB of NFC (`--enable` kan meerdere keren gebruikt worden om meerdere applicaties te specificeren):

--- a/pages.nl/common/ykman-openpgp.md
+++ b/pages.nl/common/ykman-openpgp.md
@@ -1,7 +1,7 @@
 # ykman openpgp
 
 > Beheer de OpenPGP YubiKey applicatie.
-> Opmerking: je dient `gpg --card-edit` te gebruiken voor sommige instellingen.
+> Let op: je dient `gpg --card-edit` te gebruiken voor sommige instellingen.
 > Meer informatie: <https://docs.yubico.com/software/yubikey/tools/ykman/OpenPGP_Commands.html>.
 
 - Toon algemene informatie over de OpenPGP applicatie:

--- a/pages.nl/linux/bspc.md
+++ b/pages.nl/linux/bspc.md
@@ -9,17 +9,17 @@
 
 - Focus op het gegeven bureaublad:
 
-`bspc desktop --focus {{number}}`
+`bspc desktop --focus {{nummer}}`
 
-- Sluit de vensters die afgetakt zijn van het geselecteerde knooppunt:
+- Sluit de vensters die afgetakt zijn van de geselecteerde node:
 
 `bspc node --close`
 
-- Stuur het geselecteerde knooppunt naar het opgegeven bureaublad:
+- Stuur de geselecteerde node naar het opgegeven bureaublad:
 
-`bspc node --to-desktop {{number}}`
+`bspc node --to-desktop {{nummer}}`
 
-- Schakel de modus volledig scherm in voor het geselecteerde knooppunt:
+- Schakel de modus volledig scherm in voor de geselecteerde node:
 
 `bspc node --state ~fullscreen`
 

--- a/pages.nl/linux/cgcreate.md
+++ b/pages.nl/linux/cgcreate.md
@@ -6,12 +6,12 @@
 
 - Maak een nieuwe groep:
 
-`cgcreate -g {{group_type}}:{{group_name}}`
+`cgcreate -g {{groep_type}}:{{groepsnaam}}`
 
 - Maak een nieuwe groep met meerdere cgroep typen:
 
-`cgcreate -g {{group_type1}},{{group_type2}}:{{group_name}}`
+`cgcreate -g {{groep_type1}},{{groep_type2}}:{{groepsnaam}}`
 
 - Maak een subgroep:
 
-`mkdir /sys/fs/cgroup/{{group_type}}/{{group_name}}/{{subgroup_name}}`
+`mkdir /sys/fs/cgroup/{{groep_type}}/{{groepsnaam}}/{{subgroep_naam}}`

--- a/pages.nl/linux/cp.md
+++ b/pages.nl/linux/cp.md
@@ -5,11 +5,11 @@
 
 - Kopieer een bestand naar een andere locatie:
 
-`cp {{pad/naar/bron_bestand.ext}} {{pad/naar/doel_bestand.ext}}`
+`cp {{pad/naar/bronbestand.ext}} {{pad/naar/doel_bestand.ext}}`
 
 - Kopieer een bestand naar een andere map, maar behoud de bestandsnaam:
 
-`cp {{pad/naar/bron_bestand.ext}} {{pad/naar/doel_map}}`
+`cp {{pad/naar/bronbestand.ext}} {{pad/naar/doel_map}}`
 
 - Kopieer de inhoud van een map recursief naar een andere locatie (als de doelmap bestaat, dan wordt de map hierin gekopieerd):
 
@@ -33,4 +33,4 @@
 
 - Gebruik het volledige pad van de bron bestanden, creëer missende tussenliggende mappen tijdens het kopieëren:
 
-`cp --parents {{pad/naar/bron_bestand}} {{pad/naar/doel_bestand}}`
+`cp --parents {{pad/naar/bronbestand}} {{pad/naar/doel_bestand}}`

--- a/pages.nl/linux/iptables.md
+++ b/pages.nl/linux/iptables.md
@@ -18,12 +18,12 @@
 
 - Voeg regel toe aan keten policy voor IP met [p]rotocol en poort in overweging:
 
-`sudo iptables --append {{keten}} --source {{ip}} --protocol {{tcp|udp|icmp|...}} --dport {{port}} --jump {{regel}}`
+`sudo iptables --append {{keten}} --source {{ip}} --protocol {{tcp|udp|icmp|...}} --dport {{poort}} --jump {{regel}}`
 
 - Voeg een NAT regel toe om al het verkeer van `192.168.0.0/24` subnet te vertalen naar de host's publieke IP:
 
 `sudo iptables --table {{nat}} --append {{POSTROUTING}} --source {{192.168.0.0/24}} --jump {{MASQUERADE}}`
 
-- Verwijder keten regel:
+- Verwij[D]er keten regel:
 
-`sudo iptables --delete {{keten}} {{regel_line_number}}`
+`sudo iptables --delete {{keten}} {{regelnummer}}`

--- a/pages.nl/linux/mount.cifs.md
+++ b/pages.nl/linux/mount.cifs.md
@@ -1,7 +1,7 @@
 # mount.cifs
 
 > Mount SMB (Server Message Block) of CIFS (Common Internet File System) shares.
-> Opmerking: u kunt ook hetzelfde doen door de optie `-t cifs` door te geven aan `mount`.
+> Let op: u kunt ook hetzelfde doen door de optie `-t cifs` door te geven aan `mount`.
 > Meer informatie: <https://manned.org/mount.cifs>.
 
 - Verbinding maken met de opgegeven gebruikersnaam of `$USER` als standaard (U wordt gevraagd om een wachtwoord):

--- a/pages.nl/osx/dd.md
+++ b/pages.nl/osx/dd.md
@@ -13,7 +13,7 @@
 
 - Genereer een bestand met een specifiek aantal willekeurige bytes met behulp van de kernel random driver:
 
-`dd bs={{100}} count={{1}} if=/dev/urandom of={{path/to/random_file}}`
+`dd bs={{100}} count={{1}} if=/dev/urandom of={{pad/naar/random_bestand}}`
 
 - Benchmark de schrijfsnelheid van een schijf:
 

--- a/pages.nl/osx/launchctl.md
+++ b/pages.nl/osx/launchctl.md
@@ -20,11 +20,11 @@
 
 `launchctl list`
 
-- Een momenteel geladen agent ontladen, b.v. om wijzigingen aan te brengen (let op: het plist-bestand wordt automatisch in `launchd` geladen na een herstart en/of inloggen):
+- Een momenteel geladen agent ontladen, b.v. om wijzigingen aan te brengen (Let op: het plist-bestand wordt automatisch in `launchd` geladen na een herstart en/of inloggen):
 
 `launchctl unload ~/Library/LaunchAgents/{{my_script}}.plist`
 
-- Voer handmatig een bekende (geladen) agent/daemon uit, zelfs als dit niet het juiste moment is (opmerking: deze opdracht gebruikt het label van de agent, in plaats van de bestandsnaam):
+- Voer handmatig een bekende (geladen) agent/daemon uit, zelfs als dit niet het juiste moment is (Let op: deze opdracht gebruikt het label van de agent, in plaats van de bestandsnaam):
 
 `launchctl start {{script_bestand}}`
 

--- a/pages.nl/sunos/prstat.md
+++ b/pages.nl/sunos/prstat.md
@@ -19,6 +19,6 @@
 
 `prstat -m`
 
-- Print de 5 meest CPU intensieve processen elke seconde:
+- Toon de 5 meest CPU intensieve processen elke seconde:
 
 `prstat -c -n {{5}} -s cpu {{1}}`


### PR DESCRIPTION
- rename "Druk af" to "Toon"
- rename "Print" to "Toon"
- rename "Opmerking" to "Let op"
- rename "Zie ook:" to "Bekijk ook:"
- fix some placeholders
