### PR TITLE
2to3: update Portuguese Brazilian translation

### DIFF
--- a/pages.pt_BR/common/2to3.md
+++ b/pages.pt_BR/common/2to3.md
@@ -1,6 +1,7 @@
 # 2to3
 
 Conversão automática de código Python 2 para Python 3.
+
 > Esse módulo foi depreciado no Python 3.11 e foi removido na versão 3.13.
 > Referência: <https://github.com/python/cpython/blob/8d42e2d915c3096e7eac1c649751d1da567bb7c3/Doc/whatsnew/3.13.rst?plain=1#L188>.
 > Mais informações: <https://manned.org/2to3>.

--- a/pages.pt_BR/common/2to3.md
+++ b/pages.pt_BR/common/2to3.md
@@ -1,7 +1,6 @@
 # 2to3
 
-Conversão automática de código Python 2 para Python 3.
-
+> Conversão automática de código Python 2 para Python 3.
 > Esse módulo foi depreciado no Python 3.11 e foi removido na versão 3.13.
 > Referência: <https://github.com/python/cpython/blob/8d42e2d915c3096e7eac1c649751d1da567bb7c3/Doc/whatsnew/3.13.rst?plain=1#L188>.
 > Mais informações: <https://manned.org/2to3>.

--- a/pages.pt_BR/common/2to3.md
+++ b/pages.pt_BR/common/2to3.md
@@ -1,7 +1,9 @@
 # 2to3
 
-> Conversão automática de código Python 2 para Python 3.
-> Mais informações: <https://docs.python.org/3/library/2to3.html>.
+Conversão automática de código Python 2 para Python 3.
+> Esse módulo foi depreciado no Python 3.11 e foi removido na versão 3.13.
+> Referência: <https://github.com/python/cpython/blob/8d42e2d915c3096e7eac1c649751d1da567bb7c3/Doc/whatsnew/3.13.rst?plain=1#L188>.
+> Mais informações: <https://manned.org/2to3>.
 
 - Mostra as alterações que seriam feitas sem faze-las de fato (simulação):
 


### PR DESCRIPTION
The PT-BR translation was missing the deprecated warning for the 2to3 lib, which has been deprecated since python 3.11 and removed on 3.13.


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.

