### PR TITLE
git-cliff: add page

### DIFF
--- a/pages/common/git-cliff.md
+++ b/pages/common/git-cliff.md
@@ -1,0 +1,24 @@
+# git cliff
+
+> A highly customizable changelog generator.
+> More information: <https://git-cliff.org/docs/usage/args>.
+
+- Generate a changelog from all commits in a Git repository and save it to `CHANGELOG.md`:
+
+`git cliff > {{CHANGELOG.md}}`
+
+- Generate from commits starting from the latest tag and print to `stdout`:
+
+`git cliff {{-l|--latest}}`
+
+- Generate from commits that belong to the current tag (use `git checkout` on a tag before this):
+
+`git cliff --current`
+
+- Generate from commits that do not belong to a tag:
+
+`git cliff {{-u|--unreleased}}`
+
+- Write the default config file to `cliff.toml` in the current directory:
+
+`git cliff {{-i|--init}}`

--- a/pages/common/git-cliff.md
+++ b/pages/common/git-cliff.md
@@ -7,15 +7,15 @@
 
 `git cliff > {{CHANGELOG.md}}`
 
-- Generate from commits starting from the latest tag and print to `stdout`:
+- Generate a changelog from commits starting from the latest tag and print it to `stdout`:
 
 `git cliff {{-l|--latest}}`
 
-- Generate from commits that belong to the current tag (use `git checkout` on a tag before this):
+- Generate a changelog from commits that belong to the current tag (use `git checkout` on a tag before this):
 
 `git cliff --current`
 
-- Generate from commits that do not belong to a tag:
+- Generate a changelog from commits that do not belong to a tag:
 
 `git cliff {{-u|--unreleased}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).