### PR TITLE
pages.nl/*: uniform 'Display help' translation

### DIFF
--- a/pages.nl/common/crane-append.md
+++ b/pages.nl/common/crane-append.md
@@ -28,6 +28,6 @@
 
 `crane append --set-base-image-annotations`
 
-- Toon help:
+- Toon de help:
 
 `crane append {{-h|--help}}`

--- a/pages.nl/common/crane-auth.md
+++ b/pages.nl/common/crane-auth.md
@@ -23,6 +23,6 @@
 
 `crane auth token {{registry_adres}} {{-H|--header}} {{-h|--help}} {{-m|--mount}} {{scope1 scope2 ...}} --push`
 
-- Toon help:
+- Toon de help:
 
 `crane auth {{-h|--help}}`

--- a/pages.nl/common/crane-blob.md
+++ b/pages.nl/common/crane-blob.md
@@ -7,6 +7,6 @@
 
 `crane blob {{blob_identifier}}`
 
-- Toon help:
+- Toon de help:
 
 `crane blob {{-h|--help}}`

--- a/pages.nl/common/crane-catalog.md
+++ b/pages.nl/common/crane-catalog.md
@@ -11,6 +11,6 @@
 
 `crane catalog {{registry_adres}} --full-ref`
 
-- Toon help:
+- Toon de help:
 
 `crane catalog {{-h|--help}}`

--- a/pages.nl/common/crane-config.md
+++ b/pages.nl/common/crane-config.md
@@ -7,6 +7,6 @@
 
 `crane config {{image_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane config {{-h|--help}}`

--- a/pages.nl/common/crane-copy.md
+++ b/pages.nl/common/crane-copy.md
@@ -19,6 +19,6 @@
 
 `crane copy {{bron}} {{doel}} {{-n|--no-clobber}}`
 
-- Toon help:
+- Toon de help:
 
 `crane copy {{-h|--help}}`

--- a/pages.nl/common/crane-delete.md
+++ b/pages.nl/common/crane-delete.md
@@ -7,6 +7,6 @@
 
 `crane delete {{image_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane delete {{-h|--help}}`

--- a/pages.nl/common/crane-digest.md
+++ b/pages.nl/common/crane-digest.md
@@ -15,6 +15,6 @@
 
 `crane digest {{image_naam}} --tarball {{pad/naar/tarball}}`
 
-- Toon help:
+- Toon de help:
 
 `crane digest {{-h|--help}}`

--- a/pages.nl/common/crane-flatten.md
+++ b/pages.nl/common/crane-flatten.md
@@ -12,6 +12,6 @@
 
 `crane flatten {{-t|--tag}} {{tag_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane flatten {{-h|--help}}`

--- a/pages.nl/common/crane-index-append.md
+++ b/pages.nl/common/crane-index-append.md
@@ -25,6 +25,6 @@
 
 `crane index append --flatten`
 
-- Toon help:
+- Toon de help:
 
 `crane index append {{-h|--help}}`

--- a/pages.nl/common/crane-index-filter.md
+++ b/pages.nl/common/crane-index-filter.md
@@ -15,6 +15,6 @@
 
 `crane index filter {{-t|--tags}} {{tag_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane index filter {{-h|--help}}`

--- a/pages.nl/common/crane-index.md
+++ b/pages.nl/common/crane-index.md
@@ -12,6 +12,6 @@
 
 `crane index {{subcommand}}`
 
-- Toon help:
+- Toon de help:
 
 `crane index {{-h|--help}}`

--- a/pages.nl/common/crane-ls.md
+++ b/pages.nl/common/crane-ls.md
@@ -15,6 +15,6 @@
 
 `crane ls {{-o|--omit-digest-tags}}`
 
-- Toon help:
+- Toon de help:
 
 `crane ls {{-h|--help}}`

--- a/pages.nl/common/crane-manifest.md
+++ b/pages.nl/common/crane-manifest.md
@@ -7,6 +7,6 @@
 
 `crane manifest {{image_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane manifest {{-h|--help}}`

--- a/pages.nl/common/crane-mutate.md
+++ b/pages.nl/common/crane-mutate.md
@@ -32,6 +32,6 @@
 
 `crane mutate {{-w|--workdir}} {{pad/naar/werk-map}}`
 
-- Toon help:
+- Toon de help:
 
 `crane mutate {{-h|--help}}`

--- a/pages.nl/common/crane-pull.md
+++ b/pages.nl/common/crane-pull.md
@@ -19,6 +19,6 @@
 
 `crane pull {{image_naam}} {{pad/naar/tarball}} {{-format}} {{format_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane pull {{-h|--help}}`

--- a/pages.nl/common/crane-push.md
+++ b/pages.nl/common/crane-push.md
@@ -15,6 +15,6 @@
 
 `crane push {{pad/naar/tarball}} {{image_naam}} --index`
 
-- Toon help:
+- Toon de help:
 
 `crane push {{-h|--help}}`

--- a/pages.nl/common/crane-rebase.md
+++ b/pages.nl/common/crane-rebase.md
@@ -19,6 +19,6 @@
 
 `crane rebase {{-t|--tag}} {{tag_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane rebase {{-h|--help}}`

--- a/pages.nl/common/crane-tag.md
+++ b/pages.nl/common/crane-tag.md
@@ -8,6 +8,6 @@
 
 `crane tag {{image_naam}} {{tag_naam}}`
 
-- Toon help:
+- Toon de help:
 
 `crane tag {{-h|--help}}`

--- a/pages.nl/common/crane-validate.md
+++ b/pages.nl/common/crane-validate.md
@@ -19,6 +19,6 @@
 
 `crane validate --tarball {{pad/naar/tarball}}`
 
-- Toon help:
+- Toon de help:
 
 `crane validate {{-h|--help}}`

--- a/pages.nl/common/crane-version.md
+++ b/pages.nl/common/crane-version.md
@@ -8,6 +8,6 @@
 
 `crane version`
 
-- Toon help:
+- Toon de help:
 
 `crane version {{-h|--help}}`

--- a/pages.nl/common/fc.md
+++ b/pages.nl/common/fc.md
@@ -27,6 +27,6 @@
 
 `fc '{{416}}' '{{420}}'`
 
-- Toon help:
+- Toon de help:
 
 `fc --help`

--- a/pages.nl/common/gcrane-copy.md
+++ b/pages.nl/common/gcrane-copy.md
@@ -15,6 +15,6 @@
 
 `gcrane copy {{bron}} {{doel}} {{-r|--recursive}}`
 
-- Toon help:
+- Toon de help:
 
 `gcrane copy {{-h|--help}}`

--- a/pages.nl/common/gcrane-gc.md
+++ b/pages.nl/common/gcrane-gc.md
@@ -13,6 +13,6 @@
 
 `gcrane gc {{repository}} {{-r|--recursive}}`
 
-- Toon help:
+- Toon de help:
 
 `gcrane gc {{-h|--help}}`

--- a/pages.nl/common/gcrane-help.md
+++ b/pages.nl/common/gcrane-help.md
@@ -7,6 +7,6 @@
 
 `gcrane help {{command}}`
 
-- Toon help:
+- Toon de help:
 
 `gcrane help {{-h|--help}}`

--- a/pages.nl/common/gcrane-ls.md
+++ b/pages.nl/common/gcrane-ls.md
@@ -16,6 +16,6 @@
 
 `gcrane ls {{repository}} {{-r|--recursive}}`
 
-- Toon help:
+- Toon de help:
 
 `gcrane ls {{-h|--help}}`

--- a/pages.nl/common/gcrane.md
+++ b/pages.nl/common/gcrane.md
@@ -26,6 +26,6 @@
 
 `gcrane {{-v|--verbose}} {{subcommand}}`
 
-- Toon help:
+- Toon de help:
 
 `gcrane {{-h|--help}}`

--- a/pages.nl/linux/dir.md
+++ b/pages.nl/linux/dir.md
@@ -20,6 +20,6 @@
 
 `dir --recursive`
 
-- Toon help:
+- Toon de help:
 
 `dir --help`

--- a/pages.nl/linux/dnf-config-manager.md
+++ b/pages.nl/linux/dnf-config-manager.md
@@ -23,6 +23,6 @@
 
 `dnf config-manager --setopt={{option}}={{value}}`
 
-- Toon help:
+- Toon de help:
 
 `dnf config-manager --help-cmd`

--- a/pages.nl/linux/gcrane-completion.md
+++ b/pages.nl/linux/gcrane-completion.md
@@ -32,6 +32,6 @@
 
 `gcrane completion fish > ~/.config/fish/completions/gcrane.fish`
 
-- Toon help:
+- Toon de help:
 
 `gcrane completion {{shell_naam}} {{-h|--help}}`

--- a/pages.nl/osx/gcrane-completion.md
+++ b/pages.nl/osx/gcrane-completion.md
@@ -32,6 +32,6 @@
 
 `gcrane completion fish > ~/.config/fish/completions/gcrane.fish`
 
-- Toon help:
+- Toon de help:
 
 `gcrane completion {{shell_naam}} {{-h|--help}}`

--- a/pages.nl/windows/ftp.md
+++ b/pages.nl/windows/ftp.md
@@ -31,6 +31,6 @@
 
 `mdelete {{*.txt}}`
 
-- Toon help:
+- Toon de help:
 
 `ftp --help`

--- a/pages.nl/windows/gcrane-completion.md
+++ b/pages.nl/windows/gcrane-completion.md
@@ -20,6 +20,6 @@
 
 `gcrane completion powershell | Out-String | Invoke-Expression`
 
-- Toon help:
+- Toon de help:
 
 `gcrane completion {{shell_naam}} {{-h|--help}}`

--- a/pages.nl/windows/more.md
+++ b/pages.nl/windows/more.md
@@ -27,6 +27,6 @@
 
 `more {{pad\naar\bestand}} /e`
 
-- Toon help:
+- Toon de help:
 
 `more /?`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 