### PR TITLE
pages*/linux: remove /man from links

### DIFF
--- a/pages.es/linux/getenforce.md
+++ b/pages.es/linux/getenforce.md
@@ -1,7 +1,7 @@
 # getenforce
 
 > Obtén el modo actual de SELinux (es decir, obligatorio, permisivo o deshabilitado).
-> Más información: <https://manned.org/man/getenforce>.
+> Más información: <https://manned.org/getenforce>.
 
 - Muestra el modo actual de SELinux:
 

--- a/pages.es/linux/grubby.md
+++ b/pages.es/linux/grubby.md
@@ -1,7 +1,7 @@
 # grubby
 
 > Herramienta para configurar los gestores de arranque `grub` y `zipl`.
-> Más información: <https://manned.org/man/grubby.8>.
+> Más información: <https://manned.org/grubby.8>.
 
 - Añade argumentos de arranque del núcleo a todas las entradas del menú del núcleo:
 

--- a/pages.es/linux/torify.md
+++ b/pages.es/linux/torify.md
@@ -2,7 +2,7 @@
 
 > Enruta el tráfico de red a través de la red Tor.
 > Nota: Este comando está desfasado, y ahora es un empaquetador compatible con versiones anteriores de `torsocks`.
-> Más información: <https://manned.org/man/torify>.
+> Más información: <https://manned.org/torify>.
 
 - Enruta el tráfico a través de Tor:
 

--- a/pages.nl/linux/secon.md
+++ b/pages.nl/linux/secon.md
@@ -2,7 +2,7 @@
 
 > Krijg de SELinux-beveiligingscontext van een bestand, PID, huidige uitvoeringscontext of een contextspecificatie.
 > Zie ook: `semanage`, `runcon`, `chcon`.
-> Meer informatie: <https://manned.org/man/secon>.
+> Meer informatie: <https://manned.org/secon>.
 
 - Krijg de beveiligingscontext van de huidige uitvoeringscontext:
 

--- a/pages.nl/linux/semanage-boolean.md
+++ b/pages.nl/linux/semanage-boolean.md
@@ -2,7 +2,7 @@
 
 > Beheer persistente SELinux-boolean-instellingen.
 > Zie ook: `semanage` voor het beheren van SELinux-beleid, `getsebool` voor het controleren van boolean-waarden, en `setsebool` voor het toepassen van niet-blijvende boolean-instellingen.
-> Meer informatie: <https://manned.org/man/semanage-boolean>.
+> Meer informatie: <https://manned.org/semanage-boolean>.
 
 - Toon alle boolean-instellingen:
 

--- a/pages.nl/linux/semanage-permissive.md
+++ b/pages.nl/linux/semanage-permissive.md
@@ -3,7 +3,7 @@
 > Beheer persistente SELinux permissieve domeinen.
 > Let op dat dit het proces effectief onbeperkt maakt. Voor langdurig gebruik wordt aanbevolen om SELinux correct te configureren.
 > Zie ook: `semanage`, `getenforce`, `setenforce`.
-> Meer informatie: <https://manned.org/man/semanage-permissive>.
+> Meer informatie: <https://manned.org/semanage-permissive>.
 
 - Toon alle procestypen (ook wel domeinen genoemd) die in permissieve modus zijn:
 

--- a/pages.nl/linux/semanage-port.md
+++ b/pages.nl/linux/semanage-port.md
@@ -2,7 +2,7 @@
 
 > Beheer persistente SELinux-poortdefinities.
 > Zie ook: `semanage`.
-> Meer informatie: <https://manned.org/man/semanage-port>.
+> Meer informatie: <https://manned.org/semanage-port>.
 
 - Toon alle poortlabelregels:
 

--- a/pages/linux/getenforce.md
+++ b/pages/linux/getenforce.md
@@ -2,7 +2,7 @@
 
 > Get the current mode of SELinux (i.e. enforcing, permissive, or disabled).
 > See also: `setenforce`, `semanage-permissive`.
-> More information: <https://manned.org/man/getenforce>.
+> More information: <https://manned.org/getenforce>.
 
 - Display the current mode of SELinux:
 

--- a/pages/linux/getsebool.md
+++ b/pages/linux/getsebool.md
@@ -2,7 +2,7 @@
 
 > Get SELinux boolean value.
 > See also: `semanage-boolean`, `setsebool`.
-> More information: <https://manned.org/man/getsebool>.
+> More information: <https://manned.org/getsebool>.
 
 - Show the current setting of a boolean:
 

--- a/pages/linux/grubby.md
+++ b/pages/linux/grubby.md
@@ -1,7 +1,7 @@
 # grubby
 
 > Tool for configuring `grub` and `zipl` bootloaders.
