### PR TITLE
az-feedback, az-login, az-logout: update more info link

### DIFF
--- a/pages/common/az-feedback.md
+++ b/pages/common/az-feedback.md
@@ -2,7 +2,7 @@
 
 > Send feedback to the Azure CLI Team.
 > Part of `azure-cli` (also known as `az`).
-> More information: <https://learn.microsoft.com/cli/azure/reference-index#az_feedback>.
+> More information: <https://learn.microsoft.com/cli/azure/reference-index#az-feedback>.
 
 - Send feedback to the Azure CLI Team:
 

--- a/pages/common/az-login.md
+++ b/pages/common/az-login.md
@@ -2,7 +2,7 @@
 
 > Log in to Azure.
 > Part of `azure-cli` (also known as `az`).
-> More information: <https://learn.microsoft.com/cli/azure/reference-index#az_login>.
+> More information: <https://learn.microsoft.com/cli/azure/reference-index#az-login>.
 
 - Log in interactively:
 

--- a/pages/common/az-logout.md
+++ b/pages/common/az-logout.md
@@ -2,7 +2,7 @@
 
 > Log out from an Azure subscription.
 > Part of `azure-cli` (also known as `az`).
-> More information: <https://learn.microsoft.com/cli/azure/reference-index#az_logout>.
+> More information: <https://learn.microsoft.com/cli/azure/reference-index#az-logout>.
 
 - Log out from the active account:
 


### PR DESCRIPTION
Those pages pages/common/az-feedback.md, az-login.md, and az-logout.md have an outdated more info link.
It should use `-` instead of `_` to link the correct page.