### PR TITLE
emerge: update page

### DIFF
--- a/pages/linux/emerge.md
+++ b/pages/linux/emerge.md
@@ -10,7 +10,7 @@
 
 - Update all packages, including dependencies:
 
-`sudo emerge -uDNav @world`
+`sudo emerge {{-avuDN|--ask --verbose --update --deep --newuse}} @world`
 
 - Resume a failed updated, skipping the failing package:
 
@@ -18,16 +18,16 @@
 
 - Install a new package, with confirmation:
 
-`sudo emerge -av {{package}}`
+`sudo emerge {{-av|--ask --verbose}} {{package}}`
 
-- Remove a package, with confirmation:
+- Remove a package and its dependencies with confirmation:
 
-`sudo emerge -Cav {{package}}`
+`sudo emerge {{-avc|--ask --verbose --depclean}} {{package}}`
 
-- Remove orphaned packages (that were installed only as dependencies):
+- Remove orphaned packages (installed as dependencies but no longer required by any package):
 
-`sudo emerge -avc`
+`sudo emerge {{-avc|--ask --verbose --depclean}}`
 
 - Search the package database for a keyword:
 
-`emerge -S {{keyword}}`
+`emerge {{-S|--searchdesc}} {{keyword}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

* Add long options
* Replace `--unmerge` with `--depclean`, as suggested in the Gentoo wiki:
https://wiki.gentoo.org/wiki/Emerge
> Do **not** use the `--unmerge` (`-C`) option (unless its particular behavior is known to be specifically required). This option will remove important packages that are needed for the system to function, without warning.
