### PR TITLE
style-guide: rework option syntax instructions

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -418,7 +418,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 > [!NOTE]\
 > In cases where the character isn't present in the translated word, you can highlight the option before/next to the equivalent word or you can add the English work beside the translation inside a bracket.
-> For example, `E[x]tract` in English maybe translated into `[x] ekstrak` or `ekstrak [x]` or `ekstrak (E[x]tract)` in Indonesian.
+> For example, `E[x]tract` in English may be translated into `[x] ekstrak` or `ekstrak [x]` or `ekstrak (E[x]tract)` in Indonesian.
 
 ## Example commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -418,7 +418,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 > [!NOTE]\
 > In cases where the character isn't present in the translated word, you can highlight the option before/next to the equivalent word or you can add the English work beside the translation inside a bracket.
-> For example, `E[x]tract` in English may be translated into `[x] ekstrak` or `ekstrak [x]` or `ekstrak (E[x]tract)` in Indonesian.
+> For example, `E[x]tract` in English may be translated into `ekstrak [x]` or `ekstrak (E[x]tract)` in Indonesian.
 
 ## Example commands
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -424,7 +424,6 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ### Option syntax
 
-- For commonly/frequently used commands (e.g. `grep`, `tar`, etc.), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside an option placeholder.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - For user-friendliness, use **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -424,8 +424,8 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ### Option syntax
 
+- For user-friendliness, prefer **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
-- For user-friendliness, use **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.
 - Likewise prefer separating shortform options from their arguments with a space (i.e. use `-o arg` instead of `-oarg`), unless the program does not support it.
 

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -425,6 +425,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 ### Option syntax
 
 - For user-friendliness, prefer **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
+- If the a command only supports short options, attempt to document what the letter is short for with a mnemonic.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.
 - Likewise prefer separating shortform options from their arguments with a space (i.e. use `-o arg` instead of `-oarg`), unless the program does not support it.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -425,7 +425,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 ### Option syntax
 
 - For user-friendliness, prefer **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
-- If the a command only supports short options, attempt to document what the letter is short for with a mnemonic.
+- If the a command only supports short options, attempt to document what the letter is short for with a [mnemonic](#short-option-mnemonics).
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.
 - Likewise prefer separating shortform options from their arguments with a space (i.e. use `-o arg` instead of `-oarg`), unless the program does not support it.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -424,7 +424,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 
 ### Option syntax
 
-- For commonly/frequently used commands (e.g. `grep`, `tar`, etc.), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside a placeholder.
+- For commonly/frequently used commands (e.g. `grep`, `tar`, etc.), we prefer using short options along with [mnemonics](#short-option-mnemonics) or both inside an option placeholder.
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - For user-friendliness, use **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -425,7 +425,7 @@ For example, `[d]ownload` in English may be translated into `[d]escargar` in Spa
 ### Option syntax
 
 - For user-friendliness, prefer **GNU-style long options** (like `--help` rather than `-h`) when they are cross-platform compatible (intended to work the same across multiple platforms) for pages in the `common` directory.
-- If the a command only supports short options, attempt to document what the letter is short for with a [mnemonic](#short-option-mnemonics).
+- If a command only supports short options, attempt to document what the letter is short for with a [mnemonic](#short-option-mnemonics).
 - For letting the client decide whether to show long or short options in commands, use an option placeholder i.e. `{{[-o|--output]}}`.
 - Prefer using a space instead of the equals sign (`=`) to separate options from their arguments (i.e. use `--opt arg` instead of `--opt=arg`), unless the program does not support it.
 - Likewise prefer separating shortform options from their arguments with a space (i.e. use `-o arg` instead of `-oarg`), unless the program does not support it.


### PR DESCRIPTION
I'm seeing a trend that we prefer to use shortform options by themselves less and less