### PR TITLE
CLIENT-SPECIFICATION: rephrase requirement to implement option variants

### DIFF
--- a/CLIENT-SPECIFICATION.md
+++ b/CLIENT-SPECIFICATION.md
@@ -30,7 +30,11 @@ This section describes the standardised command-line interface (CLI) for clients
 
 ### Arguments
 
-The following table documents what command-line options MUST be supported and which are optional. If an option is implemented both the short and long versions MUST be available:
+The following table documents what command-line options MUST be supported and which are optional.
+
+When adding support for an option, clients MUST implement all variants of that option listed in the table.
+For example, clients should implement _both_ `-v` and `--version`.
+When a client implements updating the offline cache, they should support _both_ `-u` and `--update`.
 
 Option                 | Required?   | Meaning
 -----------------------|-------------|----------


### PR DESCRIPTION
The new phrasing does not imply that all options have a short and long form specified in the table.

The motivation for this change is to allow adding options that only have a long form. In particular, I was aiming for such an option in https://github.com/tldr-pages/tldr/pull/15253#discussion_r1965450746 but there was no agreement on whether or not this change would be backwards compatible.

Given that all current entries in the table have both a short and long form, the implication is equivalent for both statements. Thus, this is not a breaking change.

Regardless of whether or not we keep the `-S` and `-E` flags around, I think this rephrasing makes sense so that future additions could use long forms only. Requiring only the long form of an option makes sense to release a new feature without reserving a letter for a short flag right away. Later releases of the client specification can still add a short form flag for the same option.