### PR TITLE
chromium: add Dutch translation

### DIFF
--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -5,25 +5,33 @@
 > Meer informatie: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
 
 - Open een specifieke URL of bestand:
+  
 `chromium {{https://voorbeeld.com|path/naar/bestand.html}}`
 
 - Open in incognito modus (gebruik `--inprivate` voor Microsoft Edge):
+  
 `{{chromium --incognito|msedge --inprivate}} {{voorbeeld.com}}`
 
 - Open in een nieuw venster:
+  
 `chromium --new-window {{voorbeeld.com}}`
 
 - Open in applicatie modus (zonder werkbalken, URL balk, knoppen, etc.):
+  
 `chromium --app={{https://voorbeeld.com}}`
 
 - Gebruik een proxy server:
+  
 `chromium --proxy-server="{{socks5://hostname:66}}" {{voorbeeld.com}}`
 
 - Open met een aangepaste profiel map:
+  
 `chromium --user-data-dir={{path/to/directory}}`
 
 - Open zonder CORS validatie (handig om een API te testen):
+  
 `chromium --user-data-dir={{path/to/directory}} --disable-web-security`
 
 - Open met een DevTools venster voor elk geopend tabblad:
+  
 `chromium --auto-open-devtools-for-tabs`

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -1,0 +1,28 @@
+# chromium
+> Open-source webbrowser die voornamelijk ontwikkeld en onderhouden wordt door Google.
+> Opmerking: Mogelijk moet je het `chromium` commando vervangen met jouw gewenste webbrowser, zoals `brave`, `google-chrome`, `microsoft-edge`/`msedge`, `opera`, of `vivaldi`.
+> Meer informatie: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
+
+- Open een specifieke URL of bestand:
+`chromium {{https://voorbeeld.com|path/naar/bestand.html}}`
+
+- Open in incognito modus (gebruik `--inprivate` voor Microsoft Edge):
+`{{chromium --incognito|msedge --inprivate}} {{voorbeeld.com}}`
+
+- Open in een nieuw venster:
+`chromium --new-window {{voorbeeld.com}}`
+
+- Open in applicatie modus (zonder werkbalken, URL balk, knoppen, etc.):
+`chromium --app={{https://voorbeeld.com}}`
+
+- Gebruik een proxy server:
+`chromium --proxy-server="{{socks5://hostname:66}}" {{voorbeeld.com}}`
+
+- Open met een aangepaste profiel map:
+`chromium --user-data-dir={{path/to/directory}}`
+
+- Open zonder CORS validatie (handig om een API te testen):
+`chromium --user-data-dir={{path/to/directory}} --disable-web-security`
+
+- Open met een DevTools venster voor elk geopend tabblad:
+`chromium --auto-open-devtools-for-tabs`

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -26,11 +26,11 @@
 
 - Open met een aangepaste profiel map:
 
-`chromium --user-data-dir={{path/to/directory}}`
+`chromium --user-data-dir={{pad/naar/map}}`
 
 - Open zonder CORS validatie (handig om een API te testen):
 
-`chromium --user-data-dir={{path/to/directory}} --disable-web-security`
+`chromium --user-data-dir={{pad/naar/map}} --disable-web-security`
 
 - Open met een DevTools venster voor elk geopend tabblad:
 

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -1,4 +1,5 @@
 # chromium
+
 > Open-source webbrowser die voornamelijk ontwikkeld en onderhouden wordt door Google.
 > Opmerking: Mogelijk moet je het `chromium` commando vervangen met jouw gewenste webbrowser, zoals `brave`, `google-chrome`, `microsoft-edge`/`msedge`, `opera`, of `vivaldi`.
 > Meer informatie: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -6,11 +6,11 @@
 
 - Open een specifieke URL of bestand:
 
-`chromium {{https://voorbeeld.com|path/naar/bestand.html}}`
+`chromium {{https://example.com|path/naar/bestand.html}}`
 
 - Open in incognito modus (gebruik `--inprivate` voor Microsoft Edge):
 
-`{{chromium --incognito|msedge --inprivate}} {{voorbeeld.com}}`
+`{{chromium --incognito|msedge --inprivate}} {{example.com}}`
 
 - Open in een nieuw venster:
 
@@ -18,11 +18,11 @@
 
 - Open in applicatie modus (zonder werkbalken, URL balk, knoppen, etc.):
 
-`chromium --app={{https://voorbeeld.com}}`
+`chromium --app={{https://example.com}}`
 
 - Gebruik een proxy server:
 
-`chromium --proxy-server="{{socks5://hostname:66}}" {{voorbeeld.com}}`
+`chromium --proxy-server="{{socks5://hostname:66}}" {{example.com}}`
 
 - Open met een aangepaste profiel map:
 

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -1,7 +1,7 @@
 # chromium
 
 > Open-source webbrowser die voornamelijk ontwikkeld en onderhouden wordt door Google.
-> Opmerking: Mogelijk moet je het `chromium` commando vervangen met jouw gewenste webbrowser, zoals `brave`, `google-chrome`, `microsoft-edge`/`msedge`, `opera`, of `vivaldi`.
+> Let op: mogelijk moet je het `chromium` commando vervangen met jouw gewenste webbrowser, zoals `brave`, `google-chrome`, `microsoft-edge`/`msedge`, `opera` of `vivaldi`.
 > Meer informatie: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
 
 - Open een specifieke URL of bestand:

--- a/pages.nl/windows/chromium.md
+++ b/pages.nl/windows/chromium.md
@@ -5,33 +5,33 @@
 > Meer informatie: <https://www.chromium.org/developers/how-tos/run-chromium-with-flags/>.
 
 - Open een specifieke URL of bestand:
-  
+
 `chromium {{https://voorbeeld.com|path/naar/bestand.html}}`
 
 - Open in incognito modus (gebruik `--inprivate` voor Microsoft Edge):
-  
+
 `{{chromium --incognito|msedge --inprivate}} {{voorbeeld.com}}`
 
 - Open in een nieuw venster:
-  
+
 `chromium --new-window {{voorbeeld.com}}`
 
 - Open in applicatie modus (zonder werkbalken, URL balk, knoppen, etc.):
-  
+
 `chromium --app={{https://voorbeeld.com}}`
 
 - Gebruik een proxy server:
-  
+
 `chromium --proxy-server="{{socks5://hostname:66}}" {{voorbeeld.com}}`
 
 - Open met een aangepaste profiel map:
-  
+
 `chromium --user-data-dir={{path/to/directory}}`
 
 - Open zonder CORS validatie (handig om een API te testen):
-  
+
 `chromium --user-data-dir={{path/to/directory}} --disable-web-security`
 
 - Open met een DevTools venster voor elk geopend tabblad:
-  
+
 `chromium --auto-open-devtools-for-tabs`


### PR DESCRIPTION
Adds the Chromium page in Dutch.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
