### PR TITLE
git-*: add and update Indonesian translations

### DIFF
--- a/pages.id/common/git-add.md
+++ b/pages.id/common/git-add.md
@@ -1,32 +1,36 @@
 # git add
 
-> Tambahkan file yang diubah ke indeks.
+> Tambahkan berkas yang diubah ke indeks.
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-add>.
 
-- Tambahkan file ke indeks:
+- Tambahkan suatu berkas ke dalam indeks:
 
-`git add {{alamat/ke/file}}`
+`git add {{jalan/menuju/berkas}}`
 
-- Tambahkan semua file (yang terlacak dan tidak terlacak):
+- Tambahkan seluruh berkas (baik yang terlacak maupun tidak terlacak):
 
-`git add -A`
+`git add {{-A|--all}}`
 
-- Hanya tambahkan file yang sudah terlacak:
+- Tambahkan seluruh berkas pada folder saat ini:
 
-`git add -u`
+`git add .`
 
-- Tambahkan juga file yang diabaikan:
+- Hanya tambahkan berkas yang sudah terlacak:
 
-`git add -f`
+`git add {{-u|--update}}`
 
-- Menambahkan file ke status stage secara interaktif:
+- Tambahkan juga berkas yang diabaikan:
 
-`git add -p`
+`git add {{-f|--force}}`
 
-- Menambahkan file tertentu ke status stage secara interaktif:
+- Tambahkan berkas ke status stage secara interaktif:
 
-`git add -p {{alamat/ke/file}}`
+`git add {{-p|--patch}}`
+
+- Tambahkan berkas tertentu ke status stage secara interaktif:
+
+`git add {{-p|--patch}} {{jalan/menuju/berkas}}`
 
 - Stage file secara interaktif:
 
-`git add -i`
+`git add {{-i|--interactive}}`

--- a/pages.id/common/git-bulk.md
+++ b/pages.id/common/git-bulk.md
@@ -18,7 +18,7 @@
 
 - Gandakan lebih dari satu repositori ke dalam direktori induk tertentu (menurut berkas daftar lokasi remote yang dipisah dengan barisan baru), kemudian masukkan sebagai tempat kerja:
 
-`git bulk --addworkspace {{nama_workspace}} {{/jalan/absolut/menuju/direktori_induk}} --from {/jalan/absolut/menuju/berkas}}`
+`git bulk --addworkspace {{nama_workspace}} {{/jalan/absolut/menuju/direktori_induk}} --from {{/jalan/absolut/menuju/berkas}}`
 
 - Tampilkan daftar seluruh tempat kerja yang terdaftar:
 

--- a/pages.id/common/git-bulk.md
+++ b/pages.id/common/git-bulk.md
@@ -12,13 +12,21 @@
 
 `git bulk --addworkspace {{nama_workspace}} {{/jalan/absolut/menuju/repositori}}`
 
-- Gandakan sebuah repositori ke dalam direktori induk tertentu, kemudian masukkan repositori baru tersebut sebagai tempat kerja:
+- Gandakan suatu repositori ke dalam direktori induk tertentu, kemudian masukkan repositori baru tersebut sebagai tempat kerja:
 
 `git bulk --addworkspace {{nama_workspace}} {{/jalan/absolut/menuju/direktori_induk}} --from {{lokasi_repositori_remote}}`
 
 - Gandakan lebih dari satu repositori ke dalam direktori induk tertentu (menurut berkas daftar lokasi remote yang dipisah dengan barisan baru), kemudian masukkan sebagai tempat kerja:
 
 `git bulk --addworkspace {{nama_workspace}} {{/jalan/absolut/menuju/direktori_induk}} --from {/jalan/absolut/menuju/berkas}}`
+
+- Tampilkan daftar seluruh tempat kerja yang terdaftar:
+
+`git bulk --listall`
+
+- Jalankan sebuah perintah Git pada kumpulan repositori yang dikelola oleh tempat kerja saat ini:
+
+`git bulk {{perintah}} {{argumen-argumen_perintah}}`
 
 - Hapus suatu tempat dari daftar tempat kerja (hal ini tidak akan menghilangkan seluruh isi direktori yang direferensikan sebagai tempat kerja):
 

--- a/pages.id/common/git-bundle.md
+++ b/pages.id/common/git-bundle.md
@@ -17,7 +17,7 @@
 
 - Bungkus objek dan referensi untuk perubahan sejak 7 hari terakhir:
 
