### PR TITLE
git-restore: fix default to restore from staging

### DIFF
--- a/pages/common/git-restore.md
+++ b/pages/common/git-restore.md
@@ -4,7 +4,7 @@
 > See also `git checkout` and `git reset`.
 > More information: <https://git-scm.com/docs/git-restore>.
 
-- Restore an unstaged file to the version of the current commit (HEAD):
+- Restore an unstaged file to the staged version:
 
 `git restore {{path/to/file}}`
 


### PR DESCRIPTION
By default, "git restore" restores from the index, not from HEAD. See the [git-restore documentation](https://git-scm.com/docs/git-restore):

> By default, if --staged is given, the contents are restored from HEAD, otherwise from the index.
