### PR TITLE
pages/*: standardize mentioning subcommands without the main command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ You should always add a base page (e.g. `git`) that describes the program and ba
 
 The following methods can be used to reference subcommands:
 
-- You can add a note saying ``Some subcommands such as `example command` have their own usage documentation`` to the main page. (See the [subcommand reference](/contributing-guides/translation-templates/subcommand-mention.md) page for translation templates.)
+- You can add a note saying ``Some subcommands such as `example command` have their own usage documentation`` to the main page. (See the [subcommand reference](/contributing-guides/translation-templates/subcommand-mention.md) page for translation templates). `example command` should only include the subcommand (e.g. `commit` instead of `git commit`).
 - You can use ``See also: `command1`, `command2`.`` template to reference similar commands, aliases and subcommands.
 - Alternatively, the whole page can be converted to reference the main subcommands.
 

--- a/pages/common/adb.md
+++ b/pages/common/adb.md
@@ -1,7 +1,7 @@
 # adb
 
 > Android Debug Bridge: communicate with an Android emulator instance or connected Android devices.
-> Some subcommands such as `adb shell` have their own usage documentation.
+> Some subcommands such as `shell` have their own usage documentation.
 > More information: <https://developer.android.com/tools/adb>.
 
 - Check whether the adb server process is running and start it:

--- a/pages/common/amass.md
+++ b/pages/common/amass.md
@@ -1,7 +1,7 @@
 # amass
 
 > In-depth Attack Surface Mapping and Asset Discovery tool.
-> Some subcommands such as `amass intel` have their own usage documentation.
+> Some subcommands such as `intel` have their own usage documentation.
 > More information: <https://github.com/owasp-amass/amass>.
 
 - Execute an Amass subcommand:

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -1,7 +1,7 @@
 # ansible
 
 > Manage groups of computers remotely over SSH. (use the `/etc/ansible/hosts` file to add new groups/hosts).
-> Some subcommands such as `ansible galaxy` have their own usage documentation.
+> Some subcommands such as `galaxy` have their own usage documentation.
 > More information: <https://www.ansible.com/>.
 
 - List hosts belonging to a group:

--- a/pages/common/argocd.md
+++ b/pages/common/argocd.md
@@ -1,7 +1,7 @@
 # argocd
 
 > Command-line interface to control a Argo CD server.
-> Some subcommands such as `argocd app` have their own usage documentation.
+> Some subcommands such as `app` have their own usage documentation.
 > More information: <https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd/>.
 
 - Login to Argo CD server:

--- a/pages/common/aws-s3.md
+++ b/pages/common/aws-s3.md
@@ -1,7 +1,7 @@
 # aws s3
 
 > CLI for AWS S3 - provides storage through web services interfaces.
-> Some subcommands such as `aws s3 cp` have their own usage documentation.
+> Some subcommands such as `cp` have their own usage documentation.
 > More information: <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html>.
 
 - Show files in a bucket:

--- a/pages/common/aws.md
+++ b/pages/common/aws.md
@@ -1,7 +1,7 @@
 # aws
 
 > The official CLI tool for Amazon Web Services.
-> Some subcommands such as `aws s3` have their own usage documentation.
+> Some subcommands such as `s3` have their own usage documentation.
 > More information: <https://aws.amazon.com/cli>.
 
 - Configure the AWS Command-line:

--- a/pages/common/az.md
+++ b/pages/common/az.md
@@ -1,7 +1,7 @@
 # az
 
 > The official CLI tool for Microsoft Azure.
-> Some subcommands such as `az login` have their own usage documentation.
+> Some subcommands such as `login` have their own usage documentation.
 > More information: <https://learn.microsoft.com/cli/azure>.
 
 - Log in to Azure:

--- a/pages/common/bundletool.md
+++ b/pages/common/bundletool.md
@@ -1,7 +1,7 @@
 # bundletool
 
 > Manipulate Android Application Bundles.
-> Some subcommands such as `bundletool validate` have their own usage documentation.
+> Some subcommands such as `validate` have their own usage documentation.
 > More information: <https://developer.android.com/tools/bundletool>.
 
 - Display help for a subcommand:

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -1,7 +1,7 @@
 # conan
 
 > The open source, decentralized and cross-platform package manager to create and share all your native binaries.
-> Some subcommands such as `conan frogarian` have their own usage documentation.
+> Some subcommands such as `frogarian` have their own usage documentation.
 > More information: <https://conan.io/>.
 
 - Install packages based on `conanfile.txt`:

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -1,7 +1,7 @@
 # conda
 
 > Package, dependency and environment management for any programming language.
-> Some subcommands such as `conda create` have their own usage documentation.
+> Some subcommands such as `create` have their own usage documentation.
 > More information: <https://github.com/conda/conda>.
 
 - Create a new environment, installing named packages into it:

--- a/pages/common/consul.md
+++ b/pages/common/consul.md
@@ -1,7 +1,7 @@
 # consul
 
 > Distributed key-value store with health checking and service discovery.
-> Some subcommands such as `consul kv` have their own usage documentation.
+> Some subcommands such as `kv` have their own usage documentation.
 > More information: <https://www.consul.io/commands>.
 
 - Display help:

--- a/pages/common/cradle.md
+++ b/pages/common/cradle.md
@@ -1,7 +1,7 @@
 # cradle
 
 > The Cradle PHP framework.
-> Some subcommands such as `cradle install` have their own usage documentation.
+> Some subcommands such as `install` have their own usage documentation.
 > More information: <https://cradlephp.github.io>.
 
 - Connect to a server:

--- a/pages/common/docker.md
+++ b/pages/common/docker.md
@@ -1,7 +1,7 @@
 # docker
 
 > Manage Docker containers and images.
-> Some subcommands such as `docker run` have their own usage documentation.
+> Some subcommands such as `run` have their own usage documentation.
 > More information: <https://docs.docker.com/engine/reference/commandline/cli/>.
 
 - List all Docker containers (running and stopped):

--- a/pages/common/doppler.md
+++ b/pages/common/doppler.md
@@ -1,7 +1,7 @@
 # doppler
 
 > Manage environment variables across different environments using Doppler.
-> Some subcommands such as `doppler run` and `doppler secrets` have their own usage documentation.
+> Some subcommands such as `run` and `secrets` have their own usage documentation.
 > More information: <https://docs.doppler.com/docs/cli>.
 
 - Setup Doppler CLI in the current directory:

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,7 +1,7 @@
 # dotnet
 
 > Cross platform .NET command-line tools for .NET Core.
-> Some subcommands such as `dotnet build` have their own usage documentation.
+> Some subcommands such as `build` have their own usage documentation.
 > More information: <https://learn.microsoft.com/dotnet/core/tools>.
 
 - Initialize a new .NET project:

--- a/pages/common/drupal.md
+++ b/pages/common/drupal.md
@@ -1,7 +1,7 @@
 # drupal
 
 > Generate boilerplate code, interact with and debug Drupal projects.
-> Some subcommands such as `drupal check` have their own usage documentation.
+> Some subcommands such as `check` have their own usage documentation.
 > More information: <https://drupalconsole.com/>.
 
 - Install a module:

--- a/pages/common/dvc.md
+++ b/pages/common/dvc.md
@@ -1,7 +1,7 @@
 # dvc
 
 > Data Version Control: like `git` for data.
-> Some subcommands such as `dvc commit` have their own usage documentation.
+> Some subcommands such as `commit` have their own usage documentation.
 > More information: <https://dvc.org/>.
 
 - Execute a DVC subcommand:

--- a/pages/common/flutter.md
+++ b/pages/common/flutter.md
@@ -1,7 +1,7 @@
 # flutter
 
 > Google's free, open source, and cross-platform mobile app SDK.
-> Some subcommands such as `flutter pub` have their own usage documentation.
+> Some subcommands such as `pub` have their own usage documentation.
 > More information: <https://github.com/flutter/flutter/wiki/The-flutter-tool>.
 
 - Initialize a new Flutter project in a directory of the same name:

--- a/pages/common/fossil.md
+++ b/pages/common/fossil.md
@@ -1,7 +1,7 @@
 # fossil
 
 > Distributed version control system.
-> Some subcommands such as `fossil commit` have their own usage documentation.
+> Some subcommands such as `commit` have their own usage documentation.
 > More information: <https://fossil-scm.org/>.
 
 - Execute a Fossil subcommand:

--- a/pages/common/gh-pr.md
+++ b/pages/common/gh-pr.md
@@ -1,7 +1,7 @@
 # gh pr
 
 > Manage GitHub pull requests.
-> Some subcommands such as `gh pr create` have their own usage documentation.
+> Some subcommands such as `create` have their own usage documentation.
 > More information: <https://cli.github.com/manual/gh_pr>.
 
 - Create a pull request:

--- a/pages/common/gh.md
+++ b/pages/common/gh.md
@@ -1,7 +1,7 @@
 # gh
 
 > Work seamlessly with GitHub.
-> Some subcommands such as `gh config` have their own usage documentation.
+> Some subcommands such as `config` have their own usage documentation.
 > More information: <https://cli.github.com/>.
 
 - Clone a GitHub repository locally:

--- a/pages/common/gitlab.md
+++ b/pages/common/gitlab.md
@@ -1,7 +1,7 @@
 # gitlab
 
 > Ruby wrapper for the GitLab API.
-> Some subcommands such as `gitlab ctl` have their own usage documentation.
+> Some subcommands such as `ctl` have their own usage documentation.
 > More information: <https://narkoz.github.io/gitlab/>.
 
 - Create a new project:

--- a/pages/common/glab-mr.md
+++ b/pages/common/glab-mr.md
@@ -1,7 +1,7 @@
 # glab mr
 
 > Manage GitLab merge requests.
-> Some subcommands such as `glab mr create` have their own usage documentation.
+> Some subcommands such as `create` have their own usage documentation.
 > More information: <https://glab.readthedocs.io/en/latest/mr>.
 
 - Create a merge request:

--- a/pages/common/glab.md
+++ b/pages/common/glab.md
@@ -1,7 +1,7 @@
 # glab
 
 > Work seamlessly with GitLab.
-> Some subcommands such as `glab config` have their own usage documentation.
+> Some subcommands such as `config` have their own usage documentation.
 > More information: <https://github.com/profclems/glab>.
 
 - Clone a GitLab repository locally:

--- a/pages/common/go.md
+++ b/pages/common/go.md
@@ -1,7 +1,7 @@
 # go
 
 > Manage Go source code.
-> Some subcommands such as `go build` have their own usage documentation.
+> Some subcommands such as `build` have their own usage documentation.
 > More information: <https://golang.org>.
 
 - Download and install a package, specified by its import path:

--- a/pages/common/hg.md
+++ b/pages/common/hg.md
@@ -1,7 +1,7 @@
 # hg
 
 > Mercurial - a distributed source control management system.
-> Some subcommands such as `hg commit` have their own usage documentation.
+> Some subcommands such as `commit` have their own usage documentation.
 > More information: <https://www.mercurial-scm.org>.
 
 - Execute a Mercurial command:

--- a/pages/common/kubectl.md
+++ b/pages/common/kubectl.md
@@ -1,7 +1,7 @@
 # kubectl
 
 > Command-line interface for running commands against Kubernetes clusters.
-> Some subcommands such as `kubectl run` have their own usage documentation.
+> Some subcommands such as `run` have their own usage documentation.
 > More information: <https://kubernetes.io/docs/reference/kubectl/>.
 
 - List information about a resource with more details:

--- a/pages/common/mamba.md
+++ b/pages/common/mamba.md
@@ -1,7 +1,7 @@
 # mamba
 
 > Fast, cross-platform package manager, intended as a drop-in replacement for conda.
-> Some subcommands such as `mamba repoquery` have their own usage documentation.
+> Some subcommands such as `repoquery` have their own usage documentation.
 > More information: <https://mamba.readthedocs.io/en/latest/user_guide/mamba.html>.
 
 - Create a new environment, installing the specified packages into it:

--- a/pages/common/nxc.md
+++ b/pages/common/nxc.md
@@ -1,7 +1,7 @@
 # nxc
 
 > Network service enumeration and exploitation tool.
-> Some subcommands such as `nxc smb` have their own usage documentation.
+> Some subcommands such as `smb` have their own usage documentation.
 > More information: <https://www.netexec.wiki/>.
 
 - [L]ist available modules for the specified protocol:

--- a/pages/common/odps.md
+++ b/pages/common/odps.md
@@ -1,7 +1,7 @@
 # odps
 
 > Aliyun ODPS (Open Data Processing Service) command-line tool.
-> Some subcommands such as `odps inst` have their own usage documentation.
+> Some subcommands such as `inst` have their own usage documentation.
 > More information: <https://www.alibabacloud.com/help/doc-detail/27971.htm>.
 
 - Start the command-line with a custom configuration file:

--- a/pages/common/openssl.md
+++ b/pages/common/openssl.md
@@ -1,7 +1,7 @@
 # openssl
 
 > OpenSSL cryptographic toolkit.
-> Some subcommands such as `openssl req` have their own usage documentation.
+> Some subcommands such as `req` have their own usage documentation.
 > More information: <https://www.openssl.org>.
 
 - Display help:

--- a/pages/common/pio.md
+++ b/pages/common/pio.md
@@ -1,7 +1,7 @@
 # pio
 
 > Development environment for embedded boards.
-> Some subcommands such as `pio run` have their own usage documentation.
+> Some subcommands such as `run` have their own usage documentation.
 > More information: <https://docs.platformio.org/en/latest/core/userguide/>.
 
 - Display help and list subcommands:

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -1,7 +1,7 @@
 # pip
 
 > Python package manager.
-> Some subcommands such as `pip install` have their own usage documentation.
+> Some subcommands such as `install` have their own usage documentation.
 > More information: <https://pip.pypa.io>.
 
 - Install a package (see `pip install` for more install examples):

--- a/pages/common/pueue.md
+++ b/pages/common/pueue.md
@@ -1,7 +1,7 @@
 # pueue
 
 > A task management tool for sequential and parallel execution of long-running tasks.
-> Some subcommands such as `pueue add` have their own usage documentation.
+> Some subcommands such as `add` have their own usage documentation.
 > More information: <https://github.com/Nukesor/pueue>.
 
 - Show general help and available subcommands:

--- a/pages/common/pulumi.md
+++ b/pages/common/pulumi.md
@@ -1,7 +1,7 @@
 # pulumi
 
 > Define infrastructure on any cloud using familiar programming languages.
-> Some subcommands such as `pulumi up` have their own usage documentation.
+> Some subcommands such as `up` have their own usage documentation.
 > More information: <https://www.pulumi.com/docs/cli>.
 
 - Create a new project using a template:

--- a/pages/common/puppet.md
+++ b/pages/common/puppet.md
@@ -1,7 +1,7 @@
 # puppet
 
 > Help to manage and automate the configuration of servers.
-> Some subcommands such as `puppet agent` have their own usage documentation.
+> Some subcommands such as `agent` have their own usage documentation.
 > More information: <https://puppet.com/>.
 
 - Execute a Puppet subcommand:

--- a/pages/common/rails.md
+++ b/pages/common/rails.md
@@ -1,7 +1,7 @@
 # rails
 
 > A server-side MVC framework written in Ruby.
-> Some subcommands such as `rails generate` have their own usage documentation.
+> Some subcommands such as `generate` have their own usage documentation.
 > More information: <https://guides.rubyonrails.org/command_line.html>.
 
 - Create a new rails project:

--- a/pages/common/starship.md
+++ b/pages/common/starship.md
@@ -1,7 +1,7 @@
 # starship
 
 > The minimal, blazing-fast, and infinitely customizable prompt for any shell.
-> Some subcommands such as `starship init` have their own usage documentation.
+> Some subcommands such as `init` have their own usage documentation.
 > More information: <https://starship.rs>.
 
 - Print the starship integration code for the specified shell:

--- a/pages/common/tailscale.md
+++ b/pages/common/tailscale.md
@@ -1,7 +1,7 @@
 # tailscale
 
 > A private WireGuard network service.
-> Some subcommands such as `tailscale up` have their own usage documentation.
+> Some subcommands such as `up` have their own usage documentation.
 > More information: <https://tailscale.com>.
 
 - Connect to Tailscale:

--- a/pages/common/tlmgr.md
+++ b/pages/common/tlmgr.md
@@ -1,7 +1,7 @@
 # tlmgr
 
 > Manage packages and configuration options of an existing TeX Live installation.
-> Some subcommands such as `tlmgr paper` have their own usage documentation.
+> Some subcommands such as `paper` have their own usage documentation.
 > More information: <https://www.tug.org/texlive/tlmgr.html>.
 
 - Install a package and its dependencies:

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -1,7 +1,7 @@
 # uv
 
 > A fast Python package and project manager.
-> Some subcommands such as `uv tool` and `uv python` have their own usage documentation.
+> Some subcommands such as `tool` and `python` have their own usage documentation.
 > More information: <https://docs.astral.sh/uv/reference/cli>.
 
 - Create a new Python project in the current directory:

--- a/pages/common/vboxmanage.md
+++ b/pages/common/vboxmanage.md
@@ -2,7 +2,7 @@
 
 > Command-line interface to VirtualBox.
 > Includes all the functionality of the GUI and more.
-> Some subcommands such as `vboxmanage startvm` have their own usage documentation.
+> Some subcommands such as `startvm` have their own usage documentation.
 > More information: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-intro>.
 
 - Execute a VboxManage subcommand:

--- a/pages/common/virsh.md
+++ b/pages/common/virsh.md
@@ -1,7 +1,7 @@
 # virsh
 
-> Manage virsh guest domains. (Note: 'guest_id' can be the ID, name or UUID of the guest).
-> Some subcommands such as `virsh list` have their own usage documentation.
+> Manage `virsh` guest domains. (Note: `guest_id` can be the ID, name or UUID of the guest).
+> Some subcommands such as `list` have their own usage documentation.
 > More information: <https://libvirt.org/manpages/virsh.html>.
 
 - Connect to a hypervisor session:

--- a/pages/common/vue.md
+++ b/pages/common/vue.md
@@ -1,7 +1,7 @@
 # vue
 
 > Multi-purpose CLI for Vue.js.
-> Some subcommands such as `vue build` have their own usage documentation.
+> Some subcommands such as `build` have their own usage documentation.
 > More information: <https://cli.vuejs.org>.
 
 - Create a new Vue project interactively:

--- a/pages/common/xml.md
+++ b/pages/common/xml.md
@@ -1,7 +1,7 @@
 # xml
 
 > XMLStarlet Toolkit: query, edit, check, convert and transform XML documents.
-> Some subcommands such as `xml validate` have their own usage documentation.
+> Some subcommands such as `validate` have their own usage documentation.
 > More information: <http://xmlstar.sourceforge.net/docs.php>.
 
 - Display general help, including the list of subcommands:

--- a/pages/linux/bpftool.md
+++ b/pages/linux/bpftool.md
@@ -1,7 +1,7 @@
 # bpftool
 
 > Inspect and manipulate eBPF programs and maps in a simple way.
-> Some subcommands such as `bpftool prog` have their own usage documentation.
+> Some subcommands such as `prog` have their own usage documentation.
 > More information: <https://manned.org/bpftool>.
 
 - List information about loaded `eBPF` programs:

--- a/pages/linux/btrfs.md
+++ b/pages/linux/btrfs.md
@@ -1,7 +1,7 @@
 # btrfs
 
 > A filesystem based on the copy-on-write (COW) principle for Linux.
-> Some subcommands such as `btrfs device` have their own usage documentation.
+> Some subcommands such as `device` have their own usage documentation.
 > More information: <https://btrfs.readthedocs.io/en/latest/btrfs.html>.
 
 - Create subvolume:

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -1,7 +1,7 @@
 # dpkg
 
 > Debian package manager.
-> Some subcommands such as `dpkg deb` have their own usage documentation.
+> Some subcommands such as `deb` have their own usage documentation.
 > For equivalent commands in other package managers, see <https://wiki.archlinux.org/title/Pacman/Rosetta>.
 > More information: <https://manpages.debian.org/latest/dpkg/dpkg.html>.
 

--- a/pages/linux/ip.md
+++ b/pages/linux/ip.md
@@ -1,7 +1,7 @@
 # ip
 
 > Show/manipulate routing, devices, policy routing and tunnels.
-> Some subcommands such as `ip address` have their own usage documentation.
+> Some subcommands such as `address` have their own usage documentation.
 > More information: <https://www.manned.org/ip.8>.
 
 - List interfaces with detailed info:

--- a/pages/linux/toolbox.md
+++ b/pages/linux/toolbox.md
@@ -1,7 +1,7 @@
 # toolbox
 
 > Manage containerized command-line environments on Linux.
-> Some subcommands such as `toolbox create` have their own usage documentation.
+> Some subcommands such as `create` have their own usage documentation.
 > More information: <https://manned.org/toolbox.1>.
 
 - Run a `toolbox` subcommand:

--- a/pages/osx/diskutil.md
+++ b/pages/osx/diskutil.md
@@ -1,7 +1,7 @@
 # diskutil
 
 > Utility to manage local disks and volumes.
-> Some subcommands such as `diskutil partitiondisk` have their own usage documentation.
+> Some subcommands such as `partitiondisk` have their own usage documentation.
 > More information: <https://keith.github.io/xcode-man-pages/diskutil.8.html>.
 
 - List all currently available disks, partitions and mounted volumes:

--- a/pages/windows/choco.md
+++ b/pages/windows/choco.md
@@ -1,7 +1,7 @@
 # choco
 
 > The Chocolatey package manager.
-> Some subcommands such as `choco install` have their own usage documentation.
+> Some subcommands such as `install` have their own usage documentation.
 > More information: <https://chocolatey.org>.
 
 - Execute a Chocolatey command:

--- a/pages/windows/reg.md
+++ b/pages/windows/reg.md
@@ -1,7 +1,7 @@
 # reg
 
 > Manage keys and their values in the Windows registry.
-> Some subcommands such as `reg add` have their own usage documentation.
+> Some subcommands such as `add` have their own usage documentation.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg>.
 
 - Execute a registry command:


### PR DESCRIPTION
Currently, pages mention their subcommands in two ways:

- Some subcommands such as `command subcommand` ...
- Some subcommands such as `subcommand` ...

I think the second way is better, because it's shorter and conveys the same meaning.
This PR changes all pages that include the main command.

