### PR TITLE
emerge: appended sudo before command examples

### DIFF
--- a/pages/linux/emerge.md
+++ b/pages/linux/emerge.md
@@ -26,7 +26,7 @@
 
 - Remove orphaned packages (that were installed only as dependencies):
 
-` sudo emerge -avc`
+`sudo emerge -avc`
 
 - Search the package database for a keyword:
 

--- a/pages/linux/emerge.md
+++ b/pages/linux/emerge.md
@@ -6,27 +6,27 @@
 
 - Synchronize all packages:
 
-`emerge --sync`
+`sudo emerge --sync`
 
 - Update all packages, including dependencies:
 
-`emerge -uDNav @world`
+`sudo emerge -uDNav @world`
 
 - Resume a failed updated, skipping the failing package:
 
-`emerge --resume --skipfirst`
+`sudo emerge --resume --skipfirst`
 
 - Install a new package, with confirmation:
 
-`emerge -av {{package}}`
+`sudo emerge -av {{package}}`
 
 - Remove a package, with confirmation:
 
-`emerge -Cav {{package}}`
+`sudo emerge -Cav {{package}}`
 
 - Remove orphaned packages (that were installed only as dependencies):
 
-`emerge -avc`
+` sudo emerge -avc`
 
 - Search the package database for a keyword:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ x] The page(s) have at most 8 examples.
- [ x] The page description(s) have links to documentation or a homepage.
- [ x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
