### PR TITLE
MAINTAINERS: remove @navarroaxel from Org; CODEOWNERS: update file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /pages.de/ @pixelcmtd @gutjuri
-/pages.es/ @navarroaxel @kant @tricantivu @ikks
+/pages.es/ @kant @tricantivu @ikks
 /pages.fa/ @MrMw3
 /pages.fr/ @Nico385412 @nicokosi @noraj
 /pages.hi/ @kbdharun @debghs @karthik-script
@@ -25,13 +25,13 @@
 /contributing-guides/maintainers-guide.md @sbrl @kbdharun
 /contributing-guides/style-guide.md @sbrl @kbdharun
 /contributing-guides/*.de.md @pixelcmtd @gutjuri
-/contributing-guides/*.es.md @navarroaxel @kant @tricantivu
+/contributing-guides/*.es.md @kant @tricantivu @ikks
 /contributing-guides/*.fa.md @MrMw3
 /contributing-guides/*.fr.md @Nico385412 @nicokosi @noraj
-/contributing-guides/*.hi.md @kbdharun
+/contributing-guides/*.hi.md @kbdharun @debghs @karthik-script
 /contributing-guides/*.id.md @reinhart1010
 /contributing-guides/*.it.md @mebeim @tansiret @Magrid0
-/contributing-guides/*.ko.md @IMHOJEONG
+/contributing-guides/*.ko.md @IMHOJEONG @Zamoca42 @CodePsy-2001
 /contributing-guides/*.nl.md @sebastiaanspeck @leonvsc @Waples
 /contributing-guides/*.pl.md @acuteenvy @spageektti
 /contributing-guides/*.pt_BR.md @isaacvicente @vitorhcl @renie

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -86,6 +86,8 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [02 November 2024](https://github.com/tldr-pages/tldr/issues/14538) — present
 - **CodePsy-2001 ([@CodePsy-2001](https://github.com/CodePsy-2001))**:
   [02 November 2024](https://github.com/tldr-pages/tldr/issues/14537#issuecomment-2457381463) — present
+- **Axel Navarro ([@navarroaxel](https://github.com/navarroaxel))**:
+  [24 August 2020](https://github.com/tldr-pages/tldr/issues/4291) — [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504), [14 November 2024](https://github.com/tldr-pages/tldr/issues/14541) — present
 - Owen Voke ([@owenvoke](https://github.com/owenvoke))
   [11 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258)
 - Marco Bonelli ([@mebeim](https://github.com/mebeim)):
@@ -94,8 +96,6 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [27 October 2019](https://github.com/tldr-pages/tldr/issues/3488) — [6 January 2020](https://github.com/tldr-pages/tldr/issues/3738)
 - Zlatan Vasović ([@zlatanvasovic](https://github.com/zlatanvasovic)):
   [28 November 2019](https://github.com/tldr-pages/tldr/issues/3636) — [17 December 2019](https://github.com/tldr-pages/tldr/issues/3663)
-- Axel Navarro ([@navarroaxel](https://github.com/navarroaxel)):
-  [24 August 2020](https://github.com/tldr-pages/tldr/issues/4291) — [5 October 2020](https://github.com/tldr-pages/tldr/issues/4504)
 - bl-ue ([@bl-ue](https://github.com/bl-ue)):
   [30 December 2020](https://github.com/tldr-pages/tldr/issues/5056) — [2 February 2021](https://github.com/tldr-pages/tldr/issues/5219)
 - Tan Siret Akıncı ([@tansiret](https://github.com/tansiret)):
@@ -228,8 +228,6 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   [8 May 2019](https://github.com/tldr-pages/tldr/issues/2989) — present
 - **Marco Bonelli ([@mebeim](https://github.com/mebeim))**:
   [21 December 2019](https://github.com/tldr-pages/tldr/issues/3672) — present
-- **Axel Navarro ([@navarroaxel](https://github.com/navarroaxel))**:
-  [7 April 2021](https://github.com/tldr-pages/tldr/issues/5703) — present
 - **CleanMachine1 ([@CleanMachine1](https://github.com/CleanMachine1))**:
   [14 December 2021](https://github.com/tldr-pages/tldr/issues/7541) — present
 - **Pixel Häußler ([@pixelcmtd](https://github.com/pixelcmtd))**:
@@ -268,3 +266,5 @@ An automated list can be found [here](https://github.com/orgs/tldr-pages/people)
   until [7 February 2023](https://github.com/tldr-pages/tldr/issues/10674)
 - Marcher Simon ([@marchersimon](https://github.com/marchersimon)):
   until [20 November 2023](https://github.com/tldr-pages/tldr/issues/11381)
+- Axel Navarro ([@navarroaxel](https://github.com/navarroaxel)):
+  until [14 November 2024](https://github.com/tldr-pages/tldr/issues/14541)


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Closes https://github.com/tldr-pages/tldr/issues/14541

## Changes

- Remove @navarroaxel from Org and CODEOWNERS file
- Update the CODEOWNERS file's contributing guides section to match with native reviewers for pages.