### PR TITLE
pages.pl/netbsd/*: add Polish translations

### DIFF
--- a/pages.pl/netbsd/cal.md
+++ b/pages.pl/netbsd/cal.md
@@ -1,0 +1,36 @@
+# cal
+
+> Wyświetl kalendarz.
+> Więcej informacji: <https://man.netbsd.org/cal.1>.
+
+- Wyświetl kalendarz na bieżący miesiąc:
+
+`cal`
+
+- Wyświetl kalendarz na określony rok:
+
+`cal {{rok}}`
+
+- Wyświetl kalendarz dla określonego miesiąca i roku:
+
+`cal {{miesiąc}} {{rok}}`
+
+- Wyświetl cały kalendarz na bieżący rok z użyciem dni [j]uliańskich (dni liczone od 1, począwszy od 1 stycznia):
+
+`cal -y -j`
+
+- Wyróżnij (z ang. [h]ighlight) dzisiejszą datę i wyświetl [3] miesiące ją obejmujące:
+
+`cal -h -3 {{miesiąc}} {{rok}}`
+
+- Wyświetl 2 miesiące przed (z ang. [B]efore) i 3 po (z ang. [A]fter) określonym [m]iesiącu bieżącego roku:
+
+`cal -A 3 -B 2 {{miesiąc}}`
+
+- Wyświetl określoną liczbę miesięcy przed i po ([C]ontext) określonym miesiącu:
+
+`cal -C {{miesiące}} {{miesiąc}}`
+
+- Określ początkowy [d]zień tygodnia (0: niedziela, 1: poniedziałek, ..., 6: sobota):
+
+`cal -d {{0..6}}`

--- a/pages.pl/netbsd/chpass.md
+++ b/pages.pl/netbsd/chpass.md
@@ -1,0 +1,29 @@
+# chpass
+
+> Dodaj lub zmień informacje w bazie danych użytkowników, w tym powłokę logowania i hasło.
+> Zobacz także: `passwd`.
+> Więcej informacji: <https://man.netbsd.org/chsh>.
+
+- Ustaw określoną powłokę logowania dla bieżącego użytkownika w sposób interaktywny:
+
+`su -c chpass`
+
+- Ustaw określoną powłokę (z ang. [s]hell) logowania dla bieżącego użytkownika:
+
+`chpass -s {{ścieżka/do/powłoki}}`
+
+- Ustaw powłokę (z ang. [s]hell) logowania dla określonego użytkownika:
+
+`chpass chsh -s {{ścieżka/do/powłoki}} {{nazwa_użytkownika}}`
+
+- Określ wpis bazy danych użytkownika w formacie pliku `passwd`:
+
+`su -c 'chpass -a {{nazwa_użytkownika:zaszyfrowane_hasło:uid:gid:...}} -s {{ścieżka/do/pliku}}' {{nazwa_użytkownika}}`
+
+- Aktualizuj tylko [l]okalny plik haseł:
+
+`su -c 'chpass -l -s {{ścieżka/do/powłoki}}' {{nazwa_użytkownika}}`
+
+- Wymuś zmianę wpisu w bazie danych [y]P haseł:
+
+`su -c 'chpass -y -s {{ścieżka/do/powłoki}}' {{nazwa_użytkownika}}`

--- a/pages.pl/netbsd/df.md
+++ b/pages.pl/netbsd/df.md
@@ -1,0 +1,32 @@
+# df
+
+> Wyświetl przegląd wykorzystania przestrzeni dyskowej systemu plików.
+> Więcej informacji: <https://man.netbsd.org/df.1>.
+
+- Wyświetl wszystkie systemy plików i ich wykorzystanie dysków w jednostkach 512-bajtowych:
+
+`df`
+
+- Użyj jednostek czytelnych dla człowieka (z ang. [h]uman) (opartych na potęgach 1024):
+
+`df -h`
+
+- Wyświetl wszystkie pola struktury/struktur zwróconych przez `statvfs`:
+
+`df -G`
+
+- Wyświetl wszystkie systemy plików i ich wykorzystanie dysków zawierające podany plik lub katalog:
+
+`df {{ścieżka/do/pliku_lub_katalogu}}`
+
+- Dołącz statystyki dotyczące liczby wolnych i wykorzystanych [i]węzłów:
+
+`df -i`
+
+- Użyj jednostek 1024-bajtowych do wyświetlania danych o przestrzeni dyskowej:
+
+`df -k`
+
+- Wyświetl informację w sposób [P]rzenośny:
+
+`df -P`

--- a/pages.pl/netbsd/pkgin.md
+++ b/pages.pl/netbsd/pkgin.md
@@ -1,0 +1,28 @@
+# pkgin
+
+> Zarządzaj pakietami binarnymi `pkgsrc` na NetBSD.
+> Więcej informacji: <https://pkgin.net/#usage>.
+
+- Zainstaluj pakiet:
+
+`pkgin install {{pakiet}}`
+
+- Usuń pakiet i jego zależności:
+
+`pkgin remove {{pakiet}}`
+
+- Zaktualizuj wszystkie pakiety:
+
+`pkgin full-upgrade`
+
+- Wyszukaj pakiet:
+
+`pkgin search {{słowo_kluczowe}}`
+
+- Wyświetl listę zainstalowanych pakietów:
+
+`pkgin list`
+
+- Usuń niepotrzebne zależności:
+
+`pkgin autoremove`

--- a/pages.pl/netbsd/sed.md
+++ b/pages.pl/netbsd/sed.md
@@ -1,0 +1,33 @@
+# sed
+
+> Edytuj tekst w sposób skryptowalny.
+> Zobacz także: `awk`, `ed`.
+> Więcej informacji: <https://man.netbsd.org/sed.1>.
+
+- Zamień wszystkie wystąpienia `jabłko` (podstawowe wyrażenie regularne) na `mango` (podstawowe wyrażenie regularne) we wszystkich liniach wejściowych i wypisz wynik do `stdout`:
+
+`{{komenda}} | sed 's/jabłko/mango/g'`
+
+- Uruchom określony plik (z ang. [f]ile) skryptu i wydrukuj wynik na `stdout`:
+
+`{{komenda}} | sed -f {{ścieżka/do/skryptu.sed}}`
+
+- Opóźnij otwieranie każdego pliku, dopóki polecenie zawierające powiązaną funkcję lub flagę `w` nie zostanie zastosowane do linii wejściowej:
+
+`{{komenda}} | sed -fa {{ścieżka/do/skryptu.sed}}`
+
+- Włącz rozszerzenie GNU re[g]ex:
+
+`{{komenda}} | sed -fg {{ścieżka/do/skryptu.sed}}`
+
+- Zamień wszystkie wystąpienia `jabłko` (rozszerzone wyrażenie regularne) na `JABŁKO` (rozszerzone wyrażenie regularne) we wszystkich liniach wejściowych i wypisz wynik do `stdout`:
+
+`{{komenda}} | sed -E 's/(jabłko)/\U\1/g'`
+
+- Wypisz tylko pierwszą linię do `stdout`:
+
+`{{komenda}} | sed -n '1p'`
+
+- Zamień wszystkie wystąpienia `jabłko` (podstawowe wyrażenie regularne) na `mango` (podstawowe wyrażenie regularne) w określonym pliku i nadpisz oryginalny plik:
+
+`sed -i 's/jabłko/mango/g' {{ścieżka/do/skryptu}}`

--- a/pages.pl/netbsd/sockstat.md
+++ b/pages.pl/netbsd/sockstat.md
@@ -1,0 +1,26 @@
+# sockstat
+
+> Wyświetl listę otwartych gniazd internetowych lub UNIX-owych.
+> Uwaga: ten program jest przeróbką programu `sockstat` z FreeBSD dla NetBSD 3.0.
+> Zobacz także: `netstat`.
+> Więcej informacji: <https://man.netbsd.org/sockstat.1>.
+
+- Pokaż informacje o gniazdach IPv4, IPv6 i Unix, zarówno nasłuchujących jak i połączonych:
+
+`sockstat`
+
+- Pokaż informacje o gniazdach IPv[4]/IPv[6] nasłuchujących (z ang. [l]istening) na określonych [p]ortach używając określonego [P]rotokołu:
+
+`sockstat -{{4|6}} -l -P {{tcp|udp|sctp|divert}} -p {{port1,port2...}}`
+
+- Pokaż również połączone (z ang. [c]onnected) gniazda, wyświetlając gniazda [u]nixowe:
+
+`sockstat -cu`
+
+- Pokaż tylko wynik [n]umeryczny, bez rozwiązywania symbolicznych nazw dla adresów i portów:
+
+`sockstat -n`
+
+- Pokaż tylko gniazda dla określonej rodziny (z ang. [f]amily) adresów:
+
+`sockstat -f {{inet|inet6|local|unix}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR adds Polish translations for 6 NetBSD-specific commands that were previously untranslated: `cal`, `chpass`, `df`, `pkgin`, `sed`, and `sockstat`.
