### PR TITLE
tofu: add page

### DIFF
--- a/pages/common/tofu-fmt.md
+++ b/pages/common/tofu-fmt.md
@@ -1,0 +1,20 @@
+# tofu fmt
+
+> Format configuration according to OpenTofu language style conventions.
+> More information: <https://opentofu.org/docs/cli/commands/fmt/>.
+
+- Format the configuration in the current directory:
+
+`tofu fmt`
+
+- Format the configuration in the current directory and subdirectories:
+
+`tofu fmt -recursive`
+
+- Display diffs of formatting changes:
+
+`tofu fmt -diff`
+
+- Do not list files that were formatted to `stdout`:
+
+`tofu fmt -list=false`

--- a/pages/common/tofu-output.md
+++ b/pages/common/tofu-output.md
@@ -15,6 +15,6 @@
 
 `tofu output -raw`
 
-- Format the outputs as a JSON object, with a key per output (useful with jq):
+- Format the outputs as a JSON object, with a key per output (useful with `jq`):
 
 `tofu output -json`

--- a/pages/common/tofu-output.md
+++ b/pages/common/tofu-output.md
@@ -1,0 +1,20 @@
+# tofu output
+
+> Export structured data about your OpenTofu resources.
+> More information: <https://opentofu.org/docs/cli/commands/output/>.
+
+- With no additional arguments, `output` will display all outputs for the root module:
+
+`tofu output`
+
+- Output only a value with specific name:
+
+`tofu output {{name}}`
+
+- Convert the output value to a raw string (useful for shell scripts):
+
+`tofu output -raw`
+
+- Format the outputs as a JSON object, with a key per output (useful with jq):
+
+`tofu output -json`

--- a/pages/common/tofu-plan.md
+++ b/pages/common/tofu-plan.md
@@ -1,0 +1,32 @@
+# tofu plan
+
+> Generate and show OpenTofu execution plans.
+> More information: <https://opentofu.org/docs/cli/commands/plan/>.
+
+- Generate and show the execution plan in the currently directory:
+
+`tofu plan`
+
+- Show a plan to destroy all remote objects that currently exist:
+
+`tofu plan -destroy`
+
+- Show a plan to update the Tofu state and output values:
+
+`tofu plan -refresh-only`
+
+- Specify values for input variables:
+
+`tofu plan -var '{{name1}}={{value1}}' -var '{{name2}}={{value2}}'`
+
+- Focus Tofu's attention on only a subset of resources:
+
+`tofu plan -target {{resource_type.resource_name[instance index]}}`
+
+- Output a plan as JSON:
+
+`tofu plan -json`
+
+- Write a plan to a specific file:
+
+`tofu plan -no-color > {{path/to/file}}`

--- a/pages/common/tofu.md
+++ b/pages/common/tofu.md
@@ -1,0 +1,28 @@
+# tofu
+
+> Create and deploy infrastructure as code to cloud providers. Open-source fork of Terraform.
+> More information: <https://opentofu.org/>.
+
+- Initialize a new or existing OpenTofu configuration:
+
+`tofu init`
+
+- Verify that the configuration files are syntactically valid:
+
+`tofu validate`
+
+- Format configuration according to OpenTofu language style conventions:
+
+`tofu fmt`
+
+- Generate and show an execution plan:
+
+`tofu plan`
+
+- Build or change infrastructure:
+
+`tofu apply`
+
+- Destroy Tofu-managed infrastructure:
+
+`tofu destroy`


### PR DESCRIPTION
OpenTofu is the open source fork of Terraform.
Pages based on the Terraform ones.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
