### PR TITLE
logcat: add missing German translations

### DIFF
--- a/pages.de/android/logcat.md
+++ b/pages.de/android/logcat.md
@@ -1,16 +1,24 @@
 # logcat
 
-> Gib ein Protokoll aller Systemmeldungen aus.
+> Gib ein Protokoll aller System-Logs aus.
 > Weitere Informationen: <https://developer.android.com/tools/logcat>.
 
-- Gib ein Protokoll aller Systemmeldungen aus:
+- Gib ein Protokoll aller System-Logs aus:
 
 `logcat`
 
-- Schreibe alle Systemmeldungen in eine Datei:
+- Schreibe alle System-Logs in eine Datei:
 
 `logcat -f {{pfad/zu/datei}}`
 
 - Gib Zeilen aus, die einem regulären Ausdruck entsprechen:
 
 `logcat --regex {{regex}}`
+
+- Gib System-Logs für die spezifizierte PID aus:
+
+`logcat --pid {{pid}}`
+
+- Gib System-Logs für den Prozess eines bestimmten Packets aus:
+
+`logcat --pid $(pidof -s {{packet}})`


### PR DESCRIPTION
I think that System-Logs is an appropriate translation fpr system logs. Nobody would say Systemmeldung, as this could be confused with Notifications generated by e.g. notify-send.