### PR TITLE
hyprctl: fixed false example

### DIFF
--- a/pages/linux/hyprctl.md
+++ b/pages/linux/hyprctl.md
@@ -21,7 +21,7 @@
 
 - Call a dispatcher with an argument:
 
-`hyprctl dispatch exec {{app}}`
+`hyprctl dispatch {{argument}}`
 
 - Set a configuration keyword dynamically:
 

--- a/pages/linux/hyprctl.md
+++ b/pages/linux/hyprctl.md
@@ -19,9 +19,9 @@
 
 `hyprctl workspaces`
 
-- Call a dispatcher with an argument:
+- Call a dispatcher:
 
-`hyprctl dispatch {{argument}}`
+`hyprctl dispatch {{dispatcher}}`
 
 - Set a configuration keyword dynamically:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**


The reason for this is that the old 'exec {{app}}' is too specific.

'exec' doesn't have to be the dispatcher it could be a lot of other things too.