### PR TITLE
zenity: add Spanish translation

### DIFF
--- a/pages.es/linux/zenity.md
+++ b/pages.es/linux/zenity.md
@@ -1,7 +1,7 @@
 # zenity
 
 > Muestra diálogos desde guiones de la línea de comandos.
-> Regresa los valores proveídos por el usuario o 1 si hay error.
+> Regresa los valores suministrados por el usuario o 1 si hay error.
 > Más información: <https://manned.org/zenity>.
 
 - Muestra el diálogo predeterminado de pregunta:

--- a/pages.es/linux/zenity.md
+++ b/pages.es/linux/zenity.md
@@ -1,0 +1,25 @@
+# zenity
+
+> Muestra diálogos desde guiones de la línea de comandos.
+> Regresa los valores proveídos por el usuario o 1 si hay error.
+> Más información: <https://manned.org/zenity>.
+
+- Muestra el diálogo predeterminado de pregunta:
+
+`zenity --question`
+
+- Muestra un diálogo de información que muestra el texto "¡Hola!":
+
+`zenity --info --text="{{¡Hola!}}"`
+
+- Muestra un formulario  de nombre/contraseña y retorna los datos separados por ";":
+
+`zenity --forms --add-entry="{{Nombre}}" --add-password="{{Contraseña}}" --separator="{{;}}"`
+
+- Muestra un formulario de selección de archivos en el que el usuario sólo puede seleccionar directorios:
+
+`zenity --file-selection --directory`
+
+- Muestra una barra de progreso que actualiza su mensaje cada segundo y muestra un porcentaje de progreso:
+
+`{{(echo "#1"; sleep 1; echo "50"; echo "#2"; sleep 1; echo "100")}} | zenity --progress`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
