### PR TITLE
journalctl: add quotation marks around space-separated timestamps

### DIFF
--- a/pages.pl/linux/journalctl.md
+++ b/pages.pl/linux/journalctl.md
@@ -25,7 +25,7 @@
 
 - Filtruj wiadomości w zakresie czasu (znacznik czasu lub symbol zastępczy, np. "yesterday"):
 
-`journalctl --since {{now|today|yesterday|tomorrow}} --until {{YYYY-MM-DD HH:MM:SS}}`
+`journalctl --since {{now|today|yesterday|tomorrow}} --until "{{YYYY-MM-DD HH:MM:SS}}"`
 
 - Wyświetl wszystkie wiadomości podanego procesu:
 

--- a/pages.uk/linux/journalctl.md
+++ b/pages.uk/linux/journalctl.md
@@ -21,7 +21,7 @@
 
 - Фільтрувати повідомлення в межах діапазону часу (мітка часу або покажчики місця заповнення, як-от «вчора»):
 
-`journalctl --since {{now|today|yesterday|tomorrow}} --until {{YYYY-MM-DD HH:MM:SS}}`
+`journalctl --since {{now|today|yesterday|tomorrow}} --until "{{YYYY-MM-DD HH:MM:SS}}"`
 
 - Показати всі повідомлення за певним процесом:
 

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -25,7 +25,7 @@
 
 - Filter messages within a time range (either timestamp or placeholders like "yesterday"):
 
-`journalctl --since {{now|today|yesterday|tomorrow}} --until {{YYYY-MM-DD HH:MM:SS}}`
+`journalctl --since {{now|today|yesterday|tomorrow}} --until "{{YYYY-MM-DD HH:MM:SS}}"`
 
 - Show all messages by a specific process:
 


### PR DESCRIPTION
I had trouble using `YYYY-MM-DD HH:mm:ss` style timestamps as recommended in the page for `journalctl`.  

 This was probably because the space character separated the HH:mm:ss string from its date: following the recommended syntax (in this case, on Ubuntu 24.04 and using with the HH:mm:ss string 13:33:00), the command failed with the output: ` Failed to add match '13:33:00': Invalid argument`. 

It was therefore solved by surrounding the timestamps with quotation marks. So, I'm recommending a small change to the relevant TLDR pages to demonstrate the use of quotation marks.

All the best
Tris

...
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

