### PR TITLE
gcc: add Spanish translation

### DIFF
--- a/pages.es/common/gcc.md
+++ b/pages.es/common/gcc.md
@@ -4,7 +4,7 @@
 > Parte de GCC Colección de Compilación GNU (GNU Compiler Collection).
 > Más información: <https://gcc.gnu.org>.
 
-- Compila varios archivos fuente en un ejecutable:
+- Compila varios archivos de código fuente en un ejecutable:
 
 `gcc {{ruta/a/la/fuente1.c ruta/a/la/fuente2.c ...}} {{-o|--output}} {{ruta/al/ejecutable}}`
 

--- a/pages.es/common/gcc.md
+++ b/pages.es/common/gcc.md
@@ -1,0 +1,37 @@
+# gcc
+
+> Preprocesa y compila archivos fuente C y C++, luego los ensambla y los une.
+> Parte de GCC Colección de Compilación GNU (GNU Compiler Collection).
+> Más información: <https://gcc.gnu.org>.
+
+- Compila varios archivos fuente en un ejecutable:
+
+`gcc {{ruta/a/la/fuente1.c ruta/a/la/fuente2.c ...}} {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Muestra todos los errores y advertencias:
+
+`gcc {{ruta/a/la/fuente.c}} -Wall {{-o|--output}} {{ejecutable}}`
+
+- Muestra las advertencias comunes, añade símbolos de depuración en el ejecutable, y optimiza sin afectar la depuración:
+
+`gcc {{ruta/a/la/fuente.c}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Incluye las bibliotecas de una ruta diferente:
+
+`gcc {{ruta/a/la/fuente.c}} {{-o|--output}} {{ruta/al/ejecutable}} -I{{ruta/a/header}} -L{{ruta/a/la/biblioteca}} -l{{nombre_de_biblioteca}}`
+
+- Compila el código fuente a instrucciones de Ensamblador (Assembler):
+
+`gcc {{-S|--assemble}} {{ruta/a/la/fuente.c}}`
+
+- Compila el código fuente a un archivo objeto sin vincular:
+
+`gcc {{-c|--compile}} {{ruta/a/la/fuente.c}}`
+
+- Optimiza el programa compilado en función de velocidad de ejecución:
+
+`gcc {{ruta/a/la/fuente.c}} -O{{1|2|3|fast}} {{-o|--output}} {{ruta/al/ejecutable}}`
+
+- Versión de visualización:
+
+`gcc --version`

--- a/pages.es/common/gcc.md
+++ b/pages.es/common/gcc.md
@@ -1,6 +1,6 @@
 # gcc
 
-> Preprocesa y compila archivos fuente C y C++, luego los ensambla y los une.
+> Preprocesa y compila archivos de código fuente C y C++, luego los ensambla y los une.
 > Parte de GCC Colección de Compilación GNU (GNU Compiler Collection).
 > Más información: <https://gcc.gnu.org>.
 


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
