### PR TITLE
eol, eqn, erl, ern, errno: add Korean translation

### DIFF
--- a/pages.ko/common/eol.md
+++ b/pages.ko/common/eol.md
@@ -1,0 +1,28 @@
+# eol
+
+> 여러 제품의 수명 종료 날짜(EoL)를 표시.
+> 더 많은 정보: <https://github.com/hugovk/norwegianblue>.
+
+- 사용 가능한 모든 제품의 목록을 나열:
+
+`eol`
+
+- 하나 이상의 제품에 대한 EoL을 가져옴:
+
+`eol {{제품1 제품2 ...}}`
+
+- 제품 웹페이지 열기:
+
+`eol {{제품}} --web`
+
+- 특정 형식으로 하나 이상의 제품에 대한 EoL을 가져옴노:
+
+`eol {{제품1 제품2 ...}} --format {{html|json|md|markdown|pretty|rst|csv|tsv|yaml}}`
+
+- 하나 이상의 제품에 대한 EoL을 단일 마크다운 파일로 가져옴:
+
+`eol {{제품1 제품2 ...}} --format {{마크다운}} > {{eol_보고서.md}}`
+
+- 도움말 표시:
+
+`eol --help`

--- a/pages.ko/common/eqn.md
+++ b/pages.ko/common/eqn.md
@@ -1,0 +1,13 @@
+# eqn
+
+> groff (GNU Troff) 문서 형식화 시스템용 방정식 전처리.
+> 참고: `troff` 및 `groff`.
+> 더 많은 정보: <https://manned.org/eqn>.
+
+- 방정식으로 입력을 처리하고, groff를 사용하여 향후 조판을 위해 출력을 PostScript에 저장:
+
+`eqn {{경로/대상/입력.eqn}} > {{경로/대상/출력.roff}}`
+
+- 매크로([me] macro) 패키지를 사용하여 방정식이 포함된 입력 파일을 PDF로 조판:
+
+`eqn -T {{pdf}} {{경로/대상/입력.eqn}} | groff -{{me}} -T {{pdf}} > {{경로/대상/출력.pdf}}`

--- a/pages.ko/common/erl.md
+++ b/pages.ko/common/erl.md
@@ -1,0 +1,16 @@
+# erl
+
+> Erlang 프로그래밍 언어로 프로그램을 실행하고 관리.
+> 더 많은 정보: <https://www.erlang.org>.
+
+- 순차적 Erlang 프로그램을 공통 스크립트로 컴파일하고 실행한 후 종료:
+
+`erlc {{경로/대상/파일1 경로/대상/파일2 ...}} && erl -noshell '{{mymodule:myfunction(arguments)}}, init:stop().'`
+
+- 실행중인 Erlang 노드에 연결:
+
+`erl -remsh {{노드이름}}@{{호스트명}} -sname {{커스텀_단축이름}} -hidden -setcookie {{원격노드의_쿠키}}`
+
+- 디렉터리에서 모듈을 로드하도록 Erlang 쉘에 지시:
+
+`erl -pa {{경로/대상/beam파일에_관한_디렉토리}}`

--- a/pages.ko/common/ern.md
+++ b/pages.ko/common/ern.md
@@ -1,0 +1,32 @@
+# ern
+
+> 전극 네이티브 플랫폼 명령줄 클라이언트.
+> 더 많은 정보: <https://native.electrode.io/reference/index-6>.
+
+- 새로운 `ern` 애플리케이션(`MiniApp`)을 생성:
+
+`ern create-miniapp {{애플리케이션_이름}}`
+
+- iOS/Android 러너 애플리케이션에서 하나 이상의 `MiniApps`를 실행:
+
+`ern run-{{ios|android}}`
+
+- 전극 네이티브 컨테이너 만들기:
+
+`ern create-container --miniapps {{/경로/대상/miniapp_디렉토리}} --platform {{ios|android}}`
+
+- 전극 네이티브 컨테이너를 로컬 Maven 저장소에 저장:
+
+`ern publish-container --publisher {{maven}} --platform {{android}} --extra {{'{"groupId":"com.walmart.ern","artifactId":"quickstart"}'}}`
+
+- iOS 컨테이너를 사전 컴파일된 바이너리 프레임워크로 변환:
+
+`ern transform-container --platform {{ios}} --transformer {{xcframework}}`
+
+- 설치된 모든 전극 Native 버전을 나열:
+
+`ern platform versions`
+
+- 로깅 수준을 설정:
+
+`ern platform config set logLevel {{trace|debug}}`

--- a/pages.ko/common/errno.md
+++ b/pages.ko/common/errno.md
@@ -1,0 +1,20 @@
+# errno
+
+> 오류 번호 이름과 설명을 검색.
+> 더 많은 정보: <https://joeyh.name/code/moreutils/>.
+
+- 이름이나 코드로 오류 번호 설명 조회:
+
+`errno {{name|code}}`
+
+- 모든 오류 번호 이름, 코드 및 설명을 나열:
+
+`errno --list`
+
+- 설명에 주어진 텍스트가 모두 포함된 코드를 검색:
+
+`errno --search {{텍스트}}`
+
+- 설명에 주어진 텍스트 (모든 로케일)가 모두 포함된 코드를 검색:
+
+`errno --search-all-locales {{텍스트}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
