### PR TITLE
pipewire,pw*: add Korean translation

### DIFF
--- a/pages.ko/linux/pipewire.md
+++ b/pages.ko/linux/pipewire.md
@@ -1,0 +1,20 @@
+# pipewire
+
+> PipeWire 데몬 시작.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pipewire_1.html>.
+
+- PipeWire 데몬 시작:
+
+`pipewire`
+
+- 다른 설정 파일 사용:
+
+`pipewire --config {{경로/대상/파일.conf}}`
+
+- 상세 수준 설정 (error, warn, info, debug 또는 trace):
+
+`pipewire -{{v|vv|...|vvvvv}}`
+
+- 도움말 표시:
+
+`pipewire --help`

--- a/pages.ko/linux/pw-cat.md
+++ b/pages.ko/linux/pw-cat.md
@@ -1,0 +1,20 @@
+# pw-cat
+
+> PipeWire를 통해 오디오 파일을 재생하고 녹음.
+> 더 많은 정보: <https://fedoraproject.org/wiki/QA:Testcase_PipeWire_PipeWire_CLI>.
+
+- 기본 대상으로 WAV 파일 재생:
+
+`pw-cat --playback {{경로/대상/파일.wav}}`
+
+- 지정된 리샘플러 품질(기본값 4)로 WAV 파일 재생:
+
+`pw-cat --quality {{0..15}} --playback {{경로/대상/파일.wav}}`
+
+- 125% 볼륨 수준으로 샘플 녹음:
+
+`pw-cat --record --volume {{1.25}} {{경로/대상/파일.wav}}`
+
+- 다른 샘플 레이트를 사용하여 샘플 녹음:
+
+`pw-cat --record --rate {{6000}} {{경로/대상/파일.wav}}`

--- a/pages.ko/linux/pw-cli.md
+++ b/pages.ko/linux/pw-cli.md
@@ -1,0 +1,16 @@
+# pw-cli
+
+> PipeWire 인스턴스의 모듈, 객체, 노드, 장치, 링크 등을 관리.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-cli_1.html>.
+
+- 모든 노드(싱크 및 소스)와 그 ID를 출력:
+
+`pw-cli list-objects Node`
+
+- 특정 ID를 가진 객체에 대한 정보 출력:
+
+`pw-cli info {{4}}`
+
+- 모든 객체의 정보 출력:
+
+`pw-cli info all`

--- a/pages.ko/linux/pw-config.md
+++ b/pages.ko/linux/pw-config.md
@@ -1,0 +1,32 @@
+# pw-config
+
+> PipeWire 서버와 클라이언트에서 사용될 설정 경로와 섹션 나열.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-config_1.html>.
+
+- 사용될 모든 설정 파일 나열:
+
+`pw-config`
+
+- PipeWire PulseAudio 서버에서 사용될 모든 설정 파일 나열:
+
+`pw-config --name pipewire-pulse.conf`
+
+- PipeWire PulseAudio 서버에서 사용되는 모든 설정 섹션 나열:
+
+`pw-config --name pipewire-pulse.conf list`
+
+- JACK 클라이언트에서 사용되는 `context.properties` 조각 나열:
+
+`pw-config --name jack.conf list context.properties`
+
+- JACK 클라이언트에서 사용되는 병합된 `context.properties` 나열:
+
+`pw-config --name jack.conf merge context.properties`
+
+- PipeWire 서버에서 사용되는 병합된 `context.modules` 나열 및 [r]eformat:
+
+`pw-config --name pipewire.conf --recurse merge context.modules`
+
+- 도움말 표시:
+
+`pw-config --help`

--- a/pages.ko/linux/pw-dot.md
+++ b/pages.ko/linux/pw-dot.md
@@ -1,0 +1,37 @@
+# pw-dot
+
+> PipeWire 그래프의 `.dot` 파일 생성.
+> 같이 보기: `dot`, 그래프 렌더링을 위해.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-dot_1.html>.
+
+- `pw.dot` 파일로 그래프 생성:
+
+`pw-dot`
+
+- `pw-dump` JSON 파일에서 객체 읽기:
+
+`pw-dot {{-j|--json}} {{경로/대상/파일.json}}`
+
+- [o]utput 파일 지정, 모든 객체 유형 표시:
+
+`pw-dot --output {{경로/대상/파일.dot}} {{-a|--all}}`
+
+- 모든 객체 속성을 표시하며 `.dot` 그래프를 `stdout`에 출력:
+
+`pw-dot --output - {{-d|--detail}}`
+
+- [r]emote 인스턴스에서 그래프를 생성, 연결된 객체만 표시:
+
+`pw-dot --remote {{원격_이름}} {{-s|--smart}}`
+
+- 기본적으로 dot의 위에서 아래로가 아닌 왼쪽에서 오른쪽으로 그래프 정렬:
+
+`pw-dot {{-L|--lr}}`
+
+- 엣지를 90도 각도로 사용하여 그래프 정렬:
+
+`pw-dot {{-9|--90}}`
+
+- 도움말 표시:
+
+`pw-dot --help`

