### PR TITLE
pages.pt_BR/freebsd: add Brazilian Portuguese translation

### DIFF
--- a/pages.pt_BR/freebsd/base64.md
+++ b/pages.pt_BR/freebsd/base64.md
@@ -1,0 +1,28 @@
+# base64
+
+> Codifica ou decodifica arquivo ou `stdin` de/para base64, para `stdout` ou outro arquivo.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?query=base64>.
+
+- Codifica um arquivo para `stdout`:
+
+`base64 {{-i|--input}} {{caminho/para/arquivo}}`
+
+- Codifica um arquivo para o arquivo de saída especificado:
+
+`base64 {{-i|--input}} {{caminho/para/arquivo_de_entrada}} {{-o|--output}} {{caminho/para/arquivo_de_saída}}`
+
+- Enrola saída codificada a uma largura específica (‘0’ desabilita encapsulamento):
+
+`base64 {{-b|--break}} {{0|76|...}} {{caminho/para/arquivo}}`
+
+- Decodifica um arquivo para `stdout`:
+
+`base64 {{-d|--decode}} {{-i|--input}} {{caminho/para/arquivo}}`
+
+- Codifica de `stdin` para `stdout`:
+
+`{{comando}} | base64`
+
+- Decodifica de `stdin` para `stdout`:
+
+`{{comando}} | base64 {{-d|--decode}}`

--- a/pages.pt_BR/freebsd/base64.md
+++ b/pages.pt_BR/freebsd/base64.md
@@ -11,7 +11,7 @@
 
 `base64 {{-i|--input}} {{caminho/para/arquivo_de_entrada}} {{-o|--output}} {{caminho/para/arquivo_de_saída}}`
 
-- Enrola saída codificada a uma largura específica (‘0’ desabilita encapsulamento):
+- Quebra (insere uma quebra de linha) a saída codificada em uma largura específica (‘0’ desabilita encapsulamento):
 
 `base64 {{-b|--break}} {{0|76|...}} {{caminho/para/arquivo}}`
 

--- a/pages.pt_BR/freebsd/cal.md
+++ b/pages.pt_BR/freebsd/cal.md
@@ -1,0 +1,32 @@
+# cal
+
+> Mostra um calendário com o dia atual destacado.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?cal>.
+
+- Exibe um calendário para o mês atual:
+
+`cal`
+
+- Exibe um calendário para um ano específico:
+
+`cal {{ano}}`
+
+- Exibe um calendário para um ano e mês específicos:
+
+`cal {{mês}} {{ano}}`
+
+- Exibe o calendário inteiro para o ano atual:
+
+`cal -y`
+
+- Não [d]estaca hoje e exibe [3] meses abrangendo a data:
+
+`cal -h -3 {{mês}} {{ano}}`
+
+- Exibe os 2 meses [A]ntes e 3 [D]epois de um [m]ês específico do ano atual:
+
+`cal -A 3 -B 2 {{mês}}`
+
+- Exibe dias [j]ulianos (começando de um, numerados de 1º de janeiro):
+
+`cal -j`

--- a/pages.pt_BR/freebsd/cal.md
+++ b/pages.pt_BR/freebsd/cal.md
@@ -19,7 +19,7 @@
 
 `cal -y`
 
-- Não [d]estaca hoje e exibe [3] meses abrangendo a data:
+- Não destaca hoje e exibe [3] meses abrangendo a data:
 
 `cal -h -3 {{mês}} {{ano}}`
 

--- a/pages.pt_BR/freebsd/df.md
+++ b/pages.pt_BR/freebsd/df.md
@@ -1,0 +1,32 @@
+# df
+
+> Exibe uma visão geral do uso de espaço de disco do sistema de arquivos.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?df>.
+
+- Exibe todos os sistemas de arquivos e seu uso de disco usando unidades 512-bytes:
+
+`df`
+
+- Usa unidades legíveis para [h]umanos (baseadas em potências de 1024) e exibe um total:
+
+`df -h -c`
+
+- Usa unidades legíveis para [h]umanos (baseadas em potências de 1000):
+
+`df -{{-si|H}}`
+
+- Exibe o sistema de arquivos e seu uso do disco contendo o arquivo ou diretório dado:
+
+`df {{caminho/para/arquivo_ou_diretório}}`
+
+- Inclui estatísticas do número de nós livres e usados incluindo [T]ipos do sistema de arquivos:
+
+`df -iT`
+
+- Usa unidades 1024-bytes ao escrever figuras de espaço:
+
+`df -k`
+
+- Exibe informação em uma maneira [p]ortátil:
+
+`df -P`

--- a/pages.pt_BR/freebsd/look.md
+++ b/pages.pt_BR/freebsd/look.md
@@ -1,0 +1,21 @@
+# look
+
+> Exibe linhas começando com um prefixo em um arquivo ordenado.
+> Veja também: `grep`, `sort`.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?look>.
+
+- Busca por linhas começando com um prefixo específico em um arquivo específico:
+
+`look {{prefixo}} {{caminho/para/arquivo}}`
+
+- Busca sem distinção entre maiúsculas e minúsculas apenas em caracteres alfanuméricos:
+
+`look {{-f|--ignore-case}} {{-d|--alphanum}} {{prefixo}} {{caminho/para/arquivo}}`
+
+- Especifica um caractere de término de string (espaço por padrão):
+
+`look {{-t|--terminate}} {{,}}`
+
+- Busca em `/usr/share/dict/words` (`--ignore-case` e `--alphanum` são assumidos):
+
+`look {{prefixo}}`

