### PR TITLE
mycli: add Dutch translation

### DIFF
--- a/pages.nl/common/mycli.md
+++ b/pages.nl/common/mycli.md
@@ -1,0 +1,16 @@
+# mycli
+
+> Een command-line client voor MySQL die automatische aanvulling en syntaxisaccentuering kan uitvoeren.
+> Meer informatie: <https://mycli.net>.
+
+- Verbinden met een lokale database op poort 3306, met de gebruikersnaam van de huidige gebruiker:
+
+`mycli {{database_naam}}`
+
+- Verbinden met een database (gebruiker wordt gevraagd om een wachtwoord):
+
+`mycli -u {{gebruikersnaam}} {{database_naam}}`
+
+- Verbinden met een database op een andere host:
+
+`mycli -h {{database_host}} -P {{poort}} -u {{gebruikersnaam}} {{database_naam}}`

--- a/pages.nl/linux/mycli.md
+++ b/pages.nl/linux/mycli.md
@@ -1,0 +1,16 @@
+# mycli
+
+> Een CLI voor MySQL, MariaDB en Percona met automatische aanvulling en syntaxisaccentuering.
+> Meer informatie: <https://manned.org/mycli>.
+
+- Verbinden met een database met de huidige ingelogde gebruiker:
+
+`mycli {{database_naam}}`
+
+- Verbinden met een database met de opgegeven gebruiker:
+
+`mycli -u {{gebruiker}} {{database_naam}}`
+
+- Verbinden met een database op de opgegeven host met de opgegeven gebruiker:
+
+`mycli -u {{gebruiker}} -h {{host}} {{database_naam}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 