### PR TITLE
udevadm: fix wrong reload command flag

### DIFF
--- a/pages.ko/linux/udevadm.md
+++ b/pages.ko/linux/udevadm.md
@@ -21,7 +21,7 @@
 
 - 모든 `udev` 규칙 다시 로드:
 
-`sudo udevadm control --reload-rules`
+`sudo udevadm control --reload`
 
 - 모든 `udev` 규칙 실행 트리거:
 

--- a/pages/linux/udevadm.md
+++ b/pages/linux/udevadm.md
@@ -21,7 +21,7 @@
 
 - Reload all `udev` rules:
 
-`sudo udevadm control --reload-rules`
+`sudo udevadm control --reload`
 
 - Trigger all `udev` rules to run:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
257
