### PR TITLE
git-diff: Use --stat command instead of only names

### DIFF
--- a/pages/common/git-diff.md
+++ b/pages/common/git-diff.md
@@ -19,9 +19,9 @@
 
 `git diff 'HEAD@{3 months|weeks|days|hours|seconds ago}'`
 
-- Show only names of changed files since a given commit:
+- Show diff statistics, like files changed, histogram, and total line insertions/deletions:
 
-`git diff --name-only {{commit}}`
+`git diff --stat {{commit}}`
 
 - Output a summary of file creations, renames and mode changes since a given commit:
 


### PR DESCRIPTION
There are already 8 examples. The diffstat is more useful for users to get a quick summary of what changed, and is what's shown for a git pull by default. The changed file names is more useful programmatically.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
