### PR TITLE
ffmpeg: update page

### DIFF
--- a/pages/common/ffmpeg.md
+++ b/pages/common/ffmpeg.md
@@ -21,7 +21,7 @@
 
 - Trim a video from a given start time mm:ss to an end time mm2:ss2 (omit the -to flag to trim till the end):
 
-`ffmpeg -ss {{mm:ss}} -to {{mm2:ss2}} -i {{path/to/input_video.mp4}} -codec copy {{path/to/output_video.mp4}}`
+`ffmpeg -i {{path/to/input_video.mp4}} -ss {{mm:ss}} -to {{mm2:ss2}} -codec copy {{path/to/output_video.mp4}}`
 
 - Convert AVI video to MP4. AAC Audio @ 128kbit, h264 Video @ CRF 23:
 


### PR DESCRIPTION
Moved `-ss` and `-to` flags to after input file so they function as output options. Using the example provided will result in artifacting before the ffmpeg encounters the first keyframe in the input file. Moving them to output options will force ffmpeg to decode the entire input file, which may result in performance overhead, but avoids artifacting in the output file.