### PR TITLE
pages*/freebsd, pages*/netbsd: uniform links

### DIFF
--- a/pages.es/freebsd/pkg.md
+++ b/pages.es/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > Gestor de paquetes de FreeBSD.
-> Más información: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> Más información: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - Instala un nuevo paquete:
 

--- a/pages.es/netbsd/df.md
+++ b/pages.es/netbsd/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Muestra una visión general del uso del espacio en disco del sistema de archivos.
-> Más información: <https://man.netbsd.org/NetBSD-9.3/df.1>.
+> Más información: <https://man.netbsd.org/df.1>.
 
 - Muestra todos los sistemas de ficheros y su uso de disco usando unidades de 512 bytes:
 

--- a/pages.es/netbsd/sockstat.md
+++ b/pages.es/netbsd/sockstat.md
@@ -3,7 +3,7 @@
 > Lista sockets abiertos de Internet o dominios UNIX.
 > Nota: este programa es una reescritura para NetBSD 3.0 de `sockstat` de FreeBSD.
 > Vea también: `netstat`.
-> Más información: <https://man.freebsd.org/cgi/man.cgi?sockstat>.
+> Más información: <https://man.netbsd.org/sockstat.1>.
 
 - Muestra información de sockets IPv4, IPv6 y Unix que estén escuchando y conectados:
 

--- a/pages.id/freebsd/pkg.md
+++ b/pages.id/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > Manajer paket untuk FreeBSD.
-> Informasi lebih lanjut: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> Informasi lebih lanjut: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - Pasang sebuah paket:
 

--- a/pages.ko/freebsd/pkg.md
+++ b/pages.ko/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > FreeBSD 패키지 관리자입니다.
-> 더 많은 정보: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> 더 많은 정보: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - 새 패키지 설치:
 

--- a/pages.ko/netbsd/cal.md
+++ b/pages.ko/netbsd/cal.md
@@ -1,7 +1,7 @@
 # cal
 
 > 달력을 표시합니다.
-> 더 많은 정보: <https://man.freebsd.org/cgi/man.cgi?cal>.
+> 더 많은 정보: <https://man.netbsd.org/cal.1>.
 
 - 현재 월의 달력 표시:
 

--- a/pages.ko/netbsd/chpass.md
+++ b/pages.ko/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > 사용자 데이터베이스 정보, 로그인 셸 및 비밀번호를 추가하거나 변경합니다.
 > 같이 보기: `passwd`.
-> 더 많은 정보: <https://man.openbsd.org/chsh>.
+> 더 많은 정보: <https://man.netbsd.org/chsh>.
 
 - 현재 사용자에게 특정 로그인 셸을 대화식으로 설정:
 

--- a/pages.ko/netbsd/df.md
+++ b/pages.ko/netbsd/df.md
@@ -1,7 +1,7 @@
 # df
 
 > 파일 시스템 디스크 공간 사용량 개요를 표시합니다.
-> 더 많은 정보: <https://man.netbsd.org/NetBSD-9.3/df.1>.
+> 더 많은 정보: <https://man.netbsd.org/df.1>.
 
 - 512바이트 단위로 모든 파일 시스템과 디스크 사용량 표시:
 

--- a/pages.ko/netbsd/sockstat.md
+++ b/pages.ko/netbsd/sockstat.md
@@ -3,7 +3,7 @@
 > 열린 인터넷 또는 UNIX 도메인 소켓을 나열합니다.
 > 참고: 이 프로그램은 FreeBSD의 `sockstat`를 NetBSD 3.0용으로 다시 작성한 것입니다.
 > 같이 보기: `netstat`.
-> 더 많은 정보: <https://man.freebsd.org/cgi/man.cgi?sockstat>.
+> 더 많은 정보: <https://man.netbsd.org/sockstat.1>.
 
 - IPv4, IPv6 및 Unix 소켓에 대한 수신 및 연결된 소켓에 대한 정보 표시:
 

--- a/pages.nl/freebsd/pkg.md
+++ b/pages.nl/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > FreeBSD pakketbeheerder.
-> Meer informatie: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> Meer informatie: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - Installeer een nieuw pakket:
 

