### PR TITLE
impacket-*: remove more information

### DIFF
--- a/pages.es/common/impacket-getadusers.md
+++ b/pages.es/common/impacket-getadusers.md
@@ -1,8 +1,6 @@
 # impacket-GetADUsers
 
 > Este comando es un alias de `GetADUsers.py`.
-> Forma parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-getarch.md
+++ b/pages.es/common/impacket-getarch.md
@@ -1,8 +1,6 @@
 # impacket-getArch
 
 > Este comando es un alias de `getArch.py`.
-> Forma parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-getnpusers.md
+++ b/pages.es/common/impacket-getnpusers.md
@@ -1,8 +1,6 @@
 # impacket-GetNPUsers
 
 > Este comando es un alias de `GetNPUsers.py`.
-> Forma parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-getuserspns.md
+++ b/pages.es/common/impacket-getuserspns.md
@@ -1,8 +1,6 @@
 # impacket-GetUserSPNs
 
 > Este comando es un alias de `GetNPUsers.py`.
-> Forma parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-mssqlclient.md
+++ b/pages.es/common/impacket-mssqlclient.md
@@ -1,8 +1,6 @@
 # impacket-mssqlclient
 
 > Este comando es un alias de `mssqlclient.py`.
-> Parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-secretsdump.md
+++ b/pages.es/common/impacket-secretsdump.md
@@ -1,7 +1,6 @@
 # impacket-secretsdump
 
 > Este comando es un alias de `secretsdump.py`.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-sniff.md
+++ b/pages.es/common/impacket-sniff.md
@@ -1,8 +1,6 @@
 # impacket-sniff
 
 > Este comando es un alias de `sniff.py`.
-> Parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.es/common/impacket-sniffer.md
+++ b/pages.es/common/impacket-sniffer.md
@@ -1,8 +1,6 @@
 # impacket-sniffer
 
 > Este comando es un alias de `sniffer.py`.
-> Parte de la suite Impacket.
-> Más información: <https://github.com/fortra/impacket>.
 
 - Vea la documentación del comando original:
 

--- a/pages.nl/common/impacket-getadusers.md
+++ b/pages.nl/common/impacket-getadusers.md
@@ -1,7 +1,6 @@
 # impacket-GetADUsers
 
 > Dit commando is een alias van `GetADUsers.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-getarch.md
+++ b/pages.nl/common/impacket-getarch.md
@@ -1,7 +1,6 @@
 # impacket-getArch
 
 > Dit commando is een alias van `getArch.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-getnpusers.md
+++ b/pages.nl/common/impacket-getnpusers.md
@@ -1,7 +1,6 @@
 # impacket-GetNPUsers
 
 > Dit commando is een alias van `GetNPUsers.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-getuserspns.md
+++ b/pages.nl/common/impacket-getuserspns.md
@@ -1,7 +1,6 @@
 # impacket-GetUserSPNs
 
 > Dit commando is een alias van `GetUserSPNs.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-mssqlclient.md
+++ b/pages.nl/common/impacket-mssqlclient.md
@@ -1,7 +1,6 @@
 # impacket-mssqlclient
 
 > Dit commando is een alias van `mssqlclient.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-secretsdump.md
+++ b/pages.nl/common/impacket-secretsdump.md
@@ -1,7 +1,6 @@
 # impacket-secretsdump
 
 > Dit commando is een alias van `secretsdump.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-sniff.md
+++ b/pages.nl/common/impacket-sniff.md
@@ -1,7 +1,6 @@
 # impacket-sniff
 
 > Dit commando is een alias van `sniff.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages.nl/common/impacket-sniffer.md
+++ b/pages.nl/common/impacket-sniffer.md
@@ -1,7 +1,6 @@
 # impacket-sniffer
 
 > Dit commando is een alias van `sniffer.py`.
-> Meer informatie: <https://github.com/fortra/impacket>.
 
 - Bekijk de documentatie van het originele commando:
 

--- a/pages/common/impacket-getadusers.md
+++ b/pages/common/impacket-getadusers.md
@@ -1,8 +1,6 @@
 # impacket-GetADUsers
 
 > This command is an alias of `GetADUsers.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-getarch.md
+++ b/pages/common/impacket-getarch.md
@@ -1,8 +1,6 @@
 # impacket-getArch
 
 > This command is an alias of `getArch.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-getnpusers.md
+++ b/pages/common/impacket-getnpusers.md
@@ -1,8 +1,6 @@
 # impacket-GetNPUsers
 
 > This command is an alias of `GetNPUsers.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-getuserspns.md
+++ b/pages/common/impacket-getuserspns.md
@@ -1,8 +1,6 @@
 # impacket-GetUserSPNs
 
 > This command is an alias of `GetUserSPNs.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-mssqlclient.md
+++ b/pages/common/impacket-mssqlclient.md
@@ -1,8 +1,6 @@
 # impacket-mssqlclient
 
 > This command is an alias of `mssqlclient.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-rpcdump.md
+++ b/pages/common/impacket-rpcdump.md
@@ -1,7 +1,6 @@
 # impacket-rpcdump
 
 > This command is an alias of `rpcdump.py`.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-rpcmap.md
+++ b/pages/common/impacket-rpcmap.md
@@ -1,7 +1,6 @@
 # impacket-rpcmap
 
 > This command is an alias of `rpcmap.py`.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-secretsdump.md
+++ b/pages/common/impacket-secretsdump.md
@@ -1,7 +1,6 @@
 # impacket-secretsdump
 
 > This command is an alias of `secretsdump.py`.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-sniff.md
+++ b/pages/common/impacket-sniff.md
@@ -1,8 +1,6 @@
 # impacket-sniff
 
 > This command is an alias of `sniff.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 

--- a/pages/common/impacket-sniffer.md
+++ b/pages/common/impacket-sniffer.md
@@ -1,8 +1,6 @@
 # impacket-sniffer
 
 > This command is an alias of `sniffer.py`.
-> Part of the Impacket suite.
-> More information: <https://github.com/fortra/impacket>.
 
 - View documentation for the original command:
 


### PR DESCRIPTION
These are all alias pages.

relevant issue (removal of more information links from alias pages): #14542
suggested in https://github.com/tldr-pages/tldr/pull/16177#discussion_r2045501398
