### PR TITLE
dmenu: add Spanish translation

### DIFF
--- a/pages.es/linux/dmenu.md
+++ b/pages.es/linux/dmenu.md
@@ -12,7 +12,7 @@
 
 `echo -e "{{rojo}}\n{{verde}}\n{{azul}}" | dmenu`
 
-- Deja que el usuario elija entre varios elementos y guarda el seleccionado a un archivo:
+- Deja que el usuario elija entre varios elementos y guarda el seleccionado en un archivo:
 
 `echo -e "{{rojo}}\n{{verde}}\n{{azul}}" | dmenu > {{color.txt}}`
 

--- a/pages.es/linux/dmenu.md
+++ b/pages.es/linux/dmenu.md
@@ -1,7 +1,7 @@
 # dmenu
 
 > Menú dinámico.
-> Crea un menú a partir de una entrada de texto con cada elemento en una nueva línea.
+> Crea un menú a partir de una entrada de texto con cada elemento, en una nueva línea.
 > Más información: <https://manned.org/dmenu>.
 
 - Muestra un menú a partir de la salida del comando 'ls':

--- a/pages.es/linux/dmenu.md
+++ b/pages.es/linux/dmenu.md
@@ -1,0 +1,25 @@
+# dmenu
+
+> Menú dinámico.
+> Crea un menú a partir de una entrada de texto con cada elemento en una nueva línea.
+> Más información: <https://manned.org/dmenu>.
+
+- Muestra un menú a partir de la salida del comando 'ls':
+
+`{{ls}} | dmenu`
+
+- Muestra un menú con artículos personalizados separados por una nueva línea (`\n`):
+
+`echo -e "{{rojo}}\n{{verde}}\n{{azul}}" | dmenu`
+
+- Deja que el usuario elija entre varios elementos y guarda el seleccionado a un archivo:
+
+`echo -e "{{rojo}}\n{{verde}}\n{{azul}}" | dmenu > {{color.txt}}`
+
+- Lanza dmenu en un monitor específico:
+
+`ls | dmenu -m {{1}}`
+
+- Muestra dmenu en la parte inferior de la pantalla:
+
+`ls | dmenu -b`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
