### PR TITLE
ollama: add link to model list

### DIFF
--- a/pages/common/ollama.md
+++ b/pages/common/ollama.md
@@ -1,6 +1,7 @@
 # ollama
 
 > A large language model runner.
+> For a list of available models, see <https://ollama.com/library>.
 > More information: <https://github.com/ollama/ollama>.
 
 - Start the daemon required to run other commands:


### PR DESCRIPTION
This link is necessary, because model ids from the list are required to access/use models using ollama, but it can not be viewed through the `ollama` command.

---

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** v0.3.12
