### PR TITLE
kubeadm: update page

### DIFF
--- a/pages/common/kubeadm.md
+++ b/pages/common/kubeadm.md
@@ -3,7 +3,7 @@
 > Command-line interface for creating and managing Kubernetes clusters.
 > More information: <https://kubernetes.io/docs/reference/setup-tools/kubeadm>.
 
-- Create a Kubernetes master node:
+- Create a Kubernetes control plane:
 
 `kubeadm init`
 


### PR DESCRIPTION
After v 1.20 the terminology evolved and the nodes controlling the cluster are now called control nodes

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- **Version of the command being documented (if known):**
current version stable version is 1.31, but the modified term applies to any version more recent that 1.20 (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes)