### PR TITLE
efibootmgr: update page

### DIFF
--- a/pages/linux/efibootmgr.md
+++ b/pages/linux/efibootmgr.md
@@ -3,22 +3,22 @@
 > Manipulate the UEFI Boot Manager.
 > More information: <https://manned.org/efibootmgr>.
 
-- List the current settings then bootnums with their name:
+- List all boot options with their numbers:
 
-`efibootmgr`
-
-- List the filepaths:
-
-`efibootmgr -v`
+`efibootmgr {{-u|--unicode}}`
 
 - Add UEFI Shell v2 as a boot option:
 
-`sudo efibootmgr -c -d {{/dev/sda1}} -l {{\EFI\tools\Shell.efi}} -L "{{UEFI Shell}}"`
+`sudo efibootmgr -c -d {{/dev/sda}} -p {{1}} -l "{{\path\to\shell.efi}}" -L "{{UEFI Shell}}"`
+
+- Add Linux as a boot option:
+
+`sudo efibootmgr --create --disk {{/dev/sda}} --part {{1}} --loader "{{\vmlinuz}}" --unicode "{{kernel_cmdline}}" --label "{{Linux}}"`
 
 - Change the current boot order:
 
-`sudo efibootmgr -o {{0002,0008,0001,0005}}`
+`sudo efibootmgr {{-o|--bootorder}} {{0002,0008,0001,0005}}`
 
 - Delete a boot option:
 
-`sudo efibootmgr -b {{0008}} --delete-bootnum`
+`sudo efibootmgr {{-b|--bootnum}} {{0008}} {{-B|--delete-bootnum}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

I'm not sure what the second example is about - `efibootmgr -v` does not list any paths, so I removed it.