### PR TITLE
kube*, kustomize: add Korean translation

### DIFF
--- a/pages.ko/common/kube-capacity.md
+++ b/pages.ko/common/kube-capacity.md
@@ -1,0 +1,17 @@
+# kube-capacity
+
+> Kubernetes 클러스터의 리소스 요청, 제한 및 활용 개요 제공.
+> `kubectl top`과 `kubectl describe`의 장점을 결합하여 클러스터 리소스에 초점을 맞춘 CLI.
+> 더 많은 정보: <https://github.com/robscott/kube-capacity>.
+
+- 노드를 나열하고 총 CPU 및 메모리 리소스 요청 및 제한 포함:
+
+`kube-capacity`
+
+- 파드 포함:
+
+`kube-capacity -p`
+
+- 활용도 포함:
+
+`kube-capacity -u`

--- a/pages.ko/common/kube-fzf.md
+++ b/pages.ko/common/kube-fzf.md
@@ -1,0 +1,29 @@
+# kube-fzf
+
+> Kubernetes Pod의 명령줄 퍼지 검색을 위한 셸 명령.
+> 관련 명령은 `kubectl`을 참고하세요.
+> 더 많은 정보: <https://github.com/thecasualcoder/kube-fzf>.
+
+- Pod 세부 정보 가져오기 (현재 네임스페이스에서):
+
+`findpod`
+
+- Pod 세부 정보 가져오기 (모든 네임스페이스에서):
+
+`findpod -a`
+
+- Pod 설명:
+
+`describepod`
+
+- Pod 로그 실시간 보기:
+
+`tailpod`
+
+- Pod의 컨테이너에 접속:
+
+`execpod {{셸_명령어}}`
+
+- Pod 포트 포워딩:
+
+`pfpod {{포트_번호}}`

--- a/pages.ko/common/kubeadm.md
+++ b/pages.ko/common/kubeadm.md
@@ -1,0 +1,32 @@
+# kubeadm
+
+> Kubernetes 클러스터를 생성하고 관리하기 위한 명령줄 인터페이스.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/setup-tools/kubeadm>.
+
+- Kubernetes 마스터 노드 생성:
+
+`kubeadm init`
+
+- Kubernetes 워커 노드를 부트스트랩하고 클러스터에 가입:
+
+`kubeadm join --token {{토큰}}`
+
+- TTL이 12시간인 새로운 부트스트랩 토큰 생성:
+
+`kubeadm token create --ttl {{12h0m0s}}`
+
+- Kubernetes 클러스터가 업그레이드 가능한지와 사용 가능한 버전 확인:
+
+`kubeadm upgrade plan`
+
+- 지정된 버전으로 Kubernetes 클러스터 업그레이드:
+
+`kubeadm upgrade apply {{버전}}`
+
+- 클러스터의 구성이 포함된 kubeadm ConfigMap 보기:
+
+`kubeadm config view`
+
+- 'kubeadm init' 또는 'kubeadm join'으로 호스트에 적용된 변경사항 되돌리기:
+
+`kubeadm reset`

--- a/pages.ko/common/kubectl-apply.md
+++ b/pages.ko/common/kubectl-apply.md
@@ -1,0 +1,21 @@
+# kubectl apply
+
+> Kubernetes 리소스를 정의하는 파일을 통해 애플리케이션을 관리하세요.
+> 클러스터에서 리소스를 생성하고 업데이트하세요.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply>.
+
+- 파일 이름이나 `stdin`으로 리소스에 설정 적용:
+
+`kubectl apply -f {{리소스_파일명}}`
+
+- 기본 편집기를 사용하여 리소스의 최신 마지막 적용 구성 주석 수정:
+
+`kubectl apply edit-last-applied -f {{리소스_파일명}}`
+
+- 파일 내용과 일치하도록 설정하여 최신 마지막 적용 구성 주석 설정:
+
+`kubectl apply set-last-applied -f {{리소스_파일명}}`
+
+- 유형/이름 또는 파일로 최신 마지막 적용 구성 주석 보기:
+
+`kubectl apply view-last-applied -f {{리소스_파일명}}`