-`git bundle create {{jalan/menuju/berkas.bundle}} --since={{7.days}} {{HEAD}}`
+`git bundle create {{jalan/menuju/berkas.bundle}} --since {{7.days}} {{HEAD}}`
 
 - Cek apakah suatu berkas bundle bersifat valid dan dapat diaplikasikan ke dalam repositori saat ini:
 

--- a/pages.id/common/git-bundle.md
+++ b/pages.id/common/git-bundle.md
@@ -30,3 +30,7 @@
 - Buka dan pakai isi bungkusan untuk suatu cabang pada repositori saat ini:
 
 `git pull {{jalan/menuju/berkas.bundle}} {{nama_cabang}}`
+
+- Buat sebuah repositori baru dari suatu berkas bundle:
+
+`git clone {{jalan/menuju/berkas.bundle}}`

--- a/pages.id/common/git-cherry-pick.md
+++ b/pages.id/common/git-cherry-pick.md
@@ -1,0 +1,21 @@
+# git cherry-pick
+
+> Lakukan perubahan yang tercatat pada komit-komit saat ini menuju cabang saat ini.
+> Gunakan `git checkout` terlebih dahulu jika hendak melakukan perubahan pada cabang lainnya.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-cherry-pick>.
+
+- Lakukan perubahan menurut suatu komit terhadap cabang saat ini:
+
+`git cherry-pick {{komit}}`
+
+- Lakukan perubahan berdasarkan urutan komit terhadap cabang saat ini (lihat juga `git rebase --onto`):
+
+`git cherry-pick {{komit_awal}}~..{{komit_akhir}}`
+
+- Lakukan perubahan berdasarkan kumpulan komit (tak berurut) terhadap cabang saat ini:
+
+`git cherry-pick {{komit1 komit2 ...}}`
+
+- Lakukan perubahan pada direktori kerja saat ini tanpa mencatat komit baru:
+
+`git cherry-pick --no-commit {{komit}}`

--- a/pages.id/common/git-clean.md
+++ b/pages.id/common/git-clean.md
@@ -1,0 +1,28 @@
+# git clean
+
+> Hapus berkas-berkas yang tak dilacak oleh Git pada pohon direktori kerja saat ini.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-clean>.
+
+- Hapus seluruh berkas yang tak dilacak:
+
+`git clean`
+
+- Hapus menggunakan mode [i]nteraktif:
+
+`git clean {{-i|--interactive}}`
+
+- Tampilkan kumpulan berkas yang akan dihapus tanpa menghapusnya:
+
+`git clean --dry-run`
+
+- Hapus berkas-berkas secara paksa:
+
+`git clean {{-f|--force}}`
+
+- Hapus kumpulan [d]irektori secara paksa:
+
+`git clean {{-f|--force}} -d`
+
+- Hapus berkas-berkas yang tak dilacak, termasuk berkas yang dikecualikan (menurut daftar `.gitignore` dan `.git/info/exclude`):
+
+`git clean -x`

--- a/pages.id/common/git-clear.md
+++ b/pages.id/common/git-clear.md
@@ -1,0 +1,9 @@
+# git clear
+
+> Bersihkan isi direktori kerja Git menuju kondisi semula (seperti disalin melalui `git clone`) pada cabang saat ini, termasuk berkas-berkas yang dikecualikan menurut daftar `.gitignore`.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-clear>.
+
+- Setel ulang seluruh isi berkas yang dilacak oleh Git, serta hapus seluruh berkas yang tak dilacak meskipun dikecualikan menurut daftar `.gitignore`:
+
+`git clear`

--- a/pages.id/common/git-count.md
+++ b/pages.id/common/git-count.md
@@ -1,0 +1,13 @@
+# git count
+
+> Tampilkan informasi jumlah komit dalam suatu repositori.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-count>.
+
+- Tampilkan informasi jumlah komit dalam repositori saat ini:
+
+`git count`
+
+- Tampilkan informasi jumlah komit per kontributor serta keseluruhan jumlah komit:
+
+`git count --all`

--- a/pages.id/common/git-cp.md
+++ b/pages.id/common/git-cp.md
@@ -1,0 +1,13 @@
+# git cp
+
+> Salin suatu berkas menuju lokasi baru dengan menyimpan riwayat perubahan atas berkas tersebut.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-cp>.
+
+- Salin suatu berkas dalam suatu repositori Git, menuju tujuan pada direktori yang sama:
+
+`git cp {{nama_berkas}} {{nama_berkas_baru}}`
+
+- Salin berkas menuju tujuan yang lain:
+
+`git cp {{jalan/menuju/berkas}} {{jalan/menuju/berkas_baru}}`

