### PR TITLE
duckdb: simplify read_csv command

### DIFF
--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -29,7 +29,7 @@
 
 - Read CSV from `stdin` and write CSV to `stdout`:
 
-`cat {{path/to/source.csv}} | duckdb -c "{{COPY (FROM read_csv_auto('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}"`
+`cat {{path/to/source.csv}} | duckdb -c "{{COPY (FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}"`
 
 - Display help:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

**Version of the command being documented (if known):** 0.10.0

DuckDB's `read_csv_auto` is now accessible via `read_csv` since version 0.10.0 ([released in February 2024](https://github.com/duckdb/duckdb/releases/tag/v0.10.0)). This PR reflects this change.