### PR TITLE
qm-guest-exec-status: add Spanish translation

### DIFF
--- a/pages.es/linux/qm-guest-exec-status.md
+++ b/pages.es/linux/qm-guest-exec-status.md
@@ -1,0 +1,8 @@
+# qm guest exec-status
+
+> Imprime el estado de un pid iniciado por el agente huésped en el administrador de máquinas virtuales QEMU/KVM.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Imprime el estado de un PID específico:
+
+`qm guest exec-status {{id_mv}} {{pid}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
