### PR TITLE
pages.pt_BR/*: use example.com instead of exemplo.com

### DIFF
--- a/pages.pt_BR/common/acme.sh.md
+++ b/pages.pt_BR/common/acme.sh.md
@@ -6,28 +6,28 @@
 
 - Emite um certificado usando o modo webroot:
 
-`acme.sh --issue --domain {{exemplo.com}} --webroot {{/caminho/para/webroot}}`
+`acme.sh --issue --domain {{example.com}} --webroot {{/caminho/para/webroot}}`
 
 - Emite um certificado para múltiplos domínios usando o modo standalone na porta 80:
 
-`acme.sh --issue --standalone --domain {{exemplo.com}} --domain {{www.exemplo.com}}`
+`acme.sh --issue --standalone --domain {{example.com}} --domain {{www.exemplo.com}}`
 
 - Emite um certificado usando o modo standaline TLS na porta 443:
 
-`acme.sh --issue --alpn --domain {{exemplo.com}}`
+`acme.sh --issue --alpn --domain {{example.com}}`
 
 - Emite um certificado usando uma configuração válida Nginx:
 
-`acme.sh --issue --nginx --domain {{exemplo.com}}`
+`acme.sh --issue --nginx --domain {{example.com}}`
 
 - Emite um certificado usando uma configuração válida Apache:
 
-`acme.sh --issue --apache --domain {{exemplo.com}}`
+`acme.sh --issue --apache --domain {{example.com}}`
 
 - Emite um certificado wildcard (\*) usando o modo DNS_API automático:
 
-`acme.sh --issue --dns {{dns_cf}} --domain {{*.exemplo.com}}`
+`acme.sh --issue --dns {{dns_cf}} --domain {{*.example.com}}`
 
 - Instala os arquivos dos certificaods em um local específico (útil para renovação automática do certificado):
 
-`acme.sh --install-cert -d {{exemplo.com}} --key-file {{/caminho/para/exemplo.com.key}} --fullchain-file {{/caminho/para/exemplo.com.cer}} --reloadcmd {{"systemctl force-reload nginx"}}`
+`acme.sh --install-cert -d {{example.com}} --key-file {{/caminho/para/exemplo.com.key}} --fullchain-file {{/caminho/para/exemplo.com.cer}} --reloadcmd {{"systemctl force-reload nginx"}}`

--- a/pages.pt_BR/common/chromium.md
+++ b/pages.pt_BR/common/chromium.md
@@ -5,23 +5,23 @@
 
 - Abre uma URL ou arquivo específico:
 
-`chromium {{https://exemplo.com|caminho/para/arquivo.html}}`
+`chromium {{https://example.com|caminho/para/arquivo.html}}`
 
 - Abre no modo de navegação anônima (incógnito):
 
-`chromium --incognito {{exemplo.com}}`
+`chromium --incognito {{example.com}}`
 
 - Abre em uma nova janela:
 
-`chromium --new-window {{exemplo.com}}`
+`chromium --new-window {{example.com}}`
 
 - Abre no modo aplicativo (sem barra de tarefas, barra de URL, botões, etc.):
 
-`chromium --app={{https://exemplo.com}}`
+`chromium --app={{https://example.com}}`
 
 - Usa um servidor proxy:
 
-`chromium --proxy-server="{{socks5://hostname:66}}" {{exemplo.com}}`
+`chromium --proxy-server="{{socks5://hostname:66}}" {{example.com}}`
 
 - Abre com um diretório de perfil customizado:
 

--- a/pages.pt_BR/common/dig.md
+++ b/pages.pt_BR/common/dig.md
@@ -5,19 +5,19 @@
 
 - Pesquisa o(s) IP(s) associados a um hostname (Registros A):
 
-`dig +short {{exemplo.com}}`
+`dig +short {{example.com}}`
 
 - Obtém uma resposta detalhada para um determinado domínio (Registros A):
 
-`dig +noall +answer {{exemplo.com}}`
+`dig +noall +answer {{example.com}}`
 
 - Consulta um tipo de registro DNS específico associado a um nome de domínio fornecido:
 
-`dig +short {{exemplo.com}} {{A|MX|TXT|CNAME|NS}}`
+`dig +short {{example.com}} {{A|MX|TXT|CNAME|NS}}`
 
 - Especifica um servidor DNS alternativo para consultar:
 
-`dig @{{8.8.8.8}} {{exemplo.com}}`
+`dig @{{8.8.8.8}} {{example.com}}`
 
 - Performa uma busca reversa de DNS em um endereço de IP (Registro PTR):
 
@@ -25,8 +25,8 @@
 
 - Encontra servidores de nomes autorizados para a região e exibe os registros SOA:
 
-`dig +nssearch {{exemplo.com}}`
+`dig +nssearch {{example.com}}`
 
 - Performa consultas iterativas e exibe o caminho de ratreio completo para resolver um nome de domínio:
 
-`dig +trace {{exemplo.com}}`
+`dig +trace {{example.com}}`

--- a/pages.pt_BR/common/firefox.md
+++ b/pages.pt_BR/common/firefox.md
@@ -25,7 +25,7 @@
 
 - Tire uma screenshot de uma página web no modo headless:
 
-`firefox --headless --screenshot {{caminho/para/arquivo_de_saida.png}} {{https://exemplo.com/}}`
+`firefox --headless --screenshot {{caminho/para/arquivo_de_saida.png}} {{https://example.com/}}`
 
 - Use um perfil específico para permitir que múltiplas instâncias separadas do Firefox rodem ao mesmo tempo:
 

--- a/pages.pt_BR/common/ftp.md
+++ b/pages.pt_BR/common/ftp.md
@@ -5,7 +5,7 @@
 
 - Conecta-se a um servidor FTP:
 
-`ftp {{ftp.exemplo.com}}`
+`ftp {{ftp.example.com}}`
 
 - Alterna para o modo de transferência binária (gráficos, arquivos compactados, etc):
 

--- a/pages.pt_BR/common/transmission-edit.md
+++ b/pages.pt_BR/common/transmission-edit.md
@@ -6,7 +6,7 @@
 
 - Adiciona ou remove uma URL a partir da lista de anúncio do torrent:
 
-`transmission-edit --{{add|delete}} {{http://exemplo.com}} {{caminho/para/arquivo.torrent}}`
+`transmission-edit --{{add|delete}} {{http://example.com}} {{caminho/para/arquivo.torrent}}`
 
 - Atualiza um código do rastreador em um arquivo de torrent:
 

--- a/pages.pt_BR/common/wget.md
+++ b/pages.pt_BR/common/wget.md
@@ -6,31 +6,31 @@
 
 - Baixa o conteúdo de uma URL para o arquivo (nomeado como "foo" neste caso):
 
-`wget {{https://exemplo.com/foo}}`
+`wget {{https://example.com/foo}}`
 
 - Baixa o conteúdo de uma URL para o arquivo (nomeado como "bar" neste caso):
 
-`wget --output-document {{bar}} {{https://exemplo.com/foo}}`
+`wget --output-document {{bar}} {{https://example.com/foo}}`
 
 - Baixa uma única página web e todo os seus recursos com intervalos de 3 segundos entre requisições (scripts, stylesheets, imagens, etc.):
 
-`wget --page-requisites --convert-links --wait=3 {{https://exemplo.com/algumapagina.html}}`
+`wget --page-requisites --convert-links --wait=3 {{https://example.com/algumapagina.html}}`
 
 - Baixa todos os arquivos listados dentro de um diretório e seus sub-diretórios (não baixa elementos de página incorporados):
 
-`wget --mirror --no-parent {{https://exemplo.com/algumcaminho/}}`
+`wget --mirror --no-parent {{https://example.com/algumcaminho/}}`
 
 - Limita a velocidade de download e o número de novas tentativas de conexão:
 
-`wget --limit-rate={{300k}} --tries={{100}} {{https://exemplo.com/algumcaminho/}}`
+`wget --limit-rate={{300k}} --tries={{100}} {{https://example.com/algumcaminho/}}`
 
 - Baixa um arquivo de um servidor HTTP usando Autenticação Básica (também funciona para FTP):
 
-`wget --user={{nomeusuario}} --password={{senha}} {{https://exemplo.com}}`
+`wget --user={{nomeusuario}} --password={{senha}} {{https://example.com}}`
 
 - Continua um download incompleto:
 
-`wget --continue {{https://exemplo.com}}`
+`wget --continue {{https://example.com}}`
 
 - Baixa todas as URLs armazenadas em um arquivo de texto para um diretório específico:
 

--- a/pages.pt_BR/linux/asciiart.md
+++ b/pages.pt_BR/linux/asciiart.md
@@ -9,7 +9,7 @@
 
 - Lê uma imagem de uma URL e imprime em ASCII:
 
-`asciiart {{www.exemplo.com/imagem.jpg}}`
+`asciiart {{www.example.com/imagem.jpg}}`
 
 - Escolha a largura da saída (o padrão é 100):
 


### PR DESCRIPTION
While 'exemplo' is a Brazilian Portuguese translation for 'example', the example.com is a well-known domain name used as an example and has only trust worthy HTML code. The exemplo.com, on the other side, seems to be a domain for sale, with google adsense, etc. So, this change is to stick with example.com

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
