### PR TITLE
arduino-builder: fix argument formats

### DIFF
--- a/pages.fr/common/arduino-builder.md
+++ b/pages.fr/common/arduino-builder.md
@@ -16,7 +16,7 @@
 
 `arduino-builder -build-path {{chemin/vers/dossier/de/construction}}`
 
-- Utilise un fichier d'option de construction, au lieu de spécifier `--hardware`, `--tools`, etc. Manuellement à chaque fois :
+- Utilise un fichier d'option de construction, au lieu de spécifier `-hardware`, `-tools`, etc. Manuellement à chaque fois :
 
 `arduino-builder -build-options-file {{chemin/vers/construction.options.json}}`
 

--- a/pages.pt_BR/common/arduino-builder.md
+++ b/pages.pt_BR/common/arduino-builder.md
@@ -16,7 +16,7 @@
 
 `arduino-builder -build-path {{caminho/para/diretorio}}`
 
-- Usa um arquivo com as opções de compilação, em vez de especificar `--hardware`, `--tools`, etc. manualmente toda hora:
+- Usa um arquivo com as opções de compilação, em vez de especificar `-hardware`, `-tools`, etc. manualmente toda hora:
 
 `arduino-builder -build-options-file {{caminho/para/build.options.json}}`
 

--- a/pages/common/arduino-builder.md
+++ b/pages/common/arduino-builder.md
@@ -16,7 +16,7 @@
 
 `arduino-builder -build-path {{path/to/build_directory}}`
 
-- Use a build option file, instead of specifying `--hardware`, `--tools`, etc. manually every time:
+- Use a build option file, instead of specifying `-hardware`, `-tools`, etc. manually every time:
 
 `arduino-builder -build-options-file {{path/to/build.options.json}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

The original program documentation (<https://github.com/arduino/arduino-builder>) explicitly uses command arguments with single dash, so this minor update updates the example descriptions to reflect the original docs.
