### PR TITLE
pages.es: add batch of Spanish common aliases

### DIFF
--- a/pages.es/common/npm-restart.md
+++ b/pages.es/common/npm-restart.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `npm run restart`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr npm run`

--- a/pages.es/common/npm-restart.md
+++ b/pages.es/common/npm-restart.md
@@ -1,0 +1,7 @@
+# npm restart
+
+> Este comando es un alias de `npm run restart`.
+
+- Ver documentación para el comando original:
+
+`tldr npm run`

--- a/pages.es/common/npm-run-script.md
+++ b/pages.es/common/npm-run-script.md
@@ -1,0 +1,7 @@
+# npm run-script
+
+> Este comando es un alias de `npm run`.
+
+- Ver documentación para el comando original:
+
+`tldr npm run`

--- a/pages.es/common/npm-run-script.md
+++ b/pages.es/common/npm-run-script.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `npm run`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr npm run`

--- a/pages.es/common/npm-start.md
+++ b/pages.es/common/npm-start.md
@@ -1,0 +1,7 @@
+# npm start
+
+> Este comando es un alias de `npm run start`.
+
+- Ver documentación para el comando original:
+
+`tldr npm run`

--- a/pages.es/common/npm-start.md
+++ b/pages.es/common/npm-start.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `npm run start`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr npm run`

--- a/pages.es/common/npm-stop.md
+++ b/pages.es/common/npm-stop.md
@@ -1,0 +1,7 @@
+# npm stop
+
+> Este comando es un alias de `npm run stop`.
+
+- Ver documentación para el comando original:
+
+`tldr npm run`

--- a/pages.es/common/npm-stop.md
+++ b/pages.es/common/npm-stop.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `npm run stop`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr npm run`

--- a/pages.es/common/npm-test.md
+++ b/pages.es/common/npm-test.md
@@ -1,0 +1,7 @@
+# npm test
+
+> Este comando es un alias de `npm run test`.
+
+- Ver documentación para el comando original:
+
+`tldr npm run`

--- a/pages.es/common/npm-test.md
+++ b/pages.es/common/npm-test.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `npm run test`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr npm run`

--- a/pages.es/common/pamnoraw.md
+++ b/pages.es/common/pamnoraw.md
@@ -1,0 +1,8 @@
+# pamnoraw
+
+> Este comando es un alias de `pamtopnm -plain`.
+> Más información: <https://netpbm.sourceforge.net/doc/pnmnoraw.html>.
+
+- Ver documentación para el comando original:
+
+`tldr pamtopnm`

--- a/pages.es/common/pamnoraw.md
+++ b/pages.es/common/pamnoraw.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `pamtopnm -plain`.
 > Más información: <https://netpbm.sourceforge.net/doc/pnmnoraw.html>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr pamtopnm`

--- a/pages.es/common/pnmdepth.md
+++ b/pages.es/common/pnmdepth.md
@@ -1,0 +1,8 @@
+# pnmdepth
+
+> Este comando es un alias de `pamdepth`.
+> Más información: <https://netpbm.sourceforge.net/doc/pnmdepth.html>.
+
+- Ver documentación para el comando original:
+
+`tldr pamdepth`

--- a/pages.es/common/pnmdepth.md
+++ b/pages.es/common/pnmdepth.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `pamdepth`.
 > Más información: <https://netpbm.sourceforge.net/doc/pnmdepth.html>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr pamdepth`

--- a/pages.es/common/pnmtoplainpnm.md
+++ b/pages.es/common/pnmtoplainpnm.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `pamtopnm -plain`.
 > Más información: <https://netpbm.sourceforge.net/doc/pnmtoplainpnm.html>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr pamtopnm`

--- a/pages.es/common/pnmtoplainpnm.md
+++ b/pages.es/common/pnmtoplainpnm.md
@@ -1,0 +1,8 @@
+# pnmtoplainpnm
+
+> Este comando es un alias de `pamtopnm -plain`.
+> Más información: <https://netpbm.sourceforge.net/doc/pnmtoplainpnm.html>.
+
+- Ver documentación para el comando original:
+
+`tldr pamtopnm`

--- a/pages.es/common/pnmtopnm.md
+++ b/pages.es/common/pnmtopnm.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `pamtopnm`.
 > Más información: <https://netpbm.sourceforge.net/doc/pnmtopnm.html>.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr pamtopnm`

--- a/pages.es/common/pnmtopnm.md
+++ b/pages.es/common/pnmtopnm.md
@@ -1,0 +1,8 @@
+# pnmtopnm
+
+> Este comando es un alias de `pamtopnm`.
+> Más información: <https://netpbm.sourceforge.net/doc/pnmtopnm.html>.
+
+- Ver documentación para el comando original:
+
+`tldr pamtopnm`

--- a/pages.es/common/unzstd.md
+++ b/pages.es/common/unzstd.md
@@ -1,0 +1,7 @@
+# unzstd
+
+> Este comando es un alias de `zstd --decompress`.
+
+- Ver documentación para el comando original:
+
+`tldr zstd`

--- a/pages.es/common/unzstd.md
+++ b/pages.es/common/unzstd.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `zstd --decompress`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr zstd`

--- a/pages.es/common/xzegrep.md
+++ b/pages.es/common/xzegrep.md
@@ -1,0 +1,8 @@
+# xzegrep
+
+> Este comando es un alias de `xzgrep --extended-regexp`.
+> Vea también: `egrep`.
+
+- Ver documentación para el comando original:
+
+`tldr xzgrep`

--- a/pages.es/common/xzegrep.md
+++ b/pages.es/common/xzegrep.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `xzgrep --extended-regexp`.
 > Vea también: `egrep`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr xzgrep`

--- a/pages.es/common/xzfgrep.md
+++ b/pages.es/common/xzfgrep.md
@@ -3,6 +3,6 @@
 > Este comando es un alias de `xzgrep --fixed-strings`.
 > Vea también: `fgrep`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr xzgrep`

--- a/pages.es/common/xzfgrep.md
+++ b/pages.es/common/xzfgrep.md
@@ -1,0 +1,8 @@
+# xzfgrep
+
+> Este comando es un alias de `xzgrep --fixed-strings`.
+> Vea también: `fgrep`.
+
+- Ver documentación para el comando original:
+
+`tldr xzgrep`

--- a/pages.es/common/zstdcat.md
+++ b/pages.es/common/zstdcat.md
@@ -2,6 +2,6 @@
 
 > Este comando es un alias de `zstd --decompress --stdout`.
 
-- Ver documentación para el comando original:
+- Vea la documentación del comando original:
 
 `tldr zstd`

--- a/pages.es/common/zstdcat.md
+++ b/pages.es/common/zstdcat.md
@@ -1,0 +1,7 @@
+# zstdcat
+
+> Este comando es un alias de `zstd --decompress --stdout`.
+
+- Ver documentación para el comando original:
+
+`tldr zstd`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
