### PR TITLE
lsd : add French translation

### DIFF
--- a/pages.fr/common/lsd.md
+++ b/pages.fr/common/lsd.md
@@ -1,0 +1,37 @@
+# lsd
+
+> Liste le contenu d'un répertoire.
+> La prochaine génération de la commande `ls`, écris en Rust.
+> Plus d'informations : <https://github.com/Peltoche/lsd>.
+
+- Liste les fichiers et les répertoires, un par ligne:
+
+`lsd -1`
+
+- Liste tous les fichiers et les répertoires, ainsi que ceux cachés, du répertoire courant:
+
+`lsd -a`
+
+- Liste les fichiers et les répertoires en ajoutant `/` après le nom des répertoires:
+
+`lsd -F`
+
+- Liste tous les fichiers et les répertoires dans le format long (permissions, propriétaire, taille dans un format lisible, et date de modification):
+
+`lsd -lha`
+
+- Liste les fichiers et les répertoires dans le format long, triés par taille (descendent):
+
+`lsd -lS`
+
+- Liste les fichiers et les répertoires dans le format long, triés par date de modification (plus vieux en premier):
+
+`lsd -ltr`
+
+- Liste seulement les répertoires:
+
+`lsd -d {{*/}}`
+
+- Liste récursivement tous les répertoires dans un format arborescent:
+
+`lsd --tree -d`


### PR DESCRIPTION
Adding french translation for lsd command

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
