### PR TITLE
alex, age-keygen, accelerate, airdecap-ng, airshare: fix link typo

### DIFF
--- a/pages.zh/common/accelerate.md
+++ b/pages.zh/common/accelerate.md
@@ -1,7 +1,7 @@
 # Accelerate
 
 > 一个使得可以在任何分布式配置中运行相同的 PyTorch 代码的库。
-> 更多信息： <https://huggingface.co/docs/accelerate/index>.
+> 更多信息：<https://huggingface.co/docs/accelerate/index>.
 
 - 打印环境信息：
 

--- a/pages.zh/common/age-keygen.md
+++ b/pages.zh/common/age-keygen.md
@@ -2,7 +2,7 @@
 
 > 生成 `age` 密钥对。
 > 参见：`age` 用于加密/解密文件。
-> 更多信息： <https://manned.org/age-keygen>.
+> 更多信息：<https://manned.org/age-keygen>.
 
 - 生成密钥对，将其保存到未加密文件，并将公钥打印到标准输出：
 

--- a/pages.zh/common/airdecap-ng.md
+++ b/pages.zh/common/airdecap-ng.md
@@ -2,7 +2,7 @@
 
 > 解密 WEP、WPA 或 WPA2 加密的捕获文件。
 > 是 Aircrack-ng 网络软件套件的一部分。
-> 更多信息： <https://www.aircrack-ng.org/doku.php?id=airdecap-ng>.
+> 更多信息：<https://www.aircrack-ng.org/doku.php?id=airdecap-ng>.
 
 - 从开放网络捕获文件中移除无线头，并使用接入点的 MAC 地址进行过滤：
 

--- a/pages.zh/common/airshare.md
+++ b/pages.zh/common/airshare.md
@@ -1,7 +1,7 @@
 # airshare
 
 > 在本地网络中传输数据的工具。
-> 更多信息： <https://airshare.rtfd.io/en/latest/cli.html>.
+> 更多信息：<https://airshare.rtfd.io/en/latest/cli.html>.
 
 - 共享文件或目录：
 

--- a/pages.zh/common/alex.md
+++ b/pages.zh/common/alex.md
@@ -1,7 +1,7 @@
 # alex
 
 > 捕捉文本中的不敏感、不考虑他人的写作风格。它帮助您找出文本中的性别偏向、极端化、种族相关、宗教考虑不周等不平等表达。
-> 更多信息： <https://github.com/get-alex/alex>.
+> 更多信息：<https://github.com/get-alex/alex>.
 
 - 从标准输入分析文本：
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 