### PR TITLE
pages/common/*: add option placeholders part 2

### DIFF
--- a/pages/common/gcrane-copy.md
+++ b/pages/common/gcrane-copy.md
@@ -5,16 +5,16 @@
 
 - Copy an image from source to target:
 
-`gcrane {{cp|copy}} {{source}} {{target}}`
+`gcrane {{[cp|copy]}} {{source}} {{target}}`
 
 - Set the maximum number of concurrent copies, defaults to 20:
 
-`gcrane copy {{source}} {{target}} {{-j|--jobs}} {{nr_of_copies}}`
+`gcrane copy {{source}} {{target}} {{[-j|--jobs]}} {{nr_of_copies}}`
 
 - Whether to recurse through repositories:
 
-`gcrane copy {{source}} {{target}} {{-r|--recursive}}`
+`gcrane copy {{source}} {{target}} {{[-r|--recursive]}}`
 
 - Display help:
 
-`gcrane copy {{-h|--help}}`
+`gcrane copy {{[-h|--help]}}`

--- a/pages/common/gcrane-gc.md
+++ b/pages/common/gcrane-gc.md
@@ -11,8 +11,8 @@
 
 - Whether to recurse through repositories:
 
-`gcrane gc {{repository}} {{-r|--recursive}}`
+`gcrane gc {{repository}} {{[-r|--recursive]}}`
 
 - Display help:
 
-`gcrane gc {{-h|--help}}`
+`gcrane gc {{[-h|--help]}}`

--- a/pages/common/gcrane-help.md
+++ b/pages/common/gcrane-help.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`gcrane help {{-h|--help}}`
+`gcrane help {{[-h|--help]}}`

--- a/pages/common/gcrane-ls.md
+++ b/pages/common/gcrane-ls.md
@@ -14,8 +14,8 @@
 
 - Whether to recurse through repositories:
 
-`gcrane ls {{repository}} {{-r|--recursive}}`
+`gcrane ls {{repository}} {{[-r|--recursive]}}`
 
 - Display help:
 
-`gcrane ls {{-h|--help}}`
+`gcrane ls {{[-h|--help]}}`

--- a/pages/common/gcrane.md
+++ b/pages/common/gcrane.md
@@ -24,8 +24,8 @@
 
 - Enable debug logs:
 
-`gcrane {{-v|--verbose}} {{subcommand}}`
+`gcrane {{[-v|--verbose]}} {{subcommand}}`
 
 - Display help:
 
-`gcrane {{-h|--help}}`
+`gcrane {{[-h|--help]}}`

--- a/pages/common/git-bugreport.md
+++ b/pages/common/git-bugreport.md
@@ -9,8 +9,8 @@
 
 - Create a new bug report file in the specified directory, creating it if it does not exist:
 
-`git bugreport {{-o|--output-directory}} {{path/to/directory}}`
+`git bugreport {{[-o|--output-directory]}} {{path/to/directory}}`
 
 - Create a new bug report file with the specified filename suffix in `strftime` format:
 
-`git bugreport {{-s|--suffix}} {{%m%d%y}}`
+`git bugreport {{[-s|--suffix]}} {{%m%d%y}}`

--- a/pages/common/git-cliff.md
+++ b/pages/common/git-cliff.md
@@ -9,7 +9,7 @@
 
 - Generate a changelog from commits starting from the latest tag and print it to `stdout`:
 
-`git cliff {{-l|--latest}}`
+`git cliff {{[-l|--latest]}}`
 
 - Generate a changelog from commits that belong to the current tag (use `git checkout` on a tag before this):
 
@@ -17,8 +17,8 @@
 
 - Generate a changelog from commits that do not belong to a tag:
 
-`git cliff {{-u|--unreleased}}`
+`git cliff {{[-u|--unreleased]}}`
 
 - Write the default config file to `cliff.toml` in the current directory:
 
-`git cliff {{-i|--init}}`
+`git cliff {{[-i|--init]}}`

--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -5,19 +5,19 @@
 
 - Commit staged files to the repository with a message:
 
-`git commit --message "{{message}}"`
+`git commit {{[-m|--message]}} "{{message}}"`
 
 - Commit staged files with a message read from a file:
 
-`git commit --file {{path/to/commit_message_file}}`
+`git commit {{[-F|--file]}} {{path/to/commit_message_file}}`
 
 - Auto stage all modified and deleted files and commit with a message:
 
-`git commit --all --message "{{message}}"`
+`git commit {{[-a|--all]}} {{[-m|--message]}} "{{message}}"`
 
 - Commit staged files and sign them with the specified GPG key (or the one defined in the configuration file if no argument is specified):
 
-`git commit --gpg-sign {{key_id}} --message "{{message}}"`
+`git commit {{[-S|--gpg-sign]}} {{key_id}} {{[-m|--message]}} "{{message}}"`
 
 - Update the last commit by adding the currently staged changes, changing the commit's hash:
 
@@ -29,4 +29,4 @@
 
 - Create a commit, even if there are no staged files:
 
-`git commit --message "{{message}}" --allow-empty`
+`git commit {{[-m|--message]}} "{{message}}" --allow-empty`

--- a/pages/common/git-pull.md
+++ b/pages/common/git-pull.md
@@ -9,7 +9,7 @@
 
 - Download changes from default remote repository and use fast-forward:
 
-`git pull --rebase`
+`git pull {{[-r|--rebase]}}`
 
 - Download changes from given remote repository and branch, then merge them into HEAD:
 

--- a/pages/common/git-switch.md
+++ b/pages/common/git-switch.md
@@ -10,11 +10,11 @@
 
 - Create a new branch and switch to it:
 
-`git switch --create {{branch_name}}`
+`git switch {{[-c|--create]}} {{branch_name}}`
 
 - Create a new branch based on an existing commit and switch to it:
 
-`git switch --create {{branch_name}} {{commit}}`
+`git switch {{[-c|--create]}} {{branch_name}} {{commit}}`
 
 - Switch to the previous branch:
 
@@ -26,4 +26,4 @@
 
 - Switch to a branch and automatically merge the current branch and any uncommitted changes into it:
 
-`git switch --merge {{branch_name}}`
+`git switch {{[-m|--merge]}} {{branch_name}}`

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -9,15 +9,15 @@
 
 - Search for an exact string (disables regular expressions):
 
-`grep {{-F|--fixed-strings}} "{{exact_string}}" {{path/to/file}}`
+`grep {{[-F|--fixed-strings]}} "{{exact_string}}" {{path/to/file}}`
 
 - Search for a pattern in all files recursively in a directory, showing line numbers of matches, ignoring binary files:
 
-`grep {{-r|--recursive}} {{-n|--line-number}} --binary-files {{without-match}} "{{search_pattern}}" {{path/to/directory}}`
+`grep {{[-r|--recursive]}} {{[-n|--line-number]}} --binary-files {{without-match}} "{{search_pattern}}" {{path/to/directory}}`
 
 - Use extended regular expressions (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
 
-`grep {{-E|--extended-regexp}} {{-i|--ignore-case}} "{{search_pattern}}" {{path/to/file}}`
+`grep {{[-E|--extended-regexp]}} {{[-i|--ignore-case]}} "{{search_pattern}}" {{path/to/file}}`
 
 - Print 3 lines of context around, before, or after each match:
 
@@ -25,12 +25,12 @@
 
 - Print file name and line number for each match with color output:
 
-`grep {{-H|--with-filename}} {{-n|--line-number}} --color=always "{{search_pattern}}" {{path/to/file}}`
+`grep {{[-H|--with-filename]}} {{[-n|--line-number]}} --color=always "{{search_pattern}}" {{path/to/file}}`
 
 - Search for lines matching a pattern, printing only the matched text:
 
-`grep {{-o|--only-matching}} "{{search_pattern}}" {{path/to/file}}`
+`grep {{[-o|--only-matching]}} "{{search_pattern}}" {{path/to/file}}`
 
 - Search `stdin` for lines that do not match a pattern:
 
-`cat {{path/to/file}} | grep {{-v|--invert-match}} "{{search_pattern}}"`
+`cat {{path/to/file}} | grep {{[-v|--invert-match]}} "{{search_pattern}}"`

--- a/pages/common/gzip.md
+++ b/pages/common/gzip.md
@@ -9,24 +9,24 @@
 
 - Decompress a file, replacing it with the original uncompressed version:
 
-`gzip {{-d|--decompress}} {{path/to/file.gz}}`
+`gzip {{[-d|--decompress]}} {{path/to/file.gz}}`
 
 - Compress a file, keeping the original file:
 
-`gzip {{-k|--keep}} {{path/to/file}}`
+`gzip {{[-k|--keep]}} {{path/to/file}}`
 
 - Compress a file, specifying the output filename:
 
-`gzip {{-c|--stdout}} {{path/to/file}} > {{path/to/compressed_file.gz}}`
+`gzip {{[-c|--stdout]}} {{path/to/file}} > {{path/to/compressed_file.gz}}`
 
 - Decompress a `gzip` archive specifying the output filename:
 
-`gzip {{-c|--stdout}} {{-d|--decompress}} {{path/to/file.gz}} > {{path/to/uncompressed_file}}`
+`gzip {{[-c|--stdout]}} {{[-d|--decompress]}} {{path/to/file.gz}} > {{path/to/uncompressed_file}}`
 
 - Specify the compression level. 1 is the fastest (low compression), 9 is the slowest (high compression), 6 is the default:
 
-`gzip -{{1..9}} {{-c|--stdout}} {{path/to/file}} > {{path/to/compressed_file.gz}}`
+`gzip -{{1..9}} {{[-c|--stdout]}} {{path/to/file}} > {{path/to/compressed_file.gz}}`
 
 - Display the name and reduction percentage for each file compressed or decompressed:
 
-`gzip {{-v|--verbose}} {{-d|--decompress}} {{path/to/file.gz}}`
+`gzip {{[-v|--verbose]}} {{[-d|--decompress]}} {{path/to/file.gz}}`

--- a/pages/common/http.md
+++ b/pages/common/http.md
@@ -17,7 +17,7 @@
 
 - Follow any `3xx` redirects and specify additional headers in a request:
 
-`http {{-F|--follow}} {{https://example.com}} {{'User-Agent: Mozilla/5.0' 'Accept-Encoding: gzip'}}`
+`http {{[-F|--follow]}} {{https://example.com}} {{'User-Agent: Mozilla/5.0' 'Accept-Encoding: gzip'}}`
 
 - Authenticate to a server using different authentication methods:
 

--- a/pages/common/img2sixel.md
+++ b/pages/common/img2sixel.md
@@ -9,4 +9,4 @@
 
 - Resize the image to the specified width and height before displaying it:
 
-`img2sixel {{-w|--width}} {{number}} {{-h|--height}} {{number}} {{path/to/image}}`
+`img2sixel {{[-w|--width]}} {{number}} {{[-h|--height]}} {{number}} {{path/to/image}}`

--- a/pages/common/lsar.md
+++ b/pages/common/lsar.md
@@ -14,7 +14,7 @@
 
 - Print al[L] available information about each file in the archive (it's very long):
 
-`lsar {{-L|--verylong}} {{path/to/archive}}`
+`lsar {{[-L|--verylong]}} {{path/to/archive}}`
 
 - Test the integrity of the files in the archive (if possible):
 

--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -10,11 +10,11 @@
 
 - Start `mitmproxy` bound to a custom address and port:
 
-`mitmproxy --listen-host {{ip_address}} {{-p|--listen-port}} {{port}}`
+`mitmproxy --listen-host {{ip_address}} {{[-p|--listen-port]}} {{port}}`
 
 - Start `mitmproxy` using a script to process traffic:
 
-`mitmproxy {{-s|--scripts}} {{path/to/script.py}}`
+`mitmproxy {{[-s|--scripts]}} {{path/to/script.py}}`
 
 - Export the logs with SSL/TLS master keys to external programs (wireshark, etc.):
 
@@ -22,7 +22,7 @@
 
 - Specify mode of operation of the proxy server (`regular` is the default):
 
-`mitmproxy {{-m|--mode}} {{regular|transparent|socks5|...}}`
+`mitmproxy {{[-m|--mode]}} {{regular|transparent|socks5|...}}`
 
 - Set the console layout:
 

--- a/pages/common/nettacker.md
+++ b/pages/common/nettacker.md
@@ -9,12 +9,12 @@
 
 - Run a port scan on targets:
 
-`nettacker {{-m|--modules}} port_scan {{-i|--targets}} {{192.168.0.1/24,owasp.org,scanme.org,...}}`
+`nettacker {{[-m|--modules]}} port_scan {{[-i|--targets]}} {{192.168.0.1/24,owasp.org,scanme.org,...}}`
 
 - Run a port scan on specific ports and targets listed in a file (newline separated):
 
-`nettacker {{-m|--modules}} port_scan {{-g|--ports}} {{22,80,443,...}} {{-l|--targets-list}} {{path/to/targets.txt}}`
+`nettacker {{[-m|--modules]}} port_scan {{[-g|--ports]}} {{22,80,443,...}} {{[-l|--targets-list]}} {{path/to/targets.txt}}`
 
 - Run ping test before scan and then run multiple scan types on target:
 
-`nettacker --ping-before-scan {{-m|--modules}} {{port_scan,subdomain_scan,waf_scan,...}} {{-g|--ports}} {{80,443}} {{-i|--targets}} {{owasp.org}}`
+`nettacker --ping-before-scan {{[-m|--modules]}} {{port_scan,subdomain_scan,waf_scan,...}} {{[-g|--ports]}} {{80,443}} {{[-i|--targets]}} {{owasp.org}}`

--- a/pages/common/npm-audit.md
+++ b/pages/common/npm-audit.md
@@ -14,7 +14,7 @@
 
 - Force an automatic fix to dependencies with vulnerabilities:
 
-`npm audit fix {{-f|--force}}`
+`npm audit fix {{[-f|--force]}}`
 
 - Update the lock file without modifying the `node_modules` directory:
 

--- a/pages/common/npm-install.md
+++ b/pages/common/npm-install.md
@@ -17,4 +17,4 @@
 
 - Download the latest version of a package and install it globally:
 
-`npm install {{-g|--global}} {{package_name}}`
+`npm install {{[-g|--global]}} {{package_name}}`

--- a/pages/common/ntfyme.md
+++ b/pages/common/ntfyme.md
@@ -6,7 +6,7 @@
 
 - Directly run your command:
 
-`ntfyme exec {{-c|--cmd}} {{command}}`
+`ntfyme exec {{[-c|--cmd]}} {{command}}`
 
 - Pipe your command and run:
 
@@ -18,7 +18,7 @@
 
 - Track and terminate the process after prolonged suspension:
 
-`ntfyme exec {{-t|--track-process}} {{-c|--cmd}} {{command}}`
+`ntfyme exec {{-t|--track-process}} {{[-c|--cmd]}} {{command}}`
 
 - Setup the tool configurations interactively:
 

--- a/pages/common/onefetch.md
+++ b/pages/common/onefetch.md
@@ -29,8 +29,8 @@
 
 - Ignore the specified files and directories:
 
-`onefetch {{-e|--exclude}} {{path/to/file_or_directory|regular_expression}}`
+`onefetch {{[-e|--exclude]}} {{path/to/file_or_directory|regular_expression}}`
 
 - Only detect languages from the specified categories (default: programming and markup):
 
-`onefetch {{-T|--type}} {{programming|markup|prose|data}}`
+`onefetch {{[-T|--type]}} {{programming|markup|prose|data}}`

--- a/pages/common/pandoc.md
+++ b/pages/common/pandoc.md
@@ -5,15 +5,15 @@
 
 - Convert file to PDF (the output format is determined by file extension):
 
-`pandoc {{path/to/input.md}} {{-o|--output}} {{path/to/output.pdf}}`
+`pandoc {{path/to/input.md}} {{[-o|--output]}} {{path/to/output.pdf}}`
 
 - Convert to a standalone file with the appropriate headers/footers (for LaTeX, HTML, etc.):
 
-`pandoc {{path/to/input.md}} {{-s|--standalone}} {{-o|--output}} {{path/to/output.html}}`
+`pandoc {{path/to/input.md}} {{[-s|--standalone]}} {{[-o|--output]}} {{path/to/output.html}}`
 
 - Manually specify format detection and conversion (overriding automatic format detection using filename extension or when filename extension is missing altogether):
 
-`pandoc {{-f|-r|--from|--read}} {{docx|...}} {{path/to/input}} {{-t|-w|--to|--write}} {{pdf|...}} {{-o|--output}} {{path/to/output}}`
+`pandoc {{-f|-r|--from|--read}} {{docx|...}} {{path/to/input}} {{-t|-w|--to|--write}} {{pdf|...}} {{[-o|--output]}} {{path/to/output}}`
 
 - List all supported input formats:
 

--- a/pages/common/pg_dumpall.md
+++ b/pages/common/pg_dumpall.md
@@ -9,7 +9,7 @@
 
 - Dump all databases using a specific username:
 
-`pg_dumpall {{-U|--username}} {{username}} > {{path/to/file.sql}}`
+`pg_dumpall {{[-U|--username]}} {{username}} > {{path/to/file.sql}}`
 
 - Same as above, customize host and port:
 
@@ -17,7 +17,7 @@
 
 - Dump only database data into an SQL-script file:
 
-`pg_dumpall {{-a|--data-only}} > {{path/to/file.sql}}`
+`pg_dumpall {{[-a|--data-only]}} > {{path/to/file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 

--- a/pages/common/podman-compose.md
+++ b/pages/common/podman-compose.md
@@ -17,7 +17,7 @@
 
 - Start all containers using an alternate compose file:
 
-`podman-compose {{-f|--file}} {{path/to/file.yaml}} up`
+`podman-compose {{[-f|--file]}} {{path/to/file.yaml}} up`
 
 - Stop all running containers:
 

--- a/pages/common/pulumi-login.md
+++ b/pages/common/pulumi-login.md
@@ -13,4 +13,4 @@
 
 - Use Pulumi locally, independent of a Pulumi Cloud:
 
-`pulumi login {{-l|--local}}`
+`pulumi login {{[-l|--local]}}`

--- a/pages/common/pulumi-logout.md
+++ b/pages/common/pulumi-logout.md
@@ -13,8 +13,8 @@
 
 - Log out of using local mode:
 
-`pulumi logout {{-l|--local}}`
+`pulumi logout {{[-l|--local]}}`
 
 - Display help:
 
-`pulumi logout {{-h|--help}}`
+`pulumi logout {{[-h|--help]}}`

--- a/pages/common/pulumi-version.md
+++ b/pages/common/pulumi-version.md
@@ -9,4 +9,4 @@
 
 - Display help:
 
-`pulumi version {{-h|--help}}`
+`pulumi version {{[-h|--help]}}`

--- a/pages/common/pulumi-whoami.md
+++ b/pages/common/pulumi-whoami.md
@@ -9,12 +9,12 @@
 
 - Print detailed information about the currently logged in user:
 
-`pulumi whoami {{-v|--verbose}}`
+`pulumi whoami {{[-v|--verbose]}}`
 
 - Print detailed information about the currently logged in user as JSON:
 
-`pulumi whoami {{-j|--json}}`
+`pulumi whoami {{[-j|--json]}}`
 
 - Display help:
 
-`pulumi whoami {{-h|--help}}`
+`pulumi whoami {{[-h|--help]}}`

--- a/pages/common/pulumi.md
+++ b/pages/common/pulumi.md
@@ -30,4 +30,4 @@
 
 - Use Pulumi locally, independent of a Pulumi Cloud:
 
-`pulumi login {{-l|--local}}`
+`pulumi login {{[-l|--local]}}`

--- a/pages/common/pydocstyle.md
+++ b/pages/common/pydocstyle.md
@@ -9,11 +9,11 @@
 
 - Show an explanation of each error:
 
-`pydocstyle {{-e|--explain}} {{file.py|path/to/directory}}`
+`pydocstyle {{[-e|--explain]}} {{file.py|path/to/directory}}`
 
 - Show debug information:
 
-`pydocstyle {{-d|--debug}} {{file.py|path/to/directory}}`
+`pydocstyle {{[-d|--debug]}} {{file.py|path/to/directory}}`
 
 - Display the total number of errors:
 

--- a/pages/common/toipe.md
+++ b/pages/common/toipe.md
@@ -10,16 +10,16 @@
 
 - Use a specific wordlist:
 
-`toipe {{-w|--wordlist}} {{wordlist_name}}`
+`toipe {{[-w|--wordlist]}} {{wordlist_name}}`
 
 - Use a custom wordlist:
 
-`toipe {{-f|--file}} {{path/to/file}}`
+`toipe {{[-f|--file]}} {{path/to/file}}`
 
 - Specify the number of words on each test:
 
-`toipe {{-n|--num}} {{number_of_words}}`
+`toipe {{[-n|--num]}} {{number_of_words}}`
 
 - Include punctuation:
 
-`toipe {{-p|--punctuation}}`
+`toipe {{[-p|--punctuation]}}`

--- a/pages/common/typeinc.md
+++ b/pages/common/typeinc.md
@@ -10,12 +10,12 @@
 
 - Display the top 10 rank list for input difficulty level:
 
-`typeinc {{-r|--ranklist}} {{difficulty_level}}`
+`typeinc {{[-r|--ranklist]}} {{difficulty_level}}`
 
 - Get random English words present in our wordlist:
 
-`typeinc {{-w|--words}} {{word_count}}`
+`typeinc {{[-w|--words]}} {{word_count}}`
 
 - Calculate hypothetical Typeinc score:
 
-`typeinc {{-s|--score}}`
+`typeinc {{[-s|--score]}}`

--- a/pages/common/uv-tree.md
+++ b/pages/common/uv-tree.md
@@ -13,7 +13,7 @@
 
 - Show dependency tree up to a certain depth:
 
-`uv tree {{-d|--depth}} {{n}}`
+`uv tree {{[-d|--depth]}} {{n}}`
 
 - Show the latest available version for all outdated packages:
 

--- a/pages/common/waybar.md
+++ b/pages/common/waybar.md
@@ -9,12 +9,12 @@
 
 - Use a different configuration file:
 
-`waybar {{-c|--config}} {{path/to/config.jsonc}}`
+`waybar {{[-c|--config]}} {{path/to/config.jsonc}}`
 
 - Use a different stylesheet file:
 
-`waybar {{-s|--style}} {{path/to/stylesheet.css}}`
+`waybar {{[-s|--style]}} {{path/to/stylesheet.css}}`
 
 - Set the logging level:
 
-`waybar {{-l|--log-level}} {{trace|debug|info|warning|error|critical|off}}`
+`waybar {{[-l|--log-level]}} {{trace|debug|info|warning|error|critical|off}}`

--- a/pages/common/zapier-analytics.md
+++ b/pages/common/zapier-analytics.md
@@ -9,8 +9,8 @@
 
 - Change how much information is collected:
 
-`zapier analytics {{-m|--mode}} {{enabled|anonymous|disabled}}`
+`zapier analytics {{[-m|--mode]}} {{enabled|anonymous|disabled}}`
 
 - Show extra debugging output:
 
-`zapier analytics {{-m|--mode}} {{enabled|anonymous|disabled}} {{-d|--debug}}`
+`zapier analytics {{[-m|--mode]}} {{enabled|anonymous|disabled}} {{-d|--debug}}`

--- a/pages/common/zapier-build.md
+++ b/pages/common/zapier-build.md
@@ -13,4 +13,4 @@
 
 - Show extra debugging output:
 
-`zapier build {{-d|--debug}}`
+`zapier build {{[-d|--debug]}}`

--- a/pages/common/zapier-convert.md
+++ b/pages/common/zapier-convert.md
@@ -9,7 +9,7 @@
 
 - Convert a visual builder integration with a specific version:
 
-`zapier convert {{integration_id}} {{path/to/directory}} {{-v|--version}}={{version}}`
+`zapier convert {{integration_id}} {{path/to/directory}} {{[-v|--version]}}={{version}}`
 
 - Show extra debugging output:
 

--- a/pages/common/zapier-init.md
+++ b/pages/common/zapier-init.md
@@ -9,8 +9,8 @@
 
 - Initialize a new Zapier integration with a specific template:
 
-`zapier init {{path/to/directory}} {{-t|--template}} {{basic-auth|callback|custom-auth|digest-auth|dynamic-dropdown|files|minimal|oauth1-trello|oauth2|search-or-create|session-auth|typescript}}`
+`zapier init {{path/to/directory}} {{[-t|--template]}} {{basic-auth|callback|custom-auth|digest-auth|dynamic-dropdown|files|minimal|oauth1-trello|oauth2|search-or-create|session-auth|typescript}}`
 
 - Show extra debugging output:
 
-`zapier init {{-d|--debug}}`
+`zapier init {{[-d|--debug]}}`

--- a/pages/common/zapier-push.md
+++ b/pages/common/zapier-push.md
@@ -13,4 +13,4 @@
 
 - Show extra debugging output:
 
-`zapier push {{-d|--debug}}`
+`zapier push {{[-d|--debug]}}`

--- a/pages/common/zapier-scaffold.md
+++ b/pages/common/zapier-scaffold.md
@@ -9,11 +9,11 @@
 
 - Specify a custom destination directory for the scaffolded files:
 
-`zapier scaffold {{trigger|search|create|resource}} {{noun}} {{-d|--dest}}={{path/to/directory}}`
+`zapier scaffold {{trigger|search|create|resource}} {{noun}} {{[-d|--dest]}}={{path/to/directory}}`
 
 - Overwrite existing files when scaffolding:
 
-`zapier scaffold {{trigger|search|create|resource}} {{noun}} {{-f|--force}}`
+`zapier scaffold {{trigger|search|create|resource}} {{noun}} {{[-f|--force]}}`
 
 - Exclude comments from the scaffolded files:
 
@@ -21,4 +21,4 @@
 
 - Show extra debugging output:
 
-`zapier scaffold {{-d|--debug}}`
+`zapier scaffold {{[-d|--debug]}}`


### PR DESCRIPTION
These are only the ones I caught with `grep -rE '\{\{-.*?\|--.*?\}\}' --color`
Any further option placeholders that don't contain dashes (like `ip {{l|link}}`) will have to be hunted with other means.