--- a/pages.ko/linux/pw-dump.md
+++ b/pages.ko/linux/pw-dump.md
@@ -1,0 +1,25 @@
+# pw-dump
+
+> PipeWire의 현재 상태를 노드, 장치, 모듈, 포트 및 기타 객체 정보를 포함하여 JSON 형식으로 덤프.
+> 같이 보기: `pw-mon`.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-dump_1.html>.
+
+- 기본 PipeWire 인스턴스의 현재 상태를 JSON 형식으로 출력:
+
+`pw-dump`
+
+- 현재 상태를 덤프하고, 변경 사항을 [m]onitoring하여 다시 출력:
+
+`pw-dump --monitor`
+
+- 원격 인스턴스의 현재 상태를 [r]emote하여 파일에 덤프:
+
+`pw-dump --remote {{원격_이름}} > {{경로/대상/덤프_파일.json}}`
+
+- [C]olor 설정 구성:
+
+`pw-dump --color {{never|always|auto}}`
+
+- 도움말 표시:
+
+`pw-dump --help`

--- a/pages.ko/linux/pw-link.md
+++ b/pages.ko/linux/pw-link.md
@@ -1,0 +1,24 @@
+# pw-link
+
+> PipeWire에서 포트 간의 링크를 관리.
+> 더 많은 정보: <https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Virtual-Devices>.
+
+- 모든 오디오 출력 및 입력 포트와 해당 ID 나열:
+
+`pw-link --output --input --ids`
+
+- 출력 포트와 입력 포트 간 링크 생성:
+
+`pw-link {{출력_포트_이름}} {{입력_포트_이름}}`
+
+- 두 포트 간 연결 해제:
+
+`pw-link --disconnect {{출력_포트_이름}} {{입력_포트_이름}}`
+
+- 모든 링크와 해당 ID 나열:
+
+`pw-link --links --ids`
+
+- 도움말 표시:
+
+`pw-link -h`

--- a/pages.ko/linux/pw-loopback.md
+++ b/pages.ko/linux/pw-loopback.md
@@ -1,0 +1,28 @@
+# pw-loopback
+
+> PipeWire에서 루프백 장치를 생성.
+> 더 많은 정보: <https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Virtual-Devices>.
+
+- 기본 루프백 동작으로 루프백 장치 생성:
+
+`pw-loopback`
+
+- 스피커에 자동으로 연결되는 루프백 장치 생성:
+
+`pw-loopback -m '{{[FL FR]}}' --capture-props='{{media.class=Audio/Sink}}'`
+
+- 마이크에 자동으로 연결되는 루프백 장치 생성:
+
+`pw-loopback -m '{{[FL FR]}}' --playback-props='{{media.class=Audio/Source}}'`
+
+- 자동으로 아무것에도 연결되지 않는 더미 루프백 장치 생성:
+
+`pw-loopback -m '{{[FL FR]}}' --capture-props='{{media.class=Audio/Sink}}' --playback-props='{{media.class=Audio/Source}}'`
+
+- 스피커에 자동으로 연결되고 싱크와 소스 간 좌우 채널을 교환하는 루프백 장치 생성:
+
+`pw-loopback --capture-props='{{media.class=Audio/Sink audio.position=[FL FR]}}' --playback-props='{{audio.position=[FR FL]}}'`
+
+- 마이크에 자동으로 연결되고 싱크와 소스 간 좌우 채널을 교환하는 루프백 장치 생성:
+
+`pw-loopback --capture-props='{{audio.position=[FR FL]}}' --playback-props='{{media.class=Audio/Source audio.position=[FL FR]}}'`

