### PR TITLE
certutil, cf, chafa, charm: add Korean translation

### DIFF
--- a/pages.ko/common/certutil.md
+++ b/pages.ko/common/certutil.md
@@ -1,0 +1,24 @@
+# certutil
+
+> NSS 데이터베이스와 기타 NSS 토큰 모두에서 키와 인증서를 관리.
+> 더 많은 정보: <https://manned.org/certutil>.
+
+- 현재 디렉터리([d]irectory)에 새로운([N]ew) 인증서 데이터베이스를 만듬:
+
+`certutil -N -d .`
+
+- 데이터베이스의 모든 인증서를 나열:
+
+`certutil -L -d .`
+
+- 비밀번호 파일([f]ile)을 지정하는 데이터베이스의 모든 개인 키([K]eys)를 나열:
+
+`certutil -K -d . -f {{경로/대상/패스워드_파일.txt}}`
+
+- 닉네임([n]ickname), 신뢰 속성([t]rust attributes) 및 입력([i]nput) CRT 파일을 지정하여 요청자 데이터베이스에 서명된 인증서를 추가([A]dd):
+
+`certutil -A -n "{{서버_인증서}}" -t ",," -i {{경로/대상/파일.crt}} -d .`
+
+- Add subject alternative names to a given [c]ertificate with a specific key size ([g]):
+
+`certutil -S -f {{경로/대상/패스워드_파일.txt}} -d . -t ",," -c "{{서버_인증서}}" -n "{{서버_이름}}" -g {{2048}} -s "CN={{공통_이름}},O={{조직}}"`

--- a/pages.ko/common/cf.md
+++ b/pages.ko/common/cf.md
@@ -1,0 +1,36 @@
+# cf
+
+> Cloud Foundry에서 앱과 서비스를 관리.
+> 더 많은 정보: <https://docs.cloudfoundry.org>.
+
+- Cloud Foundry API에 로그인:
+
+`cf login -a {{api_주소}}`
+
+- 기본 설정을 사용하여 앱을 푸시:
+
+`cf push {{앱_이름}}`
+
+- 조직에서 사용할 수 있는 서비스 보기:
+
+`cf marketplace`
+
+- 서비스 인스턴스를 생성:
+
+`cf create-service {{서비스}} {{플랜}} {{서비스_이름}}`
+
+- 애플리케이션을 서비스에 연결:
+
+`cf bind-service {{앱_이름}} {{서비스_이름}}`
+
+- 코드가 앱에 포함되어 있지만, 독립적으로 실행되는 스크립트를 실행:
+
+`cf run-task {{앱_이름}} "{{스크립트_명령어}}" --name {{작업_이름}}`
+
+- 앱을 호스팅하는 VM으로 대화형 SSH 세션을 시작:
+
+`cf ssh {{앱_이름}}`
+
+- 최근 앱 로그 덤프 보기:
+
+`cf logs {{앱_이름}} --recent`

--- a/pages.ko/common/chafa.md
+++ b/pages.ko/common/chafa.md
@@ -1,0 +1,25 @@
+# chafa
+
+> 터미널에서 이미지 출력.
+> 참고: `catimg`, `pixterm`.
+> 더 많은 정보: <https://hpjansson.org/chafa/man>.
+
+- 터미널에서 직접 이미지를 렌더링:
+
+`chafa {{경로/대상/파일}}`
+
+- 24비트 색깔([c]olor) 이미지 렌더링:
+
+`chafa -c full {{경로/대상/파일}}`
+
+- 디더링을 사용하여 작은 색상 팔레트로 이미지 렌더링을 개선:
+
+`chafa -c 16 --dither ordered {{경로/대상/파일}}`
+
+- 이미지를 렌더링하여, 픽셀화된 것처럼 보이게 만듬:
+
+`chafa --symbols vhalf {{경로/대상/파일}}`
+
+- 점자 문자만 사용하여 흑백 이미지를 렌더링:
+
+`chafa -c none --symbols braille {{경로/대상/파일}}`

--- a/pages.ko/common/charm.md
+++ b/pages.ko/common/charm.md
@@ -1,0 +1,32 @@
+# charm
+
+> 사용자 계정, 데이터 저장 및 암호화에 대해 걱정하지 않고 터미널 기반 애플리케이션에 백엔드를 추가할 수 있는 도구 세트.
+> 더 많은 정보: <https://github.com/charmbracelet/charm>.
+
+- Charm 계정 키를 백업:
+
+`charm backup-keys`
+
+- Charm 계정 키를 특정 위치에 백업:
+
+`charm backup-keys -o {{경로/대상/출력_파일.tar}}`
+
+- 이전에 백업한 Charm 계정 키 가져오기:
+
+`charm import-keys "{{charm-키-백업.tar}}"`
+
+- 컴퓨터에서 `cloud.charm.sh` 폴더가 있는 위치를 발견:
+
+`charm where`
+
+- Charm 서버를 시작:
+
+`charm serve`
+
+- 연결된 SSH 키 인쇄:
+
+`charm keys`
+
+- Charm ID를 인쇄:
+
+`charm id`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
