### PR TITLE
zoxide: remove nonexistent --interactive option

### DIFF
--- a/pages.de/common/zoxide.md
+++ b/pages.de/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{path/to/directory}}`
 
-- Entferne interaktiv ein Verzeichnis aus der Datenbank von `zoxide`:
+- Entferne ein Verzeichnis aus der Datenbank von `zoxide`:
 
-`zoxide remove {{path/to/directory}} --interactive`
+`zoxide remove {{path/to/directory}}`
 
 - Generiere Shell-Konfigurationen für Befehls-Aliase (`z`, `za`, `zi`, `zq`, `zr`) für die angegebene Shell:
 

--- a/pages.fr/common/zoxide.md
+++ b/pages.fr/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{chemin/du/répertoire}}`
 
-- Supprime un répertoire interactive de la base de données de `zoxide` :
+- Supprime un répertoire de la base de données de `zoxide` :
 
-`zoxide remove {{chemin/du/répertoire}} --interactive`
+`zoxide remove {{chemin/du/répertoire}}`
 
 - Génère la configuration du shell pour la mise en place des alias de commandes (`z`, `za`, `zi`, `zq`, `zr`) :
 

--- a/pages.ko/common/zoxide.md
+++ b/pages.ko/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{경로/대상/폴더}}`
 
-- `zoxide` 데이터베이스에서 대화형으로 디렉터리 제거:
+- `zoxide` 데이터베이스에서 디렉터리 제거:
 
-`zoxide remove {{경로/대상/폴더}} --interactive`
+`zoxide remove {{경로/대상/폴더}}`
 
 - 명령 별칭 (`z`, `za`, `zi`, `zq`, `zr`)에 대한 쉘 구성 생성:
 

--- a/pages.zh/common/zoxide.md
+++ b/pages.zh/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{路径/到/目录}}`
 
-- 从 `zoxide` 的数据库中交互式地移除一个目录：
+- 从 `zoxide` 的数据库中移除一个目录：
 
-`zoxide remove {{路径/到/目录}} --interactive`
+`zoxide remove {{路径/到/目录}}`
 
 - 为命令别名生成 shell 配置（`z`, `za`, `zi`, `zq`, `zr`）：
 

--- a/pages/common/zoxide.md
+++ b/pages/common/zoxide.md
@@ -20,9 +20,9 @@
 
 `zoxide add {{path/to/directory}}`
 
-- Remove a directory from `zoxide`'s database interactively:
+- Remove a directory from `zoxide`'s database:
 
-`zoxide remove {{path/to/directory}} --interactive`
+`zoxide remove {{path/to/directory}}`
 
 - Generate shell configuration for command aliases (`z`, `za`, `zi`, `zq`, `zr`):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Closes #15782
