### PR TITLE
podman-compose: fix invalid example

### DIFF
--- a/pages/common/podman-compose.md
+++ b/pages/common/podman-compose.md
@@ -17,7 +17,7 @@
 
 - Start all containers using an alternate compose file:
 
-`podman-compose {{path/to/file}} up`
+`podman-compose {{-f|--file}} {{path/to/file.yaml}} up`
 
 - Stop all running containers:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Closes #13784.
