### PR TITLE
pages.pt_BR/common/*: add Portuguese Brazilian translations 

### DIFF
--- a/pages.pt_BR/common/rc.md
+++ b/pages.pt_BR/common/rc.md
@@ -1,0 +1,13 @@
+# rc
+
+> Um ouvinte de porta moderno e simplista e shell reverso.
+> Similar a `nc`.
+> Mais informações: <https://github.com/robiot/rustcat/wiki/Basic-Usage>.
+
+- Começa a escutar em uma porta específica:
+
+`rc -lp {{porta}}`
+
+- Começa um shell reverso:
+
+`rc {{host}} {{porta}} -r {{shell}}`

--- a/pages.pt_BR/common/strings.md
+++ b/pages.pt_BR/common/strings.md
@@ -1,0 +1,20 @@
+# strings
+
+> Procura strings imprimíveis em um arquivo objeto ou binário.
+> Mais informações: <https://manned.org/strings>.
+
+- Imprime todas as strings em um binário:
+
+`strings {{caminho/para/arquivo}}`
+
+- Limita resultados a strings com pelo menos n caracteres:
+
+`strings -n {{n}} {{caminho/para/arquivo}}`
+
+- Prefixa cada resultado com seu deslocamento dentro do arquivo:
+
+`strings -t d {{caminho/para/arquivo}}`
+
+- Prefixa cada resultado com seu deslocamento dentro do arquivo em hexadecimal:
+
+`strings -t x {{caminho/para/arquivo}}`

--- a/pages.pt_BR/common/tldr-lint.md
+++ b/pages.pt_BR/common/tldr-lint.md
@@ -1,0 +1,16 @@
+# tldr-lint
+
+> Faz lint e formata páginas `tldr`.
+> Mais informações: <https://github.com/tldr-pages/tldr-lint>.
+
+- Faz lint de todas páginas:
+
+`tldr-lint {{diretorio_paginas}}`
+
+- Formata uma página específica para `stdout`:
+
+`tldr-lint --format {{page.md}}`
+
+- Formata todas as páginas no mesmo lugar em que estão:
+
+`tldr-lint --format --in-place {{diretorio_pagina}}`

--- a/pages.pt_BR/common/tlmgr-platform.md
+++ b/pages.pt_BR/common/tlmgr-platform.md
@@ -1,0 +1,24 @@
+# tlmgr platform
+
+> Gerencia plataformas de TeX Live.
+> Mais informações: <https://www.tug.org/texlive/tlmgr.html>.
+
+- Lista todas as plataformas disponíveis no repositório de pacotes:
+
+`tlmgr platform list`
+
+- Adiciona os executáveis de uma plataforma específica:
+
+`sudo tlmgr platform add {{plataforma}}`
+
+- Remove os executáveis de uma plataforma específica:
+
+`sudo tlmgr platform remove {{plataforma}}`
+
+- Detecta automaticamente e troca para a plataforma atual:
+
+`sudo tlmgr platform set auto`
+
+- Troca para uma plataforma específica:
+
+`sudo tlmgr platform set {{plataforma}}`

--- a/pages.pt_BR/common/todo.md
+++ b/pages.pt_BR/common/todo.md
@@ -1,0 +1,32 @@
+# todo
+
+> Um gerenciador de tarefas simples, de interface de linha de comando e em conformidade com os padrões.
+> Mais informações: <https://todoman.readthedocs.io>.
+
+- Lista tarefas iniciáveis:
+
+`todo list --startable`
+
+- Adiciona uma nova tarefa à lista de trabalho:
+
+`todo new {{coisas_para_fazer}} --list {{trabalho}}`
+
+- Adiciona um local para uma tarefa com um ID provido:
+
+`todo edit --location {{nome_local}} {{id_tarefa}}`
+
+- Mostra detalhes sobre uma tarefa:
+
+`todo show {{id_tarefa}}`
+
+- Marca tarefas com os IDs especificados como concluídas:
+
+`todo done {{id_tarefa1 id_tarefa2 ...}}`
+
+- Exclui uma tarefa:
+
+`todo delete {{task_id}}`
+
+- Exclui tarefas concluídas e redefine os IDs das tarefas restantes:
+
+`todo flush`

--- a/pages.pt_BR/common/transmission-cli.md
+++ b/pages.pt_BR/common/transmission-cli.md
@@ -1,0 +1,37 @@
+# transmission-cli
+
+> Um cliente BitTorrent leve e de linha de comando.
+> Esta ferramenta foi descontinuada. Por favor, veja `transmission-remote`.
+> Mais informações: <https://transmissionbt.com>.
+
+- Baixa um torrent específico:
+
+`transmission-cli {{url|magnet|caminho/para/arquivo}}`
+
+- Baixa um torrent para um diretório específico:
+
+`transmission-cli --download-dir {{caminho/para/diretório_download}} {{url|magnet|caminho/para/arquivo}}`
+
+- Cria um arquivo torrent de um arquivo ou diretório específico:
+
+`transmission-cli --new {{caminho/para/arquivo_ou_diretório_origem}}`
+
+- Especifica o limite de velocidade de download (em KB/s):
+
+`transmission-cli --downlimit {{50}} {{url|magnet|caminho/para/arquivo}}`
+
+- Especifica o limite de velocidade de upload (em KB/s):
+
+`transmission-cli --uplimit {{50}} {{url|magnet|caminho/para/arquivo}}`
+
+- Usa uma porta específica para conexões:
+
+`transmission-cli --port {{número_porta}} {{url|magnet|caminho/para/arquivo}}`
+
+- Força criptografia para conexões com pares:
+
+`transmission-cli --encryption-required {{url|magnet|caminho/para/arquivo}}`
+
+- Usa uma lista de bloqueio de pares formatados em Bluetack:
+
+`transmission-cli --blocklist {{url_lista_bloqueio|caminho/para/lista_bloqueio}} {{url|magnet|caminho/para/arquivo}}`

--- a/pages.pt_BR/common/transmission-create.md
+++ b/pages.pt_BR/common/transmission-create.md
@@ -1,0 +1,25 @@
+# transmission-create
+
+> Cria arquivos BitTorrent `.torrent`.
+> Veja também: `transmission`.
+> Mais informações: <https://manned.org/transmission-create>.
+
+- Cria um torrent com 2048 KB como o tamanho da parte:
+
+`transmission-create -o {{caminho/para/exemplo.torrent}} --tracker {{url_anuncio_tracker}} --piecesize {{2048}} {{caminho/para/arquivo_ou_diretório}}`
+
+- Cria um torrent privado com um tamanho de parte de 2048 KB:
+
+`transmission-create -p -o {{caminho/para/exemplo.torrent}} --tracker {{url_anuncio_tracker}} --piecesize {{2048}} {{caminho/para/arquivo_ou_diretório}}`
+
+- Cria um torrent com um comentário:
+
+`transmission-create -o {{caminho/para/exemplo.torrent}} --tracker {{url_rastreador1}} -c {{comentário}} {{caminho/para/arquivo_ou_diretório}}`
+
+- Cria um torrent com vários rastreadores:
+
+`transmission-create -o {{caminho/para/exemplo.torrent}} --tracker {{url_rastreador1}} --tracker {{url_rastreador2}} {{caminho/para/arquivo_ou_diretório}}`
+
+- Exibe a página de ajuda:
+
+`transmission-create --help`

--- a/pages.pt_BR/common/transmission-daemon.md
+++ b/pages.pt_BR/common/transmission-daemon.md
@@ -1,0 +1,21 @@
+# transmission-daemon
+
+> Daemon controlado com `transmission-remote` ou sua interface web.
+> Veja também: `transmission`.
+> Mais informações: <https://manned.org/transmission-daemon>.
+
+- Inicia uma sessão headless `transmission`:
+
+`transmission-daemon`
+
+- Inicia e acompanha um diretório específico por novos torrents:
+
+`transmission-daemon --watch-dir {{caminho/para/diretorio}}`
+
+- Despeja configurações do daemon em formato JSON:
+
+`transmission-daemon --dump-settings > {{caminho/para/arquivo.json}}`
+
+- Inicia com configurações específicas para a interface web:
+
+`transmission-daemon --auth --username {{usuario}} --password {{senha}} --port {{9091}} --allowed {{127.0.0.1}}`

--- a/pages.pt_BR/common/transmission-edit.md
+++ b/pages.pt_BR/common/transmission-edit.md
@@ -1,0 +1,13 @@
+# transmission-edit
+
+> Modifica URLs de anúncio a partir de arquivos de torrent.
+> Veja também: `transmission`.
+> Mais informações: <https://manned.org/transmission-edit>.
+
+- Adiciona ou remove uma URL a partir da lista de anúncio do torrent:
+
+`transmission-edit --{{add|delete}} {{http://exemplo.com}} {{caminho/para/arquivo.torrent}}`
+
+- Atualiza um código do rastreador em um arquivo de torrent:
+
+`transmission-edit --replace {{antigo-código}} {{novo-código}} {{caminho/para/arquivo.torrent}}`

--- a/pages.pt_BR/common/transmission-remote.md
+++ b/pages.pt_BR/common/transmission-remote.md
@@ -1,0 +1,32 @@
+# transmission-remote
+
+> Utilitário de controle remoto para `transmission-daemon` e `transmission`.
+> Mais informações: <https://transmissionbt.com>.
+
+- Adiciona um arquivo torrent ou link magnético para o Transmission e baixa para um diretório específico:
+
+`transmission-remote {{hostname}} -a {{torrent|url}} -w {{/caminho/para/diretorio_download}}`
+
+- Altera o diretório de download padrão:
+
+`transmission-remote {{hostname}} -w {{/caminho/para/diretorio_download}}`
+
+- Lista todos os torrents:
+
+`transmission-remote {{hostname}} --list`
+
+- Inicia os torrents 1 e 2, interrompe o torrent 3:
+
+`transmission-remote {{hostname}} -t "{{1,2}}" --start -t {{3}} --stop`
+
+- Remove os torrents 1 e 2 e também exclui dados locais do torrent 2:
+
+`transmission-remote {{hostname}} -t {{1}} --remove -t {{2}} --remove-and-delete`
+
+- Interrompe todos os torrents:
+
+`transmission-remote {{hostname}} -t {{all}} --stop`
+
+- Move os torrents 1-10 e 15-20 para um novo diretório (que será criado se não existir):
+
+`transmission-remote {{hostname}} -t "{{1-10,15-20}}" --move {{/caminho/para/nodo_diretorio}}`

--- a/pages.pt_BR/common/transmission-show.md
+++ b/pages.pt_BR/common/transmission-show.md
@@ -1,0 +1,17 @@
+# transmission-show
+
+> Obtém informações sobre um arquivo torrent.
+> Veja também: `transmission`.
+> Mais informações: <https://manned.org/transmission-show>.
+
+- Exibe metadados para um torrent específico:
+
+`transmission-show {{caminho/para/arquivo.torrent}}`
+
+- Gera um link magnético para um torrent específico:
+
+`transmission-show --magnet {{caminho/para/arquivo.torrent}}`
+
+- Consulta os rastreadores de um torrent e imprime o número atual de pares:
+
+`transmission-show --scrape {{caminho/para/arquivo.torrent}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
