### PR TITLE
timeout: update Dutch translation

### DIFF
--- a/pages.nl/common/timeout.md
+++ b/pages.nl/common/timeout.md
@@ -7,6 +7,18 @@
 
 `timeout 3s sleep 10`
 
-- Stuur een signaal naar het commando nadat de tijdslimiet is verlopen (standaard SIGTERM):
+- Stuur een [s]ignaal naar het commando nadat de tijdslimiet is verlopen (standaard `TERM`, `kill -l` om alle signalen te tonen):
 
-`timeout --signal {{INT}} {{5s}} {{sleep 10}}`
+`timeout --signal {{INT|HUP|KILL|...}} {{5s}} {{sleep 10}}`
+
+- Stuur [v]erbose output naar `stderr` en laat het signaal zien dat is verzonden bij een timeout:
+
+`timeout --verbose {{0.5s|1m|1h|1d|...}} {{commando}}`
+
+- Behoud de exit status van het commando ongeacht of er een timeout is:
+
+`timeout --preserve-status {{1s|1m|1h|1d|...}} {{commando}}`
+
+- Stuur een krachtig `KILL`-signaal na een bepaalde tijd als het commando het initiële signaal negeert bij een timeout:
+
+`timeout --kill-after={{5m}} {{30s}} {{commando}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).