### PR TITLE
gnmic-subscribe: add Spanish translation

### DIFF
--- a/pages.es/common/gnmic-subscribe.md
+++ b/pages.es/common/gnmic-subscribe.md
@@ -1,0 +1,24 @@
+# gnmic subscribe
+
+> Suscribirse a las actualizaciones de estado de un dispositivo de red gnmic.
+> Más información: <https://gnmic.kmrd.dev/cmd/subscribe>.
+
+- Suscribirse a las actualizaciones del estado objetivo bajo el subárbol de una ruta específica:
+
+`gnmic --address {{ip:puerto}} subscribe --path {{ruta}}`
+
+- Suscribirse a un objetivo con un intervalo de muestra de 30s (por defecto es 10s):
+
+`gnmic -a {{ip:puerto}} subscribe --path {{ruta}} --sample-interval 30s`
+
+- Suscribirse a un objetivo con intervalo de muestra y actualizaciones solamente cuando hay cambios:
+
+`gnmic -a {{ip:puerto}} subscribe --path {{ruta}} --stream-mode on-change --heartbeat-interval 1m`
+
+- Suscribirse a un objetivo para una sola actualización:
+
+`gnmic -a {{ip:puerto}} subscribe --path {{ruta}} --mode once`
+
+- Suscribirse a un objetivo y especificar la codificación de la respuesta (json_ietf):
+
+`gnmic -a {{ip:puerto}} subscribe --path {{ruta}} --encoding json_ietf`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
