### PR TITLE
pages/common/*: add option placeholders part 1

### DIFF
--- a/pages/common/animdl.md
+++ b/pages/common/animdl.md
@@ -10,11 +10,11 @@
 
 - Download a specific anime by specifying an episode range:
 
-`animdl download {{anime_title}} {{-r|--range}} {{start_episode}}-{{end_episode}}`
+`animdl download {{anime_title}} {{[-r|--range]}} {{start_episode}}-{{end_episode}}`
 
 - Download a specific anime by specifying a download directory:
 
-`animdl download {{anime_title}} {{-d|--download-dir}} {{path/to/download_directory}}`
+`animdl download {{anime_title}} {{[-d|--download-dir]}} {{path/to/download_directory}}`
 
 - Grab the stream URL for a specific anime:
 
@@ -34,4 +34,4 @@
 
 - Stream the latest episode of a specific anime:
 
-`animdl stream {{anime_title}} {{-s|--special}} latest`
+`animdl stream {{anime_title}} {{[-s|--special]}} latest`

--- a/pages/common/ansible-galaxy.md
+++ b/pages/common/ansible-galaxy.md
@@ -29,4 +29,4 @@
 
 - Display help about roles or collections:
 
-`ansible-galaxy {{role|collection}} {{-h|--help}}`
+`ansible-galaxy {{role|collection}} {{[-h|--help]}}`

--- a/pages/common/asciinema.md
+++ b/pages/common/asciinema.md
@@ -26,7 +26,7 @@
 
 - Make a new recording, limiting any idle time to at most 2.5 seconds:
 
-`asciinema rec {{-i|--idle-time-limit}} 2.5`
+`asciinema rec {{[-i|--idle-time-limit]}} 2.5`
 
 - Print the full output of a locally saved recording:
 

--- a/pages/common/azurite.md
+++ b/pages/common/azurite.md
@@ -5,15 +5,15 @@
 
 - Use an existing location as workspace path:
 
-`azurite {{-l|--location}} {{path/to/directory}}`
+`azurite {{[-l|--location]}} {{path/to/directory}}`
 
 - Disable access log displayed in console:
 
-`azurite {{-s|--silent}}`
+`azurite {{[-s|--silent]}}`
 
 - Enable debug log by providing a file path as log destination:
 
-`azurite {{-d|--debug}} {{path/to/debug.log}}`
+`azurite {{[-d|--debug]}} {{path/to/debug.log}}`
 
 - Customize the listening address of Blob/Queue/Table service:
 

--- a/pages/common/base32.md
+++ b/pages/common/base32.md
@@ -9,11 +9,11 @@
 
 - Wrap encoded output at a specific width (`0` disables wrapping):
 
-`base32 {{-w|--wrap}} {{0|76|...}} {{path/to/file}}`
+`base32 {{[-w|--wrap]}} {{0|76|...}} {{path/to/file}}`
 
 - Decode a file:
 
-`base32 {{-d|--decode}} {{path/to/file}}`
+`base32 {{[-d|--decode]}} {{path/to/file}}`
 
 - Encode from `stdin`:
 
@@ -21,4 +21,4 @@
 
 - Decode from `stdin`:
 
-`{{command}} | base32 {{-d|--decode}}`
+`{{command}} | base32 {{[-d|--decode]}}`

--- a/pages/common/base64.md
+++ b/pages/common/base64.md
@@ -9,11 +9,11 @@
 
 - Wrap encoded output at a specific width (`0` disables wrapping):
 
-`base64 {{-w|--wrap}} {{0|76|...}} {{path/to/file}}`
+`base64 {{[-w|--wrap]}} {{0|76|...}} {{path/to/file}}`
 
 - Decode a file:
 
-`base64 {{-d|--decode}} {{path/to/file}}`
+`base64 {{[-d|--decode]}} {{path/to/file}}`
 
 - Encode from `stdin`:
 
@@ -21,4 +21,4 @@
 
 - Decode from `stdin`:
 
-`{{command}} | base64 {{-d|--decode}}`
+`{{command}} | base64 {{[-d|--decode]}}`

--- a/pages/common/bat.md
+++ b/pages/common/bat.md
@@ -18,20 +18,20 @@
 
 - Highlight a specific line or a range of lines with a different background color:
 
-`bat {{-H|--highlight-line}} {{10|5:10|:10|10:|10:+5}} {{path/to/file}}`
+`bat {{[-H|--highlight-line]}} {{10|5:10|:10|10:|10:+5}} {{path/to/file}}`
 
 - Show non-printable characters like space, tab or newline:
 
-`bat {{-A|--show-all}} {{path/to/file}}`
+`bat {{[-A|--show-all]}} {{path/to/file}}`
 
 - Remove all decorations except line numbers in the output:
 
-`bat {{-n|--number}} {{path/to/file}}`
+`bat {{[-n|--number]}} {{path/to/file}}`
 
 - Syntax highlight a JSON file by explicitly setting the language:
 
-`bat {{-l|--language}} json {{path/to/file.json}}`
+`bat {{[-l|--language]}} json {{path/to/file.json}}`
 
 - Display all supported languages:
 
-`bat {{-L|--list-languages}}`
+`bat {{[-L|--list-languages]}}`

--- a/pages/common/calibredb.md
+++ b/pages/common/calibredb.md
@@ -22,7 +22,7 @@
 
 - Recursively add all e-books under a directory to the library:
 
-`calibredb add {{-r|--recurse}} {{path/to/directory}}`
+`calibredb add {{[-r|--recurse]}} {{path/to/directory}}`
 
 - Remove one or more e-books from the library. You need the e-book IDs (see above):
 

--- a/pages/common/clang++.md
+++ b/pages/common/clang++.md
@@ -6,31 +6,31 @@
 
 - Compile a set of source code files into an executable binary:
 
-`clang++ {{path/to/source1.cpp path/to/source2.cpp ...}} {{-o|--output}} {{path/to/output_executable}}`
+`clang++ {{path/to/source1.cpp path/to/source2.cpp ...}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Activate output of all errors and warnings:
 
-`clang++ {{path/to/source.cpp}} -Wall {{-o|--output}} {{output_executable}}`
+`clang++ {{path/to/source.cpp}} -Wall {{[-o|--output]}} {{output_executable}}`
 
 - Show common warnings, debug symbols in output, and optimize without affecting debugging:
 
-`clang++ {{path/to/source.cpp}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{path/to/output_executable}}`
+`clang++ {{path/to/source.cpp}} -Wall {{[-g|--debug]}} -Og {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Choose a language standard to compile for:
 
-`clang++ {{path/to/source.cpp}} -std={{c++20}} {{-o|--output}} {{path/to/output_executable}}`
+`clang++ {{path/to/source.cpp}} -std={{c++20}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Include libraries located at a different path than the source file:
 
-`clang++ {{path/to/source.cpp}} {{-o|--output}} {{path/to/output_executable}} -I{{path/to/header_path}} -L{{path/to/library_path}} -l{{path/to/library_name}}`
+`clang++ {{path/to/source.cpp}} {{[-o|--output]}} {{path/to/output_executable}} -I{{path/to/header_path}} -L{{path/to/library_path}} -l{{path/to/library_name}}`
 
 - Compile source code into LLVM Intermediate Representation (IR):
 
-`clang++ {{-S|--assemble}} -emit-llvm {{path/to/source.cpp}} {{-o|--output}} {{path/to/output.ll}}`
+`clang++ {{[-S|--assemble]}} -emit-llvm {{path/to/source.cpp}} {{[-o|--output]}} {{path/to/output.ll}}`
 
 - Optimize the compiled program for performance:
 
-`clang++ {{path/to/source.cpp}} -O{{1|2|3|fast}} {{-o|--output}} {{path/to/output_executable}}`
+`clang++ {{path/to/source.cpp}} -O{{1|2|3|fast}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Display version:
 

--- a/pages/common/clang.md
+++ b/pages/common/clang.md
@@ -6,31 +6,31 @@
 
 - Compile multiple source files into an executable:
 
-`clang {{path/to/source1.c path/to/source2.c ...}} {{-o|--output}} {{path/to/output_executable}}`
+`clang {{path/to/source1.c path/to/source2.c ...}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Activate output of all errors and warnings:
 
-`clang {{path/to/source.c}} -Wall {{-o|--output}} {{output_executable}}`
+`clang {{path/to/source.c}} -Wall {{[-o|--output]}} {{output_executable}}`
 
 - Show common warnings, debug symbols in output, and optimize without affecting debugging:
 
-`clang {{path/to/source.c}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{path/to/output_executable}}`
+`clang {{path/to/source.c}} -Wall {{[-g|--debug]}} -Og {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Include libraries from a different path:
 
-`clang {{path/to/source.c}} {{-o|--output}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
+`clang {{path/to/source.c}} {{[-o|--output]}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
 
 - Compile source code into LLVM Intermediate Representation (IR):
 
-`clang {{-S|--assemble}} -emit-llvm {{path/to/source.c}} {{-o|--output}} {{path/to/output.ll}}`
+`clang {{[-S|--assemble]}} -emit-llvm {{path/to/source.c}} {{[-o|--output]}} {{path/to/output.ll}}`
 
 - Compile source code into an object file without linking:
 
-`clang {{-c|--compile}} {{path/to/source.c}}`
+`clang {{[-c|--compile]}} {{path/to/source.c}}`
 
 - Optimize the compiled program for performance:
 
-`clang {{path/to/source.c}} -O{{1|2|3|fast}} {{-o|--output}} {{path/to/output_executable}}`
+`clang {{path/to/source.c}} -O{{1|2|3|fast}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Display version:
 

--- a/pages/common/crane-append.md
+++ b/pages/common/crane-append.md
@@ -6,19 +6,19 @@
 
 - Push image based on a base image:
 
-`crane append {{-b|--base}} {{image_name}}`
+`crane append {{[-b|--base]}} {{image_name}}`
 
 - Push image with appended layer from tarball:
 
-`crane append {{-f|--new_layer}} {{layer_name1 layer_name2 ...}}`
+`crane append {{[-f|--new_layer]}} {{layer_name1 layer_name2 ...}}`
 
 - Push image with appended layer with new tag:
 
-`crane append {{-t|--new_tag}} {{tag_name}}`
+`crane append {{[-t|--new_tag]}} {{tag_name}}`
 
 - Push resulting image to new tarball:
 
-`crane append {{-o|--output}} {{path/to/tarball}}`
+`crane append {{[-o|--output]}} {{path/to/tarball}}`
 
 - Use empty base image of type OCI media instead of Docker:
 
@@ -30,4 +30,4 @@
 
 - Display help:
 
-`crane append {{-h|--help}}`
+`crane append {{[-h|--help]}}`

--- a/pages/common/crane-auth.md
+++ b/pages/common/crane-auth.md
@@ -9,20 +9,20 @@
 
 - Implement credential helper:
 
-`crane auth get {{registry_address}} {{-h|--help}}`
+`crane auth get {{registry_address}} {{[-h|--help]}}`
 
 - Log in to a registry:
 
-`crane auth login {{registry_address}} {{-h|--help}} {{-p|--password}} {{password}} {{-password-stdin}} {{-u|--username}} {{username}}`
+`crane auth login {{registry_address}} {{[-h|--help]}} {{[-p|--password]}} {{password}} {{-password-stdin}} {{[-u|--username]}} {{username}}`
 
 - Log out of a registry:
 
-`crane auth logout {{registry_address}} {{-h|--help}}`
+`crane auth logout {{registry_address}} {{[-h|--help]}}`
 
 - Retrieve a token for a remote repository:
 
-`crane auth token {{registry_address}} {{-H|--header}} {{-h|--help}} {{-m|--mount}} {{scope1 scope2 ...}} --push`
+`crane auth token {{registry_address}} {{[-H|--header]}} {{[-h|--help]}} {{[-m|--mount]}} {{scope1 scope2 ...}} --push`
 
 - Display help:
 
-`crane auth {{-h|--help}}`
+`crane auth {{[-h|--help]}}`

--- a/pages/common/crane-blob.md
+++ b/pages/common/crane-blob.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`crane blob {{-h|--help}}`
+`crane blob {{[-h|--help]}}`

--- a/pages/common/crane-catalog.md
+++ b/pages/common/crane-catalog.md
@@ -13,4 +13,4 @@
 
 - Display help:
 
-`crane catalog {{-h|--help}}`
+`crane catalog {{[-h|--help]}}`

--- a/pages/common/crane-config.md
+++ b/pages/common/crane-config.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`crane config {{-h|--help}}`
+`crane config {{[-h|--help]}}`

--- a/pages/common/crane-copy.md
+++ b/pages/common/crane-copy.md
@@ -9,16 +9,16 @@
 
 - Copy all tags:
 
-`crane copy {{source}} {{target}} {{-a|--all-tags}}`
+`crane copy {{source}} {{target}} {{[-a|--all-tags]}}`
 
 - Set the maximum number of concurrent copies, defaults to GOMAXPROCS:
 
-`crane copy {{source}} {{target}} {{-j|--jobs}} {{int}}`
+`crane copy {{source}} {{target}} {{[-j|--jobs]}} {{int}}`
 
 - Avoid overwriting existing tags in target:
 
-`crane copy {{source}} {{target}} {{-n|--no-clobber}}`
+`crane copy {{source}} {{target}} {{[-n|--no-clobber]}}`
 
 - Display help:
 
-`crane copy {{-h|--help}}`
+`crane copy {{[-h|--help]}}`

--- a/pages/common/crane-delete.md
+++ b/pages/common/crane-delete.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`crane delete {{-h|--help}}`
+`crane delete {{[-h|--help]}}`

--- a/pages/common/crane-digest.md
+++ b/pages/common/crane-digest.md
@@ -17,4 +17,4 @@
 
 - Display help:
 
-`crane digest {{-h|--help}}`
+`crane digest {{[-h|--help]}}`

--- a/pages/common/crane-flatten.md
+++ b/pages/common/crane-flatten.md
@@ -10,7 +10,7 @@
 
 - Apply new tag to flattened image:
 
-`crane flatten {{-t|--tag}} {{tag_name}}`
+`crane flatten {{[-t|--tag]}} {{tag_name}}`
 
 - Display help:
 

--- a/pages/common/crane-flatten.md
+++ b/pages/common/crane-flatten.md
@@ -14,4 +14,4 @@
 
 - Display help:
 
-`crane flatten {{-h|--help}}`
+`crane flatten {{[-h|--help]}}`

--- a/pages/common/crane-index-append.md
+++ b/pages/common/crane-index-append.md
@@ -11,11 +11,11 @@
 
 - Reference to manifests to append to the base index:
 
-`crane index append {{-m|--manifest}} {{manifest_name1 manifest_name2 ...}}`
+`crane index append {{[-m|--manifest]}} {{manifest_name1 manifest_name2 ...}}`
 
 - Tag to apply to resulting image:
 
-`crane index append {{-t|--tag}} {{tag_name}}`
+`crane index append {{[-t|--tag]}} {{tag_name}}`
 
 - Empty base index will have Docker media types instead of OCI:
 
@@ -27,4 +27,4 @@
 
 - Display help:
 
-`crane index append {{-h|--help}}`
+`crane index append {{[-h|--help]}}`

--- a/pages/common/crane-index-filter.md
+++ b/pages/common/crane-index-filter.md
@@ -13,8 +13,8 @@
 
 - Tag to apply to resulting image:
 
-`crane index filter {{-t|--tags}} {{tag_name}}`
+`crane index filter {{[-t|--tags]}} {{tag_name}}`
 
 - Display help:
 
-`crane index filter {{-h|--help}}`
+`crane index filter {{[-h|--help]}}`

--- a/pages/common/crane-index.md
+++ b/pages/common/crane-index.md
@@ -14,4 +14,4 @@
 
 - Display help:
 
-`crane index {{-h|--help}}`
+`crane index {{[-h|--help]}}`

--- a/pages/common/crane-ls.md
+++ b/pages/common/crane-ls.md
@@ -13,8 +13,8 @@
 
 - Omit digest tags:
 
-`crane ls {{-o|--omit-digest-tags}}`
+`crane ls {{[-o|--omit-digest-tags]}}`
 
 - Display help:
 
-`crane ls {{-h|--help}}`
+`crane ls {{[-h|--help]}}`

--- a/pages/common/crane-manifest.md
+++ b/pages/common/crane-manifest.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`crane manifest {{-h|--help}}`
+`crane manifest {{[-h|--help]}}`

--- a/pages/common/crane-mutate.md
+++ b/pages/common/crane-mutate.md
@@ -6,15 +6,15 @@
 
 - New annotations to set (default []):
 
-`crane mutate {{-a|--annotation}}/{{-l|--label}} {{annotation/label}}`
+`crane mutate {{[-a|--annotation]}}/{{[-l|--label]}} {{annotation/label}}`
 
 - Path to tarball/command/entrypoint/environment variable/exposed-ports to append to image:
 
-`crane mutate {{--append}}/{{--cmd}}/{{--entrypoint}}/{{-e|--env}}/{{--exposed-ports}} {{var1 var2 ...}}`
+`crane mutate {{--append}}/{{--cmd}}/{{--entrypoint}}/{{[-e|--env]}}/{{--exposed-ports}} {{var1 var2 ...}}`
 
 - Path to new tarball of resulting image:
 
-`crane mutate {{-o|--output}} {{path/to/tarball}}`
+`crane mutate {{[-o|--output]}} {{path/to/tarball}}`
 
 - Repository in the form os/arch{{/variant}}{{:osversion}}{{,<platform>}} to push mutated image:
 
@@ -22,16 +22,16 @@
 
 - New tag reference to apply to mutated image:
 
-`crane mutate {{-t|--tag}} {{tag_name}}`
+`crane mutate {{[-t|--tag]}} {{tag_name}}`
 
 - New user to set:
 
-`crane mutate {{-u|--user}} {{username}}`
+`crane mutate {{[-u|--user]}} {{username}}`
 
 - New working dir to set:
 
-`crane mutate {{-w|--workdir}} {{path/to/workdir}}`
+`crane mutate {{[-w|--workdir]}} {{path/to/workdir}}`
 
 - Display help:
 
-`crane mutate {{-h|--help}}`
+`crane mutate {{[-h|--help]}}`

--- a/pages/common/crane-pull.md
+++ b/pages/common/crane-pull.md
@@ -13,7 +13,7 @@
 
 - Path to cache image layers:
 
-`crane pull {{image_name}} {{path/to/tarball}} {{-c|--cache_path}} {{path/to/cache}}`
+`crane pull {{image_name}} {{path/to/tarball}} {{[-c|--cache_path]}} {{path/to/cache}}`
 
 - Format in which to save images (default 'tarball'):
 
@@ -21,4 +21,4 @@
 
 - Display help:
 
-`crane pull {{-h|--help}}`
+`crane pull {{[-h|--help]}}`

--- a/pages/common/crane-push.md
+++ b/pages/common/crane-push.md
@@ -17,4 +17,4 @@
 
 - Display help:
 
-`crane push {{-h|--help}}`
+`crane push {{[-h|--help]}}`

--- a/pages/common/crane-rebase.md
+++ b/pages/common/crane-rebase.md
@@ -17,8 +17,8 @@
 
 - Tag to apply to rebased image:
 
-`crane rebase {{-t|--tag}} {{tag_name}}`
+`crane rebase {{[-t|--tag]}} {{tag_name}}`
 
 - Display help:
 
-`crane rebase {{-h|--help}}`
+`crane rebase {{[-h|--help]}}`

--- a/pages/common/crane-registry.md
+++ b/pages/common/crane-registry.md
@@ -18,8 +18,8 @@
 
 - Display help for `crane registry`:
 
-`crane registry {{-h|--help}}`
+`crane registry {{[-h|--help]}}`
 
 - Display help for `crane registry serve`:
 
-`crane registry serve {{-h|--help}}`
+`crane registry serve {{[-h|--help]}}`

--- a/pages/common/crane-tag.md
+++ b/pages/common/crane-tag.md
@@ -10,4 +10,4 @@
 
 - Display help:
 
-`crane tag {{-h|--help}}`
+`crane tag {{[-h|--help]}}`

--- a/pages/common/crane-validate.md
+++ b/pages/common/crane-validate.md
@@ -21,4 +21,4 @@
 
 - Display help:
 
-`crane validate {{-h|--help}}`
+`crane validate {{[-h|--help]}}`

--- a/pages/common/crane-version.md
+++ b/pages/common/crane-version.md
@@ -10,4 +10,4 @@
 
 - Display help:
 
-`crane version {{-h|--help}}`
+`crane version {{[-h|--help]}}`

--- a/pages/common/crane.md
+++ b/pages/common/crane.md
@@ -22,8 +22,8 @@
 
 - Enable debug logs for a subcommand:
 
-`crane {{-v|--verbose}} {{subcommand}}`
+`crane {{[-v|--verbose]}} {{subcommand}}`
 
 - Display help for a subcommand:
 
-`crane {{-h|--help}} {{subcommand}}`
+`crane {{[-h|--help]}} {{subcommand}}`

--- a/pages/common/diff.md
+++ b/pages/common/diff.md
@@ -9,28 +9,28 @@
 
 - Compare files, ignoring white spaces:
 
-`diff {{-w|--ignore-all-space}} {{old_file}} {{new_file}}`
+`diff {{[-w|--ignore-all-space]}} {{old_file}} {{new_file}}`
 
 - Compare files, showing the differences side by side:
 
-`diff {{-y|--side-by-side}} {{old_file}} {{new_file}}`
+`diff {{[-y|--side-by-side]}} {{old_file}} {{new_file}}`
 
 - Compare files, showing the differences in unified format (as used by `git diff`):
 
-`diff {{-u|--unified}} {{old_file}} {{new_file}}`
+`diff {{[-u|--unified]}} {{old_file}} {{new_file}}`
 
 - Compare directories recursively (shows names for differing files/directories as well as changes made to files):
 
-`diff {{-r|--recursive}} {{old_directory}} {{new_directory}}`
+`diff {{[-r|--recursive]}} {{old_directory}} {{new_directory}}`
 
 - Compare directories, only showing the names of files that differ:
 
-`diff {{-r|--recursive}} {{-q|--brief}} {{old_directory}} {{new_directory}}`
+`diff {{[-r|--recursive]}} {{[-q|--brief]}} {{old_directory}} {{new_directory}}`
 
 - Create a patch file for Git from the differences of two text files, treating nonexistent files as empty:
 
-`diff {{-a|--text}} {{-u|--unified}} {{-N|--new-file}} {{old_file}} {{new_file}} > {{diff.patch}}`
+`diff {{[-a|--text]}} {{[-u|--unified]}} {{[-N|--new-file]}} {{old_file}} {{new_file}} > {{diff.patch}}`
 
 - Compare files, showing output in color and try hard to find smaller set of changes:
 
-`diff {{-d|--minimal}} --color=always {{old_file}} {{new_file}}`
+`diff {{[-d|--minimal]}} --color=always {{old_file}} {{new_file}}`

--- a/pages/common/ffsend.md
+++ b/pages/common/ffsend.md
@@ -13,12 +13,12 @@
 
 - Upload a file with password:
 
-`ffsend upload {{path/to/file}} {{-p|--password}} {{password}}`
+`ffsend upload {{path/to/file}} {{[-p|--password]}} {{password}}`
 
 - Download a file protected by password:
 
-`ffsend download {{url}} {{-p|--password}} {{password}}`
+`ffsend download {{url}} {{[-p|--password]}} {{password}}`
 
 - Upload a file and allow 4 downloads:
 
-`ffsend upload {{path/to/file}} {{-d|--downloads}} {{4}}`
+`ffsend upload {{path/to/file}} {{[-d|--downloads]}} {{4}}`

--- a/pages/common/filebrowser.md
+++ b/pages/common/filebrowser.md
@@ -9,28 +9,28 @@
 
 - Start a new server instance serving a specific root directory:
 
-`filebrowser {{-r|--root}} {{path/to/directory}}`
+`filebrowser {{[-r|--root]}} {{path/to/directory}}`
 
 - Start an instance with different host address (defaults to `127.0.0.1`) and port (defaults to `8080`):
 
-`filebrowser {{-a|--address}} {{host}} {{-p|--port}} {{port}} {{-r|--root}} {{path/to/directory}}`
+`filebrowser {{[-a|--address]}} {{host}} {{[-p|--port]}} {{port}} {{[-r|--root]}} {{path/to/directory}}`
 
 - Start an instance with a specified configuration file, storing the application database in a specific location (defaults to `filebrowser.db` on the current directory):
 
-`filebrowser {{-c|--config}} {{path/to/file}} {{-d|--database}} {{path/to/database.db}} {{-r|--root}} {{path/to/directory}}`
+`filebrowser {{[-c|--config]}} {{path/to/file}} {{[-d|--database]}} {{path/to/database.db}} {{[-r|--root]}} {{path/to/directory}}`
 
 - Set up a different default first-time account username and password (both default to `admin`) when setting up a new instance:
 
-`filebrowser --username {{username}} --password {{password}} {{-r|--root}} {{path/to/directory}}`
+`filebrowser --username {{username}} --password {{password}} {{[-r|--root]}} {{path/to/directory}}`
 
 - Set up the maximum amount of image processors used when generating thumbnails (defaults to `4`):
 
-`filebrowser --img-processors {{4}} {{-r|--root}} {{path/to/directory}}`
+`filebrowser --img-processors {{4}} {{[-r|--root]}} {{path/to/directory}}`
 
 - Disable image thumbnails as well as the Command Runner feature, limiting access for hosted script files from being executed inside the app:
 
-`filebrowser --disable-exec --disable-thumbnails {{-r|--root}} {{path/to/directory}}`
+`filebrowser --disable-exec --disable-thumbnails {{[-r|--root]}} {{path/to/directory}}`
 
 - Disable resizing of image previews as well as detecting file types by reading their headers:
 
-`filebrowser --disable-preview-resize --disable-type-detection-by-header {{-r|--root}} {{path/to/directory}}`
+`filebrowser --disable-preview-resize --disable-type-detection-by-header {{[-r|--root]}} {{path/to/directory}}`

--- a/pages/common/frpc.md
+++ b/pages/common/frpc.md
@@ -10,15 +10,15 @@
 
 - Start the service, using the newer TOML configuration file (`frps.toml` instead of `frps.ini`) in the current directory:
 
-`frpc {{-c|--config}} ./frps.toml`
+`frpc {{[-c|--config]}} ./frps.toml`
 
 - Start the service, using a specific configuration file:
 
-`frpc {{-c|--config}} {{path/to/file}}`
+`frpc {{[-c|--config]}} {{path/to/file}}`
 
 - Check if the configuration file is valid:
 
-`frpc verify {{-c|--config}} {{path/to/file}}`
+`frpc verify {{[-c|--config]}} {{path/to/file}}`
 
 - Print autocompletion setup script for Bash, fish, PowerShell, or Zsh:
 
@@ -26,4 +26,4 @@
 
 - Display version:
 
-`frpc {{-v|--version}}`
+`frpc {{[-v|--version]}}`

--- a/pages/common/frps.md
+++ b/pages/common/frps.md
@@ -10,15 +10,15 @@
 
 - Start the service, using the newer TOML configuration file (`frps.toml` instead of `frps.ini`) in the current directory:
 
-`frps {{-c|--config}} ./frps.toml`
+`frps {{[-c|--config]}} ./frps.toml`
 
 - Start the service, using a specified config file:
 
-`frps {{-c|--config}} {{path/to/file}}`
+`frps {{[-c|--config]}} {{path/to/file}}`
 
 - Check if the configuration file is valid:
 
-`frps verify {{-c|--config}} {{path/to/file}}`
+`frps verify {{[-c|--config]}} {{path/to/file}}`
 
 - Print autocompletion setup script for Bash, fish, PowerShell, or Zsh:
 
@@ -26,4 +26,4 @@
 
 - Display version:
 
-`frps {{-v|--version}}`
+`frps {{[-v|--version]}}`

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -6,31 +6,31 @@
 
 - Compile a source code file into an executable binary:
 
-`g++ {{path/to/source1.cpp path/to/source2.cpp ...}} {{-o|--output}} {{path/to/output_executable}}`
+`g++ {{path/to/source1.cpp path/to/source2.cpp ...}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Activate output of all errors and warnings:
 
-`g++ {{path/to/source.cpp}} -Wall {{-o|--output}} {{output_executable}}`
+`g++ {{path/to/source.cpp}} -Wall {{[-o|--output]}} {{output_executable}}`
 
 - Show common warnings, debug symbols in output, and optimize without affecting debugging:
 
-`g++ {{path/to/source.cpp}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{path/to/output_executable}}`
+`g++ {{path/to/source.cpp}} -Wall {{[-g|--debug]}} -Og {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Choose a language standard to compile for (C++98/C++11/C++14/C++17):
 
-`g++ {{path/to/source.cpp}} -std={{c++98|c++11|c++14|c++17}} {{-o|--output}} {{path/to/output_executable}}`
+`g++ {{path/to/source.cpp}} -std={{c++98|c++11|c++14|c++17}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Include libraries located at a different path than the source file:
 
-`g++ {{path/to/source.cpp}} {{-o|--output}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
+`g++ {{path/to/source.cpp}} {{[-o|--output]}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
 
 - Compile and link multiple source code files into an executable binary:
 
-`g++ {{-c|--compile}} {{path/to/source1.cpp path/to/source2.cpp ...}} && g++ {{-o|--output}} {{path/to/output_executable}} {{path/to/source1.o path/to/source2.o ...}}`
+`g++ {{[-c|--compile]}} {{path/to/source1.cpp path/to/source2.cpp ...}} && g++ {{[-o|--output]}} {{path/to/output_executable}} {{path/to/source1.o path/to/source2.o ...}}`
 
 - Optimize the compiled program for performance:
 
-`g++ {{path/to/source.cpp}} -O{{1|2|3|fast}} {{-o|--output}} {{path/to/output_executable}}`
+`g++ {{path/to/source.cpp}} -O{{1|2|3|fast}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Display version:
 

--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -6,31 +6,31 @@
 
 - Compile multiple source files into an executable:
 
-`gcc {{path/to/source1.c path/to/source2.c ...}} {{-o|--output}} {{path/to/output_executable}}`
+`gcc {{path/to/source1.c path/to/source2.c ...}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Activate output of all errors and warnings:
 
-`gcc {{path/to/source.c}} -Wall {{-o|--output}} {{output_executable}}`
+`gcc {{path/to/source.c}} -Wall {{[-o|--output]}} {{output_executable}}`
 
 - Show common warnings, debug symbols in output, and optimize without affecting debugging:
 
-`gcc {{path/to/source.c}} -Wall {{-g|--debug}} -Og {{-o|--output}} {{path/to/output_executable}}`
+`gcc {{path/to/source.c}} -Wall {{[-g|--debug]}} -Og {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Include libraries from a different path:
 
-`gcc {{path/to/source.c}} {{-o|--output}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
+`gcc {{path/to/source.c}} {{[-o|--output]}} {{path/to/output_executable}} -I{{path/to/header}} -L{{path/to/library}} -l{{library_name}}`
 
 - Compile source code into Assembler instructions:
 
-`gcc {{-S|--assemble}} {{path/to/source.c}}`
+`gcc {{[-S|--assemble]}} {{path/to/source.c}}`
 
 - Compile source code into an object file without linking:
 
-`gcc {{-c|--compile}} {{path/to/source.c}}`
+`gcc {{[-c|--compile]}} {{path/to/source.c}}`
 
 - Optimize the compiled program for performance:
 
-`gcc {{path/to/source.c}} -O{{1|2|3|fast}} {{-o|--output}} {{path/to/output_executable}}`
+`gcc {{path/to/source.c}} -O{{1|2|3|fast}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Display version:
 


### PR DESCRIPTION
These are only the ones I caught with `grep -rE '\{\{-.*?\|--.*?\}\}' --color`
Any further option placeholders that don't contain dashes (like `ip {{l|link}}`) will have to be hunted with other means.
