### PR TITLE
arptables: add page

### DIFF
--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -6,7 +6,7 @@
 
 - List all ARP rules in the filter table:
 
-`sudo arptables -L`
+`sudo arptables {{[-L|--list]}}`
 
 - Append a rule to drop ARP packets from a specific IP address:
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -1,0 +1,29 @@
+# arptables
+
+> Manage ARP filtering rules using the nftables backend.
+> Part of the `xtables-nft` suite for ARP packet filtering.
+> More information: <https://man7.org/linux/man-pages/man8/arptables-nft.8.html>.
+
+- List all ARP rules in the filter table:
+
+`sudo arptables -L`
+
+- Append a rule to drop ARP packets from a specific IP address:
+
+`sudo arptables -A INPUT --source-ip {{192.168.0.1}} -j DROP`
+
+- Delete a specific rule from the INPUT chain by its rule number:
+
+`sudo arptables -D INPUT {{rule_number}}`
+
+- Flush all rules in the filter table:
+
+`sudo arptables -F`
+
+- Set the default policy of the OUTPUT chain to ACCEPT:
+
+`sudo arptables -P OUTPUT ACCEPT`
+
+- Save the current ARP rules to a file:
+
+`sudo arptables-save > {{path/to/file}}`

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -22,7 +22,7 @@
 
 - Set the default policy of the OUTPUT chain to ACCEPT:
 
-`sudo arptables -P OUTPUT ACCEPT`
+`sudo arptables {{[-P|--policy]}} OUTPUT ACCEPT`
 
 - Save the current ARP rules to a file:
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -2,7 +2,7 @@
 
 > Manage ARP filtering rules using the nftables backend.
 > Part of the `xtables-nft` suite for ARP packet filtering.
-> More information: <https://man7.org/linux/man-pages/man8/arptables-nft.8.html>.
+> More information: <https://manned.org/arptables>.
 
 - List all ARP rules in the filter table:
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -10,7 +10,7 @@
 
 - Append a rule to drop ARP packets from a specific IP address:
 
-`sudo arptables -A INPUT --source-ip {{192.168.0.1}} -j DROP`
+`sudo arptables {{[-A|--append]}} INPUT {{[-s|--source-ip]}} {{192.168.0.1}} {{[-j|--jump]}} DROP`
 
 - Delete a specific rule from the INPUT chain by its rule number:
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -14,7 +14,7 @@
 
 - Delete a specific rule from the INPUT chain by its rule number:
 
-`sudo arptables -D INPUT {{rule_number}}`
+`sudo arptables {{[-D|--delete]}} INPUT {{rule_number}}`
 
 - Flush all rules in the filter table:
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -1,6 +1,6 @@
 # arptables
 
-> Manage ARP filtering rules using the nftables backend.
+> Manage ARP filtering rules using the `nftables` backend.
 > Part of the `xtables-nft` suite for ARP packet filtering.
 > More information: <https://manned.org/arptables>.
 

--- a/pages/linux/arptables.md
+++ b/pages/linux/arptables.md
@@ -18,7 +18,7 @@
 
 - Flush all rules in the filter table:
 
-`sudo arptables -F`
+`sudo arptables {{[-F|--flush]}}`
 
 - Set the default policy of the OUTPUT chain to ACCEPT:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
---
Adds a TLDR page for `arptables`, a tool for managing ARP filtering rules using the nftables backend.

This page includes examples for listing, adding, deleting, flushing rules, setting default policies, and saving configurations.

Based on: https://man7.org/linux/man-pages/man8/arptables-nft.8.html
