### PR TITLE
btrfs-restore, swww, urpmi.removemedia, ansible, az-lock, az-storage-blob, bzip3: add or remove mnemonics

### DIFF
--- a/pages/common/ansible.md
+++ b/pages/common/ansible.md
@@ -12,7 +12,7 @@
 
 `ansible {{group}} {{[-m|--module-name]}} ping`
 
-- Display facts about a group of hosts by invoking the setup [m]odule:
+- Display facts about a group of hosts by invoking the setup module:
 
 `ansible {{group}} {{[-m|--module-name]}} setup`
 

--- a/pages/common/az-lock.md
+++ b/pages/common/az-lock.md
@@ -24,6 +24,6 @@
 
 `az lock list`
 
-- Show a subscription level lock with a specific [n]ame:
+- Show a subscription level lock with a specific name:
 
 `az lock show {{[-n|--name]}} {{lock_name}}`

--- a/pages/common/az-storage-blob.md
+++ b/pages/common/az-storage-blob.md
@@ -8,7 +8,7 @@
 
 `az storage blob download --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-c|--container-name]}} {{container_name}} {{[-n|--name]}} {{path/to/blob}} {{[-f|--file]}} {{path/to/local_file}}`
 
-- [d]ownload blobs from a blob container recursively:
+- Download blobs from a blob container recursively:
 
 `az storage blob download-batch --account-name {{storage_account_name}} --account-key {{storage_account_key}} {{[-s|--source]}} {{container_name}} {{[-d|--destination]}} {{path/to/remote}} --pattern {{filename_regex}} {{[-d|--destination]}} {{path/to/destination}}`
 

--- a/pages/common/bzip3.md
+++ b/pages/common/bzip3.md
@@ -11,7 +11,7 @@
 
 `bzip3 {{[-d|--decode]}} {{path/to/compressed_file.bz3}}`
 
-- Decompress a file to `stdout` ([c]):
+- Decompress a file to `stdout`:
 
 `bzip3 {{[-dc|--decode --stdout]}} {{path/to/compressed_file.bz3}}`
 

--- a/pages/linux/btrfs-restore.md
+++ b/pages/linux/btrfs-restore.md
@@ -15,7 +15,7 @@
 
 `sudo btrfs restore --path-regex {{regex}} -c {{path/to/btrfs_device}} {{path/to/target_directory}}`
 
-- Restore files from a btrfs filesystem using a specific root tree `bytenr` (see `btrfs-find-root`):
+- Restore files from a btrfs filesystem using a specific root [t]ree `bytenr` (see `btrfs-find-root`):
 
 `sudo btrfs restore -t {{bytenr}} {{path/to/btrfs_device}} {{path/to/target_directory}}`
 

--- a/pages/linux/swww.md
+++ b/pages/linux/swww.md
@@ -8,9 +8,9 @@
 
 `swww img {{path/to/image}}`
 
-- Set wallpaper to specified [o]utputs:
+- Set wallpaper to specified outputs:
 
-`swww img -o {{output1,output2,...}} {{path/to/image}}`
+`swww img {{[-o|--outputs]}} {{output1,output2,...}} {{path/to/image}}`
 
 - Restore last wallpaper:
 

--- a/pages/linux/urpmi.removemedia.md
+++ b/pages/linux/urpmi.removemedia.md
@@ -9,7 +9,7 @@
 
 `sudo urpmi.removemedia {{medium}}`
 
-- Remove all media:
+- Remove [a]ll media:
 
 `sudo urpmi.removemedia -a`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
