### PR TITLE
distrobox-host-exec: add Spanish translation

### DIFF
--- a/pages.es/linux/distrobox-host-exec.md
+++ b/pages.es/linux/distrobox-host-exec.md
@@ -1,0 +1,12 @@
+# distrobox-host-exec
+
+> Ejecuta un comando en el anfitrión desde dentro de un contenedor Distrobox. Vea también: `tldr distrobox`.
+> Más información: <https://distrobox.it/usage/distrobox-host-exec>.
+
+- Ejecuta el comando en el sistema anfitrión desde el interior del contenedor Distrobox:
+
+`distrobox-host-exec "{{comando}}"`
+
+- Ejecuta el comando `ls` en el sistema anfitrión desde el interior del contenedor:
+
+`distrobox-host-exec ls`


### PR DESCRIPTION

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
