### PR TITLE
clang++: add Spanish translation

### DIFF
--- a/pages.es/common/clang++.md
+++ b/pages.es/common/clang++.md
@@ -1,0 +1,37 @@
+# clang++
+
+> Compila archivos con código fuente C++.
+> Hace parte de LLVM.
+> Más información: <https://clang.llvm.org>.
+
+- Compila un conjunto de archivos de código fuente a un binario ejecutable:
+
+`clang++ {{ruta/al/código1.cpp ruta/al/código2.cpp ...}} {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Activa la visualización de todos los errores y advertencias:
+
+`clang++ {{ruta/al/código.cpp}} -Wall {{-o|--output}} {{output_executable}}`
+
+- Muestra advertencias comunes, símbolos de depuración en la salida y optimiza sin afectar la depuración:
+
+`clang++ {{ruta/al/código.cpp}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Elije un estándar de lenguaje para compilar:
+
+`clang++ {{ruta/al/código.cpp}} -std={{c++20}} {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Incluye las bibliotecas ubicadas en una ruta distinta a la del código fuente:
+
+`clang++ {{ruta/al/código.cpp}} {{-o|--output}} {{ruta/al/ejecutable}} -I{{ruta/al/directorio/de/headers}} -L{{ruta/al/directorio/de/bibliotecas}} -l{{ruta/a/la/biblioteca}}`
+
+- Compila el código fuente hacia una representación intermedia (IR) LLVM:
+
+`clang++ {{-S|--assemble}} -emit-llvm {{ruta/al/código.cpp}} {{-o|--output}} {{ruta/a/la/representación.ll}}`
+
+- Optimiza el programa compilado en función de velocidad:
+
+`clang++ {{ruta/al/código.cpp}} -O{{1|2|3|fast}} {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Muestra la versión:
+
+`clang++ --version`


### PR DESCRIPTION
clang++: add Spanish translation

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
