### PR TITLE
duckdb: add new shorthand flag

### DIFF
--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -17,7 +17,7 @@
 
 - Run an SQL script:
 
-`duckdb -c ".read {{path/to/script.sql}}"`
+`duckdb -f {{path/to/script.sql}}`
 
 - Run query on database file and keep the interactive shell open:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.2.0

This PR replaces the DuckDB command `-c ".read script.sql"` with the shorthand `-f script.sql`.