### PR TITLE
wireplumber: fix typo

### DIFF
--- a/pages/common/wireplumber.md
+++ b/pages/common/wireplumber.md
@@ -22,4 +22,4 @@
 
 - Display version:
 
-`wirepumbler --version`
+`wireplumber --version`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**


This is a word error in the original text discovered during the review. Correction is needed.
https://github.com/tldr-pages/tldr/pull/14523#issuecomment-2452050953