### PR TITLE
iptables-restore: add Spanish translation

### DIFF
--- a/pages.es/linux/iptables-restore.md
+++ b/pages.es/linux/iptables-restore.md
@@ -1,9 +1,9 @@
 # iptables-restore
 
-> Restaura la configuración IPv4 de 'iptables`.
+> Restaura la configuración IPv4 de `iptables`.
 > Use `ip6tables-restore` para hacer lo mismo para IPv6.
 > Más información: <https://manned.org/iptables-restore>.
 
-- Restaura la configuración 'iptables' de un archivo:
+- Restaura la configuración `iptables` de un archivo:
 
 `sudo iptables-restore {{ruta/al/archivo}}`

--- a/pages.es/linux/iptables-restore.md
+++ b/pages.es/linux/iptables-restore.md
@@ -1,0 +1,9 @@
+# iptables-restore
+
+> Restaura la configuración IPv4 de 'iptables`.
+> Use `ip6tables-restore` para hacer lo mismo para IPv6.
+> Más información: <https://manned.org/iptables-restore>.
+
+- Restaura la configuración 'iptables' de un archivo:
+
+`sudo iptables-restore {{ruta/al/archivo}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
