### PR TITLE
musescore: add Spanish translation

### DIFF
--- a/pages.es/common/musescore.md
+++ b/pages.es/common/musescore.md
@@ -1,0 +1,33 @@
+# musescore
+
+> MuseScore editor de música de 3 hojas.
+> Vea también: `lilypond`.
+> Más información: <https://musescore.org/en/handbook/3/command-line-options>.
+
+- Utiliza un controlador de audio específico:
+
+`musescore --audio-driver {{jack|alsa|portaudio|pulse}}`
+
+- Establece el bitrate de salida MP3 en kbit/s:
+
+`musescore --bitrate {{bitrate}}`
+
+- Inicia MuseScore en modo depuración:
+
+`musescore --debug`
+
+- Permite características experimentales, como capas:
+
+`musescore --experimental`
+
+- Exporta el archivo dado al archivo de salida especificado. El tipo de archivo depende de la extensión dada:
+
+`musescore --export-to {{archivo_de_salida}} {{archivo_de_entrada}}`
+
+- Imprime las diferencias entre las puntuaciones (scores) dadas:
+
+`musescore --diff {{ruta/al/archivo1}} {{ruta/al/archivo2}}`
+
+- Especifica un archivo de operaciones de importación MIDI:
+
+`musescore --midi-operations {{ruta/al/archivo}}`


### PR DESCRIPTION


- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
