### PR TITLE
git-commit, rubocop: use grouped parameters

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -25,7 +25,7 @@
 
 - Commit only specific (already staged) files:
 
-`git commit {{path/to/file1}} {{path/to/file2}}`
+`git commit {{path/to/file1 path/to/file2 ...}}`
 
 - Create a commit, even if there are no staged files:
 

--- a/pages/common/rubocop.md
+++ b/pages/common/rubocop.md
@@ -9,7 +9,7 @@
 
 - Check one or more specific files or directories:
 
-`rubocop {{path/to/file}} {{path/to/directory}}`
+`rubocop {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
 
 - Write output to file:
 
@@ -21,11 +21,11 @@
 
 - Exclude a cop:
 
-`rubocop --except {{cop_1}} {{cop_2}}`
+`rubocop --except {{cop1 cop2 ...}}`
 
 - Run only specified cops:
 
-`rubocop --only {{cop_1}} {{cop_2}}`
+`rubocop --only {{cop1 cop2 ...}}`
 
 - Auto-correct files (experimental):
 


### PR DESCRIPTION

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Followup to the https://github.com/tldr-pages/tldr/pulls/13609 to update `git-commit` and `rubocop` pages for English translation