--- a/pages.ko/common/kubectl-config.md
+++ b/pages.ko/common/kubectl-config.md
@@ -1,0 +1,30 @@
+# kubectl config
+
+> Kubernetes 구성(kubeconfig) 파일을 관리하여 `kubectl` 또는 Kubernetes API를 통해 클러스터에 접근할 수 있도록 함.
+> 기본적으로 Kubernetes는 `${HOME}/.kube/config`에서 구성을 가져옵니다.
+> 같이 보기: `kubectx`, `kubens`.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config>.
+
+- 기본 kubeconfig 파일에서 모든 컨텍스트 가져오기:
+
+`kubectl config get-contexts`
+
+- 사용자 지정 kubeconfig 파일에서 모든 클러스터/컨텍스트/사용자 가져오기:
+
+`kubectl config {{get-clusters|get-contexts|get-users}} --kubeconfig {{경로/대상/kubeconfig.yaml}}`
+
+- 현재 컨텍스트 가져오기:
+
+`kubectl config current-context`
+
+- 다른 컨텍스트로 전환:
+
+`kubectl config {{use|use-context}} {{컨텍스트_이름}}`
+
+- 클러스터/컨텍스트/사용자 삭제:
+
+`kubectl config {{delete-cluster|delete-context|delete-user}} {{cluster|context|user}}`
+
+- 사용자 지정 kubeconfig 파일을 영구적으로 추가:
+
+`export KUBECONFIG="{{$HOME.kube/config:경로/대상/사용자/정의/kubeconfig.yaml}}" kubectl config get-contexts`

--- a/pages.ko/common/kubectl-create.md
+++ b/pages.ko/common/kubectl-create.md
@@ -1,0 +1,28 @@
+# kubectl create
+
+> 파일 또는 `stdin`에서 리소스를 생성.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
+
+- 리소스 정의 파일을 사용하여 리소스 생성:
+
+`kubectl create -f {{경로/대상/파일.yml}}`
+
+- `stdin`에서 리소스 생성:
+
+`kubectl create -f -`
+
+- 배포 생성:
+
+`kubectl create deployment {{배포_이름}} --image={{이미지}}`
+
+- 복제본과 함께 배포 생성:
+
+`kubectl create deployment {{배포_이름}} --image={{이미지}} --replicas={{복제본_수}}`
+
+- 서비스 생성:
+
+`kubectl create service {{서비스_유형}} {{서비스_이름}} --tcp={{포트}}:{{대상_포트}}`
+
+- 네임스페이스 생성:
+
+`kubectl create namespace {{네임스페이스_이름}}`

--- a/pages.ko/common/kubectl-delete.md
+++ b/pages.ko/common/kubectl-delete.md
@@ -1,0 +1,32 @@
+# kubectl delete
+
+> Kubernetes 리소스 삭제.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete>.
+
+- 특정 포드 삭제:
+
+`kubectl delete pod {{포드_이름}}`
+
+- 특정 배포 삭제:
+
+`kubectl delete deployment {{배포_이름}}`
+
+- 특정 노드 삭제:
+
+`kubectl delete node {{노드_이름}}`
+
+- 지정된 네임스페이스의 모든 포드 삭제:
+
+`kubectl delete pods --all --namespace {{네임스페이스}}`
+
+- 지정된 네임스페이스의 모든 배포 및 서비스 삭제:
+
+`kubectl delete deployments,services --all --namespace {{네임스페이스}}`
+
+- 모든 노드 삭제:
+
+`kubectl delete nodes --all`
+
+- YAML 매니페스트에 정의된 리소스 삭제:
+
+`kubectl delete --filename {{경로/대상/매니페스트.yaml}}`

