### PR TITLE
grub*: add Korean translation

### DIFF
--- a/pages.ko/linux/grub-bios-setup.md
+++ b/pages.ko/linux/grub-bios-setup.md
@@ -1,0 +1,17 @@
+# grub-bios-setup
+
+> GRUB을 BIOS 구성으로 사용하는 장치 설정.
+> 대부분의 경우 `grub-bios-setup` 대신 `grub-install`을 사용해야 합니다.
+> 더 많은 정보: <https://manned.org/grub-bios-setup.8>.
+
+- GRUB으로 부팅하도록 장치 설정:
+
+`grub-bios-setup {{/dev/sdX}}`
+
+- 문제가 감지되어도 설치 강행:
+
+`grub-bios-setup --force {{/dev/sdX}}`
+
+- 특정 디렉터리에 GRUB 설치:
+
+`grub-bios-setup --directory={{/boot/grub}} {{/dev/sdX}}`

--- a/pages.ko/linux/grub-editenv.md
+++ b/pages.ko/linux/grub-editenv.md
@@ -1,0 +1,20 @@
+# grub-editenv
+
+> GRUB 환경 변수를 편집.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/grub.html>.
+
+- 기본 부팅 항목 설정 (부팅 항목이 이미 존재한다고 가정):
+
+`grub-editenv /boot/grub/grubenv set default={{Ubuntu}}`
+
+- `timeout` 변수의 현재 값 표시:
+
+`grub-editenv /boot/grub/grubenv list timeout`
+
+- `saved_entry` 변수를 기본값으로 재설정:
+
+`grub-editenv /boot/grub/grubenv unset saved_entry`
+
+- 커널 명령줄에 "quiet splash" 추가:
+
+`grub-editenv /boot/grub/grubenv list kernel_cmdline`

--- a/pages.ko/linux/grub-file.md
+++ b/pages.ko/linux/grub-file.md
@@ -1,0 +1,28 @@
+# grub-file
+
+> 파일이 부팅 가능한 이미지 유형인지 확인.
+> 더 많은 정보: <https://manned.org/grub-file>.
+
+- 파일이 ARM EFI 이미지인지 확인:
+
+`grub-file --is-arm-efi {{경로/대상/파일}}`
+
+- 파일이 i386 EFI 이미지인지 확인:
+
+`grub-file --is-i386-efi {{경로/대상/파일}}`
+
+- 파일이 x86_64 EFI 이미지인지 확인:
+
+`grub-file --is-x86_64-efi {{경로/대상/파일}}`
+
+- 파일이 ARM 이미지(Linux 커널)인지 확인:
+
+`grub-file --is-arm-linux {{경로/대상/파일}}`
+
+- 파일이 x86 이미지(Linux 커널)인지 확인:
+
+`grub-file --is-x86-linux {{경로/대상/파일}}`
+
+- 파일이 x86_64 XNU 이미지(macOS 커널)인지 확인:
+
+`grub-file --is-x86_64-xnu {{경로/대상/파일}}`

--- a/pages.ko/linux/grub-install.md
+++ b/pages.ko/linux/grub-install.md
@@ -1,0 +1,16 @@
+# grub-install
+
+> GRUB을 장치에 설치.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/html_node/Installing-GRUB-using-grub_002dinstall.html>.
+
+- BIOS 시스템에 GRUB 설치:
+
+`grub-install --target={{i386-pc}} {{경로/대상/장치}}`
+
+- UEFI 시스템에 GRUB 설치:
+
+`grub-install --target={{x86_64-efi}} --efi-directory={{경로/대상/efi_폴더}} --bootloader-id={{GRUB}}`
+
+- 특정 모듈을 사전 로드하여 GRUB 설치:
+
+`grub-install --target={{x86_64-efi}} --efi-directory={{경로/대상/efi_폴더}} --modules="{{part_gpt part_msdos}}"`

--- a/pages.ko/linux/grub-mkconfig.md
+++ b/pages.ko/linux/grub-mkconfig.md
@@ -1,0 +1,16 @@
+# grub-mkconfig
+
+> GRUB 구성 파일 생성.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dmkconfig.html>.
+
+- 시뮬레이션을 실행하고 구성을 `stdout`에 출력:
+
+`sudo grub-mkconfig`
+
+- 구성 파일 생성:
+
+`sudo grub-mkconfig --output={{/boot/grub/grub.cfg}}`
+
+- 도움말 표시:
+
+`grub-mkconfig --help`

--- a/pages.ko/linux/grub-reboot.md
+++ b/pages.ko/linux/grub-reboot.md
@@ -1,0 +1,12 @@
+# grub-reboot
+
+> 다음 부팅에만 적용되는 GRUB의 기본 부팅 항목 설정.
+> 더 많은 정보: <https://manned.org/grub-reboot>.
+
+- 다음 부팅을 위해 기본 부팅 항목을 항목 번호, 이름 또는 식별자로 설정:
+
+`sudo grub-reboot {{항목_번호}}`
+
+- 다음 부팅을 위해 대체 부팅 디렉토리의 항목 번호, 이름 또는 식별자로 기본 부팅 항목 설정:
+
+`sudo grub-reboot --boot-directory {{/경로/대상/부팅_디렉토리}} {{항목_번호}}`

--- a/pages.ko/linux/grub-script-check.md
+++ b/pages.ko/linux/grub-script-check.md
@@ -1,0 +1,21 @@
+# grub-script-check
+
+> `grub-script-check` 프로그램은 GRUB 스크립트 파일을 가져와 문법 오류를 검사합니다.
+> 경로를 옵션이 아닌 인수로 받을 수 있습니다. 인수가 없을 경우, `stdin`에서 읽습니다.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dscript_002dcheck.html>.
+
+- 특정 스크립트 파일의 문법 오류 검사:
+
+`grub-script-check {{경로/대상/grub_설정_파일}}`
+
+- 입력을 읽은 후 각 줄을 표시:
+
+`grub-script-check --verbose`
+
+- 도움말 표시:
+
+`grub-script-check --help`
+
+- 버전 표시:
+
+`grub-script-check --version`

--- a/pages.ko/linux/grub-set-default.md
+++ b/pages.ko/linux/grub-set-default.md
@@ -1,0 +1,12 @@
+# grub-set-default
+
+> GRUB의 기본 부트 항목 설정.
+> 더 많은 정보: <https://manned.org/grub-set-default>.
+
+- 기본 부트 항목을 항목 번호, 이름 또는 식별자로 설정:
+
+`sudo grub-set-default {{항목_번호}}`
+
+- 대체 부트 디렉토리에 대해 기본 부트 항목을 항목 번호, 이름 또는 식별자로 설정:
+
+`sudo grub-set-default --boot-directory {{/경로/대상/부트_디렉토리}} {{항목_번호}}`

--- a/pages.ko/linux/grubby.md
+++ b/pages.ko/linux/grubby.md
@@ -1,0 +1,16 @@
+# grubby
+
+> `grub` 및 `zipl` 부트로더를 설정하는 도구.
+> 더 많은 정보: <https://manned.org/grubby.8>.
+
+- 모든 커널 메뉴 항목에 커널 부팅 인자 추가:
+
+`sudo grubby --update-kernel=ALL --args '{{quiet console=ttyS0}}'`
+
+- 기본 커널 항목에서 기존 인자 제거:
+
+`sudo grubby --update-kernel=DEFAULT --remove-args {{quiet}}`
+
+- 모든 커널 메뉴 항목 나열:
+
+`sudo grubby --info=ALL`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
