### PR TITLE
pages.es: Added simple alias in linux

### DIFF
--- a/pages.es/linux/apparmor_status.md
+++ b/pages.es/linux/apparmor_status.md
@@ -1,0 +1,7 @@
+# apparmor_status
+
+> Este comando es un alias de `aa-status`.
+
+- Ver documentación para el comando original:
+
+`tldr aa-status`

--- a/pages.es/linux/google-chrome-stable.md
+++ b/pages.es/linux/google-chrome-stable.md
@@ -1,0 +1,8 @@
+# google-chrome-stable
+
+> Este comando es un alias de `chromium`.
+> Más información: <https://chrome.google.com>.
+
+- Ver documentación para el comando original:
+
+`tldr chromium`

--- a/pages.es/linux/nmtui-connect.md
+++ b/pages.es/linux/nmtui-connect.md
@@ -1,0 +1,7 @@
+# nmtui-connect
+
+> Este comando es un alias de `nmtui connect`.
+
+- Ver documentación para el comando original:
+
+`tldr nmtui`

--- a/pages.es/linux/nmtui-edit.md
+++ b/pages.es/linux/nmtui-edit.md
@@ -1,0 +1,7 @@
+# nmtui-edit
+
+> Este comando es un alias de `nmtui edit`.
+
+- Ver documentación para el comando original:
+
+`tldr nmtui`

--- a/pages.es/linux/nmtui-hostname.md
+++ b/pages.es/linux/nmtui-hostname.md
@@ -1,0 +1,7 @@
+# nmtui-hostname
+
+> Este comando es un alias de `nmtui hostname`.
+
+- Ver documentación para el comando original:
+
+`tldr nmtui`

--- a/pages.es/linux/opera-stable.md
+++ b/pages.es/linux/opera-stable.md
@@ -1,0 +1,8 @@
+# opera-stable
+
+> Este comando es un alias de `chromium`.
+> Más información: <https://opera.com>.
+
+- Ver documentación para el comando original:
+
+`tldr chromium`

--- a/pages.es/linux/qm-import-disk.md
+++ b/pages.es/linux/qm-import-disk.md
@@ -1,0 +1,7 @@
+# qm import disk
+
+> Este comando es un alias de `qm disk import`.
+
+- Ver documentación para el comando original:
+
+`tldr qm disk import`

--- a/pages.es/linux/qm-move-disk.md
+++ b/pages.es/linux/qm-move-disk.md
@@ -1,0 +1,8 @@
+# qm move disk
+
+> Este comando es un alias de `qm disk move`.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Ver documentación para el comando original:
+
+`tldr qm disk move`

--- a/pages.es/linux/qm-move_disk.md
+++ b/pages.es/linux/qm-move_disk.md
@@ -1,0 +1,8 @@
+# qm move disk
+
+> Este comando es un alias de `qm disk move`.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Ver documentación para el comando original:
+
+`tldr qm disk move`

--- a/pages.es/linux/qm-resize.md
+++ b/pages.es/linux/qm-resize.md
@@ -1,0 +1,8 @@
+# qm resize
+
+> Este comando es un alias de `qm-disk-resize`.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Ver documentación para el comando original:
+
+`tldr qm-disk-resize`

--- a/pages.es/linux/systemd-umount.md
+++ b/pages.es/linux/systemd-umount.md
@@ -1,0 +1,7 @@
+# systemd-umount
+
+> Este comando es un alias de `systemd-mount --umount`.
+
+- Ver documentación para el comando original:
+
+`tldr systemd-mount`

--- a/pages.es/linux/vivaldi-stable.md
+++ b/pages.es/linux/vivaldi-stable.md
@@ -1,0 +1,8 @@
+# vivaldi-stable
+
+> Este comando es un alias de `chromium`.
+> Más información: <https://vivaldi.com>.
+
+- Ver documentación para el comando original:
+
+`tldr chromium`

--- a/pages.es/linux/yum-config-manager.md
+++ b/pages.es/linux/yum-config-manager.md
@@ -1,0 +1,7 @@
+# yum config-manager
+
+> Este comando es un alias de `dnf config-manager`.
+
+- Ver documentación para el comando original:
+
+`tldr dnf config-manager`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
