### PR TITLE
kill: fix incorrect `-L`  to `-l` option

### DIFF
--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill -L`
+`kill -l`
 
 - Terminate a background job:
 

--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -10,7 +10,7 @@
 
 - List signal values and their corresponding names (to be used without the `SIG` prefix):
 
-`kill -l`
+`kill {{-l|-L|--table}}`
 
 - Terminate a background job:
 

--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -8,7 +8,7 @@
 
 `kill {{process_id}}`
 
-- List signal values and their corresponding names (to be used without the `SIG` prefix):
+- List signal values and their corresponding names (to be used without the `SIG` prefix). The available options may depend on the `kill` implementation:
 
 `kill {{-l|-L|--table}}`
 


### PR DESCRIPTION
# Motivation

`tldr kill` incorrectly displays the `kill -l` command as `kill -L`, as mentioned in #15694.

# What This PR Does

This PR closes #15694 by fixing the command option to `-l` (lowercase L).

Checklist:

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