--- a/pages.nl/netbsd/cal.md
+++ b/pages.nl/netbsd/cal.md
@@ -1,7 +1,7 @@
 # cal
 
 > Toon een kalender.
-> Meer informatie: <https://man.freebsd.org/cgi/man.cgi?cal>.
+> Meer informatie: <https://man.netbsd.org/cal.1>.
 
 - Toon een kalender voor de huidige maand:
 

--- a/pages.nl/netbsd/chpass.md
+++ b/pages.nl/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Gebruikersdatabase informatie toevoegen of wijzigen, inclusief login shell en wachtwoord.
 > Bekijk ook: `passwd`.
-> Meer informatie: <https://man.openbsd.org/chsh>.
+> Meer informatie: <https://man.netbsd.org/chsh>.
 
 - Stel interactief een specifieke login shell in voor de huidige gebruiker:
 

--- a/pages.nl/netbsd/df.md
+++ b/pages.nl/netbsd/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Toon een overzicht van het gebruik van het bestandssysteem op het gebied van schijfruimte.
-> Meer informatie: <https://man.netbsd.org/NetBSD-9.3/df.1>.
+> Meer informatie: <https://man.netbsd.org/df.1>.
 
 - Toon alle bestandssystemen en hun schijfgebruik met behulp van 512-byte eenheden:
 

--- a/pages.nl/netbsd/sockstat.md
+++ b/pages.nl/netbsd/sockstat.md
@@ -3,7 +3,7 @@
 > Toon open Internet- of UNIX-domeinsockets.
 > Let op: dit programma is hergeschreven voor NetBSD 3.0 van FreeBSD's `sockstat`.
 > Bekijk ook: `netstat`.
-> Meer informatie: <https://man.freebsd.org/cgi/man.cgi?sockstat>.
+> Meer informatie: <https://man.netbsd.org/sockstat.1>.
 
 - Toon informatie voor IPv4- en IPv6-sockets voor zowel luister- als verbonden sockets:
 

--- a/pages.pt_BR/freebsd/pkg.md
+++ b/pages.pt_BR/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > Gerenciador de pacotes do FreeBSD.
-> Mais informações: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - Instala um novo pacote:
 

--- a/pages/freebsd/pkg.md
+++ b/pages/freebsd/pkg.md
@@ -1,7 +1,7 @@
 # pkg
 
 > FreeBSD package manager.
-> More information: <https://man.freebsd.org/cgi/man.cgi?query=pkg&sektion=8>.
+> More information: <https://man.freebsd.org/cgi/man.cgi?pkg>.
 
 - Install a new package:
 

--- a/pages/netbsd/cal.md
+++ b/pages/netbsd/cal.md
@@ -1,7 +1,7 @@
 # cal
 
 > Display a calendar.
-> More information: <https://man.freebsd.org/cgi/man.cgi?cal>.
+> More information: <https://man.netbsd.org/cal.1>.
 
 - Display a calendar for the current month:
 

--- a/pages/netbsd/chpass.md
+++ b/pages/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Add or change user database information, including login shell and password.
 > See also: `passwd`.
-> More information: <https://man.openbsd.org/chsh>.
+> More information: <https://man.netbsd.org/chsh>.
 
 - Set a specific login shell for the current user interactively:
 

--- a/pages/netbsd/df.md
+++ b/pages/netbsd/df.md
@@ -1,7 +1,7 @@
 # df
 
 > Display an overview of the filesystem disk space usage.
-> More information: <https://man.netbsd.org/NetBSD-9.3/df.1>.
+> More information: <https://man.netbsd.org/df.1>.
 
 - Display all filesystems and their disk usage using 512-byte units:
 

--- a/pages/netbsd/sockstat.md
+++ b/pages/netbsd/sockstat.md
@@ -3,7 +3,7 @@
 > List open Internet or UNIX domain sockets.
 > Note: this program is a rewrite for NetBSD 3.0 from FreeBSD's `sockstat`.
 > See also: `netstat`.
-> More information: <https://man.freebsd.org/cgi/man.cgi?sockstat>.
+> More information: <https://man.netbsd.org/sockstat.1>.
 
 - Show information for IPv4, IPv6 and Unix sockets for both listening and connected sockets:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 

https://github.com/tldr-pages/tldr/pull/13711 - part 3