### PR TITLE
read: fix example command

### DIFF
--- a/pages/common/read.md
+++ b/pages/common/read.md
@@ -17,7 +17,7 @@
 
 - Assign multiple values to multiple variables:
 
-`{{echo "The name is Bond"}} | read {{_ variable1 _ variable2}}`
+`read {{_ variable1 _ variable2}} <<< {{"The surname is Bond"}}`
 
 - Do not let backslash (\\) act as an escape character:
 


### PR DESCRIPTION
Replaced example worked in zsh only. Fixed example works in both zsh and bash.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
