### PR TITLE
pages.de/*: replace 'zur/zum' to match guideline

### DIFF
--- a/pages.de/common/aspell.md
+++ b/pages.de/common/aspell.md
@@ -5,7 +5,7 @@
 
 - Überprüfe eine einzelne Datei auf Fehler:
 
-`aspell check {{pfad/zur/datei}}`
+`aspell check {{pfad/zu/datei}}`
 
 - Liste falsch geschriebene Worte von Standard Input:
 

--- a/pages.de/common/dart.md
+++ b/pages.de/common/dart.md
@@ -9,7 +9,7 @@
 
 - Ausführen einer Dart-Datei:
 
-`dart run {{pfad/zur/datei.dart}}`
+`dart run {{pfad/zu/datei.dart}}`
 
 - Herunterladen der Abhängigkeiten für das aktuelle Projekt:
 
@@ -25,4 +25,4 @@
 
 - Kompilieren einer Dart-Datei in eine native Binärdatei:
 
-`dart compile exe {{pfad/zur/datei.dart}}`
+`dart compile exe {{pfad/zu/datei.dart}}`

--- a/pages.de/common/docker-exec.md
+++ b/pages.de/common/docker-exec.md
@@ -13,7 +13,7 @@
 
 - Bestimme das Arbeitsverzeichnis, in dem der Befehl ausgeführt werden soll:
 
-`docker exec --interactive --tty --workdir {{pfad/zum/verzeichnis}} {{container_name}} {{befehl}}`
+`docker exec --interactive --tty --workdir {{pfad/zu/verzeichnis}} {{container_name}} {{befehl}}`
 
 - Führe einen Befehl im Hintergrund in einem laufenden Container aus, aber lies von der Standardeingabe:
 

--- a/pages.de/common/docker-ps.md
+++ b/pages.de/common/docker-ps.md
@@ -33,4 +33,4 @@
 
 - Zeige nur Container, welche einen bestimmten Datenträger oder einen Datenträger an einem bestimmten Pfad eingehängt haben:
 
-`docker ps --filter "volume={{pfad/zum/verzeichnis}}" --format "table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Mounts}}"`
+`docker ps --filter "volume={{pfad/zu/verzeichnis}}" --format "table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Mounts}}"`

--- a/pages.de/common/docker-save.md
+++ b/pages.de/common/docker-save.md
@@ -5,16 +5,16 @@
 
 - Speichere ein Image über die Standardausgabe in ein Tar-Archiv:
 
-`docker save {{image}}:{{tag}} > {{pfad/zur/datei.tar}}`
+`docker save {{image}}:{{tag}} > {{pfad/zu/datei.tar}}`
 
 - Speichere ein Image in ein Tar-Archiv:
 
-`docker save --output {{pfad/zur/datei.tar}} {{image}}:{{tag}}`
+`docker save --output {{pfad/zu/datei.tar}} {{image}}:{{tag}}`
 
 - Speichere alle Tags eines Images:
 
-`docker save --output {{pfad/zur/datei.tar}} {{image_name}}`
+`docker save --output {{pfad/zu/datei.tar}} {{image_name}}`
 
 - Speichere nur bestimmte Tags eines Images:
 
-`docker save --output {{pfad/zur/datei.tar}} {{image_name:tag1 image_name:tag2 ...}}`
+`docker save --output {{pfad/zu/datei.tar}} {{image_name:tag1 image_name:tag2 ...}}`

--- a/pages.de/common/docker-secret.md
+++ b/pages.de/common/docker-secret.md
@@ -9,7 +9,7 @@
 
 - Erstelle ein neues Secret aus einer Datei:
 
-`docker secret create {{secret_name}} {{pfad/zur/datei}}`
+`docker secret create {{secret_name}} {{pfad/zu/datei}}`
 
 - Liste alle Secrets auf:
 

--- a/pages.de/common/docker-slim.md
+++ b/pages.de/common/docker-slim.md
@@ -13,7 +13,7 @@
 
 - Linte ein Dockerfile:
 
-`docker-slim lint --target {{pfad/zum/Dockerfile}}`
+`docker-slim lint --target {{pfad/zu/Dockerfile}}`
 
 - Analysiere und generiere ein optimiertes Docker Image:
 

--- a/pages.de/common/dust.md
+++ b/pages.de/common/dust.md
@@ -9,7 +9,7 @@
 
 - Informationen für eine durch Leerzeichen getrennte Liste von Verzeichnissen anzeigen:
 
-`dust {{pfad/zum/verzeichnis1}} {{pfad/zum/verzeichnis2}}`
+`dust {{pfad/zu/verzeichnis1}} {{pfad/zu/verzeichnis2}}`
 
 - Zeige 30 Verzeichnisse an (Standardwert: 21):
 

--- a/pages.de/common/kitty.md
+++ b/pages.de/common/kitty.md
@@ -17,7 +17,7 @@
 
 - Zeige ein Bild im Terminal an:
 
-`kitty +kitten icat {{pfad/zum/bild}}`
+`kitty +kitten icat {{pfad/zu/bild}}`
 
 - Kopiere den Inhalt von `stdin` in die Zwischenablage:
 

--- a/pages.de/common/pip-install.md
+++ b/pages.de/common/pip-install.md
@@ -17,7 +17,7 @@
 
 - Installiere die Pakete von einer URL oder einem lokalen Archiv (.tar.gz | .whl):
 
-`pip install --find-links {{url|pfad/zur/datei}}`
+`pip install --find-links {{url|pfad/zu/datei}}`
 
 - Installiere das lokale Paket im aktuellen Verzeichnis im Entwicklungs-/Bearbeitungsmodus:
 

--- a/pages.de/linux/aa-complain.md
+++ b/pages.de/linux/aa-complain.md
@@ -6,8 +6,8 @@
 
 - Setze eine Richtlinie in den Beschwerde-Modus:
 
-`sudo aa-complain {{pfad/zum/profil}}`
+`sudo aa-complain {{pfad/zu/profil}}`
 
 - Setze Richtlinien in den Beschwerde-Modus:
 
-`sudo aa-complain --dir {{pfad/zum/profil}}`
+`sudo aa-complain --dir {{pfad/zu/profil}}`

--- a/pages.de/linux/addr2line.md
+++ b/pages.de/linux/addr2line.md
@@ -5,12 +5,12 @@
 
 - Zeige den Dateinamen und die Zeilennummer des Quellcodes von einer Befehlsadresse einer ausführbaren Datei an:
 
-`addr2line --exe={{pfad/zur/ausführbaren_datei}} {{adresse}}`
+`addr2line --exe={{pfad/zu/binärdatei}} {{adresse}}`
 
 - Zeige den Funktionsnamen, Dateinamen und Zeilennummer an:
 
-`addr2line --exe={{pfad/zum/executable}} --functions {{adresse}}`
+`addr2line --exe={{pfad/zu/binärdatei}} --functions {{adresse}}`
 
 - Entmangele den Funktionsnamen für C++ Code:
 
-`addr2line --exe={{pfad/zum/executable}} --functions --demangle {{adresse}}`
+`addr2line --exe={{pfad/zu/binärdatei}} --functions --demangle {{adresse}}`

--- a/pages.de/linux/alien.md
+++ b/pages.de/linux/alien.md
@@ -5,16 +5,16 @@
 
 - Ein spezifisches Installationspaket in das Debian Format umwandeln (`.deb` Erweiterung):
 
-`sudo alien --to-deb {{pfad/zum/paket}}`
+`sudo alien --to-deb {{pfad/zu/paket}}`
 
 - Ein spezifisches Installationspaket in das Red Hat Format umwandeln (`.rpm` Erweiterung):
 
-`sudo alien --to-rpm {{pfad/zum/paket}}`
+`sudo alien --to-rpm {{pfad/zu/paket}}`
 
 - Ein spezifisches Installationspaket in das Slackware Format umwandeln (`.tgz` Erweiterung):
 
-`sudo alien --to-tgz {{pfad/zum/paket}}`
+`sudo alien --to-tgz {{pfad/zu/paket}}`
 
 - Ein spezifisches Installationspaket in das Debian Format umwandeln und auf dem System installieren:
 
-`sudo alien --to-deb --install {{pfad/zum/paket}}`
+`sudo alien --to-deb --install {{pfad/zu/paket}}`

--- a/pages.de/linux/apport-bug.md
+++ b/pages.de/linux/apport-bug.md
@@ -13,7 +13,7 @@
 
 - Reiche einen Fehlerbericht über eine bestimmte ausführbare Datei ein:
 
-`apport-bug {{pfad/zum/executable}}`
+`apport-bug {{pfad/zu/binärdatei}}`
 
 - Reiche einen Fehlerbericht über einen bestimmten Prozess ein:
 

--- a/pages.de/linux/apt-file.md
+++ b/pages.de/linux/apt-file.md
@@ -9,7 +9,7 @@
 
 - Suche nach Paketen, die die/den spezifizierten Pfad/Datei enthalten:
 
-`apt-file {{search|find}} {{pfad/zur/datei}}`
+`apt-file {{search|find}} {{pfad/zu/datei}}`
 
 - Liste die Inhalte eines bestimmten Pakets auf:
 

--- a/pages.de/linux/arecord.md
+++ b/pages.de/linux/arecord.md
@@ -5,15 +5,15 @@
 
 - Nehme einen Schnipsel in CD-Qualität auf (beende die Aufnahme mit CTRL-C):
 
-`arecord -vv --format=cd {{pfad/zur/datei.wav}}`
+`arecord -vv --format=cd {{pfad/zu/datei.wav}}`
 
 - Nehme einen Schnipsel in CD-Qualität auf mit einer festen Länge von 10 Sekunden:
 
-`arecord -vv --format=cd --duration={{10}} {{pfad/zur/datei.wav}}`
+`arecord -vv --format=cd --duration={{10}} {{pfad/zu/datei.wav}}`
 
 - Nehme einen Schnipsel auf und speichere es als MP3 (beende die Aufnahme mit CTRL-C):
 
-`arecord -vv --format=cd --file-type raw | lame -r - {{path/to/file.mp3}}`
+`arecord -vv --format=cd --file-type raw | lame -r - {{pfad/zu/datei.mp3}}`
 
 - Liste alle Soundkarten und digitalen Ausgabe Geräte:
 

--- a/pages.de/linux/as.md
+++ b/pages.de/linux/as.md
@@ -18,4 +18,4 @@
 
 - Inkludiere einen gegebenen Pfad in der Liste von Verzeichnissen für die Suche nach Dateien:
 
-`as -I {{pfad/zum/verzeichnis}} {{pfad/zu/datei.s}}`
+`as -I {{pfad/zu/verzeichnis}} {{pfad/zu/datei.s}}`

--- a/pages.de/linux/asciiart.md
+++ b/pages.de/linux/asciiart.md
@@ -5,7 +5,7 @@
 
 - Lese ein Bild aus einer Datei und zeige es als ASCII:
 
-`asciiart {{pfad/zur/datei.jpg}}`
+`asciiart {{pfad/zu/datei.jpg}}`
 
 - Lese ein Bild aus einer URL und zeige es als ASCII:
 
@@ -13,16 +13,16 @@
 
 - Wähle die Breite der Ausgabe (standardmäßig 100):
 
-`asciiart --width {{50}} {{pfad/zum/bild.jpg}}`
+`asciiart --width {{50}} {{pfad/zu/bild.jpg}}`
 
 - Zeige die Ausgabe in Farbe:
 
-`asciiart --color {{pfad/zum/bild.jpg}}`
+`asciiart --color {{pfad/zu/bild.jpg}}`
 
 - Wähle das Ausgabeformat (standardmäßig text):
 
-`asciiart --format {{text|html}} {{pfad/zum/bild.jpg}}`
+`asciiart --format {{text|html}} {{pfad/zu/bild.jpg}}`
 
 - Invertiere die Zeichentabelle:
 
-`asciiart --invert-chars {{pfad/zum/bild.jpg}}`
+`asciiart --invert-chars {{pfad/zu/bild.jpg}}`

--- a/pages.de/linux/cp.md
+++ b/pages.de/linux/cp.md
@@ -5,28 +5,28 @@
 
 - Kopiere eine Datei an einen anderen Ort:
 
-`cp {{pfad/zur/ausgangs_datei.ext}} {{pfad/zur/ziel_datei.ext}}`
+`cp {{pfad/zu/ausgangs_datei.ext}} {{pfad/zu/ziel_datei.ext}}`
 
 - Kopiere eine Datei in ein anderes Verzeichnis und behalte den Dateinamen bei:
 
-`cp {{pfad/zur/ausgang_datei.ext}} {{pfad/zum/ziel_verzeichnis}}`
+`cp {{pfad/zu/ausgang_datei.ext}} {{pfad/zu/ziel_verzeichnis}}`
 
 - Kopiere die Inhalte eines Verzeichnisses rekursiv zu einem neuen Ort (wenn das Ziel existiert, wird das Verzeichnis ins bestehende Ziel Verzeichnis kopiert):
 
-`cp -r {{pfad/zum/ausgangs_verzeichnis}} {{pfad/zum/ziel_verzeichnis}}`
+`cp -r {{pfad/zu/ausgangs_verzeichnis}} {{pfad/zu/ziel_verzeichnis}}`
 
 - Kopiere ein Verzeichnis rekursiv im ausführlichen Modus (zeigt die Dateien die kopiert werden):
 
-`cp -vr {{pfad/zum/ausgangs_verzeichnis}} {{pfad/zum/ziel_verzeichnis}}`
+`cp -vr {{pfad/zu/ausgangs_verzeichnis}} {{pfad/zu/ziel_verzeichnis}}`
 
 - Kopiere text Dateien zu einem anderen Ort im interaktiven Modus (fragt die Nutzer:in bevor eine Datei überschrieben wird):
 
-`cp -i {{*.txt}} {{pfad/zum/ziel_verzeichnis}}`
+`cp -i {{*.txt}} {{pfad/zu/ziel_verzeichnis}}`
 
 - Folge symbolischen Verzeichnislinks vorm Kopieren:
 
-`cp -L {{link}} {{pfad/zum/ziel_verzeichnis}}`
+`cp -L {{link}} {{pfad/zu/ziel_verzeichnis}}`
 
 - Benutze den vollen Pfad der Ausgangsdateien und erstelle alle fehlenden Verzeichnisse beim Kopieren:
 
-`cp --parents {{quelle/pfad/zur/datei}} {{pfad/zur/ziel_datei}}`
+`cp --parents {{quelle/pfad/zu/datei}} {{pfad/zu/ziel_datei}}`

--- a/pages.de/linux/pacman-sync.md
+++ b/pages.de/linux/pacman-sync.md
@@ -26,7 +26,7 @@
 
 - Überschreibe widersprüchliche Dateien während einer Paketaktualisierung:
 
-`sudo pacman --sync --refresh --sysupgrade --overwrite {{pfad/zur/datei}}`
+`sudo pacman --sync --refresh --sysupgrade --overwrite {{pfad/zu/datei}}`
 
 - Synchronisiere und aktualisiere alle Pakete, ignoriere aber ein bestimmtes Paket (kann mehr als einmal angegeben werden):
 

--- a/pages.de/linux/zathura.md
+++ b/pages.de/linux/zathura.md
@@ -6,7 +6,7 @@
 
 - Öffne eine Datei:
 
-`zathura {{pfad/zur/datei}}`
+`zathura {{pfad/zu/datei}}`
 
 - Navigiere nach links/oben/unten/rechts:
 

--- a/pages.de/windows/ftp.md
+++ b/pages.de/windows/ftp.md
@@ -17,7 +17,7 @@
 
 - Ausführen einer Datei, die eine Liste von FTP-Befehlen enthält:
 
-`ftp -s:{{Pfad/zur/Datei}} {{host}}`
+`ftp -s:{{pfad/zu/Datei}} {{host}}`
 
 - Herunterladen von mehrerern Dateien (globaler Ausdruck):
 

--- a/pages.de/windows/robocopy.md
+++ b/pages.de/windows/robocopy.md
@@ -6,27 +6,27 @@
 
 - Alle `.jpg` und `.bmp` Dateien aus dem einen Verzeichnis in ein anderes Verzeichnis kopieren:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} {{*.jpg}} {{*.bmp}}`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} {{*.jpg}} {{*.bmp}}`
 
 - Alle Dateien und Unterverzeichnisse kopieren, einschließlich der leeren Verzeichnisse:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} /E`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} /E`
 
 - Ein Verzeichnis spiegeln/synchronisieren. Dabei wird Alles, was nicht in der Quelle vorhanden ist, gelöscht sowie alle Attribute und Berechtigungen übertragen:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} /MIR /COPYALL`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} /MIR /COPYALL`
 
 - Alle Dateien und Unterverzeichnisse kopieren, ausgenommen der Quelldateien, die älter sind als die vorhandenen Zieldateien:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} /E /XO`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} /E /XO`
 
 - Gibt alle Dateien aus, die 50 MB und größer sind, anstatt sie zu kopieren:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} /MIN:{{52428800}} /L`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} /MIN:{{52428800}} /L`
 
 - Erlaubt das Fortsetzen des Vorgangs bei Netzwerkverlust, begrenzt die Anzahl an Versuchen auf 5 und die Wartezeit zwischen Versuchen auf 15 Sekunden:
 
-`robocopy {{pfad/zur/quelle}} {{pfad/zum/ziel}} /Z /R:5 /W:15`
+`robocopy {{pfad/zu/quelle}} {{pfad/zu/ziel}} /Z /R:5 /W:15`
 
 - Gibt detaillierte Nutzungshinweise aus:
 


### PR DESCRIPTION
Uses of 'pfad/zur' or 'pfad/zum' replaced by 'pfad/zu/' to match the guideline of 'Common arguments'.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
