### PR TITLE
raspi-config: update documentation link

### DIFF
--- a/pages.pl/linux/raspi-config.md
+++ b/pages.pl/linux/raspi-config.md
@@ -1,7 +1,7 @@
 # raspi-config
 
 > GUI działające w terminalu `ncurses` do konfiguracji Raspberry Pi.
-> Więcej informacji: <https://www.raspberrypi.org/documentation/computers/configuration.html>.
+> Więcej informacji: <https://www.raspberrypi.com/documentation/computers/configuration.html>.
 
 - Uruchom `raspi-config`:
 

--- a/pages/linux/raspi-config.md
+++ b/pages/linux/raspi-config.md
@@ -1,7 +1,7 @@
 # raspi-config
 
 > An `ncurses` terminal GUI to config a Raspberry Pi.
-> More information: <https://www.raspberrypi.org/documentation/computers/configuration.html>.
+> More information: <https://www.raspberrypi.com/documentation/computers/configuration.html>.
 
 - Start `raspi-config`:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).