### PR TITLE
http, httpie.de: edit pages, http.de: add page

### DIFF
--- a/pages.de/common/http.md
+++ b/pages.de/common/http.md
@@ -1,0 +1,36 @@
+# http
+
+> HTTPie: ein benutzerfreundliches HTTP-Tool.
+> Weitere Informationen: <https://httpie.io/docs/cli/usage>.
+
+- Sende eine GET-Anfrage (Zeigt ddie Header und den Body der Antwort):
+
+`http {{https://example.com}}`
+
+- Zeige nur den angegebenen Teil der Anfrage und der Antwort (`H`: Header der Anfrage, `B`: Body der Anfrage, `h`: Header der Antwort, `b`: Body der Antwort, `m`: Metadaten der Antwort):
+
+`http --print {{H|B|h|b|m|Hh|Hhb|...}} {{https://example.com}}`
+
+- Spezifiziere die zu nutzende HTTP-Methode und nutze den angegebenen Proxy:
+
+`http {{GET|POST|HEAD|PUT|PATCH|DELETE|...}} --proxy {{http|https}}:{{http://localhost:8080|socks5://localhost:9050|...}} {{https://example.com}}`
+
+- Folge `3xx`-Umleitungen und spezifiziere zusätzliche Header für die Anfrage:
+
+`http {{-F|--follow}} {{https://example.com}} {{'User-Agent: Mozilla/5.0' 'Accept-Encoding: gzip'}}`
+
+- Authentisiere gegenüber einem Server mithilfe unterschiedlicher Anthentisierungsmethoden:
+
+`http --auth {{username:password|token}} --auth-type {{basic|digest|bearer}} {{GET|POST|...}} {{https://example.com/auth}}`
+
+- Erstelle eine Anfrage ohne diese zu senden (ähnlich zu dry-run):
+
+`http --offline {{GET|DELETE|...}} {{https://example.com}}`
+
+- Nutze die angegebene Session für persistente benutzerdefinierte Header, Credentials für die Authentisierung und Cookies:
+
+`http --session {{session_name|path/to/session.json}} {{--auth username:password https://example.com/auth API-KEY:xxx}}`
+
+- Lade eine Datei in ein Formular hoch (das folgende Beispiel geht davon aus, dass das Formularfeld als `<input type="file" name="cv" />` definiert ist):
+
+`http --form {{POST}} {{https://example.com/upload}} {{cv@path/to/file}}`

--- a/pages.de/common/httpie.md
+++ b/pages.de/common/httpie.md
@@ -1,36 +1,17 @@
 # httpie
 
-> Ein benutzerfreundliches HTTP-Tool.
-> Weitere Informationen: <https://github.com/httpie/httpie>.
+> Managementschnittstelle für HTTPie.
+> Siehe auch: `http`, das eigentliche Tool.
+> Weitere Informationen: <https://httpie.io/docs/cli/plugin-manager>.
 
-- Sende eine GET-Anfrage (Standardmethode ohne Anfragedaten):
+- Suche nach Aktualisierungen für `httpie`:
 
-`http {{https://example.com}}`
+`httpie cli check-updates`
 
-- Sende eine POST-Anfrage (Standardmethode mit Anfragedaten):
+- Zeige die installierten Plugins für `httpie`:
 
-`http {{https://example.com}} {{hello=World}}`
+`httpie cli plugins list`
 
-- Sende eine POST-Anfrage mit einer Datei als Eingabe:
+- Installiere/aktualisiere/deinstalliere Plugins:
 
-`http {{https://example.com}} < {{file.json}}`
-
-- Sende eine PUT-Anfrage mit einem bestimmten JSON-Body:
-
-`http PUT {{https://example.com/todos/7}} {{hello=world}}`
-
-- Sende eine DELETE-Anfrage mit einem bestimmten Anfrage-Header:
-
-`http DELETE {{https://example.com/todos/7}} {{API-Key:foo}}`
-
-- Zeige den gesamten HTTP-Austausch (sowohl Anfrage als auch Antwort):
-
-`http -v {{https://example.com}}`
-
-- Lade eine Datei herunter:
-
-`http --download {{https://example.com}}`
-
-- Folge Umleitungen und zeige Zwischenanfragen und -antworten:
-
-`http --follow --all {{https://example.com}}`
+`httpie cli plugins {{install|upgrade|uninstall}} {{plugin_name}}`

--- a/pages/common/http.md
+++ b/pages/common/http.md
@@ -31,6 +31,6 @@
 
 `http --session {{session_name|path/to/session.json}} {{--auth username:password https://example.com/auth API-KEY:xxx}}`
 
-- Upload a file to a form (the example below assumes form field is `<input type="file" name="cv" />`):
+- Upload a file to a form (the example below assumes that the form field is `<input type="file" name="cv" />`):
 
 `http --form {{POST}} {{https://example.com/upload}} {{cv@path/to/file}}`


### PR DESCRIPTION

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Have the german page for httpie split up into http.md and httpie.md as in the english version. Also updated the german more information link and fixed a typo in the english http.md page.
