### PR TITLE
transmission: remove wrong auto-generated alias pages

### DIFF
--- a/pages.de/common/transmission.md
+++ b/pages.de/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Dieser Befehl ist ein Alias von `transmission-daemon`.
-> Weitere Informationen: <https://transmissionbt.com/>.
-
-- Zeige die Dokumentation für den originalen Befehl an:
-
-`tldr transmission-daemon`

--- a/pages.es/common/transmission.md
+++ b/pages.es/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Este comando es un alias de `transmission-daemon`.
-> Más información: <https://transmissionbt.com/>.
-
-- Muestra la documentación del comando original:
-
-`tldr transmission-daemon`

--- a/pages.fr/common/transmission.md
+++ b/pages.fr/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Cette commande est un alias de `transmission-daemon`.
-> Plus d'informations : <https://transmissionbt.com/>.
-
-- Voir la documentation de la commande originale :
-
-`tldr transmission-daemon`

--- a/pages.hi/common/transmission.md
+++ b/pages.hi/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> यह आदेश `transmission-daemon` का उपनाम है।
-> अधिक जानकारी: <https://transmissionbt.com/>।
-
-- मूल आदेश के लिए दस्तावेज़ देखें:
-
-`tldr transmission-daemon`

--- a/pages.id/common/transmission.md
+++ b/pages.id/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Perintah ini merupakan alias dari `transmission-daemon`.
-> Informasi lebih lanjut: <https://transmissionbt.com/>.
-
-- Tampilkan dokumentasi untuk perintah asli:
-
-`tldr transmission-daemon`

--- a/pages.it/common/transmission.md
+++ b/pages.it/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Questo comando è un alias per `transmission-daemon`.
-> Maggiori informazioni: <https://transmissionbt.com/>.
-
-- Consulta la documentazione del comando originale:
-
-`tldr transmission-daemon`

--- a/pages.ko/common/transmission.md
+++ b/pages.ko/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> 이 명령은 `transmission-daemon` 의 에일리어스 (별칭) 입니다.
-> 더 많은 정보: <https://transmissionbt.com/>.
-
-- 원본 명령의 도큐멘테이션 (설명서) 보기:
-
-`tldr transmission-daemon`

--- a/pages.ne/common/transmission.md
+++ b/pages.ne/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> यो आदेश `transmission-daemon` को उपनाम हो |
-> थप जानकारी: <https://transmissionbt.com/>।
-
-- मौलिक आदेशको लागि कागजात हेर्नुहोस्:
-
-`tldr transmission-daemon`

--- a/pages.pl/common/transmission.md
+++ b/pages.pl/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> To polecenie jest aliasem `transmission-daemon`.
-> Więcej informacji: <https://transmissionbt.com/>.
-
-- Zobacz dokumentację oryginalnego polecenia:
-
-`tldr transmission-daemon`

--- a/pages.pt_PT/common/transmission.md
+++ b/pages.pt_PT/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Este comando é um alias de `transmission-daemon`.
-> Mais informações: <https://transmissionbt.com/>.
-
-- Exibe documentação do comando original:
-
-`tldr transmission-daemon`

--- a/pages.th/common/transmission.md
+++ b/pages.th/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `transmission-daemon`
-> ข้อมูลเพิ่มเติม: <https://transmissionbt.com/>
-
-- เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
-
-`tldr transmission-daemon`

--- a/pages.tr/common/transmission.md
+++ b/pages.tr/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> Bu komut `transmission-daemon` için bir takma addır.
-> Daha fazla bilgi için: <https://transmissionbt.com/>.
-
-- Asıl komutun belgelerini görüntüleyin:
-
-`tldr transmission-daemon`

--- a/pages.zh/common/transmission.md
+++ b/pages.zh/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> 这是 `transmission-daemon` 命令的一个别名。
-> 更多信息：<https://transmissionbt.com/>.
-
-- 原命令的文档在：
-
-`tldr transmission-daemon`

--- a/pages.zh_TW/common/transmission.md
+++ b/pages.zh_TW/common/transmission.md
@@ -1,8 +1,0 @@
-# transmission
-
-> 這是 `transmission-daemon` 命令的一個別名。
-> 更多資訊：<https://transmissionbt.com/>.
-
-- 原命令的文件在：
-
-`tldr transmission-daemon`


### PR DESCRIPTION
I checked each code history, if there exists a correct version, I will revert the page to that version. Otherwise, I will delete the page.

Unaffected translations: [en](https://github.com/tldr-pages/tldr/blob/main/pages/common/transmission.md), [nl](https://github.com/tldr-pages/tldr/blob/main/pages.nl/common/transmission.md), [pt_BR](https://github.com/tldr-pages/tldr/blob/main/pages.pt_BR/common/transmission.md), [ta](https://github.com/tldr-pages/tldr/blob/main/pages.ta/common/transmission.md)

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
