### PR TITLE
automount: add page

### DIFF
--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -1,6 +1,6 @@
 # automount
 
-> Reads the /etc/auto_master file and mounts `autofs` on the appropriate mount points to trigger on-demand mounting of directories. Essentially, it's a way to manually initiate the system's automounting process.
+> Read the `/etc/auto_master` file and mount `autofs` on the appropriate mount points to trigger the on-demand mounting of directories. Essentially, it's a way to manually initiate the system's automounting process.
 > Note: You'll most likely need to run with `sudo` if you don't have the necessary permissions.
 > More information: <https://keith.github.io/xcode-man-pages/automount.8.html>.
 

--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -2,7 +2,7 @@
 
 > Reads the /etc/auto_master file and mounts `autofs` on the appropriate mount points to trigger on-demand mounting of directories. Essentially, it's a way to manually initiate the system's automounting process.
 > Note: You'll most likely need to run with `sudo` if you don't have the necessary permissions.
-> More information: https://keith.github.io/xcode-man-pages/automount.8.html
+> More information: <https://keith.github.io/xcode-man-pages/automount.8.html>
 
 - Run automount, flush the cache beforehand, and be verbose about it (most common use):
 

--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -4,11 +4,11 @@
 > Note: You'll most likely need to run with `sudo` if you don't have the necessary permissions.
 > More information: <https://keith.github.io/xcode-man-pages/automount.8.html>.
 
-- Run automount, flush the cache beforehand, and be verbose about it (most common use):
+- Run automount, flush the cache(`-c`) beforehand, and be verbose(`-v`) about it (most common use):
 
 `automount -cv`
 
-- Automatically unmount after 5 minutes of inactivity:
+- Automatically unmount after 5 minutes (300 seconds) of inactivity:
 
 `automount -t 300`
 

--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -2,7 +2,7 @@
 
 > Reads the /etc/auto_master file and mounts `autofs` on the appropriate mount points to trigger on-demand mounting of directories. Essentially, it's a way to manually initiate the system's automounting process.
 > Note: You'll most likely need to run with `sudo` if you don't have the necessary permissions.
-> More information: <https://keith.github.io/xcode-man-pages/automount.8.html>
+> More information: <https://keith.github.io/xcode-man-pages/automount.8.html>.
 
 - Run automount, flush the cache beforehand, and be verbose about it (most common use):
 

--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -12,6 +12,6 @@
 
 `automount -t 300`
 
-- Unmount anything previously mounted by automount and/or defined in /etc/auto_master:
+- Unmount anything previously mounted by automount and/or defined in `/etc/auto_master`:
 
 `automount -u`

--- a/pages/osx/automount.md
+++ b/pages/osx/automount.md
@@ -1,0 +1,17 @@
+# automount
+
+> Reads the /etc/auto_master file and mounts `autofs` on the appropriate mount points to trigger on-demand mounting of directories. Essentially, it's a way to manually initiate the system's automounting process.
+> Note: You'll most likely need to run with `sudo` if you don't have the necessary permissions.
+> More information: https://keith.github.io/xcode-man-pages/automount.8.html
+
+- Run automount, flush the cache beforehand, and be verbose about it (most common use):
+
+`automount -cv`
+
+- Automatically unmount after 5 minutes of inactivity:
+
+`automount -t 300`
+
+- Unmount anything previously mounted by automount and/or defined in /etc/auto_master:
+
+`automount -u`


### PR DESCRIPTION
Added page for osx command `automount`, in English.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