--- a/pages.ko/common/kubectl-describe.md
+++ b/pages.ko/common/kubectl-describe.md
@@ -1,0 +1,24 @@
+# kubectl describe
+
+> Kubernetes 객체 및 리소스의 세부 정보 표시.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
+
+- [n]amespace의 포드 세부 정보 표시:
+
+`kubectl describe pods --namespace {{네임스페이스}}`
+
+- [n]amespace의 노드 세부 정보 표시:
+
+`kubectl describe nodes --namespace {{네임스페이스}}`
+
+- [n]amespace의 특정 포드 세부 정보 표시:
+
+`kubectl describe pods {{포드_이름}} --namespace {{네임스페이스}}`
+
+- [n]amespace의 특정 노드 세부 정보 표시:
+
+`kubectl describe nodes {{노드_이름}} --namespace {{네임스페이스}}`
+
+- YAML 매니페스트 [f]ile에 정의된 Kubernetes 객체의 세부 정보 표시:
+
+`kubectl describe --file {{경로/대상/manifest.yaml}}`

--- a/pages.ko/common/kubectl-edit.md
+++ b/pages.ko/common/kubectl-edit.md
@@ -1,0 +1,24 @@
+# kubectl edit
+
+> Kubernetes 리소스를 편집.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#edit>.
+
+- Pod 편집:
+
+`kubectl edit pod/{{pod_이름}}`
+
+- Deployment 편집:
+
+`kubectl edit deployment/{{deployment_이름}}`
+
+- Service 편집:
+
+`kubectl edit svc/{{service_이름}}`
+
+- 특정 편집기를 사용하여 리소스 편집:
+
+`KUBE_EDITOR={{nano}} kubectl edit {{resource}}/{{리소스_이름}}`
+
+- JSON 형식으로 리소스 편집:
+
+`kubectl edit {{resource}}/{{리소스_이름}} --output json`

--- a/pages.ko/common/kubectl-expose.md
+++ b/pages.ko/common/kubectl-expose.md
@@ -1,0 +1,16 @@
+# kubectl expose
+
+> 리소스를 새로운 Kubernetes 서비스로 노출.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
+
+- 컨테이너 포트에서 노드 포트로 제공될 리소스에 대한 서비스 생성:
+
+`kubectl expose {{리소스_타입}} {{리소스_이름}} --port={{노드_포트}} --target-port={{컨테이너_포트}}`
+
+- 파일로 식별된 리소스에 대한 서비스 생성:
+
+`kubectl expose -f {{경로/대상/파일.yml}} --port={{노드_포트}} --target-port={{컨테이너_포트}}`
+
+- 컨테이너 포트와 동일한 노드 포트로 제공할 이름이 있는 서비스 생성:
+
+`kubectl expose {{리소스_타입}} {{리소스_이름}} --port={{노드_포트}} --name={{서비스_이름}}`

--- a/pages.ko/common/kubectl-get.md
+++ b/pages.ko/common/kubectl-get.md
@@ -1,0 +1,32 @@
+# kubectl get
+
+> Kubernetes 객체 및 리소스 가져오기.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get>.
+
+- 현재 클러스터의 모든 네임스페이스 가져오기:
+
+`kubectl get namespaces`
+
+- 지정된 [n]amespace의 노드 가져오기:
+
+`kubectl get nodes --namespace {{네임스페이스}}`
+
+- 지정된 [n]amespace의 파드 가져오기:
+
+`kubectl get pods --namespace {{네임스페이스}}`
+
+- 지정된 [n]amespace의 배포 가져오기:
+
+`kubectl get deployments --namespace {{네임스페이스}}`
+
+- 지정된 [n]amespace의 서비스 가져오기:
+
+`kubectl get services --namespace {{네임스페이스}}`
+
+- 지정된 [n]amespace의 모든 리소스 가져오기:
+
+`kubectl get all --namespace {{네임스페이스}}`
+
+- YAML 매니페스트 [f]ile에 정의된 Kubernetes 객체 가져오기:
+
+`kubectl get --file {{경로/대상/매니페스트.yaml}}`

