### PR TITLE
style-guide: etc is not a command

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -411,7 +411,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ### Option syntax
 
-- For commonly/frequently used commands (e.g. `grep`, `tar`, etc...), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.
+- For commonly/frequently used commands (e.g. `grep`, `tar`, etc.), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - For user-friendliness, use **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -411,7 +411,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ### Option syntax
 
-- For commonly/frequently used commands (e.g. `grep`, `tar`, `etc`), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.
+- For commonly/frequently used commands (e.g. `grep`, `tar`, etc...), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - For user-friendliness, use **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
