### PR TITLE
uv-{add, tree}: Add page

### DIFF
--- a/pages/common/uv-add.md
+++ b/pages/common/uv-add.md
@@ -1,0 +1,37 @@
+# uv add
+
+> Add package dependencies to the project.
+> Packages are specified according to <https://peps.python.org/pep-0508/>.
+> More information: <https://docs.astral.sh/uv/reference/cli/#uv-add>.
+
+- Add the latest version of a package:
+
+`uv add {{package}}`
+
+- Add multiple packages:
+
+`uv add {{package1 package2 ...}}`
+
+- Add a package with a version requirement:
+
+`uv add {{package>=1.2.3}}`
+
+- Add packages to an optional dependency group, which will be included when published:
+
+`uv add --optional {{optional}} {{package1 package2 ...}}`
+
+- Add packages to a local group, which will not be included when published:
+
+`uv add --group {{group}} {{package1 package2 ...}}`
+
+- Add packages to the dev group, shorthand for `--group dev`:
+
+`uv add --dev {{package1 package2 ...}}`
+
+- Add package as editable:
+
+`uv add --editable {{path/to/package/}}`
+
+- Enable extra when installing package, may be provided multiple times:
+
+`uv add {{package}} --extra {{extra_feature}}`

--- a/pages/common/uv-add.md
+++ b/pages/common/uv-add.md
@@ -1,6 +1,6 @@
 # uv add
 
-> Add package dependencies to the project.
+> Add package dependencies to the `pyproject.toml` file.
 > Packages are specified according to <https://peps.python.org/pep-0508/>.
 > More information: <https://docs.astral.sh/uv/reference/cli/#uv-add>.
 
@@ -32,6 +32,6 @@
 
 `uv add --editable {{path/to/package/}}`
 
-- Enable extra when installing package, may be provided multiple times:
+- Enable an extra when installing package, may be provided multiple times:
 
 `uv add {{package}} --extra {{extra_feature}}`

--- a/pages/common/uv-tree.md
+++ b/pages/common/uv-tree.md
@@ -1,0 +1,28 @@
+# uv tree
+
+> Display project dependencies in a tree format.
+> More information: <https://docs.astral.sh/uv/reference/cli/#uv-tree>.
+
+- Show dependency tree for current environment:
+
+`uv tree`
+
+- Show dependency tree for all environments:
+
+`uv tree --universal`
+
+- Show dependency tree up to a certain depth:
+
+`uv tree {{-d|--depth}} {{n}}`
+
+- Show the latest available version for all outdated packages:
+
+`uv tree --outdated`
+
+- Exclude dependencies from the dev group:
+
+`uv tree --no-dev`
+
+- Show the inverted tree, so children are dependents instead of dependencies:
+
+`uv tree --invert`

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -10,7 +10,7 @@
 
 - Create a new Python project at the specified path:
 
-`uv init {{path}}`
+`uv init {{path/to/directory}}`
 
 - Add a new dependency to the project:
 

--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -8,15 +8,15 @@
 
 `uv init`
 
-- Create a new Python project in a directory with the given name:
+- Create a new Python project at the specified path:
 
-`uv init {{project_name}}`
+`uv init {{path}}`
 
-- Add a new package to the project:
+- Add a new dependency to the project:
 
 `uv add {{package}}`
 
-- Remove a package from the project:
+- Remove a dependency from the project:
 
 `uv remove {{package}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.5.13

Add pages for uv subcommands. It's difficult to limit the amount of examples, given the versatility of uv. But I think I narrowed it down to the most important actions.