### PR TITLE
fatrace: add page

### DIFF
--- a/pages/linux/fatrace.md
+++ b/pages/linux/fatrace.md
@@ -1,7 +1,7 @@
 # fatrace
 
 > Report file access events.
-> More information: <https://manned.org/man/fatrace>.
+> More information: <https://manned.org/fatrace>.
 
 - Print file access events in all mounted filesystems to `stdout`:
 

--- a/pages/linux/fatrace.md
+++ b/pages/linux/fatrace.md
@@ -7,6 +7,6 @@
 
 `sudo fatrace`
 
-- Print file access events in the [c]urrent directory, with [t]imestamps, to `stdout`:
+- Print file access events in the current directory, with timestamps, to `stdout`:
 
-`sudo fatrace -c -t`
+`sudo fatrace {{-c|--current-mount}} {{-t|--timestamp}}`

--- a/pages/linux/fatrace.md
+++ b/pages/linux/fatrace.md
@@ -1,0 +1,12 @@
+# fatrace
+
+> Report file access events.
+> More information: <https://manned.org/man/fatrace>.
+
+- Print file access events in all mounted filesystems to `stdout`:
+
+`sudo fatrace`
+
+- Print file access events in the [c]urrent directory, with [t]imestamps, to `stdout`:
+
+`sudo fatrace -c -t`

--- a/pages/linux/fatrace.md
+++ b/pages/linux/fatrace.md
@@ -7,6 +7,6 @@
 
 `sudo fatrace`
 
-- Print file access events in the current directory, with timestamps, to `stdout`:
+- Print file access events on the mount of the current directory, with timestamps, to `stdout`:
 
 `sudo fatrace {{-c|--current-mount}} {{-t|--timestamp}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.17.0

Regarding point one: it is packaged for NixOS, which I think makes it available for MacOS users, but it might be
broken because MacOS does not have a `/proc` filesystem?. No BSD packaged version I have seen.
Could arguably be placed under `common` instead of `linux` directory depending on that.
