### PR TITLE
pages.pt_BR/freebsd: add Brazilian Portuguese translation

### DIFF
--- a/pages.pt_BR/freebsd/chfn.md
+++ b/pages.pt_BR/freebsd/chfn.md
@@ -1,0 +1,7 @@
+# chfn
+
+> Esse comando é um apelido de `chpass`.
+
+- Exibe documentação sobre o comando original:
+
+`tldr chpass`

--- a/pages.pt_BR/freebsd/chsh.md
+++ b/pages.pt_BR/freebsd/chsh.md
@@ -1,0 +1,7 @@
+# chsh
+
+> Esse comando é um apelido de `chpass`.
+
+- Exibe documentação sobre o comando original:
+
+`tldr chpass`

--- a/pages.pt_BR/freebsd/ypchfn.md
+++ b/pages.pt_BR/freebsd/ypchfn.md
@@ -1,0 +1,7 @@
+# ypchfn
+
+> Esse comando é um apelido de `chpass`.
+
+- Exibe documentação sobre o comando original:
+
+`tldr chpass`

--- a/pages.pt_BR/freebsd/ypchpass.md
+++ b/pages.pt_BR/freebsd/ypchpass.md
@@ -1,0 +1,7 @@
+# ypchpass
+
+> Esse comando é um apelido de `chpass`.
+
+- Exibe documentação sobre o comando original:
+
+`tldr chpass`

--- a/pages.pt_BR/freebsd/ypchsh.md
+++ b/pages.pt_BR/freebsd/ypchsh.md
@@ -1,0 +1,7 @@
+# ypchsh
+
+> Esse comando é um apelido de `chpass`.
+
+- Exibe documentação sobre o comando original:
+
+`tldr chpass`


### PR DESCRIPTION
Add translation to  `freebsd`  "missing alias" pages.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).