### PR TITLE
oxipng: add page

### DIFF
--- a/pages/common/oxipng.md
+++ b/pages/common/oxipng.md
@@ -15,9 +15,9 @@
 
 `oxipng "{{*.png}}"`
 
-- Compress a file with a set optimization level (0-6 or max; default is 2):
+- Compress a file with a set optimization level (default is 2):
 
-`oxipng --opt {{level}} {{path/to/file.png}}`
+`oxipng --opt {{0|1|2|3|4|5|6|max}} {{path/to/file.png}}`
 
 - Set the PNG interlacing type (0 removes interlacing, 1 applies Adam7 interlacing, 'keep' preserves existing interlacing; default is 0):
 

--- a/pages/common/oxipng.md
+++ b/pages/common/oxipng.md
@@ -19,9 +19,9 @@
 
 `oxipng --opt {{0|1|2|3|4|5|6|max}} {{path/to/file.png}}`
 
-- Set the PNG interlacing type (0 removes interlacing, 1 applies Adam7 interlacing, 'keep' preserves existing interlacing; default is 0):
+- Set the PNG interlacing type (`0` removes interlacing, `1` applies Adam7 interlacing, `keep` preserves existing interlacing; default is `0`):
 
-`oxipng --interlace {{type}} {{path/to/file.png}}`
+`oxipng --interlace {{0|1|keep}} {{path/to/file.png}}`
 
 - Perform additional optimization on images with an alpha channel:
 

--- a/pages/common/oxipng.md
+++ b/pages/common/oxipng.md
@@ -1,0 +1,36 @@
+# oxipng
+
+> Losslessly improve compression of PNG files.
+> More information: <https://github.com/shssoichiro/oxipng>.
+
+- Compress a PNG file (overwrites the file by default):
+
+`oxipng {{path/to/file.png}}`
+
+- Compress a PNG file and save the output to a new file:
+
+`oxipng --out {{path/to/newfile.png}} {{path/to/file.png}}`
+
+- Compress all PNG files in the current directory using multiple threads:
+
+`oxipng "{{*.png}}"`
+
+- Compress a file with a set optimization level (0-6 or max; default is 2):
+
+`oxipng --opt {{level}} {{path/to/file.png}}`
+
+- Set the PNG interlacing type (0 removes interlacing, 1 applies Adam7 interlacing, 'keep' preserves existing interlacing; default is 0):
+
+`oxipng --interlace {{type}} {{path/to/file.png}}`
+
+- Perform additional optimization on images with an alpha channel:
+
+`oxipng --alpha {{path/to/file.png}}`
+
+- Use the much slower but stronger Zopfli compressor with max optimization:
+
+`oxipng --zopfli --opt max {{path/to/file.png}}`
+
+- Strip all non-critical metadata chunks:
+
+`oxipng --strip all {{path/to/file.png}}`

--- a/pages/common/oxipng.md
+++ b/pages/common/oxipng.md
@@ -13,7 +13,7 @@
 
 - Compress all PNG files in the current directory using multiple threads:
 
-`oxipng "{{*.png}}"`
+`oxipng "*.png"`
 
 - Compress a file with a set optimization level (default is 2):
 

--- a/pages/common/oxipng.md
+++ b/pages/common/oxipng.md
@@ -9,7 +9,7 @@
 
 - Compress a PNG file and save the output to a new file:
 
-`oxipng --out {{path/to/newfile.png}} {{path/to/file.png}}`
+`oxipng --out {{path/to/output.png}} {{path/to/file.png}}`
 
 - Compress all PNG files in the current directory using multiple threads:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 9.1.2**

[Oxipng](https://github.com/shssoichiro/oxipng) is a multithreaded lossless PNG/APNG compression optimizer written in Rust. This PR adds a page for commonly-used Oxipng commands. 🌟