### PR TITLE
vinmap: add page

### DIFF
--- a/pages/common/vinmap.md
+++ b/pages/common/vinmap.md
@@ -1,0 +1,24 @@
+# vinmap
+
+> A multithreaded Nmap scanner that splits IP ranges into chunks, performs parallel scans, and merges XML or JSON results.
+> More information: <https://pypi.org/project/vinmap>.
+
+- Perform a basic scan of a subnet:
+
+`vinmap -ip {{192.168.1.0/24}}`
+
+- Scan a domain with version and OS detection, saving results to a specific file:
+
+`vinmap -ip {{example.com}} -s "-sV -O" -o {{scan_results.xml}}`
+
+- Scan an IP range using 10 chunks and 20 concurrent threads:
+
+`vinmap -ip {{10.0.0.1-10.0.0.255}} -n {{10}} -t {{20}}`
+
+- Output scan results in JSON format:
+
+`vinmap -ip {{192.168.1.1-192.168.1.100}} -f {{json}}`
+
+- Scan multiple IPs with default settings and save merged XML output:
+
+`vinmap -ip {{192.168.1.1,192.168.1.2,192.168.1.3}}`

--- a/pages/common/vinmap.md
+++ b/pages/common/vinmap.md
@@ -1,6 +1,6 @@
 # vinmap
 
-> A multithreaded Nmap scanner that splits IP ranges into chunks, performs parallel scans, and merges XML or JSON results.
+> A multithreaded Nmap scanner that splits IP ranges into chunks, performs parallel scans, and merges XML or JSON results. **Version:** 1.0.0
 > More information: <https://pypi.org/project/vinmap>.
 
 - Perform a basic scan of a subnet:
@@ -11,7 +11,7 @@
 
 `vinmap -ip {{example.com}} -s "-sV -O" -o {{scan_results.xml}}`
 
-- Scan an IP range using 10 chunks and 20 concurrent threads:
+- Scan an IP range using 10 chunks and 20 concurrent threads, uses half of the system's CPU cores if not specified:
 
 `vinmap -ip {{10.0.0.1-10.0.0.255}} -n {{10}} -t {{20}}`
 
@@ -22,3 +22,4 @@
 - Scan multiple IPs with default settings and save merged XML output:
 
 `vinmap -ip {{192.168.1.1,192.168.1.2,192.168.1.3}}`
+

--- a/pages/common/vinmap.md
+++ b/pages/common/vinmap.md
@@ -1,6 +1,6 @@
 # vinmap
 
-> A multithreaded Nmap scanner that splits IP ranges into chunks, performs parallel scans, and merges XML or JSON results. **Version:** 1.0.0
+> A multithreaded Nmap scanner that splits IP ranges into chunks, performs parallel scans, and merges XML or JSON results. **Version:** 1.0.0.
 > More information: <https://pypi.org/project/vinmap>.
 
 - Perform a basic scan of a subnet:

--- a/pages/common/vinmap.md
+++ b/pages/common/vinmap.md
@@ -22,4 +22,3 @@
 - Scan multiple IPs with default settings and save merged XML output:
 
 `vinmap -ip {{192.168.1.1,192.168.1.2,192.168.1.3}}`
-


### PR DESCRIPTION
Added a tldr page for vinmap, a multithreaded Nmap scanner that enhances Nmap’s capabilities for large-scale network exploration.

Includes five usage examples covering basic scans, domain scanning with version and OS detection, custom chunking and threading, JSON output, and scanning multiple IPs.
Ensures clarity and user-friendliness by using descriptive explanations and appropriate placeholders.