--- a/pages.pt_BR/freebsd/sed.md
+++ b/pages.pt_BR/freebsd/sed.md
@@ -1,0 +1,29 @@
+# sed
+
+> Edita texto de uma maneira programável.
+> Veja também: `awk`, `ed`.
+> Mais informações: <https://www.freebsd.org/cgi/man.cgi?sed>.
+
+- Substitui todas as ocorrências de `maçã` (regex básico) por `manga` (regex básico) em todas as linhas de entrada e imprime o resultado para `stdout`:
+
+`{{comando}} | sed 's/maçã/manga/g'`
+
+- Executa um script específico e imprime o resultado para `stdout`:
+
+`{{comando}} | sed -f {{caminho/para/script.sed}}`
+
+- Atrasa a abertura de cada arquivo até que um comando contendo a função ou flag `w` relacionada seja aplicada a linha de entrada:
+
+`{{comando}} | sed -fa {{caminho/para/script.sed}}`
+
+- Substitui todas as ocorrências de `maçã` (regex extendido) por `MAÇÃ` (regex extendido) em todas as linhas de entrada e imprime o resultado para `stdout`:
+
+`{{comando}} | sed -E 's/(maçã)/\U\1/g'`
+
+- Imprime apenas a primeira linha para `stdout`:
+
+`{{comando}} | sed -n '1p'`
+
+- Substitui todas as ocorrências de `maçã` (regex básico) por `manga` (regex básico) em um arquivo específico e sobrescreve o arquivo original no lugar:
+
+`sed -i 's/maçã/manga/g' {{caminho/para/arquivo}}`

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -1,0 +1,36 @@
+# sockstat
+
+> Lista sockets de domínio aberto Internet ou UNIX.
+> Mais informações: <https://man.freebsd.org/cgi/man.cgi?sockstat>.
+
+- Vê quais usuários/processos estão [e]scutando em quais portas:
+
+`sockstat -l`
+
+- Exibe informação para sockets IPv[4] e IPv[6] [e]scutando em portas específicas usando um [p]rotocolo específico:
+
+`sockstat -{{4|6}} -l -P {{tcp|udp|sctp|divert}} -p {{port1,port2...}}`
+
+- Exibe também sockets [c]onectados, não resolvendo UIDs [n]uméricos para nome de usuários e usando um campo mais [l]argo:
+
+`sockstat -cnw`
+
+- Exibe somente sockets que pertencem a um ID [j]ail específico ou nome de modo detalhado:
+
+`sockstat -jv`
+
+- Exibe o [e]stado do protocolo e o número da porta do encapsulamento [U]DP remoto, se aplicável (atualmente, estes estão implementados somente para SCTP e TCP):
+
+`sockstat -sU`
+
+- Exibe o módulo de controle de [c]ongestionamento e a [p]ilha de protocolo, se aplicável (atualmente, estes estão implementados somente para TCP):
+
+`sockstat -CS`
+
+- Exibe apenas sockets da Internet se os endereços local e estrangeiro não estiverem no prefixo de rede loopback 127.0.0.0/8, ou não contiverem o endereço de loopback IPv6 ::1:
+
+`sockstat -L`
+
+- Não exibe o cabeçalho (modo [s]ilencioso), mostrando sockets [u]nix e exibindo o `inp_gencnt`:
+
+`sockstat -qui`

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -19,7 +19,7 @@
 
 `sockstat -jv`
 
-- Exibe o [e]stado do protocolo e o número da porta do encapsulamento [U]DP remoto, se aplicável (atualmente, estes estão implementados somente para SCTP e TCP):
+- Exibe o estado do protocolo e o número da porta do encapsulamento [U]DP remoto, se aplicável (atualmente, estes estão implementados somente para SCTP e TCP):
 
 `sockstat -sU`
 

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -7,7 +7,7 @@
 
 `sockstat -l`
 
-- Exibe informação para sockets IPv[4] e IPv[6] [e]scutando em portas específicas usando um [p]rotocolo específico:
+- Exibe informação para sockets IPv[4] e IPv[6] escutando em portas específicas usando um [p]rotocolo específico:
 
 `sockstat -{{4|6}} -l -P {{tcp|udp|sctp|divert}} -p {{port1,port2...}}`
 

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -31,6 +31,6 @@
 
 `sockstat -L`
 
-- Não exibe o cabeçalho (modo [s]ilencioso), mostrando sockets [u]nix e exibindo o `inp_gencnt`:
+- Não exibe o cabeçalho (modo silencioso), mostrando sockets [u]nix e exibindo o `inp_gencnt`:
 
 `sockstat -qui`

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -11,7 +11,7 @@
 
 `sockstat -{{4|6}} -l -P {{tcp|udp|sctp|divert}} -p {{port1,port2...}}`
 
-- Exibe também sockets [c]onectados, não resolvendo UIDs [n]uméricos para nome de usuários e usando um campo mais [l]argo:
+- Exibe também sockets [c]onectados, não resolvendo UIDs [n]uméricos para nome de usuários e usando um campo mais largo:
 
 `sockstat -cnw`
 

--- a/pages.pt_BR/freebsd/sockstat.md
+++ b/pages.pt_BR/freebsd/sockstat.md
@@ -23,7 +23,7 @@
 
 `sockstat -sU`
 
-- Exibe o módulo de controle de [c]ongestionamento e a [p]ilha de protocolo, se aplicável (atualmente, estes estão implementados somente para TCP):
+- Exibe o módulo de controle de [c]ongestionamento e a pilha de protocolo, se aplicável (atualmente, estes estão implementados somente para TCP):
 
 `sockstat -CS`
 


### PR DESCRIPTION
Adding translation for the remaining `freebsd` pages.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
