### PR TITLE
yt-dlp: add --playlist-items example

### DIFF
--- a/pages/common/yt-dlp.md
+++ b/pages/common/yt-dlp.md
@@ -25,6 +25,10 @@
 
 `yt-dlp --extract-audio --audio-format {{mp3}} --audio-quality {{0}} "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
 
+- Download only the second, fourth, fifth, sixth, and last items in a playlist (the first item is 1, not 0):
+
+`yt-dlp --playlist-items 2,4:6,-1 "{{https://youtube.com/playlist?list=PLbzoR-pLrL6pTJfLQ3UwtB-3V4fimdqnA}}"`
+
 - Download all playlists of a YouTube channel/user keeping each playlist in a separate directory:
 
 `yt-dlp -o "{{%(uploader)s/%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s}}" "{{https://www.youtube.com/user/TheLinuxFoundation/playlists}}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md). ***Unsure; please see note***
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2024.11.04

**Note:** I read through the content and style guides as best I could, but I was still ultimately somewhat confused about whether this sort of example should be completely placeholder'd with abstract descriptions, or whether it's acceptable to use "real" example values, given that the `--playlist-items` option requires a value in a specific format (one or more index-specification strings, separated by commas).

I felt like it would be useful to have an example that showed actual usage of "a specific index", "a range of indices", and "a negative index" (since when I looked for `tldr` examples for `yt-dlp` earlier today, that's what I was hoping to find), so that's the version I'm submitting a PR for.