### PR TITLE
pages/*: add and update Indonesian translations

### DIFF
--- a/pages.id/common/alias.md
+++ b/pages.id/common/alias.md
@@ -1,29 +1,29 @@
 # alias
 
-> Membuat alias -- kata-kata yang digantikan oleh utasan perintah (command).
+> Buat alias perintah -- kata-kata yang digantikan oleh utasan perintah (command).
 > Alias menjadi kadaluarsa sampai sesi shell saat ini berakhir, kecuali jika didefinisikan di file konfigurasi shell, misalnya `~/.bashrc`.
 > Informasi lebih lanjut: <https://tldp.org/LDP/abs/html/aliases.html>.
 
-- Menampilkan daftar semua alias:
+- Tampilkan daftar seluruh alias yang terdaftar:
 
 `alias`
 
-- Membuat alias generik:
+- Buat suatu alias generik:
 
 `alias {{kata}}="{{perintah}}"`
 
-- Melihat perintah yang dirujuk oleh alias yang diberikan:
+- Lihat perintah yang dirujuk oleh alias yang diberikan:
 
 `alias {{kata}}`
 
-- Menghapus alias dari sebuah perintah:
+- Hapus suatu perintah alias:
 
 `unalias {{kata}}`
 
-- Mengubah `rm` menjadi perintah interaktif:
+- Ubah perintah `rm` menjadi perintah interaktif:
 
-`alias {{rm}}="{{rm -i}}"`
+`alias {{rm}}="{{rm --interactive}}"`
 
-- Membuat `la` menjadi pintasan untuk `ls -a`:
+- Buat perintah `la` menjadi pintasan untuk `ls --all`:
 
-`alias {{la}}="{{ls -a}}"`
+`alias {{la}}="{{ls --all}}"`

--- a/pages.id/common/autojump.md
+++ b/pages.id/common/autojump.md
@@ -1,25 +1,25 @@
 # autojump
 
-> Melompat secara cepat ke direktori-direktori yang paling sering anda kunjungi.
+> Lompat dengan cepat menuju direktori-direktori yang paling sering anda kunjungi.
 > Alias seperti j atau jc sudah disediakan untuk mengurangi pengetikan.
 > Informasi lebih lanjut: <https://github.com/wting/autojump>.
 
-- Melompat ke direktori yang mengandung pola yang diberikan:
+- Lompat menuju direktori yang mengandung pola yang diberikan:
 
 `j {{pola}}`
 
-- Melompat ke sub-direktori (anak) dari direktori saat ini yang mengandung pola yang diberikan:
+- Lompat menuju sub-direktori (anak) dari direktori saat ini yang mengandung pola yang diberikan:
 
 `jc {{pola}}`
 
-- Membuka direktori yang mengandung pola yang diberikan dalam file manager dari sistem operasi:
+- Buka direktori yang mengandung pola yang diberikan dalam aplikasi manajemen berkas sistem operasi:
 
 `jo {{pola}}`
 
-- Membuang direktori-direktori yang tidak lagi ada dari database autojump:
+- Buang direktori-direktori dalam pangkalan data (database) autojump yang telah sebelumnya dihapus:
 
 `j --purge`
 
-- Menampilkan entri yang ada di database autojump:
+- Tampilkan entri yang ada dalam pangkalan data autojump:
 
 `j -s`

--- a/pages.id/common/bat.md
+++ b/pages.id/common/bat.md
@@ -1,7 +1,7 @@
 # bat
 
-> Mencetak dan menggabungkan berkas.
-> Klon dari `cat` dengan sintaks berwarna dan integrasi Git.
+> Cetak dan gabungkan berkas.
+> Sebuah klon atas program `cat` dengan sintaks berwarna dan integrasi Git.
 > Informasi lebih lanjut: <https://github.com/sharkdp/bat>.
 
 - Cetak rapi konten berkas ke `stdout`:
@@ -24,14 +24,14 @@
 
 `bat {{-A|--show-all}} {{jalan/menuju/berkas}}`
 
-- Memberi nomor pada setiap baris keluaran:
+- Hapus seluruh informasi dekoratif selain nomor baris pada luaran program:
 
-`bat {{-n|--number}} {{berkas}}`
+`bat {{-n|--number}} {{jalan/menuju/berkas}}`
 
-- Mencetak konten JSON dengan sintaks berwarna:
+- Tampilkan sintaks berwarna terhadap berkas JSON dengan mengatur bahasa sintaks berkas secara eksplisit:
 
 `bat {{-l|--language}} json {{jalan/menuju/berkas.json}}`
 
-- Menampilkan semua bahasa yang didukung:
+- Tampilka semua jenis bahasa sintaks berkas yang didukung:
 
 `bat {{-L|--list-languages}}`

--- a/pages.id/common/composer.md
+++ b/pages.id/common/composer.md
@@ -3,23 +3,23 @@
 > Manajer paket untuk proyek PHP.
 > Informasi lebih lanjut: <https://getcomposer.org/>.
 
-- Membuat file `composer.json` secara interaktif:
+- Buat sebuah berkas `composer.json` secara interaktif:
 
 `composer init`
 
-- Menambahkan paket sebagai dependensi untuk proyek ini, menambahkan ke `composer.json`:
+- Tambahkan paket sebagai sebuah pustaka prasyarat (dependency) untuk proyek ini, menambahkan ke `composer.json`:
 
-`composer require {{user/nama_paket}}`
+`composer require {{nama_pengguna/nama_paket}}`
 
-- Menginstal semua dependensi dalam `composer.json` proyek ini dan membuat `composer.lock`:
+- Pasang seluruh prasyarat dalam `composer.json` proyek ini dan buat berkas `composer.lock`:
 
 `composer install`
 
-- Menghapus sebuah paket dari proyek ini, menghapus paket tersebut sebagai ketergantungan dari `composer.json`:
+- Hapus pemasangan suatu paket dalam proyek ini, sehingga menghapusnya dari entri prasyarat pada `composer.json` dan `composer.lock`:
 
-`composer remove {{user/nama_paket}}`
+`composer remove {{nama_pengguna/nama_paket}}`
 
-- Memperbarui semua dependensi dalam `composer.json` proyek ini dan memperbarui versi di file `composer.lock`:
+- Perbarui semua pustaka prasyarat dalam `composer.json` proyek ini dan catat versi-versi terkini dalam berkas `composer.lock`:
 
 `composer update`
 
@@ -27,10 +27,10 @@
 
 `composer update --lock`
 
-- Memcari tahu mengapa sebuah dependensi tidak dapat diinstal:
+- Cari tahu alasa mengapa sebuah dependensi tidak dapat dipasang:
 
 `composer why-not {{user/nama_paket}}`
 
-- Memperbarui composer ke versi terbaru:
+- Perbarui program composer menuju versi terbaru:
 
 `composer self-update`

--- a/pages.id/common/ls.md
+++ b/pages.id/common/ls.md
@@ -1,32 +1,36 @@
 # ls
 
-> Menampilkan daftar konten pada direktori.
+> Tampilkan daftar konten pada direktori.
 > Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/ls>.
 
-- Menampilkan daftar berkas dengan satu item tiap baris:
+- Tampilkan daftar berkas dengan satu item tiap baris:
 
 `ls -1`
 
-- Menampilkan daftar semua berkas, termasuk berkas tersembunyi:
+- Tampilkan daftar semua berkas, termasuk berkas tersembunyi:
 
 `ls -a`
 
-- Menampilkan daftar semua berkas, dengan akhiran `/` ditambahkan ke nama direktori:
+- Tampilkan daftar semua berkas, dengan akhiran `/` ditambahkan ke nama direktori:
 
 `ls -F`
 
-- Menampilkan daftar berformat panjang (menampilkan izin, kepemilikan, ukuran dan waktu modifikasi pada setiap berkas):
+- Tampilkan daftar berformat panjang (menampilkan izin, kepemilikan, ukuran dan waktu modifikasi pada setiap berkas):
 
 `ls -la`
 
-- Menampilkan daftar berformat panjang dan ukuran ditampilkan menggunakan unit yang mudah dibaca manusia (KiB, MiB, GiB):
+- Tampilkan daftar berformat panjang dan ukuran ditampilkan menggunakan unit yang mudah dibaca manusia (KiB, MiB, GiB):
 
 `ls -lh`
 
-- Menampilkan daftar berformat panjang dan diurutkan berdasarkan ukuran (menurun):
+- Tampilkan daftar berformat panjang dan diurutkan berdasarkan ukuran (menurun):
 
 `ls -lS`
 
-- Menampilkan daftar berformat panjang dari semua berkas dan diurutkan berdasarkan tanggal modifikasi (terlama dulu):
+- Tampilkan daftar berformat panjang dari semua berkas dan diurutkan berdasarkan tanggal modifikasi (terlama dulu):
 
 `ls -ltr`
+
+- Hanya tampilkan daftar [d]irektori:
+
+`ls -d */`

--- a/pages.id/common/ps.md
+++ b/pages.id/common/ps.md
@@ -1,25 +1,25 @@
 # ps
 
-> Informasi tentang proses-proses yang berlangsung.
+> Tampilkan informasi tentang proses-proses yang berlangsung.
 > Informasi lebih lanjut: <https://manned.org/ps>.
 
-- Menampilkan daftar semua proses yang berlangsung:
+- Tampilkan daftar seluruh proses yang berlangsung:
 
 `ps aux`
 
-- Menampilkan daftar semua proses yang berlangsung termasuk _string_ perintah secara utuh:
+- Tampilkan daftar seluruh proses yang berlangsung termasuk string perintah secara utuh:
 
 `ps auxww`
 
-- Mencari proses yang sesuai dengan _string_:
+- Cari proses berdasarkan teks/string kriteria (penambahan kurung siku akan mencegah `grep` untuk mencocokkan dirinya sendiri):
 
-`ps aux | grep {{string}}`
+`ps aux | grep {{[s]tring}}`
 
-- Menampilkan daftar semua proses pengguna yang berlangsung dengan format tambahan yang utuh:
+- Tampilkan daftar seluruh proses dari pengguna saat ini dengan format tambahan ekstra:
 
 `ps --user $(id -u) -F`
 
-- Menampilkan daftar semua proses pengguna yang berlangsung sebagai pohon:
+- Tampilkan daftar seluruh proses dari pengguna saat ini dalam format pohon:
 
 `ps --user $(id -u) f`
 

--- a/pages.id/common/psalm.md
+++ b/pages.id/common/psalm.md
@@ -1,0 +1,32 @@
+# psalm
+
+> Suatu alat analisis kode statis yang dapat dimanfaatkan untuk mencari kesalahan pada aplikasi berbasis PHP.
+> Informasi lebih lanjut: <https://psalm.dev>.
+
+- Buat sebuah berkas konfigurasi Psalm baru:
+
+`psalm --init`
+
+- Periksa kesalahan pada direktori saat ini:
+
+`psalm`
+
+- Periksa kesalahan pada suatu direktori atau berkas:
+
+`psalm {{jalan/menuju/berkas_atau_direktori}}`
+
+- Periksa kesalahan menggunakan suatu berkas konfigurasi:
+
+`psalm --config {{jalan/menuju/psalm.xml}}`
+
+- Lampirkan penemuan-penemuan informasional ke dalam luaran hasil pengecekan:
+
+`psalm --show-info`
+
+- Periksa suatu proyek dan tampilkan hasil statistika:
+
+`psalm --stats`
+
+- Periksa suatu proyek secara paralel denan 4 thread pemrosesan:
+
+`psalm --threads {{4}}`

--- a/pages.id/common/rails-destroy.md
+++ b/pages.id/common/rails-destroy.md
@@ -1,24 +1,24 @@
 # rails destroy
 
-> Menghapus Rails _resources_.
+> Menghapus sumber daya (resources) yang dikelola dalam suatu proyek Rails.
 > Informasi lebih lanjut: <https://guides.rubyonrails.org/command_line.html#bin-rails-destroy>.
 
-- Menampilkan daftar semua generator yang tersedia untuk menghapus:
+- Tampilkan daftar semua generator yang tersedia untuk membantu proses penghapusan:
 
 `rails destroy`
 
-- Menghapus model yang bernama Post:
+- Hapus suatu model yang bernama Post:
 
 `rails destroy model {{Post}}`
 
-- Menghapus _controller_ yang bernama Post:
+- Hapus suatu controller yang bernama Posts:
 
 `rails destroy controller {{Posts}}`
 
-- Menghapus migrasi yang membuat Posts:
+- Hapus suatu migrasi yang membuat Posts:
 
 `rails destroy migration {{CreatePosts}}`
 
-- Menghapus _scaffold_ model yang bernama Post:
+- Hapus suatu scaffold bagi model Post:
 
 `rails destroy scaffold {{Post}}`

--- a/pages.id/common/rvm.md
+++ b/pages.id/common/rvm.md
@@ -3,34 +3,34 @@
 > Alat untuk menginstal, mengatur dan bekerja dengan berbagai lingkungan Ruby.
 > Informasi lebih lanjut: <https://rvm.io>.
 
-- Instal satu atau lebih versi Ruby (dipisah dengan spasi):
+- Pasang suatu atau beberapa versi Ruby:
 
-`rvm install {{version(s)}}`
+`rvm install {{versi1 versi2 ...}}`
 
-- Menampilkan daftar versi-versi yang terinstal:
+- Tampilkan daftar versi-versi Ruby yang terinstal:
 
 `rvm list`
 
-- Menggunakan spesifik versi Ruby:
+- Gunakan suatu versi Ruby untuk sesi saat ini:
 
-`rvm use {{version}}`
+`rvm use {{versi}}`
 
-- Menyetel versi Ruby bawaan:
+- Tetapkan versi default Ruby yang akan dipakai:
 
-`rvm --default use {{version}}`
+`rvm --default use {{versi}}`
 
-- Memperbarui versi Ruby:
+- Perbarui suatu versi Ruby:
 
-`rvm upgrade {{current_version}} {{new_version}}`
+`rvm upgrade {{versi_saat_ini}} {{versi_baru}}`
 
-- Menghapus versi Ruby dan menyimpan kode sumbernya:
+- Hapus pemasangan versi Ruby namun simpan kode sumbernya:
 
-`rvm uninstall {{version}}`
+`rvm uninstall {{versi}}`
 
-- Menghapus versi Ruby sekaligus kode sumbernya:
+- Hapus pemasangan versi Ruby beserta kode sumbernya:
 
-`rvm remove {{version}}`
+`rvm remove {{versi}}`
 
-- Menampilkan spesifik _dependencies_ untuk sistem operasi anda:
+- Tampilkan prasyarat piranti lunak tambahan yang perlu dipasang untuk sistem operasi anda:
 
 `rvm requirements`

--- a/pages.id/common/yarn.md
+++ b/pages.id/common/yarn.md
@@ -3,19 +3,19 @@
 > Pengelola paket alternatif untuk JavaScript dan Node.js.
 > Informasi lebih lanjut: <https://yarnpkg.com>.
 
-- Memasang modul secara global:
+- Pasang suatu modul secara global:
 
 `yarn global add {{nama_modul}}`
 
-- Memasang semua dependensi yang dirujuk di berkas `package.json` (`install` adalah opsional):
+- Pasang semua pustaka prasyarat (dependency) yang dirujuk dalam berkas `package.json` (perintah `install` adalah opsional):
 
 `yarn install`
 
-- Memasang modul dan menyimpannya sebagai dependensi ke berkas `package.json` (tambahkan `--dev` untuk menyimpannya sebagai dependensi pengembangan):
+- Pasang dan catat suatu modul sebagai prasyarat ke dalam berkas `package.json` (tambahkan `--dev` jika hendak menyimpannya sebagai prasyarat khusus tahap pengembangan):
 
 `yarn add {{nama_modul}}@{{versi}}`
 
-- Mencopot modul dan menghapusnya dari berkas `package.json`:
+- Hapus pemasangan modul beserta entrinya dalam berkas `package.json`:
 
 `yarn remove {{nama_modul}}`
 
@@ -23,6 +23,6 @@
 
 `yarn init`
 
-- Mengidentifikasi apakah modul merupakan dependensi dan daftar modul lainnya yang bergantung padanya:
+- Periksa apakah suatu modul merupakan suatu prasyarat serta tampilkan daftar modul lainnya yang bergantung kepadanya:
 
-`yarn why {{module_name}}`
+`yarn why {{nama_modul}}`

--- a/pages.id/osx/brightness.md
+++ b/pages.id/osx/brightness.md
@@ -1,16 +1,16 @@
 # brightness
 
-> Menampilkan dan mengubah brightness (tingkat kecerahan) untuk internal dan external displays.
+> Tampilkan dan ubah pengaturan tingkat pencahayaan (brightness) untuk layar monitor internal maupun eksternal.
 > Informasi lebih lanjut: <https://github.com/nriley/brightness>.
 
-- Menampilkan brightness sekarang:
+- Tampilkan tingkat pencahayaan saat ini:
 
 `brightness -l`
 
-- Mengubah brightness menjadi 100%:
+- Ubah tingkat pencahayaan secara spesifik:
 
-`brightness {{1}}`
+`brightness {{0..1}}`
 
-- Mengubah brightness menjadi 50%:
+- Ubah tingkat pencahayaan menjadi 50%:
 
 `brightness {{0.5}}`

--- a/pages.id/osx/cal.md
+++ b/pages.id/osx/cal.md
@@ -1,32 +1,32 @@
 # cal
 
-> Menampilkan informasi kalender.
+> Tampilkan informasi kalender.
 > Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/cal.1.html>.
 
-- Menampilkan kalender pada bulan ini:
+- Tampilkan kalender bulan ini:
 
 `cal`
 
-- Menampilan kalender pada bulan lalu, sekarang dan berikutnya:
+- Tampilkan kalender bulan lalu, sekarang, dan berikutnya:
 
 `cal -3`
 
-- Menampilkan kalender pada bulan tertentu (angka 1-12 atau nama):
+- Tampilkan kalender pada bulan tertentu (angka 1-12 atau nama):
 
 `cal -m {{bulan}}`
 
-- Menampilkan kalender pada tahun yang sedang berjalan:
+- Tampilkan kalender pada tahun yang sedang berjalan:
 
 `cal -y`
 
-- Menampilkan kalender pada tahun tertentu (4 digit):
+- Tampilkan kalender pada tahun tertentu (dalam format 4 digit):
 
 `cal {{tahun}}`
 
-- Menampilkan kalender pada bulan dan tahun tertentu:
+- Tampilkan kalender pada bulan dan tahun tertentu:
 
 `cal {{bulan}} {{tahun}}`
 
-- Menampilkan tanggal Hari Raya Paskah (Gereja Kristen Barat) pada tahun tertentu:
+- Tampilkan tanggal Hari Raya Paskah (Gereja Kristen Barat) pada tahun tertentu:
 
 `ncal -e {{tahun}}`

--- a/pages.id/osx/date.md
+++ b/pages.id/osx/date.md
@@ -1,20 +1,20 @@
 # date
 
-> Mengatur atau menampilkan tanggal sistem.
+> Atur atau tampilkan tanggal sistem.
 > Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/date.1.html>.
 
-- Menampilkan tanggal saat ini menggunakan format _locale_:
+- Tampilkan tanggal saat ini menggunakan format _locale_:
 
 `date +%c`
 
-- Menampilkan tanggal saat ini dalam format UTC and ISO 8601:
+- Tampilkan tanggal saat ini dalam format UTC and ISO 8601:
 
 `date -u +%Y-%m-%dT%H:%M:%SZ`
 
-- Menampilkan tanggal saat ini sebagai _Unix timestamp_ (detik sejak jaman Unix):
+- Tampilkan tanggal saat ini sebagai _Unix timestamp_ (detik sejak jaman Unix):
 
 `date +%s`
 
-- Menampilkan tanggal tertentu (diwakili sebagai _Unix timestamp_) menggunakan format bawaan:
+- Tampilkan tanggal tertentu (diwakili sebagai _Unix timestamp_) menggunakan format bawaan:
 
 `date -r {{1473305798}}`

--- a/pages.id/windows/color.md
+++ b/pages.id/windows/color.md
@@ -1,0 +1,16 @@
+# color
+
+> Pilih warna latar depan dan belakang konsol pada sesi saat ini.
+> Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/color>.
+
+- Kembalikan pengaturan warna latar menuju nilai bawaan (default):
+
+`color`
+
+- Tampilkan daftar pilihan warna yang tersedia beserta kodenya:
+
+`color /?`
+
+- Pilih warna latar depan dan belakang menggunakan kode warna heksadesimal (`1-9,a-f`):
+
+`color {{kode_warna_latar_depan}}{{kode_warna_latar_belakang}}`

--- a/pages.id/windows/comp.md
+++ b/pages.id/windows/comp.md
@@ -1,0 +1,37 @@
+# comp
+
+> Bandingkan isi antar kedua berkas atau himpunan berkas.
+> Gunakan wildcard (*) untukk membandingkan himpunan berkas.
+> Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/comp>.
+
+- Bandingkan isi berkas secara interaktif:
+
+`comp`
+
+- Bandingkan isi antara kedua berkas:
+
+`comp {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`
+
+- Bandingkan isi antara kedua himpunan berkas:
+
+`comp {{jalan\menuju\direktori1}}\* {{jalan\menuju\direktori2}}\*`
+
+- Tampilkan perbedaan dalam format [d]esimal:
+
+`comp /d {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`
+
+- Tampilkan perbedaan dalam format [a]SCII:
+
+`comp /a {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`
+
+- Tampilkan nomor baris di mana perbedaan antar isi terdeteksi:
+
+`comp /l {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`
+
+- Bandingkan berkas-berkas tanpa menghiraukan penggunaan huruf besar/kecil ([c]ase-insensitive):
+
+`comp /c {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`
+
+- Hanya bandingkan isi 5 baris pertama antara kedua berkas:
+
+`comp /n=5 {{jalan\menuju\berkas1}} {{jalan\menuju\berkas2}}`

--- a/pages.id/windows/dir.md
+++ b/pages.id/windows/dir.md
@@ -1,20 +1,24 @@
 # dir
 
-> Lis isi direktori.
+> Tampilkan daftar isi direktori.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/dir>.
 
-- Tampilkan isi direktori saat ini:
+- Tampilkan daftar isi direktori saat ini:
 
 `dir`
 
-- Tampilkan isi direktori yang ditentukan:
+- Tampilkan daftar isi direktori yang ditentukan:
 
-`dir {{lokasi/ke/direktori}}`
+`dir {{jalan/menuju/direktori}}`
 
-- Tampilkan isi dari direktori saat ini, termasuk yang disembunyikan:
+- Tampilkan daftar isi dari direktori saat ini, termasuk yang disembunyikan:
 
-`dir /A`
+`dir /a`
 
-- Tampilkan isi direktori yang ditentukan, termasuk yang disembunyikan:
+- Tampilkan daftar isi direktori yang ditentukan, termasuk yang disembunyikan:
 
-`dir {{lokasi/ke/direktori}} /A`
+`dir {{jalan/menuju/direktori}} /a`
+
+- Hanya tampilkan daftar isi tanpa informasi tambahahan mengenai masing-masing berkas dan subdirektori:
+
+`dir /b`

--- a/pages.id/windows/msiexec.md
+++ b/pages.id/windows/msiexec.md
@@ -1,20 +1,20 @@
 # msiexec
 
-> Memasang, memperbarui, memperbaiki, atau menghapus program Windows melalui file MSI dan MSP yang tersedia.
+> Pasang, perbarui, perbaiki, atau hapus program Windows melalui berkas MSI dan MSP yang tersedia.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/msiexec>.
 
-- Memasang sebuah program melalui file MSI:
+- Pasang suatu program melalui berkas MSI:
 
-`msiexec /package {{jalan/menuju/file.msi}}`
+`msiexec /package {{jalan\menuju\berkas.msi}}`
 
-- Memasang file MSI dari internet:
+- Pasang berkas MSI dari suatu situs web:
 
 `msiexec /package {{https://example.com/installer.msi}}`
 
-- Memasang pembaruan program melalui file MSP:
+- Pasang pembaruan suatu program melalui suatu berkas MSP:
 
-`msiexec /update {{jalan/menuju/file.msp}}`
+`msiexec /update {{jalan\menuju\berkas.msp}}`
 
-- Menghapus pemasangan atau pembaruan program melalui file MSI atau MSP yang tersedia:
+- Menghapus pemasangan atau pembaruan suatu program melalui file MSI atau MSP yang tersedia:
 
-`msiexec /uninstall {{jalan/menuju/file}}`
+`msiexec /uninstall {{jalan\menuju\berkas}}`

--- a/pages.id/windows/rd.md
+++ b/pages.id/windows/rd.md
@@ -1,8 +1,12 @@
 # rd
 
-> Perintah ini merupakan alias dari `rmdir`.
+> Perintah ini merupakan alias dari `rmdir` dalam Command Prompt, serta `Remove-Item` dalam PowerShell.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/rd>.
 
-- Tampilkan dokumentasi untuk perintah asli:
+- Tampilkan dokumentasi untuk perintah asli Command Prompt:
 
 `tldr rmdir`
+
+- Tampilkan dokumentasi untuk perintah asli PowerShell:
+
+`tldr remove-item`

--- a/pages.id/windows/scoop-bucket.md
+++ b/pages.id/windows/scoop-bucket.md
@@ -1,25 +1,25 @@
 # scoop bucket
 
-> Mengelola bucket: Repository Git yang berisi berkas yang menjelaskan bagaimana scoop menginstall aplikasi.
-> Jika Scoop tidak tahu dimana sebuah bucket terletak, lokasi repository harus ditentukan.
+> Kelola bucket: Repository Git yang berisi berkas yang menjelaskan bagaimana scoop menginstall aplikasi.
+> Jika Scoop tidak tahu di mana sebuah bucket terletak, maka lokasi repositori harus ditentukan.
 > Informasi lebih lanjut: <https://github.com/lukesampson/scoop/wiki/Buckets>.
 
-- Menampilkan daftar semua bucket yang sedang digunakan:
+- Tampilkan daftar semua bucket yang sedang digunakan:
 
 `scoop bucket list`
 
-- Menampilkan daftar semua bucket yang dikenal:
+- Tampilkan daftar semua bucket yang dikenal:
 
 `scoop bucket known`
 
-- Menambahkan bucket yang dikenal berdasarkan namanya:
+- Tambahkan bucket yang dikenal berdasarkan namanya:
 
 `scoop bucket add {{nama}}`
 
-- Menambahkan bucket yang tidak dikenal bersarkan nama dan URL repository Git:
+- Tambahkan bucket yang tidak dikenal bersarkan nama dan URL repository Git:
 
 `scoop bucket add {{nama}} {{https://contoh.com/repository.git}}`
 
-- Menghapus bucket berdasarkan namanya:
+- Hapus suatu bucket berdasarkan namanya:
 
 `scoop bucket rm {{nama}}`

--- a/pages.id/windows/tree.md
+++ b/pages.id/windows/tree.md
@@ -1,20 +1,20 @@
 # tree
 
-> Menampilkan struktur direktori pada suatu lokasi dengan tampilan grafis pohon.
+> Tampilkan struktur direktori pada suatu lokasi dengan tampilan grafis pohon.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/tree>.
 
-- Tampilkan pohon dari direktori saat ini:
+- Tampilkan pohon struktur direktori saat ini:
 
 `tree`
 
-- Tampilkan pohon dari direktori yang ditentukan:
+- Tampilkan pohon struktur direktori yang ditentukan:
 
-`tree {{lokasi/ke/direktori}}`
+`tree {{jalan\menuju\direktori}}`
 
-- Tampilkan pohon dari direktori termasuk file:
+- Tampilkan pohon struktur direktori termasuk daftar berkas ([f]ile) dalam setiap direktori:
 
-`tree {{lokasi/ke/direktori}} /f`
+`tree {{jalan\menuju\direktori}} /f`
 
-- Tampilkan pohon menggunakan karakter ASCII alih-alih karakter yang diperluas:
+- Tampilkan pohon hanya dengan menggunakan karakter [a]SCII daripada menggunakan set karakter yang lebih luas:
 
-`tree {{lokasi/ke/direktori}} /a`
+`tree {{jalan\menuju\direktori}} /a`

--- a/pages.id/windows/ver.md
+++ b/pages.id/windows/ver.md
@@ -1,8 +1,8 @@
 # ver
 
-> Menampilkan nomor versi Windows atau MS-DOS saat ini.
+> Tampilkan nomor versi Windows atau MS-DOS saat ini.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/ver>.
 
-- Menampilkan nomor versi saat ini:
+- Tampilkan nomor versi saat ini:
 
 `ver`

--- a/pages.id/windows/xcopy.md
+++ b/pages.id/windows/xcopy.md
@@ -1,36 +1,36 @@
 # xcopy
 
-> Membuat salinan file dan direktori.
+> Salin berkas dan direktori.
 > Informasi lebih lanjut: <https://learn.microsoft.com/windows-server/administration/windows-commands/xcopy>.
 
-- Membuat salinan file atau direktori ke lokasi lain:
+- Salin berkas atau direktori ke lokasi lain:
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}}`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}}`
 
-- Melihat daftar file yang akan disalin sebelum proses salinan dimulai:
+- Lihat daftar berkas yang akan disalin sebelum proses salinan dimulai:
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /p`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /p`
 
-- Membuat salinan struktur direktori saja (tanpa file di dalamnya):
+- Hanya buat salinan struktur direktori saja (tanpa memasukkan berkas apapun ke dalamnya):
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /t`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /t`
 
-- Membuat salinan direktori termasuk direktori-direktori kosong (tanpa file):
+- Salin termasuk direktori-direktori tanpa isi berkas:
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /e`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /e`
 
-- Membuat salinan file atau direktori dengan daftar hak akses pengguna (ACL) yang sama:
+- Salin berkas dan direktori termasuk informasi hak akses pengguna (ACL) masing-masing:
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /o`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /o`
 
-- Mempersilakan proses penyalinan file atau direktori saat koneksi jaringan komputer terputus:
+- Izinkan proses penyalinan berkas atau direktori untuk berlangsung saat koneksi jaringan komputer terputus:
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /z`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /z`
 
-- Mempersilakan `xcopy` untuk tetap mengganti file yang sudah ada di lokasi tujuan dengan file yang berada di lokasi sumber:
+- Izinkan `xcopy` untuk tetap mengganti berkas yang sudah ada di lokasi tujuan dengan berkas yang berada di lokasi sumber (override):
 
-`xcopy {{jalan/menuju/file_atau_direktori_sumber}} {{jalan/menuju/file_atau_direktori_tujuan}} /y`
+`xcopy {{jalan/menuju/berkas_atau_direktori_sumber}} {{jalan/menuju/berkas_atau_direktori_tujuan}} /y`
 
-- Menampilkan cara penggunaan secara lengkap:
+- Tampilkan informasi bantuan:
 
 `xcopy /?`

--- a/pages/osx/cal.md
+++ b/pages/osx/cal.md
@@ -7,7 +7,7 @@
 
 `cal`
 
-- Display previous, current and next month:
+- Display previous, current, and next month:
 
 `cal -3`
 

--- a/pages/windows/comp.md
+++ b/pages/windows/comp.md
@@ -16,19 +16,19 @@
 
 `comp {{path\to\directory1}}\* {{path\to\directory2}}\*`
 
-- Display differences in decimal format:
+- Display differences in [d]ecimal format:
 
 `comp /d {{path\to\file1}} {{path\to\file2}}`
 
-- Display differences in ASCII format:
+- Display differences in [a]SCII format:
 
 `comp /a {{path\to\file1}} {{path\to\file2}}`
 
-- Display line numbers for differences:
+- Display [l]ine numbers for differences:
 
 `comp /l {{path\to\file1}} {{path\to\file2}}`
 
-- Compare files case-insensitively:
+- Compare files [c]ase-insensitively:
 
 `comp /c {{path\to\file1}} {{path\to\file2}}`
 

--- a/pages/windows/tree.md
+++ b/pages/windows/tree.md
@@ -11,10 +11,10 @@
 
 `tree {{path\to\directory}}`
 
-- Display the tree for a directory including files:
+- Display the tree for a directory including [f]iles:
 
 `tree {{path\to\directory}} /f`
 
-- Display the tree using ASCII characters instead of extended characters:
+- Display the tree using [a]SCII characters instead of extended characters:
 
 `tree {{path\to\directory}} /a`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR attempts to resolve the remaining Indonesian pages that were not written using imperative mood (#8576). Also some pages which using an older `path/to/file` parameter convention.

I wish I can finally resolve this issue before the next Hacktoberfest so prospective contributors are more influenced to use the correct writing and language style.

This PR also updates some outdated pages that went under the radars of [tldr-maintenance](https://github.com/tldr-pages/tldr-maintenance/issues/100#issuecomment-2372257580) and [tldri18n](https://lukwebsforge.github.io/tldri18n/), including `common/bat` and `osx/brightness`.