### PR TITLE
typst: add examples for project initialization via template

### DIFF
--- a/pages/common/typst.md
+++ b/pages/common/typst.md
@@ -4,6 +4,14 @@
 > Note: Specifying the output location is optional.
 > More information: <https://github.com/typst/typst>.
 
+- Initialize a new Typst project in a given directory using a template:
+
+`typst init "{{template}}" {{path/to/directory}}`
+
+- Initialize a new Typst project in a given directory using the `@preview/charged-ieee` template:
+
+`typst init "@preview/charged-ieee" {{path/to/directory}}`
+
 - Compile a Typst file:
 
 `typst compile {{path/to/source.typ}} {{path/to/output.pdf}}`

--- a/pages/common/typst.md
+++ b/pages/common/typst.md
@@ -4,7 +4,7 @@
 > Note: Specifying the output location is optional.
 > More information: <https://github.com/typst/typst>.
 
-- Initialize a new Typst project in a given directory using a template (e.g., "@preview/charged-ieee"):
+- Initialize a new Typst project in a given directory using a template (e.g., `@preview/charged-ieee`):
 
 `typst init "{{template}}" {{path/to/directory}}`
 

--- a/pages/common/typst.md
+++ b/pages/common/typst.md
@@ -4,13 +4,9 @@
 > Note: Specifying the output location is optional.
 > More information: <https://github.com/typst/typst>.
 
-- Initialize a new Typst project in a given directory using a template:
+- Initialize a new Typst project in a given directory using a template (e.g., "@preview/charged-ieee"):
 
 `typst init "{{template}}" {{path/to/directory}}`
-
-- Initialize a new Typst project in a given directory using the `@preview/charged-ieee` template:
-
-`typst init "@preview/charged-ieee" {{path/to/directory}}`
 
 - Compile a Typst file:
 

--- a/pages/common/typst.md
+++ b/pages/common/typst.md
@@ -4,10 +4,6 @@
 > Note: Specifying the output location is optional.
 > More information: <https://github.com/typst/typst>.
 
-- List all discoverable fonts in the system and the given directory:
-
-`typst --font-path {{path/to/fonts_directory}} fonts`
-
 - Compile a Typst file:
 
 `typst compile {{path/to/source.typ}} {{path/to/output.pdf}}`
@@ -15,3 +11,7 @@
 - Watch a Typst file and recompile on changes:
 
 `typst watch {{path/to/source.typ}} {{path/to/output.pdf}}`
+
+- List all discoverable fonts in the system and the given directory:
+
+`typst --font-path {{path/to/fonts_directory}} fonts`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.11.0

This PR adds examples for creating a new Typst project via the `typst init` command. Since this is intended to be the entry point of a Typst document, I have decided to promote this example as the top example in the page. In doing so, I have relegated the previous top example to the bottom as I believe that the `typst compile` and `typst watch` commands are more relevant in typical usage.
