### PR TITLE
pihole: update page

### DIFF
--- a/pages.es/linux/pihole.md
+++ b/pages.es/linux/pihole.md
@@ -15,10 +15,6 @@
 
 `pihole {{enable|disable}}`
 
-- Reinicia el daemon (no el servidor en sí):
-
-`pihole reloaddns`
-
 - Incluye en lista blanca o negra un dominio:
 
 `pihole {{allowlist|denylist}} {{example.com}}`

--- a/pages.es/linux/pihole.md
+++ b/pages.es/linux/pihole.md
@@ -9,11 +9,7 @@
 
 - Actualiza Pi-hole y Gravity:
 
-`pihole -up`
-
-- Monitorea el estado detallado del sistema:
-
-`pihole chronometer`
+`pihole {{[-up|updatePihole]}}`
 
 - Inicia o detiene el daemon:
 
@@ -21,16 +17,16 @@
 
 - Reinicia el daemon (no el servidor en sí):
 
-`pihole restartdns`
+`pihole reloaddns`
 
 - Incluye en lista blanca o negra un dominio:
 
-`pihole {{whitelist|blacklist}} {{ejemplo.com}}`
+`pihole {{allowlist|denylist}} {{example.com}}`
 
 - Busca en las listas un dominio:
 
-`pihole query {{ejemplo.com}}`
+`pihole {{[-q|query]}} {{example.com}}`
 
 - Abre un registro de conexiones en tiempo real:
 
-`pihole tail`
+`pihole {{[-t|tail]}}`

--- a/pages.es/linux/pihole.md
+++ b/pages.es/linux/pihole.md
@@ -3,7 +3,7 @@
 > Interfaz de terminal para el servidor DNS de bloqueo de anuncios Pi-hole.
 > Más información: <https://docs.pi-hole.net/main/pihole-command>.
 
-- Verifica el estado del daemon de Pi-hole:
+- Verifica el estado del programa residente de Pi-hole:
 
 `pihole status`
 
@@ -11,7 +11,7 @@
 
 `pihole {{[-up|updatePihole]}}`
 
-- Inicia o detiene el daemon:
+- Inicia o detiene el programa residente:
 
 `pihole {{enable|disable}}`
 

--- a/pages.es/linux/pihole.md
+++ b/pages.es/linux/pihole.md
@@ -1,7 +1,7 @@
 # pihole
 
 > Interfaz de terminal para el servidor DNS de bloqueo de anuncios Pi-hole.
-> Más información: <https://docs.pi-hole.net/core/pihole-command/>.
+> Más información: <https://docs.pi-hole.net/main/pihole-command>.
 
 - Verifica el estado del daemon de Pi-hole:
 

--- a/pages.ko/linux/pihole.md
+++ b/pages.ko/linux/pihole.md
@@ -1,7 +1,7 @@
 # pihole
 
 > Pi-hole 광고 차단 DNS 서버의 터미널 인터페이스.
-> 더 많은 정보: <https://docs.pi-hole.net/core/pihole-command/>.
+> 더 많은 정보: <https://docs.pi-hole.net/main/pihole-command>.
 
 - Pi-hole 데몬의 상태 확인:
 

--- a/pages.ko/linux/pihole.md
+++ b/pages.ko/linux/pihole.md
@@ -9,11 +9,7 @@
 
 - Pi-hole 및 Gravity 업데이트:
 
-`pihole -up`
-
-- 시스템 상태 자세히 모니터링:
-
-`pihole chronometer`
+`pihole {{[-up|updatePihole]}}`
 
 - 데몬 시작 또는 중지:
 
@@ -21,16 +17,16 @@
 
 - 데몬 재시작 (서버 자체는 아님):
 
-`pihole restartdns`
+`pihole reloaddns`
 
 - 도메인 화이트리스트 또는 블랙리스트에 추가:
 
-`pihole {{whitelist|blacklist}} {{example.com}}`
+`pihole {{allowlist|denylist}} {{example.com}}`
 
 - 도메인을 목록에서 검색:
 
-`pihole query {{example.com}}`
+`pihole {{[-q|query]}} {{example.com}}`
 
 - 연결의 실시간 로그 열기:
 
-`pihole tail`
+`pihole {{[-t|tail]}}`

--- a/pages.ko/linux/pihole.md
+++ b/pages.ko/linux/pihole.md
@@ -15,10 +15,6 @@
 
 `pihole {{enable|disable}}`
 
-- 데몬 재시작 (서버 자체는 아님):
-
-`pihole reloaddns`
-
 - 도메인 화이트리스트 또는 블랙리스트에 추가:
 
 `pihole {{allowlist|denylist}} {{example.com}}`

--- a/pages/linux/pihole.md
+++ b/pages/linux/pihole.md
@@ -1,7 +1,7 @@
 # pihole
 
-> Terminal interface for the Pi-hole ad-blocking DNS server.
-> More information: <https://docs.pi-hole.net/core/pihole-command/>.
+> Manage the Pi-hole ad-blocking DNS server.
+> More information: <https://docs.pi-hole.net/main/pihole-command>.
 
 - Check the Pi-hole daemon's status:
 
@@ -9,28 +9,28 @@
 
 - Update Pi-hole and Gravity:
 
-`pihole -up`
-
-- Monitor detailed system status:
-
-`pihole chronometer`
+`pihole {{[-up|updatePihole]}}`
 
 - Start or stop the daemon:
 
 `pihole {{enable|disable}}`
 
-- Restart the daemon (not the server itself):
+- Update the lists and flush the cache without restarting the DNS server:
 
-`pihole restartdns`
+`pihole reloaddns`
 
-- Whitelist or blacklist a domain:
+- Update the list of ad-serving domains:
 
-`pihole {{whitelist|blacklist}} {{example.com}}`
+`pihole {{[-g|updateGravity]}}`
+
+- Allow or deny the specified domain:
+
+`pihole {{allowlist|denylist}} {{example.com}}`
 
 - Search the lists for a domain:
 
-`pihole query {{example.com}}`
+`pihole {{[-q|query]}} {{example.com}}`
 
 - Open a real-time log of connections:
 
-`pihole tail`
+`pihole {{[-t|tail]}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Chronometer was removed in v6.0: https://github.com/pi-hole/pi-hole/releases/tag/v6.0
whitelist and blacklist were renamed to allow/denylist some time ago
`restartdns` was also removed, I don't know when.

I replaced `restartdns` with `reloaddns` and added some more examples to the English page. I also removed examples that don't work anymore from translations.


### *This PR contains the new option syntax, please merge this after the client spec release.*