### PR TITLE
pages.*/*: fix titles and examples in alias pages

### DIFF
--- a/pages.ar/common/fossil-ci.md
+++ b/pages.ar/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - إعرض التوثيقات للأمر الأصلي:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ar/common/fossil-new.md
+++ b/pages.ar/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - إعرض التوثيقات للأمر الأصلي:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ar/common/gh-cs.md
+++ b/pages.ar/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - إعرض التوثيقات للأمر الأصلي:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ar/linux/ip-route-list.md
+++ b/pages.ar/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - إعرض التوثيقات للأمر الأصلي:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.bs/common/fossil-ci.md
+++ b/pages.bs/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Pogledaj dokumentaciju za izvornu komandu:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.bs/common/fossil-new.md
+++ b/pages.bs/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Pogledaj dokumentaciju za izvornu komandu:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.bs/common/gh-cs.md
+++ b/pages.bs/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Pogledaj dokumentaciju za izvornu komandu:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.bs/linux/ip-route-list.md
+++ b/pages.bs/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Pogledaj dokumentaciju za izvornu komandu:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ca/common/fossil-ci.md
+++ b/pages.ca/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Veure documentació per el comandament original:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ca/common/fossil-new.md
+++ b/pages.ca/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Veure documentació pel comandament original:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ca/common/gh-cs.md
+++ b/pages.ca/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Veure documentació pel comandament original:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ca/linux/ip-route-list.md
+++ b/pages.ca/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Veure documentació pel comandament original:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.da/common/fossil-ci.md
+++ b/pages.da/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Se dokumentation for den oprindelige kommando:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.da/common/fossil-new.md
+++ b/pages.da/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Se dokumentation for den oprindelige kommando:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.da/common/gh-cs.md
+++ b/pages.da/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Se dokumentation for den oprindelige kommando:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.da/linux/ip-route-list.md
+++ b/pages.da/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Se dokumentation for den oprindelige kommando:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.de/common/fossil-ci.md
+++ b/pages.de/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.de/common/fossil-new.md
+++ b/pages.de/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.de/common/gh-cs.md
+++ b/pages.de/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.de/linux/ip-route-list.md
+++ b/pages.de/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.de/windows/cpush.md
+++ b/pages.de/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Dieser Befehl ist ein Alias von `choco-push`.
+> Dieser Befehl ist ein Alias von `choco push`.
 > Weitere Informationen: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Zeige die Dokumentation für den originalen Befehl an:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.es/common/fossil-ci.md
+++ b/pages.es/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Muestra la documentación del comando original:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.es/common/fossil-new.md
+++ b/pages.es/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Muestra la documentación del comando original:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.es/common/gh-cs.md
+++ b/pages.es/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Muestra la documentación del comando original:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.es/common/npm-author.md
+++ b/pages.es/common/npm-author.md
@@ -1,4 +1,4 @@
-# npm-author
+# npm author
 
 > Este comando es un alias de `npm owner`.
 

--- a/pages.es/linux/ip-route-list.md
+++ b/pages.es/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Muestra la documentación del comando original:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.es/linux/qm-move_disk.md
+++ b/pages.es/linux/qm-move_disk.md
@@ -1,4 +1,4 @@
-# qm move disk
+# qm move_disk
 
 > Este comando es un alias de `qm disk move`.
 > Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.

--- a/pages.es/windows/cpush.md
+++ b/pages.es/windows/cpush.md
@@ -5,4 +5,4 @@
 
 - Muestra la documentación del comando original:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.fr/common/fossil-ci.md
+++ b/pages.fr/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Voir la documentation de la commande originale :
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.fr/common/fossil-new.md
+++ b/pages.fr/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Voir la documentation de la commande originale :
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.fr/common/gh-cs.md
+++ b/pages.fr/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Voir la documentation de la commande originale :
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.fr/linux/ip-route-list.md
+++ b/pages.fr/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Voir la documentation de la commande originale :
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.fr/windows/cpush.md
+++ b/pages.fr/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Cette commande est un alias de `choco-push`.
+> Cette commande est un alias de `choco push`.
 > Plus d'informations : <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Voir la documentation de la commande originale :
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.hi/common/fossil-ci.md
+++ b/pages.hi/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.hi/common/fossil-new.md
+++ b/pages.hi/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.hi/common/gh-cs.md
+++ b/pages.hi/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.hi/linux/ip-route-list.md
+++ b/pages.hi/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.hi/windows/cpush.md
+++ b/pages.hi/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> यह आदेश `choco-push` का उपनाम है।
+> यह आदेश `choco push` का उपनाम है।
 > अधिक जानकारी: <https://docs.chocolatey.org/en-us/create/commands/push>।
 
 - मूल आदेश के लिए दस्तावेज़ देखें:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.id/common/fossil-ci.md
+++ b/pages.id/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Tampilkan dokumentasi untuk perintah asli:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.id/common/fossil-new.md
+++ b/pages.id/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Tampilkan dokumentasi untuk perintah asli:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.id/common/gh-cs.md
+++ b/pages.id/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Tampilkan dokumentasi untuk perintah asli:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.id/linux/ip-route-list.md
+++ b/pages.id/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Tampilkan dokumentasi untuk perintah asli:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.id/windows/cpush.md
+++ b/pages.id/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Perintah ini merupakan alias dari `choco-push`.
+> Perintah ini merupakan alias dari `choco push`.
 > Informasi lebih lanjut: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Tampilkan dokumentasi untuk perintah asli:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.it/common/fossil-ci.md
+++ b/pages.it/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Consulta la documentazione del comando originale:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.it/common/fossil-new.md
+++ b/pages.it/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Consulta la documentazione del comando originale:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.it/common/gh-cs.md
+++ b/pages.it/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Consulta la documentazione del comando originale:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.it/linux/ip-route-list.md
+++ b/pages.it/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Consulta la documentazione del comando originale:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.it/windows/cpush.md
+++ b/pages.it/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Questo comando è un alias per `choco-push`.
+> Questo comando è un alias per `choco push`.
 > Maggiori informazioni: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Consulta la documentazione del comando originale:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.ja/common/fossil-ci.md
+++ b/pages.ja/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - オリジナルのコマンドのドキュメントを表示する:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ja/common/fossil-new.md
+++ b/pages.ja/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - オリジナルのコマンドのドキュメントを表示する:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ja/common/gh-cs.md
+++ b/pages.ja/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - オリジナルのコマンドのドキュメントを表示する:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ja/linux/ip-route-list.md
+++ b/pages.ja/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - オリジナルのコマンドのドキュメントを表示する:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ko/common/fossil-ci.md
+++ b/pages.ko/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ko/common/fossil-new.md
+++ b/pages.ko/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ko/common/gh-cs.md
+++ b/pages.ko/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ko/common/npm-author.md
+++ b/pages.ko/common/npm-author.md
@@ -1,4 +1,4 @@
-# npm-author
+# npm author
 
 > 이 명령은 `npm owner`의 별칭입니다.
 

--- a/pages.ko/linux/ip-route-list.md
+++ b/pages.ko/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ko/linux/qm-move_disk.md
+++ b/pages.ko/linux/qm-move_disk.md
@@ -1,4 +1,4 @@
-# qm move disk
+# qm move_disk
 
 > 이 명령은 `qm disk move`의 별칭입니다.
 > 더 많은 정보: <https://pve.proxmox.com/pve-docs/qm.1.html>.

--- a/pages.ko/windows/cpush.md
+++ b/pages.ko/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> 이 명령은 `choco-push` 의 에일리어스 (별칭) 입니다.
+> 이 명령은 `choco push` 의 에일리어스 (별칭) 입니다.
 > 더 많은 정보: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - 원본 명령의 도큐멘테이션 (설명서) 보기:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.lo/common/fossil-ci.md
+++ b/pages.lo/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.lo/common/fossil-new.md
+++ b/pages.lo/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.lo/common/gh-cs.md
+++ b/pages.lo/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.lo/linux/ip-route-list.md
+++ b/pages.lo/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - ເປີດເບິ່ງລາຍລະອຽດຂອງຄຳສັ່ງແບບເຕັມ:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ml/common/fossil-ci.md
+++ b/pages.ml/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ml/common/fossil-new.md
+++ b/pages.ml/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ml/common/gh-cs.md
+++ b/pages.ml/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ml/linux/ip-route-list.md
+++ b/pages.ml/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ne/common/fossil-ci.md
+++ b/pages.ne/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ne/common/fossil-new.md
+++ b/pages.ne/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ne/common/gh-cs.md
+++ b/pages.ne/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ne/linux/ip-route-list.md
+++ b/pages.ne/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ne/windows/cpush.md
+++ b/pages.ne/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> यो आदेश `choco-push` को उपनाम हो |
+> यो आदेश `choco push` को उपनाम हो |
 > थप जानकारी: <https://docs.chocolatey.org/en-us/create/commands/push>।
 
 - मौलिक आदेशको लागि कागजात हेर्नुहोस्:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.nl/common/fossil-ci.md
+++ b/pages.nl/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.nl/common/fossil-new.md
+++ b/pages.nl/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.nl/common/gh-cs.md
+++ b/pages.nl/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.nl/linux/ip-route-list.md
+++ b/pages.nl/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.nl/linux/qm-move_disk.md
+++ b/pages.nl/linux/qm-move_disk.md
@@ -1,4 +1,4 @@
-# qm move disk
+# qm move_disk
 
 > Dit commando is een alias van `qm disk move`.
 

--- a/pages.nl/windows/cpush.md
+++ b/pages.nl/windows/cpush.md
@@ -4,4 +4,4 @@
 
 - Bekijk de documentatie van het originele commando:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.no/common/fossil-ci.md
+++ b/pages.no/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Vis dokumentasjonen for den opprinnelige kommandoen:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.no/common/fossil-new.md
+++ b/pages.no/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Vis dokumentasjonen for den opprinnelige kommandoen:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.no/common/gh-cs.md
+++ b/pages.no/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Vis dokumentasjonen for den opprinnelige kommandoen:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.no/linux/ip-route-list.md
+++ b/pages.no/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Vis dokumentasjonen for den opprinnelige kommandoen:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.pl/common/fossil-ci.md
+++ b/pages.pl/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.pl/common/fossil-new.md
+++ b/pages.pl/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.pl/common/gh-cs.md
+++ b/pages.pl/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.pl/linux/ip-route-list.md
+++ b/pages.pl/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.pl/windows/cpush.md
+++ b/pages.pl/windows/cpush.md
@@ -1,7 +1,7 @@
 # cpush
 
-> To polecenie jest aliasem `choco-push`.
+> To polecenie jest aliasem `choco push`.
 
 - Zobacz dokumentację oryginalnego polecenia:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.pt_BR/common/fossil-ci.md
+++ b/pages.pt_BR/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação sobre o comando original:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.pt_BR/common/fossil-new.md
+++ b/pages.pt_BR/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação sobre o comando original:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.pt_BR/common/gh-cs.md
+++ b/pages.pt_BR/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação sobre o comando original:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.pt_BR/linux/ip-route-list.md
+++ b/pages.pt_BR/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Exibe documentação sobre o comando original:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.pt_BR/windows/cpush.md
+++ b/pages.pt_BR/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Este comando é um apelido de `choco-push`.
+> Este comando é um apelido de `choco push`.
 > Mais informações: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Exibe documentação sobre o comando original:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.pt_PT/common/fossil-ci.md
+++ b/pages.pt_PT/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação do comando original:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.pt_PT/common/fossil-new.md
+++ b/pages.pt_PT/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação do comando original:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.pt_PT/common/gh-cs.md
+++ b/pages.pt_PT/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Exibe documentação do comando original:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.pt_PT/linux/ip-route-list.md
+++ b/pages.pt_PT/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Exibe documentação do comando original:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.pt_PT/windows/cpush.md
+++ b/pages.pt_PT/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Este comando é um alias de `choco-push`.
+> Este comando é um alias de `choco push`.
 > Mais informações: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Exibe documentação do comando original:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.ru/common/fossil-ci.md
+++ b/pages.ru/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Смотри документацию для оригинальной команды:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ru/common/fossil-new.md
+++ b/pages.ru/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Смотри документацию для оригинальной команды:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ru/common/gh-cs.md
+++ b/pages.ru/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Смотри документацию для оригинальной команды:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ru/linux/ip-route-list.md
+++ b/pages.ru/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Смотри документацию для оригинальной команды:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.sv/common/fossil-ci.md
+++ b/pages.sv/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Se dokumentationen för orginalkommandot:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.sv/common/fossil-new.md
+++ b/pages.sv/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Se dokumentationen för orginalkommandot:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.sv/common/gh-cs.md
+++ b/pages.sv/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Se dokumentationen för orginalkommandot:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.sv/linux/ip-route-list.md
+++ b/pages.sv/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Se dokumentationen för orginalkommandot:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ta/common/fossil-ci.md
+++ b/pages.ta/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - அக்கட்டளையின் விளக்கத்தைக் காண:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.ta/common/fossil-new.md
+++ b/pages.ta/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - அக்கட்டளையின் விளக்கத்தைக் காண:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.ta/common/gh-cs.md
+++ b/pages.ta/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - அக்கட்டளையின் விளக்கத்தைக் காண:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.ta/linux/ip-route-list.md
+++ b/pages.ta/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - அக்கட்டளையின் விளக்கத்தைக் காண:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.ta/windows/cpush.md
+++ b/pages.ta/windows/cpush.md
@@ -5,4 +5,4 @@
 
 - அசல் கட்டளைக்கான ஆவணங்களைப் பார்க்கவும்:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.th/common/fossil-ci.md
+++ b/pages.th/common/fossil-ci.md
@@ -1,8 +1,8 @@
 # fossil ci
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `fossil-commit`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `fossil commit`
 > ข้อมูลเพิ่มเติม: <https://fossil-scm.org/home/help/commit>
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.th/common/fossil-new.md
+++ b/pages.th/common/fossil-new.md
@@ -1,8 +1,8 @@
 # fossil new
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `fossil-init`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `fossil init`
 > ข้อมูลเพิ่มเติม: <https://fossil-scm.org/home/help/new>
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.th/common/gh-cs.md
+++ b/pages.th/common/gh-cs.md
@@ -1,8 +1,8 @@
 # gh cs
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `gh-codespace`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `gh codespace`
 > ข้อมูลเพิ่มเติม: <https://cli.github.com/manual/gh_codespace>
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.th/linux/ip-route-list.md
+++ b/pages.th/linux/ip-route-list.md
@@ -1,7 +1,7 @@
 # ip route list
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `ip-route-show`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `ip route show`
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.th/windows/cpush.md
+++ b/pages.th/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `choco-push`
+> คำสั่งนี้เป็นอีกชื่อหนึ่งของคำสั่ง `choco push`
 > ข้อมูลเพิ่มเติม: <https://docs.chocolatey.org/en-us/create/commands/push>
 
 - เรียกดูรายละเอียดสำหรับคำสั่งตัวเต็ม:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.tr/common/fossil-ci.md
+++ b/pages.tr/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.tr/common/fossil-new.md
+++ b/pages.tr/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.tr/common/gh-cs.md
+++ b/pages.tr/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.tr/linux/ip-route-list.md
+++ b/pages.tr/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.tr/windows/cpush.md
+++ b/pages.tr/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> Bu komut `choco-push` için bir takma addır.
+> Bu komut `choco push` için bir takma addır.
 > Daha fazla bilgi için: <https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - Asıl komutun belgelerini görüntüleyin:
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.uk/common/fossil-ci.md
+++ b/pages.uk/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - Дивись документацію для оригінальної команди:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.uk/common/fossil-new.md
+++ b/pages.uk/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - Дивись документацію для оригінальної команди:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.uk/common/gh-cs.md
+++ b/pages.uk/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - Дивись документацію для оригінальної команди:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.uk/linux/ip-route-list.md
+++ b/pages.uk/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - Дивись документацію для оригінальної команди:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.zh/common/fossil-ci.md
+++ b/pages.zh/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - 原命令的文档在：
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.zh/common/fossil-new.md
+++ b/pages.zh/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - 原命令的文档在：
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.zh/common/gh-cs.md
+++ b/pages.zh/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - 原命令的文档在：
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.zh/linux/ip-route-list.md
+++ b/pages.zh/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - 原命令的文档在：
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.zh/windows/cpush.md
+++ b/pages.zh/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> 这是 `choco-push` 命令的一个别名。
+> 这是 `choco push` 命令的一个别名。
 > 更多信息：<https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - 原命令的文档在：
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages.zh_TW/common/fossil-ci.md
+++ b/pages.zh_TW/common/fossil-ci.md
@@ -5,4 +5,4 @@
 
 - 原命令的文件在：
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages.zh_TW/common/fossil-new.md
+++ b/pages.zh_TW/common/fossil-new.md
@@ -5,4 +5,4 @@
 
 - 原命令的文件在：
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages.zh_TW/common/gh-cs.md
+++ b/pages.zh_TW/common/gh-cs.md
@@ -5,4 +5,4 @@
 
 - 原命令的文件在：
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages.zh_TW/linux/ip-route-list.md
+++ b/pages.zh_TW/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - 原命令的文件在：
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages.zh_TW/windows/cpush.md
+++ b/pages.zh_TW/windows/cpush.md
@@ -1,8 +1,8 @@
 # cpush
 
-> 這是 `choco-push` 命令的一個別名。
+> 這是 `choco push` 命令的一個別名。
 > 更多資訊：<https://docs.chocolatey.org/en-us/create/commands/push>.
 
 - 原命令的文件在：
 
-`tldr choco-push`
+`tldr choco push`

--- a/pages/common/fossil-ci.md
+++ b/pages/common/fossil-ci.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr fossil-commit`
+`tldr fossil commit`

--- a/pages/common/fossil-new.md
+++ b/pages/common/fossil-new.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr fossil-init`
+`tldr fossil init`

--- a/pages/common/gh-cs.md
+++ b/pages/common/gh-cs.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr gh-codespace`
+`tldr gh codespace`

--- a/pages/common/npm-author.md
+++ b/pages/common/npm-author.md
@@ -1,4 +1,4 @@
-# npm-author
+# npm author
 
 > This command is an alias of `npm owner`.
 

--- a/pages/linux/ip-route-list.md
+++ b/pages/linux/ip-route-list.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr ip-route-show`
+`tldr ip route show`

--- a/pages/linux/pacman-s.md
+++ b/pages/linux/pacman-s.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr pacman-sync`
+`tldr pacman sync`

--- a/pages/linux/qm-move_disk.md
+++ b/pages/linux/qm-move_disk.md
@@ -1,4 +1,4 @@
-# qm move disk
+# qm move_disk
 
 > This command is an alias of `qm disk move`.
 

--- a/pages/windows/cpush.md
+++ b/pages/windows/cpush.md
@@ -4,4 +4,4 @@
 
 - View documentation for the original command:
 
-`tldr choco-push`
+`tldr choco push`


### PR DESCRIPTION
This PR changes `command-subcommand` to `command subcommand` in all alias pages (except when the command actually contains a hyphen).