### PR TITLE
doggo: fix link

### DIFF
--- a/pages.es/common/doggo.md
+++ b/pages.es/common/doggo.md
@@ -2,7 +2,7 @@
 
 > Cliente DNS para Humanos.
 > Escrito en Golang.
-> Más información: <https://doggo.mrkaran.dev>.
+> Más información: <https://github.com/mr-karan/doggo>.
 
 - Realiza una simple búsqueda DNS:
 

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -2,7 +2,7 @@
 
 > DNS client for Humans.
 > Written in Golang.
-> More information: <https://doggo.mrkaran.dev>.
+> More information: <https://github.com/mr-karan/doggo>.
 
 - Perform a simple DNS lookup:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

https://doggo.mrkaran.dev/ results in 502 and is currently offline
