### PR TITLE
pg_dumpall: update page

### DIFF
--- a/pages/common/pg_dumpall.md
+++ b/pages/common/pg_dumpall.md
@@ -9,7 +9,7 @@
 
 - Dump all databases using a specific username:
 
-`pg_dumpall --username={{username}} > {{path/to/file.sql}}`
+`pg_dumpall -U {{username}} > {{path/to/file.sql}}`
 
 - Same as above, customize host and port:
 
@@ -17,7 +17,7 @@
 
 - Dump only database data into an SQL-script file:
 
-`pg_dumpall --data-only > {{path/to/file.sql}}`
+`pg_dumpall -a > {{path/to/file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 

--- a/pages/common/pg_dumpall.md
+++ b/pages/common/pg_dumpall.md
@@ -15,10 +15,6 @@
 
 `pg_dumpall -h {{host}} -p {{port}} > {{output_file.sql}}`
 
-- Dump all databases into a custom-format archive file with moderate compression:
-
-`pg_dumpall -Fc > {{output_file.dump}}`
-
 - Dump only database data into an SQL-script file:
 
 `pg_dumpall --data-only > {{path/to/file.sql}}`

--- a/pages/common/pg_dumpall.md
+++ b/pages/common/pg_dumpall.md
@@ -9,7 +9,7 @@
 
 - Dump all databases using a specific username:
 
-`pg_dumpall -U {{username}} > {{path/to/file.sql}}`
+`pg_dumpall {{-U|--username}} {{username}} > {{path/to/file.sql}}`
 
 - Same as above, customize host and port:
 
@@ -17,7 +17,7 @@
 
 - Dump only database data into an SQL-script file:
 
-`pg_dumpall -a > {{path/to/file.sql}}`
+`pg_dumpall {{-a|--data-only}} > {{path/to/file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Hi!

I found an example in `pg_dumpall` which is invalid. Also tried to make the flags similar to `pg_dump`.
Should I do it the other way arount and modify the existing "single-letter options" to the long ones for both `pg_dump` and `pg_dumpall` (as it's mentioned in [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines) 3.)?

Thanks!
Andras
