### PR TITLE
pulumi-stack: add `pulumi stack rm` example, remove `pulumi stack --help`

### DIFF
--- a/pages/common/pulumi-stack.md
+++ b/pages/common/pulumi-stack.md
@@ -23,6 +23,10 @@
 
 `pulumi stack select {{stack_name}}`
 
+- Delete a stack:
+
+`pulumi stack rm {{stack_name}}`
+
 - Show stack outputs, including secrets, in plaintext:
 
 `pulumi stack output --show-secrets`
@@ -30,7 +34,3 @@
 - Export the stack state to a JSON file:
 
 `pulumi stack export --file {{path/to/file.json}}`
-
-- Display help:
-
-`pulumi stack --help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
