### PR TITLE
check-pr: add the ability to run with verbose logging

### DIFF
--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -22,7 +22,7 @@
 VERBOSE=false
 
 while getopts ":v" opt; do
-  case "$opt" in
+  case $opt in
   v)
     VERBOSE=true
     ;;
@@ -32,7 +32,7 @@ while getopts ":v" opt; do
   esac
 done
 
-if [[ "$VERBOSE" = true ]]; then
+if [[ $VERBOSE == true ]]; then
   DEBUG_LOG="debug.log"
   rm -f "$DEBUG_LOG" && touch "$DEBUG_LOG"
   exec {BASH_XTRACEFD}> "$DEBUG_LOG"


### PR DESCRIPTION
If a PR has issues, you can run the script locally using `CI=true GITHUB_REPOSITORY=tldr-pages/tldr PULL_REQUEST_ID=1 scripts/check-pr.sh -v`. This will create a debug.log in the root of the repository, and you can search for example for `+ english_commands_as_string='{{command_you_are_looking_for}}` to quicker see why a page is outdated.