### PR TITLE
octez-client: add page

### DIFF
--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -1,0 +1,32 @@
+# octez-client
+
+> Command-line client for interacting with the Tezos blockchain.
+> More information: <https://tezos.gitlab.io/user/setup-client.html>.
+
+- Configure the client with a connection to a Tezos RPC node such as `https://rpc.ghostnet.teztnets.com`:
+
+`octez-client -E {{endpoint}} config update`
+
+- Create an account and assign a local alias to it:
+
+`octez-client gen keys {{alias}}`
+
+- Get the balance of an account by alias or address:
+
+`octez-client get balance for {{alias_or_address}}`
+
+- Transfer tez to a different account:
+
+`octez-client transfer {{5}} from {{alias_or_address}} to {{alias_or_address}}`
+
+- Originate (deploy) a smart contract, assign it a local alias, and set its initial storage as a Michelson-encoded value:
+
+`octez-client originate contract {{alias}} transferring {{0}} from {{alias_or_address}} running {{source_file.tz}} --init "{{initial_storage}}" --burn_cap {{1}}`
+
+- Call a smart contract by its alias or address and pass a Michelson-encoded parameter:
+
+`octez-client transfer {{0}} from {{alias_or_address}} to {{contract}} --entrypoint "{{entrypoint}}" --arg "{{parameter}}" --burn-cap {{1}}`
+
+- Display help:
+
+`octez-client man`

--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -17,15 +17,15 @@
 
 - Transfer tez to a different account:
 
-`octez-client transfer {{5}} from {{alias_or_address}} to {{alias_or_address}}`
+`octez-client transfer {{5}} from {{alias|address}} to {{alias|address}}`
 
 - Originate (deploy) a smart contract, assign it a local alias, and set its initial storage as a Michelson-encoded value:
 
-`octez-client originate contract {{alias}} transferring {{0}} from {{alias_or_address}} running {{path/to/source_file.tz}} --init "{{initial_storage}}" --burn_cap {{1}}`
+`octez-client originate contract {{alias}} transferring {{0}} from {{alias|address}} running {{path/to/source_file.tz}} --init "{{initial_storage}}" --burn_cap {{1}}`
 
 - Call a smart contract by its alias or address and pass a Michelson-encoded parameter:
 
-`octez-client transfer {{0}} from {{alias_or_address}} to {{contract}} --entrypoint "{{entrypoint}}" --arg "{{parameter}}" --burn-cap {{1}}`
+`octez-client transfer {{0}} from {{alias|address}} to {{contract}} --entrypoint "{{entrypoint}}" --arg "{{parameter}}" --burn-cap {{1}}`
 
 - Display help:
 

--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -1,7 +1,7 @@
 # octez-client
 
 > Interact with the Tezos blockchain.
-> More information: <https://tezos.gitlab.io/user/setup-client.html>.
+> More information: <https://tezos.gitlab.io/introduction/howtouse.html#client>.
 
 - Configure the client with a connection to a Tezos RPC node such as `https://rpc.ghostnet.teztnets.com`:
 

--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -21,7 +21,7 @@
 
 - Originate (deploy) a smart contract, assign it a local alias, and set its initial storage as a Michelson-encoded value:
 
-`octez-client originate contract {{alias}} transferring {{0}} from {{alias_or_address}} running {{source_file.tz}} --init "{{initial_storage}}" --burn_cap {{1}}`
+`octez-client originate contract {{alias}} transferring {{0}} from {{alias_or_address}} running {{path/to/source_file.tz}} --init "{{initial_storage}}" --burn_cap {{1}}`
 
 - Call a smart contract by its alias or address and pass a Michelson-encoded parameter:
 

--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -3,7 +3,7 @@
 > Interact with the Tezos blockchain.
 > More information: <https://tezos.gitlab.io/introduction/howtouse.html#client>.
 
-- Configure the client with a connection to a Tezos RPC node such as `https://rpc.ghostnet.teztnets.com`:
+- Configure the client with a connection to a Tezos RPC node such as <https://rpc.ghostnet.teztnets.com>:
 
 `octez-client -E {{endpoint}} config update`
 

--- a/pages/common/octez-client.md
+++ b/pages/common/octez-client.md
@@ -1,6 +1,6 @@
 # octez-client
 
-> Command-line client for interacting with the Tezos blockchain.
+> Interact with the Tezos blockchain.
 > More information: <https://tezos.gitlab.io/user/setup-client.html>.
 
 - Configure the client with a connection to a Tezos RPC node such as `https://rpc.ghostnet.teztnets.com`:


### PR DESCRIPTION
This PR adds example commands for `octez-client`, the primary command-line client for the Tezos blockchain and one of the programs in the Octez suite of tools. TLDR, here are some quick install instructions: https://docs.tezos.com/developing/octez-client/installing. Official install instructions are at https://tezos.gitlab.io/introduction/howtoget.html. 

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 20.02**
