### PR TITLE
common-arguments: username unification for Spanish translation

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -16,7 +16,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | cs    | cesta/k/souboru       | cesta/k/adresari         | cesta/k/souboru_ci_adresari          | balíček       | jmeno_uzivatele    |
 | da    | sti/til/fil           | sti/til/mappe            | sti/til/fil_eller_mappe              | pakke         | brugernavn         |
 | de    | pfad/zu/datei         | pfad/zu/verzeichnis      | pfad/zu/datei_oder_verzeichnis       | paket         | benutzername       |
-| es    | ruta/al/archivo       | ruta/al/directorio       | ruta/al/archivo_o_directorio         | paquete       | nombre_de_usuario  |
+| es    | ruta/al/archivo       | ruta/al/directorio       | ruta/al/archivo_o_directorio         | paquete       | usuario            |
 | fi    | polku/tiedostoon      | polku/hakemistoon        | polku/tiedostoon_vai_hakemistoon     | paketti       | tunnus             |
 | fr    | chemin/vers/fichier   | chemin/vers/dossier      | chemin/vers/fichier_ou_dossier       | paquet        | nom_d_utilisateur  |
 | hi    | फ़ाइल/का/पथ           | निर्देशिका/का/पथ         | फ़ाइल_या_निर्देशिका/का/पथ            | पैकेज         | उपयोगकर्ता_नाम     |


### PR DESCRIPTION
We want to make more terse the translation for {{username}} given that we already have more translations targeted to the proposed update for this page

```command
i@h:tldr$ rg '\{\{usuario\}\}' | wc -l
44
```

Among other translations

```command
i@h:tldr$ rg '\{\{nombre_de_usuario\}\}' | wc -l
30
i@h:tldr$ rg '\{\{nombre_usuario\}\}' | wc -l
10
```

Once we merge this, I will be doing a PR to move nombre_de_usuario and nombre_usuario in to usuario in `pages.es`.
