### PR TITLE
hadolint, hakyll-init, handbrakecli: add Korean translation

### DIFF
--- a/pages.ko/common/hadolint.md
+++ b/pages.ko/common/hadolint.md
@@ -1,0 +1,24 @@
+# hadolint
+
+> Dockerfile 린터.
+> 더 많은 정보: <https://github.com/hadolint/hadolint>.
+
+- Dockerfile 린트:
+
+`hadolint {{경로/대상/Dockerfile}}`
+
+- Dockerfile을 린트하여, 출력을 JSON 형식으로 표시:
+
+`hadolint --format {{json}} {{경로/대상/Dockerfile}}`
+
+- Dockerfile을 린트하여, 특정 형식으로 출력을 표시:
+
+`hadolint --format {{tty|json|checkstyle|codeclimate|codacy}} {{경로/대상/Dockerfile}}`
+
+- 특정 규칙을 무시하고 Dockerfile을 린트:
+
+`hadolint --ignore {{DL3006}} --ignore {{DL3008}} {{경로/대상/Dockerfile}}`
+
+- 특정 신뢰할 수 있는 레지스트리를 사용하여 여러 Dockerfile을 린트하는 것:
+
+`hadolint --trusted-registry {{docker.io}} --trusted-registry {{example.com}}:{{5000}} {{경로/대상/Dockerfile1 경로/대상/Dockerfile2 ...}}`

--- a/pages.ko/common/hakyll-init.md
+++ b/pages.ko/common/hakyll-init.md
@@ -1,0 +1,12 @@
+# hakyll-init
+
+> 새로운 Hakyll 샘플 블로그 생성.
+> 더 많은 정보: <https://github.com/jaspervdj/hakyll-init>.
+
+- 새로운 Hakyll 샘플 블로그 생성:
+
+`hakyll-init {{경로/대상/디렉토리}}`
+
+- 도움말 표시:
+
+`hakyll-init --help`

--- a/pages.ko/common/handbrakecli.md
+++ b/pages.ko/common/handbrakecli.md
@@ -1,0 +1,28 @@
+# handbrakecli
+
+> HandBrake 비디오 변환 및 DVD 리핑 도구에 대한 명령줄 인터페이스.
+> 더 많은 정보: <https://handbrake.fr/>.
+
+- 비디오 파일을 MKV(AAC 160kbit 오디오 및 x264 CRF20 비디오)로 변환:
+
+`handbrakecli --input {{입력.avi}} --output {{출력.mkv}} --encoder x264 --quality 20 --ab 160`
+
+- 비디오 파일 크기를 320x240으로 조정:
+
+`handbrakecli --input {{입력.mp4}} --output {{출력.mp4}} --width 320 --height 240`
+
+- 사용 가능한 사전 설정 목록:
+
+`handbrakecli --preset-list`
+
+- Android 사전 설정을 사용하여 AVI 비디오를 MP4로 변환:
+
+`handbrakecli --preset="Android" --input {{입력.ext}} --output {{출력.mp4}}`
+
+- DVD 내용을 출력하고 그 과정에서 CSS 키를 가져옴:
+
+`handbrakecli --input {{/dev/sr0}} --title 0`
+
+- 지정된 장치에서 DVD의 첫 번째 트랙을 추출. 오디오트랙과 자막 언어는 목록으로 지정됨:
+
+`handbrakecli --input {{/dev/sr0}} --title 1 --output {{out.mkv}} --format av_mkv --encoder x264 --subtitle {{1,4,5}} --audio {{1,2}} --aencoder copy --quality {{23}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
