### PR TITLE
uv, uv-{python,tool}: add page

### DIFF
--- a/pages/common/uv-python.md
+++ b/pages/common/uv-python.md
@@ -1,0 +1,28 @@
+# uv python
+
+> Manage Python versions and installations.
+> More information: <https://docs.astral.sh/uv/reference/cli/#uv-python>.
+
+- List all available Python installations:
+
+`uv python list`
+
+- Install a Python version:
+
+`uv python install {{version}}`
+
+- Uninstall a Python version:
+
+`uv python uninstall {{version}}`
+
+- Search for a Python installation:
+
+`uv python find {{version}}`
+
+- Pin the current project to use a specific Python version:
+
+`uv python pin {{version}}`
+
+- Show the `uv` Python installation directory:
+
+`uv python dir`

--- a/pages/common/uv-tool.md
+++ b/pages/common/uv-tool.md
@@ -1,0 +1,24 @@
+# uv tool
+
+> Install and run commands provided by Python packages.
+> More information: <https://docs.astral.sh/uv/reference/cli/#uv-tool>.
+
+- Run a command from a package, without installing it.
+
+`uv tool run {{command}}`
+
+- Install a Python package system-wide.
+
+`uv tool install {{package}}`
+
+- Upgrade an installed Python package.
+
+`uv tool upgrade {{package}}`
+
+- Uninstall a Python package.
+
+`uv tool uninstall {{package}}`
+
+- List Python packages installed system-wide.
+
+`uv tool list`

--- a/pages/common/uv-tool.md
+++ b/pages/common/uv-tool.md
@@ -3,22 +3,22 @@
 > Install and run commands provided by Python packages.
 > More information: <https://docs.astral.sh/uv/reference/cli/#uv-tool>.
 
-- Run a command from a package, without installing it.
+- Run a command from a package, without installing it:
 
 `uv tool run {{command}}`
 
-- Install a Python package system-wide.
+- Install a Python package system-wide:
 
 `uv tool install {{package}}`
 
-- Upgrade an installed Python package.
+- Upgrade an installed Python package:
 
 `uv tool upgrade {{package}}`
 
-- Uninstall a Python package.
+- Uninstall a Python package:
 
 `uv tool uninstall {{package}}`
 
-- List Python packages installed system-wide.
+- List Python packages installed system-wide:
 
 `uv tool list`

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -32,6 +32,6 @@
 
 `uv sync`
 
-- Create a lockfile for the project's dependencies:
+- Create a lock file for the project's dependencies:
 
 `uv lock`

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -20,11 +20,11 @@
 
 `uv remove {{package}}`
 
-- Run a script in the project environment:
+- Run a script in the project's environment:
 
 `uv run {{path/to/script.py}}`
 
-- Run a command in the project environment:
+- Run a command in the project's environment:
 
 `uv run {{command}}`
 

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -1,0 +1,37 @@
+# uv
+
+> A fast Python package and project manager.
+> Some subcommands such as `uv tool` and `uv python` have their own usage documentation.
+> More information: <https://docs.astral.sh/uv/reference/cli>.
+
+- Create a new Python project in the current directory:
+
+`uv init`
+
+- Create a new Python project in a directory with the given name:
+
+`uv init {{project_name}}`
+
+- Add a new package to the project:
+
+`uv add {{package}}`
+
+- Remove a package from the project:
+
+`uv remove {{package}}`
+
+- Run a script in the project environment:
+
+`uv run {{path/to/script.py}}`
+
+- Run a command in the project environment:
+
+`uv run {{command}}`
+
+- Update a project's environment from `pyproject.toml`:
+
+`uv sync`
+
+- Create a lockfile for the project's dependencies:
+
+`uv lock`


### PR DESCRIPTION
Tried to do `tldr uv` but it could't find anything, so I have added the core pages for [uv](https://github.com/astral-sh/uv).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
