### PR TITLE
deb-get: correct examples and move to linux section

### DIFF
--- a/pages/linux/deb-get.md
+++ b/pages/linux/deb-get.md
@@ -6,7 +6,7 @@
 
 - Update the list of available packages and versions:
 
-`sudo deb-get update`
+`deb-get update`
 
 - Search for a given package:
 
@@ -18,15 +18,15 @@
 
 - Install a package, or update it to the latest available version:
 
-`sudo deb-get install {{package}}`
+`deb-get install {{package}}`
 
 - Remove a package (using `purge` instead also removes its configuration files):
 
-`sudo deb-get remove {{package}}`
+`deb-get remove {{package}}`
 
 - Upgrade all installed packages to their newest available versions:
 
-`sudo deb-get upgrade`
+`deb-get upgrade`
 
 - List all available packages:
 


### PR DESCRIPTION
Users must **NOT** use `sudo deb-get` - it is not needed and as well as being bad practice it causes problems.


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  0.4.2
