### PR TITLE
cmctl, convert, coproc, core-validate-commit, corepack: add Korean translation

### DIFF
--- a/pages.ko/common/cmctl.md
+++ b/pages.ko/common/cmctl.md
@@ -1,0 +1,21 @@
+# cmctl
+
+> 클러스터 내부의 cert-manager 리소스를 관리.
+> 인증서 서명 상태를 확인하고, 요청을 승인/거부하고, 새 인증서 요청을 발급.
+> 더 많은 정보: <https://cert-manager.io/docs/usage/cmctl/>.
+
+- cert-manager API가 준비되었는지 확인:
+
+`cmctl check api`
+
+- 인증서 상태를 확인:
+
+`cmctl status certificate {{인증서_이름}}`
+
+- 기존 인증서를 기반으로 새 인증서 요청을 만듬:
+
+`cmctl create certificaterequest my-cr --from-certificate-file {{cert.yaml}}`
+
+- 새 인증서 요청을 생성하고, 서명된 인증서를 가져오고, 최대 대기 시간을 설정:
+
+`cmctl create certificaterequest my-cr --from-certificate-file {{cert.yaml}} --fetch-certificate --timeout {{20m}}`

--- a/pages.ko/common/convert.md
+++ b/pages.ko/common/convert.md
@@ -1,0 +1,9 @@
+# convert
+
+> 이 명령어는 `magick convert`의 별칭.
+> 참고: ImageMagick 7부터 이 별칭은 사용되지 않음. `magick`으로 대체됨.
+> 7 이상 버전에서 이전 도구를 사용해야 하는 경우, `magick convert`를 사용해야 함.
+
+- 원래 명령에 대한 문서 보기:
+
+`tldr magick convert`

--- a/pages.ko/common/coproc.md
+++ b/pages.ko/common/coproc.md
@@ -1,0 +1,28 @@
+# coproc
+
+> 대화형 비동기 서브셸을 생성하기 위한 내장 Bash.
+> 더 많은 정보: <https://www.gnu.org/software/bash/manual/bash.html#Coprocesses>.
+
+- 서브셸을 비동기적으로 실행:
+
+`coproc { {{명령어1; 명령어2; ...}}; }`
+
+- 특정 이름을 가진 보조 프로세스를 만듬:
+
+`coproc {{이름}} { {{명령어1; 명령어2; ...}}; }`
+
+- 특정 보조 프로세스 `stdin`에 쓰기:
+
+`echo "{{입력}}" >&"${{{이름}}[1]}"`
+
+- 특정 보조 프로세스 `stdout`에서 읽음:
+
+`read {{변수}} <&"${{{이름}}[0]}"`
+
+- `stdin`을 반복적으로 읽고 입력에 대해 일부 명령을 실행하는 보조 프로세스를 만듬:
+
+`coproc {{이름}} { while read line; do {{명령어1; 명령어2; ...}}; done }`
+
+- `bc`를 실행하는 보조 프로세스를 만들고 사용:
+
+`coproc BC { bc --mathlib; }; echo "1/3" >&"${BC[1]}"; read output <&"${BC[0]}"; echo "$output"`

--- a/pages.ko/common/core-validate-commit.md
+++ b/pages.ko/common/core-validate-commit.md
@@ -1,0 +1,32 @@
+# core-validate-commit
+
+> Node.js 코어에 대한 커밋 메시지를 확인.
+> 더 많은 정보: <https://github.com/nodejs/core-validate-commit>.
+
+- 현재 커밋을 확인:
+
+`core-validate-commit`
+
+- 특정 커밋을 확인:
+
+`core-validate-commit {{커밋_해쉬}}`
+
+- 다양한 커밋의 유효성을 검사:
+
+`git rev-list {{커밋_해쉬}}..HEAD | xargs core-validate-commit`
+
+- 모든 유효성 검사 규칙을 나열:
+
+`core-validate-commit --list`
+
+- 유효한 Node.js 하위시스템을 모두 나열:
+
+`core-validate-commit --list-subsystem`
+
+- 탭 형식으로 출력 형식을 지정하는 현재 커밋의 유효성을 검사:
+
+`core-validate-commit --tap`
+
+- 도움말 표시:
+
+`core-validate-commit --help`

--- a/pages.ko/common/corepack.md
+++ b/pages.ko/common/corepack.md
@@ -1,0 +1,36 @@
+# corepack
+
+> Node 프로젝트와 해당 패키지 관리자 사이의 브라지 역할을 하는 런타임 종속성이 없는 패키지.
+> 더 많은 정보: <https://github.com/nodejs/corepack>.
+
+- Corepack shim을 Node.js 설치 디렉터리에 추가하여 전역 명령으로 사용할 수 있도록 함:
+
+`corepack enable`
+
+- 특정 디렉토리에 Corepack shim을 추가함:
+
+`corepack enable --install-directory {{경로/대상/디렉토리}}`
+
+- Node.js 설치 디렉터리에서 Corepack shim을 제거:
+
+`corepack disable`
+
+- 특정 패키지 관리자를 준비:
+
+`corepack prepare {{패키지_매니저}}@{{버전}} --activate`
+
+- 현재 경로의 프로젝트에 대해 구성된 패키지 관리자를 준비:
+
+`corepack prepare`
+
+- 전역 명령으로 설치하지 않고 패키지 관리자를 사용:
+
+`corepack {{npm|pnpm|yarn}} {{패키지_매니저_인자}}`
+
+- 지정된 아카이브에서 패키지 관리자를 설치:
+
+`corepack hydrate {{경로/대상/corepack.tgz}}`
+
+- 하위 명령어에 대한 도움말 표시:
+
+`corepack {{하위명령어}} --help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
