### PR TITLE
systemd-cryptsetup: add page

### DIFF
--- a/pages/linux/systemd-cryptsetup.md
+++ b/pages/linux/systemd-cryptsetup.md
@@ -1,0 +1,22 @@
+# systemd-cryptsetup
+
+> Create or remove decrypted mappings of encrypted volumes. Equivalent of `cryptsetup open` and `cryptsetup close`.
+> Arguments to this command are written exactly like a line in `/etc/crypttab`. It's used by systemd to unlock devices on boot.
+> See also: `cryptsetup`.
+> More information: <https://www.freedesktop.org/software/systemd/man/latest/systemd-cryptsetup.html>.
+
+- Open a LUKS volume and create a decrypted mapping at `/dev/mapper/mapping_name`:
+
+`systemd-cryptsetup attach {{mapping_name}} {{/dev/sdXY}}`
+
+- Open a LUKS volume with additional options and create a decrypted mapping at `/dev/mapper/mapping_name`:
+
+`systemd-cryptsetup attach {{mapping_name}} {{/dev/sdXY}} none {{crypttab_options}}`
+
+- Open a LUKS volume with a keyfile and create a decrypted mapping at `/dev/mapper/mapping_name`:
+
+`systemd-cryptsetup attach {{mapping_name}} {{/dev/sdXY}} {{path/to/keyfile}} {{crypttab_options}}`
+
+- Remove an existing mapping:
+
+`systemd-cryptsetup detach {{mapping_name}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

#10191