### PR TITLE
tuc: add page

### DIFF
--- a/pages/common/tuc.md
+++ b/pages/common/tuc.md
@@ -1,0 +1,25 @@
+# tuc
+
+> Cut text (or bytes) where a delimiter matches, then keep the desired parts.
+> A more user-friendly and powerful version of `cut` with sensible defaults.
+> More information: <https://github.com/riquito/tuc>.
+
+- Cut and rearrange fields:
+
+`echo "foo bar baz" | tuc -d '{{ }}' -f {{3,2,1}}`
+
+- Replace the delimiter `space` with an arrow:
+
+`echo "foo bar baz" | tuc -d ' ' -r ' ➡ '`
+
+- Keep a range of fields:
+
+`echo "foo bar    baz" | tuc -d ' ' -f {{2:}}`
+
+- Cut using regular expressions:
+
+`echo "a,b, c" | tuc -e '{{[, ]+}}' -f {{1,3}}`
+
+- Emit JSON output:
+
+`echo "foo bar baz" | tuc -d '{{ }}' --json`


### PR DESCRIPTION
The examples are taken from original repo (https://github.com/riquito/tuc), just a shorter list.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
