### PR TITLE
doggo: add page

### DIFF
--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -5,16 +5,21 @@
 > More information: <https://doggo.mrkaran.dev>.
 
 - Simple DNS lookup:
+
 `doggo {{example.com}}`
 
 - Query MX records using a specific nameserver:
+
 `doggo MX {{codeberg.org}} @{{1.1.1.2}}`
 
 - Use DNS over HTTPS:
+
 `doggo {{example.com}} @{{https://dns.quad9.net/dns-query}}`
 
 - JSON output for scripting:
+
 `doggo {{example.com}} --json | jq '{{.responses[0].answers[].address}}'`
 
 - Reverse DNS lookup:
+
 `doggo --reverse {{8.8.4.4}} --short`

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -16,7 +16,7 @@
 
 `doggo {{example.com}} @{{https://dns.quad9.net/dns-query}}`
 
-- JSON output for scripting:
+- Output in the JSON format:
 
 `doggo {{example.com}} --json | jq '{{.responses[0].answers[].address}}'`
 

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -20,6 +20,6 @@
 
 `doggo {{example.com}} --json | jq '{{.responses[0].answers[].address}}'`
 
-- Reverse DNS lookup:
+- Perform a reverse DNS lookup:
 
 `doggo --reverse {{8.8.4.4}} --short`

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -4,7 +4,7 @@
 > Written in Golang.
 > More information: <https://doggo.mrkaran.dev>.
 
-- Simple DNS lookup:
+- Perform a simple DNS lookup:
 
 `doggo {{example.com}}`
 

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -1,0 +1,20 @@
+# doggo
+
+> Command-line DNS client for Humans.
+> Written in Golang.
+> More information: <https://doggo.mrkaran.dev>.
+
+- Simple DNS lookup:
+`doggo {{example.com}}`
+
+- Query MX records using a specific nameserver:
+`doggo MX {{codeberg.org}} @{{1.1.1.2}}`
+
+- Use DNS over HTTPS:
+`doggo {{example.com}} @{{https://dns.quad9.net/dns-query}}`
+
+- JSON output for scripting:
+`doggo {{example.com}} --json | jq '{{.responses[0].answers[].address}}'`
+
+- Reverse DNS lookup:
+`doggo --reverse {{8.8.4.4}} --short`

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -1,6 +1,6 @@
 # doggo
 
-> Command-line DNS client for Humans.
+> DNS client for Humans.
 > Written in Golang.
 > More information: <https://doggo.mrkaran.dev>.
 


### PR DESCRIPTION
Add `doggo` DNS query command-line tool.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 1.0.4**