--- a/pages.ko/common/kubectl-label.md
+++ b/pages.ko/common/kubectl-label.md
@@ -1,0 +1,24 @@
+# kubectl label
+
+> Kubernetes 리소스에 레이블 지정.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label>.
+
+- 포드에 레이블 지정:
+
+`kubectl label pod {{포드_이름}} {{키}}={{값}}`
+
+- 기존 값을 덮어쓰며 포드 레이블 업데이트:
+
+`kubectl label --overwrite pod {{포드_이름}} {{키}}={{값}}`
+
+- 네임스페이스의 모든 포드에 레이블 지정:
+
+`kubectl label pods --all {{키}}={{값}}`
+
+- 포드 정의 파일로 식별된 포드에 레이블 지정:
+
+`kubectl label -f {{포드_정의_파일}} {{키}}={{값}}`
+
+- 포드에서 레이블 제거:
+
+`kubectl label pod {{포드_이름}} {{키}}-`

--- a/pages.ko/common/kubectl-logs.md
+++ b/pages.ko/common/kubectl-logs.md
@@ -1,0 +1,32 @@
+# kubectl logs
+
+> 컨테이너의 로그를 조회하는 도구.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+
+- 단일 컨테이너가 있는 파드의 로그 조회:
+
+`kubectl logs {{포드_이름}}`
+
+- 특정 컨테이너의 로그 조회:
+
+`kubectl logs --container {{컨테이너_이름}} {{포드_이름}}`
+
+- 포드 내 모든 컨테이너의 로그 조회:
+
+`kubectl logs --all-containers={{true}} {{포드_이름}}`
+
+- 포드 로그 스트리밍:
+
+`kubectl logs --follow {{포드_이름}}`
+
+- `10s`, `5m` 또는 `1h`와 같은 상대 시간 이후의 포드 로그 조회:
+
+`kubectl logs --since={{상대_시간}} {{포드_이름}}`
+
+- 가장 최근의 10개의 포드 로그 조회:
+
+`kubectl logs --tail={{10}} {{포드_이름}}`
+
+- 특정 배포의 모든 포드 로그 조회:
+
+`kubectl logs deployment/{{배포_이름}}`

--- a/pages.ko/common/kubectl-replace.md
+++ b/pages.ko/common/kubectl-replace.md
@@ -1,0 +1,16 @@
+# kubectl replace
+
+> 파일 또는 `stdin`을 통해 리소스를 교체.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#replace>.
+
+- 리소스 정의 파일을 사용하여 리소스 교체:
+
+`kubectl replace -f {{경로/대상/파일.yml}}`
+
+- `stdin`으로 전달된 입력을 사용하여 리소스 교체:
+
+`kubectl replace -f -`
+
+- 강제로 교체: 리소스를 삭제한 후 다시 생성:
+
+`kubectl replace --force -f {{경로/대상/파일.yml}}`

--- a/pages.ko/common/kubectl-rollout.md
+++ b/pages.ko/common/kubectl-rollout.md
@@ -1,0 +1,20 @@
+# kubectl rollout
+
+> Kubernetes 리소스(배포, 데몬셋, 스테이트풀셋)의 롤아웃 관리.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout>.
+
+- 리소스의 롤링 재시작 시작:
+
+`kubectl rollout restart {{리소스_유형}}/{{리소스_이름}}`
+
+- 리소스의 롤링 업데이트 상태 보기:
+
+`kubectl rollout status {{리소스_유형}}/{{리소스_이름}}`
+
+- 리소스를 이전 리비전으로 롤백:
+
+`kubectl rollout undo {{리소스_유형}}/{{리소스_이름}}`
+
+- 리소스의 롤아웃 기록 보기:
+
+`kubectl rollout history {{리소스_유형}}/{{리소스_이름}}`

