### PR TITLE
pages.es: add batch of Spanish common aliases

### DIFF
--- a/pages.es/common/crane-cp.md
+++ b/pages.es/common/crane-cp.md
@@ -1,0 +1,8 @@
+# crane cp
+
+> Este comando es un alias de `crane copy`.
+> Más información: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md>.
+
+- Ver documentación para el comando original:
+
+`tldr crane copy`

--- a/pages.es/common/crane-cp.md
+++ b/pages.es/common/crane-cp.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `crane copy`.
 > Más información: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr crane copy`

--- a/pages.es/common/docker-container-remove.md
+++ b/pages.es/common/docker-container-remove.md
@@ -1,0 +1,8 @@
+# docker container remove
+
+> Este comando es un alias de `docker rm`.
+> Más información: <https://docs.docker.com/reference/cli/docker/container/rm/>.
+
+- Ver documentación para el comando original:
+
+`tldr docker rm`

--- a/pages.es/common/docker-container-remove.md
+++ b/pages.es/common/docker-container-remove.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `docker rm`.
 > Más información: <https://docs.docker.com/reference/cli/docker/container/rm/>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr docker rm`

--- a/pages.es/common/docker-container-rename.md
+++ b/pages.es/common/docker-container-rename.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `docker rename`.
 > Más información: <https://docs.docker.com/reference/cli/docker/container/rename/>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr docker rename`

--- a/pages.es/common/docker-container-rename.md
+++ b/pages.es/common/docker-container-rename.md
@@ -1,0 +1,8 @@
+# docker container rename
+
+> Este comando es un alias de `docker rename`.
+> Más información: <https://docs.docker.com/reference/cli/docker/container/rename/>.
+
+- Ver documentación para el comando original:
+
+`tldr docker rename`

--- a/pages.es/common/docker-container-rm.md
+++ b/pages.es/common/docker-container-rm.md
@@ -1,0 +1,8 @@
+# docker container rm
+
+> Este comando es un alias de `docker rm`.
+> Más información: <https://docs.docker.com/reference/cli/docker/container/rm/>.
+
+- Ver documentación para el comando original:
+
+`tldr docker rm`

--- a/pages.es/common/docker-container-rm.md
+++ b/pages.es/common/docker-container-rm.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `docker rm`.
 > Más información: <https://docs.docker.com/reference/cli/docker/container/rm/>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr docker rm`

--- a/pages.es/common/docker-container-top.md
+++ b/pages.es/common/docker-container-top.md
@@ -1,0 +1,8 @@
+# docker container top
+
+> Este comando es un alias de `docker top`.
+> Más información: <https://docs.docker.com/reference/cli/docker/container/top/>.
+
+- Ver documentación para el comando original:
+
+`tldr docker top`

--- a/pages.es/common/docker-container-top.md
+++ b/pages.es/common/docker-container-top.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `docker top`.
 > Más información: <https://docs.docker.com/reference/cli/docker/container/top/>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr docker top`

--- a/pages.es/common/git-stage.md
+++ b/pages.es/common/git-stage.md
@@ -1,0 +1,8 @@
+# git stage
+
+> Este comando es un alias de `git add`.
+> Más información: <https://git-scm.com/docs/git-stage>.
+
+- Ver documentación para el comando original:
+
+`tldr git add`

--- a/pages.es/common/git-stage.md
+++ b/pages.es/common/git-stage.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `git add`.
 > Más información: <https://git-scm.com/docs/git-stage>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr git add`

--- a/pages.es/common/hd.md
+++ b/pages.es/common/hd.md
@@ -1,0 +1,8 @@
+# hd
+
+> Este comando es un alias de `hexdump`.
+> Más información: <https://manned.org/hd.1>.
+
+- Ver documentación para el comando original:
+
+`tldr hexdump`

--- a/pages.es/common/hd.md
+++ b/pages.es/common/hd.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `hexdump`.
 > Más información: <https://manned.org/hd.1>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr hexdump`

--- a/pages.es/common/hping.md
+++ b/pages.es/common/hping.md
@@ -1,0 +1,8 @@
+# hping
+
+> Este comando es un alias de `hping3`.
+> Más información: <https://github.com/antirez/hping>.
+
+- Ver documentación para el comando original:
+
+`tldr hping3`

--- a/pages.es/common/hping.md
+++ b/pages.es/common/hping.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `hping3`.
 > Más información: <https://github.com/antirez/hping>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr hping3`

--- a/pages.es/common/identify.md
+++ b/pages.es/common/identify.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `magick identify`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr magick identify`

--- a/pages.es/common/identify.md
+++ b/pages.es/common/identify.md
@@ -1,0 +1,7 @@
+# identify
+
+> Este comando es un alias de `magick identify`.
+
+- Ver documentación para el comando original:
+
+`tldr magick identify`

--- a/pages.es/common/import.md
+++ b/pages.es/common/import.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `magick import`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr magick import`

--- a/pages.es/common/import.md
+++ b/pages.es/common/import.md
@@ -1,0 +1,7 @@
+# import
+
+> Este comando es un alias de `magick import`.
+
+- Ver documentación para el comando original:
+
+`tldr magick import`

--- a/pages.es/common/jfrog.md
+++ b/pages.es/common/jfrog.md
@@ -1,0 +1,7 @@
+# jfrog
+
+> Este comando es un alias de `jf`.
+
+- Ver documentación para el comando original:
+
+`tldr jf`

--- a/pages.es/common/jfrog.md
+++ b/pages.es/common/jfrog.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `jf`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr jf`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
