### PR TITLE
yadm-config: fix more info line

### DIFF
--- a/pages/common/yadm-config.md
+++ b/pages/common/yadm-config.md
@@ -1,7 +1,7 @@
 # yadm-config
 
 > Pass options to `yadm`'s config file. Change the `.config` of the repository managed by `yadm`.
-> See also: <https://github.com/TheLocehiliosan/yadm/blob/master/yadm.md#configuration>.
+> More information: <https://github.com/TheLocehiliosan/yadm/blob/master/yadm.md#configuration>.
 
 - Set or update a `yadm`'s Git configuration:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).