### PR TITLE
common/e~g*: fix outdated Brazilian Portuguese pages

### DIFF
--- a/pages.pt_BR/common/emacs.md
+++ b/pages.pt_BR/common/emacs.md
@@ -12,6 +12,10 @@
 
 `emacs +{{numero_linha}} {{caminho/para/arquivo}}`
 
+- Inicia um arquivo Emacs Lisp como script:
+
+`emacs --script {{caminho/para/arquivo.el}}`
+
 - Inicia o Emacs em modo console (sem uma janela X):
 
 `emacs --no-window-system`
@@ -28,6 +32,6 @@
 
 `<Ctrl> + X, <Ctrl> + S`
 
-- Deixa o Emacs:
+- Sai do Emacs:
 
 `<Ctrl> + X, <Ctrl> + C`

--- a/pages.pt_BR/common/fc-list.md
+++ b/pages.pt_BR/common/fc-list.md
@@ -3,6 +3,14 @@
 > Exibe todas as fontes disponíveis no sistema.
 > Mais informações: <https://manned.org/fc-list>.
 
-- Exibe as fontes instaladas correspondentes ao critério de busca:
+- Retorna uma lista de fontes instaladas no seu sistema:
 
-`fc-list | grep '{{criterio_de_busca}}'`
+`fc-list`
+
+- Retorna uma lista de fontes com um dado nome:
+
+`fc-list | grep '{{DejaVu Serif}}'`
+
+- Retorna o número de fontes instaladas no seu sistema:
+
+`fc-list | wc -l`

--- a/pages.pt_BR/common/fc.md
+++ b/pages.pt_BR/common/fc.md
@@ -14,3 +14,19 @@
 - Exibe um histórico dos últimos comandos executados:
 
 `fc -l`
+
+- Lista os comandos recentes em ordem reversa:
+
+`fc -l -r`
+
+- Edita e executa um comando do histórico:
+
+`fc {{número}}`
+
+- Edita comandos em um dado intervalo e executa-os:
+
+`fc '{{416}}' '{{420}}'`
+
+- Mosta ajuda:
+
+`fc --help`

--- a/pages.pt_BR/common/ftp.md
+++ b/pages.pt_BR/common/ftp.md
@@ -30,3 +30,7 @@
 - Exclui vários arquivos do servidor remoto:
 
 `mdelete {{*.txt}}`
+
+- Renomeia um arquivo no servidor remoto:
+
+`rename {{nome_do_arquivo_original}} {{novo_nome_do_arquivo}}`

--- a/pages.pt_BR/common/ftp.md
+++ b/pages.pt_BR/common/ftp.md
@@ -7,6 +7,10 @@
 
 `ftp {{ftp.example.com}}`
 
+- Conecta a um servidor FTP especificando o endereço de IP e porta:
+
+`ftp {{endereço_IP}} {{porta}}`
+
 - Alterna para o modo de transferência binária (gráficos, arquivos compactados, etc):
 
 `binary`
@@ -23,10 +27,6 @@
 
 `mput {{*.zip}}`
 
-- Exclui vários arquivos no servidor remoto:
+- Exclui vários arquivos do servidor remoto:
 
 `mdelete {{*.txt}}`
-
-- Renomeia um arquivo no servidor remoto:
-
-`rename {{nome_do_arquivo_original}} {{nome_do_novo_arquivo}}`

--- a/pages.pt_BR/common/g++.md
+++ b/pages.pt_BR/common/g++.md
@@ -6,23 +6,31 @@
 
 - Compila um arquivo de código fonte para um binário executável:
 
-`g++ {{caminho/para/fonte.cpp}} -o {{caminho/para/executável_de_saída}}`
+`g++ {{caminho/para/fonte1.cpp caminho/para/fonte1.cpp ...}} {{-o|--output}} {{caminho/para/executável_de_saída}}`
 
-- Exibe avisos comuns:
+- Ativa saída de todos os erros e avisos:
 
-`g++ {{caminho/para/fonte.cpp}} -Wall -o {{caminho/para/executável_de_saída}}`
+`g++ {{caminho/para/fonte.css}} -Wall {{-o|--output}} {{executável_de_saída}}`
 
-- Escolha um padrão de linguagem para o qual compilar (C++98/C++11/C++14/C++17):
+- Mostra avisos comuns, símbolos de depuração na saída, e otimiza sem afetar a depuração:
 
