### PR TITLE
az: update more info link

### DIFF
--- a/pages/common/az.md
+++ b/pages/common/az.md
@@ -2,7 +2,7 @@
 
 > The official CLI tool for Microsoft Azure.
 > Some subcommands such as `login` have their own usage documentation.
-> More information: <https://learn.microsoft.com/cli/azure>.
+> More information: <https://learn.microsoft.com/cli/azure/reference-index>.
 
 - Log in to Azure:
 


### PR DESCRIPTION
use [https://learn.microsoft.com/cli/azure/reference-index](https://learn.microsoft.com/cli/azure/reference-index) to replace [https://learn.microsoft.com/cli/azure](https://learn.microsoft.com/cli/azure)

The first one is more fit on command info. The second one is more like a whole Azure CLI tool document.