### PR TITLE
Update curl.md

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -35,3 +35,7 @@
 - Resolve a hostname to a custom IP address, with [v]erbose output (similar to editing the `/etc/hosts` file for custom DNS resolution):
 
 `curl --verbose --resolve {{example.com}}:{{80}}:{{127.0.0.1}} {{http://example.com}}`
+
+- Forcing curl to trust on a server’s certificate that is signed by a custom or private Certificate Authority (CA):
+
+`curl --cacert {{location where the custom or private certificate is stored}} {{http://example.com}}`


### PR DESCRIPTION
The --cacert option is used to verify the server’s SSL certificate during development stage. Using this option avoids the man in the middle attack while accessing resources from a server. 

There are two cases when this option is handy:
1. The server's certificate is not signed by a custom or private CA like google so you end up generating your own certificate.
2. You don’t want to rely on the system's default CA certificates for security reasons.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