--- a/pages.id/common/git-create-branch.md
+++ b/pages.id/common/git-create-branch.md
@@ -1,0 +1,17 @@
+# git create-branch
+
+> Buat suatu cabang (branch) baru dalam suatu repositori Git.
+> Bagian dari `git-extras`.
+> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-create-branch>.
+
+- Buat suatu cabang baru pada repositori lokal:
+
+`git create-branch {{nama_cabang}}`
+
+- Buat cabang baru pada repositori lokal dan sumber jarak jauh (remote) origin:
+
+`git create-branch --remote {{nama_cabang}}`
+
+- Buat cabang baru pada repositori lokal dan sumber jarak jauh (remote) upstream (yang dibentuk melalui proses pencangkokan/fork):
+
+`git create-branch --remote upstream {{nama_cabang}}`

--- a/pages.id/common/git-format-patch.md
+++ b/pages.id/common/git-format-patch.md
@@ -1,0 +1,17 @@
+# git format-patch
+
+> Buat berkas-berkas .patch dari kumpulan komit Git. Dapat dipakai untuk mengirimkan perubahan/komit melalui surel/email.
+> Lihat juga `git am`, yang memungkinkan pengguna untuk melakukan perubahan melalui berkas komit .patch yang dibuat.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-format-patch>.
+
+- Buat suatu berkas `.patch` untuk mencatat seluruh komit yang belum dikirimkan (push) ke remote, menggunakan nama berkas otomatis:
+
+`git format-patch {{origin}}`
+
+- Tampilkan isi berkas `.patch` menuju `stdout` yang mengandung perubahan antara dua revisi/komit:
+
+`git format-patch {{revisi_1}}..{{revisi_2}}`
+
+- Tulis suatu berkas `.patch` yang mengandung segala perubahan dalam 3 komit terakhir:
+
+`git format-patch -{{3}}`

--- a/pages.id/common/git-init.md
+++ b/pages.id/common/git-init.md
@@ -1,0 +1,20 @@
+# git init
+
+> Inisialisasikan sebuah repositori Git lokal.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-init>.
+
+- Inisialisasikan suatu direktori menjadi repositori lokal baru:
+
+`git init`
+
+- Inisialisasikan sebuah repositori dengan nama cabang (branch) awal yang ditentukan:
+
+`git init --initial-branch={{nama_cabang}}`
+
+- Inisialisasikan sebuah repositori menggunakan format hash objek berbasis SHA256 (membutuhkan Git versi 2.29+):
+
+`git init --object-format={{sha256}}`
+
+- Inisialisasikan sebuah repositori kosong (barebones) yang dapat digunakan sebagai remote melalui koneksi SSH:
+
+`git init --bare`

--- a/pages.id/common/git-push.md
+++ b/pages.id/common/git-push.md
@@ -1,0 +1,36 @@
+# git push
+
+> Dorong kumpulan komit menuju suatu repositori jarak jauh (remote).
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-push>.
+
+- Kirim perubahan lokal dari cabang (branch) saat ini menuju cabang yang sepadan pada repositori tujuan:
+
+`git push`
+
+- Kirim perubahan dari cabang lokal yang ditentukan menuju cabang yang sepadan pada repositori tujuan:
+
+`git push {{nama_remote}} {{cabang_lokal}}`
+
+- Kirim perubahan dari cabang lokal yang ditentukan menuju cabang sepadan pada repositori tujuan, dan simpan remote sebagai target operasi dorong (push) dan tarik (pull) bagi cabang lokal tersebut:
+
+`git push -u {{nama_remote}} {{cabang_lokal}}`
+
+- Kirim perubahan dari suatu cabang lokal menuju suatu cabang remote secara spesifik:
+
+`git push {{nama_remote}} {{cabang_lokal}}:{{cabang_remote}}`
+
+- Kirim perubahan dari setiap cabang lokal menuju cabang-cabang sepadan dalam repositori tujuan:
+
+`git push --all {{nama-remote}}`
+
+- Hapus suatu cabang dalam suatu repositori remote:
+
+`git push {{nama_remote}} --delete {{cabang_remote}}`
+
+- Hapus cabang-cabang remote yang tidak memiliki padanan pada repositori lokal:
+
+`git push --prune {{nama_remote}}`
+
+- Publikasikan kumpulan tag komit yang belum dipublikasikan dalam repositori remote:
+
+`git push --tags`

--- a/pages.id/common/git-remote.md
+++ b/pages.id/common/git-remote.md
@@ -1,28 +1,32 @@
 # git remote
 
-> Mengelola kumpulan repositori yang dilacak/diikuti ("remotes").
+> Kelola kumpulan repositori yang dilacak/diikuti dari sumber jarak jauh ("remotes").
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-remote>.
 
