### PR TITLE
style-guide: add keypress documentation instructions.

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -486,8 +486,8 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
-- Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
-- Keypresses in the same context or when they form words can be grouped together in the same angle brackets: `<:><help><Enter>`.
+- Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<Ctrl k><Ctrl s>`.
+- Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`.
 - Do not place options with multiple choices inside angle brackets: Use `{{<Ctrl Shift PageUp>|<Ctrl Shift PageDown>}}` instead of `<Ctrl Shift {{PageUp|PageDown}}>`.
 
 ### Help and version commands

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -487,6 +487,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
+- Keypresses in the same context or when they form words can be grouped together in the same angle brackets: `<:><help><Enter>`.
 
 To differentiate keypress syntax from terminal file redirection, include as little additional spaces around the angle brackets as possible. Likewise include spaces around terminal file redirection whenever possible.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -499,7 +499,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
-- Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -488,7 +488,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
 - Keypresses in the same context or when they form words can be grouped together in the same angle brackets: `<:><help><Enter>`.
-- Do not place placeholders with
+- Do not place options with multiple choices inside angle brackets: Use `{{<Ctrl Shift PageUp>|<Ctrl Shift PageDown>}}` instead of `<Ctrl Shift {{PageUp|PageDown}}>`.
 
 ### Help and version commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -484,7 +484,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
-- When writing simultaneous keypresses, keep the following order: <Ctrl> -> <Super> -> <Alt> -> <AltGr> -> <Shift> -> everything else.
+- When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -373,6 +373,7 @@ It should instead be simplified to make it easier for everyone to read:
 
 - Proper names should be capitalized in the description whenever applicable (e.g. use `A tool for interacting with a Git repository.` instead of ``A tool for interacting with a `git` repository.``).
 - Acronym expansions (i.e. protocols, tools, etc) must not be translated unless there is a recognized native equivalent for them.
+- When documenting keycaps or a keyboard shortcut for a utility, make it stand out in the description (i.e. ``Print the last lines of a given file and keep reading it until `Ctrl + C`:``).
 
 ### Short option mnemonics
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -464,7 +464,7 @@ Keep the following guidelines in mind when choosing placeholders:
 
 - If a command can optionally take 1 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
   For instance, if multiple paths are expected, use `{{path/to/directory1 path/to/directory2 ...}}`.
-- If a command can optionally take 1 or more arguments of different kinds, an ellipsis: `{{placeholder1|placeholder2|...}}`.
+- If a command can optionally take 1 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values, you can use `|...` after the last item.
 - It's impossible to restrict the minimum or (and) maximum placeholder count via `ellipsis`.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -489,7 +489,6 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<Esc><u>`, `<Ctrl k><Ctrl s>`, `<Enter><~><.>`, `<d><o>`.
 - Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`. Note that the context switching keypress is marked in angle brackets despite printing on the prompt
-- Do not place options with multiple choices inside angle brackets: Use `{{<Ctrl Shift PageUp>|<Ctrl Shift PageDown>}}` instead of `<Ctrl Shift {{PageUp|PageDown}}>`.
 
 ### Help and version commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -389,7 +389,7 @@ It should instead be simplified to make it easier for everyone to read:
 
 - Proper names should be capitalized in the description whenever applicable (e.g. use `A tool for interacting with a Git repository.` instead of ``A tool for interacting with a `git` repository.``).
 - Acronym expansions (i.e. protocols, tools, etc) must not be translated unless there is a recognized native equivalent for them.
-- When documenting keycaps or a keyboard shortcut for a utility, use the same [keypress syntax](#keypress-syntax) as is used for example commands. Make sure to enclose it in backtics so that it is not invisible to markdown renderers (i.e. ``Print the last lines of a given file and keep reading it until `<Ctrl c>`:``).
+- When documenting keycaps or a keyboard shortcut for a utility, use the same [keypress syntax](#keypress-syntax) as example commands. Make sure to enclose it in backticks so that it is not invisible to markdown renderers (i.e. ``Print the last lines of a given file and keep reading it until `<Ctrl c>`:``).
 
 ### Short option mnemonics
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -498,7 +498,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
-- Single characters example: `<a>`.
+- Single character example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` / `<Windows>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -484,11 +484,12 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- When writing simultaneous keypresses, keep the following order: Ctrl -> Super -> Alt -> AltGr -> Shift -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<Esc><u>`, `<Ctrl k><Ctrl s>`, `<Enter><~><.>`, `<d><o>`.
-- Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`. Note that the context switching keypress is marked in angle brackets despite printing on the prompt
+- Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`. Note that the context switching keypress is marked in angle brackets despite printing on the prompt.
 
 ### Help and version commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -481,6 +481,19 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 
 - Use `{{path/to/source.ext}}` instead of `{{path/to/source.tar[.gz|.bz2|.xz]}}`.
 
