### PR TITLE
home-manager: remove test, add --flake example

### DIFF
--- a/pages/common/home-manager.md
+++ b/pages/common/home-manager.md
@@ -11,10 +11,6 @@
 
 `home-manager switch`
 
-- Build the configuration for testing without applying it:
-
-`home-manager test`
-
 - Roll back to a previous configuration generation:
 
 `home-manager rollback`
@@ -22,3 +18,7 @@
 - List all existing configuration generations:
 
 `home-manager generations`
+
+- When using flakes, run any operation that requires nix to run (build, switch, news) by passing the path to the flake:
+
+`home-manager <COMMAND> --flake ~/Path/to/flake/directory`

--- a/pages/common/home-manager.md
+++ b/pages/common/home-manager.md
@@ -21,4 +21,4 @@
 
 - When using flakes, run any operation that requires nix to run (build, switch, news) by passing the path to the flake:
 
-`home-manager <COMMAND> --flake ~/Path/to/flake/directory`
+`home-manager {{command}} --flake {{path/to/flake}}`


### PR DESCRIPTION
Remove command test that doesn't exist in the current version (25.05-pre).

Add an explanation for the '--flake' option, useful for anyone using home-manager as a fiake.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 25.05-pre
