### PR TITLE
distrobox-enter: add Spanish translation

### DIFF
--- a/pages.es/linux/distrobox-enter.md
+++ b/pages.es/linux/distrobox-enter.md
@@ -1,0 +1,17 @@
+# distrobox-enter
+
+> Entra a un contenedor Distrobox. Véase también: `tldr distrobox`.
+> El comando ejecutado por defecto es su SHELL, pero puede especificar otros o comandos enteros a ejecutar. Si se utiliza dentro de un script, una aplicación o un servicio, puede utilizar el modo `--headless` para desactivar tty e interactividad.
+> Más información: <https://distrobox.it/usage/distrobox-enter>.
+
+- Entra a un contenedor Distrobox:
+
+`distrobox-enter {{nombre_del_contenedor}}`
+
+- Entra a un contenedor Distrobox y ejecute un comando al iniciar sesión:
+
+`distrobox-enter {{nombre_del_contenedor}} -- {{sh -l}}`
+
+- Entra a un contenedor Distrobox sin instanciar una tty:
+
+`distrobox-enter --name {{nombre_del_contenedor}} -- {{uptime -p}}`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
