### PR TITLE
chromium, pages/*: redirect common Chromium-based browsers as aliases, add Indonesian translations

### DIFF
--- a/pages.id/common/brave.md
+++ b/pages.id/common/brave.md
@@ -1,0 +1,8 @@
+# brave
+
+> Perintah ini merupakan alias dari `chromium`.
+> Informasi lebih lanjut: <https://support.brave.com/hc/en-us/articles/360044860011-How-Do-I-Use-Command-Line-Flags-in-Brave>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/common/chromium.md
+++ b/pages.id/common/chromium.md
@@ -1,0 +1,37 @@
+# chromium
+
+> Aplikasi peramban web (web browser) bersumber terbuka yang terutama dikembangkan dan dikelola oleh Google.
+> Catatan: Anda mungkin perlu menggantikan perintah `chromium` dengan peramban tujuan Anda, seperti `brave`, `google-chrome`. `microsoft-edge`/`msedge`, `opera`, atau `vivaldi`.
+> Informasi lebih lanjut: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
+
+- Buka suatu URL atau berkas:
+
+`chromium {{https://example.com|jalan/menuju/berkas.html}}`
+
+- Buka dalam mode peramban privat (incognito) (gunakan `--inprivate` untuk Microsoft Edge):
+
+`{{chromium --incognito|microsoft-edge --inprivate}} {{example.com}}`
+
+- Buka dalam jendela aplikasi baru:
+
+`chromium --new-window {{example.com}}`
+
+- Buka dalam mode aplikasi web (tanpa bilah toolbar, URL bar, tombol navigasi, dsb.) (hanya dapat bekerja dalam `chromium` dan `google-chrome`):
+
+`{{chromium|google-chrome}} --app={{https://example.com}}`
+
+- Hubungkan peramban dengan suatu peladen proksi:
+
+`chromium --proxy-server="{{socks5://hostname:66}}" {{example.com}}`
+
+- Buka dengan direktori profil pengguna tertentu:
+
+`chromium --user-data-dir={{jalan/menuju/direktori}}`
+
+- Buka dengan menonaktifkan validasi CORS (berguna untuk menguji akses suatu API):
+
+`chromium --user-data-dir={{jalan/menuju/direktori}} --disable-web-security`
+
+- Selalu buka jendela alat DevTools (pembantu pengembang web) setiap kali membuka tab baru:
+
+`chromium --auto-open-devtools-for-tabs`

--- a/pages.id/common/microsoft-edge.md
+++ b/pages.id/common/microsoft-edge.md
@@ -1,0 +1,9 @@
+# microsoft-edge
+
+> Perintah ini merupakan alias dari `chromium`.
+> Catatan: Gunakan perintah `start msedge` atau `msedge` jika hendak membuka Microsoft Edge dalam perangkat Windows.
+> Informasi lebih lanjut: <https://microsoft.com/edge>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/common/msedge.md
+++ b/pages.id/common/msedge.md
@@ -1,0 +1,9 @@
+# msedge
+
+> Perintah ini merupakan alias dari `chromium`.
+> Catatan: Gunakan perintah `microsoft-edge` jika hendak membuka Microsoft Edge dalam perangkat Linux.
+> Informasi lebih lanjut: <https://microsoft.com/edge>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/common/opera.md
+++ b/pages.id/common/opera.md
@@ -1,0 +1,8 @@
+# opera
+
+> Perintah ini merupakan alias dari `chromium`.
+> Informasi lebih lanjut: <https://opera.com>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/common/vivaldi.md
+++ b/pages.id/common/vivaldi.md
@@ -1,0 +1,8 @@
+# vivaldi
+
+> Perintah ini merupakan alias dari `chromium`.
+> Informasi lebih lanjut: <https://vivaldi.com>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/linux/google-chrome-stable.md
+++ b/pages.id/linux/google-chrome-stable.md
@@ -1,0 +1,8 @@
+# google-chrome-stable
+
+> Perintah ini merupakan alias dari `chromium`.
+> Informasi lebih lanjut: <https://chrome.google.com>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/linux/vivaldi-stable.md
+++ b/pages.id/linux/vivaldi-stable.md
@@ -1,0 +1,8 @@
+# vivaldi-stable
+
+> Perintah ini merupakan alias dari `chromium`.
+> Informasi lebih lanjut: <https://vivaldi.com>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages.id/windows/start-msedge.md
+++ b/pages.id/windows/start-msedge.md
@@ -1,0 +1,9 @@
+# start msedge
+
+> Perintah ini merupakan alias dari `chromium`.
+> Catatan: Gunakan perintah `microsoft-edge` jika hendak membuka Microsoft Edge dalam perangkat Linux.
+> Informasi lebih lanjut: <https://microsoft.com/edge>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr chromium`

--- a/pages/common/brave.md
+++ b/pages/common/brave.md
@@ -1,0 +1,8 @@
+# brave
+
+> This command is an alias of `chromium`.
+> More information: <https://support.brave.com/hc/en-us/articles/360044860011-How-Do-I-Use-Command-Line-Flags-in-Brave>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/common/chromium.md
+++ b/pages/common/chromium.md
@@ -1,15 +1,16 @@
 # chromium
 
 > Open-source web browser principally developed and maintained by Google.
+> Note: You may need to replace the `chromium` command with your desired web browser, such as `brave`, `google-chrome`, `microsoft-edge`/`msedge`, `opera`, or `vivaldi`.
 > More information: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
 
 - Open a specific URL or file:
 
 `chromium {{https://example.com|path/to/file.html}}`
 
-- Open in incognito mode:
+- Open in incognito mode (use `--inprivate` for Microsoft Edge):
 
-`chromium --incognito {{example.com}}`
+`{{chromium --incognito|microsoft-edge --inprivate}} {{example.com}}`
 
 - Open in a new window:
 

--- a/pages/common/microsoft-edge.md
+++ b/pages/common/microsoft-edge.md
@@ -1,0 +1,9 @@
+# microsoft-edge
+
+> This command is an alias of `chromium`.
+> Note: Use the `start msedge` or `msedge` command instead to open Microsoft Edge on Windows.
+> More information: <https://microsoft.com/edge>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/common/msedge.md
+++ b/pages/common/msedge.md
@@ -1,0 +1,9 @@
+# msedge
+
+> This command is an alias of `chromium`.
+> Note: Use the `microsoft-edge` command instead to open Microsoft Edge on Linux.
+> More information: <https://microsoft.com/edge>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/common/opera.md
+++ b/pages/common/opera.md
@@ -1,0 +1,8 @@
+# opera
+
+> This command is an alias of `chromium`.
+> More information: <https://opera.com>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/common/vivaldi.md
+++ b/pages/common/vivaldi.md
@@ -1,0 +1,8 @@
+# vivaldi
+
+> This command is an alias of `chromium`.
+> More information: <https://vivaldi.com>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/linux/google-chrome-stable.md
+++ b/pages/linux/google-chrome-stable.md
@@ -1,0 +1,8 @@
+# google-chrome-stable
+
+> This command is an alias of `chromium`.
+> More information: <https://chrome.google.com>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/linux/vivaldi-stable.md
+++ b/pages/linux/vivaldi-stable.md
@@ -1,0 +1,8 @@
+# vivaldi-stable
+
+> This command is an alias of `chromium`.
+> More information: <https://vivaldi.com>.
+
+- View documentation for the original command:
+
+`tldr chromium`

--- a/pages/windows/start-msedge.md
+++ b/pages/windows/start-msedge.md
@@ -1,0 +1,9 @@
+# start msedge
+
+> This command is an alias of `chromium`.
+> Note: Use the `microsoft-edge` command instead to open Microsoft Edge on Linux.
+> More information: <https://microsoft.com/edge>.
+
+- View documentation for the original command:
+
+`tldr chromium`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

There is a lot of Chromium-based browsers and related commands, e.g. Google Chrome which is more known as `google-chrome-stable` on Linux and Microsoft Edge which is known as `msedge` in Windows and `microsoft-edge` in Linux.

I feel the best way to maintain these commands is to redirect them as alias pages.
