### PR TITLE
freebsd/base64, osx/base64: refresh page, duplicate osx to freebsd, and add Indonesian translation

### DIFF
--- a/pages.id/freebsd/base64.md
+++ b/pages.id/freebsd/base64.md
@@ -1,0 +1,28 @@
+# base64
+
+> Lakukan pengodean dan pendekodean terhadap suatu berkas atau `stdin` dari/menuju format Base64, menuju `stdout` atau berkas lainnya.
+> Informasi lebih lanjut: <https://man.freebsd.org/cgi/man.cgi?query=base64>.
+
+- Kodekan isi suatu berkas menuju format Base64, dan keluarkan hasil menuju `stdout`:
+
+`base64 {{-i|--input}} {{jalan/menuju/berkas}}`
+
+- Kodekan isi suatu berkas menuju format Base64, dan keluarkan hasil menuju suatu berkas luaran/output:
+
+`base64 {{-i|--input}} {{jalan/menuju/berkas_input}} {{-o|--output}} {{jalan/menuju/berkas_output}}`
+
+- Bungkus luaran Base64 dalam panjang karakter yang tetap (nilai `0` akan menonaktifkan pembungkusan):
+
+`base64 {{-b|--break}} {{0|76|...}} {{jalan/menuju/berkas}}`
+
+- Dekodekan kode Base64 yang tersimpan dalam suatu berkas, dan keluarkan hasil menuju `stdout`:
+
+`base64 {{-d|--decode}} {{-i|--input}} {{jalan/menuju/berkas}}`
+
+- Kodekan isi dari `stdin` menuju `stdout`:
+
+`{{perintah}} | base64`
+
+- Dekodekan kode Base64 yang berasal dari `stdin` menuju `stdout`:
+
+`{{perintah}} | base64 {{-d|--decode}}`

--- a/pages.id/osx/base64.md
+++ b/pages.id/osx/base64.md
@@ -1,0 +1,28 @@
+# base64
+
+> Lakukan pengodean dan pendekodean terhadap suatu berkas atau `stdin` dari/menuju format Base64, menuju `stdout` atau berkas lainnya.
+> Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+
+- Kodekan isi suatu berkas menuju format Base64, dan keluarkan hasil menuju `stdout`:
+
+`base64 {{-i|--input}} {{jalan/menuju/berkas}}`
+
+- Kodekan isi suatu berkas menuju format Base64, dan keluarkan hasil menuju suatu berkas luaran/output:
+
+`base64 {{-i|--input}} {{jalan/menuju/berkas_input}} {{-o|--output}} {{jalan/menuju/berkas_output}}`
+
+- Bungkus luaran Base64 dalam panjang karakter yang tetap (nilai `0` akan menonaktifkan pembungkusan):
+
+`base64 {{-b|--break}} {{0|76|...}} {{jalan/menuju/berkas}}`
+
+- Dekodekan kode Base64 yang tersimpan dalam suatu berkas, dan keluarkan hasil menuju `stdout`:
+
+`base64 {{-d|--decode}} {{-i|--input}} {{jalan/menuju/berkas}}`
+
+- Kodekan isi dari `stdin` menuju `stdout`:
+
+`{{perintah}} | base64`
+
+- Dekodekan kode Base64 yang berasal dari `stdin` menuju `stdout`:
+
+`{{perintah}} | base64 {{-d|--decode}}`

--- a/pages/freebsd/base64.md
+++ b/pages/freebsd/base64.md
@@ -1,0 +1,28 @@
+# base64
+
+> Encode or decode file or `stdin` to/from base64, to `stdout` or another file.
+> More information: <https://man.freebsd.org/cgi/man.cgi?query=base64>.
+
+- Encode a file to `stdout`:
+
+`base64 {{-i|--input}} {{path/to/file}}`
+
+- Encode a file to the specified output file:
+
+`base64 {{-i|--input}} {{path/to/input_file}} {{-o|--output}} {{path/to/output_file}}`
+
+- Wrap encoded output at a specific width (`0` disables wrapping):
+
+`base64 {{-b|--break}} {{0|76|...}} {{path/to/file}}`
+
+- Decode a file to `stdout`:
+
+`base64 {{-d|--decode}} {{-i|--input}} {{path/to/file}}`
+
+- Encode from `stdin` to `stdout`:
+
+`{{command}} | base64`
+
+- Decode from `stdin` to `stdout`:
+
+`{{command}} | base64 {{-d|--decode}}`

--- a/pages/osx/base64.md
+++ b/pages/osx/base64.md
@@ -1,20 +1,28 @@
 # base64
 
-> Encode and decode using Base64 representation.
+> Encode or decode file or `stdin` to/from base64, to `stdout` or another file.
 > More information: <https://keith.github.io/xcode-man-pages/base64.1.html>.
 
-- Encode a file:
+- Encode a file to `stdout`:
 
-`base64 --input={{plain_file}}`
+`base64 {{-i|--input}} {{path/to/file}}`
 
-- Decode a file:
+- Encode a file to the specified output file:
 
-`base64 --decode --input={{base64_file}}`
+`base64 {{-i|--input}} {{path/to/input_file}} {{-o|--output}} {{path/to/output_file}}`
 
-- Encode from `stdin`:
+- Wrap encoded output at a specific width (`0` disables wrapping):
 
-`echo -n "{{plain_text}}" | base64`
+`base64 {{-b|--break}} {{0|76|...}} {{path/to/file}}`
 
-- Decode from `stdin`:
+- Decode a file to `stdout`:
 
-`echo -n {{base64_text}} | base64 --decode`
+`base64 {{-d|--decode}} {{-i|--input}} {{path/to/file}}`
+
+- Encode from `stdin` to `stdout`:
+
+`{{command}} | base64`
+
+- Decode from `stdin` to `stdout`:
+
+`{{command}} | base64 {{-d|--decode}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

On #13807 I originally promised to migrate existing translations of `common/base64` to `osx/base64` (and `freebsd/base64`). But since the macOS and FreeBSD's `base64` command has an additional feature (i.e. to write the output directly to file), I can only provide the English and Indonesian translations right now.

I am aware that the macOS manpage also include references to `b64decode` and `b64encode`, but these commands are not available as of macOS Sonoma although `uudecode` and `uuencode` exist. The former commands might be available on FreeBSD but further confirmation is required.