### PR TITLE
fossil-commit: add Spanish translation

### DIFF
--- a/pages.es/common/fossil-commit.md
+++ b/pages.es/common/fossil-commit.md
@@ -1,0 +1,20 @@
+# fossil commit
+
+> Envía archivos a un repositorio Fossil.
+> Más información: <https://fossil-scm.org/home/help/commit>.
+
+- Crea una nueva versión que contiene todos los cambios en el checkout actual; se solicitará al usuario un comentario:
+
+`fossil commit`
+
+- Crea una versión que contiene todos los cambios en el checkout actual, utilizando el comentario especificado:
+
+`fossil commit --comment "{{comentario}}"`
+
+- Crea una versión que contiene todos los cambios en el checkout actual con un comentario leído de un archivo específico:
+
+`fossil commit --message-file {{ruta/al/archivo_con_comentario}}`
+
+- Crea una versión que contiene cambios de los archivos especificados; se solicitará al usuario un comentario:
+
+`fossil commit {{ruta/al/archivo1 ruta/al/archivo2 ...}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
