### PR TITLE
unzip: fix incorrect descriptions

### DIFF
--- a/pages/common/unzip.md
+++ b/pages/common/unzip.md
@@ -12,11 +12,11 @@
 
 `unzip {{path/to/archive1.zip path/to/archive2.zip ...}} -d {{path/to/output}}`
 
-- Extract files/directories from archives to `stdout`:
+- Extract files/directories from archives to `stdout` alongside the extracted file names:
 
 `unzip -c {{path/to/archive1.zip path/to/archive2.zip ...}}`
 
-- Extract the contents of the file(s) to `stdout` alongside the extracted file names:
+- Extract an archive created on Windows, containing files with non-ASCII (e.g. Chinese or Japanese characters) filenames:
 
 `unzip -O {{gbk}} {{path/to/archive1.zip path/to/archive2.zip ...}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

While translating this file (#14231) I discovered incorrect descriptions happened in PR #7997, I offer to fix them:

According to UnZip 6.00 in my Linux

> -O CHARSET  specify a character encoding for DOS, Windows and OS/2 archives  

According to https://manned.org/unzip

> -c     extract files to stdout/screen (``CRT'').  This option is similar to the -p option except that the name of each file is printed as it is extracted