### PR TITLE
cleanup: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- markdownlint-disable MD041 -->
-<link href="https://fosstodon.org/@tldr_pages" rel="me" />
 
 <div align="center">
   <h1><a href="https://tldr.sh/"><img alt="tldr-pages" src="images/banner.png" width=600/></a></h1>
@@ -31,7 +30,7 @@ The **tldr-pages** project is a collection of community-maintained help pages
 for command-line tools, that aims to be a simpler, more approachable complement
 to traditional [man pages](https://en.wikipedia.org/wiki/Man_page).
 
-Maybe you're new to the command-line world? Perhaps you're just a little rusty or can't always recall the arguments for commands like `lsof`, or `tar`?
+Maybe you're new to the command-line world. Perhaps you're just a little rusty or can't always recall the arguments for commands like `lsof`, or `tar`?
 
 It certainly doesn't help that, in the past, the first option explained in `man tar` was:
 
@@ -45,7 +44,7 @@ $ man tar
 ...
 ```
 
-There seems to be room for simpler help pages, focused on practical examples.
+There is room for simpler help pages focused on practical examples.
 How about:
 
 <picture>
@@ -55,7 +54,8 @@ How about:
 </picture>
 
 This repository is just that: an ever-growing collection of examples
-for the most common UNIX, Linux, macOS, SunOS, Android, and Windows command-line tools.
+for the most common UNIX, Linux, macOS, FreeBSD, NetBSD, OpenBSD,
+SunOS, Android, and Windows command-line tools.
 
 ## How do I use it?
 
@@ -89,7 +89,7 @@ accessible through typing `tldr tar` instead of the standard `man tar`.
 If you don't want to install any software, check out the [PDF version](https://github.com/tldr-pages/tldr/releases/latest/download/tldr-book.pdf) instead.
 
 > [!NOTE]
-> PDFs for translations are available for most languages. You can find them in the releases assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
+> PDFs for translations are available for most languages. You can find them in the release assets of the [latest release](https://github.com/tldr-pages/tldr/releases/latest).
 
 There are also **various other clients** provided by the community,
 both for the command-line and for other platforms.
@@ -106,7 +106,7 @@ Some ways to contribute include:
 - Adding requested pages from our issues with the [help wanted](https://github.com/tldr-pages/tldr/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) label.
 - Translating pages into different languages.
 
-All `tldr` pages are written in markdown, so they can be edited quite easily and changes can be submitted in
+All `tldr` pages are written in Markdown so that they can be edited quite easily and changes can be submitted in
 pull requests here using Git on the command-line or
 using the GitHub web interface.
 


### PR DESCRIPTION
## Changes

- Revert 9dae3aef2eb465b0c30fea1ec1adc027ef95856d since GitHub READMEs doesn't support the tag (we have already verified tldr.sh and the org on Fosstodon so these two are enough IG)
- Minor fixes to wording throughout the page.

---

Btw, should we reorder the similar projects section based on the project's activity? (since some are barely updated)