### PR TITLE
git, git-*: add Polish translations

### DIFF
--- a/pages.pl/common/git-abort.md
+++ b/pages.pl/common/git-abort.md
@@ -1,0 +1,9 @@
+# git abort
+
+> Przerwij trwający rebase, merge lub cherry-pick.
+> Jest częścią `git-extras`.
+> Więcej informacji: <https://github.com/tj/git-extras/blob/master/Commands.md#git-abort>.
+
+- Przerwij operację Git rebase, merge lub cherry-pick:
+
+`git abort`

--- a/pages.pl/common/git-add.md
+++ b/pages.pl/common/git-add.md
@@ -1,0 +1,36 @@
+# git add
+
+> Dodaj zmienione pliki do indeksu.
+> Więcej informacji: <https://git-scm.com/docs/git-add>.
+
+- Dodaj plik do indeksu:
+
+`git add {{ścieżka/do/pliku}}`
+
+- Dodaj wszystkie pliki (śledzone i nieśledzone):
+
+`git add {{-A|--all}}`
+
+- Dodaj wszystkie pliki w bieżącym katalogu:
+
+`git add .`
+
+- Dodaj tylko już śledzone pliki:
+
+`git add {{-u|--update}}`
+
+- Dodaj również ignorowane pliki:
+
+`git add {{-f|--force}}`
+
+- Dodawaj części plików interaktywnie:
+
+`git add {{-p|--patch}}`
+
+- Dodawaj części określonego pliku interaktywnie:
+
+`git add {{-p|--patch}} {{ścieżka/do/pliku}}`
+
+- Dodaj plik interaktywnie:
+
+`git add {{-i|--interactive}}`

--- a/pages.pl/common/git-alias.md
+++ b/pages.pl/common/git-alias.md
@@ -1,0 +1,17 @@
+# git alias
+
+> Twórz skróty dla komend Gita.
+> Jest częścią `git-extras`.
+> Więcej informacji: <https://github.com/tj/git-extras/blob/master/Commands.md#git-alias>.
+
+- Wyświetl wszystkie aliasy:
+
+`git alias`
+
+- Utwórz nowy alias:
+
+`git alias "{{nazwa}}" "{{komenda}}"`
+
+- Wyszukaj istniejący alias:
+
+`git alias ^{{nazwa}}`

--- a/pages.pl/common/git-am.md
+++ b/pages.pl/common/git-am.md
@@ -1,0 +1,21 @@
+# git am
+
+> Zastosuj pliki poprawki i utwórz commit. Przydatne przy otrzymywaniu commitów przez email.
+> Zobacz także `git format-patch`, który może generować pliki poprawki.
+> Więcej informacji: <https://git-scm.com/docs/git-am>.
+
+- Zastosuj i komituj zmiany z lokalnego pliku poprawki:
+
+`git am {{ścieżka/do/pliku.poprawki}}`
+
+- Zastosuj i komituj zmiany ze zdalnego pliku poprawki:
+
+`curl -L {{https://example.com/plik.poprawki}} | git apply`
+
+- Przerwij proces zastosowania pliku poprawki:
+
+`git am --abort`
+
+- Zastosuj jak największą część pliku poprawki, zapisując nieudane fragmenty w plikach odrzuceń (pliki .rej):
+
+`git am --reject {{ścieżka/do/pliku.poprawki}}`

--- a/pages.pl/common/git-am.md
+++ b/pages.pl/common/git-am.md
@@ -6,16 +6,16 @@
 
 - Zastosuj i komituj zmiany z lokalnego pliku poprawki:
 
-`git am {{ścieżka/do/pliku.poprawki}}`
+`git am {{ścieżka/do/pliku.patch}}`
 
 - Zastosuj i komituj zmiany ze zdalnego pliku poprawki:
 
-`curl -L {{https://example.com/plik.poprawki}} | git apply`
+`curl -L {{https://example.com/plik.patch}} | git apply`
 
 - Przerwij proces zastosowania pliku poprawki:
 
 `git am --abort`
 
-- Zastosuj jak największą część pliku poprawki, zapisując nieudane fragmenty w plikach odrzuceń (pliki .rej):
+- Zastosuj jak największą część pliku poprawki, zapisując nieudane fragmenty w plikach odrzuceń (pliki `.rej`):
 
-`git am --reject {{ścieżka/do/pliku.poprawki}}`
+`git am --reject {{ścieżka/do/pliku.patch}}`

--- a/pages.pl/common/git.md
+++ b/pages.pl/common/git.md
@@ -1,0 +1,29 @@
+# git
+
+> Rozproszony system kontroli wersji.
+> Niektóre podkomendy takie jak `commit`, `add`, `branch`, `checkout`, `push`, itd. mają osobną dokumentację.
+> Więcej informacji: <https://git-scm.com/>.
+
+- Wykonaj podkomendę Git:
+
+`git {{podkomenda}}`
+
+- Wykonaj podkomendę Git na określonej ścieżce głównej repozytorium:
+
+`git -C {{ścieżka/do/repozytorium}} {{podkomenda}}`
+
+- Wykonaj podkomendę Git z określoną konfiguracją:
+
+`git -c '{{klucz.konfiguracji}}={{wartość}}' {{podkomenda}}`
+
+- Wyświetl pomoc:
+
+`git --help`
+
+- Wyświetl pomoc dla określonej podkomendy (np. `clone`, `add`, `push`, `log`, itd.):
+
+`git help {{podkomenda}}`
+
+- Wyświetl wersję:
+
+`git --version`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR adds five Polish translations for `Git`-related commands.
