### PR TITLE
common/*: switch from using mnemonics to option placeholders

### DIFF
--- a/pages/common/abduco.md
+++ b/pages/common/abduco.md
@@ -1,7 +1,7 @@
 # abduco
 
 > Terminal session manager.
-> More information: <https://www.brain-dump.org/projects/abduco/>.
+> More information: <https://manned.org/abduco>.
 
 - List sessions:
 

--- a/pages/common/ac.md
+++ b/pages/common/ac.md
@@ -1,7 +1,7 @@
 # ac
 
 > Print statistics on how long users have been connected.
-> More information: <https://man.openbsd.org/ac>.
+> More information: <https://manned.org/man/ac.8>.
 
 - Print how long the current user has been connected in hours:
 

--- a/pages/common/ac.md
+++ b/pages/common/ac.md
@@ -1,7 +1,7 @@
 # ac
 
 > Print statistics on how long users have been connected.
-> More information: <https://manned.org/man/ac.8>.
+> More information: <https://manned.org/ac.8>.
 
 - Print how long the current user has been connected in hours:
 

--- a/pages/common/act.md
+++ b/pages/common/act.md
@@ -1,11 +1,11 @@
 # act
 
 > Execute GitHub Actions locally using Docker.
-> More information: <https://github.com/nektos/act>.
+> More information: <https://manned.org/act>.
 
-- [l]ist the available jobs:
+- List the available jobs:
 
-`act -l`
+`act {{[-l|--list]}}`
 
 - Run the default event:
 
@@ -15,18 +15,18 @@
 
 `act {{event_type}}`
 
-- Run a specific [j]ob:
+- Run a specific job:
 
-`act -j {{job_id}}`
+`act {{[-j|--job]}} {{job_id}}`
 
 - Do [n]ot actually run the actions (i.e. a dry run):
 
-`act -n`
+`act {{[-n|--dryrun]}}`
 
-- Show [v]erbose logs:
+- Show verbose logs:
 
-`act -v`
+`act {{[-v|--verbose]}}`
 
-- Run a specific [W]orkflow with the push event:
+- Run a specific workflow with the push event:
 
-`act push -W {{path/to/workflow}}`
+`act push {{[-W|--workflows]}} {{path/to/workflow}}`

--- a/pages/common/ag.md
+++ b/pages/common/ag.md
@@ -1,7 +1,7 @@
 # ag
 
 > The Silver Searcher. Like `ack`, but aims to be faster.
-> More information: <https://github.com/ggreer/the_silver_searcher>.
+> More information: <https://manned.org/ag>.
 
 - Find files containing "foo", and print the line matches in context:
 
@@ -11,17 +11,17 @@
 
 `ag {{foo}} {{path/to/directory}}`
 
-- Find files containing "foo", but only [l]ist the filenames:
+- Find files containing "foo", but only list the filenames:
 
-`ag -l {{foo}}`
+`ag {{[-l|--files-with-matches]}} {{foo}}`
 
-- Find files containing "FOO" case-[i]nsensitively, and print [o]nly the match, rather than the whole line:
+- Find files containing "FOO" case-insensitively, and print only the match, rather than the whole line:
 
-`ag -i -o {{FOO}}`
+`ag {{[-i|--ignore-case]}} {{[-o|--only-matching]}} {{FOO}}`
 
 - Find "foo" in files with a name matching "bar":
 
-`ag {{foo}} -G {{bar}}`
+`ag {{foo}} {{[-G|--file-search-regex]}} {{bar}}`
 
 - Find files whose contents match a regular expression:
 
@@ -29,4 +29,4 @@
 
 - Find files with a name matching "foo":
 
-`ag -g {{foo}}`
+`ag {{[-g|--filename-pattern]}} {{foo}}`

--- a/pages/common/age-keygen.md
+++ b/pages/common/age-keygen.md
@@ -6,7 +6,7 @@
 
 - Generate a key pair, save it to an unencrypted file, and print the public key to `stdout`:
 
-`age-keygen --output {{path/to/file}}`
+`age-keygen {{[-o|--output]}} {{path/to/file}}`
 
 - Convert an identit[y] to a recipient and print the public key to `stdout`:
 

--- a/pages/common/alacritty.md
+++ b/pages/common/alacritty.md
@@ -1,7 +1,7 @@
 # alacritty
 
 > Cross-platform, GPU-accelerated terminal emulator.
-> More information: <https://github.com/alacritty/alacritty>.
+> More information: <https://manned.org/alacritty>.
 
 - Start a new Alacritty process and create a window:
 
@@ -21,7 +21,7 @@
 
 - [e]xecute a command in a new Alacritty window (also works with `alacritty msg create-window`):
 
-`alacritty -e {{command}}`
+`alacritty {{[-e|--command]}} {{command}}`
 
 - Use an alternative configuration file (defaults to `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 

--- a/pages/common/ani-cli.md
+++ b/pages/common/ani-cli.md
@@ -1,36 +1,36 @@
 # ani-cli
 
 > A cli to browse and watch anime.
-> More information: <https://github.com/pystardust/ani-cli>.
+> More information: <https://manned.org/ani-cli>.
 
 - Search anime by name:
 
 `ani-cli "{{anime_name}}"`
 
-- [d]ownload episode:
+- Download episode:
 
-`ani-cli -d "{{anime_name}}"`
+`ani-cli {{[-d|--download]}} "{{anime_name}}"`
 
-- [d]ownload a [r]ange of episodes:
+- Download a range of episodes:
 
-`ani-cli -d -r "{{1 6}}" "{{anime_name}}"`
+`ani-cli {{[-d|--download]}} {{[-r|--range]}} "{{1 6}}" "{{anime_name}}"`
 
-- [d]ownload the entire series (a range of all episodes):
+- Download the entire series (a range of all episodes):
 
-`ani-cli -d -r "1 -1" "{{anime_name}}"`
+`ani-cli {{[-d|--download]}} {{[-r|--range]}} "1 -1" "{{anime_name}}"`
 
-- Use [v]LC as the media player:
+- Use VLC as the media player:
 
-`ani-cli -v "{{anime_name}}"`
+`ani-cli {{[-v|-vlc]}} "{{anime_name}}"`
 
-- Watch a specific [e]pisode:
+- Watch a specific episode:
 
-`ani-cli -e {{episode_number}} "{{anime_name}}"`
+`ani-cli {{[-e|--episode]}} {{episode_number}} "{{anime_name}}"`
 
-- [c]ontinue watching anime from history:
+- Continue watching anime from history:
 
-`ani-cli -c`
+`ani-cli {{[-c|--continue]}}`
 
-- [U]pdate `ani-cli`:
+- Update `ani-cli`:
 
-`ani-cli -U`
+`ani-cli {{[-U|--update]}}`

--- a/pages/common/ansible-playbook.md
+++ b/pages/common/ansible-playbook.md
@@ -7,21 +7,21 @@
 
 `ansible-playbook {{playbook}}`
 
-- Run tasks in playbook with custom host [i]nventory:
+- Run tasks in playbook with custom host inventory:
 
-`ansible-playbook {{playbook}} -i {{inventory_file}}`
+`ansible-playbook {{playbook}} {{[-i|--inventory]}} {{inventory_file}}`
 
-- Run tasks in playbook with [e]xtra variables defined via the command-line:
+- Run tasks in playbook with extra variables defined via the command-line:
 
-`ansible-playbook {{playbook}} -e "{{variable1}}={{value1}} {{variable2}}={{value2}}"`
+`ansible-playbook {{playbook}} {{[-e|--extra-vars]}} "{{variable1}}={{value1}} {{variable2}}={{value2}}"`
 
-- Run tasks in playbook with [e]xtra variables defined in a JSON file:
+- Run tasks in playbook with extra variables defined in a JSON file:
 
-`ansible-playbook {{playbook}} -e "@{{variables.json}}"`
+`ansible-playbook {{playbook}} {{[-e|--extra-vars]}} "@{{variables.json}}"`
 
 - Run tasks in playbook for the given tags:
 
-`ansible-playbook {{playbook}} --tags {{tag1,tag2}}`
+`ansible-playbook {{playbook}} {{[-t|--tags]}} {{tag1,tag2}}`
 
 - Run tasks in a playbook starting at a specific task:
 
@@ -29,4 +29,4 @@
 
 - Run tasks in a playbook without making any changes (dry-run):
 
-`ansible-playbook {{playbook}} --check --diff`
+`ansible-playbook {{playbook}} {{[-C|--check]}} {{[-D|--diff]}}`

--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -2,32 +2,32 @@
 
 > Manage groups of computers remotely over SSH. (use the `/etc/ansible/hosts` file to add new groups/hosts).
 > Some subcommands such as `galaxy` have their own usage documentation.
-> More information: <https://www.ansible.com/>.
+> More information: <https://docs.ansible.com/ansible/latest/cli/ansible.html>.
 
 - List hosts belonging to a group:
 
 `ansible {{group}} --list-hosts`
 
-- Ping a group of hosts by invoking the ping [m]odule:
+- Ping a group of hosts by invoking the ping module:
 
-`ansible {{group}} -m ping`
+`ansible {{group}} {{[-m|--module-name]}} ping`
 
 - Display facts about a group of hosts by invoking the setup [m]odule:
 
-`ansible {{group}} -m setup`
+`ansible {{group}} {{[-m|--module-name]}} setup`
 
 - Execute a command on a group of hosts by invoking command module with arguments:
 
-`ansible {{group}} -m command -a '{{my_command}}'`
+`ansible {{group}} {{[-m|--module-name]}} command {{[-a|--args]}} '{{my_command}}'`
 
 - Execute a command with administrative privileges:
 
-`ansible {{group}} --become --ask-become-pass -m command -a '{{my_command}}'`
+`ansible {{group}} {{[-b|--become]}} --ask-become-pass {{[-m|--module-name]}} command {{[-a|--args]}} '{{my_command}}'`
 
 - Execute a command using a custom inventory file:
 
-`ansible {{group}} -i {{inventory_file}} -m command -a '{{my_command}}'`
+`ansible {{group}} {{[-i|--inventory]}} {{inventory_file}} {{[-m|--module-name]}} command {{[-a|--args]}} '{{my_command}}'`
 
 - List the groups in an inventory:
 
-`ansible localhost -m debug -a '{{var=groups.keys()}}'`
+`ansible localhost {{[-m|--module-name]}} debug {{[-a|--args]}} '{{var=groups.keys()}}'`

--- a/pages/common/ant.md
+++ b/pages/common/ant.md
@@ -1,24 +1,24 @@
 # ant
 
 > Apache Ant: build and manage Java-based projects.
-> More information: <https://ant.apache.org>.
+> More information: <https://ant.apache.org/manual/index.html>.
 
 - Build a project with default build file `build.xml`:
 
 `ant`
 
-- Build a project using build [f]ile other than `build.xml`:
+- Build a project using build file other than `build.xml`:
 
-`ant -f {{buildfile.xml}}`
+`ant {{[-f|-buildfile]}} {{buildfile.xml}}`
 
 - Print information on possible targets for this project:
 
-`ant -p`
+`ant {{[-p|-projecthelp]}}`
 
 - Print debugging information:
 
-`ant -d`
+`ant {{[-d|-debug]}}`
 
 - Execute all targets that do not depend on fail target(s):
 
-`ant -k`
+`ant {{[-k|-keep-going]}}`

--- a/pages/common/apkleaks.md
+++ b/pages/common/apkleaks.md
@@ -4,14 +4,14 @@
 > Note: APKLeaks utilizes the `jadx` disassembler to decompile APK files.
 > More information: <https://github.com/dwisiswant0/apkleaks>.
 
-- Scan an APK [f]ile for URIs, endpoints, and secrets:
+- Scan an APK file for URIs, endpoints, and secrets:
 
-`apkleaks --file {{path/to/file.apk}}`
+`apkleaks {{[-f|--file]}} {{path/to/file.apk}}`
 
-- Scan and save the [o]utput to a specific file:
+- Scan and save the output to a specific file:
 
-`apkleaks --file {{path/to/file.apk}} --output {{path/to/output.txt}}`
+`apkleaks {{[-f|--file]}} {{path/to/file.apk}} {{[-o|--output]}} {{path/to/output.txt}}`
 
-- Pass `jadx` disassembler [a]rguments:
+- Pass `jadx` disassembler arguments:
 
-`apkleaks --file {{path/to/file.apk}} --args "{{--threads-count 5 --deobf}}"`
+`apkleaks {{[-f|--file]}} {{path/to/file.apk}} {{[-a|--args]}} "{{--threads-count 5 --deobf}}"`

--- a/pages/common/apropos.md
+++ b/pages/common/apropos.md
@@ -9,8 +9,8 @@
 
 - Search without restricting the output to the terminal width ([l]ong output):
 
-`apropos -l {{regular_expression}}`
+`apropos {{[-l|--long]}} {{regular_expression}}`
 
-- Search for pages that match [a]ll the expressions given:
+- Search for pages that match all the expressions given:
 
-`apropos {{regular_expression_1}} -a {{regular_expression_2}} -a {{regular_expression_3}}`
+`apropos {{regular_expression_1}} {{[-a|--and]}} {{regular_expression_2}} {{[-a|--and]}} {{regular_expression_3}}`

--- a/pages/common/arp.md
+++ b/pages/common/arp.md
@@ -1,7 +1,7 @@
 # arp
 
 > Show and manipulate your system's ARP cache.
-> More information: <https://manned.org/man/arp.8>.
+> More information: <https://manned.org/arp.8>.
 
 - Show the current ARP table:
 

--- a/pages/common/arp.md
+++ b/pages/common/arp.md
@@ -1,7 +1,7 @@
 # arp
 
 > Show and manipulate your system's ARP cache.
-> More information: <https://manned.org/arp>.
+> More information: <https://manned.org/man/arp.8>.
 
 - Show the current ARP table:
 

--- a/pages/common/arping.md
+++ b/pages/common/arping.md
@@ -2,7 +2,7 @@
 
 > Discover and probe hosts in a network using the ARP protocol.
 > Useful for MAC address discovery.
-> More information: <https://github.com/ThomasHabets/arping>.
+> More information: <https://manned.org/arping>.
 
 - Ping a host by ARP request packets:
 

--- a/pages/common/atoum.md
+++ b/pages/common/atoum.md
@@ -1,7 +1,7 @@
 # atoum
 
 > A simple, modern and intuitive unit testing framework for PHP.
-> More information: <https://atoum.org>.
+> More information: <https://atoum.readthedocs.io/en/latest/option_cli.html>.
 
 - Initialize a configuration file:
 
@@ -11,26 +11,26 @@
 
 `atoum`
 
-- Run tests using the specified [c]onfiguration file:
+- Run tests using the specified configuration file:
 
-`atoum -c {{path/to/file}}`
+`atoum {{[-c|--configuration]}} {{path/to/file}}`
 
-- Run a specific test [f]ile:
+- Run a specific test file:
 
-`atoum -f {{path/to/file}}`
+`atoum {{[-f|--files]}} {{path/to/file}}`
 
-- Run a specific [d]irectory of tests:
+- Run a specific directory of tests:
 
-`atoum -d {{path/to/directory}}`
+`atoum {{[-d|--directories]}} {{path/to/directory}}`
 
-- Run all tests under a specific name[s]pace:
+- Run all tests under a specific namespace:
 
-`atoum -ns {{namespace}}`
+`atoum {{[-ns|--namespaces]}} {{namespace}}`
 
-- Run all tests with a specific [t]ag:
+- Run all tests with a specific tag:
 
-`atoum -t {{tag}}`
+`atoum {{[-t|--tags]}} {{tag}}`
 
 - Load a custom bootstrap file before running tests:
 
-`atoum --bootstrap-file {{path/to/file}}`
+`atoum {{[-bf|--bootstrap-file]}} {{path/to/file}}`

--- a/pages/common/autossh.md
+++ b/pages/common/autossh.md
@@ -2,7 +2,7 @@
 
 > Run, monitor and restart SSH connections.
 > Auto-reconnects to keep port forwarding tunnels up. Accepts all SSH flags.
-> More information: <https://www.harding.motd.ca/autossh>.
+> More information: <https://manned.org/autossh>.
 
 - Start an SSH session, restarting when the [M]onitoring port fails to return data:
 

--- a/pages/common/avrdude.md
+++ b/pages/common/avrdude.md
@@ -1,7 +1,7 @@
 # avrdude
 
 > Driver program for Atmel AVR microcontrollers programming.
-> More information: <https://www.nongnu.org/avrdude/>.
+> More information: <https://www.nongnu.org/avrdude/user-manual/avrdude_3.html#Option-Descriptions>.
 
 - [r]ead the flash ROM of a AVR microcontroller with a specific [p]art ID:
 

--- a/pages/common/aws-google-auth.md
+++ b/pages/common/aws-google-auth.md
@@ -3,18 +3,18 @@
 > Acquire AWS temporary (STS) credentials using Google Apps as a federated (Single Sign-On) provider.
 > More information: <https://github.com/cevoaustralia/aws-google-auth>.
 
-- Log in with Google SSO using the specified [u]sername [I]DP and [S]P identifiers and set the credentials [d]uration to one hour:
+- Log in with Google SSO using the specified username IDP and SP identifiers and set the credentials duration to one hour:
 
-`aws-google-auth -u {{example@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}}`
+`aws-google-auth {{[-u|--username]}} {{example@example.com}} {{[-I|--idp-id]}} {{$GOOGLE_IDP_ID}} {{[-S|--sp-id]}} {{$GOOGLE_SP_ID}} {{[-d|--duration]}} {{3600}}`
 
-- Log in [a]sking which role to use (in case of several available SAML roles):
+- Log in asking which role to use (in case of several available SAML roles):
 
-`aws-google-auth -u {{example@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}} -a`
+`aws-google-auth {{[-u|--username]}} {{example@example.com}} {{[-I|--idp-id]}} {{$GOOGLE_IDP_ID}} {{[-S|--sp-id]}} {{$GOOGLE_SP_ID}} {{[-d|--duration]}} {{3600}} {{[-a|--ask-role]}}`
 
 - Resolve aliases for AWS accounts:
 
-`aws-google-auth -u {{example@example.com}} -I {{$GOOGLE_IDP_ID}} -S {{$GOOGLE_SP_ID}} -d {{3600}} -a --resolve-aliases`
+`aws-google-auth {{[-u|--username]}} {{example@example.com}} {{[-I|--idp-id]}} {{$GOOGLE_IDP_ID}} {{[-S|--sp-id]}} {{$GOOGLE_SP_ID}} {{[-d|--duration]}} {{3600}} {{[-a|--ask-role]}} --resolve-aliases`
 
 - Display help:
 
-`aws-google-auth -h`
+`aws-google-auth {{[-h|--help]}}`

--- a/pages/common/axel.md
+++ b/pages/common/axel.md
@@ -2,24 +2,24 @@
 
 > Download accelerator.
 > Supports HTTP, HTTPS, and FTP.
-> More information: <https://github.com/axel-download-accelerator/axel>.
+> More information: <https://manned.org/axel>.
 
 - Download a URL to a file:
 
 `axel {{url}}`
 
-- Download and specify an [o]utput file:
+- Download and specify an output file:
 
-`axel {{url}} -o {{path/to/file}}`
+`axel {{url}} {{[-o|--output]}} {{path/to/file}}`
 
-- Download with a specific [n]umber connections:
+- Download with a specific number connections:
 
-`axel -n {{connections_num}} {{url}}`
+`axel {{[-n|--num-connections]}} {{connections_num}} {{url}}`
 
-- [S]earch for mirrors:
+- Search for mirrors:
 
-`axel -S {{mirrors_num}} {{url}}`
+`axel {{[-S|--search]}} {{mirrors_num}} {{url}}`
 
-- Limit download [s]peed (bytes per second):
+- Limit download speed (bytes per second):
 
-`axel -s {{speed}} {{url}}`
+`axel {{[-s|--max-speed]}} {{speed}} {{url}}`

--- a/pages/common/az-lock.md
+++ b/pages/common/az-lock.md
@@ -6,19 +6,19 @@
 
 - Create a read-only subscription level lock:
 
-`az lock create --name {{lock_name}} --lock-type ReadOnly`
+`az lock create {{[-n|--name]}} {{lock_name}} {{[-t|--lock-type]}} ReadOnly`
 
 - Create a read-only resource group level lock:
 
-`az lock create --name {{lock_name}} --resource-group {{group_name}} --lock-type ReadOnly`
+`az lock create {{[-n|--name]}} {{lock_name}} {{[-g|--resource-group]}} {{group_name}} {{[-t|--lock-type]}} ReadOnly`
 
 - Delete a subscription level lock:
 
-`az lock delete --name {{lock_name}}`
+`az lock delete {{[-n|--name]}} {{lock_name}}`
 
 - Delete a resource group level lock:
 
-`az lock delete --name {{lock_name}} --resource-group {{group_name}}`
+`az lock delete {{[-n|--name]}} {{lock_name}} {{[-g|--resource-group]}} {{group_name}}`
 
 - List out all locks on the subscription level:
 
@@ -26,4 +26,4 @@
 
 - Show a subscription level lock with a specific [n]ame:
 
-`az lock show -n {{lock_name}}`
+`az lock show {{[-n|--name]}} {{lock_name}}`

--- a/pages/common/az-storage-blob.md
+++ b/pages/common/az-storage-blob.md
@@ -4,22 +4,22 @@
 > Part of `azure-cli` (also known as `az`).
 > More information: <https://learn.microsoft.com/cli/azure/storage/blob>.
 
-- Download a blob to a [f]ile path specifying a [s]ource container:
+- Download a blob to a file path specifying a source container:
 
-`az storage blob download --account-name {{storage_account_name}} --account-key {{storage_account_key}} -c {{container_name}} -n {{path/to/blob}} -f {{path/to/local_file}}`
+`az storage blob download --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-c|--container-name]}} {{container_name}} {{[-n|--name]}} {{path/to/blob}} {{[-f|--file]}} {{path/to/local_file}}`
 
 - [d]ownload blobs from a blob container recursively:
 
-`az storage blob download-batch --account-name {{storage_account_name}} --account-key {{storage_account_key}} -s {{container_name}} -d {{path/to/remote}} --pattern {{filename_regex}} --destination {{path/to/destination}}`
+`az storage blob download-batch --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-s|--source]}} {{container_name}} {{[-d|--destination]}} {{path/to/remote}} --pattern {{filename_regex}} {{[-d|--destination]}} {{path/to/destination}}`
 
 - Upload a local file to blob storage:
 
-`az storage blob upload --account-name {{storage_account_name}} --account-key {{storage_account_key}} -c {{container_name}} -n {{path/to/blob}} -f {{path/to/local_file}}`
+`az storage blob upload --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-c|--container-name]}} {{container_name}} {{[-n|--name]}} {{path/to/blob}} {{[-f|--file]}} {{path/to/local_file}}`
 
 - Delete a blob object:
 
-`az storage blob delete --account-name {{storage_account_name}} --account-key {{storage_account_key}} -c {{container_name}} -n {{path/to/blob}}`
+`az storage blob delete --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-c|--container-name]}} {{container_name}} {{[-n|--name]}} {{path/to/blob}}`
 
 - Generate a shared access signature for a blob:
 
-`az storage blob generate-sas --account-name {{storage_account_name}} --account-key {{storage_account_key}} -c {{container_name}} -n {{path/to/blob}} --permissions {{permission_set}} --expiry {{Y-m-d'T'H:M'Z'}} --https-only`
+`az storage blob generate-sas --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-c|--container-name]}} {{container_name}} {{[-n|--name]}} {{path/to/blob}} --permissions {{permission_set}} --expiry {{Y-m-d'T'H:M'Z'}} --https-only`

--- a/pages/common/az-storage.md
+++ b/pages/common/az-storage.md
@@ -4,22 +4,22 @@
 > Part of `azure-cli` (also known as `az`).
 > More information: <https://learn.microsoft.com/cli/azure/storage>.
 
-- Create a storage account specifying a [l]ocation:
+- Create a storage account specifying a location:
 
-`az storage account create --resource-group {{group_name}} --name {{account_name}} -l {{location}} --sku {{account_sku}}`
+`az storage account create {{[-g|--resource-group]}} {{group_name}} {{[-n|--name]}} {{account_name}} {{[-l|--location]}} {{location}} --sku {{account_sku}}`
 
 - List all storage accounts in a resource group:
 
-`az storage account list --resource-group {{group_name}}`
+`az storage account list {{[-g|--resource-group]}} {{group_name}}`
 
 - List the access keys for a storage account:
 
-`az storage account keys list --resource-group {{group_name}} --name {{account_name}}`
+`az storage account keys list {{[-g|--resource-group]}} {{group_name}} {{[-n|--name]}} {{account_name}}`
 
 - Delete a storage account:
 
-`az storage account delete --resource-group {{group_name}} --name {{account_name}}`
+`az storage account delete {{[-g|--resource-group]}} {{group_name}} {{[-n|--name]}} {{account_name}}`
 
 - Update the minimum tls version setting for a storage account:
 
-`az storage account update --min-tls-version {{TLS1_0|TLS1_1|TLS1_2}} --resource-group {{group_name}} --name {{account_name}}`
+`az storage account update --min-tls-version {{TLS1_0|TLS1_1|TLS1_2}} {{[-g|--resource-group]}} {{group_name}} {{[-n|--name]}} {{account_name}}`

--- a/pages/common/banner.md
+++ b/pages/common/banner.md
@@ -7,9 +7,9 @@
 
 `banner "{{Hello World}}"`
 
-- Use a banner [w]idth of 50 characters:
+- Use a banner width of 50 characters:
 
-`banner -w 50 "{{Hello World}}"`
+`banner {{[-w|--width]}} 50 "{{Hello World}}"`
 
 - Read text from `stdin`:
 

--- a/pages/common/bash.md
+++ b/pages/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, an `sh`-compatible command-line interpreter.
 > See also: `zsh`, `histexpand` (history expansion).
-> More information: <https://www.gnu.org/software/bash/>.
+> More information: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Start an interactive shell session:
 

--- a/pages/common/bats.md
+++ b/pages/common/bats.md
@@ -3,26 +3,26 @@
 > Bash Automated Testing System: a TAP (<https://testanything.org/>) compliant testing framework for Bash.
 > More information: <https://bats-core.readthedocs.io/en/stable/usage.html>.
 
-- Run a BATS test script and output results in the [t]AP (Test Anything Protocol) format:
+- Run a BATS test script and output results in the TAP (Test Anything Protocol) format:
 
-`bats --tap {{path/to/test.bats}}`
+`bats {{[-t|--tap]}} {{path/to/test.bats}}`
 
-- [c]ount test cases of a test script without running any tests:
+- Count test cases of a test script without running any tests:
 
-`bats --count {{path/to/test.bats}}`
+`bats {{[-c|--count]}} {{path/to/test.bats}}`
 
-- Run BATS test cases [r]ecursively (files with a `.bats` extension):
+- Run BATS test cases recursively (files with a `.bats` extension):
 
-`bats --recursive {{path/to/directory}}`
+`bats {{[-r|--recursive]}} {{path/to/directory}}`
 
-- Output results in a specific [F]ormat:
+- Output results in a specific format:
 
-`bats --formatter {{pretty|tap|tap13|junit}} {{path/to/test.bats}}`
+`bats {{[-F|--formatter]}} {{pretty|tap|tap13|junit}} {{path/to/test.bats}}`
 
-- Add [T]iming information to tests:
+- Add timing information to tests:
 
-`bats --timing {{path/to/test.bats}}`
+`bats {{[-T|--timing]}} {{path/to/test.bats}}`
 
-- Run specific number of [j]obs in parallel (requires GNU `parallel` to be installed):
+- Run specific number of jobs in parallel (requires GNU `parallel` to be installed):
 
-`bats --jobs {{number}} {{path/to/test.bats}}`
+`bats {{[-j|--jobs]}} {{number}} {{path/to/test.bats}}`

--- a/pages/common/bb.md
+++ b/pages/common/bb.md
@@ -3,13 +3,13 @@
 > Native Clojure interpreter for scripting.
 > More information: <https://book.babashka.org/#usage>.
 
-- [e]valuate an expression:
+- Evaluate an expression:
 
-`bb -e "(+ 1 2 3)"`
+`bb {{[-e|--eval]}} "(+ 1 2 3)"`
 
-- Evaluate a script [f]ile:
+- Evaluate a script file:
 
-`bb -f {{path/to/script.clj}}`
+`bb {{[-f|--file]}} {{path/to/script.clj}}`
 
 - Bind [i]nput to a sequence of lines from `stdin`:
 

--- a/pages/common/bc.md
+++ b/pages/common/bc.md
@@ -8,9 +8,9 @@
 
 `bc`
 
-- Start an [i]nteractive session with the standard math [l]ibrary enabled:
+- Start an interactive session with the standard math library enabled:
 
-`bc --interactive --mathlib`
+`bc {{[-i|--interactive]}} {{[-l|--mathlib]}}`
 
 - Calculate an expression:
 
@@ -26,7 +26,7 @@
 
 - Calculate a sine/cosine/arctangent/natural logarithm/exponential function using `mathlib`:
 
-`echo '{{s|c|a|l|e}}({{1}})' | bc --mathlib`
+`echo '{{s|c|a|l|e}}({{1}})' | bc {{[-l|--mathlib]}}`
 
 - Execute an inline factorial script:
 

--- a/pages/common/bdfr.md
+++ b/pages/common/bdfr.md
@@ -3,26 +3,26 @@
 > Bulk downloader for Reddit.
 > More information: <https://github.com/Serene-Arc/bulk-downloader-for-reddit>.
 
-- Download videos/images from the specified [l]inks to URL or ID's of posts:
+- Download videos/images from the specified links to URL or ID's of posts:
 
-`bdfr download {{path/to/output_directory}} -l {{post_url}}`
+`bdfr download {{path/to/output_directory}} {{[-l|--link]}} {{post_url}}`
 
-- Download the maximum possible number (roughly 1000) of videos/images from a specified [u]ser:
+- Download the maximum possible number (roughly 1000) of videos/images from a specified user:
 
-`bdfr download {{path/to/output_directory}} -u {{reddit_user}} --submitted`
+`bdfr download {{path/to/output_directory}} {{[-u|--user]}} {{reddit_user}} --submitted`
 
-- Download submission data (text, upvotes, comments, etc.) [L]imited to 10 submissions for each [s]ubreddit (30 total):
+- Download submission data (text, upvotes, comments, etc.) limited to 10 submissions for each subreddit (30 total):
 
-`bdfr archive {{path/to/output_directory}} -s '{{Python, all, mindustry}}' -L 10`
+`bdfr archive {{path/to/output_directory}} {{[-s|--subreddit]}} '{{Python, all, mindustry}}' {{[-L|--limit]}} 10`
 
-- Download videos/images from the [s]ubreddit r/Python [S]orted by top (default is hot) using [t]ime filter all, [L]imited to 10 submissions:
+- Download videos/images from the subreddit r/Python sorted by top (default is hot) using time filter all, limited to 10 submissions:
 
-`bdfr download {{path/to/output_directory}} -s Python -S top -t all -L 10`
+`bdfr download {{path/to/output_directory}} {{[-s|--subreddit]}} Python {{[-S|--sort]}} top {{[-t|--time]}} all {{[-L|--limit]}} 10`
 
-- Download the maximum possible number of both submission data and videos/images from [s]ubreddit r/Python skipping over submissions with mp4 or gif file extensions and creating hard links for duplicate files:
+- Download the maximum possible number of both submission data and videos/images from subreddit r/Python skipping over submissions with mp4 or gif file extensions and creating hard links for duplicate files:
 
-`bdfr clone {{path/to/output_directory}} -s Python --skip mp4 --skip gif --make-hard-links`
+`bdfr clone {{path/to/output_directory}} {{[-s|--subreddit]}} Python --skip mp4 --skip gif --make-hard-links`
 
 - Download saved posts of the authenticated user, naming each file according to a specified format. Avoid downloading duplicates and posts already present in the output directory:
 
-`bdfr download {{path/to/output_directory}} --user me --saved --authenticate --file-scheme '{{ {POSTID}_{TITLE}_{UPVOTES} }}' --no-dupes --search-existing`
+`bdfr download {{path/to/output_directory}} {{[-u|--user]}} me --saved --authenticate --file-scheme '{{ {POSTID}_{TITLE}_{UPVOTES} }}' --no-dupes --search-existing`

--- a/pages/common/beanstalkd.md
+++ b/pages/common/beanstalkd.md
@@ -1,7 +1,7 @@
 # beanstalkd
 
 > A simple and generic work-queue server.
-> More information: <https://beanstalkd.github.io/>.
+> More information: <https://manned.org/beanstalkd>.
 
 - Start the server, listening on port 11300:
 

--- a/pages/common/bedtools.md
+++ b/pages/common/bedtools.md
@@ -2,7 +2,7 @@
 
 > A swiss-army knife of tools for genomic-analysis tasks.
 > Used to intersect, group, convert and count data in BAM, BED, GFF/GTF, VCF format.
-> More information: <https://bedtools.readthedocs.io>.
+> More information: <https://bedtools.readthedocs.io/en/latest/content/overview.html#summary-of-available-tools>.
 
 - Intersect file [a] and file(s) [b] regarding the sequences' [s]trand and save the result to a specific file:
 

--- a/pages/common/black.md
+++ b/pages/common/black.md
@@ -7,9 +7,9 @@
 
 `black {{path/to/file_or_directory}}`
 
-- Format the [c]ode passed in as a string:
+- Format the code passed in as a string:
 
-`black -c "{{code}}"`
+`black {{[-c|--code]}} "{{code}}"`
 
 - Show whether a file or a directory would have changes made to them if they were to be formatted:
 
@@ -21,8 +21,8 @@
 
 - Auto-format a file or directory, emitting exclusively error messages to `stderr`:
 
-`black --quiet {{path/to/file_or_directory}}`
+`black {{[-q|--quiet]}} {{path/to/file_or_directory}}`
 
 - Auto-format a file or directory without replacing single quotes with double quotes (adoption helper, avoid using this for new projects):
 
-`black --skip-string-normalization {{path/to/file_or_directory}}`
+`black {{[-S|--skip-string-normalization]}} {{path/to/file_or_directory}}`

--- a/pages/common/blender.md
+++ b/pages/common/blender.md
@@ -6,28 +6,28 @@
 
 - Render all frames of an animation in the background, without loading the UI (output is saved to `/tmp`):
 
-`blender --background {{path/to/file.blend}} --render-anim`
+`blender {{[-b|--background]}} {{path/to/file.blend}} {{[-a|--render-anim]}}`
 
 - Render an animation using a specific image naming pattern, in a path relative (`//`) to the .blend file:
 
-`blender --background {{path/to/file.blend}} --render-output //{{render/frame_###.png}} --render-anim`
+`blender {{[-b|--background]}} {{path/to/file.blend}} {{[-o|--render-output]}} //{{render/frame_###.png}} {{[-a|--render-anim]}}`
 
 - Render the 10th frame of an animation as a single image, saved to an existing directory (absolute path):
 
-`blender --background {{path/to/file.blend}} --render-output {{/path/to/output_directory}} --render-frame {{10}}`
+`blender {{[-b|--background]}} {{path/to/file.blend}} {{[-o|--render-output]}} {{/path/to/output_directory}} {{[-f|--render-frame]}} {{10}}`
 
 - Render the second last frame in an animation as a JPEG image, saved to an existing directory (relative path):
 
-`blender --background {{path/to/file.blend}} --render-output //{{output_directory}} --render-frame {{JPEG}} --render-frame {{-2}}`
+`blender {{[-b|--background]}} {{path/to/file.blend}} {{[-o|--render-output]}} //{{output_directory}} {{[-f|--render-frame]}} {{JPEG}} {{[-f|--render-frame]}} {{-2}}`
 
 - Render the animation of a specific scene, starting at frame 10 and ending at frame 500:
 
-`blender --background {{path/to/file.blend}} --scene {{scene_name}} --frame-start {{10}} --frame-end {{500}} --render-anim`
+`blender {{[-b|--background]}} {{path/to/file.blend}} {{[-S|--scene]}} {{scene_name}} {{[-s|--frame-start]}} {{10}} {{[-e|--frame-end]}} {{500}} {{[-a|--render-anim]}}`
 
 - Render an animation at a specific resolution, by passing a Python expression:
 
-`blender --background {{path/to/file.blend}} --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' --render-anim`
+`blender {{[-b|--background]}} {{path/to/file.blend}} --python-expr '{{import bpy; bpy.data.scenes[0].render.resolution_percentage = 25}}' {{[-a|--render-anim]}}`
 
 - Start an interactive Blender session in the terminal with a Python console (do `import bpy` after starting):
 
-`blender --background --python-console`
+`blender {{[-b|--background]}} --python-console`

--- a/pages/common/bmaptool.md
+++ b/pages/common/bmaptool.md
@@ -1,11 +1,11 @@
 # bmaptool
 
 > Create or copy block maps intelligently (designed to be faster than `cp` or `dd`).
-> More information: <https://source.tizen.org/documentation/reference/bmaptool>.
+> More information: <https://manned.org/bmaptool>.
 
-- [o]utput a blockmap file from image file:
+- Output a blockmap file from image file:
 
-`bmaptool create -o {{blockmap.bmap}} {{source.img}}`
+`bmaptool create {{[-o|--output]}} {{blockmap.bmap}} {{source.img}}`
 
 - Copy an image file into sdb:
 

--- a/pages/common/bosh.md
+++ b/pages/common/bosh.md
@@ -3,9 +3,9 @@
 > Deploy and manage the BOSH director.
 > More information: <https://bosh.io/docs/cli-v2/>.
 
-- Create local alias for director in a specific [e]nvironment:
+- Create local alias for director in a specific environment:
 
-`bosh alias-env {{environment_name}} -e {{ip_address|URL}} --ca-cert {{ca_certificate}}`
+`bosh alias-env {{environment_name}} {{[-e|--environment]}} {{ip_address|URL}} --ca-cert {{ca_certificate}}`
 
 - List environments:
 
@@ -13,24 +13,24 @@
 
 - Log in to the director:
 
-`bosh login -e {{environment}}`
+`bosh login {{[-e|--environment]}} {{environment}}`
 
 - List deployments:
 
-`bosh -e {{environment}} deployments`
+`bosh {{[-e|--environment]}} {{environment}} deployments`
 
-- List environment virtual machines in a [d]eployment:
+- List environment virtual machines in a deployment:
 
-`bosh -e {{environment}} vms -d {{deployment}}`
+`bosh {{[-e|--environment]}} {{environment}} vms {{[-d|--deployment]}} {{deployment}}`
 
 - SSH into virtual machine:
 
-`bosh -e {{environment}} ssh {{virtual_machine}} -d {{deployment}}`
+`bosh {{[-e|--environment]}} {{environment}} ssh {{virtual_machine}} {{[-d|--deployment]}} {{deployment}}`
 
 - Upload stemcell:
 
-`bosh -e {{environment}} upload-stemcell {{stemcell_file|url}}`
+`bosh {{[-e|--environment]}} {{environment}} upload-stemcell {{stemcell_file|url}}`
 
 - Show current cloud config:
 
-`bosh -e {{environment}} cloud-config`
+`bosh {{[-e|--environment]}} {{environment}} cloud-config`

--- a/pages/common/boxes.md
+++ b/pages/common/boxes.md
@@ -7,26 +7,26 @@
 
 `echo "{{string}}" | boxes`
 
-- [r]emove a box from a string:
+- Remove a box from a string:
 
-`echo "{{string}}" | boxes -r`
+`echo "{{string}}" | boxes {{[-r|--remove]}}`
 
-- Specify the box [d]esign:
+- Specify the box design:
 
-`echo "{{string}}" | boxes -d {{parchment}}`
+`echo "{{string}}" | boxes {{[-d|--design]}} {{parchment}}`
 
-- Specify the box [s]ize (in columns by lines):
+- Specify the box size (in columns by lines):
 
-`echo "{{string}}" | boxes -s {{10}}x{{5}}`
+`echo "{{string}}" | boxes {{[-s|--size]}} {{10}}x{{5}}`
 
-- [a]lign the box text [h]orizonally (at [l]eft, [c]enter or [r]ight):
+- Align the box text [h]orizonally (at [l]eft, [c]enter or [r]ight):
 
-`echo "{{string}}" | boxes -a h{{l|c|r}}`
+`echo "{{string}}" | boxes {{[-a|--align]}} h{{l|c|r}}`
 
-- [a]lign the box text [v]ertically (at [t]op, [c]enter or [b]ottom):
+- Align the box text [v]ertically (at [t]op, [c]enter or [b]ottom):
 
-`echo "{{string}}" | boxes -a v{{t|c|b}}`
+`echo "{{string}}" | boxes {{[-a|--align]}} v{{t|c|b}}`
 
 - [j]ustify the box text (at [l]eft, [c]enter or [r]ight):
 
-`echo "{{string}}" | boxes -a j{{l|c|r}}{{vt}}`
+`echo "{{string}}" | boxes {{[-a|--align]}} j{{l|c|r}}{{vt}}`

--- a/pages/common/bpython.md
+++ b/pages/common/bpython.md
@@ -14,8 +14,8 @@
 
 - Execute a specific Python file and start a REPL:
 
-`bpython --interactive {{path/to/file.py}}`
+`bpython {{[-i|--interactive]}} {{path/to/file.py}}`
 
-- Use the specified [c]onfig file instead of the default config:
+- Use the specified config file instead of the default config:
 
 `bpython --config {{path/to/file.conf}}`

--- a/pages/common/brotli.md
+++ b/pages/common/brotli.md
@@ -1,24 +1,24 @@
 # brotli
 
 > Compress/uncompress files with Brotli compression.
-> More information: <https://github.com/google/brotli>.
+> More information: <https://manned.org/brotli>.
 
 - Compress a file, creating a compressed version next to the file:
 
 `brotli {{path/to/file}}`
 
-- [d]ecompress a file, creating an uncompressed version next to the file:
+- Decompress a file, creating an uncompressed version next to the file:
 
-`brotli -d {{path/to/file.br}}`
+`brotli {{[-d|--decompress]}} {{path/to/file.br}}`
 
-- Compress a file specifying the [o]utput filename:
+- Compress a file specifying the output filename:
 
-`brotli {{path/to/file}} -o {{path/to/compressed_output_file.br}}`
+`brotli {{path/to/file}} {{[-o|--output]}} {{path/to/compressed_output_file.br}}`
 
-- [d]ecompress a Brotli file specifying the [o]utput filename:
+- Decompress a Brotli file specifying the output filename:
 
-`brotli -d {{path/to/compressed_file.br}} -o {{path/to/output_file}}`
+`brotli {{[-d|--decompress]}} {{path/to/compressed_file.br}} {{[-o|--output]}} {{path/to/output_file}}`
 
 - Specify the compression quality (1=fastest (worst), 11=slowest (best)):
 
-`brotli -q {{11}} {{path/to/file}} -o {{path/to/compressed_output_file.br}}`
+`brotli {{[-q|--quality]}} {{11}} {{path/to/file}} {{[-o|--output]}} {{path/to/compressed_output_file.br}}`

--- a/pages/common/bup.md
+++ b/pages/common/bup.md
@@ -1,24 +1,24 @@
 # bup
 
 > Backup system based on the Git packfile format, providing incremental saves and global deduplication.
-> More information: <https://github.com/bup/bup>.
+> More information: <https://manned.org/bup>.
 
-- Initialize a backup repository in a given local [d]irectory:
+- Initialize a backup repository in a given local directory:
 
-`bup -d {{path/to/repository}} init`
+`bup {{[-d|--bup-dir]}} {{path/to/repository}} init`
 
-- Prepare a given [d]irectory before taking a backup:
+- Prepare a given directory before taking a backup:
 
-`bup -d {{path/to/repository}} index {{path/to/directory}}`
+`bup {{[-d|--bup-dir]}} {{path/to/repository}} index {{path/to/directory}}`
 
-- Backup a [d]irectory to the repository specifying its [n]ame:
+- Backup a directory to the repository specifying its name:
 
-`bup -d {{path/to/repository}} save -n {{backup_name}} {{path/to/directory}}`
+`bup {{[-d|--bup-dir]}} {{path/to/repository}} save {{[-n|--name]}} {{backup_name}} {{path/to/directory}}`
 
 - Show the backup snapshots currently stored in the repository:
 
-`bup -d {{path/to/repository}} ls`
+`bup {{[-d|--bup-dir]}} {{path/to/repository}} ls`
 
-- Restore a specific backup snapshot to a target dire[C]tory:
+- Restore a specific backup snapshot to a target directory:
 
-`bup -d {{path/to/repository}} restore -C {{path/to/target_directory}} {{backup_name}}`
+`bup {{[-d|--bup-dir]}} {{path/to/repository}} restore {{[-C|--outdir]}} {{path/to/target_directory}} {{backup_name}}`

--- a/pages/common/bzip2.md
+++ b/pages/common/bzip2.md
@@ -7,26 +7,26 @@
 
 `bzip2 {{path/to/file_to_compress}}`
 
-- [d]ecompress a file:
+- Decompress a file:
 
-`bzip2 -d {{path/to/compressed_file.bz2}}`
+`bzip2 {{[-d|--decompress]}} {{path/to/compressed_file.bz2}}`
 
-- [d]ecompress a file to `stdout`:
+- Decompress a file to `stdout`:
 
-`bzip2 -dc {{path/to/compressed_file.bz2}}`
+`bzip2 {{[-dc|--decompress --stdout]}} {{path/to/compressed_file.bz2}}`
 
 - Test the integrity of each file inside the archive file:
 
-`bzip2 --test {{path/to/compressed_file.bz2}}`
+`bzip2 {{[-t|--test]}} {{path/to/compressed_file.bz2}}`
 
 - Show the compression ratio for each file processed with detailed information:
 
-`bzip2 --verbose {{path/to/compressed_files.bz2}}`
+`bzip2 {{[-v|--verbose]}} {{path/to/compressed_files.bz2}}`
 
 - Decompress a file overwriting existing files:
 
-`bzip2 --force {{path/to/compressed_file.bz2}}`
+`bzip2 {{[-f|--force]}} {{path/to/compressed_file.bz2}}`
 
 - Display help:
 
-`bzip2 -h`
+`bzip2 {{[-h|--help]}}`

--- a/pages/common/bzip3.md
+++ b/pages/common/bzip3.md
@@ -1,32 +1,32 @@
 # bzip3
 
 > An efficient statistical file compressor.
-> More information: <https://github.com/kspalaiologos/bzip3>.
+> More information: <https://manned.org/bzip3>.
 
 - Compress a file:
 
 `bzip3 {{path/to/file_to_compress}}`
 
-- [d]ecompress a file:
+- Decompress a file:
 
-`bzip3 -d {{path/to/compressed_file.bz3}}`
+`bzip3 {{[-d|--decode]}} {{path/to/compressed_file.bz3}}`
 
 - Decompress a file to `stdout` ([c]):
 
-`bzip3 -dc {{path/to/compressed_file.bz3}}`
+`bzip3 {{[-dc|--decode --stdout]}} {{path/to/compressed_file.bz3}}`
 
 - Test the integrity of each file inside the archive file:
 
-`bzip3 --test {{path/to/compressed_file.bz3}}`
+`bzip3 {{[-t|--test]}} {{path/to/compressed_file.bz3}}`
 
 - Show the compression ratio for each file processed with detailed information:
 
-`bzip3 --verbose {{path/to/compressed_files.bz3}}`
+`bzip3 {{[-v|--verbose]}} {{path/to/compressed_files.bz3}}`
 
 - Decompress a file overwriting existing files:
 
-`bzip3 -d --force {{path/to/compressed_file.bz3}}`
+`bzip3 {{[-d|--decode]}} {{[-f--force]}} {{path/to/compressed_file.bz3}}`
 
 - Display help:
 
-`bzip3 -h`
+`bzip3 {{[-h|--help]}}`

--- a/pages/common/calc.md
+++ b/pages/common/calc.md
@@ -1,7 +1,7 @@
 # calc
 
 > An interactive arbitrary-precision calculator in the terminal.
-> More information: <https://github.com/lcn2/calc>.
+> More information: <https://manned.org/calc>.
 
 - Start `calc` in interactive mode:
 

--- a/pages/common/carbon-now.md
+++ b/pages/common/carbon-now.md
@@ -15,21 +15,21 @@
 
 `{{input}} | carbon-now --to-clipboard`
 
-- Create images [i]nteractively for custom settings and optionally save a preset:
+- Create images interactively for custom settings and optionally save a preset:
 
-`carbon-now -i {{path/to/file}}`
+`carbon-now {{[-i|--interactive]}} {{path/to/file}}`
 
-- Create images from a previously saved [p]reset:
+- Create images from a previously saved preset:
 
-`carbon-now -p {{preset}} {{path/to/file}}`
+`carbon-now {{[-p|--preset]}} {{preset}} {{path/to/file}}`
 
-- [s]tart at a specified line of text:
+- Start at a specified line of text:
 
-`carbon-now -s {{line}} {{path/to/file}}`
+`carbon-now {{[-s|--start]}} {{line}} {{path/to/file}}`
 
-- [e]nd at a specific line of text:
+- End at a specific line of text:
 
-`carbon-now -e {{line}} {{path/to/file}}`
+`carbon-now {{[-e|--end]}} {{line}} {{path/to/file}}`
 
 - Open image in a browser instead of saving:
 

--- a/pages/common/cargo-rustc.md
+++ b/pages/common/cargo-rustc.md
@@ -10,11 +10,11 @@
 
 - Build artifacts in release mode, with optimizations:
 
-`cargo rustc --release`
+`cargo rustc {{[-r|--release]}}`
 
 - Compile with architecture-specific optimizations for the current CPU:
 
-`cargo rustc --release -- -C target-cpu=native`
+`cargo rustc {{[-r|--release]}} -- -C target-cpu=native`
 
 - Compile with speed optimizations:
 
@@ -30,7 +30,7 @@
 
 - Build a specific package:
 
-`cargo rustc --package {{package}}`
+`cargo rustc {{[-p|--package]}} {{package}}`
 
 - Build only the specified binary:
 

--- a/pages/common/catimg.md
+++ b/pages/common/catimg.md
@@ -2,7 +2,7 @@
 
 > Image printing in the terminal.
 > See also: `pixterm`, `chafa`.
-> More information: <https://github.com/posva/catimg>.
+> More information: <https://manned.org/catimg>.
 
 - Print a JPEG, PNG, or GIF to the terminal:
 

--- a/pages/common/ccache.md
+++ b/pages/common/ccache.md
@@ -4,17 +4,17 @@
 > Note: packages usually provide symlinks for compilers in `/usr/lib/ccache/bin`. Prepend this directory to `$PATH` to automatically use `ccache` for them.
 > More information: <https://ccache.dev/manual/latest.html>.
 
-- Show current cache [s]tatistics:
+- Show current cache statistics:
 
-`ccache --show-stats`
+`ccache {{[-s|--show-stats]}}`
 
-- [C]lear all cache:
+- Clear all cache:
 
-`ccache --clear`
+`ccache {{[-C|--clear]}}`
 
-- Reset ([z]ero) statistics (but not cache itself):
+- Reset statistics (but not cache itself):
 
-`ccache --zero-stats`
+`ccache {{[-z|--zero-stats]}}`
 
 - Compile C code and cache compiled output (to use `ccache` on all `gcc` invocations, see the note above):
 

--- a/pages/common/cdecl.md
+++ b/pages/common/cdecl.md
@@ -1,7 +1,7 @@
 # cdecl
 
 > Compose and decode C and C++ type declarations.
-> More information: <https://github.com/paul-j-lucas/cdecl>.
+> More information: <https://manned.org/cdecl>.
 
 - Compose English phrase into C declaration, and create [c]ompilable output (include `;` and `{}`):
 

--- a/pages/common/cdk.md
+++ b/pages/common/cdk.md
@@ -23,9 +23,9 @@
 
 `cdk diff {{stack_name}}`
 
-- Create a new CDK project in the current directory for a specified [l]anguage:
+- Create a new CDK project in the current directory for a specified language:
 
-`cdk init -l {{language}}`
+`cdk init {{[-l|--language]}} {{language}}`
 
 - Open the CDK API reference in your browser:
 

--- a/pages/common/chafa.md
+++ b/pages/common/chafa.md
@@ -8,13 +8,13 @@
 
 `chafa {{path/to/file}}`
 
-- Render an image with 24-bit [c]olor:
+- Render an image with 24-bit color:
 
-`chafa -c full {{path/to/file}}`
+`chafa {{[-c|--colors]}} full {{path/to/file}}`
 
 - Improve image rendering with small color palettes using dithering:
 
-`chafa -c 16 --dither ordered {{path/to/file}}`
+`chafa {{[-c|--colors]}} 16 --dither ordered {{path/to/file}}`
 
 - Render an image, making it appear pixelated:
 
@@ -22,4 +22,4 @@
 
 - Render a monochrome image with only braille characters:
 
-`chafa -c none --symbols braille {{path/to/file}}`
+`chafa {{[-c|--colors]}} none --symbols braille {{path/to/file}}`

--- a/pages/common/chatgpt.md
+++ b/pages/common/chatgpt.md
@@ -7,17 +7,17 @@
 
 `chatgpt`
 
-- Give a [p]rompt to answer to:
+- Give a prompt to answer to:
 
-`chatgpt --prompt "{{What is the regex to match an email address?}}"`
+`chatgpt {{[-p|--prompt]}} "{{What is the regex to match an email address?}}"`
 
-- Start in chat mode using a specific [m]odel (default is `gpt-3.5-turbo`):
+- Start in chat mode using a specific model (default is `gpt-3.5-turbo`):
 
-`chatgpt --model {{gpt-4}}`
+`chatgpt {{[-m|--model]}} {{gpt-4}}`
 
-- Start in chat mode with an [i]nitial prompt:
+- Start in chat mode with an initial prompt:
 
-`chatgpt --init-prompt "{{You are Rick, from Rick and Morty. Respond to questions using his mannerism and include insulting jokes.}}"`
+`chatgpt {{[-i|--init-prompt]}} "{{You are Rick, from Rick and Morty. Respond to questions using his mannerism and include insulting jokes.}}"`
 
 - Pipe the result of a command to `chatgpt` as a prompt:
 
@@ -25,4 +25,4 @@
 
 - Generate an image using DALL-E:
 
-`chatgpt --prompt "{{image: A white cat}}"`
+`chatgpt {{[-p|--prompt]}} "{{image: A white cat}}"`

--- a/pages/common/cheatshh.md
+++ b/pages/common/cheatshh.md
@@ -2,32 +2,32 @@
 
 > CLI cheatsheet with customized descriptions, tldr and groups, to look into for your reference.
 > Press `<Enter>` to a command to copy it to your clipboard and exit.
-> More information: <https://github.com/AnirudhG07/cheatshh>.
+> More information: <https://github.com/AnirudhG07/cheatshh/blob/main/docs/man/cheatshh.1>.
 
-- [a]dd a new command to the cheatshheet:
+- Add a new command to the cheatshheet:
 
-`cheatshh --add`
+`cheatshh {{[-a|--add]}}`
 
-- Edit ([ec]) an existing command's description or group in the cheatshheet:
+- Edit an existing command's description or group in the cheatshheet:
 
-`cheatshh --edit-command`
+`cheatshh {{[-ec|--edit-command]}}`
 
-- Delete ([dc]) an existing command from the cheatshheet:
+- Delete an existing command from the cheatshheet:
 
-`cheatshh --delete-command`
+`cheatshh {{[-dc|--delete-command]}}`
 
-- Create a new [g]roup:
+- Create a new group:
 
-`cheatshh --group`
+`cheatshh {{[-g|--group]}}`
 
-- Edit ([eg]) an existing group's name or description in the cheatsheet:
+- Edit an existing group's name or description in the cheatsheet:
 
-`cheatshh --edit-group`
+`cheatshh {{[-eg|--edit-group]}}`
 
-- Delete ([dg]) an existing group and it's sub commands from commands.json file:
+- Delete an existing group and it's sub commands from commands.json file:
 
-`cheatshh --delete-group`
+`cheatshh {{[-dg|--delete-group]}}`
 
-- Display [m]an pages after tldr in the preview:
+- Display man pages after tldr in the preview:
 
-`cheatshh --man`
+`cheatshh {{[-m|--man]}}`

--- a/pages/common/chronic.md
+++ b/pages/common/chronic.md
@@ -1,7 +1,7 @@
 # chronic
 
 > Display `stdout` and `stderr` of a command if and only if it fails.
-> More information: <https://joeyh.name/code/moreutils/>.
+> More information: <https://manned.org/chronic>.
 
 - Display `stdout` and `stderr` of the specified command if and only if it produces a non-zero exit code or crashes:
 

--- a/pages/common/d2.md
+++ b/pages/common/d2.md
@@ -8,9 +8,9 @@
 
 `d2 {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
 
-- [w]atch live changes made to a D2 source file in the default web browser:
+- Watch live changes made to a D2 source file in the default web browser:
 
-`d2 --watch {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
+`d2 {{[-w|--watch]}} {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
 
 - Format a D2 source file:
 
@@ -20,10 +20,10 @@
 
 `d2 themes`
 
-- Use a different [t]heme for the output file (list available themes first to get the desired `theme_id`):
+- Use a different theme for the output file (list available themes first to get the desired `theme_id`):
 
-`d2 --theme {{theme_id}} {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
+`d2 {{[-t|--theme]}} {{theme_id}} {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
 
-- Make rendered diagrams look like hand [s]ketches:
+- Make rendered diagrams look like hand sketches:
 
-`d2 --sketch true {{path/to/input_file.d2}} {{path/to/output_file.ext}}`
+`d2 {{[-s|--sketch]}} true {{path/to/input_file.d2}} {{path/to/output_file.ext}}`

--- a/pages/common/ddev.md
+++ b/pages/common/ddev.md
@@ -1,7 +1,7 @@
 # ddev
 
 > Container based local development tool for PHP environments.
-> More information: <https://ddev.readthedocs.io>.
+> More information: <https://ddev.readthedocs.io/en/stable/users/usage/cli/>.
 
 - Start up a project:
 
@@ -11,9 +11,9 @@
 
 `ddev config`
 
-- [f]ollow the log trail:
+- Follow the log trail:
 
-`ddev logs -f`
+`ddev logs {{[-f|--follow]}}`
 
 - Run composer within the container:
 
@@ -25,7 +25,7 @@
 
 - Export a database:
 
-`ddev export-db --file={{/tmp/db.sql.gz}}`
+`ddev export-db {{[-f|--file]}} {{/tmp/db.sql.gz}}`
 
 - Run a specific command within a container:
 

--- a/pages/common/dnsx.md
+++ b/pages/common/dnsx.md
@@ -7,32 +7,32 @@
 
 - Query the A record of a (sub)domain and show [re]sponse received:
 
-`echo {{example.com}} | dnsx -a -re`
+`echo {{example.com}} | dnsx -a {{[-re|-resp]}}`
 
 - Query all the DNS records (A, AAAA, CNAME, NS, TXT, SRV, PTR, MX, SOA, AXFR, CAA):
 
-`dnsx -recon -re <<< {{example.com}}`
+`dnsx -recon {{[-re|-resp]}} <<< {{example.com}}`
 
 - Query a specific type of DNS record:
 
-`echo {{example.com}} | dnsx -re -{{a|aaaa|cname|ns|txt|srv|ptr|mx|soa|any|axfr|caa}}`
+`echo {{example.com}} | dnsx {{[-re|-resp]}} -{{a|aaaa|cname|ns|txt|srv|ptr|mx|soa|any|axfr|caa}}`
 
-- Output [r]esponse [o]nly (do not show the queried domain or subdomain):
+- Output response only (do not show the queried domain or subdomain):
 
-`echo {{example.com}} | dnsx -ro`
+`echo {{example.com}} | dnsx {{[-ro|-resp-only]}}`
 
-- Display raw response of a query, specifying [r]esolvers to use and retry attempts for failures:
+- Display raw response of a query, specifying resolvers to use and retry attempts for failures:
 
-`echo {{example.com}} | dnsx -{{debug|raw}} -resolver {{1.1.1.1,8.8.8.8,...}} -retry {{number}}`
+`echo {{example.com}} | dnsx -{{debug|raw}} {{[-r|-resolver]}} {{1.1.1.1,8.8.8.8,...}} -retry {{number}}`
 
 - Brute force DNS records using a placeholder:
 
-`dnsx -domain {{FUZZ.example.com}} -wordlist {{path/to/wordlist.txt}} -re`
+`dnsx {{[-d|-domain]}} {{FUZZ.example.com}} {{[-w|-wordlist]}} {{path/to/wordlist.txt}} {{[-re|-resp]}}`
 
-- Brute force DNS records from a list of [d]omains and wordlists, appending [o]utput to a file with [n]o [c]olor codes:
+- Brute force DNS records from a list of domains and wordlists, appending output to a file with no color codes:
 
-`dnsx -domain {{path/to/domain.txt}} -wordlist {{path/to/wordlist.txt}} -re -output {{path/to/output.txt}} -no-color`
+`dnsx {{[-d|-domain]}} {{path/to/domain.txt}} {{[-w|-wordlist]}} {{path/to/wordlist.txt}} {{[-re|-resp]}} {{[-o|-output]}} {{path/to/output.txt}} {{[-nc|-no-color]}}`
 
-- Extract `CNAME` records for the given list of subdomains, with [r]ate [l]imiting DNS queries per second:
+- Extract `CNAME` records for the given list of subdomains, with rate limiting DNS queries per second:
 
-`subfinder -silent -d {{example.com}} | dnsx -cname -re -rl {{number}}`
+`subfinder -silent {{[-d|-domain]}} {{example.com}} | dnsx -cname {{[-re|-resp]}} {{[-rl|-rate-limit]}} {{number}}`

--- a/pages/common/docker-update.md
+++ b/pages/common/docker-update.md
@@ -18,7 +18,7 @@
 
 - Update the memory limit in [M]egabytes for a specific container:
 
-`docker update --memory {{limit}}M {{container_name}}`
+`docker update {{[-m|--memory]}} {{limit}}M {{container_name}}`
 
 - Update the maximum number of process IDs allowed inside a specific container (use `-1` for unlimited):
 

--- a/pages/common/doggo.md
+++ b/pages/common/doggo.md
@@ -2,7 +2,7 @@
 
 > DNS client for Humans.
 > Written in Golang.
-> More information: <https://github.com/mr-karan/doggo>.
+> More information: <https://doggo.mrkaran.dev/docs/guide/reference/>.
 
 - Perform a simple DNS lookup:
 
@@ -18,8 +18,8 @@
 
 - Output in the JSON format:
 
-`doggo {{example.com}} --json | jq '{{.responses[0].answers[].address}}'`
+`doggo {{example.com}} {{[-J|--json]}} | jq '{{.responses[0].answers[].address}}'`
 
 - Perform a reverse DNS lookup:
 
-`doggo --reverse {{8.8.4.4}} --short`
+`doggo {{[-x|--reverse]}} {{8.8.4.4}} --short`

--- a/pages/common/duplicity.md
+++ b/pages/common/duplicity.md
@@ -3,7 +3,7 @@
 > Create incremental, compressed, encrypted and versioned backups.
 > Can also upload the backups to a variety of backend services.
 > It is worth mentioning that depending on the version, some options may not be available (e.g. `--gio` in 2.0.0).
-> More information: <https://duplicity.gitlab.io>.
+> More information: <https://duplicity.gitlab.io/stable/duplicity.1.html#name>.
 
 - Backup a directory via FTPS to a remote machine, encrypting it with a password:
 
@@ -23,7 +23,7 @@
 
 - List the files in a backup stored on a remote machine, via SSH:
 
-`duplicity list-current-files --time {{YYYY-MM-DD}} scp://{{user@hostname}}/{{path/to/backup/dir}}`
+`duplicity list-current-files {{[-t|--time]}} {{YYYY-MM-DD}} scp://{{user@hostname}}/{{path/to/backup/dir}}`
 
 - Restore a subdirectory from a GnuPG-encrypted local backup to a given location:
 

--- a/pages/common/elvish.md
+++ b/pages/common/elvish.md
@@ -2,7 +2,7 @@
 
 > Expressive programming language and a versatile interactive shell.
 > See also: `nu`.
-> More information: <https://elv.sh>.
+> More information: <https://elv.sh/ref/command.html>.
 
 - Start an interactive shell session:
 

--- a/pages/common/gh-skyline.md
+++ b/pages/common/gh-skyline.md
@@ -8,30 +8,30 @@
 
 `gh skyline`
 
-- Generate a skyline for a specific [u]ser and [y]ear:
+- Generate a skyline for a specific user and year:
 
-`gh skyline --user {{username}} --year {{year}}`
+`gh skyline {{[-u|--user]}} {{username}} {{[-y|--year]}} {{year}}`
 
-- Generate a skyline for a range of [y]ears:
+- Generate a skyline for a range of years:
 
-`gh skyline --user {{username}} --year {{first_year}}-{{last_year}}`
+`gh skyline {{[-u|--user]}} {{username}} {{[-y|--year]}} {{first_year}}-{{last_year}}`
 
-- Generate a [f]ull skyline (from the user's join year to the current year):
+- Generate a full skyline (from the user's join year to the current year):
 
-`gh skyline --user {{username}} --full`
+`gh skyline {{[-u|--user]}} {{username}} {{[-f|--full]}}`
 
-- Enable [d]ebug logging:
+- Enable debug logging:
 
-`gh skyline --debug`
+`gh skyline {{[-d|--debug]}}`
 
-- Generate a skyline and specify the [o]utput file path:
+- Generate a skyline and specify the output file path:
 
-`gh skyline --output {{path/to/output_file.stl}}`
+`gh skyline {{[-o|--output]}} {{path/to/output_file.stl}}`
 
-- Open the GitHub profile for a specific [u]ser:
+- Open the GitHub profile for a specific user:
 
-`gh skyline --user {{username}} --web`
+`gh skyline {{[-u|--user]}} {{username}} {{[-w|--web]}}`
 
-- Display [h]elp:
+- Display help:
 
-`gh skyline --help`
+`gh skyline {{[-h|--help]}}`

--- a/pages/common/gifsicle.md
+++ b/pages/common/gifsicle.md
@@ -5,11 +5,11 @@
 
 - Optimize a GIF as a new file:
 
-`gifsicle {{path/to/input.gif}} --optimize=3 -o {{path/to/output.gif}}`
+`gifsicle {{path/to/input.gif}} {{[-O|--optimize=]}}3 {{[-o|--output]}} {{path/to/output.gif}}`
 
-- Use [b]atch mode (modify each given file in place) and unoptimize a GIF:
+- Use batch mode (modify each given file in place) and unoptimize a GIF:
 
-`gifsicle -b {{path/to/input.gif}} --unoptimize`
+`gifsicle {{[-b|--batch]}} {{path/to/input.gif}} {{[-U|--unoptimize]}}`
 
 - Extract a frame from a GIF:
 
@@ -17,16 +17,16 @@
 
 - Make a GIF animation from selected GIFs:
 
-`gifsicle {{*.gif}} --delay={{10}} --loop > {{path/to/output.gif}}`
+`gifsicle {{*.gif}} {{[-d|--delay]}} {{10}} {{[-l|--loop]}} > {{path/to/output.gif}}`
 
 - Reduce file size using lossy compression:
 
-`gifsicle -b {{path/to/input.gif}} --optimize=3 --lossy={{100}} --colors={{16}} --dither`
+`gifsicle {{[-b|--batch]}} {{path/to/input.gif}} {{[-O|--optimize=]}}3 --lossy={{100}} {{[-k|--colors]}} {{16}} {{[-f|--dither]}}`
 
 - Delete the first 10 frames and all frames after frame 20 from a GIF:
 
-`gifsicle -b {{path/to/input.gif}} --delete '#{{0-9}}' '#{{20-}}'`
+`gifsicle {{[-b|--batch]}} {{path/to/input.gif}} --delete '#{{0-9}}' '#{{20-}}'`
 
 - Modify all frames by cropping them to a rectangle, changing their scale, flipping them, and rotating them:
 
-`gifsicle -b --crop {{starting_x}},{{starting_y}}+{{rect_width}}x{{rect_height}} --scale {{0.25}} --flip-horizontal --rotate-{{90|180|270}} {{path/to/input.gif}}`
+`gifsicle {{[-b|--batch]}} --crop {{starting_x}},{{starting_y}}+{{rect_width}}x{{rect_height}} --scale {{0.25}} --flip-horizontal --rotate-{{90|180|270}} {{path/to/input.gif}}`

--- a/pages/common/git-magic.md
+++ b/pages/common/git-magic.md
@@ -2,7 +2,7 @@
 
 > Automate add, commit, and push routines.
 > Part of `git-extras`.
-> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-magic>.
+> More information: <https://manned.org/git-magic>.
 
 - Commit changes with a generated message:
 

--- a/pages/common/gnatmake.md
+++ b/pages/common/gnatmake.md
@@ -1,7 +1,7 @@
 # gnatmake
 
 > A low-level build tool for Ada programs (part of the GNAT toolchain).
-> More information: <https://gcc.gnu.org/onlinedocs/gnat_ugn/Building-with-gnatmake.html>.
+> More information: <https://gcc.gnu.org/onlinedocs/gnat_ugn/Switches-for-gnatmake.html>.
 
 - Compile an executable:
 

--- a/pages/common/golangci-lint.md
+++ b/pages/common/golangci-lint.md
@@ -11,6 +11,6 @@
 
 `golangci-lint linters`
 
-- [E]nable a specific linter for this run:
+- Enable a specific linter for this run:
 
-`golangci-lint run --enable {{linter}}`
+`golangci-lint run {{[-E|--enable]}} {{linter}}`

--- a/pages/common/httpx.md
+++ b/pages/common/httpx.md
@@ -6,32 +6,32 @@
 
 - Run a probe against a [u]RL, host, IP Address or subnet (CIDR notation) showing probe status:
 
-`httpx -probe -u {{url|host|ipaddress|subnet_with_cidr}}`
+`httpx -probe {{[-u|-target]}} {{url|host|ipaddress|subnet_with_cidr}}`
 
-- Run a probe against multiple hosts showing [s]tatus [c]ode with input from `subfinder`:
+- Run a probe against multiple hosts showing status code with input from `subfinder`:
 
-`subfinder -d {{example.com}} | httpx -sc`
+`subfinder {{[-d|-domain]}} {{example.com}} | httpx {{[-sc|-status-code]}}`
 
-- Run a [r]ate [l]imited probe against a [l]ist of hosts from a file showing [t]echnology [d]etected and [r]esponse [t]ime:
+- Run a rate limited probe against a list of hosts from a file showing technology detected and response time:
 
-`httpx -rl {{150}} -l {{path/to/newline_separated_hosts_list}} -td -rt`
+`httpx {{[-rl|-rate-limit]}} {{150}} {{[-l|-list]}} {{path/to/newline_separated_hosts_list}} {{[-td|-tech-detect]}} {{[-rt|-response-time]}}`
 
 - Run a probe against a [u]RL showing its webpage title, CDN/WAF in use, and page content hash:
 
-`httpx -u {{url}} -title -cdn -hash {{sha256}}`
+`httpx {{[-u|-target]}} {{url}} -title -cdn -hash {{sha256}}`
 
-- Run a probe against a list of hosts with custom defined [p]orts and timeout after certain seconds:
+- Run a probe against a list of hosts with custom defined ports and timeout after certain seconds:
 
-`httpx -probe -u {{host1,host2,...}} -p http:{{80,8000-8080}},https:{{443,8443}} -timeout {{10}}`
+`httpx -probe {{[-u|-target]}} {{host1,host2,...}} {{[-p|-ports]}} http:{{80,8000-8080}},https:{{443,8443}} -timeout {{10}}`
 
-- Run a probe against a list of hosts [f]iltering out [c]odes of certain responses:
+- Run a probe against a list of hosts filtering out codes of certain responses:
 
-`httpx -u {{host1,host2,...}} -fc {{400,401,404}}`
+`httpx {{[-u|-target]}} {{host1,host2,...}} {{[-fc|-filter-code]}} {{400,401,404}}`
 
-- Run a probe against a list of hosts [m]atching [c]odes of certain responses:
+- Run a probe against a list of hosts matching codes of certain responses:
 
-`httpx -u {{host1,host2,...}} -mc {{200,301,304}}`
+`httpx {{[-u|-target]}} {{host1,host2,...}} {{[-mc|-match-code]}} {{200,301,304}}`
 
-- Run a probe against a URL [s]aving [s]creenshots of certain paths, with [s]creenshot [t]imeouts (assets are saved in `./output`):
+- Run a probe against a URL saving screenshots of certain paths, with screenshot timeouts (assets are saved in `./output`):
 
-`httpx -u {{https://www.github.com}} -path {{/tldr-pages/tldr,/projectdiscovery/httpx}} -ss -st {{10}}`
+`httpx {{[-u|-target]}} {{https://www.github.com}} -path {{/tldr-pages/tldr,/projectdiscovery/httpx}} {{[-ss|-screenshot]}} {{[-st|-screenshot-timeout]}} {{10}}`

--- a/pages/common/ifdata.md
+++ b/pages/common/ifdata.md
@@ -1,7 +1,7 @@
 # ifdata
 
 > Display information about a network interface.
-> More information: <https://joeyh.name/code/moreutils/>.
+> More information: <https://manned.org/ifdata>.
 
 - Display the whole configuration of the specified interface:
 

--- a/pages/common/katana.md
+++ b/pages/common/katana.md
@@ -10,20 +10,20 @@
 
 - Crawl a [u]RL using headless mode using Chromium:
 
-`katana -u {{https://example.com}} -headless`
+`katana -u {{https://example.com}} {{[-hl|-headless]}}`
 
 - Use `subfinder` to find subdomains, and then use [p]a[s]sive sources (Wayback Machine, Common Crawl, and AlienVault) for URL discovery:
 
-`subfinder -list {{path/to/domains.txt}} | katana -passive`
+`subfinder {{[-dL|-list]}} {{path/to/domains.txt}} | katana -passive`
 
-- Pass requests through a proxy (http/socks5) and use custom [H]eaders from a file:
+- Pass requests through a proxy (http/socks5) and use custom headers from a file:
 
-`katana -proxy {{http://127.0.0.1:8080}} -headers {{path/to/headers.txt}} -u {{https://example.com}}`
+`katana -proxy {{http://127.0.0.1:8080}} {{[-H|-headers]}} {{path/to/headers.txt}} -u {{https://example.com}}`
 
-- Specify the crawling [s]trategy, [d]epth of subdirectories to crawl, and rate limiting (requests per second):
+- Specify the crawling strategy, depth of subdirectories to crawl, and rate limiting (requests per second):
 
-`katana -strategy {{depth-first|breadth-first}} -depth {{value}} -rate-limit {{value}} -u {{https://example.com}}`
+`katana {{[-s|-strategy]}} {{depth-first|breadth-first}} {{[-d|-depth]}} {{value}} {{[-rl|-rate-limit]}} {{value}} -u {{https://example.com}}`
 
-- Find subdomains using `subfinder`, crawl each for a maximum number of seconds, and write results to an [o]utput file:
+- Find subdomains using `subfinder`, crawl each for a maximum number of seconds, and write results to an output file:
 
-`subfinder -list {{path/to/domains.txt}} | katana -crawl-duration {{value}} -output {{path/to/output.txt}}`
+`subfinder {{[-dL|-list]}} {{path/to/domains.txt}} | katana {{[-ct|-crawl-duration]}} {{value}} {{[-o|-output]}} {{path/to/output.txt}}`

--- a/pages/common/ksh.md
+++ b/pages/common/ksh.md
@@ -1,8 +1,8 @@
 # ksh
 
 > Korn Shell, a Bash-compatible command-line interpreter.
-> See also: `histexpand`.
-> More information: <http://kornshell.com>.
+> See also: `!`, `^`.
+> More information: <https://manned.org/ksh>.
 
 - Start an interactive shell session:
 

--- a/pages/common/kubectl-describe.md
+++ b/pages/common/kubectl-describe.md
@@ -3,22 +3,22 @@
 > Show details of Kubernetes objects and resources.
 > More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
 
-- Show details of pods in a [n]amespace:
+- Show details of pods in a namespace:
 
-`kubectl describe pods --namespace {{namespace}}`
+`kubectl describe pods {{[-n|--namespace]}} {{namespace}}`
 
-- Show details of nodes in a [n]amespace:
+- Show details of nodes in a namespace:
 
-`kubectl describe nodes --namespace {{namespace}}`
+`kubectl describe nodes {{[-n|--namespace]}} {{namespace}}`
 
-- Show the details of a specific pod in a [n]amespace:
+- Show the details of a specific pod in a namespace:
 
-`kubectl describe pods {{pod_name}} --namespace {{namespace}}`
+`kubectl describe pods {{pod_name}} {{[-n|--namespace]}} {{namespace}}`
 
-- Show the details of a specific node in a [n]amespace:
+- Show the details of a specific node in a namespace:
 
-`kubectl describe nodes {{node_name}} --namespace {{namespace}}`
+`kubectl describe nodes {{node_name}} {{[-n|--namespace]}} {{namespace}}`
 
-- Show details of Kubernetes objects defined in a YAML manifest [f]ile:
+- Show details of Kubernetes objects defined in a YAML manifest file:
 
-`kubectl describe --file {{path/to/manifest.yaml}}`
+`kubectl describe {{[-f|--file]}} {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-get.md
+++ b/pages/common/kubectl-get.md
@@ -7,26 +7,26 @@
 
 `kubectl get namespaces`
 
-- Get nodes in a specified [n]amespace:
+- Get nodes in a specified namespace:
 
-`kubectl get nodes --namespace {{namespace}}`
+`kubectl get nodes {{[-n|--namespace]}} {{namespace}}`
 
-- Get pods in a specified [n]amespace:
+- Get pods in a specified namespace:
 
-`kubectl get pods --namespace {{namespace}}`
+`kubectl get pods {{[-n|--namespace]}} {{namespace}}`
 
-- Get deployments in a specified [n]amespace:
+- Get deployments in a specified namespace:
 
-`kubectl get deployments --namespace {{namespace}}`
+`kubectl get deployments {{[-n|--namespace]}} {{namespace}}`
 
-- Get services in a specified [n]amespace:
+- Get services in a specified namespace:
 
-`kubectl get services --namespace {{namespace}}`
+`kubectl get services {{[-n|--namespace]}} {{namespace}}`
 
-- Get all resources in a specified [n]amespace:
+- Get all resources in a specified namespace:
 
-`kubectl get all --namespace {{namespace}}`
+`kubectl get all {{[-n|--namespace]}} {{namespace}}`
 
-- Get Kubernetes objects defined in a YAML manifest [f]ile:
+- Get Kubernetes objects defined in a YAML manifest file:
 
-`kubectl get --file {{path/to/manifest.yaml}}`
+`kubectl get {{[-f|--file]}} {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-wait.md
+++ b/pages/common/kubectl-wait.md
@@ -9,7 +9,7 @@
 
 - Wait for all pods with a certain [l]abel to be ready:
 
-`kubectl wait --for=condition=ready pod -l {{label_key}}={{label_value}}`
+`kubectl wait --for=condition=ready pod {{[-l|--selector]}} {{label_key}}={{label_value}}`
 
 - Wait for a pod to be deleted:
 

--- a/pages/common/latexpand.md
+++ b/pages/common/latexpand.md
@@ -3,22 +3,22 @@
 > Simplify LaTeX source files by removing comments and resolving `\include`s, `\input`s, etc.
 > More information: <https://www.ctan.org/pkg/latexpand>.
 
-- Simplify the specified source file and save the result to the specified [o]utput file:
+- Simplify the specified source file and save the result to the specified output file:
 
-`latexpand --output {{path/to/output.tex}} {{path/to/file.tex}}`
+`latexpand {{[-o|--output]}} {{path/to/output.tex}} {{path/to/file.tex}}`
 
 - Do not remove comments:
 
-`latexpand --keep-comments --output {{path/to/output.tex}} {{path/to/file.tex}}`
+`latexpand --keep-comments {{[-o|--output]}} {{path/to/output.tex}} {{path/to/file.tex}}`
 
 - Do not expand `\include`s, `\input`s etc.:
 
-`latexpand --keep-includes --output {{path/to/output.tex}} {{path/to/file.tex}}`
+`latexpand --keep-includes {{[-o|--output]}} {{path/to/output.tex}} {{path/to/file.tex}}`
 
 - Expand `\usepackage`s as far as the corresponding STY files can be found:
 
-`latexpand --expand-usepackage --output {{path/to/output.tex}} {{path/to/file.tex}}`
+`latexpand --expand-usepackage {{[-o|--output]}} {{path/to/output.tex}} {{path/to/file.tex}}`
 
 - Inline the specified BBL file:
 
-`latexpand --expand-bbl {{path/to/bibliography.bbl}} --output {{path/to/output.tex}} {{path/to/file.tex}}`
+`latexpand --expand-bbl {{path/to/bibliography.bbl}} {{[-o|--output]}} {{path/to/output.tex}} {{path/to/file.tex}}`

--- a/pages/common/licensor.md
+++ b/pages/common/licensor.md
@@ -7,9 +7,9 @@
 
 `licensor {{MIT}} > {{LICENSE}}`
 
-- Write the MIT license with a [p]laceholder copyright notice to a file named `LICENSE`:
+- Write the MIT license with a placeholder copyright notice to a file named `LICENSE`:
 
-`licensor -p {{MIT}} > {{LICENSE}}`
+`licensor {{[-p|--keep-placeholder]}} {{MIT}} > {{LICENSE}}`
 
 - Specify a copyright holder named Bobby Tables:
 
@@ -21,8 +21,8 @@
 
 - List all available licenses:
 
-`licensor --licenses`
+`licensor {{[-l|--licenses]}}`
 
 - List all available exceptions:
 
-`licensor --exceptions`
+`licensor {{[-e|--exceptions]}}`

--- a/pages/common/llvd.md
+++ b/pages/common/llvd.md
@@ -3,18 +3,18 @@
 > Linkedin Learning Video Downloader.
 > More information: <https://github.com/knowbee/llvd>.
 
-- Download a [c]ourse using cookie-based authentication:
+- Download a course using cookie-based authentication:
 
-`llvd -c {{course-slug}} --cookies`
+`llvd {{[-c|--course]}} {{course-slug}} --cookies`
 
-- Download a course at a specific [r]esolution:
+- Download a course at a specific resolution:
 
-`llvd -c {{course-slug}} -r 720`
+`llvd {{[-c|--course]}} {{course-slug}} {{[-r|--resolution]}} 720`
 
-- Download a course with [ca]ptions (subtitles):
+- Download a course with captions (subtitles):
 
-`llvd -c {{course-slug}} --caption`
+`llvd {{[-c|--course]}} {{course-slug}} {{[-ca|--caption]}}`
 
-- Download a course [p]ath with [t]hrottling between 10 to 30 seconds:
+- Download a course path with throttling between 10 to 30 seconds:
 
-`llvd -p {{path-slug}} -t {{10,30}} --cookies`
+`llvd {{[-p|--path]}} {{path-slug}} {{[-t|--throttle]}} {{10,30}} --cookies`

--- a/pages/common/lsar.md
+++ b/pages/common/lsar.md
@@ -12,7 +12,7 @@
 
 `lsar {{path/to/archive}} {{[-p|--password]}} {{password}}`
 
-- Print al[L] available information about each file in the archive (it's very long):
+- Print all available information about each file in the archive (it's very long):
 
 `lsar {{[-L|--verylong]}} {{path/to/archive}}`
 

--- a/pages/common/mamba.md
+++ b/pages/common/mamba.md
@@ -6,11 +6,11 @@
 
 - Create a new environment, installing the specified packages into it:
 
-`mamba create --name {{environment_name}} {{python=3.10 matplotlib}}`
+`mamba create {{[-n|--name]}} {{environment_name}} {{python=3.10 matplotlib}}`
 
-- Install packages into the current environment, specifying the package [c]hannel:
+- Install packages into the current environment, specifying the package channel:
 
-`mamba install -c {{conda-forge}} {{python=3.6 numpy}}`
+`mamba install {{[-c|--channel]}} {{conda-forge}} {{python=3.6 numpy}}`
 
 - Update all packages in the current environment:
 

--- a/pages/common/masscan.md
+++ b/pages/common/masscan.md
@@ -2,11 +2,11 @@
 
 > Network scanner for scanning as fast as possible.
 > Best run with elevated privileges. Nmap compatibility run `masscan --nmap` to find out more.
-> More information: <https://github.com/robertdavidgraham/masscan>.
+> More information: <https://manned.org/masscan>.
 
-- Scan an IP or network subnet for [p]ort 80:
+- Scan an IP or network subnet for port 80:
 
-`masscan {{ip_address|network_prefix}} --ports {{80}}`
+`masscan {{ip_address|network_prefix}} {{[-p|--ports]}} {{80}}`
 
 - Scan a class B subnet for the top 100 ports at 100,000 packets per second:
 
@@ -18,15 +18,15 @@
 
 - Scan the Internet for web servers running on port 80 and 443:
 
-`masscan {{0.0.0.0/0}} --ports {{80,443}} --rate {{10000000}}`
+`masscan {{0.0.0.0/0}} {{[-p|--ports]}} {{80,443}} --rate {{10000000}}`
 
 - Scan the Internet for DNS servers running on UDP port 53:
 
-`masscan {{0.0.0.0/0}} --ports {{U:53}} --rate {{10000000}}`
+`masscan {{0.0.0.0/0}} {{[-p|--ports]}} {{U:53}} --rate {{10000000}}`
 
 - Scan the Internet for a specific port range and export to a file:
 
-`masscan {{0.0.0.0/0}} --ports {{0-65535}} --output-format {{binary|grepable|json|list|xml}} --output-filename {{path/to/file}}`
+`masscan {{0.0.0.0/0}} {{[-p|--ports]}} {{0-65535}} --output-format {{binary|grepable|json|list|xml}} --output-filename {{path/to/file}}`
 
 - Read binary scan results from a file and output to `stdout`:
 

--- a/pages/common/msfconsole.md
+++ b/pages/common/msfconsole.md
@@ -7,18 +7,22 @@
 
 `msfconsole`
 
-- Launch the console [q]uietly without any banner:
+- Launch the console quietly without any banner:
 
-`msfconsole --quiet`
+`msfconsole {{[-q|--quiet]}}`
 
-- Do [n]ot enable database support:
+- Do not enable database support:
 
-`msfconsole --no-database`
+`msfconsole {{[-n|--no-database]}}`
 
-- E[x]ecute console commands (Note: use `;` for passing multiple commands):
+- Execute console commands (Note: use `;` for passing multiple commands):
 
-`msfconsole --execute-command "{{use auxiliary/server/capture/ftp; set SRVHOST 0.0.0.0; set SRVPORT 21; run}}"`
+`msfconsole {{[-x|--execute-command]}} "{{use auxiliary/server/capture/ftp; set SRVHOST 0.0.0.0; set SRVPORT 21; run}}"`
 
-- Display [v]ersion:
+- Display help:
 
-`msfconsole --version`
+`msfconsole {{[-h|--help]}}`
+
+- Display version:
+
+`msfconsole {{[-v|--version]}}`

--- a/pages/common/mypy.md
+++ b/pages/common/mypy.md
@@ -7,17 +7,17 @@
 
 `mypy {{path/to/file.py}}`
 
-- Type check a specific [m]odule:
+- Type check a specific module:
 
-`mypy -m {{module_name}}`
+`mypy {{[-m|--module]}} {{module_name}}`
 
-- Type check a specific [p]ackage:
+- Type check a specific package:
 
-`mypy -p {{package_name}}`
+`mypy {{[-p|--package]}} {{package_name}}`
 
 - Type check a string of code:
 
-`mypy -c "{{code}}"`
+`mypy {{[-c|--command]}} "{{code}}"`
 
 - Ignore missing imports:
 
@@ -25,12 +25,12 @@
 
 - Show detailed error messages:
 
-`mypy --show-traceback {{path/to/file_or_directory}}`
+`mypy {{[--tb|--show-traceback]}} {{path/to/file_or_directory}}`
 
 - Specify a custom configuration file:
 
 `mypy --config-file {{path/to/config_file}}`
 
-- Display [h]elp:
+- Display help:
 
-`mypy -h`
+`mypy {{[-h|--help]}}`

--- a/pages/common/nextclade.md
+++ b/pages/common/nextclade.md
@@ -1,15 +1,15 @@
 # nextclade
 
 > Bioinformatics tool for virus genome alignment, clade assignment and qc checks.
-> More information: <https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html>.
+> More information: <https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/reference.html>.
 
-- Align sequences to user provided [r]eference, [o]utputting the alignment to a file:
+- Align sequences to user provided reference, outputting the alignment to a file:
 
-`nextclade run {{path/to/sequences.fa}} -r {{path/to/reference.fa}} -o {{path/to/alignment.fa}}`
+`nextclade run {{path/to/sequences.fa}} {{[-r|--input-ref]}} {{path/to/reference.fa}} {{[-o|--output-fasta]}} {{path/to/alignment.fa}}`
 
-- Create a [t]SV report, auto-downloading the latest [d]ataset:
+- Create a TSV report, auto-downloading the latest dataset:
 
-`nextclade run {{path/to/fasta}} -d {{dataset_name}} -t {{path/to/report.tsv}}`
+`nextclade run {{path/to/fasta}} {{[-d|--dataset-name]}} {{dataset_name}} {{[-t|--output-tsv]}} {{path/to/report.tsv}}`
 
 - List all available datasets:
 
@@ -17,16 +17,16 @@
 
 - Download the latest SARS-CoV-2 dataset:
 
-`nextclade dataset get --name sars-cov-2 --output-dir {{path/to/directory}}`
+`nextclade dataset get {{[-n|--name]}} sars-cov-2 {{[-o|--output-dir]}} {{path/to/directory}}`
 
-- Use a downloaded [D]ataset, producing all [O]utputs:
+- Use a downloaded dataset, producing all outputs:
 
-`nextclade run -D {{path/to/dataset_dir}} -O {{path/to/output_dir}} {{path/to/sequences.fasta}}`
+`nextclade run {{[-D|--input-dataset]}} {{path/to/dataset_dir}} {{[-O|--output-all]}} {{path/to/output_dir}} {{path/to/sequences.fasta}}`
 
 - Run on multiple files:
 
-`nextclade run -d {{dataset_name}} -t {{path/to/output_tsv}} -- {{path/to/input_fasta_1 path/to/input_fasta_2 ...}}`
+`nextclade run {{[-d|--dataset-name]}} {{dataset_name}} {{[-t|--output-tsv]}} {{path/to/output_tsv}} -- {{path/to/input_fasta_1 path/to/input_fasta_2 ...}}`
 
 - Try reverse complement if sequence does not align:
 
-`nextclade run --retry-reverse-complement -d {{dataset_name}} -t {{path/to/output_tsv}} {{path/to/input_fasta}}`
+`nextclade run --retry-reverse-complement {{[-d|--dataset-name]}} {{dataset_name}} {{[-t|--output-tsv]}} {{path/to/output_tsv}} {{path/to/input_fasta}}`

--- a/pages/common/nnn.md
+++ b/pages/common/nnn.md
@@ -1,7 +1,7 @@
 # nnn
 
 > Interactive terminal file manager and disk usage analyzer.
-> More information: <https://github.com/jarun/nnn>.
+> More information: <https://github.com/jarun/nnn/wiki/Usage#program-options>.
 
 - Open the current directory (or specify one as the first argument):
 

--- a/pages/common/nvcc.md
+++ b/pages/common/nvcc.md
@@ -5,16 +5,16 @@
 
 - Compile a CUDA program:
 
-`nvcc {{path/to/source.cu}} -o {{path/to/executable}}`
+`nvcc {{path/to/source.cu}} {{[-o|--output-file]}} {{path/to/executable}}`
 
-- Generate debu[g] information:
+- Generate debug information:
 
-`nvcc {{path/to/source.cu}} -o {{path/to/executable}} --debug --device-debug`
+`nvcc {{path/to/source.cu}} {{[-o|--output-file]}} {{path/to/executable}} {{[-g|--debug]}} {{[-G|--device-debug]}}`
 
 - Include libraries from a different path:
 
-`nvcc {{path/to/source.cu}} -o {{path/to/executable}} -I{{path/to/includes}} -L{{path/to/library}} -l{{library_name}}`
+`nvcc {{path/to/source.cu}} {{[-o|--output-file]}} {{path/to/executable}} {{[-I|--include-path]}} {{path/to/includes}} {{[-L|--library-path]}} {{path/to/library}} {{[-l|--library]}} {{library_name}}`
 
 - Specify the compute capability for a specific GPU architecture:
 
-`nvcc {{path/to/source.cu}} -o {{path/to/executable}} --generate-code arch={{arch_name}},code={{gpu_code_name}}`
+`nvcc {{path/to/source.cu}} {{[-o|--output-file]}} {{path/to/executable}} {{[-gencode|--generate-code]}} arch={{arch_name}},code={{gpu_code_name}}`

--- a/pages/common/ollama.md
+++ b/pages/common/ollama.md
@@ -32,6 +32,6 @@
 
 `ollama rm {{model}}`
 
-- Create a model from a `Modelfile` ([f]):
+- Create a model from a `Modelfile`:
 
-`ollama create {{new_model_name}} -f {{path/to/Modelfile}}`
+`ollama create {{new_model_name}} {{[-f|--file]}} {{path/to/Modelfile}}`

--- a/pages/common/osmium.md
+++ b/pages/common/osmium.md
@@ -13,24 +13,24 @@
 
 - Convert file format from PBF into XML:
 
-`osmium cat {{path/to/input.osm.pbf}} -o {{path/to/output.osm}}`
+`osmium cat {{path/to/input.osm.pbf}} {{[-o|--output]}} {{path/to/output.osm}}`
 
 - Extract a geographic region by the given [b]ounding box:
 
-`osmium extract -b {{min_longitude}},{{min_latitude}},{{max_longitude}},{{max_latitude}} {{path/to/input.pbf}} -o {{path/to/output.pbf}}`
+`osmium extract {{[-b|--bbox]}} {{min_longitude}},{{min_latitude}},{{max_longitude}},{{max_latitude}} {{path/to/input.pbf}} {{[-o|--output]}} {{path/to/output.pbf}}`
 
 - Extract a geographic region by a GeoJSON file:
 
-`osmium extract -p {{path/to/polygon.geojson}} {{path/to/input.pbf}} -o {{path/to/output.pbf}}`
+`osmium extract {{[-p|--polygon]}} {{path/to/polygon.geojson}} {{path/to/input.pbf}} {{[-o|--output]}} {{path/to/output.pbf}}`
 
 - Filter all objects tagged as "restaurant":
 
-`osmium tags-filter {{path/to/input.pbf}} amenity=restaurant -o {{path/to/output.pbf}}`
+`osmium tags-filter {{path/to/input.pbf}} amenity=restaurant {{[-o|--output]}} {{path/to/output.pbf}}`
 
 - Filter for "way" objects tagged as "highway":
 
-`osmium tags-filter {{path/to/input.pbf}} w/highway -o {{path/to/output.pbf}}`
+`osmium tags-filter {{path/to/input.pbf}} w/highway {{[-o|--output]}} {{path/to/output.pbf}}`
 
 - Filter "way" and "relation" objects tagged as "building":
 
-`osmium tags-filter {{path/to/input.pbf}} wr/building -o {{path/to/output.pbf}}`
+`osmium tags-filter {{path/to/input.pbf}} wr/building {{[-o|--output]}} {{path/to/output.pbf}}`

--- a/pages/common/pbzip2.md
+++ b/pages/common/pbzip2.md
@@ -12,10 +12,10 @@
 
 `pbzip2 -p{{4}} {{path/to/file}}`
 
-- [d]ecompress a file:
+- Decompress a file:
 
-`pbzip2 --decompress {{path/to/compressed_file.bz2}}`
+`pbzip2 {{[-d|--decompress]}} {{path/to/compressed_file.bz2}}`
 
 - Display help:
 
-`pbzip2 -h`
+`pbzip2 {{[-h|--help]}}`

--- a/pages/common/pcdovtoppm.md
+++ b/pages/common/pcdovtoppm.md
@@ -7,14 +7,14 @@
 
 `pcdovtoppm {{path/to/file.pcd}} > {{path/to/output.ppm}}`
 
-- Specify the [m]aximum width of the output image and the maximum [s]ize of each of the images contained in the output:
+- Specify the maximum width of the output image and the maximum size of each of the images contained in the output:
 
-`pcdovtoppm -m {{width}} -s {{size}} {{path/to/file.pcd}} > {{path/to/output.ppm}}`
+`pcdovtoppm {{[-m|-maxwidth]}} {{width}} {{[-s|-size]}} {{size}} {{path/to/file.pcd}} > {{path/to/output.ppm}}`
 
-- Specify the maximum number of images [a]cross and the maximum number of [c]olours:
+- Specify the maximum number of images across and the maximum number of colours:
 
-`pcdovtoppm -a {{n_images}} -c {{n_colours}} {{path/to/file.pcd}} > {{path/to/output.ppm}}`
+`pcdovtoppm {{[-a|-across]}} {{n_images}} {{[-c|-colors]}} {{n_colours}} {{path/to/file.pcd}} > {{path/to/output.ppm}}`
 
-- Use the specified [f]ont for annotations and paint the background [w]hite:
+- Use the specified font for annotations and paint the background white:
 
-`pcdovtoppm -f {{font}} -w {{path/to/file.pcd}} > {{path/to/output.ppm}}`
+`pcdovtoppm {{[-f|-font]}} {{font}} {{[-w|-white]}} {{path/to/file.pcd}} > {{path/to/output.ppm}}`

--- a/pages/common/pnmtofiasco.md
+++ b/pages/common/pnmtofiasco.md
@@ -7,14 +7,14 @@
 
 `pnmtofiasco {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
 
-- Specify the [i]nput files through a pattern:
+- Specify the input files through a pattern:
 
-`pnmtofiasco --image-name "{{img[01-09+1].pnm}}" > {{path/to/file.fiasco}}`
+`pnmtofiasco {{[-i|--image-name]}} "{{img[01-09+1].pnm}}" > {{path/to/file.fiasco}}`
 
 - Specify the compression quality:
 
-`pnmtofiasco --quality {{quality_level}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
+`pnmtofiasco {{[-q|--quality]}} {{quality_level}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
 
 - Load the options to be used from the specified configuration file:
 
-`pnmtofiasco --config {{path/to/fiascorc}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
+`pnmtofiasco {{[-f|--config]}} {{path/to/fiascorc}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`

--- a/pages/common/pnpm-audit.md
+++ b/pages/common/pnpm-audit.md
@@ -16,13 +16,13 @@
 
 `pnpm audit --json > {{path/to/audit-report.json}}`
 
-- Audit only [D]ev dependencies:
+- Audit only dev dependencies:
 
-`pnpm audit --dev`
+`pnpm audit {{[-D|--dev]}}`
 
-- Audit only [P]roduction dependencies:
+- Audit only production dependencies:
 
-`pnpm audit --prod`
+`pnpm audit {{[-P|--prod]}}`
 
 - Exclude optional dependencies from the audit:
 

--- a/pages/common/pnpm-outdated.md
+++ b/pages/common/pnpm-outdated.md
@@ -10,15 +10,15 @@
 
 - Check for outdated dependencies found in every workspace package:
 
-`pnpm outdated -r`
+`pnpm outdated {{[-r|--recursive]}}`
 
 - Filter outdated packages using a package selector:
 
 `pnpm outdated --filter {{package_selector}}`
 
-- List outdated packages [g]lobally:
+- List outdated packages globally:
 
-`pnpm outdated --global`
+`pnpm outdated {{[-g|--global]}}`
 
 - Print details of outdated packages:
 
@@ -32,6 +32,6 @@
 
 `pnpm outdated --compatible`
 
-- Check only outdated [D]ev dependencies:
+- Check only outdated dev dependencies:
 
-`pnpm outdated --dev`
+`pnpm outdated {{[-D|--dev]}}`

--- a/pages/common/pnpm.md
+++ b/pages/common/pnpm.md
@@ -2,7 +2,7 @@
 
 > Fast, disk space efficient package manager for Node.js.
 > Manage Node.js projects and their module dependencies.
-> More information: <https://pnpm.io>.
+> More information: <https://pnpm.io/pnpm-cli>.
 
 - Create a `package.json` file:
 
@@ -16,13 +16,13 @@
 
 `pnpm add {{module_name}}@{{version}}`
 
-- Download a package and add it to the list of [D]ev dependencies in `package.json`:
+- Download a package and add it to the list of dev dependencies in `package.json`:
 
-`pnpm add -D {{module_name}}`
+`pnpm add {{[-D|--save-dev]}} {{module_name}}`
 
-- Download a package and install it [g]lobally:
+- Download a package and install it globally:
 
-`pnpm add -g {{module_name}}`
+`pnpm add {{[-g|--global]}} {{module_name}}`
 
 - Uninstall a package and remove it from the list of dependencies in `package.json`:
 
@@ -32,6 +32,6 @@
 
 `pnpm list`
 
-- List top-level [g]lobally installed modules:
+- List top-level globally installed modules:
 
-`pnpm list -g --depth={{0}}`
+`pnpm list {{[-g|--global]}} --depth {{0}}`

--- a/pages/common/pwgen.md
+++ b/pages/common/pwgen.md
@@ -1,16 +1,16 @@
 # pwgen
 
 > Generate pronounceable passwords.
-> More information: <https://github.com/tytso/pwgen>.
+> More information: <https://manned.org/pwgen>.
 
-- Generate random password with s[y]mbols:
+- Generate random password with symbols:
 
-`pwgen -y {{length}}`
+`pwgen {{[-y|--symbols]}} {{length}}`
 
 - Generate secure, hard-to-memorize passwords:
 
-`pwgen -s {{length}}`
+`pwgen {{[-s|--secure]}} {{length}}`
 
 - Generate password with at least one capital letter in them:
 
-`pwgen -c {{length}}`
+`pwgen {{[-c|--capitalize]}} {{length}}`

--- a/pages/common/qalc.md
+++ b/pages/common/qalc.md
@@ -4,17 +4,17 @@
 > See also: `bc`.
 > More information: <https://qalculate.github.io/manual/qalc.html>.
 
-- Launch in [i]nteractive mode:
+- Launch in interactive mode:
 
-`qalc {{--interactive}}`
+`qalc {{[-i|--interactive]}}`
 
-- Launch in [t]erse mode (print the results only):
+- Launch in terse mode (print the results only):
 
-`qalc --terse`
+`qalc {{[-t|--terse]}}`
 
-- Update currency [e]xchange rates:
+- Update currency exchange rates:
 
-`qalc --exrates`
+`qalc {{[-e|--exrates]}}`
 
 - Perform calculations non-interactively:
 
@@ -24,6 +24,6 @@
 
 `qalc --{{list-functions|list-prefixes|list-units|list-variables}}`
 
-- Execute commands from a [f]ile:
+- Execute commands from a file:
 
-`qalc --file {{path/to/file}}`
+`qalc {{[-f|--file]}} {{path/to/file}}`

--- a/pages/common/qmmp.md
+++ b/pages/common/qmmp.md
@@ -2,7 +2,7 @@
 
 > An audio player with an interface similar to Winamp or XMMS.
 > See also: `clementine`, `ncmpcpp`, `cmus`.
-> More information: <https://qmmp.ylsoftware.com>.
+> More information: <https://manned.org/qmmp>.
 
 - Launch the GUI:
 
@@ -10,7 +10,7 @@
 
 - Start or stop the currently playing audio:
 
-`qmmp --play-pause`
+`qmmp {{[-t|--play-pause]}}`
 
 - Seek [f]or[w]ar[d]s or [b]ack[w]ar[d]s a specific amount of time in seconds:
 

--- a/pages/common/redshift.md
+++ b/pages/common/redshift.md
@@ -1,7 +1,7 @@
 # redshift
 
 > Adjust the color temperature of your screen according to your surroundings.
-> More information: <http://jonls.dk/redshift>.
+> More information: <https://manned.org/redshift>.
 
 - Turn on Redshift with a specific [t]emperature during day (e.g., 5700K) and at night (e.g., 3600K):
 

--- a/pages/common/rmlint.md
+++ b/pages/common/rmlint.md
@@ -9,11 +9,11 @@
 
 - Check for duplicates bigger than a specific size, preferably keeping files in tagged directories (after the double slash):
 
-`rmlint -s {{1MB}} {{path/to/directory}} // {{path/to/original_directory}}`
+`rmlint {{[-s|--size]}} {{1MB}} {{path/to/directory}} // {{path/to/original_directory}}`
 
 - Check for space wasters, keeping everything in the untagged directories:
 
-`rmlint --keep-all-untagged {{path/to/directory}} // {{path/to/original_directory}}`
+`rmlint {{[-k|--keep-all-untagged]}} {{path/to/directory}} // {{path/to/original_directory}}`
 
 - Delete duplicate files found by an execution of `rmlint`:
 
@@ -21,16 +21,16 @@
 
 - Find duplicate directory trees based on data, ignoring names:
 
-`rmlint --merge-directories {{path/to/directory}}`
+`rmlint {{[-D|--merge-directories]}} {{path/to/directory}}`
 
 - Mark files at lower path [d]epth as originals, on tie choose shorter [l]ength:
 
-`rmlint --rank-by={{dl}} {{path/to/directory}}`
+`rmlint {{[-S|--rank-by]}} {{dl}} {{path/to/directory}}`
 
 - Find files with identical filename and contents, and link rather than delete the duplicates:
 
-`rmlint -c sh:link --match-basename {{path/to/directory}}`
+`rmlint {{[-c|--config]}} sh:link {{[-b|--match-basename]}} {{path/to/directory}}`
 
 - Use `data` as master directory. Find only duplicates in backup that are also in `data`. Do not delete any files in `data`:
 
-`rmlint {{path/to/backup}} // {{path/to/data}} --keep-all-tagged --must-match-tagged`
+`rmlint {{path/to/backup}} // {{path/to/data}} {{[-k|--keep-all-tagged]}} {{[-m|--must-match-tagged]}}`

--- a/pages/common/rustscan.md
+++ b/pages/common/rustscan.md
@@ -3,34 +3,34 @@
 > Fast Port Scanner written in Rust with `nmap` built in.
 > More information: <https://github.com/RustScan/RustScan>.
 
-- Scan all ports of one or more comma-delimited [a]ddresses using the default values:
+- Scan all ports of one or more comma-delimited addresses using the default values:
 
-`rustscan --addresses {{ip_or_hostname}}`
+`rustscan {{[-a|--addresses]}} {{ip_or_hostname}}`
 
-- Scan the [t]op 1000 ports with service and version detection:
+- Scan the top 1000 ports with service and version detection:
 
-`rustscan --top --addresses {{address_or_addresses}}`
+`rustscan --top {{[-a|--addresses]}} {{address_or_addresses}}`
 
-- Scan a specific list of [p]orts:
+- Scan a specific list of ports:
 
-`rustscan --ports {{port1,port2,...,portN}} --addresses {{address_or_addresses}}`
+`rustscan {{[-p|--ports]}} {{port1,port2,...,portN}} {{[-a|--addresses]}} {{address_or_addresses}}`
 
 - Scan a specific range of ports:
 
-`rustscan --range {{start-end}} --addresses {{address_or_addresses}}`
+`rustscan {{[-r|--range]}} {{start-end}} {{[-a|--addresses]}} {{address_or_addresses}}`
 
 - Add script arguments to `nmap`:
 
-`rustscan --addresses {{address_or_addresses}} -- -A -sC`
+`rustscan {{[-a|--addresses]}} {{address_or_addresses}} -- -A -sC`
 
-- Scan with custom [b]atch size (default: 4500) and [t]imeout (default: 1500ms):
+- Scan with custom batch size (default: 4500) and timeout (default: 1500ms):
 
-`rustscan --batch-size {{batch_size}} --timeout {{timeout}} --addresses {{address_or_addresses}}`
+`rustscan {{[-b|--batch-size]}} {{batch_size}} {{[-t|--timeout]}} {{timeout}} {{[-a|--addresses]}} {{address_or_addresses}}`
 
 - Scan with specific port order:
 
-`rustscan --scan-order {{serial|random}} --addresses {{address_or_addresses}}`
+`rustscan --scan-order {{serial|random}} {{[-a|--addresses]}} {{address_or_addresses}}`
 
 - Scan in greppable mode (only output of the ports, no `nmap`):
 
-`rustscan --greppable --addresses {{address_or_addresses}}`
+`rustscan {{[-g|--greppable]}} {{[-a|--addresses]}} {{address_or_addresses}}`

--- a/pages/common/searchsploit.md
+++ b/pages/common/searchsploit.md
@@ -14,19 +14,19 @@
 
 - Show the exploit-db link to the found resources:
 
-`searchsploit --www {{search_terms}}`
+`searchsploit {{[-w|--www]}} {{search_terms}}`
 
-- Copy ([m]irror) the resource to the current directory (requires the number of the exploit):
+- Copy the resource to the current directory (requires the number of the exploit):
 
-`searchsploit --mirror {{exploit_number}}`
+`searchsploit {{[-m|--mirror]}} {{exploit_number}}`
 
-- E[x]amine the resource, using the pager defined in the `$PAGER` environment variable:
+- Examine the resource, using the pager defined in the `$PAGER` environment variable:
 
-`searchsploit --examine {{exploit_number}}`
+`searchsploit {{[-x|--examine]}} {{exploit_number}}`
 
-- [u]pdate the local Exploit Database:
+- Update the local Exploit Database:
 
-`searchsploit --update`
+`searchsploit {{[-u|--update]}}`
 
 - Search for the [c]ommon [v]ulnerabilities and [e]xposures (CVE) value:
 

--- a/pages/common/subfinder.md
+++ b/pages/common/subfinder.md
@@ -4,22 +4,22 @@
 > Designed as a passive framework to be useful for bug bounties and safe for penetration testing.
 > More information: <https://github.com/projectdiscovery/subfinder>.
 
-- Find subdomains for a specific [d]omain:
+- Find subdomains for a specific domain:
 
-`subfinder -d {{example.com}}`
+`subfinder {{[-d|-domain]}} {{example.com}}`
 
 - Show only the subdomains found:
 
-`subfinder -silent -d {{example.com}}`
+`subfinder -silent {{[-d|-domain]}} {{example.com}}`
 
 - Show only active subdomains:
 
-`subfinder -nW -d {{example.com}}`
+`subfinder {{[-nW|-active]}} {{[-d|-domain]}} {{example.com}}`
 
 - Use all sources for enumeration:
 
-`subfinder -all -d {{example.com}}`
+`subfinder -all {{[-d|-domain]}} {{example.com}}`
 
 - Use a given comma-separated list of [r]esolvers:
 
-`subfinder -r {{8.8.8.8,1.1.1.1,...}} -d {{example.com}}`
+`subfinder -r {{8.8.8.8,1.1.1.1,...}} {{[-d|-domain]}} {{example.com}}`

--- a/pages/common/tgpt.md
+++ b/pages/common/tgpt.md
@@ -8,25 +8,25 @@
 
 `tgpt "{{prompt}}"`
 
-- Start [m]ulti-line interactive mode:
+- Start multi-line interactive mode:
 
-`tgpt --multiline`
+`tgpt {{[-m|--multiline]}}`
 
-- Generate [i]mages and save them to the current directory:
+- Generate images and save them to the current directory:
 
-`tgpt --image "{{prompt}}"`
+`tgpt {{[-img|--image]}} "{{prompt}}"`
 
-- Generate [c]ode with the default provider (GPT-3.5-turbo):
+- Generate code with the default provider (GPT-3.5-turbo):
 
-`tgpt --code "{{prompt}}"`
+`tgpt {{[-c|--code]}} "{{prompt}}"`
 
-- Chat with a specific provider [q]uietly (without animations):
+- Chat with a specific provider quietly (without animations):
 
-`tgpt --provider {{openai|opengpts|koboldai|phind|llama2|blackboxai}} --quiet --whole "{{prompt}}"`
+`tgpt --provider {{openai|opengpts|koboldai|phind|llama2|blackboxai}} {{[-q|--quiet]}} {{[-w|--whole]}} "{{prompt}}"`
 
-- Generate and execute [s]hell commands using a specific provider (with a confirmation prompt):
+- Generate and execute shell commands using a specific provider (with a confirmation prompt):
 
-`tgpt --provider {{llama2}} --shell "{{prompt}}"`
+`tgpt --provider {{llama2}} {{[-s|--shell]}} "{{prompt}}"`
 
 - Prompt with an API key, model, max response length, temperature, and `top_p` (required when using `openai` provider):
 

--- a/pages/common/tidy.md
+++ b/pages/common/tidy.md
@@ -8,10 +8,10 @@
 
 `tidy {{path/to/file.html}}`
 
-- Enable [i]ndentation, [w]rapping lines in 100, saving to `output.html`:
+- Enable indentation, wrapping lines in 100, saving to `output.html`:
 
-`tidy --indent y --wrap 100 -output {{path/to/output.html}} {{path/to/file.html}}`
+`tidy {{[-i|--indent]}} y {{[-w|--wrap]}} 100 {{[-o|-output]}} {{path/to/output.html}} {{path/to/file.html}}`
 
 - Modify an HTML file in-place using a configuration file:
 
-`tidy -config {{path/to/configuration}} -modify {{path/to/file.html}}`
+`tidy -config {{path/to/configuration}} {{[-m|-modify]}} {{path/to/file.html}}`

--- a/pages/common/troff.md
+++ b/pages/common/troff.md
@@ -8,14 +8,14 @@
 
 `troff {{path/to/input.roff}} | grops > {{path/to/output.ps}}`
 
-- Format output for a PostScript printer using the [me] macro package, saving the output to a file:
+- Format output for a PostScript printer using the me macro package, saving the output to a file:
 
 `troff -{{me}} {{path/to/input.roff}} | grops > {{path/to/output.ps}}`
 
-- Format output as [a]SCII text using the [man] macro package:
+- Format output as ASCII text using the man macro package:
 
 `troff -T {{ascii}} -{{man}} {{path/to/input.roff}} | grotty`
 
-- Format output as a [pdf] file, saving the output to a file:
+- Format output as a pdf file, saving the output to a file:
 
 `troff -T {{pdf}} {{path/to/input.roff}} | gropdf > {{path/to/output.pdf}}`

--- a/pages/common/ts.md
+++ b/pages/common/ts.md
@@ -1,7 +1,7 @@
 # ts
 
 > Add timestamps to every line from `stdin`.
-> More information: <https://joeyh.name/code/moreutils/>.
+> More information: <https://manned.org/ts>.
 
 - Add a timestamp to the beginning of each line:
 

--- a/pages/common/twine.md
+++ b/pages/common/twine.md
@@ -7,13 +7,13 @@
 
 `twine upload dist/*`
 
-- Upload to the Test PyPI [r]epository to verify things look right:
+- Upload to the Test PyPI repository to verify things look right:
 
-`twine upload -r testpypi dist/*`
+`twine upload {{[-r|--repository]}} testpypi dist/*`
 
-- Upload to PyPI with a specified [u]sername and [p]assword:
+- Upload to PyPI with a specified username and password:
 
-`twine upload -u {{username}} -p {{password}} dist/*`
+`twine upload {{[-u|--username]}} {{username}} {{[-p|--password]}} {{password}} dist/*`
 
 - Upload to an alternative repository URL:
 

--- a/pages/common/wafw00f.md
+++ b/pages/common/wafw00f.md
@@ -1,32 +1,32 @@
 # wafw00f
 
 > Identify and fingerprint Web Application Firewall (WAF) products protecting a website.
-> More information: <https://github.com/EnableSecurity/wafw00f>.
+> More information: <https://github.com/EnableSecurity/wafw00f/wiki/Usage#arguments-list>.
 
 - Check if a website is using any WAF:
 
 `wafw00f {{https://www.example.com}}`
 
-- Test for [a]ll detectable WAFs without stopping at the first match:
+- Test for all detectable WAFs without stopping at the first match:
 
-`wafw00f --findall {{https://www.example.com}}`
+`wafw00f {{[-a|--findall]}} {{https://www.example.com}}`
 
-- Pass requests through a [p]roxy (such as BurpSuite):
+- Pass requests through a proxy (such as BurpSuite):
 
-`wafw00f --proxy {{http://localhost:8080}} {{https://www.example.com}}`
+`wafw00f {{[-p|--proxy]}} {{http://localhost:8080}} {{https://www.example.com}}`
 
-- [t]est for a specific WAF product (run `wafw00f -l` to get list of all supported WAFs):
+- Test for a specific WAF product (run `wafw00f -l` to get list of all supported WAFs):
 
-`wafw00f --test {{Cloudflare|Cloudfront|Fastly|ZScaler|...}} {{https://www.example.com}}`
+`wafw00f {{[-t|--test]}} {{Cloudflare|Cloudfront|Fastly|ZScaler|...}} {{https://www.example.com}}`
 
-- Pass custom [H]eaders from a file:
+- Pass custom headers from a file:
 
-`wafw00f --headers {{path/to/headers.txt}} {{https://www.example.com}}`
+`wafw00f {{[-H|--headers]}} {{path/to/headers.txt}} {{https://www.example.com}}`
 
-- Read target [i]nputs from a file and show verbose output (multiple `v` for more verbosity):
+- Read target inputs from a file and show verbose output (multiple `v` for more verbosity):
 
-`wafw00f --input {{path/to/urls.txt}} -v{{v}}`
+`wafw00f {{[-i|--input]}} {{path/to/urls.txt}} -{{vv}}`
 
-- [l]ist all WAFs that can be detected:
+- List all WAFs that can be detected:
 
-`wafw00f --list`
+`wafw00f {{[-l|--list]}}`

--- a/pages/common/whatwaf.md
+++ b/pages/common/whatwaf.md
@@ -3,25 +3,25 @@
 > Detect and bypass web application firewalls and protection systems.
 > More information: <https://github.com/Ekultek/WhatWaf>.
 
-- Detect protection on a single [u]RL, optionally use verbose output:
+- Detect protection on a single URL, optionally use verbose output:
 
-`whatwaf --url {{https://example.com}} --verbose`
+`whatwaf {{[-u|--url]}} {{https://example.com}} --verbose`
 
-- Detect protection on a [l]ist of URLs in parallel from a file (one URL per line):
+- Detect protection on a list of URLs in parallel from a file (one URL per line):
 
-`whatwaf --threads {{number}} --list {{path/to/file}}`
+`whatwaf {{[-t|--threads]}} {{number}} {{[-l|--list]}} {{path/to/file}}`
 
 - Send requests through a proxy and use custom payload list from a file (one payload per line):
 
-`whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{path/to/file}} -u {{https://example.com}}`
+`whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{path/to/file}} {{[-u|--url]}} {{https://example.com}}`
 
-- Send requests through Tor (Tor must be installed) using custom [p]ayloads (comma-separated):
+- Send requests through Tor (Tor must be installed) using custom payloads (comma-separated):
 
-`whatwaf --tor --payloads '{{payload1,payload2,...}}' -u {{https://example.com}}`
+`whatwaf --tor {{[-p|--payloads]}} '{{payload1,payload2,...}}' {{[-u|--url]}} {{https://example.com}}`
 
-- Use a random user-agent, set throttling and timeout, send a [P]OST request, and force HTTPS connection:
+- Use a random user-agent, set throttling and timeout, send a POST request, and force HTTPS connection:
 
-`whatwaf --ra --throttle {{seconds}} --timeout {{seconds}} --post --force-ssl -u {{http://example.com}}`
+`whatwaf --ra --throttle {{seconds}} --timeout {{seconds}} {{[-P|--post]}} --force-ssl {{[-u|--url]}} {{http://example.com}}`
 
 - List all WAFs that can be detected:
 

--- a/pages/common/wiggle.md
+++ b/pages/common/wiggle.md
@@ -8,22 +8,22 @@
 
 `wiggle {{path/to/my_patch.patch}}`
 
-- Apply changes to the [o]utput file:
+- Apply changes to the output file:
 
-`wiggle {{path/to/my_patch.patch}} -o {{path/to/output_file.txt}}`
+`wiggle {{path/to/my_patch.patch}} {{[-o|--output]}} {{path/to/output_file.txt}}`
 
 - Take any changes in `file.rej` that could not have been applied and merge them into a file:
 
-`wiggle --replace {{path/to/file}} {{path/to/file.rej}}`
+`wiggle {{[-r|--replace]}} {{path/to/file}} {{path/to/file.rej}}`
 
-- E[x]tract one branch of a patch or merge file:
+- Extract one branch of a patch or merge file:
 
-`wiggle -x {{path/to/my_patch.patch}}`
+`wiggle {{[-x|--extract]}} {{path/to/my_patch.patch}}`
 
-- Apply a patch and save the compared words to the [o]utput file:
+- Apply a patch and save the compared words to the output file:
 
-`wiggle --words {{path/to/my_word_patch.patch}} -o {{path/to/word_patched_code.c}}`
+`wiggle {{[-w|--words]}} {{path/to/my_word_patch.patch}} {{[-o|--output]}} {{path/to/word_patched_code.c}}`
 
 - Display help about the merge function:
 
-`wiggle --merge --help`
+`wiggle {{[-m|--merge]}} {{[-h|--help]}}`

--- a/pages/common/wikit.md
+++ b/pages/common/wikit.md
@@ -7,9 +7,9 @@
 
 `wikit {{topic}}`
 
-- Specify a [l]anguage (ISO 639-1 language code):
+- Specify a language (ISO 639-1 language code):
 
-`wikit {{topic}} --lang {{language_code}}`
+`wikit {{topic}} {{[-l|--lang]}} {{language_code}}`
 
 - Open the full Wikipedia article in the default browser:
 

--- a/pages/common/xteddy.md
+++ b/pages/common/xteddy.md
@@ -1,7 +1,7 @@
 # xteddy
 
 > A cuddly teddy bear for your X Windows desktop.
-> More information: <https://manned.org/xteddy.1>.
+> More information: <https://manned.org/xteddy>.
 
 - Display a cuddly teddy bear on your X desktop:
 

--- a/pages/common/yq.md
+++ b/pages/common/yq.md
@@ -9,7 +9,7 @@
 
 - Output a YAML file, in pretty-print format (v3):
 
-`yq read {{path/to/file.yaml}} --colors`
+`yq read {{path/to/file.yaml}} {{[-C|--colors]}}`
 
 - Output the first element in a YAML file that contains only an array (v4+):
 
@@ -21,11 +21,11 @@
 
 - Set (or overwrite) a key to a value in a file (v4+):
 
-`yq eval '.{{key}} = "{{value}}"' --inplace {{path/to/file.yaml}}`
+`yq eval '.{{key}} = "{{value}}"' {{[-i|--inplace]}} {{path/to/file.yaml}}`
 
 - Set (or overwrite) a key to a value in a file (v3):
 
-`yq write --inplace {{path/to/file.yaml}} '{{key}}' '{{value}}'`
+`yq write {{[-i|--inplace]}} {{path/to/file.yaml}} '{{key}}' '{{value}}'`
 
 - Merge two files and print to `stdout` (v4+):
 
@@ -33,4 +33,4 @@
 
 - Merge two files and print to `stdout` (v3):
 
-`yq merge {{path/to/file1.yaml}} {{path/to/file2.yaml}} --colors`
+`yq merge {{path/to/file1.yaml}} {{path/to/file2.yaml}} {{[-C|--colors]}}`

--- a/pages/common/zipcloak.md
+++ b/pages/common/zipcloak.md
@@ -7,10 +7,10 @@
 
 `zipcloak {{path/to/archive.zip}}`
 
-- [d]ecrypt the contents of a Zip archive:
+- Decrypt the contents of a Zip archive:
 
-`zipcloak -d {{path/to/archive.zip}}`
+`zipcloak {{[-d|--decrypt]}} {{path/to/archive.zip}}`
 
-- [O]utput the encrypted contents into a new Zip archive:
+- Output the encrypted contents into a new Zip archive:
 
-`zipcloak {{path/to/archive.zip}} -O {{path/to/encrypted.zip}}`
+`zipcloak {{path/to/archive.zip}} {{[-O|--output-file]}} {{path/to/encrypted.zip}}`

--- a/pages/common/zpaq.md
+++ b/pages/common/zpaq.md
@@ -1,28 +1,28 @@
 # zpaq
 
 > Incremental journaling backup utility and archiver.
-> More information: <https://mattmahoney.net/dc/zpaq.html>.
+> More information: <https://mattmahoney.net/dc/zpaqdoc.html>.
 
-- [a]dd a file or directory to a new or existing archive:
+- Add a file or directory to a new or existing archive:
 
-`zpaq a {{path/to/archive.zpaq}} {{path/to/file_or_directory}}`
+`zpaq {{[a|add]}} {{path/to/archive.zpaq}} {{path/to/file_or_directory}}`
 
 - Create or add to an encrypted archive:
 
-`zpaq a -k{{password}} {{path/to/archive.zpaq}} {{path/to/file_or_directory}}`
+`zpaq {{[a|add]}} -k{{password}} {{path/to/archive.zpaq}} {{path/to/file_or_directory}}`
 
-- E[x]tract the most recent versions of files:
+- Extract the most recent versions of files:
 
-`zpaq x {{path/to/archive.zpaq}}`
+`zpaq {{[x|extract]}} {{path/to/archive.zpaq}}`
 
-- [l]ist the archive contents:
+- List the archive contents:
 
-`zpaq l {{path/to/archive.zpaq}}`
+`zpaq {{[l|list]}} {{path/to/archive.zpaq}}`
 
 - Set the level of compression (higher means more compression but slower):
 
-`zpaq a {{path/to/archive.zpaq}} -m{{1|2|3|4|5}} {{path/to/file_or_directory}}`
+`zpaq {{[a|add]}} {{path/to/archive.zpaq}} -m{{1|2|3|4|5}} {{path/to/file_or_directory}}`
 
-- E[x]tract the specified files from the archive that are not newer than the specified date:
+- Extract the specified files from the archive that are not newer than the specified date:
 
-`zpaq x {{path/to/archive.zpaq}} {{path/in/archive/to/extract}} -to {{path/to/output}} -until {{YYYY-MM-DD}}`
+`zpaq {{[x|extract]}} {{path/to/archive.zpaq}} {{path/in/archive/to/extract}} -to {{path/to/output}} -until {{YYYY-MM-DD}}`

--- a/pages/common/zsh.md
+++ b/pages/common/zsh.md
@@ -2,7 +2,7 @@
 
 > Z SHell, a Bash-compatible command-line interpreter.
 > See also: `bash`, `histexpand`.
-> More information: <https://www.zsh.org>.
+> More information: <https://zsh.sourceforge.io/Doc/Release/Invocation.html#Invocation>.
 
 - Start an interactive shell session:
 


### PR DESCRIPTION
These were found with `grep -r "\[.\]"`

I also changed a couple of pages more information link if I had trouble finding instructions for cli usage.

Mnemonics were preserved if the shortform was short for something else than whatwas in longform or if there were no longform available 