### PR TITLE
faillock: add non-root commands

### DIFF
--- a/pages/linux/faillock.md
+++ b/pages/linux/faillock.md
@@ -3,6 +3,14 @@
 > Display and modify authentication failure record files.
 > More information: <https://manned.org/faillock>.
 
+- List login failures of the current user:
+
+`faillock`
+
+- Reset the failure records of the current user:
+
+`faillock --reset`
+
 - List login failures of all users:
 
 `sudo faillock`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
