### PR TITLE
chpass: add Brazilian Portuguese translation

### DIFF
--- a/pages.pt_BR/freebsd/chpass.md
+++ b/pages.pt_BR/freebsd/chpass.md
@@ -1,0 +1,33 @@
+# chpass
+
+> Adiciona ou altera informação de usuário do banco de dados, incluindo login shell e senha.
+> Veja também: `passwd`.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?chpass>.
+
+- Adiciona ou altera informação de usuário do banco de dados para o usuário atual interativamente:
+
+`su -c chpass`
+
+- Define uma [s]hell de login para o usuário atual:
+
+`chpass -s {{caminho/para/shell}}`
+
+- Define uma [s]hell de login para um usuário específico:
+
+`chpass -s {{caminho/para/shell}} {{nome_do_usuário}}`
+
+- Altera o tempo de [e]xpiração da conta (Unix epoch):
+
+`su -c 'chpass -e {{tempo}} {{nome_do_usuário}}'`
+
+- Altera a senha de um usuário:
+
+`su -c 'chpass -p {{senha_criptografada}} {{nome_do_usuário}}`
+
+- Especifica [h]ostname ou endereço de um servidor NIS para consulta:
+
+`su -c 'chpass -h {{hostname}} {{nome_do_usuário}}`
+
+- Especifica um [d]omínio NIS específico (nome do domínio do sistema por padrão):
+
+`su -c 'chpass -d {{domínio}} {{nome_do_usuário}}`

--- a/pages.pt_BR/freebsd/chpass.md
+++ b/pages.pt_BR/freebsd/chpass.md
@@ -22,12 +22,12 @@
 
 - Altera a senha de um usuário:
 
-`su -c 'chpass -p {{senha_criptografada}} {{nome_do_usuário}}`
+`su -c 'chpass -p {{senha_criptografada}} {{nome_do_usuário}}'`
 
 - Especifica [h]ostname ou endereço de um servidor NIS para consulta:
 
-`su -c 'chpass -h {{hostname}} {{nome_do_usuário}}`
+`su -c 'chpass -h {{hostname}} {{nome_do_usuário}}'`
 
 - Especifica um [d]omínio NIS específico (nome do domínio do sistema por padrão):
 
-`su -c 'chpass -d {{domínio}} {{nome_do_usuário}}`
+`su -c 'chpass -d {{domínio}} {{nome_do_usuário}}'`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Add missing `freebsd` page: chpass

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