-`g++ {{caminho/para/fonte.cpp}} -std={{c++98|c++11|c++14|c++17}} -o {{caminho/para/executável_de_saída}}`
+`g++ {{caminho/para/fonte.cpp}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{caminho/para/executável_de_saída}}`
+
+- Escolhe um padrão de linguagem para o qual compilar (C++98/C++11/C++14/C++17):
+
+`g++ {{caminho/para/fonte.cpp}} -std={{c++98|c++11|c++14|c++17}} {{-o|--output}} {{caminho/para/executável_de_saída}}`
 
 - Inclui bibliotecas localizadas em um caminho diferente do arquivo de código fonte:
 
-`g++ {{caminho/para/fonte.cpp}} -o {{caminho/para/executável_de_saída}} -I{{caminho/para/cabeçalho}} -L{{caminho/para/biblioteca}} -l{{nome_da_biblioteca}}`
+`g++ {{caminho/para/fonte.cpp}} {{-o|--output}} {{caminho/para/executável_de_saída}} -I{{caminho/para/cabeçalho}} -L{{caminho/para/biblioteca}} -l{{nome_da_biblioteca}}`
 
 - Compila e vincula múltiplos arquivos de código fonte em um binário executável:
 
-`g++ -c {{caminho/para/fonte_1.cpp caminho/para/fonte_2.cpp ...}} && g++ -o {{caminho/para/executável_de_saída}} {{caminho/para/fonte_1.o caminho/para/fonte_2.o ...}}`
+`g++ {{-c|--compile}} {{caminho/para/fonte1.cpp caminho/para/fonte2.cpp ...}} && g++ {{-o|--output}} {{caminho/para/executável_de_saída}} {{caminho/para/fonte1.o caminho/para/fonte2.o ...}}`
+
+- Otimiza o programa compilado para desempenho:
+
+`g++ {{caminho/para/fonte.cpp}} -O{{1|2|3|fast}} {{-o|--output}} {{caminho/para/executavel_de_saída}}`
 
 - Exibe versão:
 

--- a/pages.pt_BR/common/gcc.md
+++ b/pages.pt_BR/common/gcc.md
@@ -1,24 +1,36 @@
 # gcc
 
-> Compilador de arquivos de código fonte C e C++, efetuando também as fases de pré-processamento, assembling e linking.
+> Pré-processa e compila arquivos de código fonte C e C++, depois monta-os e vincula-os.
 > Mais informações: <https://gcc.gnu.org>.
 
 - Compila múltiplos arquivos de código fonte, produzindo um arquivo executável:
 
-`gcc {{arquivo_fonte1.c}} {{arquivo_fonte2.c}} --output {{arquivo_executável}}`
+`gcc {{caminho/para/arquivo_fonte1.c caminho/para/arquivo_fonte2.c ...}} {{-o|--output}} {{caminho/para/executável_de_saída}}`
 
-- Habilita avisos durante a compilação:
+- Ativa a saída de todos os erros e avisos:
 
-`gcc {{arquivo_fonte.c}} -Wall -Og --output {{arquivo_executável}}`
+`gcc {{caminho/para/fonte.c}} -Wall {{-o|--output}} {{executável_de_saída}}`
+
+- Mostra avisos comuns, símbolos de depuração na saída, e otimiza sem afetar a depuração:
+
+`gcc {{caminho/para/fonte.c}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{caminho/para/executável_de_saída}}`
 
 - Inclui bibliotecas de um local diferente:
 
-`gcc {{arquivo_fonte.c}} --output {{arquivo_executável}} -I{{caminho/para/header}} -L{{caminho/para/biblioteca}} -l{{nome_biblioteca}}`
+`gcc {{caminho/para/fonte.c}} {{-o|--output}} {{caminho/para/executável_de_saída}} -I{{caminho/para/header}} -L{{caminho/para/biblioteca}} -l{{nome_biblioteca}}`
 
 - Compila o código fonte para instruções Assembler:
 
-`gcc -S {{arquivo_fonte.c}}`
+`gcc {{-S|--assemble}} {{caminho/para/fonte.c}}`
 
-- Compila o código fonte sem efetuar a fase de linking:
+- Compila o código fonte sem efetuar vinculação:
 
-`gcc -c {{arquivo_fonte.c}}`
+`gcc {{-c|--compile}} {{caminho/para/font.c}}`
+
+- Otimiza o programa compilado para desempenho:
+
+`gcc {{caminho/para/fonte.c}} -O{{1|2|3|fast}} {{-o|--output}} {{caminho/para/executável_de_saída}}`
+
+- Mostra versão:
+
+`gcc --version`

