### PR TITLE
wget: Remove wrong auto-generated alias pages

### DIFF
--- a/pages.ar/windows/wget.md
+++ b/pages.ar/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> هذا الأمر هو اسم مستعار لـ `wget -p common`.
-> لمزيد من التفاصيل: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- إعرض التوثيقات للأمر الأصلي:
-
-`tldr wget -p common`

--- a/pages.bs/windows/wget.md
+++ b/pages.bs/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Ova komanda je pseudonim za `wget -p common`.
-> Više informacija: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Pogledaj dokumentaciju za izvornu komandu:
-
-`tldr wget -p common`

--- a/pages.ca/windows/wget.md
+++ b/pages.ca/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Aquest comandament és un àlies de `wget -p common`.
-> Més informació: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Veure documentació pel comandament original:
-
-`tldr wget -p common`

--- a/pages.da/windows/wget.md
+++ b/pages.da/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Denne kommando er et alias af `wget -p common`.
-> Mere information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Se dokumentation for den oprindelige kommando:
-
-`tldr wget -p common`

--- a/pages.es/windows/wget.md
+++ b/pages.es/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Este comando es un alias de `wget -p common`.
-> Más información: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Muestra la documentación del comando original:
-
-`tldr wget -p common`

--- a/pages.fr/windows/wget.md
+++ b/pages.fr/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Cette commande est un alias de `wget -p common`.
-> Plus d'informations : <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Voir la documentation de la commande originale :
-
-`tldr wget -p common`

--- a/pages.hi/windows/wget.md
+++ b/pages.hi/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> यह आदेश `wget -p common` का उपनाम है।
-> अधिक जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>।
-
-- मूल आदेश के लिए दस्तावेज़ देखें:
-
-`tldr wget -p common`

--- a/pages.it/windows/wget.md
+++ b/pages.it/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Questo comando è un alias per `wget -p common`.
-> Maggiori informazioni: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Consulta la documentazione del comando originale:
-
-`tldr wget -p common`

--- a/pages.ja/windows/wget.md
+++ b/pages.ja/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> このコマンドは `wget -p common` のエイリアスです。
-> 詳しくはこちら: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>
-
-- オリジナルのコマンドのドキュメントを表示する:
-
-`tldr wget -p common`

--- a/pages.ko/windows/wget.md
+++ b/pages.ko/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> 이 명령은 `wget -p common` 의 에일리어스 (별칭) 입니다.
-> 더 많은 정보: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 원본 명령의 도큐멘테이션 (설명서) 보기:
-
-`tldr wget -p common`

--- a/pages.lo/windows/wget.md
+++ b/pages.lo/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> ຄຳສັ່ງນີ້ເປັນອີກຊື່ໜຶ່ງຂອງຄຳສັ່ງ `wget -p common`.
-> ຂໍ້ມູນເພີ່ມເຕີມ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
-
-`tldr wget -p common`

--- a/pages.ml/windows/wget.md
+++ b/pages.ml/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> ഈ കമാൻഡ് `wget -p common` എന്നത്തിന്റെ അപരനാമമാണ്.
-> കൂടുതൽ വിവരങ്ങൾ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
-
-`tldr wget -p common`

--- a/pages.ne/windows/wget.md
+++ b/pages.ne/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> यो आदेश `wget -p common` को उपनाम हो |
-> थप जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>।
-
-- मौलिक आदेशको लागि कागजात हेर्नुहोस्:
-
-`tldr wget -p common`

--- a/pages.no/windows/wget.md
+++ b/pages.no/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Denne kommandoen er et alias for `wget -p common`.
-> Mer informasjon: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Vis dokumentasjonen for den opprinnelige kommandoen:
-
-`tldr wget -p common`

--- a/pages.pt_PT/windows/wget.md
+++ b/pages.pt_PT/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Este comando é um alias de `wget -p common`.
-> Mais informações: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Exibe documentação do comando original:
-
-`tldr wget -p common`

--- a/pages.ru/windows/wget.md
+++ b/pages.ru/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Эта команда — псевдоним для `wget -p common`.
-> Больше информации: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Смотри документацию для оригинальной команды:
-
-`tldr wget -p common`

--- a/pages.sv/windows/wget.md
+++ b/pages.sv/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Det här kommandot är ett alias för `wget -p common`.
-> Mer information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Se dokumentationen för orginalkommandot:
-
-`tldr wget -p common`

--- a/pages.th/windows/wget.md
+++ b/pages.th/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `wget -p common`
-> ข้อมูลเพิ่มเติม: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>
-
-- เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
-
-`tldr wget -p common`

--- a/pages.tr/windows/wget.md
+++ b/pages.tr/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Bu komut `wget -p common` için bir takma addır.
-> Daha fazla bilgi için: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Asıl komutun belgelerini görüntüleyin:
-
-`tldr wget -p common`

--- a/pages.uk/windows/wget.md
+++ b/pages.uk/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> Ця команда є псевдонімом для `wget -p common`.
-> Більше інформації: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Дивись документацію для оригінальної команди:
-
-`tldr wget -p common`

--- a/pages.zh/windows/wget.md
+++ b/pages.zh/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> 这是 `wget -p common` 命令的一个别名。
-> 更多信息：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 原命令的文档在：
-
-`tldr wget -p common`

--- a/pages.zh_TW/windows/wget.md
+++ b/pages.zh_TW/windows/wget.md
@@ -1,8 +1,0 @@
-# wget
-
-> 這是 `wget -p common` 命令的一個別名。
-> 更多資訊：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 原命令的文件在：
-
-`tldr wget -p common`


### PR DESCRIPTION
I checked each code history, if there exists a correct version, I will revert the page to that version. Otherwise, I will delete the page.

Unaffected translations: [en](https://github.com/tldr-pages/tldr/blob/main/pages.en/windows/wget.md), [bn](https://github.com/tldr-pages/tldr/blob/main/pages.bn/windows/wget.md), [de](https://github.com/tldr-pages/tldr/blob/main/pages.de/windows/wget.md), [id](https://github.com/tldr-pages/tldr/blob/main/pages.id/windows/wget.md), [nl](https://github.com/tldr-pages/tldr/blob/main/pages.nl/windows/wget.md), [pl](https://github.com/tldr-pages/tldr/blob/main/pages.pl/windows/wget.md), [pt_BR](https://github.com/tldr-pages/tldr/blob/main/pages.pt_BR/windows/wget.md), [ta](https://github.com/tldr-pages/tldr/blob/main/pages.ta/windows/wget.md)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
