### PR TITLE
rpicam-vid: remove `vlc` example and "subcommand"

### DIFF
--- a/pages/linux/rpicam-vid.md
+++ b/pages/linux/rpicam-vid.md
@@ -1,13 +1,8 @@
 # rpicam-vid
 
 > Capture a video using a Raspberry Pi camera.
-> Some subcommands such as `vlc` have their own usage documentation.
 > More information: <https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-vid>.
 
 - Capture a 10 second video:
 
 `rpicam-vid -t 10000 -o {{path/to/file.h264}}`
-
-- Play the video using `vlc`:
-
-`vlc {{path/to/file.h264}}`


### PR DESCRIPTION
Vlc is not a subcommand of `rpicam-vid`.