### PR TITLE
cgroups: remove wrong auto-generated alias pages

### DIFF
--- a/pages.de/linux/cgroups.md
+++ b/pages.de/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Dieser Befehl ist ein Alias von `cgclassify`.
-> Weitere Informationen: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Zeige die Dokumentation für den originalen Befehl an:
-
-`tldr cgclassify`

--- a/pages.es/linux/cgroups.md
+++ b/pages.es/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Este comando es un alias de `cgclassify`.
-> Más información: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Muestra la documentación del comando original:
-
-`tldr cgclassify`

--- a/pages.fr/linux/cgroups.md
+++ b/pages.fr/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Cette commande est un alias de `cgclassify`.
-> Plus d'informations : <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Voir la documentation de la commande originale :
-
-`tldr cgclassify`

--- a/pages.hi/linux/cgroups.md
+++ b/pages.hi/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> यह आदेश `cgclassify` का उपनाम है।
-> अधिक जानकारी: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>।
-
-- मूल आदेश के लिए दस्तावेज़ देखें:
-
-`tldr cgclassify`

--- a/pages.id/linux/cgroups.md
+++ b/pages.id/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Perintah ini merupakan alias dari `cgclassify`.
-> Informasi lebih lanjut: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Tampilkan dokumentasi untuk perintah asli:
-
-`tldr cgclassify`

--- a/pages.it/linux/cgroups.md
+++ b/pages.it/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Questo comando è un alias per `cgclassify`.
-> Maggiori informazioni: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Consulta la documentazione del comando originale:
-
-`tldr cgclassify`

--- a/pages.ko/linux/cgroups.md
+++ b/pages.ko/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> 이 명령은 `cgclassify` 의 에일리어스 (별칭) 입니다.
-> 더 많은 정보: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- 원본 명령의 도큐멘테이션 (설명서) 보기:
-
-`tldr cgclassify`

--- a/pages.ne/linux/cgroups.md
+++ b/pages.ne/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> यो आदेश `cgclassify` को उपनाम हो |
-> थप जानकारी: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>।
-
-- मौलिक आदेशको लागि कागजात हेर्नुहोस्:
-
-`tldr cgclassify`

--- a/pages.pl/linux/cgroups.md
+++ b/pages.pl/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> To polecenie jest aliasem `cgclassify`.
-> Więcej informacji: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Zobacz dokumentację oryginalnego polecenia:
-
-`tldr cgclassify`

--- a/pages.pt_PT/linux/cgroups.md
+++ b/pages.pt_PT/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Este comando é um alias de `cgclassify`.
-> Mais informações: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Exibe documentação do comando original:
-
-`tldr cgclassify`

--- a/pages.th/linux/cgroups.md
+++ b/pages.th/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `cgclassify`
-> ข้อมูลเพิ่มเติม: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>
-
-- เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
-
-`tldr cgclassify`

--- a/pages.tr/linux/cgroups.md
+++ b/pages.tr/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> Bu komut `cgclassify` için bir takma addır.
-> Daha fazla bilgi için: <https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- Asıl komutun belgelerini görüntüleyin:
-
-`tldr cgclassify`

--- a/pages.zh/linux/cgroups.md
+++ b/pages.zh/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> 这是 `cgclassify` 命令的一个别名。
-> 更多信息：<https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- 原命令的文档在：
-
-`tldr cgclassify`

--- a/pages.zh_TW/linux/cgroups.md
+++ b/pages.zh_TW/linux/cgroups.md
@@ -1,8 +1,0 @@
-# cgroups
-
-> 這是 `cgclassify` 命令的一個別名。
-> 更多資訊：<https://www.kernel.org/doc/Documentation/cgroup-v2.txt>.
-
-- 原命令的文件在：
-
-`tldr cgclassify`


### PR DESCRIPTION
I checked each code history, if there exists a correct version, I will revert the page to that version. Otherwise, I will delete the page.

Unaffected translations: [en](https://github.com/tldr-pages/tldr/blob/main/pages/linux/cgroups.md), [nl](https://github.com/tldr-pages/tldr/blob/main/pages.nl/linux/cgroups.md), [pt_BR](https://github.com/tldr-pages/tldr/blob/main/pages.pt_BR/linux/cgroups.md), [ta](https://github.com/tldr-pages/tldr/blob/main/pages.ta/linux/cgroups.md)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