--- a/pages.ko/common/kubectl-run.md
+++ b/pages.ko/common/kubectl-run.md
@@ -1,0 +1,24 @@
+# kubectl run
+
+> Kubernetes에서 파드를 실행. 일부 K8S 버전에서 경고 메시지를 피하기 위해 파드 생성기를 지정.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run>.
+
+- nginx 파드를 실행하고 포트 80을 노출:
+
+`kubectl run {{nginx-dev}} --image=nginx --port 80`
+
+- TEST_VAR 환경 변수를 설정하여 nginx 파드 실행:
+
+`kubectl run {{nginx-dev}} --image=nginx --env="{{TEST_VAR}}={{testing}}"`
+
+- nginx 컨테이너를 생성하기 위해 수행될 API 호출을 표시:
+
+`kubectl run {{nginx-dev}} --image=nginx --dry-run={{none|server|client}}`
+
+- Ubuntu 파드를 대화형으로 실행, 재시작하지 않으며 종료 시 제거:
+
+`kubectl run {{temp-ubuntu}} --image=ubuntu:22.04 --restart=Never --rm -- /bin/bash`
+
+- 기본 명령을 echo로 변경하고 사용자 정의 인수를 지정하여 Ubuntu 파드 실행:
+
+`kubectl run {{temp-ubuntu}} --image=ubuntu:22.04 --command -- echo {{인수1 인수2 ...}}`

--- a/pages.ko/common/kubectl-scale.md
+++ b/pages.ko/common/kubectl-scale.md
@@ -1,0 +1,16 @@
+# kubectl scale
+
+> 배포, 레플리카 세트, 복제 컨트롤러 또는 스테이트풀 세트의 크기를 조정.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale>.
+
+- 레플리카 세트 크기 조정:
+
+`kubectl scale --replicas={{레플리카_수}} rs/{{레플리카_이름}}`
+
+- 파일로 식별된 리소스 크기 조정:
+
+`kubectl scale --replicas={{레플리카_수}} -f {{경로/대상/파일.yml}}`
+
+- 현재 레플리카 수를 기준으로 배포 크기 조정:
+
+`kubectl scale --current-replicas={{현재_레플리카_수}} --replicas={{레플리카_수}} deployment/{{배포_이름}}`

--- a/pages.ko/common/kubectl-taint.md
+++ b/pages.ko/common/kubectl-taint.md
@@ -1,0 +1,16 @@
+# kubectl taint
+
+> 노드에 taint 업데이트.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint>.
+
+- 노드에 taint 적용:
+
+`kubectl taint nodes {{노드_이름}} {{라벨_키}}={{라벨_값}}:{{효과}}`
+
+- 노드에서 taint 제거:
+
+`kubectl taint nodes {{노드_이름}} {{라벨_키}}:{{효과}}-`
+
+- 노드에서 모든 taint 제거:
+
+`kubectl taint nodes {{노드_이름}} {{라벨_키}}-`

