### PR TITLE
busybox: add page

### DIFF
--- a/pages/common/busybox.md
+++ b/pages/common/busybox.md
@@ -1,0 +1,14 @@
+# busybox
+
+> A collection of small system utilities in a single executable.
+> Executing `busybox` via a symlink is equivalent to running `busybox symlink_name`.
+> Linux distributions that use BusyBox will usually provide symlinks for all programs.
+> More information: <https://www.busybox.net/downloads/BusyBox.html>.
+
+- Execute a BusyBox function:
+
+`busybox {{ls|rm|mkdir|cat|...}} {{args}}`
+
+- Display help and a list of functions:
+
+`busybox --help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

I don't think it makes sense to document all BusyBox commands, as they are very similar to the already documented coreutils and util-linux. We'll end up with pages that are almost the same.

Closes #16015.