### PR TITLE
podman-login: add page

### DIFF
--- a/pages/common/podman-login.md
+++ b/pages/common/podman-login.md
@@ -1,6 +1,7 @@
 # podman login
 
 > Log in to a container registry.
+> Note: the default authfile path on Linux is `$XDG_RUNTIME_DIR/containers/auth.json`, which is usually stored in a `tmpfs` (in RAM).
 > More information: <https://docs.podman.io/en/latest/markdown/podman-login.1.html>.
 
 - Log in to a registry (non-persistent on Linux; persistent on Windows/macOS):
@@ -9,8 +10,8 @@
 
 - Log in to a registry persistently on Linux:
 
-`podman login --authfile=$HOME/.config/containers/auth.json {{registry.example.org}}`
+`podman login --authfile $HOME/.config/containers/auth.json {{registry.example.org}}`
 
 - Log in to an insecure (HTTP) registry:
 
-`podman login --tls-verify=false {{registry.example.org}}`
+`podman login --tls-verify false {{registry.example.org}}`

--- a/pages/common/podman-login.md
+++ b/pages/common/podman-login.md
@@ -1,0 +1,16 @@
+# podman login
+
+> Log in to a container registry.
+> More information: <https://docs.podman.io/en/latest/markdown/podman-login.1.html>.
+
+- Log in to a registry (non-persistent on Linux; persistent on Windows/macOS):
+
+`podman login {{registry.example.org}}`
+
+- Log in to a registry persistently on Linux:
+
+`podman login --authfile=$HOME/.config/containers/auth.json {{registry.example.org}}`
+
+- Log in to an insecure (HTTP) registry:
+
+`podman login --tls-verify=false {{registry.example.org}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 5.3.0
