### PR TITLE
pdfjoin: fix typo

### DIFF
--- a/pages/common/pdfjoin.md
+++ b/pages/common/pdfjoin.md
@@ -17,4 +17,4 @@
 
 - Merge page subranges from two PDFs:
 
-`pdfjoin {/path/to/file1.pdf}} {{2-}} {{file2}} {{last-3}} --outfile {{output_file}}`
+`pdfjoin {{/path/to/file1.pdf}} {{2-}} {{file2}} {{last-3}} --outfile {{output_file}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 