-> More information: <https://manned.org/man/grubby.8>.
+> More information: <https://manned.org/grubby.8>.
 
 - Add kernel boot arguments to all kernel menu entries:
 

--- a/pages/linux/matchpathcon.md
+++ b/pages/linux/matchpathcon.md
@@ -2,7 +2,7 @@
 
 > Lookup the persistent SELinux security context setting of a path.
 > See also: `semanage-fcontext`, `secon`, `chcon`, `restorecon`.
-> More information: <https://manned.org/man/matchpathcon.8>.
+> More information: <https://manned.org/matchpathcon.8>.
 
 - Lookup the persistent security context setting of an absolute path:
 

--- a/pages/linux/rpmbuild.md
+++ b/pages/linux/rpmbuild.md
@@ -1,7 +1,7 @@
 # rpmbuild
 
 > RPM Package Build tool.
-> More information: <https://manned.org/man/rpmbuild>.
+> More information: <https://manned.org/rpmbuild>.
 
 - Build binary and source packages:
 

--- a/pages/linux/secon.md
+++ b/pages/linux/secon.md
@@ -2,7 +2,7 @@
 
 > Get the SELinux security context of a file, pid, current execution context, or a context specification.
 > See also: `semanage`, `runcon`, `chcon`.
-> More information: <https://manned.org/man/secon>.
+> More information: <https://manned.org/secon>.
 
 - Get the security context of the current execution context:
 

--- a/pages/linux/semanage-boolean.md
+++ b/pages/linux/semanage-boolean.md
@@ -2,7 +2,7 @@
 
 > Manage persistent SELinux boolean settings.
 > See also: `semanage` for managing SELinux policies, `getsebool` for checking boolean values, and `setsebool` for applying non-persistent boolean settings.
-> More information: <https://manned.org/man/semanage-boolean>.
+> More information: <https://manned.org/semanage-boolean>.
 
 - List all booleans settings:
 

--- a/pages/linux/semanage-permissive.md
+++ b/pages/linux/semanage-permissive.md
@@ -3,7 +3,7 @@
 > Manage persistent SELinux permissive domains.
 > Note that this effectively makes the process unconfined. For long-term use, it is recommended to configure SELiunx properly.
 > See also: `semanage`, `getenforce`, `setenforce`.
-> More information: <https://manned.org/man/semanage-permissive>.
+> More information: <https://manned.org/semanage-permissive>.
 
 - List all process types (a.k.a domains) that are in permissive mode:
 

--- a/pages/linux/semanage-port.md
+++ b/pages/linux/semanage-port.md
@@ -2,7 +2,7 @@
 
 > Manage persistent SELinux port definitions.
 > See also: `semanage`.
-> More information: <https://manned.org/man/semanage-port>.
+> More information: <https://manned.org/semanage-port>.
 
 - List all port labeling rules:
 

--- a/pages/linux/setenforce.md
+++ b/pages/linux/setenforce.md
@@ -3,7 +3,7 @@
 > Toggle SELinux between enforcing and permissive modes.
 > To enable or disable SELinux, edit `/etc/selinux/config` instead.
 > See also: `getenforce`, `semanage-permissive`.
-> More information: <https://manned.org/man/setenforce>.
+> More information: <https://manned.org/setenforce>.
 
 - Put SELinux in enforcing mode:
 

--- a/pages/linux/setsebool.md
+++ b/pages/linux/setsebool.md
@@ -2,7 +2,7 @@
 
 > Set SELinux boolean value.
 > See also: `semanage-boolean`, `getsebool`.
-> More information: <https://manned.org/man/setsebool>.
+> More information: <https://manned.org/setsebool>.
 
 - Show the current setting of [a]ll booleans:
 

--- a/pages/linux/togglesebool.md
+++ b/pages/linux/togglesebool.md
@@ -2,7 +2,7 @@
 
 > Flip the current (non-persistent) values of SELinux booleans.
 > Note: This tool has been deprecated and often removed in favor of `setsebool`.
-> More information: <https://manned.org/man/togglesebool>.
+> More information: <https://manned.org/togglesebool>.
 
 - Flip the current (non-persistent) values of the specified booleans:
 

--- a/pages/linux/torify.md
+++ b/pages/linux/torify.md
@@ -2,7 +2,7 @@
 
 > Route network traffic through the Tor network.
 > Note: This command has been deprecated, and is now a backwards-compatible wrapper of `torsocks`.
-> More information: <https://manned.org/man/torify>.
+> More information: <https://manned.org/torify>.
 
 - Route traffic via Tor:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).