### PR TITLE
ver,virtualboxvm,vol,vswhere,w32tm: add Korean translation

### DIFF
--- a/pages.ko/windows/ver.md
+++ b/pages.ko/windows/ver.md
@@ -1,0 +1,8 @@
+# ver
+
+> 현재 Windows 또는 MS-DOS 버전 번호를 표시합니다.
+> 더 많은 정보: <https://learn.microsoft.com/windows-server/administration/windows-commands/ver>.
+
+- 현재 버전 번호 표시:
+
+`ver`

--- a/pages.ko/windows/virtualboxvm.md
+++ b/pages.ko/windows/virtualboxvm.md
@@ -1,0 +1,24 @@
+# virtualboxvm
+
+> VirtualBox 가상 머신을 관리합니다.
+> 더 많은 정보: <https://www.virtualbox.org>.
+
+- 가상 머신 시작:
+
+`virtualboxvm --startvm {{이름|uuid}}`
+
+- 전체 화면 모드로 가상 머신 시작:
+
+`virtualboxvm --startvm {{name|uuid}} --fullscreen`
+
+- 지정된 DVD 이미지 파일 마운트:
+
+`virtualboxvm --startvm {{이름|uuid}} --dvd {{경로\대상\이미지_파일}}`
+
+- 디버그 정보가 포함된 명령줄 창 표시:
+
+`virtualboxvm --startvm {{이름|uuid}} --debug-command-line`
+
+- 일시 중지된 상태로 가상 머신 시작:
+
+`virtualboxvm --startvm {{이름|uuid}} --start-paused`

--- a/pages.ko/windows/virtualboxvm.md
+++ b/pages.ko/windows/virtualboxvm.md
@@ -9,7 +9,7 @@
 
 - 전체 화면 모드로 가상 머신 시작:
 
-`virtualboxvm --startvm {{name|uuid}} --fullscreen`
+`virtualboxvm --startvm {{이름|uuid}} --fullscreen`
 
 - 지정된 DVD 이미지 파일 마운트:
 

--- a/pages.ko/windows/vol.md
+++ b/pages.ko/windows/vol.md
@@ -1,0 +1,12 @@
+# vol
+
+> 볼륨에 대한 정보를 표시합니다.
+> 더 많은 정보: <https://learn.microsoft.com/windows-server/administration/windows-commands/vol>.
+
+- 현재 드라이브에 대한 볼륨 레이블 및 일련 번호 표시:
+
+`vol`
+
+- 특정 볼륨에 대한 볼륨 레이블 및 일련 번호 표시:
+
+`vol {{D:}}`

--- a/pages.ko/windows/vswhere.md
+++ b/pages.ko/windows/vswhere.md
@@ -1,0 +1,20 @@
+# vswhere
+
+> Visual Studio 2017 및 더 최신 설치를 찾습니다.
+> 더 많은 정보: <https://github.com/microsoft/vswhere>.
+
+- vcvarsall.bat의 경로를 찾아 환경 변수를 설정:
+
+`vswhere -products * -latest -prerelease -find **\VC\Auxiliary\Build\vcvarsall.bat`
+
+- x64 MSVC 컴파일러 (cl.exe 등)의 디렉토리 찾기:
+
+`vswhere -products * -latest -prerelease -find **\Hostx64\x64\*`
+
+- Visual Studio에 포함된 Clang (clang-cl, clang-tidy 등)의 디렉토리 찾기:
+
+`vswhere -products * -latest -prerelease -find **\Llvm\bin\*`
+
+- `MSBuild.exe`의 경로 찾기:
+
+`vswhere -products * -latest -prerelease -find MSBuild\**\Bin\MSBuild.exe`

--- a/pages.ko/windows/w32tm.md
+++ b/pages.ko/windows/w32tm.md
@@ -1,0 +1,32 @@
+# w32tm
+
+> w32time 시간 동기화 서비스를 쿼리하고 제어합니다.
+> 더 많은 정보: <https://learn.microsoft.com/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings>.
+
+- 시간 동기화의 현재 상태 표시:
+
+`w32tm /query /status /verbose`
+
+- 시간 서버에 대한 시간 오프셋 그래프 표시:
+
+`w32tm /stripchart /computer:{{시간_서버}}`
+
+- 시간 서버에서 NTP 응답 표시:
+
+`w32tm /stripchart /packetinfo /samples:1 /computer:{{시간_서버}}`
+
+- 현재 사용되는 시간 서버의 상태 표시:
+
+`w32tm /query /peers`
+
+- w32time 서비스의 구성 표시 (관리자 권한으로 실행):
+
+`w32tm /query /configuration`
+
+- 강제 시간 재동기화를 즉시 실행 (관리자 권한으로 실행):
+
+`w32tm /resync /force`
+
+- w32time 디버그 로그를 파일에 쓰기 (관리자 권한으로 실행):
+
+`w32tm /debug /enable /file:{{경로\대상\debug.log}} /size:{{10000000}} /entries:{{0-300}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
