### PR TITLE
proxify: update page

### DIFF
--- a/pages/common/proxify.md
+++ b/pages/common/proxify.md
@@ -10,7 +10,7 @@
 
 - Start a HTTP proxy on a custom network interface and port (may require `sudo` for a port number lower than `1024`):
 
-`proxify -http-addr "{{network_interface_address}}:{{port_number}}"`
+`proxify -http-addr "{{ip_address}}:{{port_number}}"`
 
 - Specify output format and output file:
 

--- a/pages/common/proxify.md
+++ b/pages/common/proxify.md
@@ -4,13 +4,13 @@
 > See also: `mitmproxy`.
 > More information: <https://github.com/projectdiscovery/proxify>.
 
-- Start a HTTP proxy (on the loopback network interface `127.0.0.1` port `8888`):
+- Start a HTTP proxy (on the loopback network interface `127.0.0.1` and port `8888`):
 
 `proxify`
 
 - Start a HTTP proxy on a custom network interface and port (may require `sudo` for a port number lower than `1024`):
 
-`proxify -http-addr "{{network_interface}}:{{port_number}}"`
+`proxify -http-addr "{{network_interface_address}}:{{port_number}}"`
 
 - Specify output format and output file:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

This PR is mainly for clarification related to network interface. The term `network_interface` may be interpreted as the interface name like `eth0`, but the command actually looks for the listening addresses.