### PR TITLE
vboxmanage*: add Korean translation

### DIFF
--- a/pages.ko/common/vboxmanage-clonevm.md
+++ b/pages.ko/common/vboxmanage-clonevm.md
@@ -1,0 +1,20 @@
+# vboxmanage-clonevm
+
+> 기존 가상 머신(VM)의 복제본 생성.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-clonevm>.
+
+- 지정된 VM 복제:
+
+`VBoxManage clonevm {{vm_이름}}`
+
+- 새로운 VM에 대한 새 이름 지정:
+
+`VBoxManage clonevm {{vm_이름}} --name {{새_vm_이름}}`
+
+- 새 VM 구성 파일이 저장될 폴더 지정:
+
+`VBoxManage clonevm {{vm_이름}} --basefolder {{경로/대상/폴더}}`
+
+- VirtualBox에 복제된 VM 등록:
+
+`VBoxManage clonevm {{vm_이름}} --register`

--- a/pages.ko/common/vboxmanage-cloud.md
+++ b/pages.ko/common/vboxmanage-cloud.md
@@ -1,0 +1,36 @@
+# vboxmanage-cloud
+
+> 클라우드 인스턴스 및 이미지를 관리하기 위한 VirtualBox 명령줄 인터페이스.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-cloud>.
+
+- 지정된 구획에 속하는 특정 상태의 인스턴스 나열:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} list instances --state={{running|terminated|paused}} --compartment-id={{구획_id}}`
+
+- 새 인스턴스 생성:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} instance create --domain-name={{도메인_이름}} --image-id={{이미지_id}} | {{--옵션...}}`
+
+- 특정 인스턴스에 대한 정보 수집:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} instance info --id={{고유_id}}`
+
+- 인스턴스 종료:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} instance terminate --id={{고유_id}}`
+
+- 특정 구획 및 상태의 이미지 나열:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} list images --compartment-id={{구획_id}} --state={{상태_이름}}`
+
+- 새 이미지 생성:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} image create --instance-id={{인스턴스_id}} --display-name={{표시_이름}} --compartment-id={{구획_id}}`
+
+- 특정 이미지에 대한 정보 검색:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} image info --id={{고유_id}}`
+
+- 이미지 삭제:
+
+`VBoxManage cloud --provider={{제공자_이름}} --profile={{프로필_이름}} image delete --id={{고유_id}}`

--- a/pages.ko/common/vboxmanage-controlvm.md
+++ b/pages.ko/common/vboxmanage-controlvm.md
@@ -1,0 +1,36 @@
+# vboxmanage-controlvm
+
+> 현재 실행 중인 가상 머신의 상태 및 설정 변경.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-controlvm>.
+
+- 가상 머신의 실행을 일시 중지:
+
+`VBoxManage controlvm {{uuid|vm_이름}} pause`
+
+- 일시 중지된 가상 머신의 실행 재개:
+
+`VBoxManage controlvm {{uuid|vm_이름}} resume`
+
+- 가상 머신에 콜드 리셋 수행:
+
+`VBoxManage controlvm {{uuid|vm_이름}} reset`
+
+- 가상 머신의 전원을 컴퓨터의 전원 케이블을 뽑는 것과 동일한 효과로 끄기:
+
+`VBoxManage controlvm {{uuid|vm_이름}} poweroff`
+
+- 가상 머신을 종료하고 현재 상태 저장:
+
+`VBoxManage controlvm {{uuid|vm_이름}} savestate`
+
+- 가상 머신에 ACPI(Advanced Configuration and Power Interface) 종료 신호 보내기:
+
+`VBoxManage controlvm {{uuid|vm_이름}} acpipowerbutton`
+
+- 게스트 OS에 가상 머신의 자체 재부팅 명령 보내기:
+
+`VBoxManage controlvm {{uuid|vm_이름}} reboot`
+
+- 상태를 저장하지 않고 가상 머신 종료:
+
+`VBoxManage controlvm {{uuid|vm_이름}} shutdown`

--- a/pages.ko/common/vboxmanage-createvm.md
+++ b/pages.ko/common/vboxmanage-createvm.md
@@ -1,0 +1,32 @@
+# vboxmanage-createvm
+
+> 새 가상 머신 생성.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-createvm>.
+
+- 기본 설정으로 새 VM 생성:
+
+`VBoxManage createvm --name {{vm_이름}}`
+
+- VM 구성 파일이 저장될 기본 폴더 설정:
+
+`VBoxManage createvm --name {{vm_이름}} --basefolder {{경로/대상/폴더}}`
+
+- 가져온 VM의 게스트 OS 유형 설정 (`VBoxManage list ostypes` 중 하나):
+
+`VBoxManage createvm --name {{vm_이름}} --ostype {{os유형}}`
+
+- 생성된 VM을 VirtualBox에 등록:
+
+`VBoxManage createvm --name {{vm_이름}} --register`
+
+- VM을 지정된 그룹에 설정:
+
+`VBoxManage createvm --name {{vm_이름}} --group {{그룹1,그룹2,...}}`
+
+- VM의 전역 고유 식별자(UUID) 설정:
+
+`VBoxManage createvm --name {{vm_이름}} --uuid {{uuid}}`
+
+- 암호화에 사용할 암호화 방식 설정:
+
+`VBoxManage createvm --name {{vm_이름}} --cipher {{AES-128|AES-256}}`

--- a/pages.ko/common/vboxmanage-export.md
+++ b/pages.ko/common/vboxmanage-export.md
@@ -1,0 +1,24 @@
+# vboxmanage-export
+
+> 가상 머신을 가상 어플라이언스(ISO) 또는 클라우드 서비스로 내보내기.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-export>.
+
+- 대상 OVA 파일 지정:
+
+`VBoxManage export --output {{경로/대상/파일이름.ova}}`
+
+- OVF 0.9 레거시 모드로 내보내기:
+
+`VBoxManage export --legacy09`
+
+- OVF (0.9|1.0|2.0) 형식으로 내보내기:
+
+`VBoxManage export --{{ovf09|ovf10|ovf20}}`
+
+- 내보낸 파일의 매니페스트 생성:
+
+`VBoxManage export --manifest`
+
+- VM 설명 지정:
+
+`VBoxManage export --description "{{vm_설명}}"`

--- a/pages.ko/common/vboxmanage-extpack.md
+++ b/pages.ko/common/vboxmanage-extpack.md
@@ -1,0 +1,24 @@
+# vboxmanage-extpack
+
+> Oracle VirtualBox용 확장팩 관리 도구.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-extpack>.
+
+- VirtualBox에 확장팩 설치 (참고: 새 버전을 설치하기 전에 기존 버전을 제거해야 함):
+
+`VBoxManage extpack install {{경로/대상/파일.vbox-extpack}}`
+
+- 기존 VirtualBox 확장팩 버전 제거:
+
+`VBoxManage extpack install --replace`
+
+- VirtualBox에서 확장팩 제거:
+
+`VBoxManage extpack uninstall {{확장팩_이름}}`
+
+- 대부분의 제거 거부를 건너뛰고 확장팩 제거:
+
+`VBoxManage extpack uninstall --force {{확장팩_이름}}`
+
+- 확장팩이 남긴 임시 파일 및 디렉토리 정리:
+
+`VBoxManage extpack cleanup`

--- a/pages.ko/common/vboxmanage-import.md
+++ b/pages.ko/common/vboxmanage-import.md
@@ -1,0 +1,36 @@
+# vboxmanage-import
+
+> 이전에 내보낸 가상 머신(VM)을 가져오기.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-import>.
+
+- OVF 또는 OVA 파일에서 VM 가져오기:
+
+`VBoxManage import {{경로/대상/파일.ovf}}`
+
+- 가져온 VM의 이름 설정:
+
+`VBoxManage import {{경로/대상/파일.ovf}} --name {{vm_이름}}`
+
+- 가져온 VM의 구성 파일이 저장될 폴더 지정:
+
+`VBoxManage import {{경로/대상/파일.ovf}} --basefolder {{경로/대상/폴더}}`
+
+- VirtualBox에 가져온 VM 등록:
+
+`VBoxManage import {{경로/대상/파일.ovf}} --register`
+
+- 실제로 가져오지 않고 가져오기를 확인하는 드라이런 수행:
+
+`VBoxManage import {{경로/대상/파일.ovf}} --dry-run`
+
+- 가져온 VM의 게스트 OS 유형 설정 (`VBoxManage list ostypes` 중 하나):
+
+`VBoxManage import {{경로/대상/파일.ovf}} --ostype={{os유형}}`
+
+- 가져온 VM의 메모리 크기 설정 (메가바이트 단위):
+
+`VBoxManage import {{경로/대상/파일.ovf}} --memory={{1}}`
+
+- 가져온 VM의 CPU 개수 설정:
+
+`VBoxManage import {{경로/대상/파일.ovf}} --cpus={{1}}`

--- a/pages.ko/common/vboxmanage-list.md
+++ b/pages.ko/common/vboxmanage-list.md
@@ -1,0 +1,36 @@
+# vboxmanage-list
+
+> Oracle VM VirtualBox 소프트웨어 및 관련 서비스에 대한 정보를 나열합니다.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-list>.
+
+- 모든 VirtualBox 가상 머신 나열:
+
+`VBoxManage list vms`
+
+- 호스트 시스템에서 사용 가능한 DHCP 서버 표시:
+
+`VBoxManage list dhcpservers`
+
+- 현재 설치된 Oracle VM VirtualBox 확장팩 표시:
+
+`VBoxManage list extpacks`
+
+- 모든 가상 머신 그룹 표시:
+
+`VBoxManage list groups`
+
+- VirtualBox에서 현재 사용 중인 가상 디스크 설정 표시:
+
+`VBoxManage list hdds`
+
+- 호스트 시스템에서 사용 가능한 호스트 전용 네트워크 인터페이스 표시:
+
+`VBoxManage list hostonlyifs`
+
+- 현재 실행 중인 가상 머신 목록 표시:
+
+`VBoxManage list runningvms`
+
+- 호스트 시스템 정보 표시:
+
+`VBoxManage list hostinfo`

--- a/pages.ko/common/vboxmanage-movevm.md
+++ b/pages.ko/common/vboxmanage-movevm.md
@@ -1,0 +1,12 @@
+# vboxmanage movevm
+
+> 가상 머신(VM)을 호스트 시스템의 새로운 위치로 이동.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-movevm>.
+
+- 지정한 가상 머신을 현재 위치로 이동:
+
+`VBoxManage movevm {{vm_이름}}`
+
+- 가상 머신의 새 위치(전체 또는 상대 경로)를 지정:
+
+`VBoxManage movevm {{vm_이름}} --folder {{경로/대상/새로운_위치}}`

--- a/pages.ko/common/vboxmanage-registervm.md
+++ b/pages.ko/common/vboxmanage-registervm.md
@@ -1,0 +1,16 @@
+# vboxmanage-registervm
+
+> 가상 머신(VM) 등록.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-registervm>.
+
+- 기존 VM 등록:
+
+`VBoxManage registervm {{경로/대상/파일이름.vbox}}`
+
+- VM의 암호화 비밀번호 파일 제공:
+
+`VBoxManage registervm {{경로/대상/파일이름.vbox}} --password {{경로/대상/비밀번호_파일}}`
+
+- 명령줄에서 암호화 비밀번호 입력 요청:
+
+`VBoxManage registervm {{경로/대상/파일이름.vbox}} --password -`

--- a/pages.ko/common/vboxmanage-showvminfo.md
+++ b/pages.ko/common/vboxmanage-showvminfo.md
@@ -1,0 +1,28 @@
+# vboxmanage-showvminfo
+
+> 등록된 가상 머신에 대한 정보 표시.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-showvminfo>.
+
+- 특정 가상 머신에 대한 정보 표시:
+
+`VBoxManage showvminfo {{vm_이름|uuid}}`
+
+- 특정 가상 머신에 대한 더 자세한 정보 표시:
+
+`VBoxManage showvminfo --details {{vm_이름|uuid}}`
+
+- 기계 판독 형식으로 정보 표시:
+
+`VBoxManage showvminfo --machinereadable {{vm_이름|uuid}}`
+
+- 가상 머신이 암호화된 경우 암호 ID 지정:
+
+`VBoxManage showvminfo --password-id {{암호_id}} {{vm_이름|uuid}}`
+
+- 가상 머신이 암호화된 경우 암호 파일 지정:
+
+`VBoxManage showvminfo --password {{경로/대상/패스워드_파일}} {{vm_이름|uuid}}`
+
+- 특정 가상 머신의 로그 표시:
+
+`VBoxManage showvminfo --log {{vm_이름|uuid}}`

--- a/pages.ko/common/vboxmanage-startvm.md
+++ b/pages.ko/common/vboxmanage-startvm.md
@@ -1,0 +1,24 @@
+# vboxmanage-startvm
+
+> 가상 머신 시작.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-startvm>.
+
+- 가상 머신 시작:
+
+`VBoxManage startvm {{vm_이름|uuid}}`
+
+- 지정된 UI 모드로 가상 머신 시작:
+
+`VBoxManage startvm {{vm_이름|uuid}} --type {{headless|gui|sdl|separate}}`
+
+- 암호화된 가상 머신을 시작하기 위해 암호 파일 지정:
+
+`VBoxManage startvm {{vm_이름|uuid}} --password {{경로/대상/암호_파일}}`
+
+- 암호화된 가상 머신을 시작하기 위해 암호 ID 지정:
+
+`VBoxManage startvm {{vm_이름|uuid}} --password-id {{암호_id}}`
+
+- 환경 변수 쌍 이름 값을 사용하여 가상 머신 시작:
+
+`VBoxManage startvm {{vm_이름|uuid}} --put-env={{이름}}={{값}}`

--- a/pages.ko/common/vboxmanage-unregistervm.md
+++ b/pages.ko/common/vboxmanage-unregistervm.md
@@ -1,0 +1,16 @@
+# vboxmanage-unregistervm
+
+> 가상 머신(VM)을 등록 해제.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-unregistervm>.
+
+- 기존 VM 등록 해제:
+
+`VBoxManage unregistervm {{uuid|vm_이름}}`
+
+- 하드 디스크 이미지 파일, 모든 저장된 상태 파일, VM 로그 및 XML VM 머신 파일 삭제:
+
+`VBoxManage unregistervm {{uuid|vm_이름}} --delete`
+
+- VM의 모든 파일 삭제:
+
+`VBoxManage unregistervm {{uuid|vm_이름}} --delete-all`

--- a/pages.ko/common/vboxmanage.md
+++ b/pages.ko/common/vboxmanage.md
@@ -1,0 +1,22 @@
+# VBoxManage
+
+> VirtualBox의 명령줄 인터페이스.
+> GUI의 모든 기능을 포함하며 그 이상을 제공합니다.
+> `startvm`과 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
+> 더 많은 정보: <https://www.virtualbox.org/manual/ch08.html#vboxmanage-intro>.
+
+- VboxManage 하위 명령 실행:
+
+`VBoxManage {{하위_명령}}`
+
+- 도움말 표시:
+
+`VBoxManage --help`
+
+- 특정 하위 명령에 대한 도움말 표시:
+
+`VBoxManage --help {{clonevm|import|export|startvm|...}}`
+
+- 버전 표시:
+
+`VBoxManage --version`

--- a/pages/common/vboxmanage-startvm.md
+++ b/pages/common/vboxmanage-startvm.md
@@ -17,8 +17,8 @@
 
 - Specify a password ID to start an encrypted virtual machine:
 
-`VBoxManage startvm  {{vm_name|uuid}} --password-id {{password_id}}`
+`VBoxManage startvm {{vm_name|uuid}} --password-id {{password_id}}`
 
 - Start a virtual machine with an environment variable pair name value:
 
-`VBoxManage startvm  {{vm_name|uuid}} --put-env={{name}}={{value}}`
+`VBoxManage startvm {{vm_name|uuid}} --put-env={{name}}={{value}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
