### PR TITLE
dos2unix, mac2unix, unix2dos, unix2mac: standardize More Information links, add Indonesian translation

### DIFF
--- a/pages.id/linux/dos2unix.md
+++ b/pages.id/linux/dos2unix.md
@@ -1,0 +1,22 @@
+# dos2unix
+
+> Ubah format pengakhiran baris teks pada suatu berkas teks (plaintext) dari format DOS menuju Unix.
+> Program ini menggantikan simbol CRLF menjadi LF.
+> Lihat juga: `unix2dos`, `unix2mac`, dan `mac2unix`.
+> Informasi lebih lanjut: <https://manned.org/dos2unix>.
+
+- Ganti format pengakhiran baris teks dan simpan perubahan pada berkas yang sama:
+
+`dos2unix {{jalan/menuju/berkas}}`
+
+- Ganti format namun simpan perubahan sebagai berkas baru:
+
+`dos2unix {{-n|--newfile}} {{jalan/menuju/berkas}} {{jalan/menuju/berkas_baru}}`
+
+- Tampilkan informasi suatu berkas teks:
+
+`dos2unix {{-i|--info}} {{jalan/menuju/berkas}}`
+
+- Tetap jaga/tambahkan/hapus simbol Byte Order Mark (BOM) saat mengubah isi berkas:
+
+`dos2unix --{{keep-bom|add-bom|remove-bom}} {{jalan/menuju/berkas}}`

--- a/pages.id/linux/mac2unix.md
+++ b/pages.id/linux/mac2unix.md
@@ -1,0 +1,22 @@
+# mac2unix
+
+> Ubah format pengakhiran baris teks pada suatu berkas teks (plaintext) dari format DOS menuju Unix.
+> Program ini menggantikan simbol CRLF menjadi LF.
+> Lihat juga: `unix2dos`, `unix2mac`, dan `dos2unix`.
+> Informasi lebih lanjut: <https://manned.org/mac2unix>.
+
+- Ganti format pengakhiran baris teks dan simpan perubahan pada berkas yang sama:
+
+`mac2unix {{jalan/menuju/berkas}}`
+
+- Ganti format namun simpan perubahan sebagai berkas baru:
+
+`mac2unix {{-n|--newfile}} {{jalan/menuju/berkas}} {{jalan/menuju/berkas_baru}}`
+
+- Tampilkan informasi suatu berkas teks:
+
+`mac2unix {{-i|--info}} {{jalan/menuju/berkas}}`
+
+- Tetap jaga/tambahkan/hapus simbol Byte Order Mark (BOM) saat mengubah isi berkas:
+
+`mac2unix --{{keep-bom|add-bom|remove-bom}} {{jalan/menuju/berkas}}`

--- a/pages.id/linux/unix2dos.md
+++ b/pages.id/linux/unix2dos.md
@@ -1,0 +1,22 @@
+# unix2dos
+
+> Ubah format pengakhiran baris teks pada suatu berkas teks (plaintext) dari format Unix menuju DOS.
+> Program ini menggantikan simbol LF menjadi CRLF.
+> Lihat juga: `unix2mac`, `dos2unix`, dan `mac2unix`.
+> Informasi lebih lanjut: <https://manned.org/unix2dos>.
+
+- Ganti format pengakhiran baris teks dan simpan perubahan pada berkas yang sama:
+
+`unix2dos {{jalan/menuju/berkas}}`
+
+- Ganti format namun simpan perubahan sebagai berkas baru:
+
+`unix2dos {{-n|--newfile}} {{jalan/menuju/berkas}} {{jalan/menuju/berkas_baru}}`
+
+- Tampilkan informasi suatu berkas teks:
+
+`unix2dos {{-i|--info}} {{jalan/menuju/berkas}}`
+
+- Tetap jaga/tambahkan/hapus simbol Byte Order Mark (BOM) saat mengubah isi berkas:
+
+`unix2dos --{{keep-bom|add-bom|remove-bom}} {{jalan/menuju/berkas}}`

