### PR TITLE
timeout: edit page

### DIFF
--- a/pages/common/timeout.md
+++ b/pages/common/timeout.md
@@ -7,6 +7,18 @@
 
 `timeout 3s sleep 10`
 
-- Send a signal to the command after the time limit expires (SIGTERM by default):
+- Send a [s]ignal to the command after the time limit expires (`TERM` by default, `kill -l` to list all signals):
 
-`timeout --signal {{INT}} {{5s}} {{sleep 10}}`
+`timeout --signal {{INT|HUP|KILL ...}} {{5s}} {{sleep 10}}`
+
+- Send [v]erbose output to `stderr` showing signal sent upon timeout:
+
+`timout --verbose {{0.5s|1m|1h|1d}} {{command}}`
+
+- Preserve the exit status of the command regardless of timing out:
+
+`timeout --preserve status {{1s|1m|1h|1d}} {{command}}`
+
+- Send a forceful `KILL` signal after certain duration if the command ignores initial signal upon timeout:
+
+`timeout --kill-after={{5m}} {{30s}} {{command}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 8.32**
