### PR TITLE
bacon: add page

### DIFF
--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -7,9 +7,9 @@
 
 `bacon`
 
-- Run `cargo run` whenever a change is detected in the current directory:
+- Run specific job whenever a change is detected in the current directory:
 
-`bacon run`
+`bacon {{run|test|clippy|doc|...}}`
 
 - Run `cargo test` whenever a change is detected in the given directory:
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -7,10 +7,6 @@
 
 `bacon`
 
-- Run specific job whenever a change is detected in the current directory:
-
-`bacon {{run|test|clippy|doc|...}}`
-
 - Run `cargo test` whenever a change is detected in the given directory:
 
 `bacon test {{path/to/directory}}`
@@ -18,6 +14,14 @@
 - Run `cargo check` against all targets whenever a change is detected in the current directory:
 
 `bacon check-all`
+
+- Run specific job whenever a change is detected in the current directory:
+
+`bacon {{run|test|clippy|doc|...}}`
+
+- List all currently available jobs:
+
+`bacon --list-jobs`
 
 - Initialize a `bacon.toml` configuration file in the current directory:
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -13,7 +13,7 @@
 
 - Run `cargo test` whenever a change is detected in the given directory:
 
-`bacon test --path {{path/to/directory}}`
+`bacon test {{path/to/directory}}`
 
 - Run against all targets whenever a change is detected in the current directory:
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -15,7 +15,7 @@
 
 `bacon test {{path/to/directory}}`
 
-- Run against all targets whenever a change is detected in the current directory:
+- Run `cargo check` against all targets whenever a change is detected in the current directory:
 
 `bacon --job check-all`
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -17,7 +17,7 @@
 
 - Run `cargo check` against all targets whenever a change is detected in the current directory:
 
-`bacon --job check-all`
+`bacon check-all`
 
 - Initialize a `bacon.toml` configuration file in the current directory:
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -15,7 +15,7 @@
 
 `bacon check-all`
 
-- Run specific job whenever a change is detected in the current directory:
+- Run a specific job whenever a change is detected in the current directory:
 
 `bacon {{run|test|clippy|doc|...}}`
 

--- a/pages/common/bacon.md
+++ b/pages/common/bacon.md
@@ -1,0 +1,24 @@
+# bacon
+
+> A background code checker for Rust.
+> More information: <https://github.com/Canop/bacon>.
+
+- Run `cargo check` whenever a change is detected in the current directory:
+
+`bacon`
+
+- Run `cargo run` whenever a change is detected in the current directory:
+
+`bacon run`
+
+- Run `cargo test` whenever a change is detected in the given directory:
+
+`bacon test --path {{path/to/directory}}`
+
+- Run against all targets whenever a change is detected in the current directory:
+
+`bacon --job check-all`
+
+- Initialize a `bacon.toml` configuration file in the current directory:
+
+`bacon --init`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Version of command: **bacon 3.11.0**

I was unsure about how to word the descriptions, as this is a tool like `cargo watch`, which will run `cargo` commands when it detects a change in a directory. Is there a better to describe each command?

I also did not add in _every_ command, as they are only minor variations of the 2nd example listed, e.g. `bacon doc`, `bacon clippy`. Should I include those?