### PR TITLE
pages.id: refresh page

### DIFF
--- a/pages.id/common/2to3.md
+++ b/pages.id/common/2to3.md
@@ -1,32 +1,32 @@
 # 2to3
 
-> Mengkonversikan kode Python 2 menuju file Python 3 secara otomatis.
+> Alih bahasa kode program dari Python 2 menuju Python 3 secara otomatis.
 > Informasi lebih lanjut: <https://docs.python.org/3/library/2to3.html>.
 
-- Menampilkan apa saja yang akan diubah tanpa mengubahnya secara langsung (dry-run):
+- Tampilkan apa saja yang akan diubah tanpa mengubahnya secara langsung (dry-run):
 
-`2to3 {{jalan/menuju/file.py}}`
+`2to3 {{jalan/menuju/berkas.py}}`
 
-- Mengkonversikan sebuah file Python 2 menuju file Python 3:
+- Alih bahasa dan tulis ulang berkas program Python 2 menuju Python 3:
 
-`2to3 --write {{jalan/menuju/file.py}}`
+`2to3 --write {{jalan/menuju/berkas.py}}`
 
-- Mengkonversikan fitur bahasa pemrograman Python 2 tertentu menuju Python 3:
+- Pilih jenis fitur bahasa yang akan dialihbahasakan dari Python 2 menuju Python 3:
 
-`2to3 --write {{jalan/menuju/file.py}} --fix {{raw_input}} --fix {{print}}`
+`2to3 --write {{jalan/menuju/berkas.py}} --fix {{raw_input}} --fix {{print}}`
 
-- Mengkonversikan seluruh fitur Python 2 menjadi Python 3, kecuali fitur-fitur tertentu:
+- Pilih jenis fitur bahasa yang dikecualikan dari proses pengalihbahasaan:
 
 `2to3 --write {{jalan/menuju/file.py}} --nofix {{has_key}} --nofix {{isinstance}}`
 
-- Menampilkan daftar fitur-fitur bahasa pemrograman yang dapat dikonversikan dari Python 2 menuju Python 3:
+- Tampilkan daftar fitur bahasa pemrograman yang dapat dialihbahasakan dari Python 2 menuju Python 3:
 
 `2to3 --list-fixes`
 
-- Mengkonversikan seluruh file Python 2 menuju Python 3 di dalam sebuah direktori:
+- Alih bahasa dan tulis ulang seluruh berkas dari suatu direktori menuju direktori baru:
 
 `2to3 --output-dir {{jalan/menuju/direktori_python3}} --write-unchanged-files --nobackups {{jalan/menuju/direktori_python2}}`
 
-- Menjalankan program ini dengan lebih dari satu thread:
+- Jalankan program ini dengan lebih dari satu thread:
 
 `2to3 --processes {{4}} --output-dir {{jalan/menuju/direktori_python3}} --write --nobackups --no-diff {{jalan/menuju/direktori_python2}}`

--- a/pages.id/common/aapt.md
+++ b/pages.id/common/aapt.md
@@ -1,17 +1,17 @@
 # aapt
 
 > Alat Pemaketan Android Asset.
-> Menyusun dan memaketkan resource aplikasi Android.
+> Susun dan buat paket resource aplikasi Android.
 > Informasi lebih lanjut: <https://elinux.org/Android_aapt>.
 
-- Daftar berkas-berkas yang termuat dalam arsip APK:
+- Tampilkan daftar berkas yang termuat dalam suatu arsip APK:
 
-`aapt list {{alamat/ke/aplikasi.apk}}`
+`aapt list {{jalan/menuju/aplikasi.apk}}`
 
-- Menampilkan metadata aplikasi (versi, izin, dsb.):
+- Tampilkan metadata aplikasi (versi, izin, dsb.):
 
-`aapt dump badging {{alamat/ke/aplikasi.apk}}`
+`aapt dump badging {{jalan/menuju/aplikasi.apk}}`
 
-- Membuat arsip APK baru dengan berkas dari direktory yang ditentukan:
+- Buat suatu arsip APK baru dengan berkas dari direktori yang ditentukan:
 
-`aapt package -F {{alamat/ke/aplikasi.apk}} {{alamat/ke/direktori}}`
+`aapt package -F {{jalan/menuju/aplikasi.apk}} {{jalan/menuju/direktori}}`

--- a/pages.id/common/adb.md
+++ b/pages.id/common/adb.md
@@ -4,7 +4,7 @@
 > Kami mempunyai dokumentasi terpisah untuk menggunakan subperintah seperti `adb shell`.
 > Informasi lebih lanjut: <https://developer.android.com/tools/adb>.
 
-- Cek apakah proses server adb telah dimulai dan memulainya:
+- Periksa apakah proses server adb telah dimulai dan memulainya:
 
 `adb start-server`
 
@@ -16,18 +16,18 @@
 
 `adb shell`
 
-- Instal aplikasi Android ke emulator/perangkat tujuan:
+- Pasang suatu aplikasi Android menuju emulator/perangkat tujuan:
 
