### PR TITLE
dnf-config-manager: add Spanish translation

### DIFF
--- a/pages.es/linux/dnf-config-manager.md
+++ b/pages.es/linux/dnf-config-manager.md
@@ -1,0 +1,28 @@
+# dnf config-manager
+
+> Administra opciones de configuración y repositorios DNF en sistemas basados en Fedora.
+> Más información: <https://manned.org/dnf-config-manager>.
+
+- Agrega (y activa) un repositorio de una URL:
+
+`dnf config-manager --add-repo={{url_del_repositorio}}`
+
+- Imprime de valores de configuración actuales:
+
+`dnf config-manager --dump`
+
+- Habilita un repositorio específico:
+
+`dnf config-manager --set-enabled {{identificador_del_repositorio}}`
+
+- Deshabilita repositorios especificados:
+
+`dnf config-manager --set-disabled {{identificador_del_repositorio1 identificador_del_repositorio2 ...}}`
+
+- Establece una opción de configuración para un repositorio:
+
+`dnf config-manager --setopt={{opción}}={{valor}}`
+
+- Muestra la ayuda:
+
+`dnf config-manager --help-cmd`

--- a/pages.es/linux/dnf-config-manager.md
+++ b/pages.es/linux/dnf-config-manager.md
@@ -7,7 +7,7 @@
 
 `dnf config-manager --add-repo={{url_del_repositorio}}`
 
-- Imprime de valores de configuración actuales:
+- Imprime los valores de configuración actuales:
 
 `dnf config-manager --dump`
 


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
