### PR TITLE
portageq: add page

### DIFF
--- a/pages/linux/portageq.md
+++ b/pages/linux/portageq.md
@@ -1,0 +1,21 @@
+# portageq
+
+> Query for information about Portage, the Gentoo Linux package manager.
+> Queryable Portage-specific environment variables are listed in `/var/db/repos/gentoo/profiles/info_vars`.
+> More information: <https://wiki.gentoo.org/wiki/Portageq>.
+
+- Display the value of a Portage-specific environment variable:
+
+`portageq envvar {{variable}}`
+
+- Display a detailed list of repositories configured with Portage:
+
+`portageq repos_config /`
+
+- Display a list of repositories sorted by priority (highest first):
+
+`portageq get_repos /`
+
+- Display a specific piece of metadata about an atom (i.e. package name including the version):
+
+`portageq metadata / {{ebuild|porttree|binary|...}} {{category}}/{{package}} {{BDEPEND|DEFINED_PHASES|DEPEND|...}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Relevant issue: #12173