### PR TITLE
Add ipcalc: calculate IP address and subnet information

### DIFF
--- a/pages/common/ipcalc.md
+++ b/pages/common/ipcalc.md
@@ -4,16 +4,21 @@
 > More information: <https://github.com/ipcalc/ipcalc>.
 
 - Display network info for an IP address:
+
 `ipcalc {{192.168.0.1}}`
 
 - Display network info using CIDR notation:
+
 `ipcalc {{192.168.0.1/24}}`
 
 - Display network info using a separate netmask:
+
 `ipcalc {{192.168.0.1}} {{255.255.255.0}}`
 
 - Show only CIDR notation output:
+
 `ipcalc -c {{192.168.0.1/24}}`
 
 - Show version information:
+
 `ipcalc --version`

--- a/pages/common/ipcalc.md
+++ b/pages/common/ipcalc.md
@@ -1,0 +1,19 @@
+# ipcalc
+
+> A tool to calculate IP information (subnet, broadcast, host range) from an IP address and netmask.
+> More information: <https://github.com/ipcalc/ipcalc>.
+
+- Display network info for an IP address:
+`ipcalc {{192.168.0.1}}`
+
+- Display network info using CIDR notation:
+`ipcalc {{192.168.0.1/24}}`
+
+- Display network info using a separate netmask:
+`ipcalc {{192.168.0.1}} {{255.255.255.0}}`
+
+- Show only CIDR notation output:
+`ipcalc -c {{192.168.0.1/24}}`
+
+- Show version information:
+`ipcalc --version`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.0.0

---

This pull request adds a new TLDR page for the `ipcalc` command-line utility.

`ipcalc` is used to calculate and display network information based on an IP address and subnet, such as:
- Netmask
- Broadcast address
- CIDR notation
- Host range

The page includes common usage examples for:
- Basic address lookup
- CIDR notation
- Custom netmask input
- Short-format output
- Version info

This PR addresses issue #16125.

