### PR TITLE
launchd: Remove wrong auto-generated alias pages

### DIFF
--- a/pages.de/osx/launchd.md
+++ b/pages.de/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Dieser Befehl ist ein Alias von `launchctl`.
-> Weitere Informationen: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Zeige die Dokumentation für den originalen Befehl an:
-
-`tldr launchctl`

--- a/pages.es/osx/launchd.md
+++ b/pages.es/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Este comando es un alias de `launchctl`.
-> Más información: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Muestra la documentación del comando original:
-
-`tldr launchctl`

--- a/pages.fr/osx/launchd.md
+++ b/pages.fr/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Cette commande est un alias de `launchctl`.
-> Plus d'informations : <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Voir la documentation de la commande originale :
-
-`tldr launchctl`

--- a/pages.hi/osx/launchd.md
+++ b/pages.hi/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> यह आदेश `launchctl` का उपनाम है।
-> अधिक जानकारी: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>।
-
-- मूल आदेश के लिए दस्तावेज़ देखें:
-
-`tldr launchctl`

--- a/pages.id/osx/launchd.md
+++ b/pages.id/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Perintah ini merupakan alias dari `launchctl`.
-> Informasi lebih lanjut: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Tampilkan dokumentasi untuk perintah asli:
-
-`tldr launchctl`

--- a/pages.it/osx/launchd.md
+++ b/pages.it/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Questo comando è un alias per `launchctl`.
-> Maggiori informazioni: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Consulta la documentazione del comando originale:
-
-`tldr launchctl`

--- a/pages.ko/osx/launchd.md
+++ b/pages.ko/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> 이 명령은 `launchctl` 의 에일리어스 (별칭) 입니다.
-> 더 많은 정보: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- 원본 명령의 도큐멘테이션 (설명서) 보기:
-
-`tldr launchctl`

--- a/pages.ne/osx/launchd.md
+++ b/pages.ne/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> यो आदेश `launchctl` को उपनाम हो |
-> थप जानकारी: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>।
-
-- मौलिक आदेशको लागि कागजात हेर्नुहोस्:
-
-`tldr launchctl`

--- a/pages.pl/osx/launchd.md
+++ b/pages.pl/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> To polecenie jest aliasem `launchctl`.
-> Więcej informacji: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Zobacz dokumentację oryginalnego polecenia:
-
-`tldr launchctl`

--- a/pages.pt_PT/osx/launchd.md
+++ b/pages.pt_PT/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> Este comando é um alias de `launchctl`.
-> Mais informações: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- Exibe documentação do comando original:
-
-`tldr launchctl`

--- a/pages.th/osx/launchd.md
+++ b/pages.th/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `launchctl`
-> ข้อมูลเพิ่มเติม: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>
-
-- เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
-
-`tldr launchctl`

--- a/pages.zh/osx/launchd.md
+++ b/pages.zh/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> 这是 `launchctl` 命令的一个别名。
-> 更多信息：<https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- 原命令的文档在：
-
-`tldr launchctl`

--- a/pages.zh_TW/osx/launchd.md
+++ b/pages.zh_TW/osx/launchd.md
@@ -1,8 +1,0 @@
-# launchd
-
-> 這是 `launchctl` 命令的一個別名。
-> 更多資訊：<https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html>.
-
-- 原命令的文件在：
-
-`tldr launchctl`


### PR DESCRIPTION
This is the first PR to fix #12747. I checked each code history, if there exists a correct version, I will revert the page to that version. Otherwise, I will delete the page.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
