### PR TITLE
sfdk-*: update links

### DIFF
--- a/pages/common/sfdk-emulator-device-model-show.md
+++ b/pages/common/sfdk-emulator-device-model-show.md
@@ -1,7 +1,7 @@
 # sfdk emulator device-model-show
 
 > Show emulated device model's properties.
-> More information: <https://github.com/sailfishos/sailfish-qtcreator/tree/master/src/tools/sfdk>.
+> More information: <https://github.com/sailfishos/sailfish-qtcreator/blob/master/share/qtcreator/sfdk/modules/40-testing-maintain/doc/command.emulator.adoc>.
 
 - Show a model properties:
 

--- a/pages/common/sfdk-emulator-start.md
+++ b/pages/common/sfdk-emulator-start.md
@@ -1,7 +1,7 @@
 # sfdk emulator start
 
 > Starts an emulator.
-> More information: <https://github.com/sailfishos/sailfish-qtcreator/tree/master/src/tools/sfdk>.
+> More information: <https://github.com/sailfishos/sailfish-qtcreator/blob/master/share/qtcreator/sfdk/modules/40-testing-maintain/doc/command.emulator.adoc>.
 
 - Start an emulator:
 

--- a/pages/common/sfdk-maintain.md
+++ b/pages/common/sfdk-maintain.md
@@ -1,7 +1,7 @@
 # sfdk maintain
 
 > Launches the interactive SDK Maintenance tool.
-> More information: <https://github.com/sailfishos/sailfish-qtcreator/tree/master/src/tools/sfdk>.
+> More information: <https://github.com/sailfishos/sailfish-qtcreator/blob/master/share/qtcreator/sfdk/modules/10-general/doc/command.maintain.adoc>.
 
 - Launch SDK Maintenance tool:
 

--- a/pages/common/sfdk-qmltypes.md
+++ b/pages/common/sfdk-qmltypes.md
@@ -1,7 +1,7 @@
 # sfdk qmltypes
 
 > Generates qmltypes files.
-> More information: <https://github.com/sailfishos/sailfish-qtcreator/tree/master/src/tools/sfdk>.
+> More information: <https://github.com/sailfishos/sailfish-qtcreator/blob/master/share/qtcreator/sfdk/modules/80-ide-qmltypes/doc/command.qmltypes.adoc>.
 
 - Generate qmltypes files:
 

--- a/pages/common/sfdk-scrape.md
+++ b/pages/common/sfdk-scrape.md
@@ -1,7 +1,7 @@
 # sfdk scrape
 
 > Converts source code modifications to patches.
-> More information: <https://github.com/sailfishos/sailfish-qtcreator/tree/master/src/tools/sfdk>.
+> More information: <https://github.com/sailfishos/sailfish-qtcreator/blob/master/share/qtcreator/sfdk/modules/65-maintaining-mb2/doc/command.scrape.adoc>.
 
 - Save source modifications as patches:
 


### PR DESCRIPTION
I found recently where the manpages sources are located for `sfdk`, and replaced links in pages with placeholder sources link with manpages sources.

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 3.12.5**
