### PR TITLE
grub2-mkpasswd-pbkdf2: add page

### DIFF
--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -5,4 +5,4 @@
 
 - Create a password hash for GRUB 2 using PBKDF2:
 
-`sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{mySaltValue}}`
+`sudo grub2_mkpasswd_pbkdf2 -c {{number}} -s {{salt_value}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -5,4 +5,4 @@
 
 - Create a password hash for GRUB 2 using PBKDF2 and print it to `stdout`:
 
-`sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{salt_value}}`
+`sudo grub2-mkpasswd-pbkdf2 {{-c|--iteration-count}} {{number_of_pbkdf2_iterations}} {{-s|--salt}} {{salt_length}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -3,6 +3,6 @@
 > You can set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
 > More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
 
-- You can use grub2-mkpasswd-pbkdf2 to create a password hash for GRUB 2 using PBKDF2:
+- Create a password hash for GRUB 2 using PBKDF2:
 
 `sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{mySaltValue}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -1,0 +1,8 @@
+# grub2-mkpasswd-pbkdf2
+
+> You can set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
+> More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
+
+- You can use grub2-mkpasswd-pbkdf2 to create a password hash for GRUB 2 using PBKDF2.
+
+`sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{mySaltValue}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -3,6 +3,6 @@
 > Set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
 > More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
 
-- Create a password hash for GRUB 2 using PBKDF2:
+- Create a password hash for GRUB 2 using PBKDF2 and print it to `stdout`:
 
 `sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{salt_value}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -5,4 +5,4 @@
 
 - Create a password hash for GRUB 2 using PBKDF2:
 
-`sudo grub2_mkpasswd_pbkdf2 -c {{number}} -s {{salt_value}}`
+`sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{salt_value}}`

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -1,6 +1,6 @@
 # grub2-mkpasswd-pbkdf2
 
-> Set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
+> Generate a hashed password for GRUB.
 > More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
 
 - Create a password hash for GRUB 2 using PBKDF2 and print it to `stdout`:

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -1,6 +1,6 @@
 # grub2-mkpasswd-pbkdf2
 
-> You can set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
+> Set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
 > More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
 
 - Create a password hash for GRUB 2 using PBKDF2:

--- a/pages/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages/linux/grub2-mkpasswd-pbkdf2.md
@@ -3,6 +3,6 @@
 > You can set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
 > More information: <https://manned.org/grub2-mkpasswd-pbkdf2>.
 
-- You can use grub2-mkpasswd-pbkdf2 to create a password hash for GRUB 2 using PBKDF2.
+- You can use grub2-mkpasswd-pbkdf2 to create a password hash for GRUB 2 using PBKDF2:
 
 `sudo grub2-mkpasswd-pbkdf2 -c {{number}} -s {{mySaltValue}}`


### PR DESCRIPTION
grub2-mkpasswd-pbkdf2 added

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
