### PR TITLE
feat: update workflows to use commit hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "devcontainers"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
       id-token: write # grant additional permission to attestation action to mint the OIDC token permission
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: '3.12'
         cache: 'pip'
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 'lts/*'
         cache: 'npm'
@@ -41,7 +41,7 @@ jobs:
 
     - name: Upload test logging
       if: github.repository == 'tldr-pages/tldr' && github.event.pull_request.number != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: debug.log
         path: debug.log
@@ -106,7 +106,7 @@ jobs:
     - name: Attest generated files
       if: github.repository == 'tldr-pages/tldr' && github.ref == 'refs/heads/main'
       id: attest
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
       continue-on-error: true # prevent failing when no pages are modified
       with:
         subject-path: ${{ env.subject_path }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45.0.7
+        uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 # v46.0.3
         with:
           # Ignore all other languages except English
           files_ignore: |
@@ -25,7 +25,7 @@ jobs:
             contributing-guides/style-guide.*.md
             package-lock.json
 
-      - uses: codespell-project/actions-codespell@v2
+      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2.1
         with:
           ignore_words_file: .github/codespell-ignore
           # Exit with 0 regardless of typos.

--- a/.github/workflows/copy-release-assets.yml
+++ b/.github/workflows/copy-release-assets.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write # grant additional permission to attestation action to mint the OIDC token permission
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
       - name: Attest copied assets
         if: github.repository == 'tldr-pages/tldr'
         id: attest
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           subject-path: ${{ env.subject_path }}
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: tldr-pages/tldr-labeler-action@v0.6.0
+    - uses: tldr-pages/tldr-labeler-action@7cb29444b818130fe056b7e7b3dedcc7db93af45 # v0.6.0
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/monthly-check.yml
+++ b/.github/workflows/monthly-check.yml
@@ -17,7 +17,7 @@ jobs:
         key: cache-lychee-${{ github.sha }}
         restore-keys: cache-lychee-
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
         sort -u usernames.txt -o usernames.txt
 
     - name: Lychee URL checker
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
       id: lychee
       continue-on-error: true
       with:
@@ -41,7 +41,7 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Find the last report issue open
-      uses: micalevisk/last-issue-action@v2
+      uses: micalevisk/last-issue-action@044e1cb7e9a4dde20e22969cb67818bfca0797be # v2.3.0
       id: last-issue
       with:
         state: open
@@ -51,7 +51,7 @@ jobs:
 
     - name: Update last report open issue created
       if: ${{ env.lychee_exit_code != 0 }}
-      uses: peter-evans/create-issue-from-file@v5
+      uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
       with:
         title: GitHub usernames with errors
         content-filepath: lychee/out.md
@@ -63,7 +63,7 @@ jobs:
       run: gh issue close ${{ steps.last-issue.outputs.issue-number }}
 
     - name: Save lychee cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: always()
       with:
         path: .lycheecache


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR updates all workflows to use immutable commit hashes instead of rewritable tags to prevent security issues like https://github.com/tldr-pages/tldr/issues/15946.

Since we won't be getting point releases immediately, I have updated the Dependabot update check frequency of GitHub actions to "weekly" (previously "monthly" check since we only used base tags before i.e. `v4`, etc instead semver versions like `v4.0.2`) 

> [!NOTE]
> Post this PRs merge I will reenable to codespell action as the security issue has been fixed upstream.

Closes #15946, #15947

