### PR TITLE
rails-db: update documentation link

### DIFF
--- a/pages.id/common/rails-db.md
+++ b/pages.id/common/rails-db.md
@@ -1,7 +1,7 @@
 # rails db
 
 > Beragam subperintah yang berkaitan dengan database untuk Rauby on Rails.
-> Informasi lebih lanjut: <https://guides.rubyonrails.org/command_line.html>.
+> Informasi lebih lanjut: <https://guides.rubyonrails.org/active_record_migrations.html>.
 
 - Buat pangkalan data (database) baru, memuat skema dan menginisiasinya dengan data awal:
 

--- a/pages/common/rails-db.md
+++ b/pages/common/rails-db.md
@@ -1,7 +1,7 @@
 # rails db
 
 > Various database-related subcommands for Ruby on Rails.
-> More information: <https://guides.rubyonrails.org/command_line.html>.
+> More information: <https://guides.rubyonrails.org/active_record_migrations.html>.
 
 - Create databases, load the schema, and initialize with seed data:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

The new documentation link has far more `rails db` examples than the existing one.
