### PR TITLE
pages/*: remove "More information" from alias pages

### DIFF
--- a/pages/common/azure-cli.md
+++ b/pages/common/azure-cli.md
@@ -1,7 +1,6 @@
 # azure-cli
 
 > This command is an alias of `az`.
-> More information: <https://learn.microsoft.com/cli/azure>.
 
 - View documentation for the original command:
 

--- a/pages/common/crane-cp.md
+++ b/pages/common/crane-cp.md
@@ -1,7 +1,6 @@
 # crane cp
 
 > This command is an alias of `crane copy`.
-> More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md>.
 
 - View documentation for the original command:
 

--- a/pages/common/docker-container-diff.md
+++ b/pages/common/docker-container-diff.md
@@ -1,7 +1,6 @@
 # docker container diff
 
 > This command is an alias of `docker diff`.
-> More information: <https://docs.docker.com/reference/cli/docker/container/diff/>.
 
 - View documentation for the original command:
 

--- a/pages/common/docker-container-remove.md
+++ b/pages/common/docker-container-remove.md
@@ -1,7 +1,6 @@
 # docker container remove
 
 > This command is an alias of `docker rm`.
-> More information: <https://docs.docker.com/reference/cli/docker/container/rm/>.
 
 - View documentation for the original command:
 

--- a/pages/common/docker-container-rename.md
+++ b/pages/common/docker-container-rename.md
@@ -1,7 +1,6 @@
 # docker container rename
 
 > This command is an alias of `docker rename`.
-> More information: <https://docs.docker.com/reference/cli/docker/container/rename/>.
 
 - View documentation for the original command:
 

--- a/pages/common/docker-container-rm.md
+++ b/pages/common/docker-container-rm.md
@@ -1,7 +1,6 @@
 # docker container rm
 
 > This command is an alias of `docker rm`.
-> More information: <https://docs.docker.com/reference/cli/docker/container/rm/>.
 
 - View documentation for the original command:
 

--- a/pages/common/docker-container-top.md
+++ b/pages/common/docker-container-top.md
@@ -1,7 +1,6 @@
 # docker container top
 
 > This command is an alias of `docker top`.
-> More information: <https://docs.docker.com/reference/cli/docker/container/top/>.
 
 - View documentation for the original command:
 

--- a/pages/common/fossil-ci.md
+++ b/pages/common/fossil-ci.md
@@ -1,7 +1,6 @@
 # fossil ci
 
 > This command is an alias of `fossil commit`.
-> More information: <https://fossil-scm.org/home/help/commit>.
 
 - View documentation for the original command:
 

--- a/pages/common/fossil-delete.md
+++ b/pages/common/fossil-delete.md
@@ -1,7 +1,6 @@
 # fossil delete
 
 > This command is an alias of `fossil rm`.
-> More information: <https://fossil-scm.org/home/help/delete>.
 
 - View documentation for the original command:
 

--- a/pages/common/fossil-new.md
+++ b/pages/common/fossil-new.md
@@ -1,7 +1,6 @@
 # fossil new
 
 > This command is an alias of `fossil init`.
-> More information: <https://fossil-scm.org/home/help/new>.
 
 - View documentation for the original command:
 

--- a/pages/common/gh-cs.md
+++ b/pages/common/gh-cs.md
@@ -1,7 +1,6 @@
 # gh cs
 
 > This command is an alias of `gh codespace`.
-> More information: <https://cli.github.com/manual/gh_codespace>.
 
 - View documentation for the original command:
 

--- a/pages/common/git-stage.md
+++ b/pages/common/git-stage.md
@@ -1,7 +1,6 @@
 # git stage
 
 > This command is an alias of `git add`.
-> More information: <https://git-scm.com/docs/git-stage>.
 
 - View documentation for the original command:
 

--- a/pages/common/gnmic-sub.md
+++ b/pages/common/gnmic-sub.md
@@ -1,7 +1,6 @@
 # gnmic sub
 
 > This command is an alias of `gnmic subscribe`.
-> More information: <https://gnmic.kmrd.dev/cmd/subscribe>.
 
 - View documentation for the original command:
 

--- a/pages/common/hd.md
+++ b/pages/common/hd.md
@@ -1,7 +1,6 @@
 # hd
 
 > This command is an alias of `hexdump`.
-> More information: <https://manned.org/hd.1>.
 
 - View documentation for the original command:
 

--- a/pages/common/hping.md
+++ b/pages/common/hping.md
@@ -1,7 +1,6 @@
 # hping
 
 > This command is an alias of `hping3`.
-> More information: <https://github.com/antirez/hping>.
 
 - View documentation for the original command:
 

--- a/pages/common/lima.md
+++ b/pages/common/lima.md
@@ -2,7 +2,6 @@
 
 > This command is an alias of `limactl shell` for the default VM instance.
 > You can also set the `$LIMA_INSTANCE` environment variable to work on a different instance.
-> More information: <https://github.com/lima-vm/lima>.
 
 - View documentation for the original command:
 

--- a/pages/common/lzcat.md
+++ b/pages/common/lzcat.md
@@ -1,7 +1,6 @@
 # lzcat
 
 > This command is an alias of `xz --format=lzma --decompress --stdout`.
-> More information: <https://manned.org/lzcat>.
 
 - View documentation for the original command:
 

--- a/pages/common/lzma.md
+++ b/pages/common/lzma.md
@@ -1,7 +1,6 @@
 # lzma
 
 > This command is an alias of `xz --format=lzma`.
-> More information: <https://manned.org/lzma>.
 
 - View documentation for the original command:
 

--- a/pages/common/mscore.md
+++ b/pages/common/mscore.md
@@ -1,7 +1,6 @@
 # mscore
 
 > This command is an alias of `musescore`.
-> More information: <https://musescore.org/handbook/command-line-options>.
 
 - View documentation for the original command:
 

--- a/pages/common/netcat.md
+++ b/pages/common/netcat.md
@@ -1,7 +1,6 @@
 # netcat
 
 > This command is an alias of `nc`.
-> More information: <https://manned.org/nc>.
 
 - View documentation for the original command:
 

--- a/pages/common/ntl.md
+++ b/pages/common/ntl.md
@@ -1,7 +1,6 @@
 # ntl
 
 > This command is an alias of `netlify`.
-> More information: <https://cli.netlify.com>.
 
 - View documentation for the original command:
 

--- a/pages/common/pamnoraw.md
+++ b/pages/common/pamnoraw.md
@@ -1,7 +1,6 @@
 # pamnoraw
 
 > This command is an alias of `pamtopnm -plain`.
-> More information: <https://netpbm.sourceforge.net/doc/pnmnoraw.html>.
 
 - View documentation for the original command:
 

--- a/pages/common/platformio.md
+++ b/pages/common/platformio.md
@@ -1,7 +1,6 @@
 # platformio
 
 > This command is an alias of `pio`.
-> More information: <https://docs.platformio.org/en/latest/core/userguide/>.
 
 - View documentation for the original command:
 

--- a/pages/common/pnmdepth.md
+++ b/pages/common/pnmdepth.md
@@ -1,7 +1,6 @@
 # pnmdepth
 
 > This command is an alias of `pamdepth`.
-> More information: <https://netpbm.sourceforge.net/doc/pnmdepth.html>.
 
 - View documentation for the original command:
 

--- a/pages/common/pnmtoplainpnm.md
+++ b/pages/common/pnmtoplainpnm.md
@@ -1,7 +1,6 @@
 # pnmtoplainpnm
 
 > This command is an alias of `pamtopnm -plain`.
-> More information: <https://netpbm.sourceforge.net/doc/pnmtoplainpnm.html>.
 
 - View documentation for the original command:
 

--- a/pages/common/pnmtopnm.md
+++ b/pages/common/pnmtopnm.md
@@ -1,7 +1,6 @@
 # pnmtopnm
 
 > This command is an alias of `pamtopnm`.
-> More information: <https://netpbm.sourceforge.net/doc/pnmtopnm.html>.
 
 - View documentation for the original command:
 

--- a/pages/common/tldrl.md
+++ b/pages/common/tldrl.md
@@ -1,7 +1,6 @@
 # tldrl
 
 > This command is an alias of `tldr-lint`.
-> More information: <https://github.com/tldr-pages/tldr-lint>.
 
 - View documentation for the original command:
 

--- a/pages/common/tlmgr-arch.md
+++ b/pages/common/tlmgr-arch.md
@@ -1,7 +1,6 @@
 # tlmgr arch
 
 > This command is an alias of `tlmgr platform`.
-> More information: <https://www.tug.org/texlive/tlmgr.html>.
 
 - View documentation for the original command:
 

--- a/pages/common/trash-cli.md
+++ b/pages/common/trash-cli.md
@@ -1,7 +1,6 @@
 # trash-cli
 
 > This command is an alias of `trash`.
-> More information: <https://github.com/andreafrancia/trash-cli>.
 
 - View documentation for the original command:
 

--- a/pages/common/unlzma.md
+++ b/pages/common/unlzma.md
@@ -1,7 +1,6 @@
 # unlzma
 
 > This command is an alias of `xz --format=lzma --decompress`.
-> More information: <https://manned.org/unlzma>.
 
 - View documentation for the original command:
 

--- a/pages/common/unxz.md
+++ b/pages/common/unxz.md
@@ -1,7 +1,6 @@
 # unxz
 
 > This command is an alias of `xz --decompress`.
-> More information: <https://manned.org/unxz>.
 
 - View documentation for the original command:
 

--- a/pages/common/xzcat.md
+++ b/pages/common/xzcat.md
@@ -1,7 +1,6 @@
 # xzcat
 
 > This command is an alias of `xz --decompress --stdout`.
-> More information: <https://manned.org/xzcat>.
 
 - View documentation for the original command:
 

--- a/pages/linux/alternatives.md
+++ b/pages/linux/alternatives.md
@@ -1,7 +1,6 @@
 # alternatives
 
 > This command is an alias of `update-alternatives`.
-> More information: <https://manned.org/alternatives>.
 
 - View documentation for the original command:
 

--- a/pages/linux/batcat.md
+++ b/pages/linux/batcat.md
@@ -1,7 +1,6 @@
 # batcat
 
 > This command is an alias of `bat`.
-> More information: <https://github.com/sharkdp/bat>.
 
 - View documentation for the original command:
 

--- a/pages/linux/cc.md
+++ b/pages/linux/cc.md
@@ -1,7 +1,6 @@
 # cc
 
 > This command is an alias of `gcc`.
-> More information: <https://gcc.gnu.org>.
 
 - View documentation for the original command:
 

--- a/pages/linux/megadl.md
+++ b/pages/linux/megadl.md
@@ -1,7 +1,6 @@
 # megadl
 
 > This command is an alias of `megatools-dl`.
-> More information: <https://megatools.megous.com/man/megatools-dl.html>.
 
 - View documentation for the original command:
 

--- a/pages/linux/ncal.md
+++ b/pages/linux/ncal.md
@@ -1,7 +1,6 @@
 # ncal
 
 > This command is an alias of `cal`.
-> More information: <https://manned.org/ncal>.
 
 - View documentation for the original command:
 

--- a/pages/linux/qm-move-disk.md
+++ b/pages/linux/qm-move-disk.md
@@ -1,7 +1,6 @@
 # qm move disk
 
 > This command is an alias of `qm disk move`.
-> More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
 - View documentation for the original command:
 

--- a/pages/linux/qm-move_disk.md
+++ b/pages/linux/qm-move_disk.md
@@ -1,7 +1,6 @@
 # qm move disk
 
 > This command is an alias of `qm disk move`.
-> More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
 - View documentation for the original command:
 

--- a/pages/linux/qm-resize.md
+++ b/pages/linux/qm-resize.md
@@ -1,8 +1,7 @@
 # qm resize
 
-> This command is an alias of `qm-disk-resize`.
-> More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+> This command is an alias of `qm disk resize`.
 
 - View documentation for the original command:
 
-`tldr qm-disk-resize`
+`tldr qm disk resize`

--- a/pages/linux/systemd-confext.md
+++ b/pages/linux/systemd-confext.md
@@ -2,7 +2,6 @@
 
 > This command is an alias of `systemd-sysext`.
 > It follows the same principle as `systemd-sysext`, but instead of working on `/usr` and `/opt`, `confext` will extend only `/etc`.
-> More information: <https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html>.
 
 - View documentation for the original command:
 

--- a/pages/linux/ubuntu-bug.md
+++ b/pages/linux/ubuntu-bug.md
@@ -1,7 +1,6 @@
 # ubuntu-bug
 
 > This command is an alias of `apport-bug`.
-> More information: <https://manned.org/ubuntu-bug>.
 
 - View documentation for the original command:
 

--- a/pages/windows/cinst.md
+++ b/pages/windows/cinst.md
@@ -1,7 +1,6 @@
 # cinst
 
 > This command is an alias of `choco install`.
-> More information: <https://docs.chocolatey.org/en-us/choco/commands/install>.
 
 - View documentation for the original command:
 

--- a/pages/windows/clist.md
+++ b/pages/windows/clist.md
@@ -1,7 +1,6 @@
 # clist
 
 > This command is an alias of `choco list`.
-> More information: <https://docs.chocolatey.org/en-us/choco/commands/list>.
 
 - View documentation for the original command:
 

--- a/pages/windows/cls.md
+++ b/pages/windows/cls.md
@@ -2,7 +2,6 @@
 
 > Clears the screen.
 > In PowerShell, this command is an alias of `Clear-Host`. This documentation is based on the Command Prompt (`cmd`) version of `cls`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/cls>.
 
 - View the documentation of the equivalent PowerShell command:
 

--- a/pages/windows/cpush.md
+++ b/pages/windows/cpush.md
@@ -1,7 +1,6 @@
 # cpush
 
 > This command is an alias of `choco push`.
-> More information: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - View documentation for the original command:
 

--- a/pages/windows/cuninst.md
+++ b/pages/windows/cuninst.md
@@ -1,7 +1,6 @@
 # cuninst
 
 > This command is an alias of `choco uninstall`.
-> More information: <https://docs.chocolatey.org/en-us/choco/commands/uninstall>.
 
 - View documentation for the original command:
 

--- a/pages/windows/del.md
+++ b/pages/windows/del.md
@@ -2,7 +2,6 @@
 
 > Delete one or more files.
 > In PowerShell, this command is an alias of `Remove-Item`. This documentation is based on the Command Prompt (`cmd`) version of `del`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/del>.
 
 - View the documentation of the equivalent PowerShell command:
 

--- a/pages/windows/gal.md
+++ b/pages/windows/gal.md
@@ -1,7 +1,6 @@
 # gal
 
 > In PowerShell, this command is an alias of `Get-Alias`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-alias>.
 
 - View documentation for the original command:
 

--- a/pages/windows/gl.md
+++ b/pages/windows/gl.md
@@ -1,7 +1,6 @@
 # gl
 
 > In PowerShell, this command is an alias of `Get-Location`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
 
 - View documentation for the original command:
 

--- a/pages/windows/iwr.md
+++ b/pages/windows/iwr.md
@@ -1,7 +1,6 @@
 # iwr
 
 > In PowerShell, this command is an alias of `Invoke-WebRequest`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest>.
 
 - View documentation for the original command:
 

--- a/pages/windows/mi.md
+++ b/pages/windows/mi.md
@@ -1,7 +1,6 @@
 # mi
 
 > In PowerShell, this command is an alias of `Move-Item`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
 
 - View documentation for the original command:
 

--- a/pages/windows/mv.md
+++ b/pages/windows/mv.md
@@ -2,7 +2,6 @@
 
 > In PowerShell, this command is an alias of `Move-Item`.
 > However, this command is not available on the Command Prompt (`cmd`). Use `move` instead for similar functionality.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/move-item>.
 
 - View documentation for the equivalent Command Prompt command:
 

--- a/pages/windows/ni.md
+++ b/pages/windows/ni.md
@@ -1,7 +1,6 @@
 # ni
 
 > In PowerShell, this command is an alias of `New-Item`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/new-item>.
 
 - View documentation for the original command:
 

--- a/pages/windows/pwd.md
+++ b/pages/windows/pwd.md
@@ -2,7 +2,6 @@
 
 > In PowerShell, this command is an alias of `Get-Location`.
 > However, this command is not available on the Command Prompt (`cmd`). Use `cd` instead for similar functionality.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-location>.
 
 - View documentation for the equivalent Command Prompt command:
 

--- a/pages/windows/pwsh-where.md
+++ b/pages/windows/pwsh-where.md
@@ -1,7 +1,6 @@
 # pwsh where
 
 > This command is an alias of `Where-Object`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object>.
 
 - View documentation for the original command:
 

--- a/pages/windows/rd.md
+++ b/pages/windows/rd.md
@@ -1,7 +1,6 @@
 # rd
 
 > This command is an alias of `rmdir` on Command Prompt, and subsequently `Remove-Item` in PowerShell.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/rd>.
 
 - View documentation for the original Command Prompt command:
 

--- a/pages/windows/ri.md
+++ b/pages/windows/ri.md
@@ -1,7 +1,6 @@
 # ri
 
 > In PowerShell, this command is an alias of `Remove-Item`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item>.
 
 - View documentation for the original command:
 

--- a/pages/windows/rm.md
+++ b/pages/windows/rm.md
@@ -1,7 +1,6 @@
 # rm
 
 > In PowerShell, this command is an alias of `Remove-Item`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sc-config.md
+++ b/pages/windows/sc-config.md
@@ -1,7 +1,6 @@
 # sc config
 
 > This command is an alias of `sc.exe config`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/sc-config>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sc-create.md
+++ b/pages/windows/sc-create.md
@@ -1,7 +1,6 @@
 # sc create
 
 > This command is an alias of `sc.exe create`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/sc-create>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sc-delete.md
+++ b/pages/windows/sc-delete.md
@@ -1,7 +1,6 @@
 # sc delete
 
 > This command is an alias of `sc.exe delete`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/sc-delete>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sc-query.md
+++ b/pages/windows/sc-query.md
@@ -1,7 +1,6 @@
 # sc query
 
 > This command is an alias of `sc.exe query`.
-> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/sc-query>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sl.md
+++ b/pages/windows/sl.md
@@ -1,7 +1,6 @@
 # sl
 
 > In PowerShell, this command is an alias of `Set-Location`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-location>.
 
 - View documentation for the original command:
 

--- a/pages/windows/slmgr.md
+++ b/pages/windows/slmgr.md
@@ -1,7 +1,6 @@
 # slmgr
 
 > This command is an alias of `slmgr.vbs`.
-> More information: <https://learn.microsoft.com/windows-server/get-started/activation-slmgr-vbs-options>.
 
 - View documentation for the original command:
 

--- a/pages/windows/sls.md
+++ b/pages/windows/sls.md
@@ -1,7 +1,6 @@
 # sls
 
 > This command is an alias of `Select-String`.
-> More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string>.
 
 - View documentation for the original command:
 


### PR DESCRIPTION
#14542 for English pages.

I left the more info links in pages that are aliases with some differences ([`fossil forget`](https://github.com/tldr-pages/tldr/blob/main/pages/common/fossil-forget.md) for example).