--- a/pages.id/linux/unix2mac.md
+++ b/pages.id/linux/unix2mac.md
@@ -1,0 +1,22 @@
+# unix2mac
+
+> Ubah format pengakhiran baris teks pada suatu berkas teks (plaintext) dari format Unix menuju macOS.
+> Program ini menggantikan simbol LF menjadi CR.
+> Lihat juga: `unix2dos`, `dos2unix`, dan `mac2unix`.
+> Informasi lebih lanjut: <https://manned.org/unix2mac>.
+
+- Ganti format pengakhiran baris teks dan simpan perubahan pada berkas yang sama:
+
+`unix2mac {{jalan/menuju/berkas}}`
+
+- Ganti format namun simpan perubahan sebagai berkas baru:
+
+`unix2mac {{-n|--newfile}} {{jalan/menuju/berkas}} {{jalan/menuju/berkas_baru}}`
+
+- Tampilkan informasi suatu berkas teks:
+
+`unix2mac {{-i|--info}} {{jalan/menuju/berkas}}`
+
+- Tetap jaga/tambahkan/hapus simbol Byte Order Mark (BOM) saat mengubah isi berkas:
+
+`unix2mac --{{keep-bom|add-bom|remove-bom}} {{jalan/menuju/berkas}}`

--- a/pages/linux/dos2unix.md
+++ b/pages/linux/dos2unix.md
@@ -11,11 +11,11 @@
 
 - Create a copy with Unix-style line endings:
 
-`dos2unix -n {{path/to/file}} {{path/to/new_file}}`
+`dos2unix {{-n|--newfile}} {{path/to/file}} {{path/to/new_file}}`
 
 - Display file information:
 
-`dos2unix -i {{path/to/file}}`
+`dos2unix {{-i|--info}} {{path/to/file}}`
 
 - Keep/add/remove Byte Order Mark:
 

--- a/pages/linux/mac2unix.md
+++ b/pages/linux/mac2unix.md
@@ -3,7 +3,7 @@
 > Change macOS-style line endings to Unix-style.
 > Replaces CR with LF.
 > See also `unix2dos`, `unix2mac`, and `dos2unix`.
-> More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
+> More information: <https://manned.org/mac2unix>.
 
 - Change the line endings of a file:
 
@@ -11,11 +11,11 @@
 
 - Create a copy with Unix-style line endings:
 
-`mac2unix -n {{path/to/file}} {{path/to/new_file}}`
+`mac2unix {{-n|--newfile}} {{path/to/file}} {{path/to/new_file}}`
 
 - Display file information:
 
-`mac2unix -i {{path/to/file}}`
+`mac2unix {{-i|--info}} {{path/to/file}}`
 
 - Keep/add/remove Byte Order Mark:
 

--- a/pages/linux/unix2dos.md
+++ b/pages/linux/unix2dos.md
@@ -3,7 +3,7 @@
 > Change Unix-style line endings to DOS-style.
 > Replaces LF with CRLF.
 > See also `unix2mac`, `dos2unix`, and `mac2unix`.
-> More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
+> More information: <https://manned.org/unix2dos>.
 
 - Change the line endings of a file:
 
@@ -11,11 +11,11 @@
 
 - Create a copy with DOS-style line endings:
 
-`unix2dos -n {{path/to/file}} {{path/to/new_file}}`
+`unix2dos {{-n|--newfile}} {{path/to/file}} {{path/to/new_file}}`
 
 - Display file information:
 
-`unix2dos -i {{path/to/file}}`
+`unix2dos {{-i|--info}} {{path/to/file}}`
 
 - Keep/add/remove Byte Order Mark:
 

--- a/pages/linux/unix2mac.md
+++ b/pages/linux/unix2mac.md
@@ -3,7 +3,7 @@
 > Change Unix-style line endings to macOS-style.
 > Replaces LF with CR.
 > See also `unix2dos`, `dos2unix`, and `mac2unix`.
-> More information: <https://waterlan.home.xs4all.nl/dos2unix.html>.
+> Informasi lebih lanjut: <https://manned.org/unix2mac>.
 
 - Change the line endings of a file:
 
@@ -11,11 +11,11 @@
 
 - Create a copy with macOS-style line endings:
 
-`unix2mac -n {{path/to/file}} {{path/to/new_file}}`
+`unix2mac {{-n|--newfile}} {{path/to/file}} {{path/to/new_file}}`
 
 - Display file information:
 
-`unix2mac -i {{path/to/file}}`
+`unix2mac {{-i|--info}} {{path/to/file}}`
 
 - Keep/add/remove Byte Order Mark:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR encourages the use of manned.org links in place of the original project website over https://waterlan.home.xs4all.nl/dos2unix.html, adding long-form options, and also Indonesian translations.

Note that the "More Information" links of other translations are not replaced as most of them are outdated in terms of content.
