### PR TITLE
uname: reword as suggested by the style guide

### DIFF
--- a/pages/linux/uname.md
+++ b/pages/linux/uname.md
@@ -1,6 +1,6 @@
 # uname
 
-> Uname prints information about the machine and operating system it is run on.
+> Print details about the current machine and the operating system running on it.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html>.
 
 - Print all information:


### PR DESCRIPTION
https://github.com/tldr-pages/tldr/blob/85563b861f158dea05189e95ed0dce8181505348/contributing-guides/style-guide.md#wording
> Avoid using the page title in the description

I copied the description from [`common/uname.md`](https://github.com/tldr-pages/tldr/blob/85563b861f158dea05189e95ed0dce8181505348/pages/common/uname.md?plain=1).