### PR TITLE
MAINTAINERS: fix @tansiret username, add back to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,14 @@
 /pages.fr/ @Nico385412 @nicokosi @noraj
 /pages.hi/ @kbdharun
 /pages.id/ @reinhart1010
-/pages.it/ @mebeim @Magrid0
+/pages.it/ @mebeim @tansiret @Magrid0
 /pages.ko/ @IMHOJEONG
 /pages.nl/ @sebastiaanspeck @leonvsc @Waples
 /pages.pl/ @acuteenvy @spageektti
 /pages.pt_BR/ @isaacvicente @vitorhcl
 /pages.pt_PT/ @waldyrious
 /pages.ta/ @kbdharun
+/pages.tr/ @tansiret
 /pages.zh/ @blueskyson @einverne
 /pages.zh_TW/ @blueskyson
 
@@ -31,12 +32,13 @@
 /contributing-guides/*.fr.md @Nico385412 @nicokosi @noraj
 /contributing-guides/*.hi.md @kbdharun
 /contributing-guides/*.id.md @reinhart1010
-/contributing-guides/*.it.md @mebeim @Magrid0
+/contributing-guides/*.it.md @mebeim @tansiret @Magrid0
 /contributing-guides/*.ko.md @IMHOJEONG
 /contributing-guides/*.nl.md @sebastiaanspeck @leonvsc @Waples
 /contributing-guides/*.pl.md @acuteenvy @spageektti
 /contributing-guides/*.pt_BR.md @isaacvicente @vitorhcl
 /contributing-guides/*.pt_PT.md @waldyrious
 /contributing-guides/*.ta.md @kbdharun
+/contributing-guides/*.tr.md @tansiret
 /contributing-guides/*.zh.md @blueskyson @einverne
 /contributing-guides/*.zh_TW.md @blueskyson

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -86,7 +86,7 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [24 August 2020](https://github.com/tldr-pages/tldr/issues/4291) — [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504)
 - bl-ue ([@bl-ue](https://github.com/bl-ue)):
   [30 December 2020](https://github.com/tldr-pages/tldr/issues/5056) — [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219)
-- Tan Siret Akıncı ([@yutyo](https://github.com/yutyo)):
+- Tan Siret Akıncı ([@tansiret](https://github.com/tansiret)):
   [3 March 2021](https://github.com/tldr-pages/tldr/issues/5345) — [7 April 2021](https://github.com/tldr-pages/tldr/issues/5702)
 - Florian Benscheidt ([@Waples](https://github.com/Waples)):
   [16 April 2021](https://github.com/tldr-pages/tldr/issues/5774) — [19 May 2021](https://github.com/tldr-pages/tldr/issues/5989)
@@ -138,7 +138,7 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [5 January 2020](https://github.com/tldr-pages/tldr/issues/3736) — present
 - **Ein Verne ([@einverne](https://github.com/einverne))**:
   [6 January 2020](https://github.com/tldr-pages/tldr/issues/3738) — present
-- **Tan Siret Akıncı ([@yutyo](https://github.com/yutyo))**:
+- **Tan Siret Akıncı ([@tansiret](https://github.com/tansiret))**:
   [7 April 2021](https://github.com/tldr-pages/tldr/issues/5702) — present
 - **Florian Benscheidt ([@Waples](https://github.com/Waples))**:
   [19 May 2021](https://github.com/tldr-pages/tldr/issues/5989) — present


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/pull/13461#issuecomment-2295286922

This PR adds back yutyo with their renamed username to the CODEOWNERS file and updates the MAINTAINERS file for the same.
