### PR TITLE
gh-codespace: add Spanish translation

### DIFF
--- a/pages.es/common/gh-codespace.md
+++ b/pages.es/common/gh-codespace.md
@@ -1,0 +1,36 @@
+# gh codespace
+
+> Conecta y gestiona tus codespaces en GitHub.
+> Más información: <https://cli.github.com/manual/gh_codespace>.
+
+- Crea un codespace en GitHub de forma interactiva:
+
+`gh codespace create`
+
+- Lista todos los codespaces disponibles:
+
+`gh codespace list`
+
+- Conecta a un codespace vía SSH de forma interactiva:
+
+`gh codespace ssh`
+
+- Transfiere un archivo específico a un codespace interactivamente:
+
+`gh codespace cp {{ruta/al/archivo_fuente}} remote:{{ruta/al/archivo_remoto}}`
+
+- Lista los puertos de un codespace interactivo:
+
+`gh codespace ports`
+
+- Muestra los registros (logs) de un codespace interactivo:
+
+`gh codespace logs`
+
+- Elimina un codespace interactivamente:
+
+`gh codespace delete`
+
+- Muestra ayuda para un subcomando:
+
+`gh codespace {{code|cp|create|delete|edit|...}} --help`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
