### PR TITLE
cidr: add page

### DIFF
--- a/pages/common/cidr.md
+++ b/pages/common/cidr.md
@@ -1,0 +1,24 @@
+# cidr
+
+> Simplifies IPv4/IPv6 CIDR network prefix management with counting, overlap checking, explanation, and subdivision.
+> More information: <https://github.com/bschaatsbergen/cidr>.
+
+- Explain a CIDR range:
+
+`cidr explain {{10.0.0.0/16}}`
+
+- Check whether an address belongs to a CIDR range:
+
+`cidr contains {{10.0.0.0/16}} {{10.0.14.5}}`
+
+- Get a count of all addresses in a CIDR range:
+
+`cidr count {{10.0.0.0/16}}`
+
+- Check whether two CIDR ranges overlap:
+
+`cidr overlaps {{10.0.0.0/16}} {{10.0.14.0/22}}`
+
+- Divide a CIDR range into a specific number of networks:
+
+`cidr divide {{10.0.0.0/16}} {{9}}`


### PR DESCRIPTION
Adds `cidr`, which is available in Homebrew Core, all Debian/Ubuntu repositories, PureOS and more: https://repology.org/project/cidr/packages

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
