### PR TITLE
cfdisk, dnf, dnf5, exif, export: add Indonesian translations

### DIFF
--- a/pages.id/linux/cfdisk.md
+++ b/pages.id/linux/cfdisk.md
@@ -1,0 +1,12 @@
+# cfdisk
+
+> Atur tabel dan partisi alokasi penyimpanan pada perangkat penyimpanan keras menggunakan tampilan antarmuka teks interaktif berbasis curses.
+> Informasi lebih lanjut: <https://manned.org/cfdisk>.
+
+- Jalankan program pengalokasi partisi terhadap suatu perangkat penyimpanan keras:
+
+`cfdisk {{/dev/sdX}}`
+
+- Buat kemudian kelola tabel partisi baru terhadap suatu perangkat penyimpanan keras:
+
+`cfdisk --zero {{/dev/sdX}}`

--- a/pages.id/linux/dnf.md
+++ b/pages.id/linux/dnf.md
@@ -8,7 +8,7 @@
 
 `sudo dnf upgrade`
 
-- Cari paket yang tersedia dengan kata kunci tertentu:
+- Cari paket yang tersedia dengan kata-kata kunci tertentu:
 
 `dnf search {{kata_kunci1 kata_kunci2 ...}}`
 
@@ -16,11 +16,11 @@
 
 `dnf info {{paket}}`
 
-- Pasang sebuah paket (gunakan `-y` jawab untuk ya semua pertanyaan):
+- Pasang kumpulan paket (gunakan `-y` jawab untuk ya semua pertanyaan):
 
 `sudo dnf install {{paket1 paket2 ...}}`
 
-- Hapus sebuah paket:
+- Hapus kumpulan paket:
 
 `sudo dnf remove {{paket1 paket2 ...}}`
 

--- a/pages.id/linux/dnf5.md
+++ b/pages.id/linux/dnf5.md
@@ -1,0 +1,38 @@
+# dnf5
+
+> Manajer paket untuk distribusi Linux RHEL, Fedora, dan CentOS (pengganti dnf5, yang juga dirancang sebagai pengganti yum).
+> DNF5 adalah hasil penulisan ulang program manajemen paket DNF dalam C++ dengan performa yang lebih baik dan ukuran program yang lebih kecil.
+> Lihat <https://wiki.archlinux.org/title/Pacman/Rosetta> untuk daftar perintah dalam manajer paket lain yang menyerupai perintah `dnf5`.
+> Informasi lebih lanjut: <https://dnf55.readthedocs.io>.
+
+- Perbarui seluruh paket yang terpasang ke versi terbaru:
+
+`sudo dnf5 upgrade`
+
+- Cari paket yang tersedia dengan kata-kata kunci tertentu:
+
+`dnf5 search {{kata_kunci1 kata_kunci2 ...}}`
+
+- Tampilkan informasi tentang suatu paket:
+
+`dnf5 info {{paket}}`
+
+- Pasang kumpulan paket (gunakan `-y` jawab untuk ya semua pertanyaan):
+
+`sudo dnf5 install {{paket1 paket2 ...}}`
+
+- Hapus kumpulan paket:
+
+`sudo dnf5 remove {{paket1 paket2 ...}}`
+
+- Tampilkan daftar semua paket yang telah terpasang:
+
+`dnf5 list --installed`
+
+- Temukan paket mana yang menyediakan perintah tertentu:
+
+`dnf5 provides {{perintah}}`
+
+- Hapus atau tandai data cache sebagai kedaluwarsa:
+
+`sudo dnf5 clean all`

--- a/pages.id/linux/exif.md
+++ b/pages.id/linux/exif.md
@@ -1,0 +1,24 @@
+# exif
+
+> Lihat dan ubah informasi metadata EXIF pada berkas-berkas JPEG.
+> Informasi lebih lanjut: <https://github.com/libexif/exif/>.
+
+- Tampilkan daftar informasi EXIF yang terdapat pada suatu berkas gambar:
+
+`exif {{jalan/menuju/gambar.jpg}}`
+
+- Tampilkan daftar jenis tag informasi EXIF dalam format tabel, termasuk apakah tag tersebut terdapat dalam suatu gambar:
+
+`exif --list-tags --no-fixup {{gambar.jpg}}`
+
+- Ekstrak gambar pratinjau (thumbnail) dari suatu gambar menuju `thumbnail.jpg`:
+
+`exif --extract-thumbnail --output={{thumbnail.jpg}} {{gambar.jpg}}`
+
+- Tampilkan isi mentahan terhadap tag metadata "Model" dalam suatu gambar:
+
+`exif --ifd={{0}} --tag={{Model}} --machine-readable {{gambar.jpg}}`
+
+- Ganti nilai tag metadata "Artist" menjadi John Smith, dan simpan perubahan menuju berkas baru di `new.jpg`:
+
+`exif --output={{new.jpg}} --ifd={{0}} --tag="{{Artist}}" --set-value="{{John Smith}}" --no-fixup {{gambar.jpg}}`

--- a/pages.id/linux/export.md
+++ b/pages.id/linux/export.md
@@ -1,0 +1,24 @@
+# export
+
+> Ekspor variabel menuju anak-anak proses syel sistem operasi.
+> Informasi lebih lanjut: <https://www.gnu.org/software/bash/manual/bash.html#index-export>.
+
+- Setel nilai suatu variabel lingkungan syel (environment variable):
+
+`export {{VARIABEL}}={{nilai}}`
+
+- Hapus nilai variabel lingkungan:
+
+`export -n {{VARIABEL}}`
+
+- Ekspor suatu fungsi perintah (function) menuju anak-anak proses syel:
+
+`export -f {{NAMA_FUNGSI}}`
+
+- Tambahkan alamat direktori baru menuju variabel lingkungan `PATH`:
+
+`export PATH=$PATH:{{path/to/append}}`
+
+- Tampilkan daftar variabel yang telah diekspor dalam bentuk kode perintah syel:
+
+`export -p`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Note: The `dnf` translation was updated to use the plural form of `packages`.