### PR TITLE
pages/common/*: apply keypress specifications

### DIFF
--- a/pages/common/abduco.md
+++ b/pages/common/abduco.md
@@ -17,7 +17,7 @@
 
 - Detach from a session:
 
-`<Ctrl> + \`
+`<Ctrl \>`
 
 - [A]ttach to a session in [r]ead-only mode:
 

--- a/pages/common/at.md
+++ b/pages/common/at.md
@@ -8,7 +8,7 @@
 
 `systemctl start atd`
 
-- Create commands interactively and execute them in 5 minutes (press `<Ctrl> + D` when done):
+- Create commands interactively and execute them in 5 minutes (press `<Ctrl d>` when done):
 
 `at now + 5 minutes`
 

--- a/pages/common/az-serial-console.md
+++ b/pages/common/az-serial-console.md
@@ -10,4 +10,4 @@
 
 - Terminate the connection:
 
-`<Ctrl>-]`
+`<Ctrl ]>`

--- a/pages/common/bastet.md
+++ b/pages/common/bastet.md
@@ -9,15 +9,15 @@
 
 - Navigate the piece horizontally:
 
-`{{Left|Right arrow key}}`
+`{{<ArrowLeft>|<ArrowRight>}}`
 
 - Rotate the piece clockwise or counterclockwise:
 
-`{{Spacebar|Up arrow key}}`
+`{{<Space>|<ArrowUp>}}`
 
 - Soft drop the piece:
 
-`<Down arrow key>`
+`<ArrowDown>`
 
 - Hard drop the piece:
 
@@ -25,8 +25,8 @@
 
 - Pause the game:
 
-`p`
+`<p>`
 
 - Quit the game:
 
-`<Ctrl> + C`
+`<Ctrl c>`

--- a/pages/common/blockout2.md
+++ b/pages/common/blockout2.md
@@ -9,11 +9,11 @@
 
 - Navigate the current piece on a 2D plane:
 
-`{{Up|Down|Left|Right arrow key}}`
+`{{<ArrowUp>|<ArrowDown>|<ArrowLeft>|<ArrowRight>}}`
 
 - Rotate the piece on its axis:
 
-`{{Q|W|E|A|S|D}}`
+`{{<q>|<w>|<e>|<a>|<s>|<d>}}`
 
 - Hard drop the current piece:
 
@@ -21,4 +21,4 @@
 
 - Pause/unpause the game:
 
-`p`
+`<p>`

--- a/pages/common/bpytop.md
+++ b/pages/common/bpytop.md
@@ -14,15 +14,15 @@
 
 - Toggle minimal mode:
 
-`m`
+`<m>`
 
 - Search for running programs or processes:
 
-`f`
+`<f>`
 
 - Change settings:
 
-`M`
+`<M>`
 
 - Display version:
 

--- a/pages/common/clifm.md
+++ b/pages/common/clifm.md
@@ -14,24 +14,24 @@
 
 - Create a new file and a new directory:
 
-`n file dir/`
+`<n>file dir/`
 
 - Search for PDF files in the current directory:
 
-`/*.pdf`
+`</>*.pdf`
 
 - Select all PNG files in the current directory:
 
-`s *.png`
+`<s> *.png`
 
-- Remove the previously selected files (use `t` to send the files to the recycle bin instead):
+- Remove the previously selected files (use `<t>` to send the files to the recycle bin instead):
 
-`r sel`
+`<r>sel`
 
 - Display help:
 
-`?`
+`<?>`
 
 - Exit CliFM:
 
-`q`
+`<q>`

--- a/pages/common/ddgr.md
+++ b/pages/common/ddgr.md
@@ -33,4 +33,4 @@
 
 - Display help in interactive mode:
 
-`?`
+`<?>`

--- a/pages/common/elinks.md
+++ b/pages/common/elinks.md
@@ -9,7 +9,7 @@
 
 - Quit elinks:
 
-`<Ctrl> + C`
+`<Ctrl c>`
 
 - Dump output of webpage to console, colorizing the text with ANSI control codes:
 

--- a/pages/common/emacs.md
+++ b/pages/common/emacs.md
@@ -30,8 +30,8 @@
 
 - Save a file in Emacs:
 
-`<Ctrl> + X, <Ctrl> + S`
+`<Ctrl x><Ctrl s>`
 
 - Quit Emacs:
 
-`<Ctrl> + X, <Ctrl> + C`
+`<Ctrl x><Ctrl c>`

--- a/pages/common/ex.md
+++ b/pages/common/ex.md
@@ -26,7 +26,7 @@
 
 - Insert text:
 
-`i<Enter>{{text}}<C-c>`
+`i<Enter>{{text}}<Ctrl c>`
 
 - Switch to Vim:
 

--- a/pages/common/git-feature.md
+++ b/pages/common/git-feature.md
@@ -1,7 +1,7 @@
 # git feature
 
 > Create or merge feature branches.
-> Feature branches obey the format feature/<name>.
+> Feature branches obey the format feature/name.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-feature>.
 
 - Create and switch to a new feature branch:

--- a/pages/common/git-feature.md
+++ b/pages/common/git-feature.md
@@ -1,7 +1,7 @@
 # git feature
 
 > Create or merge feature branches.
-> Feature branches obey the format feature/name.
+> Feature branches obey the format feature/<name>.
 > More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-feature>.
 
 - Create and switch to a new feature branch:

--- a/pages/common/googler.md
+++ b/pages/common/googler.md
@@ -33,4 +33,4 @@
 
 - Display help in interactive mode:
 
-`?`
+`<?>`

--- a/pages/common/gpg-tui.md
+++ b/pages/common/gpg-tui.md
@@ -13,24 +13,24 @@
 
 - Quit `gpg-tui`:
 
-`q`
+`<q>`
 
 - Interactively generate a new key:
 
-`g`
+`<g>`
 
 - Export the selected key:
 
-`x`
+`<x>`
 
 - Set the detail level for the selected key:
 
-`1|2|3`
+`<1>|<2>|<3>`
 
 - Refresh `gpg-tui`:
 
-`r`
+`<r>`
 
 - Display help in `gpg-tui`:
 
-`?`
+`<?>`

--- a/pages/common/gtop.md
+++ b/pages/common/gtop.md
@@ -9,8 +9,8 @@
 
 - Sort by CPU usage:
 
-`c`
+`<c>`
 
 - Sort by memory usage:
 
-`m`
+`<m>`

--- a/pages/common/helix.md
+++ b/pages/common/helix.md
@@ -1,7 +1,7 @@
 # helix
 
 > Helix, A post-modern text editor, provides several modes for different kinds of text manipulation.
-> Pressing `i` enters insert mode. `<Esc>` enters normal mode, which enables the use of Helix commands.
+> Pressing `<i>` enters insert mode. `<Esc>` enters normal mode, which enables the use of Helix commands.
 > More information: <https://helix-editor.com>.
 
 - Open a file:
@@ -12,7 +12,7 @@
 
 `helix --vsplit {{path/to/file1 path/to/file2}}`
 
-- Show the tutorial to learn Helix (or access it within Helix by pressing `<Esc>` and typing `:tutor`):
+- Show the tutorial to learn Helix (or access it within Helix by pressing `<Esc>` and typing `<:>tutor<Enter>`):
 
 `helix --tutor`
 
@@ -32,6 +32,6 @@
 
 `<u>`
 
-- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
+- Search for a pattern in the file (press `<n>`/`<N>` to go to next/previous match):
 
 `</>{{search_pattern}}<Enter>`

--- a/pages/common/helix.md
+++ b/pages/common/helix.md
@@ -18,20 +18,20 @@
 
 - Change the Helix theme:
 
-`:theme {{theme_name}}`
+`<:>theme {{theme_name}}`
 
 - Save and Quit:
 
-`:wq<Enter>`
+`<:>wq<Enter>`
 
 - Force-quit without saving:
 
-`:q!<Enter>`
+`<:>q!<Enter>`
 
 - Undo the last operation:
 
-`u`
+`<u>`
 
 - Search for a pattern in the file (press `n`/`N` to go to next/previous match):
 
-`/{{search_pattern}}<Enter>`
+`</>{{search_pattern}}<Enter>`

--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -25,11 +25,11 @@
 
 - See interactive commands while running htop:
 
-`?`
+`<?>`
 
 - Switch to a different tab:
 
-`tab`
+`<Tab>`
 
 - Display help:
 

--- a/pages/common/kak.md
+++ b/pages/common/kak.md
@@ -10,7 +10,7 @@
 
 - Enter insert mode from normal mode, to write text into the file:
 
-`i`
+`<i>`
 
 - Escape insert mode, to go back to normal mode:
 
@@ -30,8 +30,8 @@
 
 - Insert the contents of a file:
 
-`!cat {{path/to/file}}<Enter>`
+`<!>cat {{path/to/file}}<Enter>`
 
 - Save the current file:
 
-`:w<Enter>`
+`<:>w<Enter>`

--- a/pages/common/less.md
+++ b/pages/common/less.md
@@ -9,28 +9,28 @@
 
 - Page down/up:
 
-`<Space> (down), b (up)`
+`{{<Space>|<b>}}`
 
 - Go to end/start of file:
 
-`G (end), g (start)`
+`{{<G>|<g>}}`
 
 - Forward search for a string (press `n`/`N` to go to next/previous match):
 
-`/{{something}}`
+`</>{{something}}`
 
 - Backward search for a string (press `n`/`N` to go to next/previous match):
 
-`?{{something}}`
+`<?>{{something}}`
 
 - Follow the output of the currently opened file:
 
-`F`
+`<F>`
 
 - Open the current file in an editor:
 
-`v`
+`<v>`
 
 - Exit:
 
-`q`
+`<q>`

--- a/pages/common/mail.md
+++ b/pages/common/mail.md
@@ -8,7 +8,7 @@
 
 `mail`
 
-- Send a typed email message with optional CC. The command-line below continues after pressing `<Enter>`. Input message text (can be multiline). Press `<Ctrl>-D` to complete the message text:
+- Send a typed email message with optional CC. The command-line below continues after pressing `<Enter>`. Input message text (can be multiline). Press `<Ctrl d>` to complete the message text:
 
 `mail --subject="{{subject line}}" {{to_user@example.com}} --cc="{{cc_email_address}}"`
 

--- a/pages/common/micro.md
+++ b/pages/common/micro.md
@@ -16,7 +16,7 @@
 
 `<Ctrl k>`
 
-- Search for a pattern in the file (press `Ctrl + N`/`Ctrl + P` to go to next/previous match):
+- Search for a pattern in the file (press `<Ctrl n>`/`<Ctrl p>` to go to next/previous match):
 
 `<Ctrl f>{{pattern}}<Enter>`
 

--- a/pages/common/micro.md
+++ b/pages/common/micro.md
@@ -10,24 +10,24 @@
 
 - Save a file:
 
-`<Ctrl> + S`
+`<Ctrl s>`
 
 - Cut the entire line:
 
-`<Ctrl> + K`
+`<Ctrl k>`
 
 - Search for a pattern in the file (press `Ctrl + N`/`Ctrl + P` to go to next/previous match):
 
-`<Ctrl> + F "{{pattern}}" <Enter>`
+`<Ctrl f>{{pattern}}<Enter>`
 
 - Execute a command:
 
-`<Ctrl> + E {{command}} <Enter>`
+`<Ctrl e>{{command}}<Enter>`
 
 - Perform a substitution in the whole file:
 
-`<Ctrl> + E replaceall "{{pattern}}" "{{replacement}}" <Enter>`
+`<Ctrl e>replaceall "{{pattern}}" "{{replacement}}"<Enter>`
 
 - Quit:
 
-`<Ctrl> + Q`
+`<Ctrl q>`

--- a/pages/common/moe.md
+++ b/pages/common/moe.md
@@ -21,4 +21,4 @@
 
 - Save and Quit:
 
-`<Ctrl> + X`
+`<Ctrl x>`

--- a/pages/common/most.md
+++ b/pages/common/most.md
@@ -17,20 +17,20 @@
 
 - Move through opened files:
 
-`:O n`
+`<:><n>{{<ArrowUp>|<ArrowDown>}}`
 
 - Jump to the 100th line:
 
-`{{100}}j`
+`<j>{{100}}<Enter>`
 
 - Edit current file:
 
-`e`
+`<e>`
 
 - Split the current window in half:
 
-`<CTRL-x> o`
+`<CTRL x><o>`
 
 - Exit:
 
-`Q`
+`<q>`

--- a/pages/common/mplayer.md
+++ b/pages/common/mplayer.md
@@ -25,4 +25,4 @@
 
 - Seek backward or forward 10 seconds:
 
-`{{Left|Right}}`
+`{{<ArrowLeft>|<ArrowRight>}}`

--- a/pages/common/mpv.md
+++ b/pages/common/mpv.md
@@ -10,19 +10,19 @@
 
 - Jump backward/forward 5 seconds:
 
-`LEFT <or> RIGHT`
+`{{<ArrowLeft>|<ArrowRight>}}`
 
 - Jump backward/forward 1 minute:
 
-`DOWN <or> UP`
+`{{<ArrowDown>|<ArrowUp>}}`
 
 - Decrease or increase playback speed by 10%:
 
-`[ <or> ]`
+`{{<[>|<]>}}`
 
 - Take a screenshot of the current frame (saved to `./mpv-shotNNNN.jpg` by default):
 
-`s`
+`<s>`
 
 - Play a file at a specified speed (1 by default):
 

--- a/pages/common/newsboat.md
+++ b/pages/common/newsboat.md
@@ -21,4 +21,4 @@
 
 - See keyboard shortcuts (the most relevant are visible in the status line):
 
-`?`
+`<?>`

--- a/pages/common/nnn.md
+++ b/pages/common/nnn.md
@@ -23,6 +23,6 @@
 
 `nnn -T {{a|d|e|r|s|t|v}}`
 
-- Open a file you have selected. Select the file then press `o`, and type a program to open the file in:
+- Open a file you have selected. Select the file then press `<o>`, and type a program to open the file in:
 
 `nnn -o`

--- a/pages/common/nudoku.md
+++ b/pages/common/nudoku.md
@@ -13,24 +13,24 @@
 
 - Navigate the board:
 
-`{{h|j|k|l}} OR {{Left|Down|Up|Right arrow key}}`
+`{{<h>|<j>|<k>|<l>|<ArrowKeys>}}`
 
 - Delete a number:
 
-`{{Backspace|x}}`
+`{{<Backspace>|<x>}}`
 
 - Get a hint:
 
-`H`
+`<H>`
 
 - See the complete solution:
 
-`S`
+`<S>`
 
 - Create a new puzzle:
 
-`N`
+`<N>`
 
 - Quit the game:
 
-`Q`
+`<Q>`

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -1,7 +1,7 @@
 # nvim
 
 > Neovim, a programmer's text editor based on Vim, provides several modes for different kinds of text manipulation.
-> Pressing `i` in normal mode enters insert mode. `<Esc>` goes back to normal mode, which doesn't allow regular text insertion.
+> Pressing `i` in normal mode enters insert mode. `<Esc>` or `<Ctrl c>` goes back to normal mode, which doesn't allow regular text insertion.
 > See also: `vim`, `vimtutor`, `vimdiff`.
 > More information: <https://neovim.io>.
 
@@ -11,28 +11,28 @@
 
 - Enter text editing mode (insert mode):
 
-`<Esc>i`
+`<Esc><i>`
 
-- Copy ("yank") or cut ("delete") the current line (paste it with `P`):
+- Copy ("yank") or cut ("delete") the current line (paste it with `p`):
 
-`<Esc>{{yy|dd}}`
+`<Esc>{{<y><y>|<d><d>}}`
 
 - Enter normal mode and undo the last operation:
 
-`<Esc>u`
+`<Esc><u>`
 
 - Search for a pattern in the file (press `n`/`N` to go to next/previous match):
 
-`<Esc>/{{search_pattern}}<Enter>`
+`<Esc></>{{search_pattern}}<Enter>`
 
 - Perform a regular expression substitution in the whole file:
 
-`<Esc>:%s/{{regular_expression}}/{{replacement}}/g<Enter>`
+`<Esc><:>%s/{{regular_expression}}/{{replacement}}/g<Enter>`
 
 - Enter normal mode and save (write) the file, and quit:
 
-`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
+`{{<Esc><Z><Z>|<Esc><:>x<Enter>|<Esc><:>wq<Enter>}}`
 
 - Quit without saving:
 
-`<Esc>:q!<Enter>`
+`<Esc><:>q!<Enter>`

--- a/pages/common/nvim.md
+++ b/pages/common/nvim.md
@@ -1,7 +1,7 @@
 # nvim
 
 > Neovim, a programmer's text editor based on Vim, provides several modes for different kinds of text manipulation.
-> Pressing `i` in normal mode enters insert mode. `<Esc>` or `<Ctrl c>` goes back to normal mode, which doesn't allow regular text insertion.
+> Pressing `<i>` in normal mode enters insert mode. `<Esc>` or `<Ctrl c>` goes back to normal mode, which doesn't allow regular text insertion.
 > See also: `vim`, `vimtutor`, `vimdiff`.
 > More information: <https://neovim.io>.
 
@@ -13,7 +13,7 @@
 
 `<Esc><i>`
 
-- Copy ("yank") or cut ("delete") the current line (paste it with `p`):
+- Copy ("yank") or cut ("delete") the current line (paste it with `<p>`):
 
 `<Esc>{{<y><y>|<d><d>}}`
 
@@ -21,7 +21,7 @@
 
 `<Esc><u>`
 
-- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
+- Search for a pattern in the file (press `<n>`/`<N>` to go to next/previous match):
 
 `<Esc></>{{search_pattern}}<Enter>`
 

--- a/pages/common/orca-c.md
+++ b/pages/common/orca-c.md
@@ -26,12 +26,12 @@
 
 - Show the main menu inside of ORCA:
 
-`F1`
+`<F1>`
 
 - Show all shortcuts inside of ORCA:
 
-`?`
+`<?>`
 
 - Show all ORCA operators inside of ORCA:
 
-`<Ctrl> + g`
+`<Ctrl g>`

--- a/pages/common/pio-device.md
+++ b/pages/common/pio-device.md
@@ -29,4 +29,4 @@
 
 - Go to the menu of the interactive device monitor:
 
-`<Ctrl> + T`
+`<Ctrl t>`

--- a/pages/common/ptpython.md
+++ b/pages/common/ptpython.md
@@ -17,16 +17,16 @@
 
 - Open the menu:
 
-`F2`
+`<F2>`
 
 - Open the history page:
 
-`F3`
+`<F3>`
 
 - Toggle paste mode:
 
-`F6`
+`<F6>`
 
 - Quit:
 
-`<Ctrl> + D`
+`<Ctrl d>`

--- a/pages/common/rtv.md
+++ b/pages/common/rtv.md
@@ -18,12 +18,12 @@
 
 - Open link:
 
-`o`
+`<o>`
 
 - Log in:
 
-`u`
+`<u>`
 
 - Display help:
 
-`?`
+`<?>`

--- a/pages/common/sc-im.md
+++ b/pages/common/sc-im.md
@@ -10,20 +10,20 @@
 
 - Enter a string into the current cell:
 
-`{{<|>}}`
+`{{<<>|<>>}}`
 
 - Enter a numeric constant into the current cell:
 
-`=`
+`<=>`
 
 - Edit string in the current cell:
 
-`E`
+`<E>`
 
 - Edit number in the current cell:
 
-`e`
+`<e>`
 
 - Center align the current cell:
 
-`|`
+`<|>`

--- a/pages/common/screen.md
+++ b/pages/common/screen.md
@@ -26,11 +26,11 @@
 
 - Detach from inside a screen:
 
-`<Ctrl> + A, D`
+`<Ctrl a><d>`
 
 - Kill the current screen session:
 
-`<Ctrl> + A, K`
+`<Ctrl a><k>`
 
 - Kill a detached screen:
 

--- a/pages/common/speedcrunch.md
+++ b/pages/common/speedcrunch.md
@@ -9,28 +9,28 @@
 
 - Copy the result of the most recent calculation:
 
-`<Ctrl> + R`
+`<Ctrl r>`
 
 - Open the formula book:
 
-`<Ctrl> + 1`
+`<Ctrl 1>`
 
 - Clear the calculator of recent calculations:
 
-`<Ctrl> + N`
+`<Ctrl n>`
 
 - Wrap highlighted in parentheses (defaults to wrapping all if nothing selected):
 
-`<Ctrl> + P`
+`<Ctrl p>`
 
 - Load a speedcrunch session:
 
-`<Ctrl> + L`
+`<Ctrl l>`
 
 - Save a speedcrunch session:
 
-`<Ctrl> + S`
+`<Ctrl s>`
 
 - Toggle keypad:
 
-`<Ctrl> + K`
+`<Ctrl k>`

--- a/pages/common/ssh.md
+++ b/pages/common/ssh.md
@@ -34,4 +34,4 @@
 
 - Close a hanged session:
 
-`<Enter> ~ .`
+`<Enter><~><.>`

--- a/pages/common/telnet.md
+++ b/pages/common/telnet.md
@@ -17,7 +17,7 @@
 
 - Emit the default escape character combination for terminating the session:
 
-`<Ctrl> + ]`
+`<Ctrl ]>`
 
 - Start `telnet` with "x" as the session termination character:
 

--- a/pages/common/tig.md
+++ b/pages/common/tig.md
@@ -30,4 +30,4 @@
 
 - Display help in TUI:
 
-`h`
+`<h>`

--- a/pages/common/tmux.md
+++ b/pages/common/tmux.md
@@ -23,15 +23,15 @@
 
 - Detach from the current session (inside a tmux session):
 
-`<Ctrl>-B d`
+`<Ctrl b><d>`
 
 - Create a new window (inside a tmux session):
 
-`<Ctrl>-B c`
+`<Ctrl b><c>`
 
 - Switch between sessions and windows (inside a tmux session):
 
-`<Ctrl>-B w`
+`<Ctrl b><w>`
 
 - Kill a session by name:
 

--- a/pages/common/tuir.md
+++ b/pages/common/tuir.md
@@ -10,11 +10,11 @@
 
 - Open a subreddit:
 
-`/{{subreddit_name}}`
+`</>{{subreddit_name}}`
 
 - Open a link:
 
-`o`
+`<o>`
 
 - Open a specific subreddit on launch:
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -1,7 +1,7 @@
 # vim
 
 > Vim (Vi IMproved), a command-line text editor, provides several modes for different kinds of text manipulation.
-> Pressing `i` in normal mode enters insert mode. Pressing `<Esc>` goes back to normal mode, which enables the use of Vim commands.
+> Pressing `<i>` in normal mode enters insert mode. Pressing `<Esc>` goes back to normal mode, which enables the use of Vim commands.
 > See also: `vimdiff`, `vimtutor`, `nvim`.
 > More information: <https://www.vim.org>.
 
@@ -25,7 +25,7 @@
 
 `<Esc><u>`
 
-- Search for a pattern in the file (press `n`/`N` to go to next/previous match):
+- Search for a pattern in the file (press `<n>`/`<N>` to go to next/previous match):
 
 `</>{{search_pattern}}<Enter>`
 

--- a/pages/common/vim.md
+++ b/pages/common/vim.md
@@ -15,24 +15,24 @@
 
 - View Vim's help manual:
 
-`:help<Enter>`
+`<:>help<Enter>`
 
 - Save and quit the current buffer:
 
-`{{<Esc>ZZ|<Esc>:x<Enter>|<Esc>:wq<Enter>}}`
+`{{<Esc><Z><Z>|<Esc><:>x<Enter>|<Esc><:>wq<Enter>}}`
 
 - Enter normal mode and undo the last operation:
 
-`<Esc>u`
+`<Esc><u>`
 
 - Search for a pattern in the file (press `n`/`N` to go to next/previous match):
 
-`/{{search_pattern}}<Enter>`
+`</>{{search_pattern}}<Enter>`
 
 - Perform a regular expression substitution in the whole file:
 
-`:%s/{{regular_expression}}/{{replacement}}/g<Enter>`
+`<:>%s/{{regular_expression}}/{{replacement}}/g<Enter>`
 
 - Display the line numbers:
 
-`:set nu<Enter>`
+`<:>set nu<Enter>`

--- a/pages/common/vimdiff.md
+++ b/pages/common/vimdiff.md
@@ -10,28 +10,28 @@
 
 - Move the cursor to the window on the left|right:
 
-`<Ctrl> + w {{h|l}}`
+`<Ctrl w>{{<h>|<l>}}`
 
 - Jump to the previous difference:
 
-`[c`
+`<[><c>`
 
 - Jump to the next difference:
 
-`]c`
+`<]><c>`
 
 - Copy the highlighted difference from the other window to the current window:
 
-`do`
+`<d><o>`
 
 - Copy the highlighted difference from the current window to the other window:
 
-`dp`
+`<d><p>`
 
 - Update all highlights and folds:
 
-`:diffupdate`
+`<:>diffupdate`
 
 - Toggle the highlighted code fold:
 
-`za`
+`<z><a>`

--- a/pages/common/vimtutor.md
+++ b/pages/common/vimtutor.md
@@ -10,4 +10,4 @@
 
 - Exit the tutor:
 
-`<Esc> :q <Enter>`
+`<Esc><:>q<Enter>`

--- a/pages/common/w3m.md
+++ b/pages/common/w3m.md
@@ -18,12 +18,12 @@
 
 - Open a new browser tab:
 
-`<Shift> + T`
+`<Shift t>`
 
 - Display your browser history:
 
-`<Ctrl> + H`
+`<Ctrl h>`
 
 - Quit w3m:
 
-`q + y`
+`<q><y>`

--- a/pages/common/wordgrinder.md
+++ b/pages/common/wordgrinder.md
@@ -13,4 +13,4 @@
 
 - Show the menu:
 
-`<Alt> + M`
+`<Alt m>`

--- a/pages/common/wuzz.md
+++ b/pages/common/wuzz.md
@@ -9,16 +9,16 @@
 
 - Send an HTTP request:
 
-`<Ctrl> + R`
+`<Ctrl r>`
 
 - Switch to the next view:
 
-`<Ctrl> + J, <Tab>`
+`<Ctrl j><Tab>`
 
 - Switch to the previous view:
 
-`<Ctrl> + K, <Shift> + <Tab>`
+`<Ctrl k><Shift Tab>`
 
 - Display help:
 
-`F1`
+`<F1>`

--- a/pages/common/zellij.md
+++ b/pages/common/zellij.md
@@ -18,8 +18,8 @@
 
 - Open a new pane (inside a zellij session):
 
-`<Alt> + N`
+`<Alt n>`
 
 - Detach from the current session (inside a zellij session):
 
-`<Ctrl> + O, D`
+`<Ctrl o><d>`

--- a/pages/common/zmore.md
+++ b/pages/common/zmore.md
@@ -13,12 +13,12 @@
 
 - Search for a pattern in the file (press `n` to go to next match):
 
-`/{{regular_expression}}`
+`</>{{regular_expression}}`
 
 - Exit:
 
-`q`
+`<q>`
 
 - Display interactive command help:
 
-`h`
+`<h>`

--- a/pages/common/zmore.md
+++ b/pages/common/zmore.md
@@ -11,7 +11,7 @@
 
 `<Space>`
 
-- Search for a pattern in the file (press `n` to go to next match):
+- Search for a pattern in the file (press `<n>` to go to next match):
 
 `</>{{regular_expression}}`
 

--- a/pages/linux/more.md
+++ b/pages/linux/more.md
@@ -18,12 +18,12 @@
 
 - Search for a string (press `n` to go to the next match):
 
-`/{{something}}`
+`</>{{something}}`
 
 - Exit:
 
-`q`
+`<q>`
 
 - Display help about interactive commands:
 
-`h`
+`<h>`

--- a/pages/linux/top.md
+++ b/pages/linux/top.md
@@ -29,4 +29,4 @@
 
 - Display help about interactive commands:
 
-`?`
+`<?>`


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/pull/15798

These required a bit of trickery to find. I used various methods such as ``grep -r "<" | grep ">" | grep -v http | sort``, ``grep -ri "ctrl"``, ``grep -ri "alt"``, ``grep -Er '`.`'`` and ``grep -Er '`[^\n]*[A-Z]+[^\n]*`'``

Once the these pages are merged, I will create pull requests to fix the translations.