### PR TITLE
common/*: add option placeholders part 1

### DIFF
--- a/pages/common/ddgr.md
+++ b/pages/common/ddgr.md
@@ -13,11 +13,11 @@
 
 - Limit the number of search results to `n`:
 
-`ddgr -n {{n}} {{keyword}}`
+`ddgr {{[-n|--num]}} {{n}} {{keyword}}`
 
 - Display the complete URL in search results:
 
-`ddgr -x {{keyword}}`
+`ddgr {{[-x|--expand]}} {{keyword}}`
 
 - Search DuckDuckGo for a keyword and open the first result in the browser:
 
@@ -25,7 +25,7 @@
 
 - Perform a website-specific search:
 
-`ddgr -w {{site}} {{keyword}}`
+`ddgr {{[-w|--site]}} {{site}} {{keyword}}`
 
 - Search for a specific file type:
 

--- a/pages/common/egrep.md
+++ b/pages/common/egrep.md
@@ -17,12 +17,12 @@
 
 - Print file name and line number for each match:
 
-`egrep --with-filename --line-number "{{search_pattern}}" {{path/to/file}}`
+`egrep {{[-H|--with-filename]}} {{[-n|--line-number]}} "{{search_pattern}}" {{path/to/file}}`
 
 - Search for a pattern in all files recursively in a directory, ignoring binary files:
 
-`egrep --recursive --binary-files={{without-match}} "{{search_pattern}}" {{path/to/directory}}`
+`egrep {{[-r|--recursive]}} --binary-files={{without-match}} "{{search_pattern}}" {{path/to/directory}}`
 
 - Search for lines that do not match a pattern:
 
-`egrep --invert-match "{{search_pattern}}" {{path/to/file}}`
+`egrep {{[-v|--invert-match]}} "{{search_pattern}}" {{path/to/file}}`

--- a/pages/common/faker.md
+++ b/pages/common/faker.md
@@ -11,18 +11,18 @@
 
 `faker {{name|address|passport_full|credit_card_full|phone_number|email|company|date_time|user_name|password|job|...}}`
 
-- Generate a number of fake addresses from a specific country (use `localectl list-locales | cut -d. -f1` to get list of locales):
+- Generate a number of fake addresses from a specific country (use `localectl list-locales | cut --delimiter . --fields 1` to get list of locales):
 
-`faker --repeat {{number}} --lang {{de_DE|de_CH|...}} address`
+`faker {{[-r|--repeat]}} {{number}} {{[-l|--lang]}} {{de_DE|de_CH|...}} address`
 
-- Generate a number of cities in a specific country and output them to a file (use `localectl list-locales | cut -d. -f1` to get list of locales):
+- Generate a number of cities in a specific country and output them to a file (use `localectl list-locales | cut --delimiter . --fields 1` to get list of locales):
 
-`faker --repeat {{number}} --lang {{en_AU|en_US|...}} city -o {{path/to/file.txt}}`
+`faker {{[-r|--repeat]}} {{number}} {{[-l|--lang]}} {{en_AU|en_US|...}} city -o {{path/to/file.txt}}`
 
 - Generate a number of random HTTP user-agents showing verbose output:
 
-`faker --repeat {{number}} --verbose user_agent`
+`faker {{[-r|--repeat]}} {{number}} {{[-v|--verbose]}} user_agent`
 
 - Generate a number of domain names and separate each using a specific separator:
 
-`faker --repeat {{number}} --sep '{{,}}' domain_name`
+`faker {{[-r|--repeat]}} {{number}} {{[-s|--sep]}} '{{,}}' domain_name`

--- a/pages/common/googler.md
+++ b/pages/common/googler.md
@@ -9,19 +9,19 @@
 
 - Search Google and open the first result in web browser:
 
-`googler -j {{keyword}}`
+`googler {{[-j|--first]}} {{keyword}}`
 
 - Show `n` search results (default: 10):
 
-`googler -n {{n}} {{keyword}}`
+`googler {{[-n|--count]}} {{n}} {{keyword}}`
 
 - Disable automatic spelling correction:
 
-`googler -x {{keyword}}`
+`googler {{[-x|--exact]}} {{keyword}}`
 
 - Search one site for a keyword:
 
-`googler -w {{site}} {{keyword}}`
+`googler {{[-w|--site]}} {{site}} {{keyword}}`
 
 - Show Google search result in JSON format:
 
@@ -29,7 +29,7 @@
 
 - Perform in-place self-upgrade:
 
-`googler -u`
+`googler {{[-u|--upgrade]}}`
 
 - Display help in interactive mode:
 

--- a/pages/common/jq.md
+++ b/pages/common/jq.md
@@ -9,7 +9,7 @@
 
 - Execute a specific script:
 
-`{{cat path/to/file.json}} | jq --from-file {{path/to/script.jq}}`
+`{{cat path/to/file.json}} | jq {{[-f|--from-file]}} {{path/to/script.jq}}`
 
 - Pass specific arguments:
 

--- a/pages/common/julia.md
+++ b/pages/common/julia.md
@@ -17,16 +17,16 @@
 
 - Evaluate a string containing Julia code:
 
-`julia -e '{{julia_code}}'`
+`julia {{[-e|--eval]}} '{{julia_code}}'`
 
 - Evaluate a string of Julia code, passing arguments to it:
 
-`julia -e '{{for x in ARGS; println(x); end}}' {{arguments}}`
+`julia {{[-e|--eval]}} '{{for x in ARGS; println(x); end}}' {{arguments}}`
 
 - Evaluate an expression and print the result:
 
-`julia -E '{{(1 - cos(pi/4))/2}}'`
+`julia {{[-E|--print]}} '{{(1 - cos(pi/4))/2}}'`
 
 - Start Julia in multithreaded mode, using `n` threads:
 
-`julia -t {{n}}`
+`julia {{[-t|--threads]}} {{n}}`

--- a/pages/common/mpg321.md
+++ b/pages/common/mpg321.md
@@ -2,11 +2,11 @@
 
 > High Performance MPEG 1.0/2.0/2.5 Audio Player for Layer 1, 2, and 3.
 > Mpg321 was written (sometime in 1999) to be a drop-in replacement for the (previously) non-free mpg123 player.
-> More information: <https://mpg321.sourceforge.net/>.
+> More information: <https://manned.org/mpg321>.
 
 - Play an audio source exactly `n` times (0 means forever):
 
-`mpg321 -l {{n}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
+`mpg321 {{[-l|--loop]}} {{n}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
 
 - Play a directory recursively:
 
@@ -18,12 +18,12 @@
 
 - Play files randomly until interrupted:
 
-`mpg321 -Z {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
+`mpg321 {{[-Z|--random]}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
 
 - Shuffle the files before playing them once:
 
-`mpg321 -z {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
+`mpg321 {{[-z|--shuffle]}} {{path/to/file_a|URL}} {{path/to/file_b|URL}} {{...}}`
 
 - Play all files in the current directory and subdirectories, randomly (until interrupted), with Basic Keys enabled:
 
-`mpg321 -B -Z -K .`
+`mpg321 -B {{[-Z|--random]}} -K .`

--- a/pages/common/mytop.md
+++ b/pages/common/mytop.md
@@ -9,12 +9,12 @@
 
 - Connect with a specified username and password:
 
-`mytop -u {{user}} -p {{password}}`
+`mytop {{[-u|-user]}} {{user}} {{[-p|-password]}} {{password}}`
 
 - Connect with a specified username (the user will be prompted for a password):
 
-`mytop -u {{user}} --prompt`
+`mytop {{[-u|-user]}} {{user}} -prompt`
 
 - Do not show any idle (sleeping) threads:
 
-`mytop -u {{user}} -p {{password}} --noidle`
+`mytop {{[-u|-user]}} {{user}} {{[-p|-password]}} {{password}} --noidle`

--- a/pages/common/naabu.md
+++ b/pages/common/naabu.md
@@ -10,24 +10,24 @@
 
 - Display available network interfaces and public IP address of the local host:
 
-`naabu -interface-list`
+`naabu {{[-il|-interface-list]}}`
 
 - Scan all ports of the remote host (CONNECT scan without `sudo`):
 
-`naabu -p - -host {{host}}`
+`naabu {{[-p|-port]}} - -host {{host}}`
 
 - Scan the top 1000 ports of the remote host:
 
-`naabu -top-ports 1000 -host {{host}}`
+`naabu {{[-tp|-top-ports]}} 1000 -host {{host}}`
 
 - Scan TCP ports 80, 443 and UDP port 53 of the remote host:
 
-`naabu -p 80,443,u:53 -host {{host}}`
+`naabu {{[-p|-port]}} 80,443,u:53 -host {{host}}`
 
 - Show CDN type the remote host is using, if any:
 
-`naabu -p 80,443 -cdn -host {{host}}`
+`naabu {{[-p|-port]}} 80,443 -cdn -host {{host}}`
 
 - Run `nmap` from `naabu` for additional functionalities (`nmap` must be installed):
 
-`sudo naabu -v -host {{host}} -nmap-cli 'nmap {{-v -T5 -sC}}'`
+`sudo naabu {{[-v|-verbose]}} -host {{host}} -nmap-cli 'nmap {{-v -T5 -sC}}'`

--- a/pages/common/newsboat.md
+++ b/pages/common/newsboat.md
@@ -5,7 +5,7 @@
 
 - First import feed URLs from an OPML file:
 
-`newsboat -i {{my-feeds.xml}}`
+`newsboat {{[-i|--import-from-opml]}} {{my-feeds.xml}}`
 
 - Alternatively, add feeds manually:
 
@@ -13,11 +13,11 @@
 
 - Start Newsboat and refresh all feeds on startup:
 
-`newsboat -r`
+`newsboat {{[-r|--refresh-on-start]}}`
 
 - Execute one or more commands in non-interactive mode:
 
-`newsboat -x {{reload print-unread ...}}`
+`newsboat {{[-x|--execute]}} {{reload print-unread ...}}`
 
 - See keyboard shortcuts (the most relevant are visible in the status line):
 

--- a/pages/common/nikto.md
+++ b/pages/common/nikto.md
@@ -5,20 +5,20 @@
 
 - Perform a basic Nikto scan against a target host:
 
-`perl nikto.pl -h {{192.168.0.1}}`
+`perl nikto.pl {{[-h|-host]}} {{192.168.0.1}}`
 
 - Specify the port number when performing a basic scan:
 
-`perl nikto.pl -h {{192.168.0.1}} -p {{443}}`
+`perl nikto.pl {{[-h|-host]}} {{192.168.0.1}} {{[-p|-port]}} {{443}}`
 
 - Scan ports and protocols with full URL syntax:
 
-`perl nikto.pl -h {{https://192.168.0.1:443/}}`
+`perl nikto.pl {{[-h|-host]}} {{https://192.168.0.1:443/}}`
 
 - Scan multiple ports in the same scanning session:
 
-`perl nikto.pl -h {{192.168.0.1}} -p {{80,88,443}}`
+`perl nikto.pl {{[-h|-host]}} {{192.168.0.1}} {{[-p|-port]}} {{80,88,443}}`
 
 - Update to the latest plugins and databases:
 
-`perl nikto.pl -update`
+`perl nikto.pl {{[-u|-update]}}`

--- a/pages/common/nim.md
+++ b/pages/common/nim.md
@@ -6,19 +6,19 @@
 
 - Compile a source file:
 
-`nim compile {{path/to/file.nim}}`
+`nim {{[c|compile]}} {{path/to/file.nim}}`
 
 - Compile and run a source file:
 
-`nim compile -r {{path/to/file.nim}}`
+`nim {{[c|compile]}} {{[-r|--run]}} {{path/to/file.nim}}`
 
 - Compile a source file with release optimizations enabled:
 
-`nim compile -d:release {{path/to/file.nim}}`
+`nim {{[c|compile]}} {{[-d|--define]}}:release {{path/to/file.nim}}`
 
 - Build a release binary optimized for low file size:
 
-`nim compile -d:release --opt:size {{path/to/file.nim}}`
+`nim {{[c|compile]}} {{[-d|--define]}}:release --opt:size {{path/to/file.nim}}`
 
 - Generate HTML documentation for a module (output will be placed in the current directory):
 

--- a/pages/common/nimble.md
+++ b/pages/common/nimble.md
@@ -14,7 +14,7 @@
 
 - List installed packages:
 
-`nimble list -i`
+`nimble list {{[-i|--installed]}}`
 
 - Create a new Nimble package in the current directory:
 

--- a/pages/common/nix-classic.md
+++ b/pages/common/nix-classic.md
@@ -6,19 +6,19 @@
 
 - Search for a package in nixpkgs via its name:
 
-`nix-env -qaP {{search_term_regexp}}`
+`nix-env {{[-qaP|--query --available --attr-path]}} {{search_term_regexp}}`
 
 - Start a shell with the specified packages available:
 
-`nix-shell -p {{pkg1 pkg2 pkg3...}}`
+`nix-shell {{[-p|--packages]}} {{pkg1 pkg2 pkg3...}}`
 
 - Install some packages permanently:
 
-`nix-env -iA {{nixpkgs.pkg1 nixpkgs.pkg2...}}`
+`nix-env {{[-iA|--install --attr]}} {{nixpkgs.pkg1 nixpkgs.pkg2...}}`
 
 - Show all dependencies of a store path (package), in a tree format:
 
-`nix-store --query --tree {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --tree {{/nix/store/...}}`
 
 - Update the channels (repositories):
 

--- a/pages/common/nix-env.md
+++ b/pages/common/nix-env.md
@@ -5,32 +5,32 @@
 
 - List all installed packages:
 
-`nix-env -q`
+`nix-env {{[-q|--query]}}`
 
 - Query installed packages:
 
-`nix-env -q {{search_term}}`
+`nix-env {{[-q|--query]}} {{search_term}}`
 
 - Query available packages:
 
-`nix-env -qa {{search_term}}`
+`nix-env {{[-qa|--query --available]}} {{search_term}}`
 
 - Install package:
 
-`nix-env -iA nixpkgs.{{pkg_name}}`
+`nix-env {{[-iA|--install --attr]}} nixpkgs.{{pkg_name}}`
 
 - Install a package from a URL:
 
-`nix-env -i {{pkg_name}} --file {{example.com}}`
+`nix-env {{[-i|--install]}} {{pkg_name}} {{[-f|--file]}} {{example.com}}`
 
 - Uninstall package:
 
-`nix-env -e {{pkg_name}}`
+`nix-env {{[-e|--uninstall]}} {{pkg_name}}`
 
 - Upgrade one package:
 
-`nix-env -u {{pkg_name}}`
+`nix-env {{[-u|--upgrade]}} {{pkg_name}}`
 
 - Upgrade all packages:
 
-`nix-env -u`
+`nix-env {{[-u|--upgrade]}}`

--- a/pages/common/nix-shell.md
+++ b/pages/common/nix-shell.md
@@ -18,12 +18,12 @@
 
 - Start with packages loaded from nixpkgs:
 
-`nix-shell --packages {{package1 package2 ...}}`
+`nix-shell {{[-p|--packages]}} {{package1 package2 ...}}`
 
 - Start with packages loaded from specific nixpkgs revision:
 
-`nix-shell --packages {{package1 package2 ...}} -I nixpkgs={{https://github.com/NixOS/nixpkgs/archive/nixpkgs_revision.tar.gz}}`
+`nix-shell {{[-p|--packages]}} {{package1 package2 ...}} {{[-I|--include]}} nixpkgs={{https://github.com/NixOS/nixpkgs/archive/nixpkgs_revision.tar.gz}}`
 
 - Evaluate rest of file in specific interpreter, for use in `#!-scripts` (see <https://nixos.org/manual/nix/stable/#use-as-a-interpreter>):
 
-`nix-shell -i {{interpreter}} --packages {{package1 package2 ...}}`
+`nix-shell -i {{interpreter}} {{[-p|--packages]}} {{package1 package2 ...}}`

--- a/pages/common/nix-store.md
+++ b/pages/common/nix-store.md
@@ -18,12 +18,12 @@
 
 - Show all dependencies of a store path (package), in a tree format:
 
-`nix-store --query --tree {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --tree {{/nix/store/...}}`
 
 - Calculate the total size of a certain store path with all the dependencies:
 
-`du -cLsh $(nix-store --query --references {{/nix/store/...}})`
+`du {{[-cLsh|--total --dereference --summarize --human-readable]}} $(nix-store {{[-q|--query]}} --references {{/nix/store/...}})`
 
 - Show all dependents of a particular store path:
 
-`nix-store --query --referrers {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --referrers {{/nix/store/...}}`

--- a/pages/common/nix.md
+++ b/pages/common/nix.md
@@ -7,7 +7,7 @@
 
 - Enable the `nix` command:
 
-`mkdir -p ~/.config/nix; echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf`
+`mkdir {{[-p|--parents]}} ~/.config/nix; echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf`
 
 - Search for a package in nixpkgs via its name or description:
 

--- a/pages/common/node.md
+++ b/pages/common/node.md
@@ -17,11 +17,11 @@
 
 - Evaluate JavaScript code by passing it as an argument:
 
-`node -e "{{code}}"`
+`node {{[-e|--eval]}} "{{code}}"`
 
 - Evaluate and print the result, useful to print node's dependencies versions:
 
-`node -p "process.versions"`
+`node {{[-p|--print]}} "process.versions"`
 
 - Activate inspector, pausing execution until a debugger is connected once source code is fully parsed:
 

--- a/pages/common/noti.md
+++ b/pages/common/noti.md
@@ -13,4 +13,4 @@
 
 - Monitor a process by PID and trigger a notification when the PID disappears:
 
-`noti -w {{process_id}}`
+`noti {{[-w|--pwatch]}} {{process_id}}`

--- a/pages/common/npm-access.md
+++ b/pages/common/npm-access.md
@@ -17,7 +17,7 @@
 
 - Set package status (public or private):
 
-`npm access set status={{public|private}} {{package_name}}`
+`npm access set status {{public|private}} {{package_name}}`
 
 - Grant access to a package:
 
@@ -29,4 +29,4 @@
 
 - Configure two-factor authentication requirement:
 
-`npm access set mfa={{none|publish|automation}} {{package_name}}`
+`npm access set mfa {{none|publish|automation}} {{package_name}}`

--- a/pages/common/npm-adduser.md
+++ b/pages/common/npm-adduser.md
@@ -5,16 +5,16 @@
 
 - Create a new user in the specified registry and save credentials to `.npmrc`:
 
-`npm adduser --registry={{registry_url}}`
+`npm adduser --registry {{registry_url}}`
 
 - Log in to a private registry with a specific scope:
 
-`npm login --scope={{@mycorp}} --registry={{https://registry.mycorp.com}}`
+`npm login --scope {{@mycorp}} --registry {{https://registry.mycorp.com}}`
 
 - Log out from a specific scope and remove the auth token:
 
-`npm logout --scope={{@mycorp}}`
+`npm logout --scope {{@mycorp}}`
 
 - Create a scoped package during initialization:
 
-`npm init --scope={{@foo}} {{--yes}}`
+`npm init --scope {{@foo}} {{[-y|--yes]}}`

--- a/pages/common/npm-audit.md
+++ b/pages/common/npm-audit.md
@@ -30,4 +30,4 @@
 
 - Configure the audit to only fail on vulnerabilities above a specified severity:
 
-`npm audit --audit-level={{info|low|moderate|high|critical}}`
+`npm audit --audit-level {{info|low|moderate|high|critical}}`

--- a/pages/common/npm-check.md
+++ b/pages/common/npm-check.md
@@ -9,12 +9,12 @@
 
 - Interactively update out-of-date packages:
 
-`npm-check --update`
+`npm-check {{[-u|--update]}}`
 
 - Update everything without prompting:
 
-`npm-check --update-all`
+`npm-check {{[-y|--update-all]}}`
 
 - Don't check for unused packages:
 
-`npm-check --skip-unused`
+`npm-check {{[-s|--skip-unused]}}`

--- a/pages/common/npm-ci.md
+++ b/pages/common/npm-ci.md
@@ -10,7 +10,7 @@
 
 - Install project dependencies but skip the specified dependency type:
 
-`npm ci --omit={{dev|optional|peer}}`
+`npm ci --omit {{dev|optional|peer}}`
 
 - Install project dependencies without running any pre-/post-scripts defined in `package.json`:
 

--- a/pages/common/npm-dedupe.md
+++ b/pages/common/npm-dedupe.md
@@ -17,11 +17,11 @@
 
 - Skip optional/peer dependencies during deduplication:
 
-`npm dedupe --omit={{optional|peer}}`
+`npm dedupe --omit {{optional|peer}}`
 
 - Enable detailed logging for troubleshooting:
 
-`npm dedupe --loglevel=verbose`
+`npm dedupe --loglevel verbose`
 
 - Limit deduplication to a specific package:
 

--- a/pages/common/npm-find-dupes.md
+++ b/pages/common/npm-find-dupes.md
@@ -9,7 +9,7 @@
 
 - Include `devDependencies` in duplicate detection:
 
-`npm find-dupes --include=dev`
+`npm find-dupes --include dev`
 
 - List all duplicate instances of a specific package in `node-modules`:
 
@@ -17,11 +17,11 @@
 
 - Exclude optional dependencies from duplicate detection:
 
-`npm find-dupes --omit=optional`
+`npm find-dupes --omit optional`
 
 - Set the logging level for output:
 
-`npm find-dupes --loglevel={{silent|error|warn|info|verbose}}`
+`npm find-dupes --loglevel {{silent|error|warn|info|verbose}}`
 
 - Output duplicate information in JSON format:
 
@@ -29,8 +29,8 @@
 
 - Limit duplicate search to specific scopes:
 
-`npm find-dupes --scope={{@scope1,@scope2}}`
+`npm find-dupes --scope {{@scope1,@scope2}}`
 
 - Exclude specific scopes from duplicate detection:
 
-`npm find-dupes --omit-scope={{@scope1,@scope2}}`
+`npm find-dupes --omit-scope {{@scope1,@scope2}}`

--- a/pages/common/npm-fund.md
+++ b/pages/common/npm-fund.md
@@ -11,6 +11,6 @@
 
 `npm fund {{package}}`
 
-- List dependencies with a funding URL for a specific [w]orkspace for the project in the current directory:
+- List dependencies with a funding URL for a specific workspace for the project in the current directory:
 
-`npm fund -w {{workspace}}`
+`npm fund {{[-w|--workspace]}} {{workspace}}`

--- a/pages/common/npm-home.md
+++ b/pages/common/npm-home.md
@@ -1,4 +1,4 @@
-# npm home
+# npm-home
 
 > Open the npm page, Yarn page, or GitHub repository of a package in the web browser.
 > More information: <https://github.com/sindresorhus/npm-home>.
@@ -9,8 +9,8 @@
 
 - Open the GitHub repository of a specific package in the web browser:
 
-`npm-home -g {{package}}`
+`npm-home {{[-g|--github]}} {{package}}`
 
 - Open the Yarn page of a specific package in the web browser:
 
-`npm-home -y {{package}}`
+`npm-home {{[-y|--yarn]}} {{package}}`

--- a/pages/common/npm-init.md
+++ b/pages/common/npm-init.md
@@ -9,7 +9,7 @@
 
 - Initialize a new package with default values:
 
-`npm init -y`
+`npm init {{[-y|--yes]}}`
 
 - Initialize a new package using a specific initializer:
 

--- a/pages/common/npm-login.md
+++ b/pages/common/npm-login.md
@@ -10,8 +10,8 @@
 
 - Log in using a custom registry:
 
-`npm login --registry={{registry_url}}`
+`npm login --registry {{registry_url}}`
 
 - Log in using a specific authentication strategy:
 
-`npm login --auth-type={{legacy|web}}`
+`npm login --auth-type {{legacy|web}}`

--- a/pages/common/npm-logout.md
+++ b/pages/common/npm-logout.md
@@ -10,4 +10,4 @@
 
 - Log out using a custom registry:
 
-`npm logout --registry={{registry_url}}`
+`npm logout --registry {{registry_url}}`

--- a/pages/common/npm-ls.md
+++ b/pages/common/npm-ls.md
@@ -9,15 +9,15 @@
 
 - Print all installed packages including peer dependencies:
 
-`npm ls --all`
+`npm ls {{[-a|--all]}}`
 
 - Print dependencies with extended information:
 
-`npm ls --long`
+`npm ls {{[-l|--long]}}`
 
 - Print dependencies in parseable format:
 
-`npm ls --parseable`
+`npm ls {{[-p|--parseable]}}`
 
 - Print dependencies in JSON format:
 

--- a/pages/common/npm-outdated.md
+++ b/pages/common/npm-outdated.md
@@ -9,4 +9,4 @@
 
 - Find packages that are outdated regardless of the current project:
 
-`npm outdated --all`
+`npm outdated {{[-a|--all]}}`

--- a/pages/common/npm-query.md
+++ b/pages/common/npm-query.md
@@ -25,8 +25,8 @@
 
 - Find all dependencies with postinstall scripts and uninstall them:
 
-`npm query ":attr(scripts, [postinstall])" | jq 'map(.name) | join("\n")' -r | xargs -I {} npm uninstall {}`
+`npm query ":attr(scripts, [postinstall])" | jq 'map(.name) | join("\n")' {{[-r|--raw-output]}} | xargs -I _ npm uninstall _`
 
 - Find all Git dependencies and print which application requires them:
 
-`npm query ":type(git)" | jq 'map(.name)' | xargs -I {} npm why {}`
+`npm query ":type(git)" | jq 'map(.name)' | xargs -I _ npm why _`

--- a/pages/common/npm-root.md
+++ b/pages/common/npm-root.md
@@ -9,4 +9,4 @@
 
 - Display path to the global `node_modules` directory:
 
-`npm root --global`
+`npm root {{[-g|--global]}}`

--- a/pages/common/npm-uninstall.md
+++ b/pages/common/npm-uninstall.md
@@ -9,7 +9,7 @@
 
 - Remove a package globally:
 
-`npm uninstall -g {{package_name}}`
+`npm uninstall {{[-g|--global]}} {{package_name}}`
 
 - Remove multiple packages at once:
 

--- a/pages/common/npm-unpublish.md
+++ b/pages/common/npm-unpublish.md
@@ -9,7 +9,7 @@
 
 - Unpublish the entire package:
 
-`npm unpublish {{package_name}} --force`
+`npm unpublish {{package_name}} {{[-f|--force]}}`
 
 - Unpublish a package that is scoped:
 

--- a/pages/common/npm-update.md
+++ b/pages/common/npm-update.md
@@ -13,7 +13,7 @@
 
 - Update a package globally:
 
-`npm update -g {{package}}`
+`npm update {{[-g|--global]}} {{package}}`
 
 - Update multiple packages at once:
 

--- a/pages/common/npm-version.md
+++ b/pages/common/npm-version.md
@@ -21,4 +21,4 @@
 
 - Bump the major version with a custom commit message:
 
-`npm version major -m "{{Upgrade to %s for reasons}}"`
+`npm version major {{[-m|--message]}} "{{Upgrade to %s for reasons}}"`

--- a/pages/common/nth.md
+++ b/pages/common/nth.md
@@ -5,16 +5,16 @@
 
 - Name a hash:
 
-`nth -t {{5f4dcc3b5aa765d61d8327deb882cf99}}`
+`nth {{[-t|--text]}} {{5f4dcc3b5aa765d61d8327deb882cf99}}`
 
 - Name hashes in a file:
 
-`nth -f {{path/to/hashes}}`
+`nth {{[-f|--file]}} {{path/to/hashes}}`
 
 - Print in JSON format:
 
-`nth -t {{5f4dcc3b5aa765d61d8327deb882cf99}} -g`
+`nth {{[-t|--text]}} {{5f4dcc3b5aa765d61d8327deb882cf99}} {{[-g|--greppable]}}`
 
 - Decode hash in Base64 before naming it:
 
-`nth -t {{NWY0ZGNjM2I1YWE3NjVkNjFkODMyN2RlYjg4MmNmOTkK}} -b64`
+`nth {{[-t|--text]}} {{NWY0ZGNjM2I1YWE3NjVkNjFkODMyN2RlYjg4MmNmOTkK}} {{[-b64|--base64]}}`

--- a/pages/common/nxc.md
+++ b/pages/common/nxc.md
@@ -2,7 +2,7 @@
 
 > Network service enumeration and exploitation tool.
 > Some subcommands such as `smb` have their own usage documentation.
-> More information: <https://www.netexec.wiki/>.
+> More information: <https://www.netexec.wiki/getting-started/selecting-and-using-a-protocol>.
 
 - [L]ist available modules for the specified protocol:
 

--- a/pages/common/objdump.md
+++ b/pages/common/objdump.md
@@ -5,20 +5,20 @@
 
 - Display the file header information:
 
-`objdump -f {{path/to/binary}}`
+`objdump {{[-f|--file-headers]}} {{path/to/binary}}`
 
 - Display all header information:
 
-`objdump -x {{path/to/binary}}`
+`objdump {{[-x|--all-headers]}} {{path/to/binary}}`
 
 - Display the disassembled output of executable sections:
 
-`objdump -d {{path/to/binary}}`
+`objdump {{[-d|--disassemble]}} {{path/to/binary}}`
 
 - Display the disassembled executable sections in Intel syntax:
 
-`objdump -M intel -d {{path/to/binary}}`
+`objdump {{[-M|--disassembler-options]}} intel {{[-d|--disassemble]}} {{path/to/binary}}`
 
 - Display a complete binary hex dump of all sections:
 
-`objdump -s {{path/to/binary}}`
+`objdump {{[-s|--full-contents]}} {{path/to/binary}}`

--- a/pages/common/olevba.md
+++ b/pages/common/olevba.md
@@ -14,15 +14,15 @@
 
 - Provide a password for encrypted Microsoft Office files (may be repeated):
 
-`olevba --password {{password}} {{path/to/encrypted_file}}`
+`olevba {{[-p|--password]}} {{password}} {{path/to/encrypted_file}}`
 
 - Display only analysis results, without showing macro source code:
 
-`olevba -a {{path/to/file}}`
+`olevba {{[-a|--analysis]}} {{path/to/file}}`
 
 - Display only macro source code:
 
-`olevba -c {{path/to/file}}`
+`olevba {{[-c|--code]}} {{path/to/file}}`
 
 - Show obfuscated strings and their decoded content:
 

--- a/pages/common/onionsearch.md
+++ b/pages/common/onionsearch.md
@@ -22,4 +22,4 @@
 
 - List all supported search engines:
 
-`onionsearch --help | grep -A1 -i "supported engines"`
+`onionsearch --help | grep {{[-A|--after-context]}} 1 {{[-i|--ignore-case]}} "supported engines"`

--- a/pages/common/open.md
+++ b/pages/common/open.md
@@ -4,7 +4,7 @@
 
 - View documentation for the command available in macOS:
 
-`tldr open -p osx`
+`tldr open {{[-p|--platform]}} osx`
 
 - View documentation for the command available through fish:
 

--- a/pages/common/openscad.md
+++ b/pages/common/openscad.md
@@ -1,7 +1,7 @@
 # openscad
 
 > Software for creating solid 3D CAD objects.
-> More information: <https://openscad.org>.
+> More information: <https://manned.org/openscad>.
 
 - Open a file:
 

--- a/pages/common/openttd.md
+++ b/pages/common/openttd.md
@@ -1,7 +1,7 @@
 # openttd
 
 > Open source clone of the Microprose game "Transport Tycoon Deluxe".
-> More information: <https://www.openttd.org>.
+> More information: <https://wiki.openttd.org/en/Manual/Command%20line>.
 
 - Start a new game:
 

--- a/pages/common/optipng.md
+++ b/pages/common/optipng.md
@@ -9,11 +9,11 @@
 
 - Compress a PNG with the best compression:
 
-`optipng -o{{7}} {{path/to/file.png}}`
+`optipng -o {{7}} {{path/to/file.png}}`
 
 - Compress a PNG with the fastest compression:
 
-`optipng -o{{0}} {{path/to/file.png}}`
+`optipng -o {{0}} {{path/to/file.png}}`
 
 - Compress a PNG and add interlacing:
 

--- a/pages/common/p7zip.md
+++ b/pages/common/p7zip.md
@@ -10,16 +10,16 @@
 
 - Archive a file keeping the input file:
 
-`p7zip -k {{path/to/file}}`
+`p7zip {{[-k|--heep]}} {{path/to/file}}`
 
 - Decompress a file, replacing it with the original uncompressed version:
 
-`p7zip -d {{compressed.ext}}.7z`
+`p7zip {{[-d|--decompress]}} {{compressed.ext}}.7z`
 
 - Decompress a file keeping the input file:
 
-`p7zip -d -k {{compressed.ext}}.7z`
+`p7zip {{[-d|--decompress]}} {{[-k|--heep]}} {{compressed.ext}}.7z`
 
 - Skip some checks and force compression or decompression:
 
-`p7zip -f {{path/to/file}}`
+`p7zip {{[-f|--force]}} {{path/to/file}}`

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -9,7 +9,7 @@
 
 - Read arguments from `stdin`, run 4 jobs at once:
 
-`ls *.txt | parallel -j4 gzip`
+`ls *.txt | parallel {{[-j|--jobs]}} 4 gzip`
 
 - Convert JPEG images to PNG using replacement strings:
 
@@ -25,11 +25,11 @@
 
 - Run on multiple machines via SSH:
 
-`parallel -S {{machine1}},{{machine2}} {{command}} ::: {{arg1}} {{arg2}}`
+`parallel {{[-S|--sshlogin]}} {{machine1}},{{machine2}} {{command}} ::: {{arg1}} {{arg2}}`
 
 - Download 4 files simultaneously from a text file containing links showing progress:
 
-`parallel -j4 --bar --eta wget {{[-q|--quote]}} {} :::: {{path/to/links.txt}}`
+`parallel {{[-j|--jobs]}} 4 --bar --eta wget {{[-q|--quote]}} {} :::: {{path/to/links.txt}}`
 
 - Print the jobs which `parallel` is running in `stderr`:
 

--- a/pages/common/pass.md
+++ b/pages/common/pass.md
@@ -10,7 +10,7 @@
 
 - Save a new password and additional information (press `<Ctrl d>` on a new line to complete):
 
-`pass insert --multiline {{path/to/data}}`
+`pass insert {{[-m|--multiline]}} {{path/to/data}}`
 
 - Edit an entry:
 
@@ -18,7 +18,7 @@
 
 - Copy a password (first line of the data file) to the clipboard:
 
-`pass -c {{path/to/data}}`
+`pass {{[-c|--clip]}} {{path/to/data}}`
 
 - List the whole store tree:
 
@@ -26,7 +26,7 @@
 
 - Generate a new random password with a given length, and copy it to the clipboard:
 
-`pass generate -c {{path/to/data}} {{num}}`
+`pass generate {{[-c|--clip]}} {{path/to/data}} {{num}}`
 
 - Initialize a new Git repository (any changes done by pass will be committed automatically):
 

--- a/pages/common/patch.md
+++ b/pages/common/patch.md
@@ -14,12 +14,12 @@
 
 - Patch a file writing the result to a different file:
 
-`patch {{path/to/input_file}} -o {{path/to/output_file}} < {{patch.diff}}`
+`patch {{path/to/input_file}} {{[-o|--output]}} {{path/to/output_file}} < {{patch.diff}}`
 
 - Apply a patch to the current directory:
 
-`patch -p1 < {{patch.diff}}`
+`patch {{[-p|--strip]}} 1 < {{patch.diff}}`
 
 - Apply the reverse of a patch:
 
-`patch -R < {{patch.diff}}`
+`patch {{[-R|--reverse]}} < {{patch.diff}}`

--- a/pages/common/pathchk.md
+++ b/pages/common/pathchk.md
@@ -13,7 +13,7 @@
 
 - Check pathnames for validity on all POSIX compliant systems:
 
-`pathchk --portability {{path1 path2 …}}`
+`pathchk {{[-p -P|--portability]}} {{path1 path2 …}}`
 
 - Only check for empty pathnames or leading dashes (-):
 

--- a/pages/common/peerindex.md
+++ b/pages/common/peerindex.md
@@ -10,4 +10,4 @@
 
 - Display all peers that have provided routing information:
 
-`peerindex -r {{master6.mrt}}`
+`peerindex {{[-r|--only-refs]}} {{master6.mrt}}`

--- a/pages/common/pg_ctl.md
+++ b/pages/common/pg_ctl.md
@@ -5,20 +5,20 @@
 
 - Initialize a new PostgreSQL database cluster:
 
-`pg_ctl -D {{data_directory}} init`
+`pg_ctl {{[-D|--pgdata]}} {{data_directory}} init`
 
 - Start a PostgreSQL server:
 
-`pg_ctl -D {{data_directory}} start`
+`pg_ctl {{[-D|--pgdata]}} {{data_directory}} start`
 
 - Stop a PostgreSQL server:
 
-`pg_ctl -D {{data_directory}} stop`
+`pg_ctl {{[-D|--pgdata]}} {{data_directory}} stop`
 
 - Restart a PostgreSQL server:
 
-`pg_ctl -D {{data_directory}} restart`
+`pg_ctl {{[-D|--pgdata]}} {{data_directory}} restart`
 
 - Reload the PostgreSQL server configuration:
 
-`pg_ctl -D {{data_directory}} reload`
+`pg_ctl {{[-D|--pgdata]}} {{data_directory}} reload`

--- a/pages/common/pg_dump.md
+++ b/pages/common/pg_dump.md
@@ -9,20 +9,20 @@
 
 - Same as above, customize username:
 
-`pg_dump -U {{username}} {{db_name}} > {{output_file.sql}}`
+`pg_dump {{[-U|--username]}} {{username}} {{db_name}} > {{output_file.sql}}`
 
 - Same as above, customize host and port:
 
-`pg_dump -h {{host}} -p {{port}} {{db_name}} > {{output_file.sql}}`
+`pg_dump {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{db_name}} > {{output_file.sql}}`
 
 - Dump a database into a custom-format archive file:
 
-`pg_dump -Fc {{db_name}} > {{output_file.dump}}`
+`pg_dump {{[-F|--format]}} {{[c|custom]}} {{db_name}} > {{output_file.dump}}`
 
 - Dump only database data into an SQL-script file:
 
-`pg_dump -a {{db_name}} > {{path/to/output_file.sql}}`
+`pg_dump {{[-a|--data-only]}} {{db_name}} > {{path/to/output_file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 
-`pg_dump -s {{db_name}} > {{path/to/output_file.sql}}`
+`pg_dump {{[-s|--schema-only]}} {{db_name}} > {{path/to/output_file.sql}}`

--- a/pages/common/pg_isready.md
+++ b/pages/common/pg_isready.md
@@ -9,8 +9,8 @@
 
 - Check connection with a specific hostname and port:
 
-`pg_isready --host={{hostname}} --port={{port}}`
+`pg_isready {{[-h|--host]}} {{hostname}} {{[-p|--port]}} {{port}}`
 
 - Check connection displaying a message only when the connection fails:
 
-`pg_isready --quiet`
+`pg_isready {{[-q|--quiet]}}`

--- a/pages/common/pg_restore.md
+++ b/pages/common/pg_restore.md
@@ -5,24 +5,24 @@
 
 - Restore an archive into an existing database:
 
-`pg_restore -d {{db_name}} {{archive_file.dump}}`
+`pg_restore {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
 
 - Same as above, customize username:
 
-`pg_restore -U {{username}} -d {{db_name}} {{archive_file.dump}}`
+`pg_restore {{[-U|--username]}} {{username}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
 
 - Same as above, customize host and port:
 
-`pg_restore -h {{host}} -p {{port}} -d {{db_name}} {{archive_file.dump}}`
+`pg_restore {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
 
 - List database objects included in the archive:
 
-`pg_restore --list {{archive_file.dump}}`
+`pg_restore {{[-l|--list]}} {{archive_file.dump}}`
 
 - Clean database objects before creating them:
 
-`pg_restore --clean -d {{db_name}} {{archive_file.dump}}`
+`pg_restore {{[-c|--clean]}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
 
 - Use multiple jobs to do the restoring:
 
-`pg_restore -j {{2}} -d {{db_name}} {{archive_file.dump}}`
+`pg_restore {{[-j|--jobs]}} {{2}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`

--- a/pages/common/phing.md
+++ b/pages/common/phing.md
@@ -1,7 +1,7 @@
 # phing
 
 > A PHP build tool based on Apache Ant.
-> More information: <https://www.phing.info>.
+> More information: <https://www.phing.info/guide/chunkhtml/ch03s03.html>.
 
 - Perform the default task in the `build.xml` file:
 
@@ -9,7 +9,7 @@
 
 - Initialize a new build file:
 
-`phing -i {{path/to/build.xml}}`
+`phing {{[-i|--init]}} {{path/to/build.xml}}`
 
 - Perform a specific task:
 
@@ -17,7 +17,7 @@
 
 - Use the given build file path:
 
-`phing -f {{path/to/build.xml}} {{task_name}}`
+`phing {{[-f|-buildfile]}} {{path/to/build.xml}} {{task_name}}`
 
 - Log to the given file:
 

--- a/pages/common/phpspec.md
+++ b/pages/common/phpspec.md
@@ -17,11 +17,11 @@
 
 - Run specifications using a specific configuration file:
 
-`phpspec run -c {{path/to/configuration_file}}`
+`phpspec run {{[-c|--config]}} {{path/to/configuration_file}}`
 
 - Run specifications using a specific bootstrap file:
 
-`phpspec run -b {{path/to/bootstrap_file}}`
+`phpspec run {{[-b|--bootstrap]}} {{path/to/bootstrap_file}}`
 
 - Disable code generation prompts:
 

--- a/pages/common/pigz.md
+++ b/pages/common/pigz.md
@@ -9,11 +9,11 @@
 
 - Compress a file using the best compression method:
 
-`pigz -9 {{path/to/file}}`
+`pigz {{[-9|--best]}} {{path/to/file}}`
 
 - Compress a file using no compression and 4 processors:
 
-`pigz -0 -p{{4}} {{path/to/file}}`
+`pigz -0 {{[-p|--processes]}} {{4}} {{path/to/file}}`
 
 - Compress a directory using tar:
 
@@ -21,8 +21,8 @@
 
 - Decompress a file:
 
-`pigz -d {{archive.gz}}`
+`pigz {{[-d|--decompress]}} {{archive.gz}}`
 
 - List the contents of an archive:
 
-`pigz -l {{archive.tar.gz}}`
+`pigz {{[-l|--list]}} {{archive.tar.gz}}`

--- a/pages/common/pip-freeze.md
+++ b/pages/common/pip-freeze.md
@@ -13,7 +13,7 @@
 
 - List installed packages in a virtual environment, excluding globally installed packages:
 
-`pip freeze --local > requirements.txt`
+`pip freeze {{[-l|--local]}} > requirements.txt`
 
 - List installed packages in the user-site:
 

--- a/pages/common/pip-install.md
+++ b/pages/common/pip-install.md
@@ -13,12 +13,12 @@
 
 - Install packages listed in a file:
 
-`pip install -r {{path/to/requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{path/to/requirements.txt}}`
 
 - Install packages from an URL or local file archive (.tar.gz | .whl):
 
-`pip install --find-links {{url|path/to/file}}`
+`pip install {{[-f|--find-links]}} {{url|path/to/file}}`
 
 - Install the local package in the current directory in develop (editable) mode:
 
-`pip install --editable {{.}}`
+`pip install {{[-e|--editable]}} {{.}}`

--- a/pages/common/pip-uninstall.md
+++ b/pages/common/pip-uninstall.md
@@ -9,8 +9,8 @@
 
 - Uninstall packages listed in a specific file:
 
-`pip uninstall --requirement {{path/to/requirements.txt}}`
+`pip uninstall {{[-r|--requirement]}} {{path/to/requirements.txt}}`
 
 - Uninstall package without asking for confirmation:
 
-`pip uninstall --yes {{package}}`
+`pip uninstall {{[-y|--yes]}} {{package}}`

--- a/pages/common/pip.md
+++ b/pages/common/pip.md
@@ -14,7 +14,7 @@
 
 - Upgrade a package:
 
-`pip install --upgrade {{package}}`
+`pip install {{[-U|--upgrade]}} {{package}}`
 
 - Uninstall a package:
 
@@ -30,4 +30,4 @@
 
 - Install packages from a file:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages/common/pip3.md
+++ b/pages/common/pip3.md
@@ -13,7 +13,7 @@
 
 - Upgrade a package:
 
-`pip3 install --upgrade {{package}}`
+`pip3 install {{[-U|--upgrade]}} {{package}}`
 
 - Uninstall a package:
 
@@ -25,7 +25,7 @@
 
 - Install packages from a file:
 
-`pip3 install --requirement {{requirements.txt}}`
+`pip3 install {{[-r|--requirement]}} {{requirements.txt}}`
 
 - Show installed package info:
 

--- a/pages/common/podman-compose.md
+++ b/pages/common/podman-compose.md
@@ -9,7 +9,7 @@
 
 - Create and start all containers in the background using a local `docker-compose.yml`:
 
-`podman-compose up -d`
+`podman-compose up {{[-d|--detach]}}`
 
 - Start all containers, building if needed:
 
@@ -25,11 +25,11 @@
 
 - Remove all containers, networks, and volumes:
 
-`podman-compose down --volumes`
+`podman-compose down {{[-v|--volumes]}}`
 
 - Follow logs for a container (omit all container names):
 
-`podman-compose logs --follow {{container_name}}`
+`podman-compose logs {{[-f|--follow]}} {{container_name}}`
 
 - Run a one-time command in a service with no ports mapped:
 

--- a/pages/common/popeye.md
+++ b/pages/common/popeye.md
@@ -9,12 +9,12 @@
 
 - Scan a specific namespace:
 
-`popeye -n {{namespace}}`
+`popeye {{[-n|--namespace]}} {{namespace}}`
 
 - Scan specific Kubernetes context:
 
-`popeye --context={{context}}`
+`popeye --context {{context}}`
 
 - Use a spinach configuration file for scanning:
 
-`popeye -f {{spinach.yaml}}`
+`popeye {{[-f|--file]}} {{spinach.yaml}}`

--- a/pages/common/powershell.md
+++ b/pages/common/powershell.md
@@ -10,4 +10,4 @@
 
 - View the documentation for the command referring to the legacy Windows PowerShell (version 5.1 and below):
 
-`tldr powershell -p windows`
+`tldr powershell {{[-p|--platform]}} windows`

--- a/pages/common/progress.md
+++ b/pages/common/progress.md
@@ -9,12 +9,12 @@
 
 - Show the progress of running coreutils in quiet mode:
 
-`progress -q`
+`progress {{[-q|--quiet]}}`
 
 - Launch and monitor a single long-running command:
 
-`{{command}} & progress --monitor --pid $!`
+`{{command}} & progress {{[-m|--monitor]}} {{[-p|--pid]}} $!`
 
 - Include an estimate of time remaining for completion:
 
-`progress --wait --command {{firefox}}`
+`progress {{[-w|--wait]}} {{[-c|--command]}} {{firefox}}`

--- a/pages/common/proxify.md
+++ b/pages/common/proxify.md
@@ -10,11 +10,11 @@
 
 - Start a HTTP proxy on a custom network interface and port (may require `sudo` for a port number lower than `1024`):
 
-`proxify -http-addr "{{ip_address}}:{{port_number}}"`
+`proxify {{[-ha|-http-addr]}} "{{ip_address}}:{{port_number}}"`
 
 - Specify output format and output file:
 
-`proxify -output-format {{jsonl|yaml}} -output {{path/to/file}}`
+`proxify {{[-of|-output-format]}} {{jsonl|yaml}} {{[-o|-output]}} {{path/to/file}}`
 
 - Display help:
 

--- a/pages/common/psql.md
+++ b/pages/common/psql.md
@@ -9,16 +9,16 @@
 
 - Connect to the database on given server host running on given port with given username, without a password prompt:
 
-`psql -h {{host}} -p {{port}} -U {{username}} {{database}}`
+`psql {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{database}}`
 
 - Connect to the database; user will be prompted for password:
 
-`psql -h {{host}} -p {{port}} -U {{username}} -W {{database}}`
+`psql {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-W|--password]}} {{database}}`
 
 - Execute a single SQL query or PostgreSQL command on the given database (useful in shell scripts):
 
-`psql -c '{{query}}' {{database}}`
+`psql {{[-c|--command]}} '{{query}}' {{database}}`
 
 - Execute commands from a file on the given database:
 
-`psql {{database}} -f {{file.sql}}`
+`psql {{database}} {{[-f|--file]}} {{file.sql}}`

--- a/pages/common/pssh.md
+++ b/pages/common/pssh.md
@@ -5,24 +5,24 @@
 
 - Run a command on two hosts, and print its output on each server inline:
 
-`pssh -i -H "{{host1}} {{host2}}" {{hostname -i}}`
+`pssh {{[-i|--inline]}} {{[-H|--host]}} "{{host1}} {{host2}}" {{hostname --ip-addresses}}`
 
 - Run a command and save the output to separate files:
 
-`pssh -H {{host1}} -H {{host2}} -o {{path/to/output_dir}} {{hostname -i}}`
+`pssh {{[-H|--host]}} {{host1}} {{[-H|--host]}} {{host2}} {{[-o|--outdir]}} {{path/to/output_dir}} {{hostname --ip-addresses}}`
 
 - Run a command on multiple hosts, specified in a new-line separated file:
 
-`pssh -i -h {{path/to/hosts_file}} {{hostname -i}}`
+`pssh {{[-i|--inline]}} {{[-h|--hosts]}} {{path/to/hosts_file}} {{hostname --ip-addresses}}`
 
 - Run a command as root (this asks for the root password):
 
-`pssh -i -h {{path/to/hosts_file}} -A -l {{root_username}} {{hostname -i}}`
+`pssh {{[-i|--inline]}} {{[-h|--hosts]}} {{path/to/hosts_file}} {{[-A|--askpass]}} {{[-l|--user]}} {{root_username}} {{hostname --ip-addresses}}`
 
 - Run a command with extra SSH arguments:
 
-`pssh -i -h {{path/to/hosts_file}} -x "{{-O VisualHostKey=yes}}" {{hostname -i}}`
+`pssh {{[-i|--inline]}} {{[-h|--hosts]}} {{path/to/hosts_file}} {{[-x|--extra-arg]}} "{{-O VisualHostKey=yes}}" {{hostname --ip-addresses}}`
 
 - Run a command limiting the number of parallel connections to 10:
 
-`pssh -i -h {{path/to/hosts_file}} -p {{10}} '{{cd dir; ./script.sh; exit}}'`
+`pssh {{[-i|--inline]}} {{[-h|--hosts]}} {{path/to/hosts_file}} {{[-p|-par]}} {{10}} '{{cd dir; ./script.sh; exit}}'`

--- a/pages/common/pt.md
+++ b/pages/common/pt.md
@@ -10,15 +10,15 @@
 
 - Find files containing "foo" and display count of matches in each file:
 
-`pt -c {{foo}}`
+`pt {{[-c|--count]}} {{foo}}`
 
 - Find files containing "foo" as a whole word and ignore its case:
 
-`pt -wi {{foo}}`
+`pt {{[-wi|--word-regexp --ignore-case]}} {{foo}}`
 
 - Find "foo" in files with a given extension using a regular expression:
 
-`pt -G='{{\.bar$}}' {{foo}}`
+`pt {{[-G|--file-search-regexp]}}='{{\.bar$}}' {{foo}}`
 
 - Find files whose contents match the regular expression, up to 2 directories deep:
 

--- a/pages/common/ptpython.md
+++ b/pages/common/ptpython.md
@@ -13,7 +13,7 @@
 
 - Execute a specific Python file and start a REPL:
 
-`ptpython -i {{path/to/file.py}}`
+`ptpython {{[-i|--interactive]}} {{path/to/file.py}}`
 
 - Open the menu:
 

--- a/pages/common/pueue-add.md
+++ b/pages/common/pueue-add.md
@@ -13,16 +13,16 @@
 
 - Add a command but do not start it if it's the first in a queue:
 
-`pueue add --stashed -- {{rsync --archive --compress /local/directory /remote/directory}}`
+`pueue add {{[-s|--stashed]}} -- {{rsync {{[-a|--archive]}} {{[-z|--compress]}} /local/directory /remote/directory}}`
 
 - Add a command to a group and start it immediately, see `pueue group` to manage groups:
 
-`pueue add --immediate --group "{{CPU_intensive}}" -- {{ffmpeg -i input.mp4 frame_%d.png}}`
+`pueue add {{[-i|--immediate]}} {{[-g|--group]}} "{{CPU_intensive}}" -- {{ffmpeg -i input.mp4 frame_%d.png}}`
 
 - Add a command and start it after commands 9 and 12 finish successfully:
 
-`pueue add --after {{9}} {{12}} --group "{{torrents}}" -- {{transmission-cli torrent_file.torrent}}`
+`pueue add {{[-a|--after]}} {{9}} {{12}} {{[-g|--group]}} "{{torrents}}" -- {{transmission-cli torrent_file.torrent}}`
 
 - Add a command with a label after some delay has passed, see `pueue enqueue` for valid datetime formats:
 
-`pueue add --label "{{compressing large file}}" --delay "{{wednesday 10:30pm}}" -- "{{7z a compressed_file.7z large_file.xml}}"`
+`pueue add {{[-l|--label]}} "{{compressing large file}}" {{[-d|--delay]}} "{{wednesday 10:30pm}}" -- "{{7z a compressed_file.7z large_file.xml}}"`

--- a/pages/common/pueue-clean.md
+++ b/pages/common/pueue-clean.md
@@ -9,4 +9,4 @@
 
 - Only clean commands that finished successfully:
 
-`pueue clean --successful-only`
+`pueue clean {{[-s|--successful-only]}}`

--- a/pages/common/pueue-enqueue.md
+++ b/pages/common/pueue-enqueue.md
@@ -10,20 +10,20 @@
 
 - Enqueue a stashed task after 60 seconds:
 
-`pueue enqueue --delay {{60}} {{task_id}}`
+`pueue enqueue {{[-d|--delay]}} {{60}} {{task_id}}`
 
 - Enqueue a stashed task next Wednesday:
 
-`pueue enqueue --delay {{wednesday}} {{task_id}}`
+`pueue enqueue {{[-d|--delay]}} {{wednesday}} {{task_id}}`
 
 - Enqueue a stashed task after four months:
 
-`pueue enqueue --delay "4 months" {{task_id}}`
+`pueue enqueue {{[-d|--delay]}} "4 months" {{task_id}}`
 
 - Enqueue a stashed task on 2021-02-19:
 
-`pueue enqueue --delay {{2021-02-19}} {{task_id}}`
+`pueue enqueue {{[-d|--delay]}} {{2021-02-19}} {{task_id}}`
 
 - List all available date/time formats:
 
-`pueue enqueue --help`
+`pueue enqueue {{[-h|--help]}}`

--- a/pages/common/pueue-group.md
+++ b/pages/common/pueue-group.md
@@ -9,8 +9,8 @@
 
 - Add a custom group:
 
-`pueue group --add "{{group_name}}"`
+`pueue group add "{{group_name}}"`
 
 - Remove a group and move its tasks to the default group:
 
-`pueue group --remove "{{group_name}}"`
+`pueue group remove "{{group_name}}"`

--- a/pages/common/pueue-kill.md
+++ b/pages/common/pueue-kill.md
@@ -17,8 +17,8 @@
 
 - Kill all tasks in a group and pause the group:
 
-`pueue kill --group {{group_name}}`
+`pueue kill {{[-g|--group]}} {{group_name}}`
 
 - Kill all tasks across all groups and pause all groups:
 
-`pueue kill --all`
+`pueue kill {{[-a|--all]}}`

--- a/pages/common/pueue-log.md
+++ b/pages/common/pueue-log.md
@@ -18,4 +18,4 @@
 
 - Print a specific number of lines from the tail of output:
 
-`pueue log --lines {{number_of_lines}} {{task_id}}`
+`pueue log {{[-l|--lines]}} {{number_of_lines}} {{task_id}}`

--- a/pages/common/pueue-parallel.md
+++ b/pages/common/pueue-parallel.md
@@ -9,4 +9,4 @@
 
 - Set the maximum number of tasks allowed to run in parallel, in a specific group:
 
-`pueue parallel --group {{group_name}} {{maximum_number_of_parallel_tasks}}`
+`pueue parallel {{[-g|--group]}} {{group_name}} {{maximum_number_of_parallel_tasks}}`

--- a/pages/common/pueue-pause.md
+++ b/pages/common/pueue-pause.md
@@ -18,8 +18,8 @@
 
 - Pause all tasks in a group and prevent it from starting new tasks:
 
-`pueue pause --group {{group_name}}`
+`pueue pause {{[-g|--group]}} {{group_name}}`
 
 - Pause all tasks and prevent all groups from starting new tasks:
 
-`pueue pause --all`
+`pueue pause {{[-a|--all]}}`

--- a/pages/common/pueue-reset.md
+++ b/pages/common/pueue-reset.md
@@ -13,4 +13,4 @@
 
 - Reset without asking for confirmation:
 
-`pueue reset --force`
+`pueue reset {{[-f|--force]}}`

--- a/pages/common/pueue-restart.md
+++ b/pages/common/pueue-restart.md
@@ -9,7 +9,7 @@
 
 - Restart multiple tasks at once, and start them immediately (do not enqueue):
 
-`pueue restart --start-immediately {{task_id}} {{task_id}}`
+`pueue restart {{[-k|--immediately]}} {{task_id}} {{task_id}}`
 
 - Restart a specific task from a different path:
 
@@ -17,12 +17,12 @@
 
 - Edit a command before restarting:
 
-`pueue restart --edit {{task_id}}`
+`pueue restart {{[-e|--edit]}} {{task_id}}`
 
 - Restart a task in-place (without enqueuing as a separate task):
 
-`pueue restart --in-place {{task_id}}`
+`pueue restart {{[-i|--in-place]}} {{task_id}}`
 
 - Restart all failed tasks and stash them:
 
-`pueue restart --all-failed --stashed`
+`pueue restart {{[-a|--all-failed]}} --stashed`

--- a/pages/common/pueue-start.md
+++ b/pages/common/pueue-start.md
@@ -18,7 +18,7 @@
 
 - Resume all tasks and start their children:
 
-`pueue start --all --children`
+`pueue start {{[-a|--all]}} --children`
 
 - Resume all tasks in a specific group:
 

--- a/pages/common/pueue-status.md
+++ b/pages/common/pueue-status.md
@@ -9,4 +9,4 @@
 
 - Show the status of a specific group:
 
-`pueue status --group {{group_name}}`
+`pueue status {{[-g|--group]}} {{group_name}}`

--- a/pages/common/pueue.md
+++ b/pages/common/pueue.md
@@ -6,7 +6,7 @@
 
 - Show general help and available subcommands:
 
-`pueue --help`
+`pueue {{[-h|--help]}}`
 
 - Execute a pueue subcommand:
 
@@ -14,4 +14,4 @@
 
 - Check the version of pueue:
 
-`pueue --version`
+`pueue {{[-V|--version]}}`

--- a/pages/common/pushd.md
+++ b/pages/common/pushd.md
@@ -2,7 +2,7 @@
 
 > Place a directory on a stack so it can be accessed later.
 > See also `popd` to switch back to original directory and `dirs` to display directory stack contents.
-> More information: <https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html>.
+> More information: <https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html#index-popd>.
 
 - Switch to directory and push it on the stack:
 

--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -9,20 +9,20 @@
 
 - Measure the speed and amount of data flow between pipes (`--size` is optional):
 
-`command1 | pv --size {{expected_amount_of_data_for_eta}} | command2`
+`command1 | pv {{[-s|--size]}} {{expected_amount_of_data_for_eta}} | command2`
 
 - Filter a file, see both progress and amount of output data:
 
-`pv -cN in {{big_text_file}} | grep {{pattern}} | pv -cN out > {{filtered_file}}`
+`pv {{[-cN|--cursor --name]}} in {{big_text_file}} | grep {{pattern}} | pv {{[-cN|--cursor --name]}} out > {{filtered_file}}`
 
 - Attach to an already running process and see its file reading progress:
 
-`pv -d {{PID}}`
+`pv {{[-d|--watchfd]}} {{PID}}`
 
 - Read an erroneous file, skip errors as `dd conv=sync,noerror` would:
 
-`pv -EE {{path/to/faulty_media}} > image.img`
+`pv {{[-EE|--skip-errors --skip-errors]}} {{path/to/faulty_media}} > image.img`
 
 - Stop reading after reading specified amount of data, rate limit to 1K/s:
 
-`pv -L 1K --stop-at --size {{maximum_file_size_to_be_read}}`
+`pv {{[-L|--rate-limit]}} 1K {{[-S|--stop-at-size]}} {{maximum_file_size_to_be_read}}`

--- a/pages/common/py-spy.md
+++ b/pages/common/py-spy.md
@@ -5,7 +5,7 @@
 
 - Show a live view of the functions that take the most execution time of a running process:
 
-`py-spy top --pid {{pid}}`
+`py-spy top {{[-p|--pid]}} {{pid}}`
 
 - Start a program and show a live view of the functions that take the most execution time:
 
@@ -13,8 +13,8 @@
 
 - Produce an SVG flame graph of the function call execution time:
 
-`py-spy record -o {{path/to/profile.svg}} --pid {{pid}}`
+`py-spy record {{[-o|--output]}} {{path/to/profile.svg}} {{[-p|--pid]}} {{pid}}`
 
 - Dump the call stack of a running process:
 
-`py-spy dump --pid {{pid}}`
+`py-spy dump {{[-p|--pid]}} {{pid}}`

--- a/pages/common/q.md
+++ b/pages/common/q.md
@@ -5,15 +5,15 @@
 
 - Query a CSV file by specifying the delimiter as ',':
 
-`q -d',' "SELECT * from {{path/to/file}}"`
+`q {{[-d|--delimiter]}} ',' "SELECT * from {{path/to/file}}"`
 
 - Query a TSV file:
 
-`q -t "SELECT * from {{path/to/file}}"`
+`q {{[-t|--tab-delimited]}} "SELECT * from {{path/to/file}}"`
 
 - Query file with header row:
 
-`q -d{{delimiter}} -H "SELECT * from {{path/to/file}}"`
+`q {{[-d|--delimiter]}} {{delimiter}} {{[-H|--skip-header]}} "SELECT * from {{path/to/file}}"`
 
 - Read data from `stdin`; '-' in the query represents the data from `stdin`:
 
@@ -25,4 +25,4 @@
 
 - Format output using an output delimiter with an output header line (Note: command will output column names based on the input file header or the column aliases overridden in the query):
 
-`q -D{{delimiter}} -O "SELECT {{column}} as {{alias}} from {{path/to/file}}"`
+`q {{[-D|--output-delimiter]}} {{delimiter}} {{[-O|--output-header]}} "SELECT {{column}} as {{alias}} from {{path/to/file}}"`

--- a/pages/common/qrencode.md
+++ b/pages/common/qrencode.md
@@ -1,20 +1,20 @@
 # qrencode
 
 > QR Code generator. Supports PNG and EPS.
-> More information: <https://fukuchi.org/works/qrencode>.
+> More information: <https://manned.org/qrencode>.
 
 - Convert a string to a QR code and save to an output file:
 
-`qrencode -o {{path/to/output_file.png}} {{string}}`
+`qrencode {{[-o|--output]}} {{path/to/output_file.png}} {{string}}`
 
 - Convert an input file to a QR code and save to an output file:
 
-`qrencode -o {{path/to/output_file.png}} -r {{path/to/input_file}}`
+`qrencode {{[-o|--output]}} {{path/to/output_file.png}} {{[-r|--read-from]}} {{path/to/input_file}}`
 
 - Convert a string to a QR code and print it in terminal:
 
-`qrencode -t ansiutf8 {{string}}`
+`qrencode {{[-t|--type]}} ansiutf8 {{string}}`
 
 - Convert input from pipe to a QR code and print it in terminal:
 
-`echo {{string}} | qrencode -t ansiutf8`
+`echo {{string}} | qrencode {{[-t|--type]}} ansiutf8`

--- a/pages/common/quilt.md
+++ b/pages/common/quilt.md
@@ -1,7 +1,7 @@
 # quilt
 
 > Manage a series of patches.
-> More information: <https://savannah.nongnu.org/projects/quilt>.
+> More information: <https://manned.org/quilt>.
 
 - Import an existing patch from a file:
 

--- a/pages/common/quota.md
+++ b/pages/common/quota.md
@@ -5,20 +5,20 @@
 
 - Show disk quotas in human-readable units for the current user:
 
-`quota -s`
+`quota {{[-s|--human-readable]}}`
 
 - Verbose output (also display quotas on filesystems where no storage is allocated):
 
-`quota -v`
+`quota {{[-v|--verbose]}}`
 
 - Quiet output (only display quotas on filesystems where usage is over quota):
 
-`quota -q`
+`quota {{[-q|--quiet]}}`
 
 - Print quotas for the groups of which the current user is a member:
 
-`quota -g`
+`quota {{[-g|--group]}}`
 
 - Show disk quotas for another user:
 
-`sudo quota -u {{username}}`
+`sudo quota {{[-u|--user]}} {{username}}`

--- a/pages/common/r.md
+++ b/pages/common/r.md
@@ -9,11 +9,11 @@
 
 - Start R in vanilla mode (i.e. a blank session that doesn't save the workspace at the end):
 
-`R --vanilla`
+`R {{[-v|--vanilla]}}`
 
 - Execute a file:
 
-`R -f {{path/to/file.R}}`
+`R {{[-f|--file]}} {{path/to/file.R}}`
 
 - Execute an R expression and then exit:
 
@@ -21,7 +21,7 @@
 
 - Run R with a debugger:
 
-`R -d {{debugger}}`
+`R {{[-d|--debugger]}} {{debugger}}`
 
 - Check R packages from package sources:
 

--- a/pages/common/rails-console.md
+++ b/pages/common/rails-console.md
@@ -9,12 +9,12 @@
 
 - Start the Rails console and roll back all data modifications on exit:
 
-`rails console --sandbox`
+`rails console {{[-s|--sandbox]}}`
 
 - Start the Rails console on a specified environment:
 
-`rails console --environment {{dev|test|production|...}}`
+`rails console {{[-e|--environment]}} {{dev|test|production|...}}`
 
 - Display help:
 
-`rails console --help`
+`rails console {{[-h|--help]}}`

--- a/pages/common/rails-new.md
+++ b/pages/common/rails-new.md
@@ -13,12 +13,12 @@
 
 - Create a Rails app with `postgresql` as the database:
 
-`rails new {{app_name}} --database postgresql`
+`rails new {{app_name}} {{[-d|--database]}} postgresql`
 
 - Create a Rails app without generating JavaScript files:
 
-`rails new {{app_name}} --skip-javascript`
+`rails new {{app_name}} {{[-J|--skip-javascript]}}`
 
 - Display help:
 
-`rails new --help`
+`rails new {{[-h|--help]}}`

--- a/pages/common/rails-routes.md
+++ b/pages/common/rails-routes.md
@@ -13,8 +13,8 @@
 
 - List routes partially matching URL helper method name, HTTP verb, or URL path:
 
-`rails routes -g {{posts_path|GET|/posts}}`
+`rails routes {{[-g|--grep]}} {{posts_path|GET|/posts}}`
 
 - List routes that map to a specified controller:
 
-`rails routes -c {{posts|Posts|Blogs::PostsController}}`
+`rails routes {{[-c|--controller]}} {{posts|Posts|Blogs::PostsController}}`

--- a/pages/common/rails-server.md
+++ b/pages/common/rails-server.md
@@ -9,16 +9,16 @@
 
 - Run the web server on a specified port:
 
-`rails server --port {{port_number}}`
+`rails server {{[-p|--port]}} {{port_number}}`
 
 - Run the web server on a specified IP address:
 
-`rails server --binding {{ip_address}}`
+`rails server {{[-b|--binding]}} {{ip_address}}`
 
 - Run the web server on a specified environment:
 
-`rails server --environment {{environment}}`
+`rails server {{[-e|--environment]}} {{environment}}`
 
 - Display help:
 
-`rails server --help`
+`rails server {{[-h|--help]}}`

--- a/pages/common/rails.md
+++ b/pages/common/rails.md
@@ -26,7 +26,7 @@
 
 - Start local server for current project on a specified port:
 
-`rails server -p "{{port}}"`
+`rails server {{[-p|--port]}} "{{port}}"`
 
 - Open console to interact with application from command-line:
 
@@ -34,4 +34,4 @@
 
 - Check current version of rails:
 
-`rails --version`
+`rails {{[-v|--version]}}`

--- a/pages/common/rapper.md
+++ b/pages/common/rapper.md
@@ -6,8 +6,8 @@
 
 - Convert an RDF/XML document to Turtle:
 
-`rapper -i rdfxml -o turtle {{path/to/file}}`
+`rapper {{[-i|--input]}} rdfxml {{[-o|--output]}} turtle {{path/to/file}}`
 
 - Count the number of triples in a Turtle file:
 
-`rapper -i turtle -c {{path/to/file}}`
+`rapper {{[-i|--input]}} turtle {{[-c|--count]}} {{path/to/file}}`

--- a/pages/common/rbac-lookup.md
+++ b/pages/common/rbac-lookup.md
@@ -13,11 +13,11 @@
 
 - View all RBAC bindings along with the source role binding:
 
-`rbac-lookup -o wide`
+`rbac-lookup {{[-o|--output]}} wide`
 
 - View all RBAC bindings filtered by subject:
 
-`rbac-lookup -k {{user|group|serviceaccount}}`
+`rbac-lookup {{[-k|--kind]}} {{user|group|serviceaccount}}`
 
 - View all RBAC bindings along with IAM roles (if you are using GKE):
 

--- a/pages/common/rclone.md
+++ b/pages/common/rclone.md
@@ -17,7 +17,7 @@
 
 - Copy files changed within the past 24 hours to a remote from the local machine, asking the user to confirm each file:
 
-`rclone copy --interactive --max-age 24h {{remote_name}}:{{path/to/directory}} {{path/to/local_directory}}`
+`rclone copy {{[-i|--interactive]}} --max-age 24h {{remote_name}}:{{path/to/directory}} {{path/to/local_directory}}`
 
 - Mirror a specific file or directory (Note: Unlike copy, sync removes files from the remote if it does not exist locally):
 
@@ -25,7 +25,7 @@
 
 - Delete a remote file or directory (Note: `--dry-run` means test, remove it from the command to actually delete):
 
-`rclone --dry-run delete {{remote_name}}:{{path/to/file_or_directory}}`
+`rclone {{[-n|--dry-run]}} delete {{remote_name}}:{{path/to/file_or_directory}}`
 
 - Mount rclone remote (experimental):
 
@@ -33,4 +33,4 @@
 
 - Unmount rclone remote if `<Ctrl c>` fails (experimental):
 
-`fusermount -u {{path/to/mount_point}}`
+`fusermount {{[-u|--update]}} {{path/to/mount_point}}`

--- a/pages/common/route.md
+++ b/pages/common/route.md
@@ -1,6 +1,6 @@
 # route
 
-> Use route cmd to set the route table.
+> Show and manipulate the route table.
 > More information: <https://manned.org/route>.
 
 - Display the information of route table:

--- a/pages/common/rss2email.md
+++ b/pages/common/rss2email.md
@@ -25,4 +25,4 @@
 
 - Display help:
 
-`r2e -h`
+`r2e {{[-h|--help]}}`

--- a/pages/common/rsstail.md
+++ b/pages/common/rsstail.md
@@ -1,7 +1,7 @@
 # rsstail
 
 > `tail` for RSS feeds.
-> More information: <https://github.com/gvalkov/rsstail.py>.
+> More information: <https://manned.org/rsstail>.
 
 - Show the feed of a given URL and wait for new entries appearing at the bottom:
 

--- a/pages/common/rtmpdump.md
+++ b/pages/common/rtmpdump.md
@@ -5,16 +5,16 @@
 
 - Download a file:
 
-`rtmpdump --rtmp {{rtmp://example.com/path/to/video}} -o {{file.ext}}`
+`rtmpdump {{[-r|--rtmp]}} {{rtmp://example.com/path/to/video}} {{[-o|--flv]}} {{file.ext}}`
 
 - Download a file from a Flash player:
 
-`rtmpdump --rtmp {{rtmp://example.com/path/to/video}} --swfVfy {{http://example.com/player}} --flashVer "{{LNX 10,0,32,18}}" -o {{file.ext}}`
+`rtmpdump {{[-r|--rtmp]}} {{rtmp://example.com/path/to/video}} {{[-W|--swfVfy]}} {{http://example.com/player}} {{[-f|--flashVer]}} "{{LNX 10,0,32,18}}" {{[-o|--flv]}} {{file.ext}}`
 
 - Specify connection parameters if they are not detected correctly:
 
-`rtmpdump --rtmp {{rtmp://example.com/path/to/video}} --app {{app_name}} --playpath {{path/to/video}} -o {{file.ext}}`
+`rtmpdump {{[-r|--rtmp]}} {{rtmp://example.com/path/to/video}} {{[-a|--app]}} {{app_name}} {{[-y|--playpath]}} {{path/to/video}} {{[-o|--flv]}} {{file.ext}}`
 
 - Download a file from a server that requires a referrer:
 
-`rtmpdump --rtmp {{rtmp://example.com/path/to/video}} --pageUrl {{http://example.com/webpage}} -o {{file.ext}}`
+`rtmpdump {{[-r|--rtmp]}} {{rtmp://example.com/path/to/video}} {{[-p|--pageUrl]}} {{http://example.com/webpage}} {{[-o|--flv]}} {{file.ext}}`

--- a/pages/common/rustc.md
+++ b/pages/common/rustc.md
@@ -10,7 +10,7 @@
 
 - Compile with optimizations (`s` means optimize for binary size; `z` is the same with even more optimizations):
 
-`rustc -C lto -C opt-level={{0|1|2|3|s|z}} {{path/to/main.rs}}`
+`rustc {{[-C|--codegen]}} lto {{[-C|--codegen]}} opt-level={{0|1|2|3|s|z}} {{path/to/main.rs}}`
 
 - Compile with debugging information:
 
@@ -22,7 +22,7 @@
 
 - Compile with architecture-specific optimizations for the current CPU:
 
-`rustc -C target-cpu={{native}} {{path/to/main.rs}}`
+`rustc {{[-C|--codegen]}} target-cpu={{native}} {{path/to/main.rs}}`
 
 - Display the target list (Note: you have to add a target using `rustup` first to be able to compile for it):
 

--- a/pages/common/salt-call.md
+++ b/pages/common/salt-call.md
@@ -13,7 +13,7 @@
 
 - Perform a highstate with verbose debugging output:
 
-`salt-call -l debug state.highstate`
+`salt-call {{[-l|--log-level]}} debug state.highstate`
 
 - List this minion's grains:
 

--- a/pages/common/salt-key.md
+++ b/pages/common/salt-key.md
@@ -6,16 +6,16 @@
 
 - List all accepted, unaccepted and rejected minion keys:
 
-`salt-key -L`
+`salt-key {{[-L|--list-all]}}`
 
 - Accept a minion key by name:
 
-`salt-key -a {{MINION_ID}}`
+`salt-key {{[-a|--accept-all]}} {{MINION_ID}}`
 
 - Reject a minion key by name:
 
-`salt-key -r {{MINION_ID}}`
+`salt-key {{[-r|--reject]}} {{MINION_ID}}`
 
 - Print fingerprints of all public keys:
 
-`salt-key -F`
+`salt-key {{[-F|--finger-all]}}`

--- a/pages/common/samtools.md
+++ b/pages/common/samtools.md
@@ -6,15 +6,15 @@
 
 - Convert a SAM input file to BAM stream and save to file:
 
-`samtools view -S -b {{input.sam}} > {{output.bam}}`
+`samtools view -S {{[-b|--bam]}} {{input.sam}} > {{output.bam}}`
 
 - Take input from `stdin` (-) and print the SAM header and any reads overlapping a specific region to `stdout`:
 
-`{{other_command}} | samtools view -h - chromosome:start-end`
+`{{other_command}} | samtools view {{[-h|--with-header]}} - chromosome:start-end`
 
 - Sort file and save to BAM (the output format is automatically determined from the output file's extension):
 
-`samtools sort {{input}} -o {{output.bam}}`
+`samtools sort {{input}} {{[-o|--output]}} {{output.bam}}`
 
 - Index a sorted BAM file (creates `sorted_input.bam.bai`):
 

--- a/pages/common/scc.md
+++ b/pages/common/scc.md
@@ -17,11 +17,11 @@
 
 - Display output using a specific output format (defaults to `tabular`):
 
-`scc --format {{tabular|wide|json|csv|cloc-yaml|html|html-table}}`
+`scc {{[-f|--format]}} {{tabular|wide|json|csv|cloc-yaml|html|html-table}}`
 
 - Only count files with specific file extensions:
 
-`scc --include-ext {{go,java,js}}`
+`scc {{[-i|--include-ext]}} {{go,java,js}}`
 
 - Exclude directories from being counted:
 
@@ -29,8 +29,8 @@
 
 - Display output and sort by column (defaults to by files):
 
-`scc --sort {{files|name|lines|blanks|code|comments|complexity}}`
+`scc {{[-s|--sort]}} {{files|name|lines|blanks|code|comments|complexity}}`
 
 - Display help:
 
-`scc -h`
+`scc {{[-h|--help]}}`

--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -13,7 +13,7 @@
 
 - Find and replace in a specific file (output stream: `stdout`):
 
-`sd -p {{'window.fetch'}} {{'fetch'}} {{path/to/file.js}}`
+`sd {{[-p|--preview]}} {{'window.fetch'}} {{'fetch'}} {{path/to/file.js}}`
 
 - Find and replace in all files in the current project (output stream: `stdout`):
 

--- a/pages/common/sdiff.md
+++ b/pages/common/sdiff.md
@@ -9,16 +9,16 @@
 
 - Compare 2 files, ignoring all tabs and whitespace:
 
-`sdiff -W {{path/to/file1}} {{path/to/file2}}`
+`sdiff {{[-W|--ignore-all-space]}} {{path/to/file1}} {{path/to/file2}}`
 
 - Compare 2 files, ignoring whitespace at the end of lines:
 
-`sdiff -Z {{path/to/file1}} {{path/to/file2}}`
+`sdiff {{[-Z|--ignore-trailing-space]}} {{path/to/file1}} {{path/to/file2}}`
 
 - Compare 2 files in a case-insensitive manner:
 
-`sdiff -i {{path/to/file1}} {{path/to/file2}}`
+`sdiff {{[-i|--ignore-case]}} {{path/to/file1}} {{path/to/file2}}`
 
 - Compare and then merge, writing the output to a new file:
 
-`sdiff -o {{path/to/merged_file}} {{path/to/file1}} {{path/to/file2}}`
+`sdiff {{[-o|--output]}} {{path/to/merged_file}} {{path/to/file1}} {{path/to/file2}}`

--- a/pages/common/serverless.md
+++ b/pages/common/serverless.md
@@ -26,4 +26,4 @@
 
 - Follow the logs for a project:
 
-`serverless logs -t`
+`serverless logs {{[-t|--tail]}}`

--- a/pages/common/shred.md
+++ b/pages/common/shred.md
@@ -25,4 +25,4 @@
 
 - Overwrite a file 100 times, add a final overwrite with zeros, remove the file after overwriting it and show verbose progress on the screen:
 
-`shred {{[-vzun|--verbose --zero -u --iterations]}} 100 {{path/to/file}}`
+`shred {{[-vzun|--verbose --zero --remove --iterations]}} 100 {{path/to/file}}`

--- a/pages/common/skaffold.md
+++ b/pages/common/skaffold.md
@@ -5,20 +5,20 @@
 
 - Build the artifacts:
 
-`skaffold build -f {{skaffold.yaml}}`
+`skaffold build {{[-f|--filename]}} {{skaffold.yaml}}`
 
 - Build and deploy your app every time your code changes:
 
-`skaffold dev -f {{skaffold.yaml}}`
+`skaffold dev {{[-f|--filename]}} {{skaffold.yaml}}`
 
 - Run a pipeline file:
 
-`skaffold run -f {{skaffold.yaml}}`
+`skaffold run {{[-f|--filename]}} {{skaffold.yaml}}`
 
 - Run a diagnostic on Skaffold:
 
-`skaffold diagnose -f {{skaffold.yaml}}`
+`skaffold diagnose {{[-f|--filename]}} {{skaffold.yaml}}`
 
 - Deploy the artifacts:
 
-`skaffold deploy -f {{skaffold.yaml}}`
+`skaffold deploy {{[-f|--filename]}} {{skaffold.yaml}}`

--- a/pages/common/sonar-scanner.md
+++ b/pages/common/sonar-scanner.md
@@ -9,12 +9,12 @@
 
 - Scan a project using configuration file other than `sonar-project.properties`:
 
-`sonar-scanner -D{{project.settings=myproject.properties}}`
+`sonar-scanner {{[-D|--define]}} {{project.settings=myproject.properties}}`
 
 - Print debugging information:
 
-`sonar-scanner -X`
+`sonar-scanner {{[-X|--debug]}}`
 
 - Display help:
 
-`sonar-scanner -h`
+`sonar-scanner {{[-h|--help]}}`

--- a/pages/common/sox.md
+++ b/pages/common/sox.md
@@ -2,11 +2,11 @@
 
 > Sound eXchange: play, record and convert audio files.
 > Audio formats are identified by the extension.
-> More information: <https://sox.sourceforge.net>.
+> More information: <https://manned.org/sox>.
 
 - Merge two audio files into one:
 
-`sox -m {{path/to/input_audio1}} {{path/to/input_audio2}} {{path/to/output_audio}}`
+`sox {{[-m|--combine mix]}} {{path/to/input_audio1}} {{path/to/input_audio2}} {{path/to/output_audio}}`
 
 - Trim an audio file to the specified times:
 
@@ -22,8 +22,8 @@
 
 - Print statistical data of an audio file:
 
-`sox {{path/to/input_audio}} -n stat`
+`sox {{path/to/input_audio}} {{[-n|--null]}} stat`
 
 - Increase the volume of an audio file by 2x:
 
-`sox -v 2.0 {{path/to/input_audio}} {{path/to/output_audio}}`
+`sox {{[-v|--volume]}} 2.0 {{path/to/input_audio}} {{path/to/output_audio}}`

--- a/pages/common/sphinx-build.md
+++ b/pages/common/sphinx-build.md
@@ -5,8 +5,8 @@
 
 - Build documentation:
 
-`sphinx-build -b {{html|epub|text|latex|man|...}} {{path/to/source_dir}} {{path/to/build_dir}}`
+`sphinx-build {{[-b|--builder]}} {{html|epub|text|latex|man|...}} {{path/to/source_dir}} {{path/to/build_dir}}`
 
 - Build documentations intended for readthedocs.io (requires the sphinx-rtd-theme pip package):
 
-`sphinx-build -b {{html}} {{path/to/docs_dir}} {{path/to/build_dir}}`
+`sphinx-build {{[-b|--builder]}} {{html}} {{path/to/docs_dir}} {{path/to/build_dir}}`

--- a/pages/common/sponge.md
+++ b/pages/common/sponge.md
@@ -9,4 +9,4 @@
 
 - Remove all lines starting with # in a file:
 
-`grep -v '^{{#}}' {{path/to/file}} | sponge {{path/to/file}}`
+`grep {{[-v|--invert-match]}} '^{{#}}' {{path/to/file}} | sponge {{path/to/file}}`

--- a/pages/common/sqlite-utils.md
+++ b/pages/common/sqlite-utils.md
@@ -33,4 +33,4 @@
 
 - Display help:
 
-`sqlite-utils -h`
+`sqlite-utils {{[-h|--help]}}`

--- a/pages/common/sqlmap.md
+++ b/pages/common/sqlmap.md
@@ -5,20 +5,20 @@
 
 - Run sqlmap against a single target URL:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php?id=1}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.target.com/vuln.php?id=1}}"`
 
 - Send data in a POST request (`--data` implies POST request):
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --data="{{id=1}}"`
+`python sqlmap.py  {{[-u|--url]}} "{{http://www.target.com/vuln.php}}" --data="{{id=1}}"`
 
 - Change the parameter delimiter (& is the default):
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
+`python sqlmap.py  {{[-u|--url]}} "{{http://www.target.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
 
 - Select a random `User-Agent` from `./txt/user-agents.txt` and use it:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --random-agent`
+`python sqlmap.py  {{[-u|--url]}} "{{http://www.target.com/vuln.php}}" --random-agent`
 
 - Provide user credentials for HTTP protocol authentication:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`
+`python sqlmap.py  {{[-u|--url]}} "{{http://www.target.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`

--- a/pages/common/srm.md
+++ b/pages/common/srm.md
@@ -6,7 +6,7 @@
 
 - Remove a file after a single-pass overwriting with random data:
 
-`srm -s {{path/to/file}}`
+`srm {{[-s|--simple]}} {{path/to/file}}`
 
 - Remove a file after seven passes of overwriting with random data:
 
@@ -14,8 +14,8 @@
 
 - Recursively remove a directory and its contents overwriting each file with a single-pass of random data:
 
-`srm -r -s {{path/to/directory}}`
+`srm {{[-r|--recursive]}} {{[-s|--simple]}} {{path/to/directory}}`
 
 - Prompt before every removal:
 
-`srm -i {{\*}}`
+`srm {{[-i|--interactive]}} {{\*}}`

--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -5,7 +5,7 @@
 
 - Run GDB server on port 4500:
 
-`st-util -p {{4500}}`
+`st-util {{[-p|--listen_port]}} {{4500}}`
 
 - Connect to GDB server:
 

--- a/pages/common/strings.md
+++ b/pages/common/strings.md
@@ -9,12 +9,12 @@
 
 - Limit results to strings at least n characters long:
 
-`strings -n {{n}} {{path/to/file}}`
+`strings {{[-n|--bytes]}} {{n}} {{path/to/file}}`
 
 - Prefix each result with its offset within the file:
 
-`strings -t d {{path/to/file}}`
+`strings {{[-t|--radix]}} d {{path/to/file}}`
 
 - Prefix each result with its offset within the file in hexadecimal:
 
-`strings -t x {{path/to/file}}`
+`strings {{[-t|--radix]}} x {{path/to/file}}`

--- a/pages/common/subliminal.md
+++ b/pages/common/subliminal.md
@@ -5,4 +5,4 @@
 
 - Download English subtitles for a video:
 
-`subliminal download -l {{en}} {{video.ext}}`
+`subliminal download {{[-l|--language]}} {{en}} {{video.ext}}`

--- a/pages/common/supervisord.md
+++ b/pages/common/supervisord.md
@@ -6,8 +6,8 @@
 
 - Start `supervisord` with specified configuration file:
 
-`supervisord -c {{path/to/file}}`
+`supervisord {{[-c|--configuration]}} {{path/to/file}}`
 
 - Run supervisord in the foreground:
 
-`supervisord -n`
+`supervisord {{[-n|--nodaemon]}}`

--- a/pages/common/svgo.md
+++ b/pages/common/svgo.md
@@ -10,23 +10,23 @@
 
 - Optimize a file and save the result to another file:
 
-`svgo {{test.svg}} -o {{test.min.svg}}`
+`svgo {{test.svg}} {{[-o|--output]}} {{test.min.svg}}`
 
 - Optimize all SVG files within a directory (overwrites the original files):
 
-`svgo -f {{path/to/directory/with/svg/files}}`
+`svgo {{[-f|--folder]}} {{path/to/directory/with/svg/files}}`
 
 - Optimize all SVG files within a directory and save the resulting files to another directory:
 
-`svgo -f {{path/to/input/directory}} -o {{path/to/output/directory}}`
+`svgo {{[-f|--folder]}} {{path/to/input/directory}} {{[-o|--output]}} {{path/to/output/directory}}`
 
 - Optimize SVG content passed from another command, and save the result to a file:
 
-`{{cat test.svg}} | svgo -i - -o {{test.min.svg}}`
+`{{cat test.svg}} | svgo {{[-i|--input]}} - {{[-o|--output]}} {{test.min.svg}}`
 
 - Optimize a file and print out the result:
 
-`svgo {{test.svg}} -o -`
+`svgo {{test.svg}} {{[-o|--output]}} -`
 
 - Show available plugins:
 

--- a/pages/common/swagger-codegen.md
+++ b/pages/common/swagger-codegen.md
@@ -5,11 +5,11 @@
 
 - Generate documentation and code from an OpenAPI/swagger file:
 
-`swagger-codegen generate -i {{swagger_file}} -l {{language}}`
+`swagger-codegen generate {{[-i|--input-spec]}} {{swagger_file}} {{[-l|--lang]}} {{language}}`
 
 - Generate Java code using the library retrofit2 and the option useRxJava2:
 
-`swagger-codegen generate -i {{http://petstore.swagger.io/v2/swagger.json}} -l {{java}} --library {{retrofit2}} -D{{useRxJava2}}={{true}}`
+`swagger-codegen generate {{[-i|--input-spec]}} {{http://petstore.swagger.io/v2/swagger.json}} {{[-l|--lang]}} {{java}} --library {{retrofit2}} -D{{useRxJava2}}={{true}}`
 
 - List available languages:
 

--- a/pages/common/tcpreplay.md
+++ b/pages/common/tcpreplay.md
@@ -9,20 +9,20 @@
 
 - Replay traffic to interface:
 
-`tcpreplay -i {{eth0}} {{traffic.pcap}}`
+`tcpreplay {{[-i|--intf1]}} {{eth0}} {{traffic.pcap}}`
 
 - Replay traffic to interface and `stdout`:
 
-`tcpreplay -i {{eth0}} --verbose {{traffic.pcap}}`
+`tcpreplay {{[-i|--intf1]}} {{eth0}} {{[-v|--verbose]}} {{traffic.pcap}}`
 
 - Replay traffic to interface as fast as possible:
 
-`tcpreplay -i {{eth0}} --topspeed {{traffic.pcap}}`
+`tcpreplay {{[-i|--intf1]}} {{eth0}} {{[-t|--topspeed]}} {{traffic.pcap}}`
 
 - Replay traffic to interface at given Mbps:
 
-`tcpreplay -i {{eth0}} -M {{10}} {{traffic.pcap}}`
+`tcpreplay {{[-i|--intf1]}} {{eth0}} {{[-M|--mbps]}} {{10}} {{traffic.pcap}}`
 
 - Replay traffic to interface several times:
 
-`tcpreplay -i {{eth0}} --loop={{num_times}} {{traffic.pcap}}`
+`tcpreplay {{[-i|--intf1]}} {{eth0}} {{[-l|--loop]}} {{num_times}} {{traffic.pcap}}`

--- a/pages/common/tee.md
+++ b/pages/common/tee.md
@@ -17,4 +17,4 @@
 
 - Create a directory called "example", count the number of characters in "example" and write "example" to the terminal:
 
-`echo "example" | tee >(xargs mkdir) >(wc -c)`
+`echo "example" | tee >(xargs mkdir) >(wc {{[-c|--bytes]}})`

--- a/pages/common/telnet.md
+++ b/pages/common/telnet.md
@@ -21,7 +21,7 @@
 
 - Start `telnet` with "x" as the session termination character:
 
-`telnet -e {{x}} {{ip_address}} {{port}}`
+`telnet {{[-e|--escape]}} {{x}} {{ip_address}} {{port}}`
 
 - Telnet to Star Wars animation:
 

--- a/pages/common/tokei.md
+++ b/pages/common/tokei.md
@@ -9,12 +9,12 @@
 
 - Display a report for a directory excluding `.min.js` files:
 
-`tokei {{path/to/directory}} -e {{*.min.js}}`
+`tokei {{path/to/directory}} {{[-e|--exclude]}} {{*.min.js}}`
 
 - Display statistics for individual files in a directory:
 
-`tokei {{path/to/directory}} --files`
+`tokei {{path/to/directory}} {{[-f|--files]}}`
 
 - Display a report for all files of type Rust and Markdown:
 
-`tokei {{path/to/directory}} -t={{Rust}},{{Markdown}}`
+`tokei {{path/to/directory}} {{[-t|--type]}} {{Rust}},{{Markdown}}`

--- a/pages/common/topgrade.md
+++ b/pages/common/topgrade.md
@@ -9,11 +9,11 @@
 
 - Say yes to all updates:
 
-`topgrade -y`
+`topgrade {{[-y|--yes]}}`
 
 - Cleanup temporary/old files:
 
-`topgrade -c`
+`topgrade {{[-c|--cleanup]}}`
 
 - Disable a certain update operation:
 

--- a/pages/common/tox.md
+++ b/pages/common/tox.md
@@ -14,7 +14,7 @@
 
 - List the available environments:
 
-`tox --listenvs-all`
+`tox {{[-a|--listenvs-all]}}`
 
 - Run tests on a specific environment (e.g. Python 3.6):
 
@@ -22,4 +22,4 @@
 
 - Force the virtual environment to be recreated:
 
-`tox --recreate -e {{py27}}`
+`tox {{[-r|--recreate]}} -e {{py27}}`

--- a/pages/common/tqdm.md
+++ b/pages/common/tqdm.md
@@ -13,8 +13,8 @@
 
 - Create an archive out of a directory and use the file count of that directory to create a progress bar:
 
-`zip -r {{path/to/archive.zip}} {{path/to/directory}} | tqdm --total $(find {{path/to/directory}} | wc -l) --unit files --null`
+`zip {{[-r|--recurse-paths]}} {{path/to/archive.zip}} {{path/to/directory}} | tqdm --total $(find {{path/to/directory}} | wc {{[-l|--lines]}}) --unit files --null`
 
 - Create an archive with tar and create a progress bar (system agnostic, GNU tar uses `stdout` while BSD tar uses `stderr`):
 
-`tar vzcf {{path/to/archive.tar.gz}} {{path/to/directory}} 2>&1 | tqdm --total $(find {{path/to/directory}} | wc -l) --unit files --null`
+`tar vzcf {{path/to/archive.tar.gz}} {{path/to/directory}} 2>&1 | tqdm --total $(find {{path/to/directory}} | wc {{[-l|--lines]}}) --unit files --null`

--- a/pages/common/traceroute.md
+++ b/pages/common/traceroute.md
@@ -13,11 +13,11 @@
 
 - Specify wait time in seconds for response:
 
-`traceroute --wait={{0.5}} {{example.com}}`
+`traceroute {{[-w|--wait]}} {{0.5}} {{example.com}}`
 
 - Specify number of queries per hop:
 
-`traceroute --queries={{5}} {{example.com}}`
+`traceroute {{[-q|--queries]}} {{5}} {{example.com}}`
 
 - Specify size in bytes of probing packet:
 
@@ -29,4 +29,4 @@
 
 - Use ICMP instead of UDP for tracerouting:
 
-`traceroute --icmp {{example.com}}`
+`traceroute {{[-I|--icmp]}} {{example.com}}`

--- a/pages/common/trans.md
+++ b/pages/common/trans.md
@@ -9,7 +9,7 @@
 
 - Get a brief translation:
 
-`trans --brief "{{word_or_sentence_to_translate}}"`
+`trans {{[-b|-brief]}} "{{word_or_sentence_to_translate}}"`
 
 - Translate a word into french:
 
@@ -21,4 +21,4 @@
 
 - Behave like a dictionary to get the meaning of a word:
 
-`trans -d {{word}}`
+`trans {{[-d|-dictionary]}} {{word}}`

--- a/pages/common/transmission-cli.md
+++ b/pages/common/transmission-cli.md
@@ -2,7 +2,7 @@
 
 > A lightweight, command-line BitTorrent client.
 > This tool has been deprecated, please see `transmission-remote`.
-> More information: <https://transmissionbt.com>.
+> More information: <https://manned.org/transmission-cli>.
 
 - Download a specific torrent:
 
@@ -10,7 +10,7 @@
 
 - Download a torrent to a specific directory:
 
-`transmission-cli --download-dir {{path/to/download_directory}} {{url|magnet|path/to/file}}`
+`transmission-cli {{[-w|--download-dir]}} {{path/to/download_directory}} {{url|magnet|path/to/file}}`
 
 - Create a torrent file from a specific file or directory:
 
@@ -18,20 +18,20 @@
 
 - Specify the download speed limit (in KB/s):
 
-`transmission-cli --downlimit {{50}} {{url|magnet|path/to/file}}`
+`transmission-cli {{[-d|--downlimit]}} {{50}} {{url|magnet|path/to/file}}`
 
 - Specify the upload speed limit (in KB/s):
 
-`transmission-cli --uplimit {{50}} {{url|magnet|path/to/file}}`
+`transmission-cli {{[-u|--uplimit]}} {{50}} {{url|magnet|path/to/file}}`
 
 - Use a specific port for connections:
 
-`transmission-cli --port {{port_number}} {{url|magnet|path/to/file}}`
+`transmission-cli {{[-p|--port]}} {{port_number}} {{url|magnet|path/to/file}}`
 
 - Force encryption for peer connections:
 
-`transmission-cli --encryption-required {{url|magnet|path/to/file}}`
+`transmission-cli {{[-er|--encryption-required]}} {{url|magnet|path/to/file}}`
 
 - Use a Bluetack-formatted peer blocklist:
 
-`transmission-cli --blocklist {{blocklist_url|path/to/blocklist}} {{url|magnet|path/to/file}}`
+`transmission-cli {{[-b|--blocklist]}} {{blocklist_url|path/to/blocklist}} {{url|magnet|path/to/file}}`

--- a/pages/common/transmission-create.md
+++ b/pages/common/transmission-create.md
@@ -6,20 +6,20 @@
 
 - Create a torrent with 2048 KB as the piece size:
 
-`transmission-create -o {{path/to/example.torrent}} --tracker {{tracker_announce_url}} --piecesize {{2048}} {{path/to/file_or_directory}}`
+`transmission-create {{[-o|--outfile]}} {{path/to/example.torrent}} {{[-t|--tracker]}} {{tracker_announce_url}} {{[-s|--piecesize]}} {{2048}} {{path/to/file_or_directory}}`
 
 - Create a private torrent with a 2048 KB piece size:
 
-`transmission-create -p -o {{path/to/example.torrent}} --tracker {{tracker_announce_url}} --piecesize {{2048}} {{path/to/file_or_directory}}`
+`transmission-create {{[-p|--private]}} {{[-o|--outfile]}} {{path/to/example.torrent}} {{[-t|--tracker]}} {{tracker_announce_url}} {{[-s|--piecesize]}} {{2048}} {{path/to/file_or_directory}}`
 
 - Create a torrent with a comment:
 
-`transmission-create -o {{path/to/example.torrent}} --tracker {{tracker_url1}} -c {{comment}} {{path/to/file_or_directory}}`
+`transmission-create {{[-o|--outfile]}} {{path/to/example.torrent}} {{[-t|--tracker]}} {{tracker_url1}} {{[-c|--comment]}} {{comment}} {{path/to/file_or_directory}}`
 
 - Create a torrent with multiple trackers:
 
-`transmission-create -o {{path/to/example.torrent}} --tracker {{tracker_url1}} --tracker {{tracker_url2}} {{path/to/file_or_directory}}`
+`transmission-create {{[-o|--outfile]}} {{path/to/example.torrent}} {{[-t|--tracker]}} {{tracker_url1}} {{[-t|--tracker]}} {{tracker_url2}} {{path/to/file_or_directory}}`
 
 - Display help page:
 
-`transmission-create --help`
+`transmission-create {{[-h|--help]}}`

--- a/pages/common/transmission-daemon.md
+++ b/pages/common/transmission-daemon.md
@@ -10,12 +10,12 @@
 
 - Start and watch a specific directory for new torrents:
 
-`transmission-daemon --watch-dir {{path/to/directory}}`
+`transmission-daemon {{[-c|--watch-dir]}} {{path/to/directory}}`
 
 - Dump daemon settings in JSON format:
 
-`transmission-daemon --dump-settings > {{path/to/file.json}}`
+`transmission-daemon {{[-d|--dump-settings]}} > {{path/to/file.json}}`
 
 - Start with specific settings for the web interface:
 
-`transmission-daemon --auth --username {{username}} --password {{password}} --port {{9091}} --allowed {{127.0.0.1}}`
+`transmission-daemon {{[-t|--auth]}} {{[-u|--username]}} {{username}} {{[-v|--password]}} {{password}} {{[-p|--port]}} {{9091}} {{[-a|--allowed]}} {{127.0.0.1}}`

--- a/pages/common/transmission-edit.md
+++ b/pages/common/transmission-edit.md
@@ -4,10 +4,14 @@
 > See also: `transmission`.
 > More information: <https://manned.org/transmission-edit>.
 
-- Add or remove a URL from a torrent's announce list:
+- Add a URL to a torrent's announce list:
 
-`transmission-edit --{{add|delete}} {{http://example.com}} {{path/to/file.torrent}}`
+`transmission-edit {{[-a|--add]}} {{http://example.com}} {{path/to/file.torrent}}`
+
+- Remove a URL from a torrent's announce list:
+
+`transmission-edit {{[-d|--delete]}} {{http://example.com}} {{path/to/file.torrent}}`
 
 - Update a tracker's passcode in a torrent file:
 
-`transmission-edit --replace {{old-passcode}} {{new-passcode}} {{path/to/file.torrent}}`
+`transmission-edit {{[-r|--replace]}} {{old-passcode}} {{new-passcode}} {{path/to/file.torrent}}`

--- a/pages/common/transmission-remote.md
+++ b/pages/common/transmission-remote.md
@@ -1,32 +1,32 @@
 # transmission-remote
 
 > Remote control utility for `transmission-daemon` and `transmission`.
-> More information: <https://transmissionbt.com>.
+> More information: <https://manned.org/transmission-remote>.
 
 - Add a torrent file or magnet link to Transmission and download to a specified directory:
 
-`transmission-remote {{hostname}} -a {{torrent|url}} -w {{/path/to/download_directory}}`
+`transmission-remote {{hostname}} {{[-a|--all]}} {{torrent|url}} {{[-w|--download-dir]}} {{/path/to/download_directory}}`
 
 - Change the default download directory:
 
-`transmission-remote {{hostname}} -w {{/path/to/download_directory}}`
+`transmission-remote {{hostname}} {{[-w|--download-dir]}} {{/path/to/download_directory}}`
 
 - List all torrents:
 
-`transmission-remote {{hostname}} --list`
+`transmission-remote {{hostname}} {{[-l|--list]}}`
 
 - Start torrent 1 and 2, stop torrent 3:
 
-`transmission-remote {{hostname}} -t "{{1,2}}" --start -t {{3}} --stop`
+`transmission-remote {{hostname}} {{[-t|--torrent]}} "{{1,2}}" {{[-s|--start]}} {{[-t|--torrent]}} {{3}} {{[-S|--stop]}}`
 
 - Remove torrent 1 and 2, and also delete local data for torrent 2:
 
-`transmission-remote {{hostname}} -t {{1}} --remove -t {{2}} --remove-and-delete`
+`transmission-remote {{hostname}} {{[-t|--torrent]}} {{1}} {{[-r|--remove]}} {{[-t|--torrent]}} {{2}} {{[-rad|--remove-and-delete]}}`
 
 - Stop all torrents:
 
-`transmission-remote {{hostname}} -t {{all}} --stop`
+`transmission-remote {{hostname}} {{[-t|--torrent]}} {{all}} {{[-S|--stop]}}`
 
 - Move torrents 1-10 and 15-20 to a new directory (which will be created if it does not exist):
 
-`transmission-remote {{hostname}} -t "{{1-10,15-20}}" --move {{/path/to/new_directory}}`
+`transmission-remote {{hostname}} {{[-t|--torrent]}} "{{1-10,15-20}}" --move {{/path/to/new_directory}}`

--- a/pages/common/transmission-show.md
+++ b/pages/common/transmission-show.md
@@ -10,8 +10,8 @@
 
 - Generate a magnet link for a specific torrent:
 
-`transmission-show --magnet {{path/to/file.torrent}}`
+`transmission-show {{[-m|--magnet]}} {{path/to/file.torrent}}`
 
 - Query a torrent's trackers and print the current number of peers:
 
-`transmission-show --scrape {{path/to/file.torrent}}`
+`transmission-show {{[-s|--scrape]}} {{path/to/file.torrent}}`

--- a/pages/common/trivy.md
+++ b/pages/common/trivy.md
@@ -9,7 +9,7 @@
 
 - Scan a Docker image filtering the output by severity:
 
-`trivy image --severity {{HIGH,CRITICAL}} {{alpine:3.15}}`
+`trivy image {{[-s|--severity]}} {{HIGH,CRITICAL}} {{alpine:3.15}}`
 
 - Scan a Docker image ignoring any unfixed/unpatched vulnerabilities:
 
@@ -33,4 +33,4 @@
 
 - Generate output with a SARIF template:
 
-`trivy image --format {{template}} --template "{{@sarif.tpl}}" -o {{path/to/report.sarif}} {{image:tag}}`
+`trivy image {{[-f|--format]}} {{template}} {{[-t|--template]}} "{{@sarif.tpl}}" {{[-o|--output]}} {{path/to/report.sarif}} {{image:tag}}`

--- a/pages/common/tspin.md
+++ b/pages/common/tspin.md
@@ -9,11 +9,11 @@
 
 - Read from another command and print to stdout:
 
-`journalctl -b --follow | tspin`
+`journalctl {{[-b|--boot]}} {{[-f|--follow]}} | tspin`
 
 - Read from file and print to `stdout`:
 
-`tspin {{path/to/application.log}} --print`
+`tspin {{path/to/application.log}} {{[-p|--print]}}`
 
 - Read from `stdin` and print to `stdout`:
 

--- a/pages/common/tuc.md
+++ b/pages/common/tuc.md
@@ -6,20 +6,20 @@
 
 - Cut and rearrange fields:
 
-`echo "foo bar baz" | tuc -d '{{ }}' -f {{3,2,1}}`
+`echo "foo bar baz" | tuc {{[-d|--delimiter]}} '{{ }}' {{[-f|--fields]}} {{3,2,1}}`
 
 - Replace the delimiter `space` with an arrow:
 
-`echo "foo bar baz" | tuc -d ' ' -r ' ➡ '`
+`echo "foo bar baz" | tuc {{[-d|--delimiter]}} ' ' {{[-r|--replace-delimiter]}} ' ➡ '`
 
 - Keep a range of fields:
 
-`echo "foo bar    baz" | tuc -d ' ' -f {{2:}}`
+`echo "foo bar    baz" | tuc {{[-d|--delimiter]}} ' ' {{[-f|--fields]}} {{2:}}`
 
 - Cut using regular expressions:
 
-`echo "a,b, c" | tuc -e '{{[, ]+}}' -f {{1,3}}`
+`echo "a,b, c" | tuc {{[-e|--regex]}} '{{[, ]+}}' {{[-f|--fields]}} {{1,3}}`
 
 - Emit JSON output:
 
-`echo "foo bar baz" | tuc -d '{{ }}' --json`
+`echo "foo bar baz" | tuc {{[-d|--delimiter]}} '{{ }}' --json`

--- a/pages/common/twm.md
+++ b/pages/common/twm.md
@@ -1,7 +1,7 @@
 # twm
 
 > A window manager for the X Window system.
-> More information: <https://gitlab.freedesktop.org/xorg/app/twm>.
+> More information: <https://manned.org/twm>.
 
 - Connect to the default X server:
 
@@ -9,16 +9,16 @@
 
 - Connect to a specific X server:
 
-`twm -display {{display}}`
+`twm {{[-d|-display]}} {{display}}`
 
 - Only manage the default screen:
 
-`twm -s`
+`twm {{[-s|-single]}}`
 
 - Use a specific startup file:
 
-`twm -f {{path/to/file}}`
+`twm {{[-f|-file]}} {{path/to/file}}`
 
 - Enable verbose mode and print unexpected errors in X:
 
-`twm -v`
+`twm {{[-v|-verbose]}}`

--- a/pages/common/twurl.md
+++ b/pages/common/twurl.md
@@ -5,23 +5,23 @@
 
 - Authorize `twurl` to access a Twitter account:
 
-`twurl authorize --consumer-key {{twitter_api_key}} --consumer-secret {{twitter_api_secret}}`
+`twurl authorize {{[-c|--consumer-key]}} {{twitter_api_key}} {{[-s|--consumer-secret]}} {{twitter_api_secret}}`
 
 - Make a GET request to an API endpoint:
 
-`twurl -X GET {{twitter_api_endpoint}}`
+`twurl {{[-X|--request-method]}} GET {{twitter_api_endpoint}}`
 
 - Make a POST request to an API endpoint:
 
-`twurl -X POST -d '{{endpoint_params}}' {{twitter_api_endpoint}}`
+`twurl {{[-X|--request-method]}} POST {{[-d|--data]}} '{{endpoint_params}}' {{twitter_api_endpoint}}`
 
 - Upload media to Twitter:
 
-`twurl -H "{{twitter_upload_url}}" -X POST "{{twitter_upload_endpoint}}" --file "{{path/to/media.jpg}}" --file-field "media"`
+`twurl {{[-H|--host]}} "{{twitter_upload_url}}" {{[-X|--request-method]}} POST "{{twitter_upload_endpoint}}" {{[-f|--file]}} "{{path/to/media.jpg}}" {{[-F|--file-field]}} "media"`
 
 - Access a different Twitter API host:
 
-`twurl -H {{twitter_api_url}} -X GET {{twitter_api_endpoint}}`
+`twurl {{[-H|--host]}} {{twitter_api_url}} {{[-X|--request-method]}} GET {{twitter_api_endpoint}}`
 
 - Create an alias for a requested resource:
 

--- a/pages/common/ulimit.md
+++ b/pages/common/ulimit.md
@@ -1,7 +1,7 @@
 # ulimit
 
 > Get and set resource limits for user processes.
-> More information: <https://manned.org/ulimit>.
+> More information: <https://www.gnu.org/software/bash/manual/bash.html#index-ulimit>.
 
 - Get the properties of all the user limits:
 

--- a/pages/common/unar.md
+++ b/pages/common/unar.md
@@ -9,16 +9,16 @@
 
 - Extract an archive to the specified directory:
 
-`unar -o {{path/to/directory}} {{path/to/archive}}`
+`unar {{[-o|-output-directory]}} {{path/to/directory}} {{path/to/archive}}`
 
 - Force overwrite if files to be unpacked already exist:
 
-`unar -f {{path/to/archive}}`
+`unar {{[-f|-force-overwrite]}} {{path/to/archive}}`
 
 - Force rename if files to be unpacked already exist:
 
-`unar -r {{path/to/archive}}`
+`unar {{[-r|-force-rename]}} {{path/to/archive}}`
 
 - Force skip if files to be unpacked already exist:
 
-`unar -s {{path/to/archive}}`
+`unar {{[-s|-force-skip]}} {{path/to/archive}}`

--- a/pages/common/uuencode.md
+++ b/pages/common/uuencode.md
@@ -13,4 +13,4 @@
 
 - Encode a file using Base64 instead of the default uuencode encoding and write the result to a file:
 
-`uuencode -m -o {{path/to/output_file}} {{path/to/input_file}} {{output_file_name_after_decoding}}`
+`uuencode {{[-m|--base64]}} -o {{path/to/output_file}} {{path/to/input_file}} {{output_file_name_after_decoding}}`

--- a/pages/common/vinmap.md
+++ b/pages/common/vinmap.md
@@ -5,20 +5,20 @@
 
 - Perform a basic scan of a subnet:
 
-`vinmap -ip {{192.168.1.0/24}}`
+`vinmap {{[-ip|--ip_range]}} {{192.168.1.0/24}}`
 
 - Scan a domain with version and OS detection, saving results to a specific file:
 
-`vinmap -ip {{example.com}} -s "-sV -O" -o {{path/to/scan_results.xml}}`
+`vinmap {{[-ip|--ip_range]}} {{example.com}} {{[-s|--scan_type]}} "-sV -O" -o {{path/to/scan_results.xml}}`
 
 - Scan an IP range using 10 chunks and 20 concurrent threads, uses half of the system's CPU cores if not specified:
 
-`vinmap -ip {{10.0.0.1-10.0.0.255}} -n 10 -t 20`
+`vinmap {{[-ip|--ip_range]}} {{10.0.0.1-10.0.0.255}} {{[-n|--num_chunks]}} 10 {{[-t|--threads]}} 20`
 
 - Output scan results in JSON format:
 
-`vinmap -ip {{192.168.1.1-192.168.1.100}} -f json`
+`vinmap {{[-ip|--ip_range]}} {{192.168.1.1-192.168.1.100}} {{[-f|--format]}} json`
 
 - Scan multiple IPs with default settings and save merged XML output:
 
-`vinmap -ip {{192.168.1.1,192.168.1.2,...}}`
+`vinmap {{[-ip|--ip_range]}} {{192.168.1.1,192.168.1.2,...}}`

--- a/pages/common/visudo.md
+++ b/pages/common/visudo.md
@@ -9,7 +9,7 @@
 
 - Check the sudoers file for errors:
 
-`sudo visudo -c`
+`sudo visudo {{[-c|--check]}}`
 
 - Edit the sudoers file using a specific editor:
 
@@ -17,4 +17,4 @@
 
 - Display version information:
 
-`visudo --version`
+`visudo {{[-V|--version]}}`

--- a/pages/common/viu.md
+++ b/pages/common/viu.md
@@ -9,16 +9,16 @@
 
 - Render an image or GIF from the internet using `curl`:
 
-`curl -s {{https://example.com/image.png}} | viu -`
+`curl {{[-s|--silent]}} {{https://example.com/image.png}} | viu -`
 
 - Render an image with a transparent background:
 
-`viu -t {{path/to/file}}`
+`viu {{[-t|--transparent]}} {{path/to/file}}`
 
 - Render an image with a specific width and height in pixels:
 
-`viu -w {{width}} -h {{height}} {{path/to/file}}`
+`viu {{[-w|--width]}} {{width}} {{[-h|--height]}} {{height}} {{path/to/file}}`
 
 - Render an image or GIF and display its file name:
 
-`viu -n {{path/to/file}}`
+`viu {{[-n|--name]}} {{path/to/file}}`

--- a/pages/common/wafw00f.md
+++ b/pages/common/wafw00f.md
@@ -15,7 +15,7 @@
 
 `wafw00f {{[-p|--proxy]}} {{http://localhost:8080}} {{https://www.example.com}}`
 
-- Test for a specific WAF product (run `wafw00f -l` to get list of all supported WAFs):
+- Test for a specific WAF product (run `wafw00f --list` to get list of all supported WAFs):
 
 `wafw00f {{[-t|--test]}} {{Cloudflare|Cloudfront|Fastly|ZScaler|...}} {{https://www.example.com}}`
 

--- a/pages/common/wakeonlan.md
+++ b/pages/common/wakeonlan.md
@@ -9,12 +9,12 @@
 
 - Send packet to a specific device via IP address:
 
-`wakeonlan {{01:02:03:04:05:06}} -i {{192.168.178.2}}`
+`wakeonlan {{01:02:03:04:05:06}} {{[-i|--ip]}} {{192.168.178.2}}`
 
 - Print the commands, but don't execute them (dry-run):
 
-`wakeonlan -n {{01:02:03:04:05:06}}`
+`wakeonlan {{[-n|--dry-run]}} {{01:02:03:04:05:06}}`
 
 - Run in quiet mode:
 
-`wakeonlan -q {{01:02:03:04:05:06}}`
+`wakeonlan {{[-q|--quiet]}} {{01:02:03:04:05:06}}`

--- a/pages/common/wasm-objdump.md
+++ b/pages/common/wasm-objdump.md
@@ -5,16 +5,16 @@
 
 - Display the section headers of a given binary:
 
-`wasm-objdump -h {{file.wasm}}`
+`wasm-objdump {{[-h|--headers]}} {{file.wasm}}`
 
 - Display the entire disassembled output of a given binary:
 
-`wasm-objdump -d {{file.wasm}}`
+`wasm-objdump {{[-d|--disassemble]}} {{file.wasm}}`
 
 - Display the details of each section:
 
-`wasm-objdump --details {{file.wasm}}`
+`wasm-objdump {{[-x|--details]}} {{file.wasm}}`
 
 - Display the details of a given section:
 
-`wasm-objdump --section '{{import}}' --details {{file.wasm}}`
+`wasm-objdump {{[-j|--section]}} '{{import}}' {{[-x|--details]}} {{file.wasm}}`

--- a/pages/common/wasm-opt.md
+++ b/pages/common/wasm-opt.md
@@ -5,15 +5,15 @@
 
 - Apply default optimizations and write to a given file:
 
-`wasm-opt -O {{input.wasm}} -o {{output.wasm}}`
+`wasm-opt -O {{input.wasm}} {{[-o|--output]}} {{output.wasm}}`
 
 - Apply all optimizations and write to a given file (takes more time, but generates optimal code):
 
-`wasm-opt -O4 {{input.wasm}} -o {{output.wasm}}`
+`wasm-opt -O4 {{input.wasm}} {{[-o|--output]}} {{output.wasm}}`
 
 - Optimize a file for size:
 
-`wasm-opt -Oz {{input.wasm}} -o {{output.wasm}}`
+`wasm-opt -Oz {{input.wasm}} {{[-o|--output]}} {{output.wasm}}`
 
 - Print the textual representation of the binary to console:
 

--- a/pages/common/wasm2c.md
+++ b/pages/common/wasm2c.md
@@ -9,4 +9,4 @@
 
 - Write the output to a given file (`file.h` gets additionally generated):
 
-`wasm2c {{file.wasm}} -o {{file.c}}`
+`wasm2c {{file.wasm}} {{[-o|--output]}} {{file.c}}`

--- a/pages/common/wasm2wat.md
+++ b/pages/common/wasm2wat.md
@@ -9,4 +9,4 @@
 
 - Write the output to a given file:
 
-`wasm2wat {{file.wasm}} -o {{file.wat}}`
+`wasm2wat {{file.wasm}} {{[-o|--output]}} {{file.wat}}`

--- a/pages/common/wat2wasm.md
+++ b/pages/common/wat2wasm.md
@@ -9,8 +9,8 @@
 
 - Write the output binary to a given file:
 
-`wat2wasm {{file.wat}} -o {{file.wasm}}`
+`wat2wasm {{file.wat}} {{[-o|--output]}} {{file.wasm}}`
 
 - Display simplified representation of every byte:
 
-`wat2wasm -v {{file.wat}}`
+`wat2wasm {{[-v|--verbose]}} {{file.wat}}`

--- a/pages/common/waymore.md
+++ b/pages/common/waymore.md
@@ -6,16 +6,16 @@
 
 - Search for URLs of a domain (output will typically be in `~/.config/waymore/results/`):
 
-`waymore -i {{example.com}}`
+`waymore {{[-i|--input]}} {{example.com}}`
 
 - Limit search results to only include a list of URLs for a domain and store outputs to the specified file:
 
-`waymore -mode U -oU {{path/to/example.com-urls.txt}} -i {{example.com}}`
+`waymore -mode U {{[-oU|--output-urls]}} {{path/to/example.com-urls.txt}} {{[-i|--input]}} {{example.com}}`
 
 - Only output the content bodies of URLs and store outputs to the specified directory:
 
-`waymore -mode R -oR {{path/to/example.com-url-responses}} -i {{example.com}}`
+`waymore -mode R {{[-oR|--output-responses]}} {{path/to/example.com-url-responses}} {{[-i|--input]}} {{example.com}}`
 
 - Filter the results by specifying date ranges:
 
-`waymore -from {{YYYYMMDD|YYYYMM|YYYY}} -to {{YYYYMMDD|YYYYMM|YYYY}} -i {{example.com}}`
+`waymore -from {{YYYYMMDD|YYYYMM|YYYY}} {{[-to|--to-date]}} {{YYYYMMDD|YYYYMM|YYYY}} {{[-i|--input]}} {{example.com}}`

--- a/pages/common/webstorm.md
+++ b/pages/common/webstorm.md
@@ -11,7 +11,7 @@
 
 `webstorm {{path/to/directory}}`
 
-- Open specific files in the LightEdit mode﻿:
+- Open specific files in the LightEdit mode:
 
 `webstorm -e {{path/to/file1 path/to/file2 ...}}`
 

--- a/pages/common/whatweb.md
+++ b/pages/common/whatweb.md
@@ -9,15 +9,15 @@
 
 - Read targets/websites from a file:
 
-`whatweb -i {{targets_file}}`
+`whatweb {{[-i|--input-file]}} {{targets_file}}`
 
 - Scan a website/target in verbose mode:
 
-`whatweb -v {{example.com}}`
+`whatweb {{[-v|--verbose]}} {{example.com}}`
 
 - Run an aggressive scan on a website:
 
-`whatweb -a 3 {{example.com}}`
+`whatweb {{[-a|--aggression]}} 3 {{example.com}}`
 
 - Scan a network and suppress errors:
 
@@ -25,8 +25,8 @@
 
 - List plugins:
 
-`whatweb -l`
+`whatweb {{[-l|--list-plugins]}}`
 
 - List plugin details:
 
-`whatweb -I {{plugin_name}}`
+`whatweb {{[-I|--info-plugins]}} {{plugin_name}}`

--- a/pages/common/which.md
+++ b/pages/common/which.md
@@ -9,4 +9,4 @@
 
 - If there are multiple executables which match, display all:
 
-`which -a {{executable}}`
+`which {{[-a|--all]}} {{executable}}`

--- a/pages/common/wondershaper.md
+++ b/pages/common/wondershaper.md
@@ -3,9 +3,6 @@
 > Allows the user to limit the bandwidth of network adapters.
 > More information: <https://github.com/magnific0/wondershaper#usage>.
 
-- Display [h]elp:
-
-`wondershaper -h`
 
 - Show the current [s]tatus of a specific [a]dapter:
 
@@ -26,3 +23,7 @@
 - Set a specific maximum [d]ownload rate and [u]pload rate (in Kpbs):
 
 `wondershaper -a {{adapter_name}} -d {{1024}} -u {{512}}`
+
+- Display [h]elp:
+
+`wondershaper -h`

--- a/pages/common/wondershaper.md
+++ b/pages/common/wondershaper.md
@@ -3,7 +3,6 @@
 > Allows the user to limit the bandwidth of network adapters.
 > More information: <https://github.com/magnific0/wondershaper#usage>.
 
-
 - Show the current [s]tatus of a specific [a]dapter:
 
 `wondershaper -s -a {{adapter_name}}`

--- a/pages/common/wrk.md
+++ b/pages/common/wrk.md
@@ -5,12 +5,12 @@
 
 - Run a benchmark for `30` seconds, using `12` threads, and keeping `400` HTTP connections open:
 
-`wrk -t{{12}} -c{{400}} -d{{30s}} "{{http://127.0.0.1:8080/index.html}}"`
+`wrk {{[-t|--threads]}} {{12}} {{[-c|--connections]}} {{400}} {{[-d|--duration]}} {{30s}} "{{http://127.0.0.1:8080/index.html}}"`
 
 - Run a benchmark with a custom header:
 
-`wrk -t{{2}} -c{{5}} -d{{5s}} -H "{{Host: example.com}}" "{{http://example.com/index.html}}"`
+`wrk {{[-t|--threads]}} {{2}} {{[-c|--connections]}} {{5}} {{[-d|--duration]}} {{5s}} {{[-H|--header]}} "{{Host: example.com}}" "{{http://example.com/index.html}}"`
 
 - Run a benchmark with a request timeout of `2` seconds:
 
-`wrk -t{{2}} -c{{5}} -d{{5s}} --timeout {{2s}} "{{http://example.com/index.html}}"`
+`wrk {{[-t|--threads]}} {{2}} {{[-c|--connections]}} {{5}} {{[-d|--duration]}} {{5s}} --timeout {{2s}} "{{http://example.com/index.html}}"`

--- a/pages/common/x_x.md
+++ b/pages/common/x_x.md
@@ -9,8 +9,8 @@
 
 - View an XLSX or CSV file, using the first row as table headers:
 
-`x_x -h {{0}} {{file.xlsx|file.csv}}`
+`x_x {{[-h|--heading]}} {{0}} {{file.xlsx|file.csv}}`
 
 - View a CSV file with unconventional delimiters:
 
-`x_x --delimiter={{';'}} --quotechar={{'|'}} {{file.csv}}`
+`x_x {{[-d|--delimiter]}} {{';'}} {{[-q|--quotechar]}} {{'|'}} {{file.csv}}`

--- a/pages/common/xkcdpass.md
+++ b/pages/common/xkcdpass.md
@@ -10,8 +10,8 @@
 
 - Generate one passphrase whose first letters of each word match the provided argument:
 
-`xkcdpass -a {{acrostic}}`
+`xkcdpass {{[-a|--acrostic]}} {{acrostic}}`
 
 - Generate passwords interactively:
 
-`xkcdpass -i`
+`xkcdpass {{[-i|--interactive]}}`

--- a/pages/common/xmake.md
+++ b/pages/common/xmake.md
@@ -5,20 +5,20 @@
 
 - Create an Xmake C project, consisting of a hello world and `xmake.lua`:
 
-`xmake create --language c -P {{project_name}}`
+`xmake create {{[-l|--language]}} {{[c|clean]}} {{[-P|--project]}} {{project_name}}`
 
 - Build and run an Xmake project:
 
-`xmake build run`
+`xmake {{[b|build]}} {{[r|run]}}`
 
 - Run a compiled Xmake target directly:
 
-`xmake run {{target_name}}`
+`xmake {{[r|run]}} {{target_name}}`
 
 - Configure a project's build targets:
 
-`xmake config --plat={{macosx|linux|iphoneos|...}} --arch={{x86_64|i386|arm64|...}} --mode={{debug|release}}`
+`xmake {{[f|config]}} {{[-p |--plat=]}}{{macosx|linux|iphoneos|...}} {{[-a |--arch=]}}{{x86_64|i386|arm64|...}} {{[-m |--mode=]}}{{debug|release}}`
 
 - Install the compiled target to a directory:
 
-`xmake install -o {{path/to/directory}}`
+`xmake {{[i|install]}} {{[-o |--installdir=]}}{{path/to/directory}}`

--- a/pages/common/xxd.md
+++ b/pages/common/xxd.md
@@ -13,20 +13,20 @@
 
 - Display a more compact output, replacing consecutive zeros (if any) with a star:
 
-`xxd -a {{input_file}}`
+`xxd {{[-a|-autoskip]}} {{input_file}}`
 
 - Display the output with 10 columns of one octet (byte) each:
 
-`xxd -c {{10}} {{input_file}}`
+`xxd {{[-c|-cols]}} {{10}} {{input_file}}`
 
 - Display output only up to a length of 32 bytes:
 
-`xxd -l {{32}} {{input_file}}`
+`xxd {{[-l|-len]}} {{32}} {{input_file}}`
 
 - Display the output in plain mode, without any gaps between the columns:
 
-`xxd -p {{input_file}}`
+`xxd {{[-p|-postscript]}} {{input_file}}`
 
 - Revert a plaintext hexdump back into binary, and save it as a binary file:
 
-`xxd -r -p {{input_file}} {{output_file}}`
+`xxd {{[-r|-revert]}} {{[-p|-postscript]}} {{input_file}} {{output_file}}`

--- a/pages/common/ya.md
+++ b/pages/common/ya.md
@@ -5,11 +5,11 @@
 
 - Add a package:
 
-`ya pack -a {{package}}`
+`ya pack {{[-a|--all]}} {{package}}`
 
 - Upgrade all packages:
 
-`ya pack -u`
+`ya pack {{[-u|--upgrade]}}`
 
 - Subscribe to messages from all remote instances:
 

--- a/pages/common/youtube-dl.md
+++ b/pages/common/youtube-dl.md
@@ -10,23 +10,23 @@
 
 - List all formats that a video or playlist is available in:
 
-`youtube-dl --list-formats '{{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}'`
+`youtube-dl {{[-F|--list-formats]}} '{{https://www.youtube.com/watch?v=Mwa0_nE9H7A}}'`
 
 - Download a video or playlist at a specific quality:
 
-`youtube-dl --format "{{best[height<=480]}}" '{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}'`
+`youtube-dl {{[-f|--format]}} "{{best[height<=480]}}" '{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}'`
 
 - Download the audio from a video and convert it to an MP3:
 
-`youtube-dl -x --audio-format {{mp3}} '{{url}}'`
+`youtube-dl {{[-x|--extract-audio]}} --audio-format {{mp3}} '{{url}}'`
 
 - Download the best quality audio and video and merge them:
 
-`youtube-dl -f bestvideo+bestaudio '{{url}}'`
+`youtube-dl {{[-f|--format]}} bestvideo+bestaudio '{{url}}'`
 
 - Download video(s) as MP4 files with custom filenames:
 
-`youtube-dl --format {{mp4}} -o "{{%(playlist_index)s-%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s}}" '{{url}}'`
+`youtube-dl {{[-f|--format]}} {{mp4}} {{[-o|--output]}} "{{%(playlist_index)s-%(title)s by %(uploader)s on %(upload_date)s in %(playlist)s.%(ext)s}}" '{{url}}'`
 
 - Download a particular language's subtitles along with the video:
 
@@ -34,4 +34,4 @@
 
 - Download a playlist and extract MP3s from it:
 
-`youtube-dl -f "bestaudio" --continue --no-overwrites --ignore-errors --extract-audio --audio-format mp3 -o "%(title)s.%(ext)s" '{{url_to_playlist}}'`
+`youtube-dl {{[-f|--format]}} "bestaudio" {{[-c|--continue]}} {{[-w|--no-overwrites]}} {{[-i|--ignore-errors]}} {{[-x|--extract-audio]}} --audio-format mp3 {{[-o|--output]}} "%(title)s.%(ext)s" '{{url_to_playlist}}'`

--- a/pages/common/yt-dlp.md
+++ b/pages/common/yt-dlp.md
@@ -11,28 +11,28 @@
 
 - List the available downloadable formats for a video:
 
-`yt-dlp --list-formats "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
+`yt-dlp {{[-F|--list-formats]}} "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
 
 - Download a video or playlist using the best MP4 video available (default is "bv\*+ba/b"):
 
-`yt-dlp --format "{{bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]}}" "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
+`yt-dlp {{[-f|--format]}} "{{bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]}}" "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
 
 - Extract audio from a video (requires ffmpeg or ffprobe):
 
-`yt-dlp --extract-audio "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
+`yt-dlp {{[-x|--extract-audio]}} "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
 
 - Specify audio format and audio quality of extracted audio (between 0 (best) and 10 (worst), default = 5):
 
-`yt-dlp --extract-audio --audio-format {{mp3}} --audio-quality {{0}} "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
+`yt-dlp {{[-x|--extract-audio]}} --audio-format {{mp3}} --audio-quality {{0}} "{{https://www.youtube.com/watch?v=oHg5SJYRHA0}}"`
 
 - Download only the second, fourth, fifth, sixth, and last items in a playlist (the first item is 1, not 0):
 
-`yt-dlp --playlist-items 2,4:6,-1 "{{https://youtube.com/playlist?list=PLbzoR-pLrL6pTJfLQ3UwtB-3V4fimdqnA}}"`
+`yt-dlp {{[-I|--playlist-items]}} 2,4:6,-1 "{{https://youtube.com/playlist?list=PLbzoR-pLrL6pTJfLQ3UwtB-3V4fimdqnA}}"`
 
 - Download all playlists of a YouTube channel/user keeping each playlist in a separate directory:
 
-`yt-dlp -o "{{%(uploader)s/%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s}}" "{{https://www.youtube.com/user/TheLinuxFoundation/playlists}}"`
+`yt-dlp {{[-o|--output]}} "{{%(uploader)s/%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s}}" "{{https://www.youtube.com/user/TheLinuxFoundation/playlists}}"`
 
 - Download a Udemy course keeping each chapter in a separate directory:
 
-`yt-dlp -u {{user}} -p {{password}} -P "{{path/to/directory}}" -o "{{%(playlist)s/%(chapter_number)s - %(chapter)s/%(title)s.%(ext)s}}" "{{https://www.udemy.com/java-tutorial}}"`
+`yt-dlp {{[-u|--username]}} {{user}} {{[-p|--password]}} {{password}} {{[-P|--paths]}} "{{path/to/directory}}" {{[-o|--output]}} "{{%(playlist)s/%(chapter_number)s - %(chapter)s/%(title)s.%(ext)s}}" "{{https://www.udemy.com/java-tutorial}}"`

--- a/pages/common/zipgrep.md
+++ b/pages/common/zipgrep.md
@@ -9,11 +9,11 @@
 
 - Print file name and line number for each match:
 
-`zipgrep -H -n "{{search_pattern}}" {{path/to/file.zip}}`
+`zipgrep {{[-H|--with-filename]}} {{[-n|--line-number]}} "{{search_pattern}}" {{path/to/file.zip}}`
 
 - Search for lines that do not match a pattern:
 
-`zipgrep -v "{{search_pattern}}" {{path/to/file.zip}}`
+`zipgrep {{[-v|--invert-match]}} "{{search_pattern}}" {{path/to/file.zip}}`
 
 - Specify files inside a Zip archive from search:
 
@@ -21,4 +21,4 @@
 
 - Exclude files inside a Zip archive from search:
 
-`zipgrep "{{search_pattern}}" {{path/to/file.zip}} -x {{file/to/exclude1}} {{file/to/exclude2}}`
+`zipgrep "{{search_pattern}}" {{path/to/file.zip}} {{[-x|--line-regexp]}} {{file/to/exclude1}} {{file/to/exclude2}}`

--- a/pages/common/zmap.md
+++ b/pages/common/zmap.md
@@ -1,15 +1,15 @@
 # zmap
 
 > Fast, open-source network scanner for Internet-wide surveys.
-> More information: <https://github.com/zmap/zmap>.
+> More information: <https://manned.org/zmap>.
 
 - Scan a subnet or full IPv4 space for a specific TCP port (default: 80):
 
-`zmap {{SUBNETS}} -p {{port}}`
+`zmap {{SUBNETS}} {{[-p|--target-ports]}} {{port}}`
 
 - Scan specific ports or port ranges across a subnet:
 
-`zmap {{--target-ports}} {{port1,port2-port3,...}} {{SUBNETS}}`
+`zmap {{[-p|--target-ports]}} {{port1,port2-port3,...}} {{SUBNETS}}`
 
 - Output results to a CSV file with custom fields:
 


### PR DESCRIPTION
These were hunted down with `grep -rl " -[a-z][^a-z]"` to find lone short options and then checking documentation if there's existing long options. Couple of these were found because I noticed a group of pages from a project that consistently provides short and long options like `find . -iname "transmission*" | xargs -n1 basename | xargs -n1 code` or `find . -iname "pueue*" | xargs -n1 basename | xargs -n1 code`