### PR TITLE
osascript: fix single and double quotes

### DIFF
--- a/pages.es/osx/osascript.md
+++ b/pages.es/osx/osascript.md
@@ -5,11 +5,11 @@
 
 - Ejecuta un comando AppleScript:
 
-`osascript -e "{{say 'Hello world'}}"`
+`osascript -e '{{say "Hello world"}}'`
 
 - Ejecuta varios comandos AppleScript:
 
-`osascript -e "{{say 'Hello'}}" -e "{{say 'world'}}"`
+`osascript -e '{{say "Hello"}}' -e '{{say "world"}}'`
 
 - Ejecuta un archivo AppleScript compilado (`*.scpt`), empaquetado (`*.scptd`) o un archivo Applescript en texto plano (`*.applescript`):
 

--- a/pages.id/osx/osascript.md
+++ b/pages.id/osx/osascript.md
@@ -5,11 +5,11 @@
 
 - Jalankan sebuah perintah AppleScript:
 
-`osascript -e "{{say 'Halo dunia'}}"`
+`osascript -e '{{say "Halo dunia"}}'`
 
 - Jalankan beberapa perintah AppleScript:
 
-`osascript -e "{{say 'Halo'}}" -e "{{say 'dunia'}}"`
+`osascript -e '{{say "Halo"}}' -e '{{say "dunia"}}'`
 
 - Mengeksekusi perintah dari file AppleScript yang telah terkompilasi (`*.scpt`), terbundel (`*.scptd`), atau secara plaintext (`*.applescript`):
 

--- a/pages.ko/osx/osascript.md
+++ b/pages.ko/osx/osascript.md
@@ -5,11 +5,11 @@
 
 - AppleScript 명령 실행:
 
-`osascript -e "{{say 'Hello world'}}"`
+`osascript -e '{{say "Hello world"}}'`
 
 - 여러 AppleScript 명령 실행:
 
-`osascript -e "{{say 'Hello'}}" -e "{{say 'world'}}"`
+`osascript -e '{{say "Hello"}}' -e '{{say "world"}}'`
 
 - 컴파일된(`*.scpt`), 번들(`*.scptd`), 또는 텍스트(`*.applescript`) 형식의 AppleScript 파일 실행:
 

--- a/pages.zh/osx/osascript.md
+++ b/pages.zh/osx/osascript.md
@@ -5,11 +5,11 @@
 
 - 运行一个 AppleScript 命令：
 
-`osascript -e "{{say '你好世界'}}"`
+`osascript -e '{{say "你好世界"}}'`
 
 - 运行多条 AppleScript 命令：
 
-`osascript -e "{{say '你好'}}" -e "{{say '世界'}}"`
+`osascript -e '{{say "你好"}}' -e '{{say "世界"}}'`
 
 - 运行一个已编译的脚本（`*.scpt`），包脚本（`*.scptd`），或明文的（`*.applescript`）AppleScript 文件：
 

--- a/pages/osx/osascript.md
+++ b/pages/osx/osascript.md
@@ -5,11 +5,11 @@
 
 - Run an AppleScript command:
 
-`osascript -e "{{say 'Hello world'}}"`
+`osascript -e '{{say "Hello world"}}'`
 
 - Run multiple AppleScript commands:
 
-`osascript -e "{{say 'Hello'}}" -e "{{say 'world'}}"`
+`osascript -e '{{say "Hello"}}' -e '{{say "world"}}'`
 
 - Run a compiled (`*.scpt`), bundled (`*.scptd`), or plaintext (`*.applescript`) AppleScript file:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**?

macOS gives an error when running the examples the way they are provided currently:
```
4:5: syntax error: Expected “given”, “in”, “of”, expression, “with”, “without”, other parameter name, etc. but found unknown token. (-2741)
```

This is fixed with this PR.
