### PR TITLE
exit: add Spanish translation

### DIFF
--- a/pages.es/common/exit.md
+++ b/pages.es/common/exit.md
@@ -1,0 +1,12 @@
+# exit
+
+> Sale de la interfaz de comandos.
+> Más información: <https://manned.org/exit.1posix>.
+
+- Sale con el estado de salida del comando más recientemente ejecutado:
+
+`exit`
+
+- Sale con un estado de salida específico:
+
+`exit {{estado_de_salida}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
