### PR TITLE
smartctl: add an example and option placeholders

### DIFF
--- a/pages.ko/common/smartctl.md
+++ b/pages.ko/common/smartctl.md
@@ -1,24 +1,24 @@
 # smartctl
 
 > 디스크 상태를 SMART 데이터를 통해 모니터링.
-> 더 많은 정보: <https://www.smartmontools.org>.
+> 더 많은 정보: <https://manned.org/smartctl>.
 
 - SMART 건강 요약 표시:
 
-`sudo smartctl --health {{/dev/sdX}}`
+`sudo smartctl {{[-H|--health]}} {{/dev/sdX}}`
 
 - 장치 정보 표시:
 
-`sudo smartctl --info {{/dev/sdX}}`
+`sudo smartctl {{[-i|--info]}} {{/dev/sdX}}`
 
 - 백그라운드에서 짧은 자체 테스트 시작:
 
-`sudo smartctl --test short {{/dev/sdX}}`
+`sudo smartctl {{[-t|--test]}} short {{/dev/sdX}}`
 
 - 현재/마지막 자체 테스트 상태 및 기타 SMART 기능 표시:
 
-`sudo smartctl --capabilities {{/dev/sdX}}`
+`sudo smartctl {{[-c|--capabilities]}} {{/dev/sdX}}`
 
 - 포괄적인 SMART 데이터 표시:
 
-`sudo smartctl --all {{/dev/sdX}}`
+`sudo smartctl {{[-a|--all]}} {{/dev/sdX}}`

--- a/pages/common/smartctl.md
+++ b/pages/common/smartctl.md
@@ -1,24 +1,28 @@
 # smartctl
 
 > Monitor disk health including SMART data.
-> More information: <https://www.smartmontools.org>.
+> More information: <https://manned.org/smartctl>.
 
 - Display SMART health summary:
 
-`sudo smartctl --health {{/dev/sdX}}`
+`sudo smartctl {{[-H|--health]}} {{/dev/sdX}}`
 
 - Display device information:
 
-`sudo smartctl --info {{/dev/sdX}}`
+`sudo smartctl {{[-i|--info]}} {{/dev/sdX}}`
 
-- Start a short self-test in the background:
+- Start a short/long self-test in the background:
 
-`sudo smartctl --test short {{/dev/sdX}}`
+`sudo smartctl {{[-t|--test]}} {{short|long}} {{/dev/sdX}}`
+
+- Display the self-test log:
+
+`sudo smartctl {{[-l|--log]}} selftest`
 
 - Display current/last self-test status and other SMART capabilities:
 
-`sudo smartctl --capabilities {{/dev/sdX}}`
+`sudo smartctl {{[-c|--capabilities]}} {{/dev/sdX}}`
 
 - Display exhaustive SMART data:
 
-`sudo smartctl --all {{/dev/sdX}}`
+`sudo smartctl {{[-a|--all]}} {{/dev/sdX}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).