### PR TITLE
chsh, echo, mkdir, mv, tldr: add and improve Indonesian translations

### DIFF
--- a/pages.id/common/chsh.md
+++ b/pages.id/common/chsh.md
@@ -1,0 +1,17 @@
+# chsh
+
+> Ubah program syel bawaan (login shell) yang akan digunakan pengguna sejak masuk (login) ke sistem operasi.
+> Lihat halaman bantuan per platform (sistem operasi) untuk melihat opsi khusus.
+> Informasi lebih lanjut: <https://manned.org/chsh>.
+
+- Pilih suatu login shell untuk pengguna saat ini secara interaktif:
+
+`chsh`
+
+- Pilih suatu login [s]hell untuk pengguna saat ini secara spesifik:
+
+`chsh -s {{jalan/menuju/syel}}`
+
+- Pilih suatu login [s]hell untuk pengguna lain:
+
+`chsh -s {{jalan/menuju/syel}} {{username}}`

--- a/pages.id/common/echo.md
+++ b/pages.id/common/echo.md
@@ -1,0 +1,28 @@
+# echo
+
+> Cetak ulang argumen-argumen yang dimasukkan ke dalam layar perangkat.
+> Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+
+- Cetak sebuah pesan teks. Catatan: penggunaan tanda petik bersifat opsional:
+
+`echo "{{Halo Dunia}}"`
+
+- Cetak sebuah pesan bersama suatu variabel lingkungan (environment variable):
+
+`echo "{{Variabel path saya adalah $PATH}}"`
+
+- Cetak sebuah pesan tanpa mencetak baris teks baru (tanpa [n]ewline):
+
+`echo -n "{{Halo Dunia}}"`
+
+- Tambahkan isi pesan ke dalam suatu berkas teks:
+
+`echo "{{Halo Dunia}}" >> {{berkas.txt}}`
+
+- Aktifkan fitur interpretasi penggunaan tanda garis miring terbalik sebagai penanda karakter khusus:
+
+`echo -e "{{Kolom 1\tKolom 2}}"`
+
+- Cetak status keluar dari perintah terakhir yang dieksekusi (Catatan: Dalam Windows Command Prompt dan PowerShell, perintah yang setara adalah `echo %errorlevel%` dan `$lastexitcode`):
+
+`echo $?`

--- a/pages.id/common/mkdir.md
+++ b/pages.id/common/mkdir.md
@@ -1,12 +1,16 @@
 # mkdir
 
-> Membuat sebuah direktori.
+> Buat dan atur hak akses atas sejumlah direktori.
 > Informasi lebih lanjut: <https://www.gnu.org/software/coreutils/mkdir>.
 
-- Membuat sebuah direktori di dalam direktori saat ini atau dalam jalan (path) yang diberikan:
+- Buat sejumlah direktori baru secara spesifik:
 
-`mkdir {{direktori}}`
+`mkdir {{jalan/menuju/direktori1 jalan/menuju/direktori2 ...}}`
 
-- Membuat sejumlah direktori secara rekursif (berguna untuk membuat direktori bersarang):
+- Buat sejumlah direktori baru secara spesifik beserta induk-induknya, bila dibutuhkan:
 
-`mkdir {{-p|--parents}} {{jalan/menuju/direktori}}`
+`mkdir {{-p|--parents}} {{jalan/menuju/direktori1 jalan/menuju/direktori2 ...}}`
+
+- Buat sejumlah direktori baru dengan konfigurasi hak akses tertentu:
+
+`mkdir {{-m|--mode}} {{rwxrw-r--}} {{jalan/menuju/direktori1 jalan/menuju/direktori2 ...}}`

--- a/pages.id/common/mv.md
+++ b/pages.id/common/mv.md
@@ -17,16 +17,20 @@
 
 - Pindahkan tanpa meminta konfirmasi sebelum menimpa file yang sudah ada:
 
-`mv -f {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
+`mv --force {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
 
 - Minta konfirmasi sebelum menimpa berkas yang sudah ada, tanpa memerhatikan hak akses hedua file tersebut:
 
-`mv -i {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
+`mv --interactive {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
 
 - Jangan menimpa file yang sudah ada di direktori tujuan:
 
-`mv -n {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
+`mv --no-clobber {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
 
 - Pindahkan berkas dalam mode [v]erbose, tampilkan berkas-berkas yang dipindahkan:
 
-`mv -v {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
+`mv --verbose {{jalan/menuju/sumber}} {{jalan/menuju/tujuan}}`
+
+- Tetapkan direktori tujuan ([t]arget) agar Anda dapat menggunakan alat atau perintah eksternal untuk mengelola kumpulan berkas yang dapat dipindahkan:
+
+`{{find /var/log -type f -name '*.log' -print0}} | {{xargs -0}} mv --target-directory {{jalan/menuju/direktori_tujuan}}`

--- a/pages.id/common/tldr.md
+++ b/pages.id/common/tldr.md
@@ -1,0 +1,37 @@
+# tldr
+
+> Tampilkan laman bantuan sederhana untuk alat baris perintah (command-line) dari proyek dokumentasi tldr-pages.
+> Catatan: opsi `--language` dan `--list` sering diimplementasikan oleh program-program klien meskipun tak diwajibkan menurut spesifikasi teknis.
+> Informasi lebih lanjut: <https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#command-line-interface>.
+
+- Tampilkan laman bantuan sederhana untuk suatu perintah (catatan: beginilah cara Anda sampai di sini!):
+
+`tldr {{perintah}}`
+
+- Tampilkan laman bantuan sederhana untuk suatu subperintah:
+
+`tldr {{perintah}} {{subperintah}}`
+
+- Tampilkan laman bantuan untuk suatu perintah dalam suatu bahasa (jika tersedia, selainnya dalam bahasa Inggris):
+
+`tldr --language {{kode_bahasa}} {{perintah}}`
+
+- Tampilkan laman bantuan untuk suatu perintah pada [p]latform tujuan:
+
+`tldr --platform {{android|common|freebsd|linux|osx|netbsd|openbsd|sunos|windows}} {{command}}`
+
+- M[u]takhirkan data cache lokal untuk laman-laman bantuan:
+
+`tldr --update`
+
+- Tampilkan daftar seluruh laman bantuan untuk perintah-perintah yang tersedia pada platform saat ini dan `common` (lintas platform):
+
+`tldr --list`
+
+- Tampilkan daftar seluruh laman bantuan subperintah yang tersedia untuk dokumentasi suatu perintah induk:
+
+`tldr --list | grep {{perintah}} | column`
+
+- Tampilkan suatu laman bantuan untuk perintah yang dipilih secara acak:
+
+`tldr --list | shuf -n1 | xargs tldr`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR adds the following new translations, which was organized based on the number of existing (non-Indonesian) translations for each command.

+ `common/chsh` (Translated in 13 languages)
+ `common/echo` (Translated in 14 languages)
+ `common/mkdir` (Outdated, translated in 14 languages)
+ `common/mv` (Outdated, translated in 11 languages)
+ `common/tldr` (Translated in 18 languages)
