### PR TITLE
14851: Do not use serial comma in negative example

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -239,7 +239,7 @@ use a [serial comma](https://en.wikipedia.org/wiki/Serial_comma),
 also known as the Oxford comma,
 since omitting it can create ambiguity.
 
-> Delete the Git branches, tags, and remotes.
+> Delete the Git branches, tags and remotes.
 
 The example above does not use a serial comma, so this could mean one of two things:
 


### PR DESCRIPTION
The example used to highlight the ambiguity when not using a serial comma was actually using the serial comma. Thus, making the example not helpful. This commit removes this erroneous usage of the comma in the example.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
