### PR TITLE
tcpreplay: add page

### DIFF
--- a/pages/common/tcpreplay.md
+++ b/pages/common/tcpreplay.md
@@ -1,6 +1,6 @@
 # tcpreplay
 
-> Replay network traffic stored in pcap file
+> Replay network traffic stored in pcap file.
 > More information: <https://tcpreplay.appneta.com/>.
 
 - List available network interfaces:

--- a/pages/common/tcpreplay.md
+++ b/pages/common/tcpreplay.md
@@ -1,0 +1,28 @@
+# tcpreplay
+
+> Replay network traffic stored in pcap file
+> More information: <https://tcpreplay.appneta.com/>.
+
+- List available network interfaces:
+
+`tcpreplay --listnics`
+
+- Replay traffic to interface:
+
+`tcpreplay -i {{eth0}} {{traffic.pcap}}`
+
+- Replay traffic to interface and stdout:
+
+`tcpreplay -i {{eth0}} --verbose {{traffic.pcap}}`
+
+- Replay traffic to interface as fast as possible:
+
+`tcpreplay -i {{eth0}} --topspeed {{traffic.pcap}}`
+
+- Replay traffic to interface at given Mbps:
+
+`tcpreplay -i {{eth0}} -M {{10}} {{traffic.pcap}}`
+
+- Replay traffic to interface several times:
+
+`tcpreplay -i {{eth0}} --loop={{num_times}} {{traffic.pcap}}`

--- a/pages/common/tcpreplay.md
+++ b/pages/common/tcpreplay.md
@@ -1,6 +1,6 @@
 # tcpreplay
 
-> Replay network traffic stored in pcap file.
+> Replay network traffic stored in a `pcap` file.
 > More information: <https://tcpreplay.appneta.com/>.
 
 - List available network interfaces:
@@ -11,7 +11,7 @@
 
 `tcpreplay -i {{eth0}} {{traffic.pcap}}`
 
-- Replay traffic to interface and stdout:
+- Replay traffic to interface and `stdout`:
 
 `tcpreplay -i {{eth0}} --verbose {{traffic.pcap}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
```
tcpreplay version: 4.4.4 (build git:v4.4.4) (debug)
Copyright 2013-2022 by Fred Klassen <tcpreplay at appneta dot com> - AppNeta
Copyright 2000-2012 by Aaron Turner <aturner at synfin dot net>
The entire Tcpreplay Suite is licensed under the GPLv3
Cache file supported: 04
Compiled against libdnet: 1.17.0 (libdumbnet)
Compiled against libpcap: 1.10.4
64 bit packet counters: enabled
Verbose printing via tcpdump: enabled
Packet editing: disabled
Fragroute engine: enabled
Injection method: PF_PACKET send()
Not compiled with netmap
```