### PR TITLE
distrobox-export: add Spanish translation

### DIFF
--- a/pages.es/linux/distrobox-export.md
+++ b/pages.es/linux/distrobox-export.md
@@ -1,0 +1,24 @@
+# distrobox-export
+
+> Exporta aplicaciones/servicios/binarios del contenedor al sistema operativo anfitrión. Vea también: `tldr distrobox`.
+> Más información: <https://distrobox.it/usage/distrobox-export>.
+
+- Exporta una aplicación del contenedor al anfitrión (la entrada de escritorio/ícono aparecerá en la lista de aplicaciones del sistema anfitrión):
+
+`distrobox-export --app {{paquete}} --extra-flags "--foreground"`
+
+- Exporta un binario del contenedor al anfitrión:
+
+`distrobox-export --bin {{ruta/al/binario}} --export-path {{ruta/al/binario_en_anfitrión}}`
+
+- Exporta un binario del contenedor al anfitrión (es decir, `$HOME/.local/bin`) :
+
+`distrobox-export --bin {{ruta/al/binario}} --export-path {{ruta/a/exportar}}`
+
+- Exporta un servicio desde el contenedor al anfitrión (`--sudo` ejecutará el servicio como root dentro del contenedor):
+
+`distrobox-export --service {{paquete}} --extra-flags "--allow-newer-config" --sudo`
+
+- Elimina o deja de exportar una aplicación exportada:
+
+`distrobox-export --app {{paquete}} --delete`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
