### PR TITLE
eselect, eselect-{repository,locale}: add page

### DIFF
--- a/pages/linux/eselect-locale.md
+++ b/pages/linux/eselect-locale.md
@@ -1,0 +1,16 @@
+# eselect locale
+
+> An `eselect` module for managing the `LANG` environment variable, which sets the system language.
+> More information: <https://wiki.gentoo.org/wiki/Eselect#Locale>.
+
+- List available locales:
+
+`eselect locale list`
+
+- Set the `LANG` environment variable in `/etc/profile.env` by name or index from the `list` command:
+
+`eselect locale set {{name|index}}`
+
+- Display the value of `LANG` in `/etc/profile.env`:
+
+`eselect locale show`

--- a/pages/linux/eselect-repository.md
+++ b/pages/linux/eselect-repository.md
@@ -1,0 +1,33 @@
+# eselect repository
+
+> An `eselect` module for configuring ebuild repositories for Portage.
+> After enabling a repository, you have to run `emerge --sync repo_name` to download ebuilds.
+> More information: <https://wiki.gentoo.org/wiki/Eselect/Repository>.
+
+- List all ebuild repositories registered on <https://repos.gentoo.org>:
+
+`eselect repository list`
+
+- List enabled repositories:
+
+`eselect repository list -i`
+
+- Enable a repository from the list by its name or index from the `list` command:
+
+`eselect repository enable {{name|index}}`
+
+- Enable an unregistered repository:
+
+`eselect repository add {{name}} {{rsync|git|mercurial|svn|...}} {{sync_uri}}`
+
+- Disable repositories without removing their contents:
+
+`eselect repository disable {{repo1 repo2 ...}}`
+
+- Disable repositories and remove their contents:
+
+`eselect repository remove {{repo1 repo2 ...}}`
+
+- Create a local repository and enable it:
+
+`eselect repository create {{name}} {{path/to/repo}}`

--- a/pages/linux/eselect.md
+++ b/pages/linux/eselect.md
@@ -1,0 +1,17 @@
+# eselect
+
+> Gentoo's multi-purpose configuration and management tool.
+> It consists of various modules that take care of individual administrative tasks.
+> More information: <https://wiki.gentoo.org/wiki/Eselect>.
+
+- Display a list of installed modules:
+
+`eselect`
+
+- View documentation for a specific module:
+
+`tldr eselect {{module}}`
+
+- Display a help message for a specific module:
+
+`eselect {{module}} help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

There are a lot more `eselect` modules; this is just the main page and 2 modules