### PR TITLE
find: fix two examples with wrong or misleading syntax

### DIFF
--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -9,7 +9,7 @@
 
 - Find files matching multiple path/name patterns:
 
-`find {{root_path}} -path '{{**/path/**/*.ext}}' -or -name '{{*pattern*}}'`
+`find {{root_path}} -path '{{*/path/*/*.ext}}' -or -name '{{*pattern*}}'`
 
 - Find directories matching a given name, in case-insensitive mode:
 
@@ -33,4 +33,4 @@
 
 - Find empty files (0 byte) or directories and delete them verbosely:
 
-`find {{root_path}} -type {{f|d}} -empty -delete -print`
+`find {{root_path}} -type {{f,d}} -empty -delete -print`

--- a/pages/common/find.md
+++ b/pages/common/find.md
@@ -33,4 +33,4 @@
 
 - Find empty files (0 byte) or directories and delete them verbosely:
 
-`find {{root_path}} -type {{f,d}} -empty -delete -print`
+`find {{root_path}} -type '{{f,d}}' -empty -delete -print`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Fixes #15107
