### PR TITLE
useradd, userdel, usermod: highlighting both long and short options

### DIFF
--- a/pages/linux/useradd.md
+++ b/pages/linux/useradd.md
@@ -10,24 +10,24 @@
 
 - Create a new user with the specified user ID:
 
-`sudo useradd --uid {{id}} {{username}}`
+`sudo useradd {{-u|--uid}} {{id}} {{username}}`
 
 - Create a new user with the specified shell:
 
-`sudo useradd --shell {{path/to/shell}} {{username}}`
+`sudo useradd {{-s|--shell}} {{path/to/shell}} {{username}}`
 
 - Create a new user belonging to additional groups (mind the lack of whitespace):
 
-`sudo useradd --groups {{group1,group2,...}} {{username}}`
+`sudo useradd {{-G|--groups}} {{group1,group2,...}} {{username}}`
 
 - Create a new user with the default home directory:
 
-`sudo useradd --create-home {{username}}`
+`sudo useradd {{-m|--create-home}} {{username}}`
 
 - Create a new user with the home directory filled by template directory files:
 
-`sudo useradd --skel {{path/to/template_directory}} --create-home {{username}}`
+`sudo useradd {{-k|--skel}} {{path/to/template_directory}} {{-m|--create-home}} {{username}}`
 
 - Create a new system user without the home directory:
 
-`sudo useradd --system {{username}}`
+`sudo useradd {{-r|--system}} {{username}}`

--- a/pages/linux/userdel.md
+++ b/pages/linux/userdel.md
@@ -10,8 +10,8 @@
 
 - Remove a user in other root directory:
 
-`sudo userdel --root {{path/to/other/root}} {{username}}`
+`sudo userdel {{-R|--root}} {{path/to/other/root}} {{username}}`
 
 - Remove a user along with the home directory and mail spool:
 
-`sudo userdel --remove {{username}}`
+`sudo userdel {{-r|--remove}} {{username}}`

--- a/pages/linux/usermod.md
+++ b/pages/linux/usermod.md
@@ -6,20 +6,20 @@
 
 - Change a username:
 
-`sudo usermod --login {{new_username}} {{username}}`
+`sudo usermod {{-l|--login}} {{new_username}} {{username}}`
 
 - Change a user ID:
 
-`sudo usermod --uid {{id}} {{username}}`
+`sudo usermod {{-u|--uid}} {{id}} {{username}}`
 
 - Change a user shell:
 
-`sudo usermod --shell {{path/to/shell}} {{username}}`
+`sudo usermod {{-s|--shell}} {{path/to/shell}} {{username}}`
 
 - Add a user to supplementary groups (mind the lack of whitespace):
 
-`sudo usermod --append --groups {{group1,group2,...}} {{username}}`
+`sudo usermod {{-a|--append}} {{-G|--groups}} {{group1,group2,...}} {{username}}`
 
 - Change a user home directory:
 
-`sudo usermod --move-home --home {{path/to/new_home}} {{username}}`
+`sudo usermod {{-m|--move-home}} {{-d|--home}} {{path/to/new_home}} {{username}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Motivation:
When user confronts the command `sudo usermod -aG docker $USER` he may use `tldr` to reveal meaning of `-aG`. This adds hightlighting both long and short option as recommended in [Style guide for Option Syntax](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#option-syntax)
