### PR TITLE
pages/common/*: put `npm` in code ticks

### DIFF
--- a/pages/common/lambo-new.md
+++ b/pages/common/lambo-new.md
@@ -19,7 +19,7 @@
 
 `lambo new --{{vue|bootstrap|react}} {{app_name}}`
 
-- Install npm dependencies after the project has been created:
+- Install `npm` dependencies after the project has been created:
 
 `lambo new --node {{app_name}}`
 

--- a/pages/common/ncu.md
+++ b/pages/common/ncu.md
@@ -8,7 +8,7 @@
 
 `ncu`
 
-- List outdated global npm packages:
+- List outdated global `npm` packages:
 
 `ncu --global`
 

--- a/pages/common/npm-doctor.md
+++ b/pages/common/npm-doctor.md
@@ -3,19 +3,19 @@
 > Check the health of the npm environment.
 > More information: <https://docs.npmjs.com/cli/commands/npm-doctor>.
 
-- Run all default health checks for npm:
+- Run all default health checks for `npm`:
 
 `npm doctor`
 
-- Check the connection to the npm registry:
+- Check the connection to the `npm` registry:
 
 `npm doctor connection`
 
-- Check the versions of Node.js and npm in use:
+- Check the versions of Node.js and `npm` in use:
 
 `npm doctor versions`
 
-- Check for permissions issues with npm directories and cache:
+- Check for permissions issues with `npm` directories and cache:
 
 `npm doctor permissions`
 

--- a/pages/common/npm-home.md
+++ b/pages/common/npm-home.md
@@ -3,7 +3,7 @@
 > Open the npm page, Yarn page, or GitHub repository of a package in the web browser.
 > More information: <https://github.com/sindresorhus/npm-home>.
 
-- Open the npm page of a specific package in the web browser:
+- Open the `npm` page of a specific package in the web browser:
 
 `npm-home {{package}}`
 

--- a/pages/common/npm-name.md
+++ b/pages/common/npm-name.md
@@ -3,10 +3,10 @@
 > Check whether a package or organization name is available on npm.
 > More information: <https://github.com/sindresorhus/npm-name-cli>.
 
-- Check if a specific package name is available in the npm registry:
+- Check if a specific package name is available in the `npm` registry:
 
 `npm-name {{package}}`
 
-- Find similar package names in the npm registry:
+- Find similar package names in the `npm` registry:
 
 `npm-name --similar {{package}}`

--- a/pages/common/npm-why.md
+++ b/pages/common/npm-why.md
@@ -3,6 +3,6 @@
 > Identifies why an npm package is installed.
 > More information: <https://github.com/amio/npm-why>.
 
-- Show why an npm package is installed:
+- Show why an `npm` package is installed:
 
 `npm-why {{package}}`

--- a/pages/common/pnpx.md
+++ b/pages/common/pnpx.md
@@ -4,11 +4,11 @@
 > Note: This command is deprecated! Use `pnpm exec` and `pnpm dlx` instead.
 > More information: <https://cuyl.github.io/pnpm.github.io/pnpx-cli>.
 
-- Execute the binary from a given npm module:
+- Execute the binary from a given `npm` module:
 
 `pnpx {{module_name}}`
 
-- Execute a specific binary from a given npm module, in case the module has multiple binaries:
+- Execute a specific binary from a given `npm` module, in case the module has multiple binaries:
 
 `pnpx --package {{package_name}} {{module_name}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 