### PR TITLE
fswatch: fix flag

### DIFF
--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -17,4 +17,4 @@
 
 - Filter by event type:
 
-`fswatch --event {{Updated|Removed|Created}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`
+`fswatch --event {{Updated|Removed|Created|...}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`

--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -17,4 +17,4 @@
 
 - Filter by event type:
 
-`fswatch --event {{Updated|Deleted|Created}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`
+`fswatch --event {{Updated|Removed|Created}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`


### PR DESCRIPTION
The `fswatch` command supports the "Removed" event flag, not the "Deleted" event flag.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.17.1
