### PR TITLE
fdupes: correct description of `-rH` to 'consider hardlinks'

### DIFF
--- a/pages/common/fdupes.md
+++ b/pages/common/fdupes.md
@@ -19,7 +19,7 @@
 
 `fdupes {{directory1}} -R {{directory2}}`
 
-- Search recursively and replace duplicates with hardlinks:
+- Search recursively, considering hardlinks as duplicates:
 
 `fdupes -rH {{path/to/directory}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This corrects the description of 'fdupes -rH', which causes `fdupes` to consider hardlinks as duplicates.  `fdupes` is not designed to convert duplicate files to hardlinks as implied by the original description.

```
❯ fdupes --version
fdupes 2.3.2

❯ fdupes --help
Usage: fdupes [options] DIRECTORY...

 -r --recurse            for every directory given follow subdirectories
                         encountered within
 -R --recurse:           for each directory given after this option follow
                         subdirectories encountered within (note the ':' at the
                         end of the option, manpage for more details)
 -s --symlinks           follow symlinks
 -H --hardlinks          normally, when two or more files point to the same
                         disk area they are treated as non-duplicates; this
                         option will change this behavior
```

The pertinent  code is:
``` c
file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *file)
{
  int cmpresult;
  char *fullpath;

  if (ISFLAG(flags, F_CONSIDERHARDLINKS))
  {
    /* If node already contains file, we don't want to add it again.
    */
    if (has_same_file(checktree, file))
      return NULL;
  }
  else
  {
    /* If device and inode fields are equal one of the files is a
       hard link to the other or the files have been listed twice
       unintentionally. We don't want to flag these files as
       duplicates unless the user specifies otherwise.
    */
    if (is_hardlink(checktree, file))
      return NULL;
  }

```