### PR TITLE
firewall-cmd: clarify runtime/permanent configuration and add commands

### DIFF
--- a/pages/linux/firewall-cmd.md
+++ b/pages/linux/firewall-cmd.md
@@ -1,15 +1,12 @@
 # firewall-cmd
 
 > The firewalld command-line client.
+> View and adapt the runtime or permanent firewall configuration state.
 > More information: <https://firewalld.org/documentation/man-pages/firewall-cmd>.
 
-- View the available firewall zones:
+- View all available firewall zones and rules in their runtime configuration state:
 
-`firewall-cmd --get-active-zones`
-
-- View the rules which are currently applied:
-
-`firewall-cmd --list-all`
+`firewall-cmd --list-all-zones`
 
 - Permanently move the interface into the block zone, effectively blocking all communication:
 
@@ -23,10 +20,18 @@
 
 `firewall-cmd --permanent --zone={{public}} --remove-service={{http}}`
 
-- Permanently open two arbitrary ports in the specified zone:
+- Permanently forward a port for incoming packets in the specified zone (like port 443 to 8443 when entering the `public` zone):
 
-`firewall-cmd --permanent --zone={{public}} --add-port={{25565/tcp}} --add-port={{19132/udp}}`
+`firewall-cmd --permanent --zone={{public}} --add-rich-rule='rule family="{{ipv4|ipv6}}" forward-port port="{{443}}" protocol="{{udp|tcp}}" to-port="{{8443}}"'`
 
-- Reload firewalld to force rule changes to take effect:
+- Reload firewalld to lose any runtime changes and force the permanent configuration to take effect immediately:
 
 `firewall-cmd --reload`
+
+- Save the runtime configuration state to the permanent configuraion:
+
+`firewall-cmd --runtime-to-permanent`
+
+- Enable panic mode in case of Emergency. All traffic is dropped, any active connection will be terminated:
+
+`firewall-cmd --panic-on`

--- a/pages/linux/firewall-cmd.md
+++ b/pages/linux/firewall-cmd.md
@@ -28,7 +28,7 @@
 
 `firewall-cmd --reload`
 
-- Save the runtime configuration state to the permanent configuraion:
+- Save the runtime configuration state to the permanent configuration:
 
 `firewall-cmd --runtime-to-permanent`
 


### PR DESCRIPTION
**Changes**
- Added short additional description in heading
- Made the differentiation between runtime and permanent configuration clearer
- Switched from "--get-active-zone" to "--list-all-zones" to show all available zones and their rules
- Removed command "--list-all" as it returns a subset of the first command (the runtime state of the default zone)
- Removed additional command for adding arbitrary ports
- Added command to create a new local port forwarding (for example for rootless reverse proxy containers) to showcase rich rules
- Added information about loss of runtime configuration/changes to reload command
- Added command for saving the current runtime configuration state to the permanent configuration ( in contrast to editing the permanent configuration directly and reloading firewalld afterward)
- Added command for enabling panic mode

_The commands were and are mostly in order of usual execution instead of difficulty._

If the command for adding arbitrary ports should stay, I'd remove the "--remove-service" command or alternatively the panic mode command.
The arbitrary port command is needed more often by inexperienced users (that don't necessarily know about and create a custom service for their arbitrary ports), the panic mode command  is a fundamental feature that would be good to know for anyone making changes to firewalld.
The "--remove-service" command could be considered superfluous, as any add-action usually has a rem- or remove-action.

**Pull request Template**
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2.1.0
