### PR TITLE
vim, nim: add `:x` and fix inconsistency

### DIFF
--- a/pages.de/common/vim.md
+++ b/pages.de/common/vim.md
@@ -18,7 +18,7 @@
 
 - Speichere und schließe die aktuelle Datei:
 
-`{{ZZ|:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Mache die letzte Aktion rückgängig:
 

--- a/pages.es/common/vim.md
+++ b/pages.es/common/vim.md
@@ -18,7 +18,7 @@
 
 - Guarda y sale:
 
-`{{ZZ|:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Deshaz la última operación:
 

--- a/pages.fr/common/vim.md
+++ b/pages.fr/common/vim.md
@@ -18,7 +18,7 @@
 
 - Sauvegarder et fermer :
 
-`{{ZZ|:wq<Entrée>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Annuler la dernière opération :
 

--- a/pages.id/common/nvim.md
+++ b/pages.id/common/nvim.md
@@ -30,7 +30,7 @@
 
 - Menyimpan (write) berkas, dan keluar:
 
-`{{<Esc>ZZ|<Esc>:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Keluar tanpa menyimpan:
 

--- a/pages.it/common/nvim.md
+++ b/pages.it/common/nvim.md
@@ -30,7 +30,7 @@
 
 - Salvare (scrivere) il file per poi uscire:
 
-`{{<Esc>ZZ|<Esc>:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Uscire senza salvare:
 

--- a/pages.ja/common/vim.md
+++ b/pages.ja/common/vim.md
@@ -18,7 +18,7 @@
 
 - 保存と終了:
 
-`{{ZZ|:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - 最後の操作を元に戻す:
 

--- a/pages.nl/common/nvim.md
+++ b/pages.nl/common/nvim.md
@@ -31,7 +31,7 @@
 
 - Ga naar de normale modus, sla (write) het bestand op en sluit af:
 
-`{{<Esc>ZZ|<Esc>:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Sluit af zonder op te slaan:
 

--- a/pages.pt_BR/common/nvim.md
+++ b/pages.pt_BR/common/nvim.md
@@ -31,7 +31,7 @@
 
 - Entra no modo normal, salva (grava) o arquivo e sai:
 
-`{{<Esc>ZZ|<Esc>:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Sai sem salvar:
 

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -31,7 +31,7 @@
 
 - Enter normal mode and save (write) the file, and quit:
 
-`{{<Esc>ZZ|<Esc>:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Quit without saving:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -19,7 +19,7 @@
 
 - Save and quit the current buffer:
 
-`{{ZZ|:wq<Enter>}}`
+`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
 
 - Enter normal mode and undo the last operation:
 


### PR DESCRIPTION
Fix issues mentioned in the #14208 review

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
