### PR TITLE
ruff-check: add Spanish translation

### DIFF
--- a/pages.es/common/ruff-check.md
+++ b/pages.es/common/ruff-check.md
@@ -1,0 +1,33 @@
+# ruff check
+
+> Un linter extremadamente rápido para Python. `check` es el comando predeterminado - se puede omitir en todas partes.
+> Si no se especifican archivos o directorios, el directorio de trabajo actual se utiliza por defecto.
+> Más información: <https://docs.astral.sh/ruff/linter>.
+
+- Ejecuta el linter en los archivos o directorios dados:
+
+`ruff check {{ruta/al/archivo_o_directorio1 ruta/al/archivo_o_directorio2 ...}}`
+
+- Aplica las correcciones sugeridas, modificando los archivos afectados:
+
+`ruff check --fix`
+
+- Ejecuta el linter y lo aplica de nuevo ante algún cambio:
+
+`ruff check --watch`
+
+- Sólo habilita las reglas especificadas (o todas las reglas), ignorando el archivo de configuración:
+
+`ruff check --select {{ALL|regla_de_código1,regla_de_código2,...}}`
+
+- Además, habilita las reglas especificadas:
+
+`ruff check --extend-select {{regla_de_código1,regla_de_código2,...}}`
+
+- Desactiva las reglas especificadas:
+
+`ruff check --ignore {{regla_de_código1,regla_de_código2,...}}`
+
+- Ignora todas las violaciones existentes de una regla añadiendo las directivas "# noqa" a todas las líneas que la violan:
+
+`ruff check --select {{regla_de_código}} --add-noqa`

--- a/pages.es/common/ruff-check.md
+++ b/pages.es/common/ruff-check.md
@@ -16,7 +16,7 @@
 
 `ruff check --watch`
 
-- Sólo habilita las reglas especificadas (o todas las reglas), ignorando el archivo de configuración:
+- Solo habilita las reglas especificadas (o todas las reglas), ignorando el archivo de configuración:
 
 `ruff check --select {{ALL|regla_de_código1,regla_de_código2,...}}`
 


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
