### PR TITLE
whatwaf: add page

### DIFF
--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -19,7 +19,7 @@
 
 `whatwaf --tor --payloads '{{payload1,payload2,...}}' -u {{https://example.com}}`
 
-- Use random user-agent, set throttling and timeout, use [P]OST request, and force HTTPS connection:
+- Use a random user-agent, set throttling and timeout, send a [P]OST request, and force HTTPS connection:
 
 `whatwaf --ra --throttle {{seconds}} --timeout {{seconds}} --post --force-ssl -u {{http://example.com}}`
 

--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -27,6 +27,6 @@
 
 `whatwaf --wafs`
 
-- List all tamper scripts available:
+- List all available tamper scripts:
 
 `whatwaf --tampers`

--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -15,7 +15,7 @@
 
 `whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{path/to/file}} -u {{https://example.com}}`
 
-- Send requests through tor (tor must be installed) using custom [p]ayloads (comma separated):
+- Send requests through Tor (Tor must be installed) using custom [p]ayloads (comma-separated):
 
 `whatwaf --tor --payloads '{{payload1,payload2,...}}' -u {{https://example.com}}`
 

--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -1,0 +1,32 @@
+# whatwaf
+
+> Detect and bypass web application firewalls and protection systems.
+> More information: <https://github.com/Ekultek/WhatWaf>.
+
+- Detect protection on a single [u]RL, optionally use verbose output:
+
+`whatwaf --url {{https://example.com}} --verbose`
+
+- Detect protection on a [l]ist of URLs in parallel from a file (one URL per line):
+
+`whatwaf --threads {{number}} --list {{path/to/file}}`
+
+- Send requests through a proxy and use custom [p]ayload [l]ist from a file (one payload per line):
+
+`whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{path/to/file}} -u {{https://example.com}}`
+
+- Send requests through tor (tor must be installed) using custom [p]ayloads (comma separated):
+
+`whatwaf --tor --payloads '{{payload1,payload2,...}}' -u {{https://example.com}}`
+
+- Use random user-agent, set throttling and timeout, use [P]OST request, and force HTTPS connection:
+
+`whatwaf --ra --throttle {{seconds}} --timeout {{seconds}} --post --force-ssl -u {{http://example.com}}`
+
+- List all WAFs that can be detected:
+
+`whatwaf --wafs`
+
+- List all tamper scripts available:
+
+`whatwaf --tampers`

--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -11,7 +11,7 @@
 
 `whatwaf --threads {{number}} --list {{path/to/file}}`
 
-- Send requests through a proxy and use custom [p]ayload [l]ist from a file (one payload per line):
+- Send requests through a proxy and use custom payload list from a file (one payload per line):
 
 `whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{path/to/file}} -u {{https://example.com}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
