### PR TITLE
contributing-guides: fix pt_BR templates

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -375,7 +375,7 @@ The templates can be changed when necessary.
 
 > Este comando é um apelido de `example`.
 
-- Ver documentação sobre o comando original:
+- Veja documentação sobre o comando original:
 
 `tldr example`
 ```

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -232,7 +232,7 @@ Niektóre podkomendy takie jak `example command` mają osobną dokumentację.
 ### pt_BR
 
 ```markdown
-Alguns subcomandos como `example command` tem sua própia documentação de uso.
+Alguns subcomandos como `example command` têm sua própria documentação de uso.
 ```
 
 ---


### PR DESCRIPTION
In translation-templates, use imperative mood  for pt_BR instead of the verb's infinite conjugation.

In alias-pages, fix two typos in pt_BR: "tem" (has in English) receives a caret when the substantive is plural, making it têm (have). Also "própria" is the proper translation for "own" translation.

- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