+### Keypress syntax
+
+To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
+
+- Single characters example: `<a>`.
+- Special keys are to be written with pascal case: `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, ...
+- Special keys can be translated if they have culturally relevant translations.
+- When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
+- Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
+- Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
+
+To differentiate keypress syntax from terminal file redirection, include as little additional spaces around the angle brackets as possible. Likewise include spaces around terminal file redirection whenever possible.
+
 ### Help and version commands
 
 - We generally put, **in this order**, the help and version commands as the **last two** examples of the page to highlight more practical commands at the beginning of the page. They can be replaced to accommodate other useful examples if required.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -487,8 +487,8 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
-- Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<Ctrl k><Ctrl s>`.
-- Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`.
+- Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<Esc><u>`, `<Ctrl k><Ctrl s>`, `<Enter><~><.>`, `<d><o>`.
+- Keys that are typed into a prompt do not need to be marked as keypresses: `<:>help<Enter>`. Note that the context switching keypress is marked in angle brackets despite printing on the prompt
 - Do not place options with multiple choices inside angle brackets: Use `{{<Ctrl Shift PageUp>|<Ctrl Shift PageDown>}}` instead of `<Ctrl Shift {{PageUp|PageDown}}>`.
 
 ### Help and version commands

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -499,7 +499,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
-- Special keys are to be written with [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -464,7 +464,7 @@ Keep the following guidelines in mind when choosing placeholders:
 
 - If a command can optionally take 1 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
   For instance, if multiple paths are expected, use `{{path/to/directory1 path/to/directory2 ...}}`.
-- If a command can optionally take 1 or more arguments of different kinds, use an ellipsis: `{{placeholder1|placeholder2|...}}`.
+- If a command can optionally take 1 or more arguments of different kinds, separate the options with a vertical like and mark the overflow with an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values, you can use `|...` after the last item.
 - It's impossible to restrict the minimum or (and) maximum placeholder count via `ellipsis`.
 
@@ -488,6 +488,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
 - Keypresses in the same context or when they form words can be grouped together in the same angle brackets: `<:><help><Enter>`.
+- Do not place placeholders with
 
 ### Help and version commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -482,7 +482,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
-- Special keys are to be written with pascal case: `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, ...
+- Special keys are to be written with pascal case: `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -389,7 +389,7 @@ It should instead be simplified to make it easier for everyone to read:
 
 - Proper names should be capitalized in the description whenever applicable (e.g. use `A tool for interacting with a Git repository.` instead of ``A tool for interacting with a `git` repository.``).
 - Acronym expansions (i.e. protocols, tools, etc) must not be translated unless there is a recognized native equivalent for them.
-- When documenting keycaps or a keyboard shortcut for a utility, make it stand out in the description (i.e. ``Print the last lines of a given file and keep reading it until `Ctrl + C`:``).
+- When documenting keycaps or a keyboard shortcut for a utility, use the same [keypress syntax](#keypress-syntax) as is used for example commands. Make sure to enclose it in backtics so that it is not invisible to markdown renderers (i.e. ``Print the last lines of a given file and keep reading it until `<Ctrl c>`:``).
 
 ### Short option mnemonics
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -489,8 +489,6 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 - Consecutive keypresses need to be contained in their own angle brackets with no space in between: `<:><w><q><Enter>`, `<Ctrl k><Ctrl s>`.
 - Keypresses in the same context or when they form words can be grouped together in the same angle brackets: `<:><help><Enter>`.
 
-To differentiate keypress syntax from terminal file redirection, include as little additional spaces around the angle brackets as possible. Likewise include spaces around terminal file redirection whenever possible.
-
 ### Help and version commands
 
 - We generally put, **in this order**, the help and version commands as the **last two** examples of the page to highlight more practical commands at the beginning of the page. They can be replaced to accommodate other useful examples if required.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -373,10 +373,6 @@ It should instead be simplified to make it easier for everyone to read:
 
 - Proper names should be capitalized in the description whenever applicable (e.g. use `A tool for interacting with a Git repository.` instead of ``A tool for interacting with a `git` repository.``).
 - Acronym expansions (i.e. protocols, tools, etc) must not be translated unless there is a recognized native equivalent for them.
-- When documenting keycaps or a keyboard shortcut for a utility, make it stand out in the description:
-
-1. If it is not translatable, enclose it with backticks (i.e. ``Print the last lines of a given file and keep reading it until `Ctrl + C`:``)
-2. If it is translatable, enclose it with double angled brackets inside a placeholder (i.e. ``:wq{{<<Enter>>}}``).
 
 ### Short option mnemonics
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -483,7 +483,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
-- Special keys are to be written with pascal case: `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- Special keys are to be written with [PascalCase](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -496,7 +496,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 
 ### Keypress syntax
 
-To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
+To mark keypresses for TUI or GUI programs, use angle brackets `<` and `>`.
 
 - Single character example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, `<LeftClick>`, `<MiddleClick>`, ...

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -500,7 +500,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, ...
-- When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
+- When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` / `<Windows>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -484,7 +484,7 @@ To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
 - Special keys are to be written with [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
-- When writing simultaneous keypresses, keep the following order: Ctrl -> Super -> Alt -> AltGr -> Shift -> everything else.
+- When writing simultaneous keypresses, keep the following order: <Ctrl> -> <Super> -> <Alt> -> <AltGr> -> <Shift> -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -483,7 +483,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single characters example: `<a>`.
-- Special keys are to be written with [PascalCase](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- Special keys are to be written with [`PascalCase`](https://en.wikipedia.org/wiki/Camel_case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<PageUp>`, `<F5>`, `<F12>`, ...
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.
 - Mark simultaneous keypresses inside the same angle brackets separated by a single space:  `<Ctrl c>`, `<Alt F4>`, `<Ctrl Shift k>`, `<Super Shift PrtSc>`.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -389,7 +389,7 @@ It should instead be simplified to make it easier for everyone to read:
 
 - Proper names should be capitalized in the description whenever applicable (e.g. use `A tool for interacting with a Git repository.` instead of ``A tool for interacting with a `git` repository.``).
 - Acronym expansions (i.e. protocols, tools, etc) must not be translated unless there is a recognized native equivalent for them.
-- When documenting keycaps or a keyboard shortcut for a utility, use the same [keypress syntax](#keypress-syntax) as example commands. Make sure to enclose it in backticks so that it is not invisible to markdown renderers (i.e. ``Print the last lines of a given file and keep reading it until `<Ctrl c>`:``).
+- When documenting keycaps or a keyboard shortcut for a utility, use the same [keypress syntax](#keypress-syntax) as in example commands. Make sure to enclose it in backticks so that it is not invisible to markdown renderers (i.e. ``Print the last lines of a given file and keep reading it until `<Ctrl c>`:``).
 
 ### Short option mnemonics
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -464,7 +464,7 @@ Keep the following guidelines in mind when choosing placeholders:
 
 - If a command can optionally take 1 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
   For instance, if multiple paths are expected, use `{{path/to/directory1 path/to/directory2 ...}}`.
-- If a command can optionally take 1 or more arguments of different kinds, separate the options with a vertical like and mark the overflow with an ellipsis: `{{placeholder1|placeholder2|...}}`.
+- If a command can optionally take 1 or more arguments of different kinds, an ellipsis: `{{placeholder1|placeholder2|...}}`.
   If there are more than 5 possible values, you can use `|...` after the last item.
 - It's impossible to restrict the minimum or (and) maximum placeholder count via `ellipsis`.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -499,7 +499,7 @@ When documenting optional placeholders like paths or file extensions, it is sugg
 To mark keypresses for TUI or UI programs, use angle brackets `<` and `>`.
 
 - Single character example: `<a>`.
-- Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, ...
+- Special keys are to be written with [`PascalCase`](https://www.theserverside.com/definition/Pascal-case): `<Ctrl>`, `<Super>`, `<Alt>`, `<Shift>`, `<Cmd>`, `<Option>`, `<Windows>`, `<Enter>`, `<Home>`, `<Space>`, `<Esc>`, `<ArrowUp>`, `<ArrowLeft>`, `<ArrowKeys>`, `<PageUp>`, `<F5>`, `<F12>`, `<LeftClick>`, `<MiddleClick>`, ...
 - When writing simultaneous keypresses, keep the following order: `<Ctrl>` -> `<Super>` / `<Windows>` -> `<Alt>` -> `<AltGr>` -> `<Shift>` -> everything else.
 - Special keys can be translated if they have culturally relevant translations.
 - When a program takes in uppercase character literals mark them as `<A>` instead of marking it with shift. Otherwise always mark characters in lowercase.


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
