### PR TITLE
abrt: add page

### DIFF
--- a/pages/linux/abrt.md
+++ b/pages/linux/abrt.md
@@ -1,0 +1,23 @@
+# abrt
+
+> Automatic Bug Reporting Tool for Fedora-based systems.
+> Used to detect, analyze, and report application crashes.
+> More information: <https://abrt.readthedocs.io/>.
+
+- List detected problems:
+  `abrt-cli list`
+
+- Show details of a specific problem:
+  `abrt-cli info {{problem_id}}`
+
+- Remove a crash report:
+  `abrt-cli remove {{problem_id}}`
+
+- Report a problem to the configured bug tracker (e.g., Bugzilla):
+  `abrt-cli report {{problem_id}}`
+
+- Watch for new crashes in real time (requires abrt-watch-log service):
+  `abrt-watch-log -f {{/path/to/logfile}}`
+
+- Generate a report for debugging manually:
+  `abrt-cli report --analyze {{problem_id}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Version of the command being documented (if known): *2.17.6*
---

Adds a TLDR page for `abrt`, Fedora’s Automatic Bug Reporting Tool.

Includes examples for listing, inspecting, removing, and reporting crash problems via `abrt-cli` and `abrt-watch-log`.