-`adb install -r {{alamat/ke/berkas.apk}}`
+`adb install -r {{jalan/menuju/berkas.apk}}`
 
 - Salin berkas/direktori dari perangkat tujuan:
 
-`adb pull {{alamat/ke/berkas_atau_direktori_perangkat}} {{alamat/ke/direktori_lokal_tujuan}}`
+`adb pull {{jalan/menuju/berkas_atau_direktori_perangkat}} {{jalan/menuju/direktori_lokal_tujuan}}`
 
-- Salin berkas/direktori ke perangkat tujuan:
+- Salin berkas/direktori menuju perangkat tujuan:
 
-`adb push {{alamat/ke/berkas_atau_direktori_lokal}} {{alamat/ke/direktori_perangkat_tujuan}}`
+`adb push {{jalan/menuju/berkas_atau_direktori_lokal}} {{jalan/menuju/direktori_perangkat_tujuan}}`
 
-- Dapatkan daftar perangkat yang terhubung:
+- Tampilkan daftar perangkat yang terhubung:
 
 `adb devices`

--- a/pages.id/common/alacritty.md
+++ b/pages.id/common/alacritty.md
@@ -3,22 +3,22 @@
 > Lintas platform, terakselerasi GPU terminal emulator.
 > Informasi lebih lanjut: <https://github.com/alacritty/alacritty>.
 
-- Membuka jendela Alacritty baru:
+- Buka jendela Alacritty baru:
 
 `alacritty`
 
-- Menjalankan Alacritty pada direktori tertentu:
+- Jalankan Alacritty pada direktori tertentu:
 
-`alacritty --working-directory {{alamat/ke/direktori}}`
+`alacritty --working-directory {{jalan/menuju/direktori}}`
 
-- Menjalankan perintah di jendela Alacritty baru:
+- Jalankan perintah di jendela Alacritty baru:
 
 `alacritty -e {{perintah}}`
 
