### PR TITLE
quickget: fix correct examples and update changed options

### DIFF
--- a/pages/linux/quickget.md
+++ b/pages/linux/quickget.md
@@ -19,16 +19,20 @@
 
 - Download a macOS recovery image and creates a virtual machine configuration:
 
-`quickget macos {{high-sierra|mojave|catalina|big-sur|monterey|ventura}}`
+`quickget macos {{mojave|catalina|big-sur|monterey|ventura|sonoma}}`
 
-- Show an ISO URL for an operating system (Note: it does not work for Windows):
+- Show an ISO URL for an operating system:
 
-`quickget --show-iso-url fedora {{release}} {{edition}}`
+`quickget --url fedora {{release}} {{edition}}`
 
 - Test if an ISO file is available for an operating system:
 
-`quickget --test-iso-url nixos {{edition}} {{plasma5}}`
+`quickget --check nixos {{release}} {{edition}}`
 
-- Open an operating system distribution's homepage in a browser (Note: it does not work for Windows):
+- Download an image without building any VM configuration:
 
-`quickget --open-distro-homepage {{os}}`
+`quickget --download {{os}} {{release}} {{edition}}`
+
+- Create a VM configuration for an OS image:
+
+`quickget --create-config {{os}} {{path/to/iso}}`


### PR DESCRIPTION
the nixos example was incorrect, the macos release list has been updated and some options have been added, renamed or removed


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- 4.9.6 **Version of the command being documented (if known):**
