### PR TITLE
rmlint: include some more advanced flags

### DIFF
--- a/pages/common/rmlint.md
+++ b/pages/common/rmlint.md
@@ -7,7 +7,7 @@
 
 `rmlint {{path/to/directory1 path/to/directory2 ...}}`
 
-- Check for duplicates bigger than 1MB, preferably keeping files in tagged directories (after the double slash):
+- Check for duplicates bigger than a specific size, preferably keeping files in tagged directories (after the double slash):
 
 `rmlint -s {{1MB}} {{path/to/directory}} // {{path/to/original_directory}}`
 
@@ -31,6 +31,6 @@
 
 `rmlint -c sh:link --match-basename {{path/to/directory}}`
 
-- Use data as master directory. Find only duplicates in backup that are also in data. Do not delete any files in data:
+- Use `data` as master directory. Find only duplicates in backup that are also in `data`. Do not delete any files in `data`:
 
-`rmlint {{backup}} // {{data}} --keep-all-tagged --must-match-tagged`
+`rmlint {{path/to/backup}} // {{path/to/data}} --keep-all-tagged --must-match-tagged`

--- a/pages/common/rmlint.md
+++ b/pages/common/rmlint.md
@@ -1,15 +1,15 @@
 # rmlint
 
 > Find space waste and other broken things on your filesystem.
-> More information: <https://rmlint.readthedocs.io/en/latest/rmlint.1.html>.
+> More examples on the man page: <https://rmlint.readthedocs.io/en/latest/rmlint.1.html>.
 
 - Check directories for duplicated, empty and broken files:
 
 `rmlint {{path/to/directory1 path/to/directory2 ...}}`
 
-- Check for space wasters, preferably keeping files in tagged directories (after the double slash):
+- Check for duplicates bigger than 1MB, preferably keeping files in tagged directories (after the double slash):
 
-`rmlint {{path/to/directory}} // {{path/to/original_directory}}`
+`rmlint -s {{1MB}} {{path/to/directory}} // {{path/to/original_directory}}`
 
 - Check for space wasters, keeping everything in the untagged directories:
 
@@ -19,7 +19,7 @@
 
 `./rmlint.sh`
 
-- Find duplicate directory trees:
+- Find duplicate directory trees based on data, ignoring names:
 
 `rmlint --merge-directories {{path/to/directory}}`
 
@@ -27,10 +27,10 @@
 
 `rmlint --rank-by={{dl}} {{path/to/directory}}`
 
-- Find only duplicates that have the same filename in addition to the same contents:
+- Find files with identical filename and contents, and link rather than delete the duplicates:
 
-`rmlint --match-basename {{path/to/directory}}`
+`rmlint -c sh:link --match-basename {{path/to/directory}}`
 
-- Find only duplicates that have the same extension in addition to the same contents:
+- Use data as master directory. Find only duplicates in backup that are also in data. Do not delete any files in data:
 
-`rmlint --match-extension {{path/to/directory}}`
+`rmlint {{backup}} // {{data}} --keep-all-tagged --must-match-tagged`

--- a/pages/common/rmlint.md
+++ b/pages/common/rmlint.md
@@ -1,7 +1,7 @@
 # rmlint
 
 > Find space waste and other broken things on your filesystem.
-> More examples on the man page: <https://rmlint.readthedocs.io/en/latest/rmlint.1.html>.
+> More information: <https://rmlint.readthedocs.io/en/latest/rmlint.1.html>.
 
 - Check directories for duplicated, empty and broken files:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

The current examples were rather redundant, so added some more info

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
