### PR TITLE
kill: remove the `--table` long option

### DIFF
--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill -l`
+`kill -L`
 
 - Terminate a background job:
 

--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill {{-L|--table}}`
+`kill {{-l}}`
 
 - Terminate a background job:
 

--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill {{-l}}`
+`kill -l`
 
 - Terminate a background job:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
2.40.2