### PR TITLE
dtc: add page

### DIFF
--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -4,6 +4,6 @@
 > A tool for recompiling device trees between formats.
 > See <https://github.com/dgibson/dtc>
 
--- Decompile a dtb file into a readable dts file
+-- Decompile a dtb file into a readable dts file:
 
-`dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}
+`dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}`

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -5,4 +5,4 @@
 
 - Decompile a `.dtb` file into a readable `.dts` file:
 
-`dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}`
+`dtc -I dtb -O dts -o {{path/to/output_file.dts}} {{path/to/input_file.dtb}}`

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -1,8 +1,8 @@
 # dtc
 
-> The Device Tree Compiler, A tool for recompiling device trees between formats.
+> The Device Tree Compiler, a tool for recompiling device trees between formats.
 > See <https://github.com/dgibson/dtc>.
 
--- Decompile a dtb file into a readable dts file:
+- Decompile a dtb file into a readable dts file:
 
 `dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}`

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -1,8 +1,7 @@
 # dtc
 
-> Device Tree Compiler
-> A tool for recompiling device trees between formats.
-> See <https://github.com/dgibson/dtc>
+> The Device Tree Compiler, A tool for recompiling device trees between formats.
+> See <https://github.com/dgibson/dtc>.
 
 -- Decompile a dtb file into a readable dts file:
 

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -1,7 +1,7 @@
 # dtc
 
 > The Device Tree Compiler, a tool for recompiling device trees between formats.
-> See <https://github.com/dgibson/dtc>.
+> More information: <https://github.com/dgibson/dtc>.
 
 - Decompile a `.dtb` file into a readable `.dts` file:
 

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -3,6 +3,6 @@
 > The Device Tree Compiler, a tool for recompiling device trees between formats.
 > See <https://github.com/dgibson/dtc>.
 
-- Decompile a dtb file into a readable dts file:
+- Decompile a `.dtb` file into a readable `.dts` file:
 
 `dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}`

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -1,0 +1,11 @@
+# dtc
+
+> Device Tree Compiler
+> A tool for recompiling device trees between formats.
+> See <https://github.com/dgibson/dtc>
+
+`dtc`
+
+-- Decompile a dtb file into a readable dts file
+
+`dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}

--- a/pages/common/dtc.md
+++ b/pages/common/dtc.md
@@ -4,8 +4,6 @@
 > A tool for recompiling device trees between formats.
 > See <https://github.com/dgibson/dtc>
 
-`dtc`
-
 -- Decompile a dtb file into a readable dts file
 
 `dtc -I dtb -O dts -o {{output_file.dts}} {{input_file.dtb}}


### PR DESCRIPTION
Add an initial example for a common way to use dtc, the Device Tree Compiler which can create and decompile device trees for embedded Linux systems.

I started using this tool today and was sad I couldn't find a tldr, but didn't let that stop me from reading the man page, using it successfully, and making this.

I've only used it on Linux but Googling around says it should also function on Window (using the Linux subsystem) and the common BSDs as well.