### PR TITLE
cargo-clippy: add lint group example

### DIFF
--- a/pages/common/cargo-clippy.md
+++ b/pages/common/cargo-clippy.md
@@ -19,6 +19,10 @@
 
 `cargo clippy --package {{package}}`
 
+- Run checks for a lint group (see <https://rust-lang.github.io/rust-clippy/stable/index.html#?groups=cargo,complexity,correctness,deprecated,nursery,pedantic,perf,restriction,style,suspicious>):
+
+`cargo clippy -- --warn clippy::{{lint_group}}`
+
 - Treat warnings as errors:
 
 `cargo clippy -- --deny warnings`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `clippy 0.1.78`
