### PR TITLE
ip-route*: swap from show to list

### DIFF
--- a/pages/linux/ip-route-list.md
+++ b/pages/linux/ip-route-list.md
@@ -1,7 +1,36 @@
 # ip route list
 
-> This command is an alias of `ip route show`.
+> Display subcommand for IP Routing table management.
+> More information: <https://manned.org/ip-route>.
 
-- View documentation for the original command:
+- Display the `main` routing table:
 
-`tldr ip route show`
+`ip {{[r|route]}} {{[l|list]}}`
+
+- Display the main routing table (same as first example):
+
+`ip {{[r|route]}} {{[l|list]}} {{[t|table]}} {{main|254}}`
+
+- Display the local routing table:
+
+`ip {{[r|route]}} {{[l|list]}} {{[t|table]}} {{local|255}}`
+
+- Display all routing tables:
+
+`ip {{[r|route]}} {{[l|list]}} {{[t|table]}} {{all|unspec|0}}`
+
+- List routes from a given device only:
+
+`ip {{[r|route]}} {{[l|list]}} dev {{eth0}}`
+
+- List routes within a given scope:
+
+`ip {{[r|route]}} {{[l|list]}} {{[s|scope]}} link`
+
+- Display the routing cache:
+
+`ip {{[r|route]}} {{[l|list]}} {{[c|cache]}}`
+
+- Display only IPv6 or IPv4 routes:
+
+`ip {{-6|-4}} {{[r|route]}}`

--- a/pages/linux/ip-route-show.md
+++ b/pages/linux/ip-route-show.md
@@ -1,36 +1,7 @@
 # ip route show
 
-> Display subcommand for IP Routing table management.
-> More information: <https://manned.org/ip-route>.
+> This command is an alias of `ip route list`.
 
-- Display the `main` routing table:
+- View documentation for the original command:
 
-`ip {{[r|route]}} {{[s|show]}}`
-
-- Display the main routing table (same as first example):
-
-`ip {{[r|route]}} {{[s|show]}} {{[t|table]}} {{main|254}}`
-
-- Display the local routing table:
-
-`ip {{[r|route]}} {{[s|show]}} {{[t|table]}} {{local|255}}`
-
-- Display all routing tables:
-
-`ip {{[r|route]}} {{[s|show]}} {{[t|table]}} {{all|unspec|0}}`
-
-- List routes from a given device only:
-
-`ip {{[r|route]}} {{[s|show]}} dev {{eth0}}`
-
-- List routes within a given scope:
-
-`ip {{[r|route]}} {{[s|show]}} {{[s|scope]}} link`
-
-- Display the routing cache:
-
-`ip {{[r|route]}} {{[s|show]}} {{[c|cache]}}`
-
-- Display only IPv6 or IPv4 routes:
-
-`ip {{-6|-4}} {{[r|route]}} {{[s|show]}}`
+`tldr ip route list`

--- a/pages/linux/ip-route.md
+++ b/pages/linux/ip-route.md
@@ -33,4 +33,4 @@
 
 - Display a specific routing table:
 
-`ip {{[r|route]}} {{[s|show]}} {{[t|table]}} {{table_number}}`
+`ip {{[r|route]}} {{[l|list]}} {{[t|table]}} {{table_number}}`


### PR DESCRIPTION
`ip route sh<Tab>` autocompletes to `showdump` whereas `ip route l<Tab>` autocompletes to `list`.