### PR TITLE
pulumi-config: add `--stack` example

### DIFF
--- a/pages/common/pulumi-config.md
+++ b/pages/common/pulumi-config.md
@@ -7,6 +7,10 @@
 
 `pulumi config --json`
 
+- View configuration for a specified stack:
+
+`pulumi config --stack {{stack_name}}`
+
 - Get the value of a configuration key:
 
 `pulumi config get {{key}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

