### PR TITLE
windows/curl: remove wrong auto-generated alias pages

### DIFF
--- a/pages.ar/windows/curl.md
+++ b/pages.ar/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> هذا الأمر هو اسم مستعار لـ `curl -p common`.
-> لمزيد من التفاصيل: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- إعرض التوثيقات للأمر الأصلي:
-
-`tldr curl -p common`

--- a/pages.bs/windows/curl.md
+++ b/pages.bs/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Ova komanda je pseudonim za `curl -p common`.
-> Više informacija: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Pogledaj dokumentaciju za izvornu komandu:
-
-`tldr curl -p common`

--- a/pages.ca/windows/curl.md
+++ b/pages.ca/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Aquest comandament és un àlies de `curl -p common`.
-> Més informació: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Veure documentació pel comandament original:
-
-`tldr curl -p common`

--- a/pages.da/windows/curl.md
+++ b/pages.da/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Denne kommando er et alias af `curl -p common`.
-> Mere information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Se dokumentation for den oprindelige kommando:
-
-`tldr curl -p common`

--- a/pages.es/windows/curl.md
+++ b/pages.es/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Este comando es un alias de `curl -p common`.
-> Más información: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Muestra la documentación del comando original:
-
-`tldr curl -p common`

--- a/pages.fr/windows/curl.md
+++ b/pages.fr/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Cette commande est un alias de `curl -p common`.
-> Plus d'informations : <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Voir la documentation de la commande originale :
-
-`tldr curl -p common`

--- a/pages.hi/windows/curl.md
+++ b/pages.hi/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> यह आदेश `curl -p common` का उपनाम है।
-> अधिक जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>।
-
-- मूल आदेश के लिए दस्तावेज़ देखें:
-
-`tldr curl -p common`

--- a/pages.it/windows/curl.md
+++ b/pages.it/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Questo comando è un alias per `curl -p common`.
-> Maggiori informazioni: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Consulta la documentazione del comando originale:
-
-`tldr curl -p common`

--- a/pages.ja/windows/curl.md
+++ b/pages.ja/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> このコマンドは `curl -p common` のエイリアスです。
-> 詳しくはこちら: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>
-
-- オリジナルのコマンドのドキュメントを表示する:
-
-`tldr curl -p common`

--- a/pages.ko/windows/curl.md
+++ b/pages.ko/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> 이 명령은 `curl -p common` 의 에일리어스 (별칭) 입니다.
-> 더 많은 정보: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 원본 명령의 도큐멘테이션 (설명서) 보기:
-
-`tldr curl -p common`

--- a/pages.lo/windows/curl.md
+++ b/pages.lo/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> ຄຳສັ່ງນີ້ເປັນອີກຊື່ໜຶ່ງຂອງຄຳສັ່ງ `curl -p common`.
-> ຂໍ້ມູນເພີ່ມເຕີມ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
-
-`tldr curl -p common`

--- a/pages.ml/windows/curl.md
+++ b/pages.ml/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> ഈ കമാൻഡ് `curl -p common` എന്നത്തിന്റെ അപരനാമമാണ്.
-> കൂടുതൽ വിവരങ്ങൾ: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
-
-`tldr curl -p common`

--- a/pages.ne/windows/curl.md
+++ b/pages.ne/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> यो आदेश `curl -p common` को उपनाम हो |
-> थप जानकारी: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>।
-
-- मौलिक आदेशको लागि कागजात हेर्नुहोस्:
-
-`tldr curl -p common`

--- a/pages.no/windows/curl.md
+++ b/pages.no/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Denne kommandoen er et alias for `curl -p common`.
-> Mer informasjon: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Vis dokumentasjonen for den opprinnelige kommandoen:
-
-`tldr curl -p common`

--- a/pages.pt_PT/windows/curl.md
+++ b/pages.pt_PT/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Este comando é um alias de `curl -p common`.
-> Mais informações: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Exibe documentação do comando original:
-
-`tldr curl -p common`

--- a/pages.ru/windows/curl.md
+++ b/pages.ru/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Эта команда — псевдоним для `curl -p common`.
-> Больше информации: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Смотри документацию для оригинальной команды:
-
-`tldr curl -p common`

--- a/pages.sv/windows/curl.md
+++ b/pages.sv/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Det här kommandot är ett alias för `curl -p common`.
-> Mer information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Se dokumentationen för orginalkommandot:
-
-`tldr curl -p common`

--- a/pages.th/windows/curl.md
+++ b/pages.th/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `curl -p common`
-> ข้อมูลเพิ่มเติม: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>
-
-- เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
-
-`tldr curl -p common`

--- a/pages.tr/windows/curl.md
+++ b/pages.tr/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Bu komut `curl -p common` için bir takma addır.
-> Daha fazla bilgi için: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Asıl komutun belgelerini görüntüleyin:
-
-`tldr curl -p common`

--- a/pages.uk/windows/curl.md
+++ b/pages.uk/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> Ця команда є псевдонімом для `curl -p common`.
-> Більше інформації: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- Дивись документацію для оригінальної команди:
-
-`tldr curl -p common`

--- a/pages.zh/windows/curl.md
+++ b/pages.zh/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> 这是 `curl -p common` 命令的一个别名。
-> 更多信息：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 原命令的文档在：
-
-`tldr curl -p common`

--- a/pages.zh_TW/windows/curl.md
+++ b/pages.zh_TW/windows/curl.md
@@ -1,8 +1,0 @@
-# curl
-
-> 這是 `curl -p common` 命令的一個別名。
-> 更多資訊：<https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
-
-- 原命令的文件在：
-
-`tldr curl -p common`


### PR DESCRIPTION
I checked each code history, if there exists a correct version, I will revert the page to that version. Otherwise, I will delete the page.

Unaffected translations: [en](https://github.com/tldr-pages/tldr/blob/main/pages/windows/curl.md), [bn](https://github.com/tldr-pages/tldr/blob/main/pages.bn/windows/curl.md), [de](https://github.com/tldr-pages/tldr/blob/main/pages.de/windows/curl.md), [id](https://github.com/tldr-pages/tldr/blob/main/pages.id/windows/curl.md), [nl](https://github.com/tldr-pages/tldr/blob/main/pages.nl/windows/curl.md), [pl](https://github.com/tldr-pages/tldr/blob/main/pages.pl/windows/curl.md), [pt_BR](https://github.com/tldr-pages/tldr/blob/main/pages.pt_BR/windows/curl.md), [ta](https://github.com/tldr-pages/tldr/blob/main/pages.ta/windows/curl.md)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
