### PR TITLE
fastfetch: refresh English and Korean pages

### DIFF
--- a/pages.ko/common/fastfetch.md
+++ b/pages.ko/common/fastfetch.md
@@ -9,7 +9,7 @@
 
 - 모든 모듈과 함께 전체 시스템 정보 표시:
 
-`fastfetch -c all`
+`fastfetch {{[-c|--config]}} all`
 
 - 특정 구조를 가져오기:
 

--- a/pages.ko/common/fastfetch.md
+++ b/pages.ko/common/fastfetch.md
@@ -11,10 +11,6 @@
 
 `fastfetch -c all`
 
-- 로고와 이스케이프 시퀀스 없이 시스템 정보를 표기:
-
-`fastfetch --pipe`
-
 - 특정 구조를 가져오기:
 
 `fastfetch --structure {{구조}}`
@@ -26,6 +22,10 @@
 - 특정 로고 사용:
 
 `fastfetch --logo {{로고}}`
+
+- 로고 없이 시스템 정보를 표기:
+
+`fastfetch --logo none`
 
 - 키와 제목에 특정 색상을 사용:
 

--- a/pages.ko/common/fastfetch.md
+++ b/pages.ko/common/fastfetch.md
@@ -7,6 +7,10 @@
 
 `fastfetch`
 
+- 모든 모듈과 함께 전체 시스템 정보 표시:
+
+`fastfetch -c all`
+
 - 로고와 이스케이프 시퀀스 없이 시스템 정보를 표기:
 
 `fastfetch --pipe`

--- a/pages.ko/common/fastfetch.md
+++ b/pages.ko/common/fastfetch.md
@@ -1,7 +1,7 @@
 # fastfetch
 
 > 운영체제, 소프트웨어 및 하드웨어에 대한 정보 표시.
-> 더 많은 정보: <https://github.com/fastfetch-cli/fastfetch>.
+> 더 많은 정보: <https://manned.org/fastfetch>.
 
 - 시스템 정보 표시:
 
@@ -11,21 +11,21 @@
 
 `fastfetch {{[-c|--config]}} all`
 
-- 특정 구조를 가져오기:
-
-`fastfetch --structure {{구조}}`
-
 - 사용자 정의 구성 파일 로드:
 
-`fastfetch --load-config {{경로/대상/구성_파일}}`
+`fastfetch {{[-c|--config]}} {{경로/대상/구성_파일}}`
+
+- 특정 구조를 가져오기:
+
+`fastfetch {{[-s|--structure]}} {{구조}}`
 
 - 특정 로고 사용:
 
-`fastfetch --logo {{로고}}`
+`fastfetch {{[-l|--logo]}} {{로고}}`
 
 - 로고 없이 시스템 정보를 표기:
 
-`fastfetch --logo none`
+`fastfetch {{[-l|--logo]}} none`
 
 - 키와 제목에 특정 색상을 사용:
 

--- a/pages.ko/common/fastfetch.md
+++ b/pages.ko/common/fastfetch.md
@@ -1,7 +1,7 @@
 # fastfetch
 
 > 운영체제, 소프트웨어 및 하드웨어에 대한 정보 표시.
-> 더 많은 정보: <https://github.com/LinusDierheimer/fastfetch>.
+> 더 많은 정보: <https://github.com/fastfetch-cli/fastfetch>.
 
 - 시스템 정보 표시:
 

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -9,7 +9,7 @@
 
 - Display full system information with all the modules enabled:
 
-`fastfetch -c all`
+`fastfetch {{[-c|--config]}} all`
 
 - Fetch a specific structure:
 

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -1,7 +1,7 @@
 # fastfetch
 
 > Display information about your operating system, software and hardware.
-> More information: <https://github.com/fastfetch-cli/fastfetch>.
+> More information: <https://manned.org/fastfetch>.
 
 - Display system information:
 
@@ -11,21 +11,21 @@
 
 `fastfetch {{[-c|--config]}} all`
 
-- Fetch a specific structure:
-
-`fastfetch --structure {{structure}}`
-
 - Load a custom configuration file:
 
-`fastfetch --load-config {{path/to/config_file}}`
+`fastfetch {{[-c|--config]}} {{path/to/config_file}}`
+
+- Fetch a specific structure:
+
+`fastfetch {{[-s|--structure]}} {{structure}}`
 
 - Use a specific logo:
 
-`fastfetch --logo {{logo}}`
+`fastfetch {{[-l|--logo]}} {{logo}}`
 
 - Display system information without a logo:
 
-`fastfetch --logo none`
+`fastfetch {{[-l|--logo]}} none`
 
 - Use a specific color for the keys and title:
 

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -1,7 +1,7 @@
 # fastfetch
 
 > Display information about your operating system, software and hardware.
-> More information: <https://github.com/LinusDierheimer/fastfetch>.
+> More information: <https://github.com/fastfetch-cli/fastfetch>.
 
 - Display system information:
 

--- a/pages/common/fastfetch.md
+++ b/pages/common/fastfetch.md
@@ -7,6 +7,10 @@
 
 `fastfetch`
 
+- Display full system information with all the modules enabled:
+
+`fastfetch -c all`
+
 - Fetch a specific structure:
 
 `fastfetch --structure {{structure}}`


### PR DESCRIPTION
- **fastfetch: update repo to fastfetch-cli/fastfetch**
- **fastfetch: add command to display full system info**

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2.40.3

~~I suggest doing a traditional `git merge` rather than a squash merge in order to preserve the commits.~~

**Edit**: was decided against in the review comments