### PR TITLE
hugo: add subcommand notice

### DIFF
--- a/pages/common/hugo.md
+++ b/pages/common/hugo.md
@@ -1,6 +1,7 @@
 # hugo
 
 > Template-based static site generator. Uses modules, components, and themes.
+> Some subcommands such as `server` have their own usage documentation.
 > More information: <https://gohugo.io>.
 
 - Create a new Hugo site:


### PR DESCRIPTION
The page for `hugo server` was added in #13610.
