### PR TITLE
qm-guest-passwd: add Spanish translation

### DIFF
--- a/pages.es/linux/qm-guest-passwd.md
+++ b/pages.es/linux/qm-guest-passwd.md
@@ -1,0 +1,12 @@
+# qm guest passwd
+
+> Establece la contraseña para un usuario en el administrador de máquinas virtuales QEMU/KVM.
+> Más información: <https://pve.proxmox.com/pve-docs/qm.1.html>.
+
+- Establece una contraseña para un usuario específico en una máquina virtual de forma interactiva:
+
+`qm guest passwd {{id_mv}} {{usuario}}`
+
+- Establece una contraseña ya procesada (hashed) para un usuario específico en una máquina virtual de forma interactiva:
+
+`qm guest passwd {{id_mv}} {{usuario}} --crypted 1`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
