### PR TITLE
npm-cache: fix the command to show cache path

### DIFF
--- a/pages/common/npm-cache.md
+++ b/pages/common/npm-cache.md
@@ -27,9 +27,9 @@
 
 `npm cache verify`
 
-- Show information about the npm cache location and configuration:
+- Show the cache path:
 
-`npm cache dir`
+`npm config get cache`
 
 - Change the cache path:
 


### PR DESCRIPTION
Relates-to: #14391

`npm cache dir` was added in #14391, but the command does not exist.
https://docs.npmjs.com/cli/v11/commands/npm-cache

This PR changes it to `npm config get cache`.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** v10/v11.
