### PR TITLE
2to3: fix Portuguese Brazilian translation

### DIFF
--- a/pages.pt_BR/common/2to3.md
+++ b/pages.pt_BR/common/2to3.md
@@ -1,7 +1,7 @@
 # 2to3
 
 > Conversão automática de código Python 2 para Python 3.
-> Esse módulo foi depreciado no Python 3.11 e foi removido na versão 3.13.
+> Esse módulo foi descontinuado no Python 3.11 e foi removido na versão 3.13.
 > Referência: <https://github.com/python/cpython/blob/8d42e2d915c3096e7eac1c649751d1da567bb7c3/Doc/whatsnew/3.13.rst?plain=1#L188>.
 > Mais informações: <https://manned.org/2to3>.
 


### PR DESCRIPTION
For some reason the suggestion of @rffontenelle did not show up to me on [this PR](https://github.com/tldr-pages/tldr/pull/14401#discussion_r1817925259). It was a quite relevant comment and I've merged it before the suggestion was applied. So I am fixing the mistake on this PR and applying his suggestion.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