-- Menentukan berkas konfigurasi alternatif (nilai default `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
+- Gunakan berkas konfigurasi alternatif untuk memuat program (nilai default `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
-`alacritty --config-file {{alamat/ke/konfigurasi.toml}}`
+`alacritty --config-file {{jalan/menuju/konfigurasi.toml}}`
 
-- Menjalankan dengan mengaktifkan pemuatan ulang konfigurasi secara langsung/otomatis (dapat juga diaktifkan secara default di `alacritty.toml`):
+- Jalankan dan aktifkan fitur muat ulang konfigurasi secara langsung/otomatis (dapat juga diaktifkan secara default di `alacritty.toml`):
 
-`alacritty --live-config-reload --config-file {{alamat/ke/konfigurasi.toml}}`
+`alacritty --live-config-reload --config-file {{jalan/menuju/konfigurasi.toml}}`

--- a/pages.id/common/apktool.md
+++ b/pages.id/common/apktool.md
@@ -3,14 +3,14 @@
 > Me-reverse engineer berkas APK.
 > Informasi lebih lanjut: <https://ibotpeaches.github.io/Apktool/>.
 
-- Dekode berkas APK:
+- Bongkar isi ([d]ekode) berkas APK:
 
 `apktool d {{berkas.apk}}`
 
-- Men-build folder menjadi berkas APK:
+- [b]angun kode sumber dalam suatu direktori menjadi berkas APK:
 
-`apktool b {{alamat/ke/direktori}}`
+`apktool b {{jalan/menuju/direktori}}`
 
-- Menginstal dan menyimpan frameworks:
+- Pasang ([i]nstal) dan simpan komponen [f]rameworks dari suatu berkas APK:
 
 `apktool if {{framework.apk}}`

--- a/pages.id/common/asar.md
+++ b/pages.id/common/asar.md
@@ -5,16 +5,16 @@
 
 - Arsipkan sebuah berkas atau direktori:
 
-`asar pack {{alamat/ke/berkas_atau_direktori}} {{arsip.asar}}`
+`asar pack {{jalan/menuju/berkas_atau_direktori}} {{arsip.asar}}`
 
-- Mengekstrak sebuah arsip:
+- Bongkar isi suatu arsip:
 
 `asar extract {{arsip.asar}}`
 
-- Mengekstrak berkas tertentu dari sebuah arsip:
+- Bongkar isi berkas tertentu dari suatu arsip:
 
 `asar extract-file {{arsip.asar}} {{berkas}}`
 
-- Mendapatkan daftar konten dari berkas arsip:
+- Tampilkan daftar isi dari suatu berkas arsip:
 
 `asar list {{arsip.asar}}`

--- a/pages.id/common/deno.md
+++ b/pages.id/common/deno.md
@@ -3,22 +3,22 @@
 > Runtime aman untuk JavaScript dan TypeScript.
 > Informasi lebih lanjut: <https://deno.land>.
 
-- Menjalankan berkas JavaScript atau TypeScript:
+- Jalankan program dari suatu berkas JavaScript atau TypeScript:
 
-`deno run {{alamat/ke/berkas.ts}}`
+`deno run {{jalan/menuju/berkas.ts}}`
 
-- Menjalankan REPL (shell interaktif):
+- Jalankan REPL (shell interaktif):
 
 `deno`
 
-- Menjalankan berkas dengan memperbolehkan akses jaringan:
+- Jalankan berkas dengan memperbolehkan akses jaringan:
 
-`deno run --allow-net {{alamat/ke/berkas.ts}}`
+`deno run --allow-net {{jalan/menuju/berkas.ts}}`
 
-- Menjalankan berkas dari URL:
+- Jalankan berkas dari URL:
 
 `deno run {{https://deno.land/std/examples/welcome.ts}}`
 
-- Memasang skrip yang dapat dieksekusi dari URL:
+- Pasang skrip yang dapat dieksekusi dari URL:
 
 `deno install {{https://deno.land/std/examples/colors.ts}}`

--- a/pages.id/common/gdb.md
+++ b/pages.id/common/gdb.md
@@ -1,24 +1,24 @@
 # gdb
 
-> GNU Debugger.
+> GNU Debugger, alat pengawakutu program komputer.
 > Informasi lebih lanjut: <https://www.gnu.org/software/gdb>.
 
-- Menjalankan debug pada sebuah berkas yang dapat dieksekusi:
+- Jalankan pengawakutu pada sebuah berkas program yang dapat dieksekusi:
 
 `gdb {{berkas_exe}}`
 
-- Menambahkan sebuah proses pada gdb:
+- Tambahkan suatu proses untuk diawasi oleh gdb:
 
 `gdb -p {{berkas_exe}}`
 
-- Menjalankan debug dengan berkas core:
+- Jalankan pengawakutu dengan berkas core:
 
 `gdb -c {{core}} {{berkas_exe}}`
 
-- Mengeksekusi perintah GDB pada saat dijanlakan:
+- Kirim perintah menuju pengawakutu pada saat dijalankan:
 
 `gdb -ex "{{perintah}}" {{berkas_exe}}`
 
-- Menjalankan gdb dan melemparkan argumen pada berkas yang dieksekusi:
+- Lemparkan argumen terhadap berkas program yang dieksekusi saat hendak diawasi oleh GDB:
 
 `gdb --args {{berkas_exe}} {{argumen1}} {{argumen2}}`

--- a/pages.id/common/git-add.md
+++ b/pages.id/common/git-add.md
@@ -1,32 +1,32 @@
 # git add
 
-> Tambahkan file yang diubah ke indeks.
+> Tambahkan berkas yang diubah ke dalam indeks.
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-add>.
 
-- Tambahkan file ke indeks:
+- Tambahkan berkas ke dalam indeks:
 
-`git add {{alamat/ke/file}}`
+`git add {{jalan/menuju/berkas}}`
 
-- Tambahkan semua file (yang terlacak dan tidak terlacak):
+- Tambahkan semua berkas (baik yang terlacak maupun tidak terlacak):
 
 `git add -A`
 
-- Hanya tambahkan file yang sudah terlacak:
+- Hanya tambahkan berkas yang sudah terlacak:
 
 `git add -u`
 
-- Tambahkan juga file yang diabaikan:
+- Tambahkan juga berkas yang diabaikan:
 
 `git add -f`
 
-- Menambahkan file ke status stage secara interaktif:
+- Tambahkan berkas ke status stage secara interaktif:
 
 `git add -p`
 
-- Menambahkan file tertentu ke status stage secara interaktif:
+- Tambahkan berkas tertentu ke status stage secara interaktif:
 
-`git add -p {{alamat/ke/file}}`
+`git add -p {{jalan/menuju/berkas}}`
 
-- Stage file secara interaktif:
+- Stage berkas secara interaktif:
 
 `git add -i`

--- a/pages.id/common/git-commit.md
+++ b/pages.id/common/git-commit.md
@@ -1,21 +1,21 @@
 # git commit
 
-> Komit file ke dalam sebuah repositori.
+> Komit berkas ke dalam sebuah repositori.
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-commit>.
 
-- Komit file bertahap ke repositori dengan sebuah pesan:
+- Komit berkas bertahap ke repositori dengan sebuah pesan:
 
 `git commit --message "{{pesan}}"`
 
-- Komit file bertahap dengan pesan yang disimpan dalam suatu file:
+- Komit berkas bertahap dengan pesan yang disimpan dalam suatu berkas:
 
-`git commit --file {{jalan/menuju/file_pesan_komit}}`
+`git commit --berkas {{jalan/menuju/berkas_pesan_komit}}`
 
-- Ubah secara otomatis semua file yang dimodifikasi menjadi ke status stage dan menambahkan sebuah pesan:
+- Ubah secara otomatis semua berkas yang dimodifikasi menjadi ke status stage dan menambahkan sebuah pesan:
 
 `git commit --all --message "{{pesan}}"`
 
-- Komit file bertahap kemudian tandatangani komit tersebut menggunakan kunci GPG (atau kunci yang didefinisikan dalam file konfigurasi jika tidak didefinisikan):
+- Komit berkas bertahap kemudian tandatangani komit tersebut menggunakan kunci GPG (atau kunci yang didefinisikan dalam berkas konfigurasi jika tidak didefinisikan):
 
 `git commit --gpg-sign {{id_kunci_gpg}} --message "{{pesan}}"`
 
@@ -23,10 +23,10 @@
 
 `git commit --amend`
 
-- Komit file tertentu (yang sudah di status stage):
+- Komit berkas tertentu (yang sudah di status stage):
 
-`git commit {{alamat/ke/file1}} {{alamat/ke/file2}}`
+`git commit {{jalan/menuju/berkas1}} {{jalan/menuju/berkas2}}`
 
-- Buat komit kosong, tanpa file bertahap:
+- Buat komit kosong, tanpa berkas bertahap:
 
 `git commit --message "{{pesan}}" --allow-empty`

--- a/pages.id/common/git.md
+++ b/pages.id/common/git.md
@@ -22,7 +22,7 @@
 
 - Jalankan subperintah Git di jalur root repositori kustom:
 
-`git -C {{alamat/ke/repositori}} {{subcommand}}`
+`git -C {{jalan/menuju/repositori}} {{subcommand}}`
 
 - Jalankan subperintah Git dengan set konfigurasi yang diberikan:
 

--- a/pages.id/common/hugo.md
+++ b/pages.id/common/hugo.md
@@ -1,32 +1,36 @@
 # hugo
 
-> Penghasil website statis berbasis template. Menggunakan modul, komponen dan tema.
+> Penghasil situs web statis berbasis template. Menggunakan modul, komponen dan tema.
 > Informasi lebih lanjut: <https://gohugo.io>.
 
-- Membuat website Hugo baru:
+- Buat sebuah proyek situs web Hugo baru:
 
-`hugo new site {{alamat/ke/website}}`
+`hugo new site {{jalan/menuju/website}}`
 
-- Membuat tema Hugo baru (tema juga dapat diunduh dari <https://themes.gohugo.io/>):
+- Buat sebuah proyek tema Hugo baru (tema juga dapat diunduh dari <https://themes.gohugo.io/>):
 
 `hugo new theme {{nama_tema}}`
 
-- Membuat halaman baru:
+- Buat sebuah halaman situs web baru:
 
-`hugo new {{nama_bagian}}/{{nama_berkas}}`
+`hugo new {{nama_bagian}}/{{nama_halaman}}`
 
-- Menbuild website ke direktori `./public`:
+- Bangun situs web dari direktori sumber menuju direktori `./public`:
 
 `hugo`
 
-- Menbuild website termasuk halaman yang ditandai sebagai "draft":
+- Bangun situs web termasuk halaman yang ditandai sebagai "draft":
 
 `hugo --buildDrafts`
 
-- Menbuild website ke direktori yang ditentukan:
+- Bangun situs web dengan untuk dijalankan pada alamat IP lokal:
+
+`hugo server --bind {{ip-lokal}} --baseURL {{http://ip-lokal}}`
+
+- Bangun situs web menuju direktori yang ditentukan:
 
 `hugo --destination {{alamat/tujuan}}`
 
-- Menbuild website, memulai webserver untuk menyajikannya, dan secara otomatis memuat ulang jika ada halaman yang berubah:
+- Bangun situs web dan jalankan peladen (server) untuk menyajikannya, dengan memuat ulang saat terdapat halaman yang berubah:
 
 `hugo server`

--- a/pages.id/common/node.md
+++ b/pages.id/common/node.md
@@ -3,22 +3,26 @@
 > Platform JavaScript sisi server (Node.js).
 > Informasi lebih lanjut: <https://nodejs.org>.
 
-- Menjalankan berkas JavaScript:
+- Jalankan berkas program JavaScript:
 
-`node {{alamat/ke/berkas}}`
+`node {{jalan/menuju/berkas}}`
 
-- Memulai sebuah REPL (shell interaktif):
+- Jalankan sebuah REPL (shell interaktif):
 
 `node`
 
-- Mengevaluasi kode JavaScript dengan memberikanya sebagai sebuah argument:
+- Jalankan berkas program dan jalankan ulang saat isi dari berkas tersebut terubah (membutuhkan Node.js versi 18.11+):
+
+`node --watch {{jalan/menuju/file}}`
+
+- Evaluasi kode JavaScript dengan memberikanya sebagai sebuah argument:
 
 `node -e "{{kode}}"`
 
-- Mengevaluasi dan mencetak hasil, berguna untuk melihat versi dependesni node:
+- Evaluasi kode dan cetak hasil, berguna untuk melihat versi dependesni node:
 
-`node -p "{{process.versions}}"`
+`node -p "process.versions"`
 
-- Mengaktifkan inspector, menjeda eksekusi sampai debugger terhubung segera setelah kode sumber sepenuhnya terparser:
+- Aktifkan inspector, yang akan menjeda eksekusi sampai debugger terhubung segera setelah kode sumber sepenuhnya terparser:
 
-`node --no-lazy --inspect-brk {{alamat/ke/berkas}}`
+`node --no-lazy --inspect-brk {{jalan/menuju/berkas}}`

--- a/pages.id/common/nvm.md
+++ b/pages.id/common/nvm.md
@@ -1,33 +1,33 @@
 # nvm
 
-> Memasang, melepas, atau mengganti versi Node.js yang dipakai.
+> Memasang, lepas, atau ganti versi Node.js yang dipakai.
 > Mendukung nomor versi seperti "12.8" or "v16.13.1", dan label versi seperti "stable", "system", dsb.
 > Informasi lebih lanjut: <https://github.com/creationix/nvm>.
 
-- Memasang versi Node.js yang ditentukan:
+- Pasang suatu versi Node.js:
 
 `nvm install {{versi_node_js}}`
 
-- Menggunakan versi Node.js tertentu untuk sesi saat ini:
+- Gunakan suatu versi Node.js untuk sesi saat ini:
 
 `nvm use {{versi_node_js}}`
 
-- Menyetel versi Node.js secara default:
+- Tentukan versi default Node.js untuk sesi-sesi berikutnya:
 
 `nvm alias default {{versi_node_js}}`
 
-- Menunjukkan daftar versi Node.js yang tersedia dan versi Node.js yang disetel sebagai default:
+- Tunjukkan daftar versi Node.js yang tersedia dan yang disetel sebagai default:
 
 `nvm list`
 
-- Menghapus sebuah versi Node.js yang terpasang melalui `nvm`:
+- Hapus pemasangan versi Node.js yang terpasang melalui `nvm`:
 
 `nvm uninstall {{versi_node_js}}`
 
-- Menjalankan interpreter (REPL) Node.js dengan versi tertentu:
+- Jalankan interpreter (REPL) Node.js dengan versi tertentu:
 
 `nvm run {{versi_node_js}} --version`
 
-- Menjalankan sebuah file atau aplikasi JavaScript di dalam Node.js versi tertentu:
+- Jalankan suatu berkas atau program JavaScript di dalam Node.js versi tertentu:
 
 `nvm exec {{versi_node_js}} node {{app.js}}`

--- a/pages.id/common/python.md
+++ b/pages.id/common/python.md
@@ -3,26 +3,34 @@
 > Penerjemah bahasa Python.
 > Informasi lebih lanjut: <https://www.python.org>.
 
-- Menjalankan REPL (shell interaktif):
+- Jalankan REPL (shell interaktif):
 
 `python`
 
-- Menjalankan skrip pada berkas Python:
+- Jalankan skrip pada berkas Python:
 
 `python {{skrip.py}}`
 
-- Menjalankan skrip sebagai bagian dari shell interaktif:
+- Jalankan skrip sebagai bagian dari shell interaktif:
 
 `python -i {{skrip.py}}`
 
-- Menjalankan ekspresi Python:
+- Jalankan ekspresi Python:
 
 `python -c "{{ekspresi}}"`
 
-- Menjalankan modul perpustakaan sebagai skrip (diakhiri dengan daftar opsi):
+- Jalankan suatu modul perpustakaan sebagai skrip (diakhiri dengan daftar opsi):
 
 `python -m {{modul}} {{argumen}}`
 
-- Mendebug skrip Python secara interaktif:
+- Pasang suatu paket pustaka menggunakan `pip`:
 
-`python -m pdb {{script.py}}`
+`python -m pip install {{paket}}`
+
+- Jalankan pengawakutu (debugger) terhadap skrip Python secara interaktif:
+
+`python -m pdb {{jalan/menuju/berkas.py}}`
+
+- Nyalakan program peladen (server) HTTP bawaan terhadap direktori ini menuju port 8000:
+
+`python -m http.server`

--- a/pages.id/common/rspec.md
+++ b/pages.id/common/rspec.md
@@ -1,32 +1,32 @@
 # rspec
 
-> Kerangka pengujian dalam Behavior-driven development yang ditulis dalam bahasa Ruby untuk menguji kode Ruby.
+> Kerangka pengujian kode Ruby berbasis Ruby dan pola pengembangan berbasis kebiasaan (behavior-driven development).
 > Informasi lebih lanjut: <https://rspec.info>.
 
-- Menginisiasi file konfigurasi `.rspec` dan spec helper:
+- Buat suatu berkas konfigurasi `.rspec` dan berkas pendukung spesifikasi pengujian (spec helper):
 
 `rspec --init`
 
-- Menjalankan semua file tes:
+- Jalankan semua pengujian menurut berkas-berkas spesifikasi:
 
 `rspec`
 
-- Menjalankan file tes dalam direktori khusus:
+- Jalankan pengujian menurut berkas-berkas spesifikasi dalam direktori khusus:
 
 `rspec {{jalan/menuju/directory}}`
 
-- Menjalankan file tes khusus:
+- Jalankan pengujian menurut suatu berkas spesifikasi:
 
-`rspec {{jalan/menuju/file}}`
+`rspec {{jalan/menuju/berkas}}`
 
-- Menjalankan beberapa file tes:
+- Jalankan beberapa pengujian menurut kumpulan berkas spesifikasi:
 
-`rspec {{jalan/menuju/file1}} {{jalan/menuju/file2}}`
+`rspec {{jalan/menuju/berkas1 jalan/menuju/berkas2 ...}}`
 
-- Menjalankan kasus khusus dalam file tes (misalnya tes yang ada di baris 83):
+- Jalankan kasus khusus dalam pengujian menurut berkas-berkas spesifikasi (misalnya tes yang ada di baris 83):
 
-`rspec {{jalan/menuju/file}}:{{83}}`
+`rspec {{jalan/menuju/berkas}}:{{83}}`
 
-- Menjalankan tes dengan seed khusus:
+- Jalankan tes dengan seed khusus:
 
 `rspec --seed {{angka_seed}}`

--- a/pages.id/common/rubocop.md
+++ b/pages.id/common/rubocop.md
@@ -1,32 +1,32 @@
 # rubocop
 
-> Analisa file Ruby.
+> Analisa berkas Ruby.
 > Informasi lebih lanjut: <https://docs.rubocop.org/rubocop/usage/basic_usage.html>.
 
-- Periksa semua file dalam direktori saat ini (termasuk direktori-direktori di dalamnya):
+- Periksa semua berkas dalam direktori saat ini (termasuk direktori-direktori di dalamnya):
 
 `rubocop`
 
-- Periksa satu atau lebih file atau direktori secara khusus:
+- Periksa satu atau lebih berkas atau direktori secara khusus:
 
-`rubocop {{jalan/menuju/file}} {{jalan/menuju/direktori}}`
+`rubocop {{jalan/menuju/berkas_atau_direktori1 jalan/menuju/berkas_atau_direktori2 ...}}`
 
-- Tulis output ke file:
+- Tulis output ke berkas:
 
-`rubocop --out {{jalan/menuju/file}}`
+`rubocop --out {{jalan/menuju/berkas}}`
 
-- Melihat daftar cop (aturan-aturan dalam menganalisa):
+- Lihat daftar cop (aturan-aturan dalam menganalisa):
 
 `rubocop --show-cops`
 
-- Mengecualikan cop:
+- Kecualikan kumpulan cop dalam proses analisa:
 
-`rubocop --except {{cop_1}} {{cop_2}}`
+`rubocop --except {{cop1 cop2 ...}}`
 
-- Menjalankan hanya beberapa cop:
+- Jalankan hanya beberapa cop:
 
-`rubocop --only {{cop_1}} {{cop_2}}`
+`rubocop --only {{cop1 cop2 ...}}`
 
-- Memperbaiki file secara otomatis (fitur percobaan):
+- Perbaiki berkas secara otomatis (fitur percobaan):
 
 `rubocop --auto-correct`

--- a/pages.id/common/ruby.md
+++ b/pages.id/common/ruby.md
@@ -3,22 +3,26 @@
 > Interpreter bahasa pemrograman Ruby.
 > Informasi lebih lanjut: <https://www.ruby-lang.org>.
 
-- Memulai REPL (_shell_ interaktif):
+- Jalankan suatu berkas skrip atau program Ruby:
 
-`irb`
+`ruby {{jalan/menuju/skrip.rb}}`
 
-- Menjalankan skrip Ruby:
+- Jalankan suatu perintah Ruby dalam command-line:
 
-`ruby {{lokasi/ke/script.rb}}`
+`ruby -e {{perintah}}`
 
-- Menjalankan sebuah perintah Ruby dalam _command-line_:
+- Periksa kesalahan sintaks dari suatu berkas skrip Ruby:
 
-`ruby -e {{command}}`
+`ruby -c {{jalan/menuju/skrip.rb}}`
 
-- Memeriksa kesalahan sintaks dari skrip Ruby:
+- Jalankan program peladen (server) HTTP bawaan terrhadap direktori saat ini menuju port 8080:
 
-`ruby -c {{lokasi/ke/script.rb}}`
+`ruby -run -e httpd`
 
-- Menampilkan versi Ruby yang anda gunakan:
+- Jalankan suatu berkas biner program Ruby tanpa memasang suatu pustaka (library) pendukung yang diwajibkan:
+
+`ruby -I {{jalan/menuju/direktori_pustaka}} -r {{nama_pustaka_yang_dikecualikan}} {{jalan/menuju/direktori_bin/nama_berkas_bin}}`
+
+- Tampilkan [v]ersi Ruby saat ini:
 
 `ruby -v`

--- a/pages.id/linux/apt.md
+++ b/pages.id/linux/apt.md
@@ -2,36 +2,37 @@
 
 > Manajer paket untuk distribusi Linux berbasis Debian.
 > Pengganti `apt-get` yang direkomendasikan ketika digunakan secara interaktif di Ubuntu versi 16.04 atau yang lebih baru.
+> Lihat <https://wiki.archlinux.org/title/Pacman/Rosetta> untuk daftar perintah dalam manajer paket lain yang menyerupai perintah `apt`.
 > Informasi lebih lanjut: <https://manpages.debian.org/latest/apt/apt.8.html>.
 
-- Memperbarui daftar paket yang tersedia dan versinya (direkomendasikan untuk menggunakan perintah ini sebelum perintah `apt` lainnya.):
+- Perbarui daftar paket yang tersedia dan versinya (direkomendasikan untuk menggunakan perintah ini sebelum perintah `apt` lainnya.):
 
 `sudo apt update`
 
-- Mencari paket yang tersedia dengan nama atau deskripsi tertentu:
+- Cari paket yang tersedia dengan nama atau deskripsi tertentu:
 
 `apt search {{nama_atau_deskripsi_paket}}`
 
-- Memperlihatkan informasi tentang suatu paket:
+- Tampilkan informasi tentang suatu paket:
 
 `apt show {{nama_paket}}`
 
-- Menginstal sebuah paket, atau memperbarui paket ke versi terbaru:
+- Pasang atau perbarui sebuah paket menuju versi terbaru:
 
 `sudo apt install {{nama_paket}}`
 
-- Menghapus sebuah paket (gunakan `sudo apt purge` untuk menghapus paket beserta file konfigurasinya):
+- Hapus paket yang terpasang sebelumnya (gunakan `sudo apt purge` untuk sekaligus menghapus file konfigurasi yang dibuat oleh paket tersebut):
 
 `sudo apt remove {{nama_paket}}`
 
-- Memperbarui seluruh paket yang terpasang ke versi terbaru:
+- Perbarui seluruh paket yang terpasang ke versi terbaru:
 
 `sudo apt upgrade`
 
-- Memperlihatkan daftar semua paket yang tersedia di dalam repositori:
+- Tampilkan daftar semua paket yang tersedia di dalam repositori:
 
 `apt list`
 
-- Memperlihatkan daftar paket yang telah terpasang:
+- Tampilkan daftar paket yang telah terpasang:
 
 `apt list --installed`

--- a/pages.id/linux/xfce4-terminal.md
+++ b/pages.id/linux/xfce4-terminal.md
@@ -15,7 +15,7 @@
 
 `xfce4-terminal --tab`
 
-- Menjalankan sebuah perintah di jendela terminal baru:
+- Jalankan sebuah perintah di jendela terminal baru:
 
 `xfce4-terminal --command "{{perintah_dengan_argumen}}"`
 

--- a/pages.id/linux/yum.md
+++ b/pages.id/linux/yum.md
@@ -1,14 +1,14 @@
 # yum
 
 > Utilitas manajemen paket untuk RHEL, Fedora, dan CentOS (untuk versi-versi yang lebih lama).
-> Untuk perintah-perintah setara dalam pengelola paket lainnya, lihat <https://wiki.archlinux.org/title/Pacman/Rosetta>.
+> Lihat <https://wiki.archlinux.org/title/Pacman/Rosetta> untuk daftar perintah dalam manajer paket lain yang menyerupai perintah `yum`.
 > Informasi lebih lanjut: <https://manned.org/yum>.
 
-- Instal sebuah paket baru:
+- Pasang suatu paket:
 
 `yum install {{nama_paket}}`
 
-- Instal sebuah paket baru dan mengasumsikan jawaban [y]a untuk semua pertanyaan (juga berfungsi dengan perintah pembaruan, sangat berguna untuk pembaruan otomatis):
+- Pasang paket dengan mengasumsikan jawaban [y]a untuk semua pertanyaan (juga berfungsi dengan perintah pembaruan, sangat berguna untuk pembaruan otomatis):
 
 `yum -y install {{nama_paket}}`
 

--- a/pages.id/osx/osascript.md
+++ b/pages.id/osx/osascript.md
@@ -3,11 +3,11 @@
 > Jalankan AppleScript atau JavaScript for Automation (JXA) dari command-line.
 > Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/osascript.1.html>.
 
-- Menjalankan sebuah perintah AppleScript:
+- Jalankan sebuah perintah AppleScript:
 
 `osascript -e "{{say 'Halo dunia'}}"`
 
-- Menjalankan beberapa perintah AppleScript:
+- Jalankan beberapa perintah AppleScript:
 
 `osascript -e "{{say 'Halo'}}" -e "{{say 'dunia'}}"`
 
@@ -19,7 +19,7 @@
 
 `osascript -e 'id of app "{{Aplikasi}}"'`
 
-- Menjalankan sebuah perintah JavaScript:
+- Jalankan sebuah perintah JavaScript:
 
 `osascript -l JavaScript -e "{{console.log('Halo dunia');}}"`
 

--- a/pages.id/windows/cls.md
+++ b/pages.id/windows/cls.md
@@ -1,7 +1,12 @@
 # cls
 
-> Membersihkan layar.
+> Bersihkan layar terminal.
+> Dalam PowerShell, perintah ini merupakan alias dari `Clear-Host`. Dokumentasi ini ditulis menurut perintah `cd` versi Command Prompt (`cls`).
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/cls>.
+
+- Lihat dokumentasi untuk perintah PowerShell serupa:
+
+`tldr clear-host`
 
 - Bersihkan layar:
 

--- a/pages.id/windows/explorer.md
+++ b/pages.id/windows/explorer.md
@@ -13,4 +13,4 @@
 
 - Membuka Windows Explorer di direktori tertentu:
 
-`explorer {{alamat/ke/direktori}}`
+`explorer {{jalan/menuju/direktori}}`

--- a/pages.id/windows/ipconfig.md
+++ b/pages.id/windows/ipconfig.md
@@ -1,24 +1,28 @@
 # ipconfig
 
-> Menampilkan dan mengatur konfigurasi jaringan dalam sistem operasi Windows.
+> Tampilkan dan atur konfigurasi jaringan dalam sistem operasi Windows.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/ipconfig>.
 
-- Menunjukkan daftar adaptor jaringan:
+- Tampilkan daftar seluruh adaptor jaringan yang terpasang:
 
 `ipconfig`
 
-- Menunjukkan daftar adaptor jaringan secara lengkap:
+- Tampilkan daftar adaptor jaringan secara rinci:
 
 `ipconfig /all`
 
-- Memperbarui alamat IP sebuah adaptor jaringan:
+- Perbarui alamat IP suatu adaptor jaringan:
 
 `ipconfig /renew {{adaptor}}`
 
-- Mengosongkan alamat-alamat IP yang disetel dalam sebuah adaptor jaringan:
+- Kosongkan alamat-alamat IP yang disetel dalam suatu adaptor jaringan:
 
 `ipconfig /release {{adaptor}}`
 
-- Mengosongkan cache DNS:
+- Tampilkan dafter informasi DNS yang disimpan dalam cache:
+
+`ipconfig /displaydns`
+
+- Kosongkan cache DNS:
 
 `ipconfig /flushdns`

--- a/pages.id/windows/whoami.md
+++ b/pages.id/windows/whoami.md
@@ -1,24 +1,28 @@
 # whoami
 
-> Menampilkan detail informasi pengguna saat ini.
+> Tampilkan informasi identitas pengguna saat ini secara rinci.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/whoami>.
 
-- Menampilkan username pengguna saat ini:
+- Tampilkan username pengguna saat ini:
 
 `whoami`
 
-- Menampilkan daftar grup dari pengguna saat ini:
+- Tampilkan daftar grup dari pengguna saat ini:
 
 `whoami /groups`
 
-- Menampilkan hak (privileges) pengguna saat ini:
+- Tampilkan hak (privileges) pengguna saat ini:
 
 `whoami /priv`
 
-- Menampilkan nama utama pengguna (UPN) saat ini:
+- Tampilkan nama utama pengguna (UPN) saat ini:
 
 `whoami /upn`
 
-- Menampilkan ID logon dari pengguna saat ini:
+- Tampilkan ID logon dari pengguna saat ini:
 
 `whoami /logonid`
+
+- Tampilkan seluruh informasi identitas pengguna saat ini:
+
+`whoami /all`

--- a/pages.id/windows/winget.md
+++ b/pages.id/windows/winget.md
@@ -3,9 +3,13 @@
 > Manajer Paket Antarmuka Baris Perintah Windows.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows/package-manager/winget>.
 
-- Instal paket:
+- Pasang suatu paket:
 
 `winget install {{nama_paket}}`
+
+- Hapus paket yang terpasang sebelumnya (Catatan: subperintah `uninstall` juga dapat digantikan dengan `remove`):
+
+`winget uninstall {{nama_paket}}`
 
 - Tampilkan informasi tentang paket:
 
@@ -15,18 +19,18 @@
 
 `winget search {{nama_paket}}`
 
-- Perbarui paket:
+- Perbarui seluruh paket menuju versi terkini:
 
-`winget upgrade {{nama_paket}}`
+`winget upgrade --all`
 
-- Tampilkan paket:
+- Tampilkan paket terpasang yang dapat dikelola oleh `winget`:
 
-`winget list {{nama_paket}}`
+`winget list --source winget`
 
-- Hapus paket:
+- Impor atau ekspor daftar paket terpasang ke dalam suatu file:
 
-`winget uninstall {{nama_paket}}`
+`winget {{import|export}} {{--import-file|--output}} {{jalan/menuju/berkas}}`
 
-- Bantuan daftar lengkap perintah:
+- Lakukan uji validasi manifes pemaketan winget sebelum mengirimkan rencana perubahan (Pull Request) menuju repositori winget-pkgs:
 
-`winget --help`
+`winget validate {{jalan/menuju/manifes}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This commit brings the upstream changes to the Indonesian translations, including:

+ Refresh outdated pages, e.g. for `node` and `python`
+ Rewrite some pages to use proper Indonesian imperative mood equivalence, part of https://github.com/tldr-pages/tldr/issues/8576
+ Standardize writing style for package manager-related documentation, such as `apt` and `winget`
+ Replace deprecated placeholder names `{{alamat/ke/file_atau_direktori}}` to `{{jalan/menuju/berkas_atau_direktori}}`

Note that the `rubocop` documentation may trigger an "outdated translation" warning. This is false positive as the Indonesian translation updates some placeholders to use the newer [grouped placeholder syntax](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#grouping-placeholders) which is not applied to the English version yet. The English version must be changed accordingly to reflect the updated guidelines.