### PR TITLE
kill: remove the `--table` long option

### DIFF
--- a/pages.nl/linux/kill.md
+++ b/pages.nl/linux/kill.md
@@ -10,7 +10,7 @@
 
 - Lijst signaalwaarden en hun overeenkomstige namen op (te gebruiken zonder het `SIG` voorvoegsel):
 
-`kill {{-L|--table}}`
+`kill -L`
 
 - Beëindig een achtergrondtaak:
 


### PR DESCRIPTION
Ref:  #13241

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).