### PR TITLE
podman-run: add Spanish translation

### DIFF
--- a/pages.es/common/podman-run.md
+++ b/pages.es/common/podman-run.md
@@ -25,7 +25,7 @@
 
 - Ejecuta comando en un nuevo contenedor con los puertos publicados:
 
-`podman run --publish {{puerto_de_anfitrion}}:{{puerto_de_contenedor}} {{imagen:tag}} {{comando}}`
+`podman run --publish {{puerto_del_anfitrion}}:{{puerto_del_contenedor}} {{imagen:tag}} {{comando}}`
 
 - Ejecuta el comando en un nuevo contenedor sobrescribiendo el punto de entrada (entrypoint) de la imagen:
 

--- a/pages.es/common/podman-run.md
+++ b/pages.es/common/podman-run.md
@@ -1,0 +1,36 @@
+# podman run
+
+> Ejecuta un comando en un nuevo contenedor Podman.
+> Más información: <https://docs.podman.io/en/latest/markdown/podman-run.1.html>.
+
+- Ejecuta el comando en un nuevo contenedor de una imagen etiquetada:
+
+`podman run {{imagen:tag}} {{comando}}`
+
+- Ejecuta el comando en un nuevo contenedor en el fondo y muestra su ID:
+
+`podman run --detach {{imagen:tag}} {{comando}}`
+
+- Ejecuta el comando en un contenedor único en modo interactivo y pseudo-TTY:
+
+`podman run --rm --interactive --tty {{imagen:tag}} {{comando}}`
+
+- Ejecuta el comando en un nuevo contenedor con variables de entorno enviadas:
+
+`podman run --env '{{variable}}={{valor}}' --env {{variable}} {{imagen:tag}} {{comando}}`
+
+- Ejecuta el comando en un nuevo contenedor con volúmenes montados en un contenedor:
+
+`podman run --volume {{/ruta/a/ruta_del_host}}:{{/ruta/a/ruta_del_contenedor}} {{imagen:tag}} {{comando}}`
+
+- Ejecuta comando en un nuevo contenedor con los puertos publicados:
+
+`podman run --publish {{puerto_de_anfitrion}}:{{puerto_de_contenedor}} {{imagen:tag}} {{comando}}`
+
+- Ejecuta el comando en un nuevo contenedor sobrescribiendo el punto de entrada (entrypoint) de la imagen:
+
+`podman run --entrypoint {{comando}} {{imagen:tag}}`
+
+- Ejecuta el comando en un nuevo contenedor que lo conecta a una red:
+
+`podman run --network {{red}} {{imagen:tag}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
