### PR TITLE
iwctl: fix more info link

### DIFF
--- a/pages/linux/iwctl.md
+++ b/pages/linux/iwctl.md
@@ -1,7 +1,7 @@
 # iwctl
 
 > Control the `iwd` network supplicant.
-> More information: <https://iwd.wiki.kernel.org/gettingstarted>.
+> More information: <https://archive.kernel.org/oldwiki/iwd.wiki.kernel.org/gettingstarted.html>.
 
 - Start the interactive mode, in this mode you can enter the commands directly, with autocompletion:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).