### PR TITLE
pulumi-stack: update example

### DIFF
--- a/pages/common/pulumi-stack.md
+++ b/pages/common/pulumi-stack.md
@@ -7,9 +7,9 @@
 
 `pulumi stack init {{stack_name}}`
 
-- View the stack state:
+- Show the stack state along with resource URNs:
 
-`pulumi stack`
+`pulumi stack --show-urns`
 
 - List stacks in the current project:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Made the example more useful. Resource URNs are useful when running other `pulumi` commands such as `pulumi state delete`, `pulumi state move`, and `pulumi state rename`.