--- a/pages.ko/common/kubectl.md
+++ b/pages.ko/common/kubectl.md
@@ -1,0 +1,37 @@
+# kubectl
+
+> Kubernetes 클러스터에서 명령을 실행하기 위한 명령줄 인터페이스.
+> `run`과 같은 일부 하위 명령에는 자체 사용 설명서가 있습니다.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/>.
+
+- 리소스에 대한 정보를 자세히 나열:
+
+`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+
+- 지정된 포드에 'unhealthy' 레이블과 'true' 값을 추가:
+
+`kubectl label pods {{이름}} unhealthy=true`
+
+- 다양한 유형의 모든 리소스 나열:
+
+`kubectl get all`
+
+- 노드 또는 포드의 리소스(CPU/메모리/스토리지) 사용량 표시:
+
+`kubectl top {{pod|node}}`
+
+- 마스터 및 클러스터 서비스의 주소 출력:
+
+`kubectl cluster-info`
+
+- 특정 필드에 대한 설명 표시:
+
+`kubectl explain {{pods.spec.containers}}`
+
+- 포드 또는 지정된 리소스의 컨테이너 로그 출력:
+
+`kubectl logs {{포드_이름}}`
+
+- 기존 포드에서 명령 실행:
+
+`kubectl exec {{포드_이름}} -- {{ls /}}`

--- a/pages.ko/common/kubectx.md
+++ b/pages.ko/common/kubectx.md
@@ -1,0 +1,28 @@
+# kubectx
+
+> `kubectl` 컨텍스트를 관리하고 전환하는 도구.
+> 더 많은 정보: <https://github.com/ahmetb/kubectx>.
+
+- 컨텍스트 나열:
+
+`kubectx`
+
+- 지정된 이름의 컨텍스트로 전환:
+
+`kubectx {{이름}}`
+
+- 이전 컨텍스트로 전환:
+
+`kubectx -`
+
+- 지정된 이름의 컨텍스트 이름 변경:
+
+`kubectx {{별칭}}={{이름}}`
+
+- 현재 사용 중인 컨텍스트 표시:
+
+`kubectx -c`
+
+- 지정된 이름의 컨텍스트 삭제:
+
+`kubectx -d {{이름}}`

--- a/pages.ko/common/kubens.md
+++ b/pages.ko/common/kubens.md
@@ -1,0 +1,16 @@
+# kubens
+
+> Kubernetes 네임스페이스 간 전환 유틸리티.
+> 더 많은 정보: <https://github.com/ahmetb/kubectx>.
+
+- 네임스페이스 나열:
+
+`kubens`
+
+- 활성 네임스페이스 변경:
+
+`kubens {{이름}}`
+
+- 이전 네임스페이스로 전환:
+
+`kubens -`

--- a/pages.ko/common/kubetail.md
+++ b/pages.ko/common/kubetail.md
@@ -1,0 +1,20 @@
+# kubetail
+
+> 여러 Kubernetes 포드의 로그를 동시에 추적하는 유틸리티.
+> 더 많은 정보: <https://github.com/johanhaleby/kubetail>.
+
+- 여러 포드의 로그를 한 번에 추적 (포드 이름이 "my_app"으로 시작하는 경우):
+
+`kubetail {{my_app}}`
+
+- 여러 포드에서 특정 컨테이너의 로그만 추적:
+
+`kubetail {{my_app}} -c {{my_container}}`
+
+- 여러 포드에서 여러 컨테이너의 로그를 추적:
+
+`kubetail {{my_app}} -c {{my_container_1}} -c {{my_container_2}}`
+
+- 여러 애플리케이션의 로그를 동시에 추적하려면 쉼표로 구분:
+
+`kubetail {{my_app_1}},{{my_app_2}}`

--- a/pages.ko/common/kustomize.md
+++ b/pages.ko/common/kustomize.md
@@ -1,0 +1,20 @@
+# kustomize
+
+> Kubernetes 리소스를 쉽게 배포.
+> 더 많은 정보: <https://github.com/kubernetes-sigs/kustomize>.
+
+- 리소스 및 네임스페이스가 포함된 커스터마이제이션 파일 생성:
+
+`kustomize create --resources {{deployment.yaml,service.yaml}} --namespace {{staging}}`
+
+- 커스터마이제이션 파일을 빌드하고 `kubectl`로 배포:
+
+`kustomize build . | kubectl apply -f -`
+
+- 커스터마이제이션 파일에 이미지 설정:
+
+`kustomize edit set image {{busybox=alpine:3.6}}`
+
+- 현재 디렉터리의 Kubernetes 리소스를 검색하여 커스터마이제이션 파일에 추가:
+
+`kustomize create --autodetect`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
