### PR TITLE
pulumi-state: add `pulumi state edit` example

### DIFF
--- a/pages/common/pulumi-state.md
+++ b/pages/common/pulumi-state.md
@@ -19,6 +19,10 @@
 
 `pulumi state repair`
 
+- Edit a stack's state in the editor specified by the `EDITOR` environment variable:
+
+` pulumi state edit --stack {{stack_name}}`
+
 - Display help:
 
 `pulumi state --help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

