### PR TITLE
venv: add alias example

### DIFF
--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -18,3 +18,7 @@
 - Deactivate the virtual environment:
 
 `deactivate`
+
+- Create an alias that generates a `venv` folder and automatically activate it:
+
+`alias venv='python -m venv .venv && source .venv/bin/activate'`

--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -19,6 +19,6 @@
 
 `deactivate`
 
-- Create an alias that generates a `venv` folder and automatically activate it:
+- Create an alias that generates a `venv` folder and automatically activates it:
 
 `alias venv='python -m venv .venv && source .venv/bin/activate'`

--- a/pages/common/venv.md
+++ b/pages/common/venv.md
@@ -21,4 +21,4 @@
 
 - Create an alias that generates a `venv` folder and automatically activates it:
 
-`alias venv='python -m venv .venv && source .venv/bin/activate'`
+`alias venv='python -m venv .venv && source {{.venv/bin/activate|.venv\Scripts\activate.bat}}'`


### PR DESCRIPTION
This page is interesting in that `venv` doesn't exist as a command, but there is value in keeping the page.