### PR TITLE
pulumi-up: add --continue-on-error example

### DIFF
--- a/pages/common/pulumi-up.md
+++ b/pages/common/pulumi-up.md
@@ -18,3 +18,7 @@
 - Don't display stack outputs:
 
 `pulumi up --suppress-outputs`
+
+- Continue updating resources even if an error is encountered:
+
+`pulumi up --continue-on-error`

--- a/pages/common/pulumi-up.md
+++ b/pages/common/pulumi-up.md
@@ -19,6 +19,6 @@
 
 `pulumi up --suppress-outputs`
 
-- Continue updating resources even if an error is encountered:
+- Continue updating the resources, even if an error is encountered:
 
 `pulumi up --continue-on-error`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