--- a/pages.ko/linux/pw-metadata.md
+++ b/pages.ko/linux/pw-metadata.md
@@ -1,0 +1,33 @@
+# pw-metadata
+
+> PipeWire 객체의 메타데이터를 모니터링, 설정 및 삭제.
+> 같이 보기: `pipewire`, `pw-mon`, `pw-cli`.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-metadata_1.html>.
+
+- `default` 이름의 메타데이터 표시:
+
+`pw-metadata`
+
+- `settings`에서 ID 0의 메타데이터 표시:
+
+`pw-metadata {{-n|--name}} {{settings}} {{0}}`
+
+- 사용 가능한 모든 메타데이터 객체 나열:
+
+`pw-metadata {{-l|--list}}`
+
+- 실행을 유지하며 메타데이터 변경 사항 기록:
+
+`pw-metadata {{-m|--monitor}}`
+
+- 모든 메타데이터 삭제:
+
+`pw-metadata {{-d|--delete}}`
+
+- `settings`에서 `log.level`을 1로 설정:
+
+`pw-metadata --name {{settings}} {{0}} {{log.level}} {{1}}`
+
+- 도움말 표시:
+
+`pw-metadata --help`

--- a/pages.ko/linux/pw-mon.md
+++ b/pages.ko/linux/pw-mon.md
@@ -1,0 +1,20 @@
+# pw-mon
+
+> PipeWire 인스턴스의 객체를 모니터링.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-mon_1.html>.
+
+- 기본 PipeWire 인스턴스 모니터링:
+
+`pw-mon`
+
+- 특정 원격 인스턴스 모니터링:
+
+`pw-mon --remote={{원격_이름}}`
+
+- 색상 설정을 지정하여 기본 인스턴스 모니터링:
+
+`pw-mon --color={{never|always|auto}}`
+
+- 도움말 표시:
+
+`pw-mon --help`

--- a/pages.ko/linux/pw-play.md
+++ b/pages.ko/linux/pw-play.md
@@ -1,0 +1,14 @@
+# pw-play
+
+> PipeWire를 통해 오디오 파일 재생.
+> `pw-cat --playback`의 약어.
+> 같이 보기: `play`.
+> 더 많은 정보: <https://fedoraproject.org/wiki/QA:Testcase_PipeWire_PipeWire_CLI>.
+
+- 기본 대상에서 WAV 사운드 파일 재생:
+
+`pw-play {{경로/대상/파일.wav}}`
+
+- 다른 볼륨 수준으로 WAV 사운드 파일 재생:
+
+`pw-play --volume={{0.1}} {{경로/대상/파일.wav}}`

--- a/pages.ko/linux/pw-profiler.md
+++ b/pages.ko/linux/pw-profiler.md
@@ -1,0 +1,20 @@
+# pw-profiler
+
+> 로컬 또는 원격 인스턴스를 프로파일링.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-profiler_1.html>.
+
+- 기본 인스턴스를 프로파일링하고 `profile.log`에 기록 (`gnuplot` 파일과 결과 시각화를 위한 HTML 파일도 생성됨):
+
+`pw-profiler`
+
+- 로그 출력 파일 변경:
+
+`pw-profiler --output {{경로/대상/파일.log}}`
+
+- 원격 인스턴스를 프로파일링:
+
+`pw-profiler --remote {{원격_이름}}`
+
+- 도움말 표시:
+
+`pw-profiler --help`

--- a/pages.ko/linux/pw-record.md
+++ b/pages.ko/linux/pw-record.md
@@ -1,0 +1,17 @@
+# pw-record
+
+> PipeWire를 통해 오디오 파일을 녹음.
+> `pw-cat --record`의 축약형.
+> 더 많은 정보: <https://fedoraproject.org/wiki/QA:Testcase_PipeWire_PipeWire_CLI>.
+
+- 기본 대상 장치를 사용하여 샘플 녹음:
+
+`pw-record {{경로/대상/파일.wav}}`
+
+- 다른 볼륨 레벨로 샘플 녹음:
+
+`pw-record --volume={{0.1}} {{경로/대상/파일.wav}}`
+
+- 다른 샘플 속도를 사용하여 샘플 녹음:
+
+`pw-record --rate={{6000}} {{경로/대상/파일.wav}}`

--- a/pages.ko/linux/pw-top.md
+++ b/pages.ko/linux/pw-top.md
@@ -1,0 +1,21 @@
+# pw-top
+
+> 실시간으로 PipeWire 노드 및 장치 통계를 확인.
+> 같이 보기: `pipewire`, `pw-dump`, `pw-cli`, `pw-profiler`.
+> 더 많은 정보: <https://docs.pipewire.org/page_man_pw-top_1.html>.
+
+- PipeWire 노드와 장치의 대화형 뷰 표시:
+
+`pw-top`
+
+- 원격 인스턴스 모니터링:
+
+`pw-top --remote {{원격_이름}}`
+
+- 대화형 모드 대신 주기적으로 정보 출력:
+
+`pw-top --batch-mode`
+
+- 특정 횟수만큼 주기적으로 정보 출력:
+
+`pw-top --batch-mode --iterations {{3}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