-- Menampilkan daftar remote, namanya dan URL:
+- Tampilkan daftar remote, namanya dan URL:
 
-`git remote -v`
+`git remote {{-v|--verbose}}`
 
-- Menampilkan informasi tentang remote:
+- Tampilkan informasi tentang suatu remote:
 
 `git remote show {{nama_remote}}`
 
-- Menambahkan remote:
+- Tambahkan suatu remote untuk diikuti pada repositori saat ini:
 
 `git remote add {{nama_remote}} {{url_remote}}`
 
-- Mengubah URL dari remote (gunakan `--add` untuk tetap menyimpan URL lama):
+- Ubah alamat URL dari remote (gunakan `--add` untuk tetap menyimpan URL lama):
 
 `git remote set-url {{nama_remote}} {{url_baru}}`
 
-- Menghapus remote:
+- Tampilkan alamat URL dari suatu remote:
+
+`git remote get-url {{nama_remote}}`
+
+- Hapus remote dari daftar remote yang dilacak pada repositori saat ini:
 
 `git remote remove {{nama_remote}}`
 
-- Mengubah nama remote:
+- Ubah nama remote untuk dikelola dalam repositori saat ini:
 
 `git remote rename {{nama_lama}} {{nama_baru}}`

--- a/pages.id/common/git-rm.md
+++ b/pages.id/common/git-rm.md
@@ -1,0 +1,16 @@
+# git rm
+
+> Hapus berkas-berkas dari indeks repositori dan sistem manajemen berkas (filesystem) lokal.
+> Informasi lebih lanjut: <https://git-scm.com/docs/git-rm>.
+
+- Hapus berkas dari indeks repositori dan filesystem lokal:
+
+`git rm {{jalan/menuju/berkas}}`
+
+- Hapus suatu direktori:
+
+`git rm -r {{jalan/menuju/direktori}}`
+
+- Hapus suatu berkas dari indeks repositori tanpa menghapusnya pada filesystem lokal:
+
+`git rm --cached {{jalan/menuju/berkas}}`

--- a/pages.id/common/git-status.md
+++ b/pages.id/common/git-status.md
@@ -10,7 +10,7 @@
 
 - Tampilkan informasi dalam format [s]ingkat:
 
-`git status -s`
+`git status --short`
 
 - Tampilkan informasi secara terperinci ([v]erbose) baik dalam panggung rencana perubahan (staging) dan direktori kerja saat ini:
 

--- a/pages.id/common/git-status.md
+++ b/pages.id/common/git-status.md
@@ -1,21 +1,33 @@
 # git status
 
-> Menampilkan perubahan pada file dalam repositori Git.
-> Menmapilkan daftar perubahan , menambahkan dan menghapus file dibandingkan dengan komit yang saat ini di check-out.
+> Tampilkan perubahan pada berkas dalam repositori Git.
+> Menampilkan daftar perubahan, menambahkan dan menghapus berkas dibandingkan dengan komit yang saat ini diperiksa (checkout).
 > Informasi lebih lanjut: <https://git-scm.com/docs/git-status>.
 
-- Tampilkan file yang diubah yang belum ditambahkan untuk komit:
+- Tampilkan daftar berkas yang diubah yang belum ditambahkan untuk komit:
 
 `git status`
 
-- Berikan keluaran dalam format [s]hort (pendek):
+- Tampilkan informasi dalam format [s]ingkat:
 
 `git status -s`
 
-- Jangan tampilkan file yang tidak terlacak di output:
+- Tampilkan informasi secara terperinci ([v]erbose) baik dalam panggung rencana perubahan (staging) dan direktori kerja saat ini:
+
+`git status --verbose --verbose`
+
+- Tampilkan informasi mengenai cabang ([b]ranch) dan status pelacakan dari remote:
+
+`git status --branch`
+
+- Tampilkan daftar berkas beserta informasi cabang ([b]ranch) dalam format [s]ingkat:
+
+`git status --short --branch`
+
+- Tampilkan jumlah entri yang disimpan ke dalam kumpulan stash:
+
+`git status --show-stash`
+
+- Jangan tampilkan berkas yang tidak terlacak:
 
 `git status --untracked-files=no`
-
-- Tampilkan keluaran dalam format [s]hort (pendek) bersama dengan [b] info cabangnya:
-
-`git status -sb`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This commit updates some subcommands (e.g. `common/git-pull`) to use the imperative mood (see #8576), updates outdated Git subcommands (see #13572), while also prioritizes translation for commonly-translated subcommands including `common/git-push` and `common/git-pull`.