### PR TITLE
linux/*: add option placeholders

### DIFF
--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -5,12 +5,12 @@
 
 - Link a specific object file with no dependencies into an executable:
 
-`ld {{path/to/file.o}} --output {{path/to/output_executable}}`
+`ld {{path/to/file.o}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Link two object files together:
 
-`ld {{path/to/file1.o}} {{path/to/file2.o}} --output {{path/to/output_executable}}`
+`ld {{path/to/file1.o}} {{path/to/file2.o}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Dynamically link an x86_64 program to glibc (file paths change depending on the system):
 
-`ld --output {{path/to/output_executable}} --dynamic-linker /lib/ld-linux-x86-64.so.2 /lib/crt1.o /lib/crti.o -lc {{path/to/file.o}} /lib/crtn.o`
+`ld {{[-o|--output]}} {{path/to/output_executable}} {{[-I|--dynamic-linker]}} /lib/ld-linux-x86-64.so.2 /lib/crt1.o /lib/crti.o -lc {{path/to/file.o}} /lib/crtn.o`

--- a/pages/common/nm.md
+++ b/pages/common/nm.md
@@ -5,16 +5,16 @@
 
 - List global (extern) functions in a file (prefixed with T):
 
-`nm -g {{path/to/file.o}}`
+`nm {{[-g|--extern-only]}} {{path/to/file.o}}`
 
 - List only undefined symbols in a file:
 
-`nm -u {{path/to/file.o}}`
+`nm {{[-u|--undefined-only]}} {{path/to/file.o}}`
 
 - List all symbols, even debugging symbols:
 
-`nm -a {{path/to/file.o}}`
+`nm {{[-a|--debug-syms]}} {{path/to/file.o}}`
 
 - Demangle C++ symbols (make them readable):
 
-`nm --demangle {{path/to/file.o}}`
+`nm {{[-C|--demangle]}} {{path/to/file.o}}`

--- a/pages/linux/acpi.md
+++ b/pages/linux/acpi.md
@@ -1,7 +1,7 @@
 # acpi
 
 > Shows battery status or thermal information.
-> More information: <https://sourceforge.net/projects/acpiclient/files/acpiclient/>.
+> More information: <https://manned.org/acpi>.
 
 - Show battery information:
 
@@ -9,20 +9,20 @@
 
 - Show thermal information:
 
-`acpi -t`
+`acpi {{[-t|--thermal]}}`
 
 - Show cooling device information:
 
-`acpi -c`
+`acpi {{[-c|--cooling]}}`
 
 - Show thermal information in Fahrenheit:
 
-`acpi -tf`
+`acpi {{[-tf|--thermal --fahrenheit]}}`
 
 - Show all information:
 
-`acpi -V`
+`acpi {{[-V|--everything]}}`
 
 - Extract information from `/proc` instead of `/sys`:
 
-`acpi -p`
+`acpi {{[-p|--proc]}}`

--- a/pages/linux/apt-key.md
+++ b/pages/linux/apt-key.md
@@ -18,7 +18,7 @@
 
 - Add a remote key to the trusted keystore:
 
-`wget -qO - {{https://host.tld/filename.key}} | apt-key add -`
+`wget {{[-qO|--quiet --output-document]}} - {{https://host.tld/filename.key}} | apt-key add -`
 
 - Add a key from keyserver with only key ID:
 

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -9,7 +9,7 @@
 
 `sudo apt update`
 
-- Search for a given package (use `apt search -n package` to search within package name only):
+- Search for a given package (use `apt search --name-only package` to search within package name only):
 
 `apt search {{package}}`
 
@@ -35,4 +35,4 @@
 
 - List installed packages:
 
-`apt list --installed`
+`apt list {{[-i|--installed]}}`

--- a/pages/linux/arecord.md
+++ b/pages/linux/arecord.md
@@ -5,24 +5,24 @@
 
 - Record a snippet in "CD" quality (finish with `<Ctrl c>` when done):
 
-`arecord -vv --format=cd {{path/to/file.wav}}`
+`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{path/to/file.wav}}`
 
 - Record a snippet in "CD" quality, with a fixed duration of 10 seconds:
 
-`arecord -vv --format=cd --duration={{10}} {{path/to/file.wav}}`
+`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{[-d|--duration]}} {{10}} {{path/to/file.wav}}`
 
 - Record a snippet and save it as an MP3 (finish with `<Ctrl c>` when done):
 
-`arecord -vv --format=cd --file-type raw | lame -r - {{path/to/file.mp3}}`
+`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{[-t|--file-type]}} raw | lame -r - {{path/to/file.mp3}}`
 
 - List all sound cards and digital audio devices:
 
-`arecord --list-devices`
+`arecord {{[-l|--list-devices]}}`
 
 - Allow interactive interface (e.g. use `<Space>` or `<Enter>` to play or pause):
 
-`arecord --interactive`
+`arecord {{[-i|--interactive]}}`
 
 - Test your microphone by recording a 5 second sample and playing it back:
 
-`arecord -d 5 test-mic.wav && aplay test-mic.wav && rm test-mic.wav`
+`arecord {{[-d|--duration]}} 5 test-mic.wav && aplay test-mic.wav && rm test-mic.wav`

--- a/pages/linux/arecord.md
+++ b/pages/linux/arecord.md
@@ -13,7 +13,7 @@
 
 - Record a snippet and save it as an MP3 (finish with `<Ctrl c>` when done):
 
-`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{[-t|--file-type]}} raw | lame -r - {{path/to/file.mp3}}`
+`arecord {{[-vv|--verbose --verbose]}} {{[-f|--format]}} cd {{[-t|--file-type]}} raw | lame -r - {{path/to/file.mp3}}`
 
 - List all sound cards and digital audio devices:
 

--- a/pages/linux/arecord.md
+++ b/pages/linux/arecord.md
@@ -5,7 +5,7 @@
 
 - Record a snippet in "CD" quality (finish with `<Ctrl c>` when done):
 
-`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{path/to/file.wav}}`
+`arecord {{[-vv|--verbose --verbose]}} {{[-f|--format]}} cd {{path/to/file.wav}}`
 
 - Record a snippet in "CD" quality, with a fixed duration of 10 seconds:
 

--- a/pages/linux/arecord.md
+++ b/pages/linux/arecord.md
@@ -9,7 +9,7 @@
 
 - Record a snippet in "CD" quality, with a fixed duration of 10 seconds:
 
-`arecord {{[-vv|--verbose -verbose]}} {{[-f|--format]}} cd {{[-d|--duration]}} {{10}} {{path/to/file.wav}}`
+`arecord {{[-vv|--verbose --verbose]}} {{[-f|--format]}} cd {{[-d|--duration]}} {{10}} {{path/to/file.wav}}`
 
 - Record a snippet and save it as an MP3 (finish with `<Ctrl c>` when done):
 

--- a/pages/linux/audit2allow.md
+++ b/pages/linux/audit2allow.md
@@ -6,7 +6,7 @@
 
 - Generate a local policy to allow access for all denied services:
 
-`sudo audit2allow --all -M {{local_policy_name}}`
+`sudo audit2allow {{[-a|--all]}} -M {{local_policy_name}}`
 
 - Generate a local policy module to grant access to a specific process/service/command from the audit logs:
 
@@ -18,4 +18,4 @@
 
 - Install a local policy module:
 
-`sudo semodule -i {{local_policy_name}}.pp`
+`sudo semodule {{[-i|--install]}} {{local_policy_name}}.pp`

--- a/pages/linux/beep.md
+++ b/pages/linux/beep.md
@@ -17,8 +17,8 @@
 
 - Play each new frequency and duration as a distinct beep:
 
-`beep -f {{frequency}} -l {{duration}} -n -f {{frequency}} -l {{duration}}`
+`beep -f {{frequency}} -l {{duration}} {{[-n|--new]}} -f {{frequency}} -l {{duration}}`
 
 - Play the C major scale:
 
-`beep -f {{262}} -n -f {{294}} -n -f {{330}} -n -f {{349}} -n -f {{392}} -n -f {{440}} -n -f {{494}} -n -f {{523}}`
+`beep -f {{262}} {{[-n|--new]}} -f {{294}} {{[-n|--new]}} -f {{330}} {{[-n|--new]}} -f {{349}} {{[-n|--new]}} -f {{392}} {{[-n|--new]}} -f {{440}} {{[-n|--new]}} -f {{494}} {{[-n|--new]}} -f {{523}}`

--- a/pages/linux/betterlockscreen.md
+++ b/pages/linux/betterlockscreen.md
@@ -5,16 +5,16 @@
 
 - Lock the screen:
 
-`betterlockscreen --lock`
+`betterlockscreen {{[-l|--lock]}}`
 
 - Change the lock screen background:
 
-`betterlockscreen -u {{path/to/image.png}}`
+`betterlockscreen {{[-u|--update]}} {{path/to/image.png}}`
 
 - Lock the screen, showing some custom text:
 
-`betterlockscreen -l pixel -t "{{custom lock screen text}}"`
+`betterlockscreen {{[-l|--lock]}} pixel --text "{{custom lock screen text}}"`
 
 - Lock the screen, with a custom monitor off timeout in seconds:
 
-`betterlockscreen --off {{5}} -l`
+`betterlockscreen --off {{5}} {{[-l|--lock]}}`

--- a/pages/linux/blight.md
+++ b/pages/linux/blight.md
@@ -5,7 +5,7 @@
 
 - Set display brightness to 50%:
 
-`blight set {{50}} -r`
+`blight set {{50}} {{[-r|--relative]}}`
 
 - Show current display brightness:
 
@@ -17,7 +17,7 @@
 
 - Increase display brightness in %:
 
-`blight inc {{number}} -r`
+`blight inc {{number}} {{[-r|--relative]}}`
 
 - Decrease display brightness with internal units:
 

--- a/pages/linux/bmon.md
+++ b/pages/linux/bmon.md
@@ -5,16 +5,16 @@
 
 - Display the list of all the interfaces:
 
-`bmon -a`
+`bmon {{[-a|--show-all]}}`
 
 - Display data transfer rates in bits per second:
 
-`bmon -b`
+`bmon {{[-b|--use-bit]}}`
 
 - Specify the policy to define which network interface(s) is/are displayed:
 
-`bmon -p {{interface_1,interface_2,interface_3}}`
+`bmon {{[-p|--policy]}} {{interface_1,interface_2,interface_3}}`
 
 - Specify the interval (in seconds) in which rate per counter is calculated:
 
-`bmon -R {{2.0}}`
+`bmon {{[-R|--rate-interval]}} {{2.0}}`

--- a/pages/linux/btrfs-filesystem.md
+++ b/pages/linux/btrfs-filesystem.md
@@ -13,11 +13,11 @@
 
 - Defragment a single file on a btrfs filesystem (avoid while a deduplication agent is running):
 
-`sudo btrfs filesystem defragment -v {{path/to/file}}`
+`sudo btrfs filesystem defragment {{[-v|--verbose]}} {{path/to/file}}`
 
 - Defragment a directory recursively (does not cross subvolume boundaries):
 
-`sudo btrfs filesystem defragment -v -r {{path/to/directory}}`
+`sudo btrfs filesystem defragment {{[-v|--verbose]}} -r {{path/to/directory}}`
 
 - Force syncing unwritten data blocks to disk(s):
 
@@ -25,4 +25,4 @@
 
 - Summarize disk usage for the files in a directory recursively:
 
-`sudo btrfs filesystem du --summarize {{path/to/directory}}`
+`sudo btrfs filesystem du {{[-s|--summarize]}} {{path/to/directory}}`

--- a/pages/linux/btrfs-restore.md
+++ b/pages/linux/btrfs-restore.md
@@ -9,7 +9,7 @@
 
 - List (don't write) files to be restored from a btrfs filesystem:
 
-`sudo btrfs restore --dry-run {{path/to/btrfs_device}} {{path/to/target_directory}}`
+`sudo btrfs restore {{[-D|--dry-run]}} {{path/to/btrfs_device}} {{path/to/target_directory}}`
 
 - Restore files matching a given regex ([c]ase-insensitive) files to be restored from a btrfs filesystem (all parent directories of target file(s) must match as well):
 
@@ -21,4 +21,4 @@
 
 - Restore files from a btrfs filesystem (along with metadata, extended attributes, and Symlinks), overwriting files in the target:
 
-`sudo btrfs restore --metadata --xattr --symlinks --overwrite {{path/to/btrfs_device}} {{path/to/target_directory}}`
+`sudo btrfs restore {{[-m|--metadata]}} {{[-x|--xattr]}} {{[-S|--symlinks]}} {{[-o|--overwrite]}} {{path/to/btrfs_device}} {{path/to/target_directory}}`

--- a/pages/linux/btrfs-scrub.md
+++ b/pages/linux/btrfs-scrub.md
@@ -26,4 +26,4 @@
 
 - Start a scrub in quiet mode (does not print errors or statistics):
 
-`sudo btrfs scrub start -q {{path/to/btrfs_mount}}`
+`sudo btrfs scrub start {{[-q|--quiet]}} {{path/to/btrfs_mount}}`

--- a/pages/linux/cacaclock.md
+++ b/pages/linux/cacaclock.md
@@ -9,8 +9,8 @@
 
 - Change the font:
 
-`cacaclock -f {{font}}`
+`cacaclock {{[-f|--font]}} {{font}}`
 
 - Change the format using an `strftime` format specification:
 
-`cacaclock -d {{strftime_arguments}}`
+`cacaclock {{[-d|--dateformat]}} {{strftime_arguments}}`

--- a/pages/linux/conky.md
+++ b/pages/linux/conky.md
@@ -9,20 +9,20 @@
 
 - Create a new default config:
 
-`conky -C > ~/.conkyrc`
+`conky {{[-C|--print-config]}} > ~/.conkyrc`
 
 - Launch Conky with a given configuration file:
 
-`conky -c {{path/to/config}}`
+`conky {{[-c|--config]}} {{path/to/config}}`
 
 - Start in the background (daemonize):
 
-`conky -d`
+`conky {{[-d|--daemonize]}}`
 
 - Align Conky on the desktop:
 
-`conky -a {{top|bottom|middle}}_{{left|right|middle}}`
+`conky {{[-a|--alignment]}} {{top|bottom|middle}}_{{left|right|middle}}`
 
 - Pause for 5 seconds at startup before launching:
 
-`conky -p {{5}}`
+`conky {{[-p|--pause]}} {{5}}`

--- a/pages/linux/conntrack.md
+++ b/pages/linux/conntrack.md
@@ -6,20 +6,20 @@
 
 - List all currently tracked connections:
 
-`conntrack --dump`
+`conntrack {{[-L|--dump]}}`
 
 - Display a real-time event log of connection changes:
 
-`conntrack --event`
+`conntrack {{[-E|--event]}}`
 
 - Display a real-time event log of connection changes and associated timestamps:
 
-`conntrack --event -o timestamp`
+`conntrack {{[-E|--event]}} {{[-o|--output]}} timestamp`
 
 - Display a real-time event log of connection changes for a specific IP address:
 
-`conntrack --event --orig-src {{ip_address}}`
+`conntrack {{[-E|--event]}} {{[-s|--orig-src]}} {{ip_address}}`
 
 - Delete all flows for a specific source IP address:
 
-`conntrack --delete --orig-src {{ip_address}}`
+`conntrack {{[-D|--delete]}} {{[-s|--orig-src]}} {{ip_address}}`

--- a/pages/linux/cpufreq-aperf.md
+++ b/pages/linux/cpufreq-aperf.md
@@ -10,12 +10,12 @@
 
 - Start calculating for CPU 1 only:
 
-`sudo cpufreq-aperf -c {{1}}`
+`sudo cpufreq-aperf {{[-c|--cpu]}} {{1}}`
 
 - Start calculating with a 3 second refresh interval for all CPU cores:
 
-`sudo cpufreq-aperf -i {{3}}`
+`sudo cpufreq-aperf {{[-i|--interval]}} {{3}}`
 
 - Calculate only once:
 
-`sudo cpufreq-aperf -o`
+`sudo cpufreq-aperf {{[-o|--once]}}`

--- a/pages/linux/cpufreq-info.md
+++ b/pages/linux/cpufreq-info.md
@@ -9,24 +9,24 @@
 
 - Show CPU frequency information for the specified CPU:
 
-`cpufreq-info -c {{cpu_number}}`
+`cpufreq-info {{[-c|--cpu]}} {{cpu_number}}`
 
 - Show the allowed minimum and maximum CPU frequency:
 
-`cpufreq-info -l`
+`cpufreq-info {{[-l|--hwlimits]}}`
 
 - Show the current minimum and maximum CPU frequency and policy in table format:
 
-`cpufreq-info -o`
+`cpufreq-info {{[-o|--proc]}}`
 
 - Show available CPU frequency policies:
 
-`cpufreq-info -g`
+`cpufreq-info {{[-g|--governors]}}`
 
 - Show current CPU work frequency in a human-readable format, according to the cpufreq kernel module:
 
-`cpufreq-info -f -m`
+`cpufreq-info {{[-f|--freq]}} {{[-m|--human]}}`
 
 - Show current CPU work frequency in a human-readable format, by reading it from hardware (only available to root):
 
-`sudo cpufreq-info -w -m`
+`sudo cpufreq-info {{[-w|--hwfreq]}} {{[-m|--human]}}`

--- a/pages/linux/cpufreq-set.md
+++ b/pages/linux/cpufreq-set.md
@@ -6,16 +6,16 @@
 
 - Set the CPU frequency policy of CPU 1 to "userspace":
 
-`sudo cpufreq-set -c {{1}} -g {{userspace}}`
+`sudo cpufreq-set {{[-c|--cpu]}} {{1}} {{[-g|--governor]}} {{userspace}}`
 
 - Set the current minimum CPU frequency of CPU 1:
 
-`sudo cpufreq-set -c {{1}} --min {{min_frequency}}`
+`sudo cpufreq-set {{[-c|--cpu]}} {{1}} {{[-d|--min]}} {{min_frequency}}`
 
 - Set the current maximum CPU frequency of CPU 1:
 
-`sudo cpufreq-set -c {{1}} --max {{max_frequency}}`
+`sudo cpufreq-set {{[-c|--cpu]}} {{1}} {{[-u|--max]}} {{max_frequency}}`
 
 - Set the current work frequency of CPU 1:
 
-`sudo cpufreq-set -c {{1}} -f {{work_frequency}}`
+`sudo cpufreq-set {{[-c|--cpu]}} {{1}} {{[-f|--freq]}} {{work_frequency}}`

--- a/pages/linux/cpuid.md
+++ b/pages/linux/cpuid.md
@@ -1,7 +1,7 @@
 # cpuid
 
 > Display detailed information about all CPUs.
-> More information: <https://etallen.com/cpuid.html>.
+> More information: <https://manned.org/man/cpuid.1>.
 
 - Display information for all CPUs:
 
@@ -9,8 +9,8 @@
 
 - Display information only for the current CPU:
 
-`cpuid -1`
+`cpuid {{[-1|--one-cpu]}}`
 
 - Display raw hex information with no decoding:
 
-`cpuid -r`
+`cpuid {{[-r|--raw]}}`

--- a/pages/linux/createrepo.md
+++ b/pages/linux/createrepo.md
@@ -9,8 +9,8 @@
 
 - Initialize a repository, exclude test RPMs and display verbose logs:
 
-`createrepo -v -x {{test_*.rpm}} {{path/to/directory}}`
+`createrepo {{[-v|--verbose]}} {{[-x|--excludes]}} {{test_*.rpm}} {{path/to/directory}}`
 
 - Initialize a repository, using SHA1 as the checksum algorithm, and ignoring symbolic links:
 
-`createrepo -S -s {{sha1}} {{path/to/directory}}`
+`createrepo {{[-S|--skip-symlinks]}} {{[-s|--checksum]}} {{sha1}} {{path/to/directory}}`

--- a/pages/linux/dd.md
+++ b/pages/linux/dd.md
@@ -25,4 +25,4 @@
 
 - Check the progress of an ongoing `dd` operation (run this command from another shell):
 
-`kill -USR1 $(pgrep -x dd)`
+`kill -USR1 $(pgrep {{[-x|--exact]}} dd)`

--- a/pages/linux/ddcutil.md
+++ b/pages/linux/ddcutil.md
@@ -10,12 +10,12 @@
 
 - Change the brightness (option 0x10) of display 1 to 50%:
 
-`ddcutil --display {{1}} setvcp {{10}} {{50}}`
+`ddcutil {{[-d|--display]}} {{1}} setvcp {{10}} {{50}}`
 
 - Increase the contrast (option 0x12) of display 1 by 5%:
 
-`ddcutil -d {{1}} setvcp {{12}} {{+}} {{5}}`
+`ddcutil {{[-d|--display]}} {{1}} setvcp {{12}} {{+}} {{5}}`
 
 - Read the settings of display 1:
 
-`ddcutil -d {{1}} getvcp {{ALL}}`
+`ddcutil {{[-d|--display]}} {{1}} getvcp {{ALL}}`

--- a/pages/linux/dget.md
+++ b/pages/linux/dget.md
@@ -13,4 +13,4 @@
 
 - Download a package source tarball from its `.dsc` file but don't extract it:
 
-`dget -d {{http://deb.debian.org/debian/pool/main/h/haskell-tldr/haskell-tldr_0.4.0-2.dsc}}`
+`dget {{[-d|--download-only]}} {{http://deb.debian.org/debian/pool/main/h/haskell-tldr/haskell-tldr_0.4.0-2.dsc}}`

--- a/pages/linux/dirb.md
+++ b/pages/linux/dirb.md
@@ -1,7 +1,7 @@
 # dirb
 
 > Scan HTTP-based webservers for directories and files.
-> More information: <https://dirb.sourceforge.net>.
+> More information: <https://manned.org/dirb>.
 
 - Scan a webserver using the default wordlist:
 

--- a/pages/linux/distrobox-create.md
+++ b/pages/linux/distrobox-create.md
@@ -6,8 +6,8 @@
 
 - Create a Distrobox container using the Ubuntu image:
 
-`distrobox-create {{container_name}} --image {{ubuntu:latest}}`
+`distrobox-create {{container_name}} {{[-i|--image]}} {{ubuntu:latest}}`
 
 - Clone a Distrobox container:
 
-`distrobox-create --clone {{container_name}} {{cloned_container_name}}`
+`distrobox-create {{[-c|--clone]}} {{container_name}} {{cloned_container_name}}`

--- a/pages/linux/distrobox-enter.md
+++ b/pages/linux/distrobox-enter.md
@@ -14,4 +14,4 @@
 
 - Enter a Distrobox container without instantiating a tty:
 
-`distrobox-enter --name {{container_name}} -- {{uptime -p}}`
+`distrobox-enter {{[-n|--name]}} {{container_name}} -- {{uptime --pretty}}`

--- a/pages/linux/distrobox-export.md
+++ b/pages/linux/distrobox-export.md
@@ -5,20 +5,20 @@
 
 - Export an app from the container to the host (the desktop entry/icon will show up in your host system's application list):
 
-`distrobox-export --app {{package}} --extra-flags "--foreground"`
+`distrobox-export {{[-a|--app]}} {{package}} {{[-ef|--extra-flags]}} "--foreground"`
 
 - Export a binary from the container to the host:
 
-`distrobox-export --bin {{path/to/binary}} --export-path {{path/to/binary_on_host}}`
+`distrobox-export {{[-b|--bin]}} {{path/to/binary}} {{[-ep|--export-path]}} {{path/to/binary_on_host}}`
 
 - Export a binary from the container to the host (i.e.`$HOME/.local/bin`) :
 
-`distrobox-export --bin {{path/to/binary}} --export-path {{path/to/export}}`
+`distrobox-export {{[-b|--bin]}} {{path/to/binary}} {{[-ep|--export-path]}} {{path/to/export}}`
 
 - Export a service from the container to the host (`--sudo` will run the service as root inside the container):
 
-`distrobox-export --service {{package}} --extra-flags "--allow-newer-config" --sudo`
+`distrobox-export --service {{package}} {{[-ef|--extra-flags]}} "--allow-newer-config" {{[-S|--sudo]}}`
 
 - Unexport/delete an exported application:
 
-`distrobox-export --app {{package}} --delete`
+`distrobox-export {{[-a|--app]}} {{package}} {{[-d|--delete]}}`

--- a/pages/linux/distrobox-list.md
+++ b/pages/linux/distrobox-list.md
@@ -10,4 +10,4 @@
 
 - List all Distrobox containers with verbose information:
 
-`distrobox-list --verbose`
+`distrobox-list {{[-v|--verbose]}}`

--- a/pages/linux/distrobox-rm.md
+++ b/pages/linux/distrobox-rm.md
@@ -9,4 +9,4 @@
 
 - Remove a Distrobox container forcefully:
 
-`distrobox-rm {{container_name}} --force`
+`distrobox-rm {{container_name}} {{[-f|--force]}}`

--- a/pages/linux/distrobox-stop.md
+++ b/pages/linux/distrobox-stop.md
@@ -9,4 +9,4 @@
 
 - Stop a Distrobox container non-interactively (without confirmation):
 
-`distrobox-stop --name {{container_name}} --yes`
+`distrobox-stop {{[-n|--name]}} {{container_name}} {{[-Y|--yes]}}`

--- a/pages/linux/distrobox-upgrade.md
+++ b/pages/linux/distrobox-upgrade.md
@@ -9,7 +9,7 @@
 
 - Upgrade all containers using the container's native package managers:
 
-`distrobox-upgrade --all`
+`distrobox-upgrade {{[-a|--all]}}`
 
 - Upgrade specific containers via the container's native package manager:
 

--- a/pages/linux/dmesg.md
+++ b/pages/linux/dmesg.md
@@ -11,7 +11,7 @@
 
 `sudo dmesg {{[-l|--level]}} err`
 
-- Show kernel messages and keep reading new ones, similar to `tail -f` (available in kernels 3.5.0 and newer):
+- Show kernel messages and keep reading new ones, similar to `tail --follow` (available in kernels 3.5.0 and newer):
 
 `sudo dmesg {{[-w|--follow]}}`
 

--- a/pages/linux/dmidecode.md
+++ b/pages/linux/dmidecode.md
@@ -10,20 +10,20 @@
 
 - Show the BIOS version:
 
-`sudo dmidecode -s bios-version`
+`sudo dmidecode {{[-s|--string]}} bios-version`
 
 - Show the system's serial number:
 
-`sudo dmidecode -s system-serial-number`
+`sudo dmidecode {{[-s|--string]}} system-serial-number`
 
 - Show BIOS information:
 
-`sudo dmidecode -t bios`
+`sudo dmidecode {{[-t|--type]}} bios`
 
 - Show CPU information:
 
-`sudo dmidecode -t processor`
+`sudo dmidecode {{[-t|--type]}} processor`
 
 - Show memory information:
 
-`sudo dmidecode -t memory`
+`sudo dmidecode {{[-t|--type]}} memory`

--- a/pages/linux/dnsrecon.md
+++ b/pages/linux/dnsrecon.md
@@ -5,28 +5,28 @@
 
 - Scan a domain and save the results to an SQLite database:
 
-`dnsrecon --domain {{example.com}} --db {{path/to/database.sqlite}}`
+`dnsrecon {{[-d|--domain]}} {{example.com}} --db {{path/to/database.sqlite}}`
 
 - Scan a domain, specifying the nameserver and performing a zone transfer:
 
-`dnsrecon --domain {{example.com}} --name_server {{nameserver.example.com}} --type axfr`
+`dnsrecon {{[-d|--domain]}} {{example.com}} {{[-n|--name_server]}} {{nameserver.example.com}} {{[-t|--type]}} axfr`
 
 - Scan a domain, using a brute-force attack and a dictionary of subdomains and hostnames:
 
-`dnsrecon --domain {{example.com}} --dictionary {{path/to/dictionary.txt}} --type brt`
+`dnsrecon {{[-d|--domain]}} {{example.com}} {{[-D|--dictionary]}} {{path/to/dictionary.txt}} {{[-t|--type]}} brt`
 
 - Scan a domain, performing a reverse lookup of IP ranges from the SPF record and saving the results to a JSON file:
 
-`dnsrecon --domain {{example.com}} -s --json`
+`dnsrecon {{[-d|--domain]}} {{example.com}} -s {{[-j|--json]}}`
 
 - Scan a domain, performing a Google enumeration and saving the results to a CSV file:
 
-`dnsrecon --domain {{example.com}} -g --csv`
+`dnsrecon {{[-d|--domain]}} {{example.com}} -g {{[-c|--csv]}}`
 
 - Scan a domain, performing DNS cache snooping:
 
-`dnsrecon --domain {{example.com}} --type snoop --name_server {{nameserver.example.com}} --dictionary {{path/to/dictionary.txt}}`
+`dnsrecon {{[-d|--domain]}} {{example.com}} {{[-t|--type]}} snoop {{[-n|--name_server]}} {{nameserver.example.com}} {{[-D|--dictionary]}} {{path/to/dictionary.txt}}`
 
 - Scan a domain, performing zone walking:
 
-`dnsrecon --domain {{example.com}} --type zonewalk`
+`dnsrecon {{[-d|--domain]}} {{example.com}} {{[-t|--type]}} zonewalk`

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -7,28 +7,28 @@
 
 - Install a package:
 
-`dpkg -i {{path/to/file.deb}}`
+`dpkg {{[-i|--install]}} {{path/to/file.deb}}`
 
 - Remove a package:
 
-`dpkg -r {{package}}`
+`dpkg {{[-r|--remove]}} {{package}}`
 
 - List installed packages:
 
-`dpkg -l {{pattern}}`
+`dpkg {{[-l|--list]}} {{pattern}}`
 
 - List a package's contents:
 
-`dpkg -L {{package}}`
+`dpkg {{[-L|--listfiles]}} {{package}}`
 
 - List contents of a local package file:
 
-`dpkg -c {{path/to/file.deb}}`
+`dpkg {{[-c|--contents]}} {{path/to/file.deb}}`
 
 - Find out which package owns a file:
 
-`dpkg -S {{path/to/file}}`
+`dpkg {{[-S|--search]}} {{path/to/file}}`
 
 - Purge an installed or already removed package, including configuration:
 
-`dpkg -P {{package}}`
+`dpkg {{[-P|--purge]}} {{package}}`

--- a/pages/linux/dunstify.md
+++ b/pages/linux/dunstify.md
@@ -10,12 +10,12 @@
 
 - Show a notification with specified urgency:
 
-`dunstify "{{Title}}" "{{Message}}" -u {{low|normal|critical}}`
+`dunstify "{{Title}}" "{{Message}}" {{[-u|--urgency]}} {{low|normal|critical}}`
 
 - Specify a message ID (overwrites any previous messages with the same ID):
 
-`dunstify "{{Title}}" "{{Message}}" -r {{123}}`
+`dunstify "{{Title}}" "{{Message}}" {{[-r|--replace]}} {{123}}`
 
 - Display help:
 
-`dunstify --help`
+`dunstify {{[-?|--help]}}`

--- a/pages/linux/edquota.md
+++ b/pages/linux/edquota.md
@@ -6,24 +6,24 @@
 
 - Edit quota of the current user:
 
-`edquota --user $(whoami)`
+`edquota {{[-u|--user]}} $(whoami)`
 
 - Edit quota of a specific user:
 
-`sudo edquota --user {{username}}`
+`sudo edquota {{[-u|--user]}} {{username}}`
 
 - Edit quota for a group:
 
-`sudo edquota --group {{group}}`
+`sudo edquota {{[-g|--group]}} {{group}}`
 
 - Restrict operations to a given filesystem (by default edquota operates on all filesystems with quotas):
 
-`sudo edquota --file-system {{filesystem}}`
+`sudo edquota {{[-f|--file-system]}} {{filesystem}}`
 
 - Edit the default grace period:
 
-`sudo edquota -t`
+`sudo edquota {{[-t|--edit-period]}}`
 
 - Duplicate a quota to other users:
 
-`sudo edquota -p {{reference_user}} {{destination_user1}} {{destination_user2}}`
+`sudo edquota {{[-p|--prototype]}} {{reference_user}} {{destination_user1}} {{destination_user2}}`

--- a/pages/linux/envycontrol.md
+++ b/pages/linux/envycontrol.md
@@ -5,7 +5,7 @@
 
 - Switch between different GPU modes:
 
-`sudo envycontrol -s {{nvidia|integrated|hybrid}}`
+`sudo envycontrol {{[-s|--switch]}} {{nvidia|integrated|hybrid}}`
 
 - Specify your display manager manually:
 
@@ -13,7 +13,7 @@
 
 - Check current GPU mode:
 
-`sudo envycontrol --query`
+`sudo envycontrol {{[-q|--query]}}`
 
 - Reset settings:
 
@@ -21,8 +21,8 @@
 
 - Display help:
 
-`envycontrol --help`
+`envycontrol {{[-h|--help]}}`
 
 - Display version:
 
-`envycontrol --version`
+`envycontrol {{[-v|--version]}}`

--- a/pages/linux/ethtool.md
+++ b/pages/linux/ethtool.md
@@ -9,20 +9,20 @@
 
 - Display the driver information for an interface:
 
-`ethtool --driver {{eth0}}`
+`ethtool {{[-i|--driver]}} {{eth0}}`
 
 - Display all supported features for an interface:
 
-`ethtool --show-features {{eth0}}`
+`ethtool {{[-k|--show-features]}} {{eth0}}`
 
 - Display the network usage statistics for an interface:
 
-`ethtool --statistics {{eth0}}`
+`ethtool {{[-S|--statistics]}} {{eth0}}`
 
 - Blink one or more LEDs on an interface for 10 seconds:
 
-`ethtool --identify {{eth0}} {{10}}`
+`ethtool {{[-p|--identify]}} {{eth0}} {{10}}`
 
 - Set the link speed, duplex mode, and parameter auto-negotiation for a given interface:
 
-`ethtool -s {{eth0}} speed {{10|100|1000}} duplex {{half|full}} autoneg {{on|off}}`
+`ethtool {{[-s|--change]}} {{eth0}} speed {{10|100|1000}} duplex {{half|full}} autoneg {{on|off}}`

--- a/pages/linux/eww.md
+++ b/pages/linux/eww.md
@@ -9,11 +9,11 @@
 
 - Open a widget:
 
-`eww -c {{path/to/source_code_directory}} open {{window_name}}`
+`eww {{[-c|--config]}} {{path/to/source_code_directory}} open {{window_name}}`
 
 - Close a widget:
 
-`eww -c {{path/to/source_code_directory}} close {{window_name}}`
+`eww {{[-c|--config]}} {{path/to/source_code_directory}} close {{window_name}}`
 
 - Reload the configuration:
 

--- a/pages/linux/expac.md
+++ b/pages/linux/expac.md
@@ -6,20 +6,20 @@
 
 - List the dependencies of a package:
 
-`expac -S '%D' {{package}}`
+`expac {{[-S|--sync]}} '%D' {{package}}`
 
 - List the optional dependencies of a package:
 
-`expac -S "%o" {{package}}`
+`expac {{[-S|--sync]}} "%o" {{package}}`
 
 - List the download size of packages in MiB:
 
-`expac -S -H M '%k\t%n' {{package1 package2 ...}}`
+`expac {{[-S|--sync]}} {{[-H|--humansize]}} M '%k\t%n' {{package1 package2 ...}}`
 
 - List packages marked for upgrade with their download size:
 
-`expac -S -H M '%k\t%n' $(pacman -Qqu) | sort -sh`
+`expac {{[-S|--sync]}} {{[-H|--humansize]}} M '%k\t%n' $(pacman -Qqu) | sort {{[-sh|--sort --human-numeric-sort]}}`
 
 - List explicitly-installed packages with their optional dependencies:
 
-`expac -d '\n\n' -l '\n\t' -Q '%n\n\t%O' $(pacman -Qeq)`
+`expac {{[-d|--delim]}} '\n\n' {{[-l|listdelim]}} '\n\t' {{[-Q|--query]}} '%n\n\t%O' $(pacman -Qeq)`

--- a/pages/linux/fakeroot.md
+++ b/pages/linux/fakeroot.md
@@ -21,8 +21,8 @@
 
 - Run a command keeping the real ownership of files instead of pretending they are owned by root:
 
-`fakeroot --unknown-is-real -- {{command}} {{command_arguments}}`
+`fakeroot {{[-u|--unknown-is-real]}} -- {{command}} {{command_arguments}}`
 
 - Display help:
 
-`fakeroot --help`
+`fakeroot {{[-h|--help]}}`

--- a/pages/linux/fcrackzip.md
+++ b/pages/linux/fcrackzip.md
@@ -5,24 +5,24 @@
 
 - Brute-force a password with a length of 4 to 8 characters, and contains only alphanumeric characters (order matters):
 
-`fcrackzip --brute-force --length 4-8 --charset aA1 {{archive}}`
+`fcrackzip {{[-b|--brute-force]}} {{[-l|--length]}} 4-8 {{[-c|--charset]}} aA1 {{archive}}`
 
 - Brute-force a password in verbose mode with a length of 3 characters that only contains lowercase characters, `$` and `%`:
 
-`fcrackzip -v --brute-force --length 3 --charset a:$% {{archive}}`
+`fcrackzip {{[-v|--verbose]}} {{[-b|--brute-force]}} {{[-l|--length]}} 3 {{[-c|--charset]}} a:$% {{archive}}`
 
 - Brute-force a password that contains only lowercase and special characters:
 
-`fcrackzip --brute-force --length 4 --charset a! {{archive}}`
+`fcrackzip {{[-b|--brute-force]}} {{[-l|--length]}} 4 {{[-c|--charset]}} a! {{archive}}`
 
 - Brute-force a password containing only digits, starting from the password `12345`:
 
-`fcrackzip --brute-force --length 5 --charset 1 --init-password 12345 {{archive}}`
+`fcrackzip {{[-b|--brute-force]}} {{[-l|--length]}} 5 {{[-c|--charset]}} 1 {{[-p|--init-password]}} 12345 {{archive}}`
 
 - Crack a password using a wordlist:
 
-`fcrackzip --use-unzip --dictionary --init-password {{wordlist}} {{archive}}`
+`fcrackzip {{[-u|--use-unzip]}} {{[-D|--dictionary]}} {{[-p|--init-password]}} {{wordlist}} {{archive}}`
 
 - Benchmark cracking performance:
 
-`fcrackzip --benchmark`
+`fcrackzip {{[-B|--benchmark]}}`

--- a/pages/linux/file-rename.md
+++ b/pages/linux/file-rename.md
@@ -10,11 +10,11 @@
 
 - Dry-run - display which renames would occur without performing them:
 
-`rename -n {{'s/foo/bar/'}} {{*}}`
+`rename {{[-n|--nono]}} {{'s/foo/bar/'}} {{*}}`
 
 - Force renaming even if the operation would remove existing destination files:
 
-`rename -f {{'s/foo/bar/'}} {{*}}`
+`rename {{[-f|--force]}} {{'s/foo/bar/'}} {{*}}`
 
 - Convert filenames to lower case (use `-f` in case-insensitive filesystems to prevent "already exists" errors):
 

--- a/pages/linux/flashrom.md
+++ b/pages/linux/flashrom.md
@@ -5,20 +5,20 @@
 
 - Probe the chip, ensuring the wiring is correct:
 
-`flashrom --programmer {{programmer}}`
+`flashrom {{[-p|--programmer]}} {{programmer}}`
 
 - Read flash and save it to a file:
 
-`flashrom -p {{programmer}} --read {{path/to/file}}`
+`flashrom {{[-p|--programmer]}} {{programmer}} {{[-r|--read]}} {{path/to/file}}`
 
 - Write a file to the flash:
 
-`flashrom -p {{programmer}} --write {{path/to/file}}`
+`flashrom {{[-p|--programmer]}} {{programmer}} {{[-w|--write]}} {{path/to/file}}`
 
 - Verify the flash against a file:
 
-`flashrom -p {{programmer}} --verify {{path/to/file}}`
+`flashrom {{[-p|--programmer]}} {{programmer}} {{[-v|--verify]}} {{path/to/file}}`
 
 - Probe the chip using Raspberry Pi:
 
-`flashrom -p {{linux_spi:dev=/dev/spidev0.0}}`
+`flashrom {{[-p|--programmer]}} {{linux_spi:dev=/dev/spidev0.0}}`

--- a/pages/linux/foreman.md
+++ b/pages/linux/foreman.md
@@ -9,7 +9,7 @@
 
 - Start an application with a specified Procfile:
 
-`foreman start -f {{Procfile}}`
+`foreman start {{[-f|--procfile]}} {{Procfile}}`
 
 - Start a specific application:
 
@@ -25,4 +25,4 @@
 
 - Start all processes except the one named "worker":
 
-`foreman start -m all=1,{{worker}}=0`
+`foreman start {{[-m|--formation]}} all=1,{{worker}}=0`

--- a/pages/linux/fuzzel.md
+++ b/pages/linux/fuzzel.md
@@ -25,7 +25,7 @@
 
 - Reset apps usage count (default cache directory: `$XDG_CACHE_HOME/fuzzel`):
 
-`rm -v $HOME/.cache/fuzzel`
+`rm {{[-v|--verbose]}} $HOME/.cache/fuzzel`
 
 - Launch `fuzzel` on a specific monitor, see `wlr-randr` or `swaymsg -t get_outputs`:
 

--- a/pages/linux/genie.md
+++ b/pages/linux/genie.md
@@ -6,12 +6,12 @@
 
 - Initialize the bottle (run once, at start):
 
-`genie -i`
+`genie {{[-i|--initialize]}}`
 
 - Run a login shell inside the bottle:
 
-`genie -s`
+`genie {{[-s|--shell]}}`
 
 - Run a specified command inside the bottle:
 
-`genie -c {{command}}`
+`genie {{[-c|--command]}} {{command}}`

--- a/pages/linux/getfattr.md
+++ b/pages/linux/getfattr.md
@@ -5,8 +5,8 @@
 
 - Retrieve all extended attributes of a file and display them in a detailed format:
 
-`getfattr -d {{path/to/file}}`
+`getfattr {{[-d|--dump]}} {{path/to/file}}`
 
 - Get a specific attribute of a file:
 
-`getfattr -n user.{{attribute_name}} {{path/to/file}}`
+`getfattr {{[-n|--name]}} user.{{attribute_name}} {{path/to/file}}`

--- a/pages/linux/goaccess.md
+++ b/pages/linux/goaccess.md
@@ -13,8 +13,8 @@
 
 - Analyze a log from `stdin`:
 
-`tail -f {{path/to/logfile}} | goaccess -`
+`tail {{[-f|--follow]}} {{path/to/logfile}} | goaccess -`
 
 - Analyze a log and write it to an HTML file in real-time:
 
-`goaccess {{path/to/logfile}} --output {{path/to/file.html}} --real-time-html`
+`goaccess {{path/to/logfile}} {{[-o|--output]}} {{path/to/file.html}} --real-time-html`

--- a/pages/linux/hardinfo.md
+++ b/pages/linux/hardinfo.md
@@ -9,8 +9,8 @@
 
 - Print report to `stdout`:
 
-`hardinfo -r`
+`hardinfo {{[-r|--generate-report]}}`
 
 - Save report to HTML file:
 
-`hardinfo -r -f html > hardinfo.html`
+`hardinfo {{[-r|--generate-report]}} {{[-f|--report-format]}} html > hardinfo.html`

--- a/pages/linux/hollywood.md
+++ b/pages/linux/hollywood.md
@@ -13,4 +13,4 @@
 
 - Display help:
 
-`hollywood -h`
+`hollywood {{[-h|--help]}}`

--- a/pages/linux/ifdown.md
+++ b/pages/linux/ifdown.md
@@ -9,4 +9,4 @@
 
 - Disable all interfaces which are enabled:
 
-`ifdown -a`
+`ifdown {{[-a|--all]}}`

--- a/pages/linux/ifup.md
+++ b/pages/linux/ifup.md
@@ -9,4 +9,4 @@
 
 - Enable all the interfaces defined with "auto" in `/etc/network/interfaces`:
 
-`ifup -a`
+`ifup {{[-a|--all]}}`

--- a/pages/linux/imgp.md
+++ b/pages/linux/imgp.md
@@ -5,12 +5,12 @@
 
 - Convert single images and/or whole directories containing valid image formats:
 
-`imgp -x {{1366x1000}} {{path/to/directory}} {{path/to/file}}`
+`imgp {{[-x|--res]}} {{1366x1000}} {{path/to/directory}} {{path/to/file}}`
 
 - Scale an image by 75% and overwrite the source image to a target resolution:
 
-`imgp -x {{75}} -w {{path/to/file}}`
+`imgp {{[-x|--res]}} {{75}} z-w {{path/to/file}}`
 
 - Rotate an image clockwise by 90 degrees:
 
-`imgp -o {{90}} {{path/to/file}}`
+`imgp {{[-o|--rotate]}} {{90}} {{path/to/file}}`

--- a/pages/linux/iostat.md
+++ b/pages/linux/iostat.md
@@ -13,7 +13,7 @@
 
 - Display CPU statistics:
 
-`iostat {{[-c|--compact]}}`
+`iostat -c`
 
 - Display disk statistics with disk names (including LVM):
 

--- a/pages/linux/kexec.md
+++ b/pages/linux/kexec.md
@@ -5,16 +5,16 @@
 
 - Load a new kernel:
 
-`kexec -l {{path/to/kernel}} --initrd={{path/to/initrd}} --command-line={{arguments}}`
+`kexec {{[-l|--load]}} {{path/to/kernel}} --initrd={{path/to/initrd}} --command-line={{arguments}}`
 
 - Load a new kernel with current boot parameters:
 
-`kexec -l {{path/to/kernel}} --initrd={{path/to/initrd}} --reuse-cmdline`
+`kexec {{[-l|--load]}} {{path/to/kernel}} --initrd={{path/to/initrd}} --reuse-cmdline`
 
 - Execute a currently loaded kernel:
 
-`kexec -e`
+`kexec {{[-e|--exec]}}`
 
 - Unload current kexec target kernel:
 
-`kexec -u`
+`kexec {{[-u|--unload]}}`

--- a/pages/linux/knock.md
+++ b/pages/linux/knock.md
@@ -9,7 +9,7 @@
 
 - Knock on port using UDP:
 
-`knock -u {{hostname}} {{portnumber}}`
+`knock {{[-u|--udp]}} {{hostname}} {{portnumber}}`
 
 - Force usage of IPv4/IPv6:
 
@@ -17,4 +17,4 @@
 
 - Display errors and details of connection:
 
-`knock -v {{hostname}} {{portnumber}}`
+`knock {{[-v|--verbose]}} {{hostname}} {{portnumber}}`

--- a/pages/linux/knockd.md
+++ b/pages/linux/knockd.md
@@ -5,8 +5,8 @@
 
 - Start knockd system daemon:
 
-`knockd -d`
+`knockd {{[-d|--daemon]}}`
 
 - Use specified configuration file for knockd:
 
-`knockd -c {{path/to/file}}.configuration`
+`knockd {{[-c|--config]}} {{path/to/file}}.configuration`

--- a/pages/linux/konsave.md
+++ b/pages/linux/konsave.md
@@ -5,28 +5,28 @@
 
 - Save the current configuration as a profile:
 
-`konsave --save {{profile_name}}`
+`konsave {{[-s|--save]}} {{profile_name}}`
 
 - Apply a profile:
 
-`konsave --apply {{profile_name}}`
+`konsave {{[-a|--apply]}} {{profile_name}}`
 
 - Save the current configuration as a profile, overwriting existing profiles if they exist with the same name:
 
-`konsave -s {{profile_name}} --force`
+`konsave {{[-s|--save]}} {{profile_name}} {{[-f|--force]}}`
 
 - List all profiles:
 
-`konsave --list`
+`konsave {{[-l|--list]}}`
 
 - Remove a profile:
 
-`konsave --remove {{profile_name}}`
+`konsave {{[-r|--remove]}} {{profile_name}}`
 
 - Export a profile as a `.knsv` to the home directory:
 
-`konsave --export-profile {{profile_name}}`
+`konsave {{[-e|--export-profile]}} {{profile_name}}`
 
 - Import a `.knsv` profile:
 
-`konsave --import-profile {{path/to/profile_name.knsv}}`
+`konsave {{[-i|--import-profile]}} {{path/to/profile_name.knsv}}`

--- a/pages/linux/ldconfig.md
+++ b/pages/linux/ldconfig.md
@@ -13,4 +13,4 @@
 
 - Print the libraries in the cache and check whether a given library is present:
 
-`ldconfig -p | grep {{library_name}}`
+`ldconfig {{[-p|--print-cache]}} | grep {{library_name}}`

--- a/pages/linux/lsb_release.md
+++ b/pages/linux/lsb_release.md
@@ -5,16 +5,16 @@
 
 - Print all available information:
 
-`lsb_release -a`
+`lsb_release {{[-a|--all]}}`
 
 - Print a description (usually the full name) of the operating system:
 
-`lsb_release -d`
+`lsb_release {{[-d|--description]}}`
 
 - Print only the operating system name (ID), suppressing the field name:
 
-`lsb_release -i -s`
+`lsb_release {{[-is|--id --short]}}`
 
 - Print the release number and codename of the distribution, suppressing the field names:
 
-`lsb_release -rcs`
+`lsb_release {{[-rcs|--release --codename --short]}}`

--- a/pages/linux/lsfd.md
+++ b/pages/linux/lsfd.md
@@ -17,7 +17,7 @@
 
 - List open IPv4 or IPv6 sockets:
 
-`lsfd -i{{4|6}}`
+`lsfd {{-i4|-i6}}`
 
 - Display help:
 

--- a/pages/linux/lsscsi.md
+++ b/pages/linux/lsscsi.md
@@ -1,7 +1,7 @@
 # lsscsi
 
 > List SCSI devices (or hosts) and their attributes.
-> More information: <https://manned.org/lspci>.
+> More information: <https://manned.org/lsscsi>.
 
 - List all SCSI devices:
 
@@ -9,8 +9,8 @@
 
 - List all SCSI devices with detailed attributes:
 
-`lsscsi -L`
+`lsscsi {{[-L|--list]}}`
 
 - List all SCSI devices with human-readable disk capacity:
 
-`lsscsi -s`
+`lsscsi {{[-s|--size]}}`

--- a/pages/linux/ltrace.md
+++ b/pages/linux/ltrace.md
@@ -17,4 +17,4 @@
 
 - Write to file instead of terminal:
 
-`ltrace -o {{file}} {{path/to/program}}`
+`ltrace {{[-o|--output]}} {{file}} {{path/to/program}}`

--- a/pages/linux/lvcreate.md
+++ b/pages/linux/lvcreate.md
@@ -6,16 +6,16 @@
 
 - Create a logical volume of 10 gigabytes in the volume group vg1:
 
-`lvcreate -L {{10G}} {{vg1}}`
+`lvcreate {{[-L|--size]}} {{10G}} {{vg1}}`
 
 - Create a 1500 megabyte linear logical volume named mylv in the volume group vg1:
 
-`lvcreate -L {{1500}} -n {{mylv}} {{vg1}}`
+`lvcreate {{[-L|--size]}} {{1500}} {{[-n|--name]}} {{mylv}} {{vg1}}`
 
 - Create a logical volume called mylv that uses 60% of the total space in volume group vg1:
 
-`lvcreate -l {{60%VG}} -n {{mylv}} {{vg1}}`
+`lvcreate {{[-l|--extents]}} {{60%VG}} {{[-n|--name]}} {{mylv}} {{vg1}}`
 
 - Create a logical volume called mylv that uses all the unallocated space in the volume group vg1:
 
-`lvcreate -l {{100%FREE}} -n {{mylv}} {{vg1}}`
+`lvcreate {{[-l|--extents]}} {{100%FREE}} {{[-n|--name]}} {{mylv}} {{vg1}}`

--- a/pages/linux/lvextend.md
+++ b/pages/linux/lvextend.md
@@ -6,12 +6,12 @@
 
 - Increase a volume's size to 120 GB:
 
-`lvextend --size {{120G}} {{logical_volume}}`
+`lvextend {{[-L|--size]}} {{120G}} {{logical_volume}}`
 
 - Increase a volume's size by 40 GB as well as the underlying filesystem:
 
-`lvextend --size +{{40G}} -r {{logical_volume}}`
+`lvextend {{[-L|--size]}} +{{40G}} {{[-r|--resizefs]}} {{logical_volume}}`
 
 - Increase a volume's size to 100% of the free physical volume space:
 
-`lvextend --size +{{100}}%FREE {{logical_volume}}`
+`lvextend {{[-L|--size]}} +{{100}}%FREE {{logical_volume}}`

--- a/pages/linux/lvreduce.md
+++ b/pages/linux/lvreduce.md
@@ -6,8 +6,8 @@
 
 - Reduce a volume's size to 120 GB:
 
-`lvreduce --size {{120G}} {{logical_volume}}`
+`lvreduce {{[-L|--size]}} {{120G}} {{logical_volume}}`
 
 - Reduce a volume's size by 40 GB as well as the underlying filesystem:
 
-`lvreduce --size -{{40G}} -r {{logical_volume}}`
+`lvreduce {{[-L|--size]}} -{{40G}} {{[-r|--resizefs]}} {{logical_volume}}`

--- a/pages/linux/lvs.md
+++ b/pages/linux/lvs.md
@@ -10,19 +10,19 @@
 
 - Display all logical volumes:
 
-`lvs -a`
+`lvs {{[-a|--all]}}`
 
 - Change default display to show more details:
 
-`lvs -v`
+`lvs {{[-v|--verbose]}}`
 
 - Display only specific fields:
 
-`lvs -o {{field_name_1}},{{field_name_2}}`
+`lvs {{[-o|--options]}} {{field_name_1}},{{field_name_2}}`
 
 - Append field to default display:
 
-`lvs -o +{{field_name}}`
+`lvs {{[-o|--options]}} +{{field_name}}`
 
 - Suppress heading line:
 

--- a/pages/linux/lxterminal.md
+++ b/pages/linux/lxterminal.md
@@ -9,7 +9,7 @@
 
 - Open an LXTerminal window, run a command, and then exit:
 
-`lxterminal -e "{{command}}"`
+`lxterminal {{[-e|--command]}} "{{command}}"`
 
 - Open an LXTerminal window with multiple tabs:
 

--- a/pages/linux/matchpathcon.md
+++ b/pages/linux/matchpathcon.md
@@ -1,4 +1,4 @@
-g# matchpathcon
+# matchpathcon
 
 > Lookup the persistent SELinux security context setting of a path.
 > See also: `semanage-fcontext`, `secon`, `chcon`, `restorecon`.

--- a/pages/linux/matchpathcon.md
+++ b/pages/linux/matchpathcon.md
@@ -1,4 +1,4 @@
-# matchpathcon
+g# matchpathcon
 
 > Lookup the persistent SELinux security context setting of a path.
 > See also: `semanage-fcontext`, `secon`, `chcon`, `restorecon`.

--- a/pages/linux/mkfs.btrfs.md
+++ b/pages/linux/mkfs.btrfs.md
@@ -6,12 +6,12 @@
 
 - Create a btrfs filesystem on a single device:
 
-`sudo mkfs.btrfs --metadata single --data single {{/dev/sda}}`
+`sudo mkfs.btrfs {{[-m|--metadata]}} single {{[-d|--data]}} single {{/dev/sda}}`
 
 - Create a btrfs filesystem on multiple devices with raid1:
 
-`sudo mkfs.btrfs --metadata raid1 --data raid1 {{/dev/sda}} {{/dev/sdb}} {{/dev/sdN}}`
+`sudo mkfs.btrfs {{[-m|--metadata]}} raid1 {{[-d|--data]}} raid1 {{/dev/sda}} {{/dev/sdb}} {{/dev/sdN}}`
 
 - Set a label for the filesystem:
 
-`sudo mkfs.btrfs --label "{{label}}" {{/dev/sda}} [{{/dev/sdN}}]`
+`sudo mkfs.btrfs {{[-L|--label]}} "{{label}}" {{/dev/sda}} [{{/dev/sdN}}]`

--- a/pages/linux/mkfs.ntfs.md
+++ b/pages/linux/mkfs.ntfs.md
@@ -9,8 +9,8 @@
 
 - Create filesystem with a volume-label:
 
-`mkfs.ntfs -L {{volume_label}} {{/dev/sdb1}}`
+`mkfs.ntfs {{[-L|--label]}} {{volume_label}} {{/dev/sdb1}}`
 
 - Create filesystem with specific UUID:
 
-`mkfs.ntfs -U {{UUID}} {{/dev/sdb1}}`
+`mkfs.ntfs {{[-U|--with-uuid]}} {{UUID}} {{/dev/sdb1}}`

--- a/pages/linux/mopac.md
+++ b/pages/linux/mopac.md
@@ -9,4 +9,4 @@
 
 - Minimal working example with HF that writes to the current directory and streams the output file:
 
-`touch test.out; echo "PM7\n#comment\n\nH 0.95506 0.05781 -0.03133\nF 1.89426 0.05781 -0.03133" > test.mop; mopac test.mop & tail -f test.out`
+`touch test.out; echo "PM7\n#comment\n\nH 0.95506 0.05781 -0.03133\nF 1.89426 0.05781 -0.03133" > test.mop; mopac test.mop & tail {{[-f|--follow]}} test.out`

--- a/pages/linux/ncat.md
+++ b/pages/linux/ncat.md
@@ -6,11 +6,11 @@
 
 - Listen for input on the specified port and write it to the specified file:
 
-`ncat -l {{port}} > {{path/to/file}}`
+`ncat {{[-l|--listen]}} {{port}} > {{path/to/file}}`
 
 - Accept multiple connections and keep ncat open after they have been closed:
 
-`ncat -lk {{port}}`
+`ncat {{[-lk|--listen --keep-open]}} {{port}}`
 
 - Write output of specified file to the specified host on the specified port:
 
@@ -18,7 +18,7 @@
 
 - Accept multiple incoming connections on an encrypted channel evading detection of traffic content:
 
-`ncat --ssl -k -l {{port}}`
+`ncat --ssl {{[-k|--keep-open]}} {{[-l|--listen]}} {{port}}`
 
 - Connect to an open `ncat` connection over SSL:
 
@@ -26,4 +26,4 @@
 
 - Check connectivity to a remote host on a particular port with timeout:
 
-`ncat -w {{seconds}} -vz {{host}} {{port}}`
+`ncat {{[-w|--wait]}} {{seconds}} {{[-vz|--verbose -z]}} {{host}} {{port}}`

--- a/pages/linux/netselect-apt.md
+++ b/pages/linux/netselect-apt.md
@@ -13,8 +13,8 @@
 
 - Include non-free section:
 
-`sudo netselect-apt --non-free`
+`sudo netselect-apt {{[-n|--non-free]}}`
 
 - Specify a country for the mirror list lookup:
 
-`sudo netselect-apt -c {{India}}`
+`sudo netselect-apt {{[-c|--country]}} {{India}}`

--- a/pages/linux/nixos-option.md
+++ b/pages/linux/nixos-option.md
@@ -25,4 +25,4 @@
 
 - Show recursively all values of a user:
 
-`nixos-option -r users.users.{{user}}`
+`nixos-option {{[-r|--recursive]}} users.users.{{user}}`

--- a/pages/linux/nixos-rebuild.md
+++ b/pages/linux/nixos-rebuild.md
@@ -9,7 +9,7 @@
 
 - Build and switch to the new configuration, making it the boot default and naming the boot entry:
 
-`sudo nixos-rebuild switch -p {{name}}`
+`sudo nixos-rebuild switch {{[-p|--profile-name]}} {{name}}`
 
 - Build and switch to the new configuration, making it the boot default and installing updates:
 

--- a/pages/linux/notify-send.md
+++ b/pages/linux/notify-send.md
@@ -9,12 +9,12 @@
 
 - Show a notification with a custom icon:
 
-`notify-send -i {{icon.png}} "{{Test}}" "{{This is a test}}"`
+`notify-send {{[-i|--icon]}} {{icon.png}} "{{Test}}" "{{This is a test}}"`
 
 - Show a notification for 5 seconds:
 
-`notify-send -t 5000 "{{Test}}" "{{This is a test}}"`
+`notify-send {{[-t|--expire-time]}} 5000 "{{Test}}" "{{This is a test}}"`
 
 - Show a notification with an app's icon and name:
 
-`notify-send "{{Test}}" --icon={{google-chrome}} --app-name="{{Google Chrome}}"`
+`notify-send "{{Test}}" {{[-i|--icon]}} {{google-chrome}} {{[-a|--app-name]}} "{{Google Chrome}}"`

--- a/pages/linux/nsxiv.md
+++ b/pages/linux/nsxiv.md
@@ -13,7 +13,7 @@
 
 - Search directories recursively for images to view:
 
-`nsxiv -r {{path/to/directory1 path/to/directory2 ...}}`
+`nsxiv {{[-r|--recursive]}} {{path/to/directory1 path/to/directory2 ...}}`
 
 - Quit nsxiv:
 

--- a/pages/linux/paccache.md
+++ b/pages/linux/paccache.md
@@ -5,16 +5,16 @@
 
 - Remove all but the 3 most recent package versions from the `pacman` cache:
 
-`paccache -r`
+`paccache {{[-r|--remove]}}`
 
 - Set the number of package versions to keep:
 
-`paccache -rk {{num_versions}}`
+`paccache {{[-rk|--remove --keep]}} {{num_versions}}`
 
 - Perform a dry-run and show the number of candidate packages for deletion:
 
-`paccache -d`
+`paccache {{[-d|--dryrun]}}`
 
 - Move candidate packages to a directory instead of deleting them:
 
-`paccache -m {{path/to/directory}}`
+`paccache {{[-m|--move]}} {{path/to/directory}}`

--- a/pages/linux/pacdiff.md
+++ b/pages/linux/pacdiff.md
@@ -9,11 +9,11 @@
 
 - Use sudo and sudoedit to remove and merge files:
 
-`pacdiff --sudo`
+`pacdiff {{[-s|--sudo]}}`
 
 - Review files needing maintenance, creating `.bak`ups of the original if you `(O)verwrite`:
 
-`pacdiff --sudo --backup`
+`pacdiff {{[-s|--sudo]}} {{[-b|--backup]}}`
 
 - Use a specific editor to view and merge configuration files (default is `vim -d`):
 
@@ -21,8 +21,8 @@
 
 - Scan for configuration files with `locate` instead of using `pacman` database:
 
-`pacdiff --locate`
+`pacdiff {{[-l|--locate]}}`
 
 - Display help:
 
-`pacdiff --help`
+`pacdiff {{[-h|--help]}}`

--- a/pages/linux/pasuspender.md
+++ b/pages/linux/pasuspender.md
@@ -5,4 +5,4 @@
 
 - Suspend PulseAudio while running `jackd`:
 
-`pasuspender -- {{jackd -d alsa --device hw:0}}`
+`pasuspender -- {{jackd {{[-d|--driver]}} alsa {{[-d|--device]}} hw:0}}`

--- a/pages/linux/paxs.md
+++ b/pages/linux/paxs.md
@@ -10,20 +10,20 @@
 
 - Upgrade all packages:
 
-`paxs -u`
+`paxs {{[-u|--upgrade-all]}}`
 
 - Install a package (prompting for the source):
 
-`paxs -i {{package}}`
+`paxs {{[-i|--install]}} {{package}}`
 
 - Remove a package (prompting for the source):
 
-`paxs -r {{package}}`
+`paxs {{[-r|--remove]}} {{package}}`
 
 - Check for updates across all package managers:
 
-`paxs -c`
+`paxs {{[-c|--check-update]}}`
 
 - Display help:
 
-`paxs -h`
+`paxs {{[-h|--help]}}`

--- a/pages/linux/pdfattach.md
+++ b/pages/linux/pdfattach.md
@@ -14,7 +14,7 @@
 
 - Display help:
 
-`pdfattach -h`
+`pdfattach {{[-h|--help]}}`
 
 - Display version:
 

--- a/pages/linux/pdfxup.md
+++ b/pages/linux/pdfxup.md
@@ -6,12 +6,12 @@
 
 - Create a 2-up PDF:
 
-`pdfxup -o {{path/to/output.pdf}} {{path/to/input.pdf}}`
+`pdfxup {{[-o|--output]}} {{path/to/output.pdf}} {{path/to/input.pdf}}`
 
 - Create a PDF with 3 columns and 2 lines per page:
 
-`pdfxup -x {{3}} -y {{2}} -o {{path/to/output.pdf}} {{path/to/input.pdf}}`
+`pdfxup {{[-x|--columns]}} {{3}} {{[-y|--rows]}} {{2}} {{[-o|--output]}} {{path/to/output.pdf}} {{path/to/input.pdf}}`
 
 - Create a PDF in booklet mode (2-up, and pages are sorted to form a book when folded):
 
-`pdfxup -b -o {{path/to/output.pdf}} {{path/to/input.pdf}}`
+`pdfxup {{[-b|--booklet]}} {{[-o|--output]}} {{path/to/output.pdf}} {{path/to/input.pdf}}`

--- a/pages/linux/perf.md
+++ b/pages/linux/perf.md
@@ -17,7 +17,7 @@
 
 - Record the profile of an existing process into `perf.data`:
 
-`sudo perf record -p {{pid}}`
+`sudo perf record {{[-p|--pid]}} {{pid}}`
 
 - Read `perf.data` (created by `perf record`) and display the profile:
 

--- a/pages/linux/perl-rename.md
+++ b/pages/linux/perl-rename.md
@@ -10,7 +10,7 @@
 
 - Dry-run - display which renames would occur without performing them:
 
-`rename -n {{'s/foo/bar/'}} {{*}}`
+`rename {{[-n|--no-act]}} {{'s/foo/bar/'}} {{*}}`
 
 - Force renaming even if the operation would remove existing destination files:
 

--- a/pages/linux/picom.md
+++ b/pages/linux/picom.md
@@ -9,7 +9,7 @@
 
 - Start `picom` as a background process:
 
-`picom -b`
+`picom {{[-b|--daemon]}}`
 
 - Use a custom configuration file:
 

--- a/pages/linux/pinout.md
+++ b/pages/linux/pinout.md
@@ -9,4 +9,4 @@
 
 - Open <https://pinout.xyz/> in the default browser:
 
-`pinout -x`
+`pinout {{[-x|--xyz]}}`

--- a/pages/linux/pkginfo.md
+++ b/pages/linux/pkginfo.md
@@ -5,15 +5,15 @@
 
 - List installed packages and their versions:
 
-`pkginfo -i`
+`pkginfo {{[-i|--installed]}}`
 
 - List files owned by a package:
 
-`pkginfo -l {{package}}`
+`pkginfo {{[-l|--list]}} {{package}}`
 
 - List the owner(s) of files matching a pattern:
 
-`pkginfo -o {{pattern}}`
+`pkginfo {{[-o|--owner]}} {{pattern}}`
 
 - Print the footprint of a file:
 

--- a/pages/linux/prename.md
+++ b/pages/linux/prename.md
@@ -10,11 +10,11 @@
 
 - Dry-run - display which renames would occur without performing them:
 
-`rename -n {{'s/foo/bar/'}} {{*}}`
+`rename {{[-n|--nono]}} {{'s/foo/bar/'}} {{*}}`
 
 - Force renaming even if the operation would remove existing destination files:
 
-`rename -f {{'s/foo/bar/'}} {{*}}`
+`rename {{[-f|--force]}} {{'s/foo/bar/'}} {{*}}`
 
 - Convert filenames to lower case (use `-f` in case-insensitive filesystems to prevent "already exists" errors):
 

--- a/pages/linux/pridecat.md
+++ b/pages/linux/pridecat.md
@@ -1,6 +1,6 @@
 # pridecat
 
-> Like cat but more colorful :).
+> Like cat but more colorful.
 > More information: <https://github.com/lunasorcery/pridecat>.
 
 - Print the contents of a file in pride colors to `stdout`:
@@ -9,15 +9,15 @@
 
 - Print contents of a file in trans colors:
 
-`pridecat {{path/to/file}} --{{transgender|trans}}`
+`pridecat {{path/to/file}} {{[--trans|--transgender]}}`
 
 - Alternate between lesbian and bisexual pride flags:
 
-`pridecat {{path/to/file}} --lesbian --bi`
+`pridecat {{path/to/file}} --lesbian {{[--bi|--bisexual]}}`
 
 - Print contents of a file with the background colors changed:
 
-`pridecat {{path/to/file}} -b`
+`pridecat {{path/to/file}} {{[-b|--background]}}`
 
 - List directory contents in pride flag colors:
 

--- a/pages/linux/protonvpn-connect.md
+++ b/pages/linux/protonvpn-connect.md
@@ -25,4 +25,4 @@
 
 - Display help:
 
-`protonvpn connect --help`
+`protonvpn {{[c|connect]}} --help`

--- a/pages/linux/pvs.md
+++ b/pages/linux/pvs.md
@@ -10,19 +10,19 @@
 
 - Display non-physical volumes:
 
-`pvs -a`
+`pvs {{[-a|--all]}}`
 
 - Change default display to show more details:
 
-`pvs -v`
+`pvs {{[-v|--verbose]}}`
 
 - Display only specific fields:
 
-`pvs -o {{field_name_1}},{{field_name_2}}`
+`pvs {{[-o|--options]}} {{field_name_1}},{{field_name_2}}`
 
 - Append field to default display:
 
-`pvs -o +{{field_name}}`
+`pvs {{[-o|--options]}} +{{field_name}}`
 
 - Suppress heading line:
 

--- a/pages/linux/pw-cat.md
+++ b/pages/linux/pw-cat.md
@@ -5,19 +5,19 @@
 
 - Play a WAV file over the default target:
 
-`pw-cat --playback {{path/to/file.wav}}`
+`pw-cat {{[-p|--playback]}} {{path/to/file.wav}}`
 
 - Play a WAV file with a specified resampler quality (4 by default):
 
-`pw-cat --quality {{0..15}} --playback {{path/to/file.wav}}`
+`pw-cat {{[-q|--quality]}} {{0..15}} {{[-p|--playback]}} {{path/to/file.wav}}`
 
 - Record a sample recording at a volume level of 125%:
 
-`pw-cat --record --volume {{1.25}} {{path/to/file.wav}}`
+`pw-cat {{[-r|--record]}} --volume {{1.25}} {{path/to/file.wav}}`
 
 - Record a sample recording using a different sample rate:
 
-`pw-cat --record --rate {{6000}} {{path/to/file.wav}}`
+`pw-cat {{[-r|--record]}} --rate {{6000}} {{path/to/file.wav}}`
 
 - Display help:
 

--- a/pages/linux/pw-loopback.md
+++ b/pages/linux/pw-loopback.md
@@ -9,20 +9,20 @@
 
 - Create a loopback device that automatically connects to the speakers:
 
-`pw-loopback -m '{{[FL FR]}}' --capture-props='{{media.class=Audio/Sink}}'`
+`pw-loopback {{[-m|--channel-map]}} '{{[FL FR]}}' {{[-i|--capture-props]}} '{{media.class=Audio/Sink}}'`
 
 - Create a loopback device that automatically connects to the microphone:
 
-`pw-loopback -m '{{[FL FR]}}' --playback-props='{{media.class=Audio/Source}}'`
+`pw-loopback {{[-m|--channel-map]}} '{{[FL FR]}}' {{[-o|--playback-props]}} '{{media.class=Audio/Source}}'`
 
 - Create a dummy loopback device that doesn't automatically connect to anything:
 
-`pw-loopback -m '{{[FL FR]}}' --capture-props='{{media.class=Audio/Sink}}' --playback-props='{{media.class=Audio/Source}}'`
+`pw-loopback {{[-m|--channel-map]}} '{{[FL FR]}}' {{[-i|--capture-props]}} '{{media.class=Audio/Sink}}' {{[-o|--playback-props]}} '{{media.class=Audio/Source}}'`
 
 - Create a loopback device that automatically connects to the speakers and swaps the left and right channels between the sink and source:
 
-`pw-loopback --capture-props='{{media.class=Audio/Sink audio.position=[FL FR]}}' --playback-props='{{audio.position=[FR FL]}}'`
+`pw-loopback {{[-i|--capture-props]}} '{{media.class=Audio/Sink audio.position=[FL FR]}}' {{[-o|--playback-props]}} '{{audio.position=[FR FL]}}'`
 
 - Create a loopback device that automatically connects to the microphone and swaps the left and right channels between the sink and source:
 
-`pw-loopback --capture-props='{{audio.position=[FR FL]}}' --playback-props='{{media.class=Audio/Source audio.position=[FL FR]}}'`
+`pw-loopback {{[-i|--capture-props]}} '{{audio.position=[FR FL]}}' {{[-o|--playback-props]}} '{{media.class=Audio/Source audio.position=[FL FR]}}'`

--- a/pages/linux/pw-mon.md
+++ b/pages/linux/pw-mon.md
@@ -9,12 +9,12 @@
 
 - Monitor a specific remote instance:
 
-`pw-mon --remote={{remote_name}}`
+`pw-mon {{[-r|--remote]}} {{remote_name}}`
 
 - Monitor the default instance specifying a color configuration:
 
-`pw-mon --color={{never|always|auto}}`
+`pw-mon {{[-N|--color]}} {{never|always|auto}}`
 
 - Display help:
 
-`pw-mon --help`
+`pw-mon {{[-h|--help]}}`

--- a/pages/linux/pw-top.md
+++ b/pages/linux/pw-top.md
@@ -10,12 +10,12 @@
 
 - Monitor a remote instance:
 
-`pw-top --remote {{remote_name}}`
+`pw-top {{[-r|--remote]}} {{remote_name}}`
 
 - Print information periodically instead of running in interactive mode:
 
-`pw-top --batch-mode`
+`pw-top {{[-b|--batch-mode]}}`
 
 - Print information periodically for a specific number of times:
 
-`pw-top --batch-mode --iterations {{3}}`
+`pw-top {{[-b|--batch-mode]}} {{[-n|--iterations]}} {{3}}`

--- a/pages/linux/rankmirrors.md
+++ b/pages/linux/rankmirrors.md
@@ -14,12 +14,12 @@
 
 - Be verbose when generating the mirrorlist:
 
-`rankmirrors -v {{/etc/pacman.d/mirrorlist}}`
+`rankmirrors {{[-v|--verbose]}} {{/etc/pacman.d/mirrorlist}}`
 
 - Test only a specific URL:
 
-`rankmirrors --url {{url}}`
+`rankmirrors {{[-u|--url]}} {{url}}`
 
 - Output only the response times instead of a full mirrorlist:
 
-`rankmirrors --times {{/etc/pacman.d/mirrorlist}}`
+`rankmirrors {{[-t|--times]}} {{/etc/pacman.d/mirrorlist}}`

--- a/pages/linux/reportbug.md
+++ b/pages/linux/reportbug.md
@@ -13,4 +13,4 @@
 
 - Write the bug report to a file instead of sending it by e-mail:
 
-`reportbug -o {{filename}} {{package}}`
+`reportbug {{[-o|--output]}} {{filename}} {{package}}`

--- a/pages/linux/repquota.md
+++ b/pages/linux/repquota.md
@@ -5,24 +5,24 @@
 
 - Report stats for all quotas in use:
 
-`sudo repquota -all`
+`sudo repquota {{[-a|--all]}}`
 
 - Report quota stats for all users, even those who aren't using any of their quota:
 
-`sudo repquota -v {{filesystem}}`
+`sudo repquota {{[-v|--verbose]}} {{filesystem}}`
 
 - Report on quotas for users only:
 
-`repquota --user {{filesystem}}`
+`repquota {{[-u|--user]}} {{filesystem}}`
 
 - Report on quotas for groups only:
 
-`sudo repquota --group {{filesystem}}`
+`sudo repquota {{[-g|--group]}} {{filesystem}}`
 
 - Report on used quota and limits in a human-readable format:
 
-`sudo repquota --human-readable {{filesystem}}`
+`sudo repquota {{[-s|--human-readable]}} {{filesystem}}`
 
 - Report on all quotas for users and groups in a human-readable format:
 
-`sudo repquota -augs`
+`sudo repquota {{[-augs|--all --user --group --human-readable]}}`

--- a/pages/linux/rpicam-hello.md
+++ b/pages/linux/rpicam-hello.md
@@ -5,7 +5,7 @@
 
 - Display a camera preview stream for a specific amount of time (in milliseconds):
 
-`rpicam-hello -t {{time}}`
+`rpicam-hello {{[-t|--timeout]}} {{time}}`
 
 - Tune the configuration for a particular camera sensor:
 

--- a/pages/linux/rpicam-jpeg.md
+++ b/pages/linux/rpicam-jpeg.md
@@ -5,12 +5,12 @@
 
 - Capture an image and name the file:
 
-`rpicam-jpeg -o {{path/to/file.jpg}}`
+`rpicam-jpeg {{[-o|--output]}} {{path/to/file.jpg}}`
 
 - Capture an image with set dimensions:
 
-`rpicam-jpeg -o {{path/to/file.jpg}} --width {{1920}} --height {{1080}}`
+`rpicam-jpeg {{[-o|--output]}} {{path/to/file.jpg}} --width {{1920}} --height {{1080}}`
 
 - Capture an image with an exposure of 20 seconds and a gain of 150%:
 
-`rpicam-jpeg -o {{path/to/file.jpg}} --shutter 20000 --gain 1.5`
+`rpicam-jpeg {{[-o|--output]}} {{path/to/file.jpg}} --shutter 20000 --gain 1.5`

--- a/pages/linux/rpicam-raw.md
+++ b/pages/linux/rpicam-raw.md
@@ -5,8 +5,8 @@
 
 - Capture a video for a specific amount of seconds:
 
-`rpicam-raw -t {{2000}} -o {{path/to/file.raw}}`
+`rpicam-raw {{[-t|--timeout]}} {{2000}} {{[-o|--output]}} {{path/to/file.raw}}`
 
 - Change video dimensions and framerate:
 
-`rpicam-raw -t {{5000}} --width {{4056}} --height {{3040}} -o {{path/to/file.raw}} --framerate {{8}}`
+`rpicam-raw {{[-t|--timeout]}} {{5000}} --width {{4056}} --height {{3040}} {{[-o|--output]}} {{path/to/file.raw}} --framerate {{8}}`

--- a/pages/linux/rpicam-still.md
+++ b/pages/linux/rpicam-still.md
@@ -5,12 +5,12 @@
 
 - Capture a photo with different encoding:
 
-`rpicam-still -e {{bmp|png|rgb|yuv420}} -o {{path/to/file.{{bmp|png|rgb|yuv420}}}}`
+`rpicam-still {{[-e|--encoding]}} {{bmp|png|rgb|yuv420}} {{[-o|--output]}} {{path/to/file.{{bmp|png|rgb|yuv420}}}}`
 
 - Capture a raw image:
 
-`rpicam-still -r -o {{path/to/file.jpg}}`
+`rpicam-still {{[-r|--raw]}} {{[-o|--output]}} {{path/to/file.jpg}}`
 
 - Capture a 100 second exposure image:
 
-`rpicam-still -o {{path/to/file.jpg}} --shutter 100000`
+`rpicam-still {{[-o|--output]}} {{path/to/file.jpg}} --shutter 100000`

--- a/pages/linux/rpicam-vid.md
+++ b/pages/linux/rpicam-vid.md
@@ -6,4 +6,4 @@
 
 - Capture a 10 second video:
 
-`rpicam-vid -t 10000 -o {{path/to/file.h264}}`
+`rpicam-vid {{[-t|--timeout]}} 10000 {{[-o|--output]}} {{path/to/file.h264}}`

--- a/pages/linux/rusnapshot.md
+++ b/pages/linux/rusnapshot.md
@@ -5,24 +5,24 @@
 
 - Create a snapshot using a configuration file:
 
-`sudo rusnapshot --config {{path/to/config.toml}} --cr`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} --cr`
 
 - List created snapshots:
 
-`sudo rusnapshot -c {{path/to/config.toml}} --list`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} {{[-l|--list]}}`
 
 - Delete a snapshot by ID or the name of the snapshot:
 
-`sudo rusnapshot -c {{path/to/config.toml}} --del --id {{snapshot_id}}`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} --del --id {{snapshot_id}}`
 
 - Delete all `hourly` snapshots:
 
-`sudo rusnapshot -c {{path/to/config.toml}} --list --keep {{0}} --clean --kind {{hourly}}`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} {{[-l|--list]}} {{[-k|--keep]}} {{0}} --clean --kind {{hourly}}`
 
 - Create a read-write snapshot:
 
-`sudo rusnapshot -c {{path/to/config.toml}} --cr --rw`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} --cr {{[-r|--rw]}}`
 
 - Restore a snapshot:
 
-`sudo rusnapshot -c {{path/to/config.toml}} --id {{snapshot_id}} --restore`
+`sudo rusnapshot {{[-c|--config]}} {{path/to/config.toml}} --id {{snapshot_id}} {{[-r|--restore]}}`

--- a/pages/linux/sacct.md
+++ b/pages/linux/sacct.md
@@ -9,20 +9,20 @@
 
 - Display job ID, job state, job exit code for recent jobs:
 
-`sacct --brief`
+`sacct {{[-b|--brief]}}`
 
 - Display the allocations of a job:
 
-`sacct --jobs {{job_id}} --allocations`
+`sacct {{[-j|--jobs]}} {{job_id}} {{[-X|--allocations]}}`
 
 - Display elapsed time, job name, number of requested CPUs, and memory requested of a job:
 
-`sacct --jobs {{job_id}} --format=Elapsed,JobName,ReqCPUS,ReqMem`
+`sacct {{[-j|--jobs]}} {{job_id}} {{[-o|--format]}} Elapsed,JobName,ReqCPUS,ReqMem`
 
 - Display recent jobs that occurred from one week ago up to the present day:
 
-`sacct --starttime=$(date -d "1 week ago" +'%F')`
+`sacct {{[-S|--starttime]}} $(date {{[-d|--date]}} "1 week ago" +'%F')`
 
 - Output a larger number of characters for an attribute:
 
-`sacct --format=JobID,JobName%100`
+`sacct {{[-o|--format]}} JobID,JobName%100`

--- a/pages/linux/salloc.md
+++ b/pages/linux/salloc.md
@@ -9,8 +9,8 @@
 
 - Execute the specified command synchronously on a node in the cluster:
 
-`salloc {{ls -a}}`
+`salloc {{ls --all}}`
 
 - Only allocate nodes fulfilling the specified constraints:
 
-`salloc --constraint={{(amd|intel)&gpu}}`
+`salloc {{[-C|--constraint]}} {{(amd|intel)&gpu}}`

--- a/pages/linux/screenkey.md
+++ b/pages/linux/screenkey.md
@@ -9,7 +9,7 @@
 
 - Display keys and mouse buttons which are currently being pressed on the screen:
 
-`screenkey --mouse`
+`screenkey {{[-M|--mouse]}}`
 
 - Launch the settings menu of screenkey:
 
@@ -17,7 +17,7 @@
 
 - Launch screenkey at a specific position:
 
-`screenkey --position {{top|center|bottom|fixed}}`
+`screenkey {{[-p|--position]}} {{top|center|bottom|fixed}}`
 
 - Change the format of the key modifiers displayed on screen:
 
@@ -25,8 +25,8 @@
 
 - Change the appearance of screenkey:
 
-`screenkey --bg-color "{{#a1b2c3}}" --font {{Hack}} --font-color {{yellow}} --opacity {{0.8}}`
+`screenkey --bg-color "{{#a1b2c3}}" {{[-f|--font]}} {{Hack}} --font-color {{yellow}} --opacity {{0.8}}`
 
 - Drag and select a window on screen to display screenkey:
 
-`screenkey --position fixed --geometry {{$(slop -n -f '%g')}}`
+`screenkey {{[-p|--position]}} fixed {{[-g|--geometry]}} {{$(slop {{[-n|--nodecorations]}} {{[-f|--format]}} '%g')}}`

--- a/pages/linux/sdiag.md
+++ b/pages/linux/sdiag.md
@@ -5,16 +5,16 @@
 
 - Show all performance counters related to the execution of `slurmctld`:
 
-`sdiag --all`
+`sdiag {{[-a|--all]}}`
 
 - Reset performance counters related to the execution of `slurmctld`:
 
-`sdiag --reset`
+`sdiag {{[-r|--reset]}}`
 
 - Specify the output format:
 
-`sdiag --all --{{json|yaml}}`
+`sdiag {{[-a|--all]}} --{{json|yaml}}`
 
 - Specify the cluster to send commands to:
 
-`sdiag --all --cluster={{cluster_name}}`
+`sdiag {{[-a|--all]}} {{[-M|--cluster]}} {{cluster_name}}`

--- a/pages/linux/semanage-fcontext.md
+++ b/pages/linux/semanage-fcontext.md
@@ -6,19 +6,19 @@
 
 - List all file labelling rules:
 
-`sudo semanage fcontext --list`
+`sudo semanage fcontext {{[-l|--list]}}`
 
 - List all user-defined file labelling rules without headings:
 
-`sudo semanage fcontext --list --locallist --noheading`
+`sudo semanage fcontext {{[-l|--list]}} {{[-C|--locallist]}} {{[-n|--noheading]}}`
 
 - Add a user-defined rule that labels any path which matches a PCRE regex:
 
-`sudo semanage fcontext --add --type {{samba_share_t}} {{'/mnt/share(/.*)?'}}`
+`sudo semanage fcontext {{[-a|--add]}} {{[-t|--type]}} {{samba_share_t}} {{'/mnt/share(/.*)?'}}`
 
 - Delete a user-defined rule using its PCRE regex:
 
-`sudo semanage fcontext --delete {{'/mnt/share(/.*)?'}}`
+`sudo semanage fcontext {{[-d|--delete]}} {{'/mnt/share(/.*)?'}}`
 
 - Relabel a directory recursively by applying the new rules:
 

--- a/pages/linux/setfattr.md
+++ b/pages/linux/setfattr.md
@@ -5,12 +5,12 @@
 
 - Set name of attribute for file:
 
-`setfattr -n user.{{attribute_name}} {{path/to/file}}`
+`setfattr {{[-n|--name]}} user.{{attribute_name}} {{path/to/file}}`
 
 - Set a user-defined value of an extended attribute on a file:
 
-`setfattr -n user.{{attribute_name}} -v "{{value}}" {{path/to/file}}`
+`setfattr {{[-n|--name]}} user.{{attribute_name}} {{[-v|--value]}} "{{value}}" {{path/to/file}}`
 
 - Remove a specific attribute of a file:
 
-`setfattr -x user.{{attribute_name}} {{path/to/file}}`
+`setfattr {{[-x|--remove]}} user.{{attribute_name}} {{path/to/file}}`

--- a/pages/linux/sh5util.md
+++ b/pages/linux/sh5util.md
@@ -5,12 +5,12 @@
 
 - Merge HDF5 files produced on each allocated node for the specified job or step:
 
-`sh5util --jobs={{job_id|job_id.step_id}}`
+`sh5util {{[-j|--jobs]}} {{job_id|job_id.step_id}}`
 
 - Extract one or more data series from a merged job file:
 
-`sh5util --jobs={{job_id|job_id.step_id}} --extract -i {{path/to/file.h5}} --series={{Energy|Filesystem|Network|Task}}`
+`sh5util {{[-j|--jobs]}} {{job_id|job_id.step_id}} {{[-E|--extract]}} {{[-i|--input]}} {{path/to/file.h5}} {{[-s|--series]}} {{Energy|Filesystem|Network|Task}}`
 
 - Extract one data item from all nodes in a merged job file:
 
-`sh5util --jobs={{job_id|job_id.step_id}} --item-extract --series={{Energy|Filesystem|Network|Task}} --data={{data_item}}`
+`sh5util {{[-j|--jobs]}} {{job_id|job_id.step_id}} {{[-I|--item-extract]}} {{[-s|--series]}} {{Energy|Filesystem|Network|Task}} {{[-d|--data]}} {{data_item}}`

--- a/pages/linux/sic.md
+++ b/pages/linux/sic.md
@@ -2,7 +2,7 @@
 
 > Simple IRC client.
 > Part of the suckless tools.
-> More information: <https://tools.suckless.org/sic/>.
+> More information: <https://manned.org/sic>.
 
 - Connect to the default host (irc.ofct.net) with the nickname set in the `$USER` environment variable:
 

--- a/pages/linux/sinfo.md
+++ b/pages/linux/sinfo.md
@@ -6,7 +6,7 @@
 
 - Show a quick summary overview of the cluster:
 
-`sinfo --summarize`
+`sinfo {{[-s|--summarize]}}`
 
 - View the detailed status of all partitions across the entire cluster:
 
@@ -14,16 +14,16 @@
 
 - View the detailed status of a specific partition:
 
-`sinfo --partition {{partition_name}}`
+`sinfo {{[-p|--partition]}} {{partition_name}}`
 
 - View information about idle nodes:
 
-`sinfo --states {{idle}}`
+`sinfo {{[-t|--states]}} {{idle}}`
 
 - Summarise dead nodes:
 
-`sinfo --dead`
+`sinfo {{[-d|--dead]}}`
 
 - List dead nodes and the reasons why:
 
-`sinfo --list-reasons`
+`sinfo {{[-R|--list-reasons]}}`

--- a/pages/linux/slop.md
+++ b/pages/linux/slop.md
@@ -9,16 +9,16 @@
 
 - Double click, rather than click and drag, to draw a selection:
 
-`slop -D`
+`slop {{[-D|--nodrag]}}`
 
 - Highlight the selection rather than outlining it:
 
-`slop -l`
+`slop {{[-l|--highlight]}}`
 
 - Specify the output format:
 
-`slop -f {{format_string}}`
+`slop {{[-f|--format]}} {{format_string}}`
 
 - Specify the selection rectangle's color:
 
-`slop -c {{red}},{{green}},{{blue}},{{alpha}}`
+`slop {{[-c|--color]}} {{red}},{{green}},{{blue}},{{alpha}}`

--- a/pages/linux/slurmrestd.md
+++ b/pages/linux/slurmrestd.md
@@ -5,7 +5,7 @@
 
 - Change the group ID (and drop supplemental groups) before processing client requests:
 
-`slurmrestd --g {{group_id}} {{[host]:port | unix:/path/to/socket}}`
+`slurmrestd -g {{group_id}} {{[host]:port | unix:/path/to/socket}}`
 
 - Comma-delimited list of authentication plugins to load:
 

--- a/pages/linux/sm.md
+++ b/pages/linux/sm.md
@@ -9,19 +9,19 @@
 
 - Display a message with inverted colors:
 
-`sm -i "{{Hello World!}}"`
+`sm {{[-i|--invert]}} "{{Hello World!}}"`
 
 - Display a message with a custom foreground color:
 
-`sm -f {{blue}} "{{Hello World!}}"`
+`sm {{[-f|--foreground]}} {{blue}} "{{Hello World!}}"`
 
 - Display a message with a custom background color:
 
-`sm -b {{#008888}} "{{Hello World!}}"`
+`sm {{[-b|--background]}} {{#008888}} "{{Hello World!}}"`
 
 - Display a message rotated 3 times (in steps of 90 degrees, counterclockwise):
 
-`sm -r {{3}} "{{Hello World!}}"`
+`sm {{[-r|--rotate]}} {{3}} "{{Hello World!}}"`
 
 - Display a message using the output from another command:
 

--- a/pages/linux/snapper.md
+++ b/pages/linux/snapper.md
@@ -9,20 +9,20 @@
 
 - Create snapper config:
 
-`snapper -c {{config}} create-config {{path/to/directory}}`
+`snapper {{[-c|--config]}} {{config}} create-config {{path/to/directory}}`
 
 - Create a snapshot with a description:
 
-`snapper -c {{config}} create -d "{{snapshot_description}}"`
+`snapper {{[-c|--config]}} {{config}} create {{[-d|--description]}} "{{snapshot_description}}"`
 
 - List snapshots for a config:
 
-`snapper -c {{config}} list`
+`snapper {{[-c|--config]}} {{config}} list`
 
 - Delete a snapshot:
 
-`snapper -c {{config}} delete {{snapshot_number}}`
+`snapper {{[-c|--config]}} {{config}} delete {{snapshot_number}}`
 
 - Delete a range of snapshots:
 
-`snapper -c {{config}} delete {{snapshot1}}-{{snapshot2}}`
+`snapper {{[-c|--config]}} {{config}} delete {{snapshot1}}-{{snapshot2}}`

--- a/pages/linux/sport.md
+++ b/pages/linux/sport.md
@@ -5,7 +5,7 @@
 
 - Pull the list of SlackBuilds to run `sport` for the first time:
 
-`sudo mkdir -p /usr/ports && sudo rsync -av rsync://slackbuilds.org /slackbuilds/$(awk '{print $2}' /etc/slackware-version)/ /usr/ports/`
+`sudo mkdir {{[-p|--parents]}} /usr/ports && sudo rsync {{[-av|--archive --verbose]}} rsync://slackbuilds.org /slackbuilds/$(awk '{print $2}' /etc/slackware-version)/ /usr/ports/`
 
 - Pull in any updates to the system's tree via `rsync`:
 

--- a/pages/linux/sprio.md
+++ b/pages/linux/sprio.md
@@ -9,16 +9,16 @@
 
 - View the factors determining the specified job's scheduling priority:
 
-`sprio --jobs={{job_id_1,job_id_2,...}}`
+`sprio {{[-j|--jobs]}} {{job_id_1,job_id_2,...}}`
 
 - Output additional information:
 
-`sprio --long`
+`sprio {{[-l|--long]}}`
 
 - View information for the jobs of specified users:
 
-`sprio --user={{user_name_1,user_name_2,...}}`
+`sprio {{[-u|--user]}} {{user_name_1,user_name_2,...}}`
 
 - Print the weights for each factor determining job scheduling priority:
 
-`sprio --weights`
+`sprio {{[-w|--weights]}}`

--- a/pages/linux/squeue.md
+++ b/pages/linux/squeue.md
@@ -9,11 +9,11 @@
 
 - View jobs queued by a specific user:
 
-`squeue -u {{username}}`
+`squeue {{[-u|--user]}} {{username}}`
 
 - View the queue and refresh every 5 seconds:
 
-`squeue -i {{5}}`
+`squeue {{[-i|--iterate]}} {{5}}`
 
 - View the queue with expected start times:
 

--- a/pages/linux/sreport.md
+++ b/pages/linux/sreport.md
@@ -5,7 +5,7 @@
 
 - Show pipe delimited cluster utilization data:
 
-`sreport --parsable cluster utilization`
+`sreport {{[-p|--parsable]}} cluster utilization`
 
 - Show number of jobs run:
 

--- a/pages/linux/sshare.md
+++ b/pages/linux/sshare.md
@@ -13,8 +13,8 @@
 
 - Control the fields to display:
 
-`sshare --format={{format_string}}`
+`sshare {{[-o|--format]}} {{format_string}}`
 
 - Display information for the specified users only:
 
-`sshare --users={{user_id_1,user_id_2,...}}`
+`sshare {{[-u|--users]}} {{user_id_1,user_id_2,...}}`

--- a/pages/linux/sstat.md
+++ b/pages/linux/sstat.md
@@ -5,12 +5,12 @@
 
 - Display status information of a comma-separated list of jobs:
 
-`sstat --jobs={{job_id}}`
+`sstat {{[-j|--jobs]}} {{job_id}}`
 
 - Display job ID, average CPU and average virtual memory size of a comma-separated list of jobs, with pipes as column delimiters:
 
-`sstat --parsable --jobs={{job_id}} --format={{JobID,AveCPU,AveVMSize}}`
+`sstat {{[-p|--parsable]}} {{[-j|--jobs]}} {{job_id}} {{[-o|--format]}} {{JobID,AveCPU,AveVMSize}}`
 
 - Display list of fields available:
 
-`sstat --helpformat`
+`sstat {{[-e|--helpformat]}}`

--- a/pages/linux/stress.md
+++ b/pages/linux/stress.md
@@ -5,16 +5,16 @@
 
 - Spawn 4 workers to stress test CPU:
 
-`stress -c {{4}}`
+`stress {{[-c|--cpu]}} {{4}}`
 
 - Spawn 2 workers to stress test IO and timeout after 5 seconds:
 
-`stress -i {{2}} -t {{5}}`
+`stress {{[-i|--io]}} {{2}} {{[-t|--timeout]}} {{5}}`
 
 - Spawn 2 workers to stress test memory (each worker allocates 256M bytes):
 
-`stress -m {{2}} --vm-bytes {{256M}}`
+`stress {{[-m|--vm]}} {{2}} --vm-bytes {{256M}}`
 
 - Spawn 2 workers spinning on write()/unlink() (each worker writes 1G bytes):
 
-`stress -d {{2}} --hdd-bytes {{1GB}}`
+`stress {{[-d|--hdd]}} {{2}} --hdd-bytes {{1GB}}`

--- a/pages/linux/strigger.md
+++ b/pages/linux/strigger.md
@@ -6,11 +6,11 @@
 
 - Register a new trigger. Execute the specified program when the specified event occurs:
 
-`strigger --set --{{primary_database_failure|primary_slurmdbd_failure|primary_slurmctld_acct_buffer_full|primary_slurmctld_failure|...}} --program={{path/to/executable}}`
+`strigger --set --{{primary_database_failure|primary_slurmdbd_failure|primary_slurmctld_acct_buffer_full|primary_slurmctld_failure|...}} {{[-p|--program]}} {{path/to/executable}}`
 
 - Execute the specified program when the specified job terminated:
 
-`strigger --set --jobid={{job_id}} --fini --program="{{path/to/executable}} {{argument1 argument2 ...}}"`
+`strigger --set {{[-j|--jobid]}} {{job_id}} {{[-f|--fini]}} {{[-p|--program]}} "{{path/to/executable}} {{argument1 argument2 ...}}"`
 
 - View active triggers:
 
@@ -18,7 +18,7 @@
 
 - View active triggers regarding the specified job:
 
-`strigger --get --jobid={{job_id}}`
+`strigger --get {{[-j|--jobid]}} {{job_id}}`
 
 - Clear the specified trigger:
 

--- a/pages/linux/strip.md
+++ b/pages/linux/strip.md
@@ -13,4 +13,4 @@
 
 - Strip debug symbols only:
 
-`strip --strip-debug {{path/to/file.o}}`
+`strip {{[-d|--strip-debug]}} {{path/to/file.o}}`

--- a/pages/linux/swaks.md
+++ b/pages/linux/swaks.md
@@ -5,20 +5,20 @@
 
 - Deliver a standard test email to `user@example.com` on port 25 of `test-server.example.net`:
 
-`swaks --to {{user@example.com}} --server {{test-server.example.net}}`
+`swaks {{[-t|--to]}} {{user@example.com}} {{[-s|--server]}} {{test-server.example.net}}`
 
 - Deliver a standard test email, requiring CRAM-MD5 authentication as user `me@example.com`. An "X-Test" header will be added to the email body:
 
-`swaks --to {{user@example.com}} --from {{me@example.com}} --auth {{CRAM-MD5}} --auth-user {{me@example.com}} --header-X-Test "{{test_email}}"`
+`swaks {{[-t|--to]}} {{user@example.com}} {{[-f|--from]}} {{me@example.com}} {{[-a|--auth]}} {{CRAM-MD5}} {{[-au|--auth-user]}} {{me@example.com}} --header-X-Test "{{test_email}}"`
 
 - Test a virus scanner using EICAR in an attachment. Don't show the message DATA part:
 
-`swaks -t {{user@example.com}} --attach - --server {{test-server.example.com}} --suppress-data {{path/to/eicar.txt}}`
+`swaks {{[-t|--to]}} {{user@example.com}} --attach - {{[-s|--server]}} {{test-server.example.com}} {{[-n|--suppress-data]}} {{path/to/eicar.txt}}`
 
 - Test a spam scanner using GTUBE in the body of an email, routed via the MX records for `example.com`:
 
-`swaks --to {{user@example.com}} --body {{path/to/gtube_file}}`
+`swaks {{[-t|--to]}} {{user@example.com}} --body {{path/to/gtube_file}}`
 
 - Deliver a standard test email to `user@example.com` using the LMTP protocol via a UNIX domain socket file:
 
-`swaks --to {{user@example.com}} --socket {{/var/lda.sock}} --protocol {{LMTP}}`
+`swaks {{[-t|--to]}} {{user@example.com}} --socket {{/var/lda.sock}} --protocol {{LMTP}}`

--- a/pages/linux/sysctl.md
+++ b/pages/linux/sysctl.md
@@ -5,11 +5,11 @@
 
 - Show all available variables and their values:
 
-`sysctl -a`
+`sysctl {{[-a|--all]}}`
 
 - Set a changeable kernel state variable:
 
-`sysctl -w {{section.tunable}}={{value}}`
+`sysctl {{[-w|--write]}} {{section.tunable}}={{value}}`
 
 - Get currently open file handlers:
 
@@ -21,4 +21,4 @@
 
 - Apply changes from `/etc/sysctl.conf`:
 
-`sysctl -p`
+`sysctl {{[-p|--load]}}`

--- a/pages/linux/sysdig.md
+++ b/pages/linux/sysdig.md
@@ -10,11 +10,11 @@
 
 - Capture all the events from the live system and save them to disk:
 
-`sysdig -w {{path/to/file}}.scap`
+`sysdig {{[-w|--write]}} {{path/to/file}}.scap`
 
 - Read events from a file and print them to screen:
 
-`sysdig -r {{path/to/file}}.scap`
+`sysdig {{[-r|--read]}} {{path/to/file}}.scap`
 
 - Filter and Print all the open system calls invoked by cat:
 
@@ -26,8 +26,8 @@
 
 - List the available chisels:
 
-`sysdig -cl`
+`sysdig {{[-cl|--list-chisels]}}`
 
 - Use the spy_ip chisel to look at the data exchanged with ip address:
 
-`sysdig -c spy_ip {{ip_address}}`
+`sysdig {{[-c|--chisel]}} spy_ip {{ip_address}}`

--- a/pages/linux/systemd-socket-activate.md
+++ b/pages/linux/systemd-socket-activate.md
@@ -21,4 +21,4 @@
 
 - Activate a service with a specified port:
 
-`systemd-socket-activate {{path/to/socket.service}} -l {{8080}}`
+`systemd-socket-activate {{path/to/socket.service}} {{{[-l|--listen]}}} {{8080}}`

--- a/pages/linux/toilet.md
+++ b/pages/linux/toilet.md
@@ -9,12 +9,12 @@
 
 - Generate ASCII art using a custom font file:
 
-`toilet {{input_text}} -f {{font_filename}}`
+`toilet {{input_text}} {{[-f|--font]}} {{font_filename}}`
 
 - Generate ASCII art using a filter:
 
-`toilet {{input_text}} --filter {{filter_name}}`
+`toilet {{input_text}} {{[-F|--filter]}} {{filter_name}}`
 
 - Show available toilet filters:
 
-`toilet --filter list`
+`toilet {{[-F|--filter]}} list`

--- a/pages/linux/turbostat.md
+++ b/pages/linux/turbostat.md
@@ -9,7 +9,7 @@
 
 - Display statistics every specified amount of seconds:
 
-`sudo turbostat -i {{n_seconds}}`
+`sudo turbostat {{[-i|--interval]}} {{n_seconds}}`
 
 - Do not decode and print the system configuration header information:
 
@@ -17,7 +17,7 @@
 
 - Display useful information about CPU every 1 second, without header information:
 
-`sudo turbostat --quiet --interval 1 --cpu 0-{{CPU_thread_count}} --show "PkgWatt","Busy%","Core","CoreTmp","Thermal"`
+`sudo turbostat --quiet {{[-i|--interval]}} 1 --cpu 0-{{CPU_thread_count}} --show "PkgWatt","Busy%","Core","CoreTmp","Thermal"`
 
 - Display help:
 

--- a/pages/linux/unsquashfs.md
+++ b/pages/linux/unsquashfs.md
@@ -9,20 +9,20 @@
 
 - Extract a squashfs filesystem to the specified directory:
 
-`unsquashfs -dest {{path/to/directory}} {{filesystem.squashfs}}`
+`unsquashfs {{[-d|-dest]}} {{path/to/directory}} {{filesystem.squashfs}}`
 
 - Display the names of files as they are extracted:
 
-`unsquashfs -info {{filesystem.squashfs}}`
+`unsquashfs {{[-i|-info]}} {{filesystem.squashfs}}`
 
 - Display the names of files and their attributes as they are extracted:
 
-`unsquashfs -linfo {{filesystem.squashfs}}`
+`unsquashfs {{[-li|-linfo]}} {{filesystem.squashfs}}`
 
 - List files inside the squashfs filesystem (without extracting):
 
-`unsquashfs -ls {{filesystem.squashfs}}`
+`unsquashfs {{[-l|-ls]}} {{filesystem.squashfs}}`
 
 - List files and their attributes inside the squashfs filesystem (without extracting):
 
-`unsquashfs -lls {{filesystem.squashfs}}`
+`unsquashfs {{[-ll|-lls]}} {{filesystem.squashfs}}`

--- a/pages/linux/updpkgsums.md
+++ b/pages/linux/updpkgsums.md
@@ -10,8 +10,8 @@
 
 - Display help:
 
-`updpkgsums -h`
+`updpkgsums {{[-h|--help]}}`
 
 - Display version:
 
-`updpkgsums -v`
+`updpkgsums {{[-v|--version]}}`

--- a/pages/linux/urpmq.md
+++ b/pages/linux/urpmq.md
@@ -14,11 +14,11 @@
 
 - Display direct and indirect dependencies of a package:
 
-`urpmq --requires-recursive {{package}}`
+`urpmq {{[-d|--requires-recursive]}} {{package}}`
 
 - List the not installed packages needed for an RPM file with their sources:
 
-`sudo urpmq --requires-recursive -m --sources {{path/to/file.rpm}}`
+`sudo urpmq {{[-d|--requires-recursive]}} -m --sources {{path/to/file.rpm}}`
 
 - List all configured media with their URLs, including inactive media:
 
@@ -26,7 +26,7 @@
 
 - Search for a package printing [g]roup, version and [r]elease:
 
-`urpmq -g -r --fuzzy {{keyword}}`
+`urpmq -g -r {{[-y|--fuzzy]}} {{keyword}}`
 
 - Search for a package with using its exact name:
 

--- a/pages/linux/usbip.md
+++ b/pages/linux/usbip.md
@@ -5,7 +5,7 @@
 
 - List all local USB devices and their bus ID's:
 
-`usbip list --local`
+`usbip list {{[-l|--local]}}`
 
 - Start a `usbip` daemon on the server:
 
@@ -13,7 +13,7 @@
 
 - Bind a USB device to `usbip` on the server:
 
-`sudo usbip bind --busid {{bus_id}}`
+`sudo usbip bind {{[-b|--busid]}} {{bus_id}}`
 
 - Load the kernel module required by `usbip` on the client:
 
@@ -21,7 +21,7 @@
 
 - Attach to the `usbip` device on the client (bus ID is the same as on the server):
 
-`sudo usbip attach -r {{ip_address}} --busid {{bus_id}}`
+`sudo usbip attach {{[-r|--remote]}} {{ip_address}} {{[-b|--busid]}} {{bus_id}}`
 
 - List attached devices:
 
@@ -29,8 +29,8 @@
 
 - Detach from a device:
 
-`sudo usbip detach --port {{port}}`
+`sudo usbip detach {{[-p|--port]}} {{port}}`
 
 - Unbind a device:
 
-`usbip unbind --busid {{bus_id}}`
+`usbip unbind {{[-b|--busid]}} {{bus_id}}`

--- a/pages/linux/uvcdynctrl.md
+++ b/pages/linux/uvcdynctrl.md
@@ -5,28 +5,28 @@
 
 - List all available cameras:
 
-`uvcdynctrl -l`
+`uvcdynctrl {{[-l|--list]}}`
 
 - Use a specific device (defaults to `video0`):
 
-`uvcdynctrl -d {{device_name}}`
+`uvcdynctrl {{[-d|--device]}} {{device_name}}`
 
 - List available controls:
 
-`uvcdynctrl -c`
+`uvcdynctrl {{[-c|--clist]}}`
 
 - Set a new control value (for negative values, use `-- -value`):
 
-`uvcdynctrl -s {{control_name}} {{value}}`
+`uvcdynctrl {{[-s|--set]}} {{control_name}} {{value}}`
 
 - Get the current control value:
 
-`uvcdynctrl -g {{control_name}}`
+`uvcdynctrl {{[-g|--get]}} {{control_name}}`
 
 - Save the state of the current controls to a file:
 
-`uvcdynctrl -W {{filename}}`
+`uvcdynctrl {{[-W|--save]}} {{filename}}`
 
 - Load the state of the controls from a file:
 
-`uvcdynctrl -L {{filename}}`
+`uvcdynctrl {{[-L|--load]}} {{filename}}`

--- a/pages/linux/vgs.md
+++ b/pages/linux/vgs.md
@@ -10,19 +10,19 @@
 
 - Display all volume groups:
 
-`vgs -a`
+`vgs {{[-a|--all]}}`
 
 - Change default display to show more details:
 
-`vgs -v`
+`vgs {{[-v|--verbose]}}`
 
 - Display only specific fields:
 
-`vgs -o {{field_name_1}},{{field_name_2}}`
+`vgs {{[-o|--options]}} {{field_name_1}},{{field_name_2}}`
 
 - Append field to default display:
 
-`vgs -o +{{field_name}}`
+`vgs {{[-o|--options]}} +{{field_name}}`
 
 - Suppress heading line:
 

--- a/pages/linux/vnstat.md
+++ b/pages/linux/vnstat.md
@@ -9,16 +9,16 @@
 
 - Display traffic summary for a specific network interface:
 
-`vnstat -i {{network_interface}}`
+`vnstat {{[-i|--iface]}} {{network_interface}}`
 
 - Display live stats for a specific network interface:
 
-`vnstat -l -i {{network_interface}}`
+`vnstat {{[-l|--live]}} {{[-i|--iface]}} {{network_interface}}`
 
 - Show traffic statistics on an hourly basis for the last 24 hours using a bar graph:
 
-`vnstat -hg`
+`vnstat {{[-hg|--hoursgraph]}}`
 
 - Measure and show average traffic for 30 seconds:
 
-`vnstat -tr {{30}}`
+`vnstat {{[-tr|--traffic]}} {{30}}`

--- a/pages/linux/wf-recorder.md
+++ b/pages/linux/wf-recorder.md
@@ -6,12 +6,12 @@
 
 - Record storing to an MP4 file:
 
-`wf-recorder --file={{output.mp4}}`
+`wf-recorder {{[-f|--file]}} {{output.mp4}}`
 
 - Record including audio, both with mic and system sounds:
 
-`wf-recorder --audio --file={{/path/to/file_with_audio.webm}}`
+`wf-recorder {{[-a|--audio]}} {{[-f|--file]}} {{/path/to/file_with_audio.webm}}`
 
 - Select and record a portion of the screen using `slurp`, outputting to default `recording.mp4`:
 
-`wf-recorder -g "$(slurp)"`
+`wf-recorder {{[-g|--geometry]}} "$(slurp)"`

--- a/pages/linux/xclip.md
+++ b/pages/linux/xclip.md
@@ -11,28 +11,28 @@
 
 - Copy the output from a command to a given X11 selection area:
 
-`echo 123 | xclip -selection {{primary|secondary|clipboard}}`
+`echo 123 | xclip {{[-se|-selection]}} {{primary|secondary|clipboard}}`
 
 - Copy the output from a command to the system clipboard, using short notation:
 
-`echo 123 | xclip -sel clip`
+`echo 123 | xclip {{[-se|-selection]}} clip`
 
 - Copy the contents of a file into the system clipboard:
 
-`xclip -sel clip {{input_file.txt}}`
+`xclip {{[-se|-selection]}} clip {{input_file.txt}}`
 
 - Copy the contents of a PNG into the system clipboard (can be pasted in other programs correctly):
 
-`xclip -sel clip -t image/png {{input_file.png}}`
+`xclip {{[-se|-selection]}} clip {{[-t|-target]}} image/png {{input_file.png}}`
 
 - Copy the user input in the console into the system clipboard:
 
-`xclip -i`
+`xclip {{[-i|-in]}}`
 
 - Paste the contents of the X11 primary selection area to the console:
 
-`xclip -o`
+`xclip {{[-o|-out]}}`
 
 - Paste the contents of the system clipboard to the console:
 
-`xclip -o -sel clip`
+`xclip {{[-o|-out]}} {{[-se|-selection]}} clip`

--- a/pages/linux/yum.md
+++ b/pages/linux/yum.md
@@ -10,7 +10,7 @@
 
 - Install a new package and assume yes to all questions (also works with update, great for automated updates):
 
-`yum -y install {{package}}`
+`yum {{[-y|--assumeyes]}} install {{package}}`
 
 - Find the package that provides a particular command:
 


### PR DESCRIPTION
These were hunted down with `grep -rl " -[a-z][^a-z]"` to find lone short options and then checking documentation if there's existing long options. Couple of these were found because I noticed a group of pages from a project that consistently provides short and long options like `grep -rl "slurm" | xargs -n1 code` or `compgen -c pw- | xargs -I _ code _.md` or `find . -iname "distrobox*" | xargs -n1 basename | xargs -n1 code`