### PR TITLE
nautilus: edit page replaced 'sudo nautilus' with 'nautilus admin:/' for accessing files and Directories as root

### DIFF
--- a/pages.ca/linux/nautilus.md
+++ b/pages.ca/linux/nautilus.md
@@ -10,7 +10,7 @@
 
 - Obre Nautilus com a root:
 
-`sudo nautilus`
+`nautilus admin:/`
 
 - Obre Nautilus en un directori específic:
 

--- a/pages.es/linux/nautilus.md
+++ b/pages.es/linux/nautilus.md
@@ -10,7 +10,7 @@
 
 - Inicia Nautilus como usuario root:
 
-`sudo nautilus`
+`nautilus admin:/`
 
 - Inicia Nautilus y muestra un directorio específico:
 

--- a/pages/linux/nautilus.md
+++ b/pages/linux/nautilus.md
@@ -11,7 +11,7 @@
 
 - Launch Nautilus as root user:
 
-`sudo nautilus`
+`nautilus admin:/`
 
 - Launch Nautilus and display a specific directory:
 


### PR DESCRIPTION
requiring administrative privileges.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
