### PR TITLE
qm-cloud-init: add Spanish translation

### DIFF
--- a/pages.es/linux/qm-cloud-init.md
+++ b/pages.es/linux/qm-cloud-init.md
@@ -1,0 +1,24 @@
+# qm cloud init
+
+> Configuración de ajustes de cloudinit para máquinas virtuales gestionadas por Ambiente Virtual Proxmox (Virtual Environment) (PVE).
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Configura ajustes de cloudinit para un usuario específico y establece una contraseña para el mismo:
+
+`qm cloud-init {{id_mv}} -user={{usuario}} -password={{contraseña}}`
+
+- Configura ajustes de cloudinit para un usuario específico y le establece una contraseña con una clave SSH específica:
+
+`qm cloud-init {{id_mv}} -user={{usuario}} -password={{contraseña}} -sshkey={{clave_ssh}}`
+
+- Establece el nombre de host para una máquina virtual específica:
+
+`qm cloud-init {{id_mv}} -hostname={{nombre_del_equipo}}`
+
+- Configura los ajustes de interfaz de red para una máquina virtual específica:
+
+`qm cloud-init {{id_mv}} -ipconfig {{ipconfig}}`
+
+- Configura un script de interfaz de comandos (shell) para ejecutarse antes de que `cloud-ini` se ejecute en una máquina virtual:
+
+`qm cloud-init {{id_mv}} -pre {{script}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
