### PR TITLE
cbonsai, cbt, ccache, ccomps, cdk: add Korean translation

### DIFF
--- a/pages.ko/common/cbonsai.md
+++ b/pages.ko/common/cbonsai.md
@@ -1,0 +1,24 @@
+# cbonsai
+
+> 아름답고 랜덤한 분재 나무 생성도구.
+> 더 많은 정보: <https://gitlab.com/jallbrit/cbonsai>.
+
+- 라이브 모드에서 분재를 생성:
+
+`cbonsai -l`
+
+- 무한 모드에서 분재를 생성:
+
+`cbonsai -i`
+
+- 분재에 메시지를 추가:
+
+`cbonsai -m "{{메시지}}"`
+
+- 분재에 대한 추가 정보 표시:
+
+`cbonsai -v`
+
+- 도움말 표시:
+
+`cbonsai -h`

--- a/pages.ko/common/cbt.md
+++ b/pages.ko/common/cbt.md
@@ -1,0 +1,28 @@
+# cbt
+
+> Google Cloud's Bigtable에서 데이터를 읽는 유틸리티.
+> 더 많은 정보: <https://cloud.google.com/bigtable/docs/cbt-reference>.
+
+- 현재 프로젝트의 테이블 나열:
+
+`cbt ls`
+
+- 현재 프로젝트의 특정 테이블에 있는 행 수를 인쇄:
+
+`cbt count "{{테이블_이름}}"`
+
+- 현재 프로젝트의 열 당 1개의 (가장 최근) 셀 수정만 사용하여 특정 테이블의 단일 행을 표시:
+
+`cbt lookup "{{테이블_이름}}" "{{열_키}}" cells-per-column={{1}}`
+
+- 현재 프로젝트에서 특정 열만 있는 단일 행 표시 (전체 패밀리를 반환하려면 한정자를 생략):
+
+`cbt lookup "{{테이블_이름}}" "{{열_키}}" columns="{{family1:qualifier1,family2:qualifier2,...}}"`
+
+- 특정 정규식 패턴으로 현재 프로젝트에서 최대 5개 행을 검색하고 인쇄:
+
+`cbt read "{{테이블_이름}}" regex="{{열_키_패턴}}" count={{5}}`
+
+- 특정 행 범위를 읽고, 현재 프로젝트에서 반환된 행 키만 인쇄:
+
+`cbt read {{테이블_이름}} start={{시작_열_키}} end={{마지막_열_키}} keys-only=true`

--- a/pages.ko/common/ccache.md
+++ b/pages.ko/common/ccache.md
@@ -1,0 +1,21 @@
+# ccache
+
+> C/C++ 컴파일러 캐시.
+> 참고: 패키지는 일반적으로 `/usr/lib/ccache/bin`에 컴파일러에 대한 심볼릭 링크를 제공. 자동으로 `ccache`를 사용하려면 이 디렉토리를 `$PATH` 앞에 추가.
+> 더 많은 정보: <https://ccache.dev/manual/latest.html>.
+
+- 현재 캐시 통계 표시([s]tatistics):
+
+`ccache --show-stats`
+
+- 모든 캐시 지우기([C]lear):
+
+`ccache --clear`
+
+- 통계 재설정 ([z]ero) (캐시 자체는 아님):
+
+`ccache --zero-stats`
+
+- C 코드를 컴파일하고 컴파일된 출력을 캐시 (모든 `gcc` 호출에서 `ccache`를 사용하려면, 위를 참고):
+
+`ccache gcc {{경로/대상/파일.c}}`

--- a/pages.ko/common/ccomps.md
+++ b/pages.ko/common/ccomps.md
@@ -1,0 +1,21 @@
+# ccomps
+
+> 그래프를 연결된 구성 요소로 분해.
+> 그래프비즈 필터: `acyclic`, `bcomps`, `comps`, `edgepaint`, `gvcolor`, `gvpack`, `mingle`, `nop`, `sccmap`, `tred`, & `unflatten`.
+> 더 많은 정보: <https://graphviz.org/pdf/ccomps.1.pdf>.
+
+- 하나 이상의 그래프를 연결된 구성 요소로 분해:
+
+`ccomps {{경로/대상/입력파일1.gv}} {{경로/대상/입력파일2.gv ...}} > {{경로/대상/출력파일.gv}}`
+
+- 하나 이상의 그래프에서 노드, 간선 및 연결된 구성요소의 수를 인쇄:
+
+`ccomps -v -s {{경로/대상/입력파일1.gv}} {{경로/대상/입력파일2.gv ...}}`
+
+- `output.gv`를 기반으로 번호가 매겨진 파일이름에 연결된 각 구성요소를 작성:
+
+`ccomps -x -o {{경로/대상/출력파일.gv}} {{경로/대상/입력파일1.gv}} {{경로/대상/입력파일2.gv ...}}`
+
+- 도움말 표시:
+
+`ccomps -?`

--- a/pages.ko/common/cdk.md
+++ b/pages.ko/common/cdk.md
@@ -1,0 +1,32 @@
+# cdk
+
+> AWS Cloud 개발 키트 (CDK)용 CLI.
+> 더 많은 정보: <https://docs.aws.amazon.com/cdk/latest/guide/cli.html>.
+
+- 애플리케이션의 스택 나열:
+
+`cdk ls`
+
+- Synthesize and print the CloudFormation template for the specified stack(s):
+
+`cdk synth {{스택_이름}}`
+
+- 하나 이상의 스택을 배포:
+
+`cdk deploy {{스택_이름1 스택_이름2 ...}}`
+
+- 하나 이상의 스택을 파괴:
+
+`cdk destroy {{스택_이름1 스택_이름2 ...}}`
+
+- 지정된 스택을 배포된 스택 또는 로컬 CloudFormation 템플릿과 비교:
+
+`cdk diff {{스택_이름}}`
+
+- 지정된 언어([l]anguage)에 대해 현재 디렉터리에 새 CDK 프로젝트를 만듬:
+
+`cdk init -l {{언어}}`
+
+- 브라우저에서 CDK API 참조를 열기:
+
+`cdk docs`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
