### PR TITLE
qm-create: add Spanish translation

### DIFF
--- a/pages.es/linux/qm-create.md
+++ b/pages.es/linux/qm-create.md
@@ -17,7 +17,7 @@
 
 - Reemplaza una máquina existente (requiere archivarla):
 
-`qm create {{100}} --archive {{ruta/a/archivo_de_respaldo.tar}} --force 1`
+`qm create {{100}} --archive {{ruta/al/archivo_de_respaldo.tar}} --force 1`
 
 - Especifica un guión (script) a ejecutar automáticamente dependiendo del estado de la máquina virtual:
 

--- a/pages.es/linux/qm-create.md
+++ b/pages.es/linux/qm-create.md
@@ -11,7 +11,7 @@
 
 `qm create {{100}} --start 1`
 
-- Especifica el tipo de sistema operativo en la máquina:
+- Especifica el tipo de sistema operativo en la máquina virtual:
 
 `qm create {{100}} --ostype {{win10}}`
 

--- a/pages.es/linux/qm-create.md
+++ b/pages.es/linux/qm-create.md
@@ -7,7 +7,7 @@
 
 `qm create {{100}}`
 
-- Inicia automáticamente la máquina después de la creación:
+- Inicia automáticamente la máquina después de su creación:
 
 `qm create {{100}} --start 1`
 

--- a/pages.es/linux/qm-create.md
+++ b/pages.es/linux/qm-create.md
@@ -1,0 +1,24 @@
+# qm create
+
+> Crea o restaura una máquina virtual en el administrador de máquinas virtuales QEMU/KVM.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Crea una máquina virtual:
+
+`qm create {{100}}`
+
+- Inicia automáticamente la máquina después de la creación:
+
+`qm create {{100}} --start 1`
+
+- Especifica el tipo de sistema operativo en la máquina:
+
+`qm create {{100}} --ostype {{win10}}`
+
+- Reemplaza una máquina existente (requiere archivarla):
+
+`qm create {{100}} --archive {{ruta/a/archivo_de_respaldo.tar}} --force 1`
+
+- Especifica un guión (script) a ejecutar automáticamente dependiendo del estado de la máquina virtual:
+
+`qm create {{100}} --hookscript {{ruta/a/guión.pl}}`

--- a/pages.es/linux/qm-create.md
+++ b/pages.es/linux/qm-create.md
@@ -21,4 +21,4 @@
 
 - Especifica un guión (script) a ejecutar automáticamente dependiendo del estado de la máquina virtual:
 
-`qm create {{100}} --hookscript {{ruta/a/guión.pl}}`
+`qm create {{100}} --hookscript {{ruta/al/guión.pl}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