--- a/pages.pt_BR/common/gzip.md
+++ b/pages.pt_BR/common/gzip.md
@@ -5,24 +5,28 @@
 
 - Compacta um arquivo, substituindo-o por uma versão compactada gzip:
 
-`gzip {{arquivo.ext}}`
+`gzip {{caminho_para_arquivo}}`
 
-- Descompacta um arquivo, substituindo-o pela versão não compactada original:
+- Descompacta um arquivo, substituindo-o pela versão descompactada original:
 
-`gzip -d {{arquivo.ext}}.gz`
+`gzip {{-d|--decompress}} {{caminho/para/arquivo.gz}}`
 
 - Compacta um arquivo, mantendo o arquivo original:
 
-`gzip --keep {{arquivo.ext}}`
+`gzip {{-k|--keep}} {{caminho/para/arquivo}}`
 
 - Compacta um arquivo definindo o nome do arquivo de saída:
 
-`gzip -c {{arquivo.ext}} > {{arquivo_compactado.ext.gz}}`
+`gzip {{-c|--stdout}} {{caminho/para/arquivo}} > {{caminho/para/arquivo_compactado.gz}}`
 
 - Descompacta um arquivo gzip definindo o nome do arquivo de saída:
 
-`gzip -c -d {{arquivo.ext}}.gz > {{arquivo_descompactado.ext}}`
+`gzip {{-c|--stdout}} {{-d|--decompress}} {{caminho/para/arquivo.gz}} > {{caminho/para/arquivo_descompactado}}`
 
-- Especifica o nível de compactação. 1=mais rápido (pior), 9=mais lendo 9melhor, o nível padrão é 6:
+- Especifica o nível de compactação. 1 é o mais rápido (baixa compressão), 9 é o mais lento (baixa compressão), o nível padrão é 6:
 
-`gzip -9 -c {{arquivo.ext}} > {{arquivo_compactado.ext.gz}}`
+`gzip -{{1..9}} {{-c|--stdout}} {{caminho/para/arquivo}} > {{caminho/para/arquivo_compactado.gz}}`
+
+- Mostra o nome e o percentual de redução para cada arquivo comprimido ou descomprimido:
+
+`gzip {{-v|--verbose}} {{-d|--decompress}} {{caminho/para/arquivo.gz}}`

--- a/pages.pt_BR/common/gzip.md
+++ b/pages.pt_BR/common/gzip.md
@@ -9,11 +9,11 @@
 
 - Descompacta um arquivo, substituindo-o pela versão descompactada original:
 
-`gzip {{-d|--decompress}} {{caminho/para/arquivo.gz}}`
+`gzip {{-d|--decompress caminho/para/arquivo.gz}}`
 
 - Compacta um arquivo, mantendo o arquivo original:
 
-`gzip {{-k|--keep}} {{caminho/para/arquivo}}`
+`gzip {{-k|--keep caminho/para/arquivo}}`
 
 - Compacta um arquivo definindo o nome do arquivo de saída:
 

--- a/pages.pt_BR/common/gzip.md
+++ b/pages.pt_BR/common/gzip.md
@@ -17,7 +17,7 @@
 
 - Compacta um arquivo definindo o nome do arquivo de saída:
 
-`gzip {{-c|--stdout}} {{caminho/para/arquivo}} > {{caminho/para/arquivo_compactado.gz}}`
+`gzip {{-c|--stdout caminho/para/arquivo}} > {{caminho/para/arquivo_compactado.gz}}`
 
 - Descompacta um arquivo gzip definindo o nome do arquivo de saída:
 

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -9,11 +9,11 @@
 
 - Decompress a file, replacing it with the original uncompressed version:
 
-`gzip {{-d|--decompress}} {{path/to/file.gz}}`
+`gzip {{-d|--decompress path/to/file.gz}}`
 
 - Compress a file, keeping the original file:
 
-`gzip {{-k|--keep}} {{path/to/file}}`
+`gzip {{-k|--keep path/to/file}}`
 
 - Compress a file, specifying the output filename:
 

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -9,11 +9,11 @@
 
 - Decompress a file, replacing it with the original uncompressed version:
 
-`gzip {{-d|--decompress path/to/file.gz}}`
+`gzip {{-d|--decompress}} {{path/to/file.gz}}`
 
 - Compress a file, keeping the original file:
 
-`gzip {{-k|--keep path/to/file}}`
+`gzip {{-k|--keep}} {{path/to/file}}`
 
 - Compress a file, specifying the output filename:
 


### PR DESCRIPTION
- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
