### PR TITLE
pages/*: use lowercase `n` for integer placeholders

### DIFF
--- a/pages/common/%.md
+++ b/pages/common/%.md
@@ -11,9 +11,9 @@
 
 `%-`
 
-- Bring a job numbered `N` to front:
+- Bring the job number `n` to front:
 
-`%{{N}}`
+`%{{n}}`
 
 - Bring a job whose command starts with `string` to front:
 

--- a/pages/common/ddgr.md
+++ b/pages/common/ddgr.md
@@ -11,9 +11,9 @@
 
 `ddgr {{keyword}}`
 
-- Limit the number of search results to `N`:
+- Limit the number of search results to `n`:
 
-`ddgr -n {{N}} {{keyword}}`
+`ddgr -n {{n}} {{keyword}}`
 
 - Display the complete URL in search results:
 

--- a/pages/common/dirs.md
+++ b/pages/common/dirs.md
@@ -12,9 +12,9 @@
 
 `dirs -p`
 
-- Display only the nth entry in the directory stack, starting at 0:
+- Display only the `n`th entry in the directory stack, starting at 0:
 
-`dirs +{{N}}`
+`dirs +{{n}}`
 
 - Clear the directory stack:
 

--- a/pages/common/go-vet.md
+++ b/pages/common/go-vet.md
@@ -20,9 +20,9 @@
 
 `go tool vet help {{check_name}}`
 
-- Display offending lines plus N lines of surrounding context:
+- Display offending lines plus `n` lines of surrounding context:
 
-`go vet -c={{N}}`
+`go vet -c={{n}}`
 
 - Output analysis and errors in JSON format:
 

--- a/pages/common/googler.md
+++ b/pages/common/googler.md
@@ -11,9 +11,9 @@
 
 `googler -j {{keyword}}`
 
-- Show N search results (default 10):
+- Show `n` search results (default: 10):
 
-`googler -n {{N}} {{keyword}}`
+`googler -n {{n}} {{keyword}}`
 
 - Disable automatic spelling correction:
 

--- a/pages/common/julia.md
+++ b/pages/common/julia.md
@@ -27,6 +27,6 @@
 
 `julia -E '{{(1 - cos(pi/4))/2}}'`
 
-- Start Julia in multithreaded mode, using N threads:
+- Start Julia in multithreaded mode, using `n` threads:
 
-`julia -t {{N}}`
+`julia -t {{n}}`

--- a/pages/common/logout.md
+++ b/pages/common/logout.md
@@ -9,4 +9,4 @@
 
 - Exit a login shell and specify a return value:
 
-`logout {{N}}`
+`logout {{exit_code}}`

--- a/pages/common/lp.md
+++ b/pages/common/lp.md
@@ -15,9 +15,9 @@
 
 `lp -d {{printer_name}} {{path/to/filename}}`
 
-- Print N copies of file to default printer (replace N with desired number of copies):
+- Print `n` copies of a file to the default printer:
 
-`lp -n {{N}} {{path/to/filename}}`
+`lp -n {{n}} {{path/to/filename}}`
 
 - Print only certain pages to the default printer (print pages 1, 3-5, and 16):
 

--- a/pages/common/macptopbm.md
+++ b/pages/common/macptopbm.md
@@ -8,9 +8,9 @@
 
 `macptopbm {{path/to/file.macp}} > {{path/to/output.pbm}}`
 
-- Skip over a specified number of bytes when reading the file:
+- Skip over `n` bytes when reading the file:
 
-`macptopbm -extraskip {{N}} > {{path/to/output.pbm}}`
+`macptopbm -extraskip {{n}} > {{path/to/output.pbm}}`
 
 - Suppress all informational messages:
 

--- a/pages/common/mpg321.md
+++ b/pages/common/mpg321.md
@@ -4,9 +4,9 @@
 > Mpg321 was written (sometime in 1999) to be a drop-in replacement for the (previously) non-free mpg123 player.
 > More information: <https://mpg321.sourceforge.net/>.
 
-- Play an audio source exactly N times (N=0 means forever):
+- Play an audio source exactly `n` times (0 means forever):
 
-`mpg321 -l {{N}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
+`mpg321 -l {{n}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
 
 - Play a directory recursively:
 

--- a/pages/common/pamenlarge.md
+++ b/pages/common/pamenlarge.md
@@ -6,8 +6,8 @@
 
 - Enlarge the specified image by the specified factor:
 
-`pamenlarge -scale {{N}} {{path/to/image.pam}} > {{path/to/output.pam}}`
+`pamenlarge -scale {{n}} {{path/to/image.pam}} > {{path/to/output.pam}}`
 
 - Enlarge the specified image by the specified factors horizontally and vertically:
 
-`pamenlarge -xscale {{XN}} -yscale {{YN}} {{path/to/image.pam}} > {{path/to/output.pam}}`
+`pamenlarge -xscale {{xn}} -yscale {{yn}} {{path/to/image.pam}} > {{path/to/output.pam}}`

--- a/pages/common/pamoil.md
+++ b/pages/common/pamoil.md
@@ -7,6 +7,6 @@
 
 `pamoil {{path/to/input_file.pam}} > {{path/to/output_file.pam}}`
 
-- Consider a neighborhood of N pixels for the "smearing" effect:
+- Consider a neighborhood of `n` pixels for the "smearing" effect:
 
-`pamoil -n {{N}} {{path/to/input_file.pam}} > {{path/to/output_file.pam}}`
+`pamoil -n {{n}} {{path/to/input_file.pam}} > {{path/to/output_file.pam}}`

--- a/pages/common/pamstretch-gen.md
+++ b/pages/common/pamstretch-gen.md
@@ -6,4 +6,4 @@
 
 - Scale up a PAM image by the specified decimal factor:
 
-`pamstretch-gen {{N}} {{path/to/image.pam}} > {{path/to/output.pam}}`
+`pamstretch-gen {{n}} {{path/to/image.pam}} > {{path/to/output.pam}}`

--- a/pages/common/pamstretch.md
+++ b/pages/common/pamstretch.md
@@ -6,8 +6,8 @@
 
 - Scale up a PAM image by an integer factor:
 
-`pamstretch {{N}} {{path/to/image.pam}} > {{path/to/output.pam}}`
+`pamstretch {{n}} {{path/to/image.pam}} > {{path/to/output.pam}}`
 
 - Scale up a PAM image by the specified factors in the horizontal and vertical directions:
 
-`pamstretch -xscale {{XN}} -yscale {{YN}} {{path/to/image.pam}} > {{path/to/output.pam}}`
+`pamstretch -xscale {{xn}} -yscale {{yn}} {{path/to/image.pam}} > {{path/to/output.pam}}`

--- a/pages/common/pbmpscale.md
+++ b/pages/common/pbmpscale.md
@@ -6,4 +6,4 @@
 
 - Enlarge a PBM image by the specified factor with edge smoothing:
 
-`pbmpscale {{N}} {{path/to/image.pbm}} > {{path/to/file.pbm}}`
+`pbmpscale {{n}} {{path/to/image.pbm}} > {{path/to/file.pbm}}`

--- a/pages/common/pbmreduce.md
+++ b/pages/common/pbmreduce.md
@@ -6,12 +6,12 @@
 
 - Reduce the specified image by the specified factor:
 
-`pbmreduce {{N}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`
+`pbmreduce {{n}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`
 
 - Use simple thresholding when reducing:
 
-`pbmreduce -threshold {{N}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`
+`pbmreduce -threshold {{n}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`
 
 - Use the specified threshold for all quantizations:
 
-`pbmreduce -value {{0.6}} {{N}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`
+`pbmreduce -value {{0.6}} {{n}} {{path/to/image.pbm}} > {{path/to/output.pbm}}`

--- a/pages/common/rawtopgm.md
+++ b/pages/common/rawtopgm.md
@@ -15,7 +15,7 @@
 
 `rawtopgm {{width}} {{height}} -bottomfirst {{path/to/image.raw}} > {{path/to/output.pgm}}`
 
-- Ignore the first n bytes of the specified file:
+- Ignore the first `n` bytes of the specified file:
 
 `rawtopgm {{width}} {{height}} -headerskip {{n}} {{path/to/image.raw}} > {{path/to/output.pgm}}`
 
@@ -23,9 +23,9 @@
 
 `rawtopgm {{width}} {{height}} -rowskip {{m}} {{path/to/image.raw}} > {{path/to/output.pgm}}`
 
-- Specify the maxval for the grey values in the input to be equal to N:
+- Specify the maxval for the grey values in the input to be equal to `n`:
 
-`rawtopgm {{width}} {{height}} -maxval {{N}} {{path/to/image.raw}} > {{path/to/output.pgm}}`
+`rawtopgm {{width}} {{height}} -maxval {{n}} {{path/to/image.raw}} > {{path/to/output.pgm}}`
 
 - Specify the number of bytes that represent each sample in the input and that the byte-sequence is to be interpreted as little-endian:
 

--- a/pages/common/readarray.md
+++ b/pages/common/readarray.md
@@ -15,9 +15,9 @@
 
 `readarray -t {{array_name}} < {{path/to/file.txt}}`
 
-- Copy at most the specified number of lines:
+- Copy at most `n` lines:
 
-`readarray -n {{N}} {{array_name}} < {{path/to/file.txt}}`
+`readarray -n {{n}} {{array_name}} < {{path/to/file.txt}}`
 
 - Display help:
 

--- a/pages/common/return.md
+++ b/pages/common/return.md
@@ -9,4 +9,4 @@
 
 - Specify the function's return value:
 
-`{{func_name}}() { return {{N}}; }`
+`{{func_name}}() { return {{exit_code}}; }`

--- a/pages/common/shift.md
+++ b/pages/common/shift.md
@@ -7,6 +7,6 @@
 
 `shift`
 
-- Remove the first `N` positional parameters:
+- Remove the first `n` positional parameters:
 
-`shift {{N}}`
+`shift {{n}}`

--- a/pages/common/wait.md
+++ b/pages/common/wait.md
@@ -13,7 +13,7 @@
 
 - Wait for a job to finish:
 
-`wait %{{N}}`
+`wait %{{job_number}}`
 
 - Display help:
 

--- a/pages/linux/dpigs.md
+++ b/pages/linux/dpigs.md
@@ -3,9 +3,9 @@
 > Show which installed packages occupy the most space on `apt` based systems.
 > More information: <https://manned.org/dpigs>.
 
-- Display the N largest packages on the system:
+- Display the `n` largest packages on the system:
 
-`dpigs --lines={{N}}`
+`dpigs --lines={{n}}`
 
 - Use the specified file instead of the default dpkg [s]tatus file:
 

--- a/pages/linux/duperemove.md
+++ b/pages/linux/duperemove.md
@@ -19,4 +19,4 @@
 
 - Limit I/O threads (for hashing and dedupe stage) and CPU threads (for duplicate extent finding stage):
 
-`duperemove -r -d --hashfile={{path/to/hashfile}} --io-threads={{N}} --cpu-threads={{N}} {{path/to/directory}}`
+`duperemove -r -d --hashfile={{path/to/hashfile}} --io-threads={{n}} --cpu-threads={{n}} {{path/to/directory}}`

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -11,9 +11,9 @@
 
 `journalctl --vacuum-time 2d`
 
-- Show only the last N lines and follow new messages (like `tail -f` for traditional syslog):
+- Show only the last `n` lines and follow new messages (like `tail -f` for traditional syslog):
 
-`journalctl {{[-n|--lines]}} {{N}} {{[-f|--follow]}}`
+`journalctl {{[-n|--lines]}} {{n}} {{[-f|--follow]}}`
 
 - Show all messages by a specific unit:
 

--- a/pages/linux/logread.md
+++ b/pages/linux/logread.md
@@ -7,9 +7,9 @@
 
 `logread`
 
-- Print a specified number of messages:
+- Print `n` messages:
 
-`logread -l {{N}}`
+`logread -l {{n}}`
 
 - Filter messages by (Keyword/Regular Expression):
 

--- a/pages/linux/netselect.md
+++ b/pages/linux/netselect.md
@@ -15,9 +15,9 @@
 
 `sudo netselect -m {{10}} {{host_1}} {{host_2}}`
 
-- Print fastest N servers among the hosts:
+- Print `n` fastest servers among the hosts:
 
-`sudo netselect -s {{N}} {{host_1}} {{host_2}} {{host_3}}`
+`sudo netselect -s {{n}} {{host_1}} {{host_2}} {{host_3}}`
 
 - Display help:
 

--- a/pages/linux/pdftoppm.md
+++ b/pages/linux/pdftoppm.md
@@ -3,9 +3,9 @@
 > Convert PDF document pages to portable Pixmap (image formats).
 > More information: <https://manned.org/pdftoppm>.
 
-- Specify the range of pages to convert (N-first page, M-last page):
+- Specify the range of pages to convert (`n` - first page, `m` - last page):
 
-`pdftoppm -f {{N}} -l {{M}} {{path/to/file.pdf}} {{image_name_prefix}}`
+`pdftoppm -f {{n}} -l {{m}} {{path/to/file.pdf}} {{image_name_prefix}}`
 
 - Convert only the first page of a PDF:
 

--- a/pages/windows/choice.md
+++ b/pages/windows/choice.md
@@ -21,7 +21,7 @@
 
 - Prompt the current user to select a choice and prefer the [d]efault choice in a specific [t]ime:
 
-`choice /t {{5}} /d {{N}}`
+`choice /t {{5}} /d {{default_choice}}`
 
 - Display help:
 


### PR DESCRIPTION
Lowercase `n` is used more often.
```sh
$ rg "\{\{N\}\}" pages -l | wc -l
28

$ rg "\{\{n\}\}" pages -l | wc -l
37
```