### PR TITLE
common/*: add option placeholders part 2

### DIFF
--- a/pages/common/a2ping.md
+++ b/pages/common/a2ping.md
@@ -29,4 +29,4 @@
 
 - Display help:
 
-`a2ping -h`
+`a2ping {{[-h|--help]}}`

--- a/pages/common/acme.sh.md
+++ b/pages/common/acme.sh.md
@@ -6,28 +6,28 @@
 
 - Issue a certificate using webroot mode:
 
-`acme.sh --issue --domain {{example.com}} --webroot {{/path/to/webroot}}`
+`acme.sh --issue {{[-d|--domain]}} {{example.com}} {{[-w|--webroot]}} {{/path/to/webroot}}`
 
 - Issue a certificate for multiple domains using standalone mode using port 80:
 
-`acme.sh --issue --standalone --domain {{example.com}} --domain {{www.example.com}}`
+`acme.sh --issue --standalone {{[-d|--domain]}} {{example.com}} {{[-d|--domain]}} {{www.example.com}}`
 
 - Issue a certificate using standalone TLS mode using port 443:
 
-`acme.sh --issue --alpn --domain {{example.com}}`
+`acme.sh --issue --alpn {{[-d|--domain]}} {{example.com}}`
 
 - Issue a certificate using a working Nginx configuration:
 
-`acme.sh --issue --nginx --domain {{example.com}}`
+`acme.sh --issue --nginx {{[-d|--domain]}} {{example.com}}`
 
 - Issue a certificate using a working Apache configuration:
 
-`acme.sh --issue --apache --domain {{example.com}}`
+`acme.sh --issue --apache {{[-d|--domain]}} {{example.com}}`
 
 - Issue a wildcard (\*) certificate using an automatic DNS API mode:
 
-`acme.sh --issue --dns {{dns_cf}} --domain {{*.example.com}}`
+`acme.sh --issue --dns {{dns_cf}} {{[-d|--domain]}} {{*.example.com}}`
 
 - Install certificate files into the specified locations (useful for automatic certificate renewal):
 
-`acme.sh --install-cert -d {{example.com}} --key-file {{/path/to/example.com.key}} --fullchain-file {{/path/to/example.com.cer}} --reloadcmd "{{systemctl force-reload nginx}}"`
+`acme.sh {{[-i|--install-cert]}} {{[-d|--domain]}} {{example.com}} --key-file {{/path/to/example.com.key}} --fullchain-file {{/path/to/example.com.cer}} --reloadcmd "{{systemctl force-reload nginx}}"`

--- a/pages/common/agate.md
+++ b/pages/common/agate.md
@@ -13,4 +13,4 @@
 
 - Display help:
 
-`agate -h`
+`agate {{[-h|--help]}}`

--- a/pages/common/ansible-doc.md
+++ b/pages/common/ansible-doc.md
@@ -6,11 +6,11 @@
 
 - List available action plugins (modules):
 
-`ansible-doc --list`
+`ansible-doc {{[-l|--list]}}`
 
 - List available plugins of a specific type:
 
-`ansible-doc --type {{become|cache|callback|cliconf|connection|...}} --list`
+`ansible-doc {{[-t|--type]}} {{become|cache|callback|cliconf|connection|...}} {{[-l|--list]}}`
 
 - Show information about a specific action plugin (module):
 
@@ -18,12 +18,12 @@
 
 - Show information about a plugin with a specific type:
 
-`ansible-doc --type {{become|cache|callback|cliconf|connection|...}} {{plugin_name}}`
+`ansible-doc {{[-t|--type]}} {{become|cache|callback|cliconf|connection|...}} {{plugin_name}}`
 
 - Show the playbook snippet for action plugin (modules):
 
-`ansible-doc --snippet {{plugin_name}}`
+`ansible-doc {{[-s|--snippet]}} {{plugin_name}}`
 
 - Show information about an action plugin (module) as JSON:
 
-`ansible-doc --json {{plugin_name}}`
+`ansible-doc {{[-j|--json]}} {{plugin_name}}`

--- a/pages/common/ansible-inventory.md
+++ b/pages/common/ansible-inventory.md
@@ -10,11 +10,11 @@
 
 - Display a custom inventory:
 
-`ansible-inventory --list --inventory {{path/to/file_or_script_or_directory}}`
+`ansible-inventory --list {{[-i|--inventory-file]}} {{path/to/file_or_script_or_directory}}`
 
 - Display the default inventory in YAML:
 
-`ansible-inventory --list --yaml`
+`ansible-inventory --list {{[-y|--yaml]}}`
 
 - Dump the default inventory to a file:
 

--- a/pages/common/ansible-pull.md
+++ b/pages/common/ansible-pull.md
@@ -5,16 +5,16 @@
 
 - Pull a playbook from a VCS and execute a default local.yml playbook:
 
-`ansible-pull -U {{repository_url}}`
+`ansible-pull {{[-U|--url]}} {{repository_url}}`
 
 - Pull a playbook from a VCS and execute a specific playbook:
 
-`ansible-pull -U {{repository_url}} {{playbook}}`
+`ansible-pull {{[-U|--url]}} {{repository_url}} {{playbook}}`
 
 - Pull a playbook from a VCS at a specific branch and execute a specific playbook:
 
-`ansible-pull -U {{repository_url}} -C {{branch}} {{playbook}}`
+`ansible-pull {{[-U|--url]}} {{repository_url}} {{[-C|--checkout]}} {{branch}} {{playbook}}`
 
 - Pull a playbook from a VCS, specify hosts file and execute a specific playbook:
 
-`ansible-pull -U {{repository_url}} -i {{hosts_file}} {{playbook}}`
+`ansible-pull {{[-U|--url]}} {{repository_url}} {{[-i|--inventory-file]}} {{hosts_file}} {{playbook}}`

--- a/pages/common/asciidoctor.md
+++ b/pages/common/asciidoctor.md
@@ -9,12 +9,12 @@
 
 - Convert a specific `.adoc` file to HTML and link a CSS stylesheet:
 
-`asciidoctor -a stylesheet {{path/to/stylesheet.css}} {{path/to/file.adoc}}`
+`asciidoctor {{[-a|--attribute]}} stylesheet {{path/to/stylesheet.css}} {{path/to/file.adoc}}`
 
 - Convert a specific `.adoc` file to embeddable HTML, removing everything except the body:
 
-`asciidoctor --embedded {{path/to/file.adoc}}`
+`asciidoctor {{[-e|--embedded]}} {{path/to/file.adoc}}`
 
 - Convert a specific `.adoc` file to a PDF using the `asciidoctor-pdf` library:
 
-`asciidoctor --backend {{pdf}} --require {{asciidoctor-pdf}} {{path/to/file.adoc}}`
+`asciidoctor {{[-b|--backend]}} {{pdf}} {{[-r|--require ]}}{{asciidoctor-pdf}} {{path/to/file.adoc}}`

--- a/pages/common/cbonsai.md
+++ b/pages/common/cbonsai.md
@@ -5,20 +5,20 @@
 
 - Generate a bonsai in live mode:
 
-`cbonsai -l`
+`cbonsai {{[-l|--live]}}`
 
 - Generate a bonsai in infinite mode:
 
-`cbonsai -i`
+`cbonsai {{[-i|--infinite]}}`
 
 - Append a message to the bonsai:
 
-`cbonsai -m "{{message}}"`
+`cbonsai {{[-m|--message]}} "{{message}}"`
 
 - Display extra information about the bonsai:
 
-`cbonsai -v`
+`cbonsai {{[-v|--verbose]}}`
 
 - Display help:
 
-`cbonsai -h`
+`cbonsai {{[-h|--help]}}`

--- a/pages/common/charm.md
+++ b/pages/common/charm.md
@@ -9,7 +9,7 @@
 
 - Backup Charm account keys to a specific location:
 
-`charm backup-keys -o {{path/to/output_file.tar}}`
+`charm backup-keys {{[-o|--output]}} {{path/to/output_file.tar}}`
 
 - Import previously backed up Charm account keys:
 

--- a/pages/common/cheat.md
+++ b/pages/common/cheat.md
@@ -9,16 +9,16 @@
 
 - Edit the cheat sheet for a command:
 
-`cheat -e {{command}}`
+`cheat {{[-e|--edit]}} {{command}}`
 
 - List the available cheat sheets:
 
-`cheat -l`
+`cheat {{[-l|--list]}}`
 
 - Search available the cheat sheets for a specified command name:
 
-`cheat -s {{command}}`
+`cheat {{[-s|--search]}} {{command}}`
 
 - Display version:
 
-`cheat -v`
+`cheat {{[-v|--version]}}`

--- a/pages/common/circup.md
+++ b/pages/common/circup.md
@@ -19,6 +19,6 @@
 
 `circup freeze`
 
-- Save all libraries on a connected device in the current directory:
+- Save all libraries on a connected device in `requirements.txt` in current directory:
 
-`circup freeze -r`
+`circup freeze {{[-r|--requirement]}}`

--- a/pages/common/clamscan.md
+++ b/pages/common/clamscan.md
@@ -9,7 +9,7 @@
 
 - Scan all files recursively in a specific directory:
 
-`clamscan -r {{path/to/directory}}`
+`clamscan {{[-r|--recursive]}} {{path/to/directory}}`
 
 - Scan data from `stdin`:
 
@@ -17,15 +17,15 @@
 
 - Specify a virus database file or directory of files:
 
-`clamscan --database {{path/to/database_file_or_directory}}`
+`clamscan {{[-d|--database]}} {{path/to/database_file_or_directory}}`
 
 - Scan the current directory and output only infected files:
 
-`clamscan --infected`
+`clamscan {{[-i|--infected]}}`
 
 - Print the scan report to a log file:
 
-`clamscan --log {{path/to/log_file}}`
+`clamscan {{[-l|--log]}} {{path/to/log_file}}`
 
 - Move infected files to a specific directory:
 

--- a/pages/common/clj.md
+++ b/pages/common/clj.md
@@ -14,7 +14,7 @@
 
 - Run the main function of a specified namespace:
 
-`clj -M -m {{namespace}} {{args}}`
+`clj -M {{[-m|--main]}} {{namespace}} {{args}}`
 
 - Prepare a project by resolving dependencies, downloading libraries, and making/caching classpaths:
 
@@ -22,8 +22,8 @@
 
 - Start an nREPL server with the CIDER middleware:
 
-`clj -Sdeps '{:deps {nrepl {:mvn/version "0.7.0"} cider/cider-nrepl {:mvn/version "0.25.2"}}}' -m nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]' --interactive`
+`clj -Sdeps '{:deps {nrepl {:mvn/version "0.7.0"} cider/cider-nrepl {:mvn/version "0.25.2"}}}' {{[-m|--main]}} nrepl.cmdline --middleware '["cider.nrepl/cider-middleware"]' --interactive`
 
 - Start a REPL for ClojureScript and open a web browser:
 
-`clj -Sdeps '{:deps {org.clojure/clojurescript {:mvn/version "1.10.758"}}}' --main cljs.main --repl`
+`clj -Sdeps '{:deps {org.clojure/clojurescript {:mvn/version "1.10.758"}}}' {{[-m|--main]}} cljs.main {{[-r|--repl]}}`

--- a/pages/common/conda-create.md
+++ b/pages/common/conda-create.md
@@ -5,12 +5,12 @@
 
 - Create a new environment named `py39`, and install Python 3.9 and NumPy v1.11 or above in it:
 
-`conda create --yes --name {{py39}} python={{3.9}} "{{numpy>=1.11}}"`
+`conda create {{[-y|--yes]}} {{[-n|--name]}} {{py39}} python={{3.9}} "{{numpy>=1.11}}"`
 
 - Make exact copy of an environment:
 
-`conda create --clone {{py39}} --name {{py39-copy}}`
+`conda create --clone {{py39}} {{[-n|--name]}} {{py39-copy}}`
 
 - Create a new environment with a specified name and install a given package:
 
-`conda create --name {{env_name}} {{package}}`
+`conda create {{[-n|--name]}} {{env_name}} {{package}}`

--- a/pages/common/conda-install.md
+++ b/pages/common/conda-install.md
@@ -9,11 +9,11 @@
 
 - Install a single package into the currently active conda environment using channel conda-forge:
 
-`conda install -c conda-forge {{package}}`
+`conda install {{[-c|--channel]}} conda-forge {{package}}`
 
 - Install a single package into the currently active conda environment using channel conda-forge and ignoring other channels:
 
-`conda install -c conda-forge --override-channels {{package}}`
+`conda install {{[-c|--channel]}} conda-forge --override-channels {{package}}`
 
 - Install a specific version of a package:
 
@@ -21,7 +21,7 @@
 
 - Install a package into a specific environment:
 
-`conda install --name {{environment}} {{package}}`
+`conda install {{[-n|--name]}} {{environment}} {{package}}`
 
 - Update a package in the current environment:
 
@@ -29,4 +29,4 @@
 
 - Install a package and agree to the transactions without prompting:
 
-`conda install --yes {{package}}`
+`conda install {{[-y|--yes]}} {{package}}`

--- a/pages/common/conda.md
+++ b/pages/common/conda.md
@@ -2,15 +2,15 @@
 
 > Package, dependency and environment management for any programming language.
 > Some subcommands such as `create` have their own usage documentation.
-> More information: <https://github.com/conda/conda>.
+> More information: <https://docs.conda.io/projects/conda/en/latest/commands/index.html>.
 
 - Create a new environment, installing named packages into it:
 
-`conda create --name {{environment_name}} {{python=3.9 matplotlib}}`
+`conda create {{[-n|--name]}} {{environment_name}} {{python=3.9 matplotlib}}`
 
 - List all environments:
 
-`conda info --envs`
+`conda info {{[-e|--envs]}}`
 
 - Load an environment:
 
@@ -22,7 +22,7 @@
 
 - Delete an environment (remove all packages):
 
-`conda remove --name {{environment_name}} --all`
+`conda remove {{[-n|--name]}} {{environment_name}} --all`
 
 - Install packages into the current environment:
 
@@ -34,4 +34,4 @@
 
 - Delete unused packages and caches:
 
-`conda clean --all`
+`conda clean {{[-a|--all]}}`

--- a/pages/common/core-validate-commit.md
+++ b/pages/common/core-validate-commit.md
@@ -17,16 +17,16 @@
 
 - List all validation rules:
 
-`core-validate-commit --list`
+`core-validate-commit {{[-l|--list]}}`
 
 - List all valid Node.js subsystems:
 
-`core-validate-commit --list-subsystem`
+`core-validate-commit {{[-ls|--list-subsystem]}}`
 
 - Validate the current commit formatting the output in tap format:
 
-`core-validate-commit --tap`
+`core-validate-commit {{[-t|--tap]}}`
 
 - Display help:
 
-`core-validate-commit --help`
+`core-validate-commit {{[-h|--help]}}`

--- a/pages/common/cowsay.md
+++ b/pages/common/cowsay.md
@@ -1,7 +1,7 @@
 # cowsay
 
 > Print ASCII art (by default a cow) saying or thinking something.
-> More information: <https://github.com/tnalpgge/rank-amateur-cowsay>.
+> More information: <https://manned.org/cowsay>.
 
 - Print an ASCII cow saying "hello, world":
 

--- a/pages/common/crunch.md
+++ b/pages/common/crunch.md
@@ -1,7 +1,7 @@
 # crunch
 
 > Wordlist generator.
-> More information: <https://sourceforge.net/projects/crunch-wordlist/>.
+> More information: <https://manned.org/crunch>.
 
 - Output a list of words of length 1 to 3 with only lowercase characters:
 

--- a/pages/common/csvcut.md
+++ b/pages/common/csvcut.md
@@ -6,16 +6,16 @@
 
 - Print indices and names of all columns:
 
-`csvcut -n {{data.csv}}`
+`csvcut {{[-n|--names]}} {{data.csv}}`
 
 - Extract the first and third columns:
 
-`csvcut -c {{1,3}} {{data.csv}}`
+`csvcut {{[-c|--columns]}} {{1,3}} {{data.csv}}`
 
 - Extract all columns except the fourth one:
 
-`csvcut -C {{4}} {{data.csv}}`
+`csvcut {{[-C|--not-columns]}} {{4}} {{data.csv}}`
 
 - Extract the columns named "id" and "first name" (in that order):
 
-`csvcut -c {{id,"first name"}} {{data.csv}}`
+`csvcut {{[-c|--columns]}} {{id,"first name"}} {{data.csv}}`

--- a/pages/common/csvformat.md
+++ b/pages/common/csvformat.md
@@ -6,20 +6,20 @@
 
 - Convert to a tab-delimited file (TSV):
 
-`csvformat -T {{data.csv}}`
+`csvformat {{[-T|--out-tabs]}} {{data.csv}}`
 
 - Convert delimiters to a custom character:
 
-`csvformat -D "{{custom_character}}" {{data.csv}}`
+`csvformat {{[-D|--out-delimiter]}} "{{custom_character}}" {{data.csv}}`
 
 - Convert line endings to carriage return (^M) + line feed:
 
-`csvformat -M "{{\r\n}}" {{data.csv}}`
+`csvformat {{[-M|--out-lineterminator]}} "{{\r\n}}" {{data.csv}}`
 
 - Minimize use of quote characters:
 
-`csvformat -U 0 {{data.csv}}`
+`csvformat {{[-U|--out-quoting]}} 0 {{data.csv}}`
 
 - Maximize use of quote characters:
 
-`csvformat -U 1 {{data.csv}}`
+`csvformat {{[-U|--out-quoting]}} 1 {{data.csv}}`

--- a/pages/common/csvgrep.md
+++ b/pages/common/csvgrep.md
@@ -6,12 +6,12 @@
 
 - Find rows that have a certain string in column 1:
 
-`csvgrep -c {{1}} -m {{string_to_match}} {{data.csv}}`
+`csvgrep {{[-c|--columns]}} {{1}} {{[-m|--match]}} {{string_to_match}} {{data.csv}}`
 
 - Find rows in which columns 3 or 4 match a certain regular expression:
 
-`csvgrep -c {{3,4}} -r {{regular_expression}} {{data.csv}}`
+`csvgrep {{[-c|--columns]}} {{3,4}} {{[-r|--regex]}} {{regular_expression}} {{data.csv}}`
 
 - Find rows in which the "name" column does NOT include the string "John Doe":
 
-`csvgrep -i -c {{name}} -m "{{John Doe}}" {{data.csv}}`
+`csvgrep {{[-i|--invert-match]}} {{[-c|--columns]}} {{name}} {{[-m|--match]}} "{{John Doe}}" {{data.csv}}`

--- a/pages/common/csvkit.md
+++ b/pages/common/csvkit.md
@@ -2,20 +2,20 @@
 
 > Manipulation toolkit for CSV files.
 > See also: `csvclean`, `csvcut`, `csvformat`, `csvgrep`, `csvlook`, `csvpy`, `csvsort`, `csvstat`.
-> More information: <https://csvkit.readthedocs.io/en/0.9.1/cli.html>.
+> More information: <https://csvkit.readthedocs.io/en/latest/cli.html>.
 
 - Run a command on a CSV file with a custom delimiter:
 
-`{{command}} -d {{delimiter}} {{path/to/file.csv}}`
+`{{command}} {{[-d|--delimiter]}} {{delimiter}} {{path/to/file.csv}}`
 
 - Run a command on a CSV file with a tab as a delimiter (overrides -d):
 
-`{{command}} -t {{path/to/file.csv}}`
+`{{command}} {{[-t|--tabs]}} {{path/to/file.csv}}`
 
 - Run a command on a CSV file with a custom quote character:
 
-`{{command}} -q {{quote_char}} {{path/to/file.csv}}`
+`{{command}} {{[-q|--quotechar]}} {{quote_char}} {{path/to/file.csv}}`
 
 - Run a command on a CSV file with no header row:
 
-`{{command}} -H {{path/to/file.csv}}`
+`{{command}} {{[-H|--no-header-row]}} {{path/to/file.csv}}`

--- a/pages/common/csvsort.md
+++ b/pages/common/csvsort.md
@@ -6,16 +6,16 @@
 
 - Sort a CSV file by column 9:
 
-`csvsort -c {{9}} {{data.csv}}`
+`csvsort {{[-c|--columns]}} {{9}} {{data.csv}}`
 
 - Sort a CSV file by the "name" column in descending order:
 
-`csvsort -r -c {{name}} {{data.csv}}`
+`csvsort {{[-r|--reverse]}} {{[-c|--columns]}} {{name}} {{data.csv}}`
 
 - Sort a CSV file by column 2, then by column 4:
 
-`csvsort -c {{2,4}} {{data.csv}}`
+`csvsort {{[-c|--columns]}} {{2,4}} {{data.csv}}`
 
 - Sort a CSV file without inferring data types:
 
-`csvsort --no-inference -c {{columns}} {{data.csv}}`
+`csvsort {{[-I|--no-inference]}} {{[-c|--columns]}} {{columns}} {{data.csv}}`

--- a/pages/common/csvstat.md
+++ b/pages/common/csvstat.md
@@ -10,7 +10,7 @@
 
 - Show all stats for columns 2 and 4:
 
-`csvstat -c {{2,4}} {{data.csv}}`
+`csvstat {{[-c|--columns]}} {{2,4}} {{data.csv}}`
 
 - Show sums for all columns:
 
@@ -18,8 +18,8 @@
 
 - Show the max value length for column 3:
 
-`csvstat -c {{3}} --len {{data.csv}}`
+`csvstat {{[-c|--columns]}} {{3}} --len {{data.csv}}`
 
 - Show the number of unique values in the "name" column:
 
-`csvstat -c {{name}} --unique {{data.csv}}`
+`csvstat {{[-c|--columns]}} {{name}} --unique {{data.csv}}`

--- a/pages/common/ctest.md
+++ b/pages/common/ctest.md
@@ -3,14 +3,14 @@
 > CMake test driver program.
 > More information: <https://gitlab.kitware.com/cmake/community/wikis/doc/ctest/Testing-With-CTest>.
 
-- Run all tests defined in the CMake project, executing 4 jobs at a time in parallel:
+- Run all tests defined in the CMake project, executing 4 [j]obs at a time in parallel:
 
-`ctest -j{{4}} --output-on-failure`
+`ctest {{[-j|--parallel]}} {{4}} --output-on-failure`
 
 - List available tests:
 
-`ctest -N`
+`ctest {{[-N|--show-only]}}`
 
 - Run a single test based on its name, or filter on a regular expression:
 
-`ctest --output-on-failure -R '^{{test_name}}$'`
+`ctest --output-on-failure {{[-R|--tests-regex]}} '^{{test_name}}$'`

--- a/pages/common/daps.md
+++ b/pages/common/daps.md
@@ -5,19 +5,19 @@
 
 - Check if a DocBook XML file is valid:
 
-`daps -d {{path/to/file.xml}} validate`
+`daps {{[-d|--docconfig]}} {{path/to/file.xml}} validate`
 
 - Convert a DocBook XML file into PDF:
 
-`daps -d {{path/to/file.xml}} pdf`
+`daps {{[-d|--docconfig]}} {{path/to/file.xml}} pdf`
 
 - Convert a DocBook XML file into a single HTML file:
 
-`daps -d {{path/to/file.xml}} html --single`
+`daps {{[-d|--docconfig]}} {{path/to/file.xml}} html --single`
 
 - Display help:
 
-`daps --help`
+`daps {{[-h|--help]}}`
 
 - Display version:
 

--- a/pages/common/deluge.md
+++ b/pages/common/deluge.md
@@ -1,7 +1,7 @@
 # deluge
 
 > A command-line BitTorrent client.
-> More information: <https://deluge-torrent.org>.
+> More information: <https://manned.org/deluge>.
 
 - Download a torrent:
 
@@ -9,7 +9,7 @@
 
 - Download a torrent using a specific configuration file:
 
-`deluge -c {{path/to/configuration_file}} {{url|magnet|path/to/file}}`
+`deluge {{[-c|--config]}} {{path/to/configuration_file}} {{url|magnet|path/to/file}}`
 
 - Download a torrent and launch the specified user interface:
 
@@ -17,4 +17,4 @@
 
 - Download a torrent and output the log to a file:
 
-`deluge -l {{path/to/log_file}} {{url|magnet|path/to/file}}`
+`deluge {{[-l|--logfile]}} {{path/to/log_file}} {{url|magnet|path/to/file}}`

--- a/pages/common/deluged.md
+++ b/pages/common/deluged.md
@@ -1,7 +1,7 @@
 # deluged
 
 > A daemon process for the Deluge BitTorrent client.
-> More information: <https://deluge-torrent.org>.
+> More information: <https://manned.org/deluged>.
 
 - Start the Deluge daemon:
 
@@ -9,12 +9,12 @@
 
 - Start the Deluge daemon on a specific port:
 
-`deluged -p {{port}}`
+`deluged {{[-p|--port]}} {{port}}`
 
 - Start the Deluge daemon using a specific configuration file:
 
-`deluged -c {{path/to/configuration_file}}`
+`deluged {{[-c|--config]}} {{path/to/configuration_file}}`
 
 - Start the Deluge daemon and output the log to a file:
 
-`deluged -l {{path/to/log_file}}`
+`deluged {{[-l|--logfile]}} {{path/to/log_file}}`

--- a/pages/common/detox.md
+++ b/pages/common/detox.md
@@ -2,7 +2,7 @@
 
 > Renames files to make them easier to work with.
 > It removes spaces and other such annoyances like duplicate underline characters.
-> More information: <https://github.com/dharple/detox>.
+> More information: <https://manned.org/detox>.
 
 - Remove spaces and other undesirable characters from a file's name:
 
@@ -10,7 +10,7 @@
 
 - Show how detox would rename all the files in a directory tree:
 
-`detox --dry-run -r {{path/to/directory}}`
+`detox {{[-n|--dry-run]}} -r {{path/to/directory}}`
 
 - Remove spaces and other undesirable characters from all files in a directory tree:
 

--- a/pages/common/dexdump.md
+++ b/pages/common/dexdump.md
@@ -1,7 +1,7 @@
 # dexdump
 
 > Display information about Android DEX files.
-> More information: <https://manned.org/dexdump>.
+> More information: <https://manned.org/man/debian-stretch/dexdump>.
 
 - Extract classes and methods from an APK file:
 

--- a/pages/common/dexter.md
+++ b/pages/common/dexter.md
@@ -5,8 +5,8 @@
 
 - Create and authenticate a user with Google OIDC:
 
-`dexter auth -i {{client_id}} -s {{client_secret}}`
+`dexter auth {{[-i|--client-id]}} {{client_id}} {{[-s|--client-secret]}} {{client_secret}}`
 
 - Override the default kube configuration file location:
 
-`dexter auth -i {{client_id}} -s {{client_secret}} --kube-config {{sample/config}}`
+`dexter auth {{[-i|--client-id]}} {{client_id}} {{[-s|--client-secret]}} {{client_secret}} {{[-k|--kube-config]}} {{sample/config}}`

--- a/pages/common/dhcpig.md
+++ b/pages/common/dhcpig.md
@@ -10,24 +10,24 @@
 
 - Exhaust IPv6 addresses using eth1 interface:
 
-`sudo ./pig.py -6 {{eth1}}`
+`sudo ./pig.py {{[-6|--ipv6]}} {{eth1}}`
 
 - Send fuzzed/malformed data packets using the interface:
 
-`sudo ./pig.py --fuzz {{eth1}}`
+`sudo ./pig.py {{[-f|--fuzz]}} {{eth1}}`
 
 - Enable color output:
 
-`sudo ./pig.py -c {{eth1}}`
+`sudo ./pig.py {{[-c|--color]}} {{eth1}}`
 
 - Enable minimal verbosity and color output:
 
-`sudo ./pig.py -c --verbosity=1 {{eth1}}`
+`sudo ./pig.py {{[-c|--color]}} {{[-v|--verbosity]}} 1 {{eth1}}`
 
 - Use a debug verbosity of 100 and scan network of neighboring devices using ARP packets:
 
-`sudo ./pig.py -c --verbosity=100 --neighbors-scan-arp {{eth1}}`
+`sudo ./pig.py {{[-c|--color]}} {{[-v|--verbosity]}} 100 {{[-n|--neighbors-scan-arp]}} {{eth1}}`
 
 - Enable printing lease information, attempt to scan and release all neighbor IP addresses:
 
-`sudo ./pig.py --neighbors-scan-arp -r --show-options {{eth1}}`
+`sudo ./pig.py {{[-n|--neighbors-scan-arp]}} {{[-r|--neighbors-attack-release]}} {{[-o|--show-options]}} {{eth1}}`

--- a/pages/common/dict.md
+++ b/pages/common/dict.md
@@ -5,15 +5,15 @@
 
 - List available databases:
 
-`dict -D`
+`dict {{[-D|--dbs]}}`
 
 - Get information about a database:
 
-`dict -i {{database_name}}`
+`dict {{[-i|--info]}} {{database_name}}`
 
 - Look up a word in a specific database:
 
-`dict -d {{database_name}} {{word}}`
+`dict {{[-d|--database]}} {{database_name}} {{word}}`
 
 - Look up a word in all available databases:
 
@@ -21,4 +21,4 @@
 
 - Show information about the DICT server:
 
-`dict -I`
+`dict {{[-I|--serverinfo]}}`

--- a/pages/common/docker-build.md
+++ b/pages/common/docker-build.md
@@ -13,19 +13,19 @@
 
 - Build a Docker image and tag it:
 
-`docker build --tag {{name:tag}} .`
+`docker build {{[-t|--tag]}} {{name:tag}} .`
 
 - Build a Docker image with no build context:
 
-`docker build --tag {{name:tag}} - < {{Dockerfile}}`
+`docker build {{[-t|--tag]}} {{name:tag}} - < {{Dockerfile}}`
 
 - Do not use the cache when building the image:
 
-`docker build --no-cache --tag {{name:tag}} .`
+`docker build --no-cache {{[-t|--tag]}} {{name:tag}} .`
 
 - Build a Docker image using a specific Dockerfile:
 
-`docker build --file {{Dockerfile}} .`
+`docker build {{[-f|--file]}} {{Dockerfile}} .`
 
 - Build with custom build-time variables:
 

--- a/pages/common/docker-commit.md
+++ b/pages/common/docker-commit.md
@@ -9,23 +9,23 @@
 
 - Apply a `CMD` Dockerfile instruction to the created image:
 
-`docker commit --change "CMD {{command}}" {{container}} {{image}}:{{tag}}`
+`docker commit {{[-c|--change]}} "CMD {{command}}" {{container}} {{image}}:{{tag}}`
 
 - Apply an `ENV` Dockerfile instruction to the created image:
 
-`docker commit --change "ENV {{name}}={{value}}" {{container}} {{image}}:{{tag}}`
+`docker commit {{[-c|--change]}} "ENV {{name}}={{value}}" {{container}} {{image}}:{{tag}}`
 
 - Create an image with a specific author in the metadata:
 
-`docker commit --author "{{author}}" {{container}} {{image}}:{{tag}}`
+`docker commit {{[-a|--author]}} "{{author}}" {{container}} {{image}}:{{tag}}`
 
 - Create an image with a specific comment in the metadata:
 
-`docker commit --message "{{comment}}" {{container}} {{image}}:{{tag}}`
+`docker commit {{[-m|--message]}} "{{comment}}" {{container}} {{image}}:{{tag}}`
 
 - Create an image without pausing the container during commit:
 
-`docker commit --pause {{false}} {{container}} {{image}}:{{tag}}`
+`docker commit {{[-p|--pause]}} {{false}} {{container}} {{image}}:{{tag}}`
 
 - Display help:
 

--- a/pages/common/docker-compose.md
+++ b/pages/common/docker-compose.md
@@ -9,7 +9,7 @@
 
 - Create and start all containers in the background using a `docker-compose.yml` file from the current directory:
 
-`docker compose up --detach`
+`docker compose up {{[-d|--detach]}}`
 
 - Start all containers, rebuild if necessary:
 
@@ -17,7 +17,7 @@
 
 - Start all containers by specifying a project name and using an alternate compose file:
 
-`docker compose -p {{project_name}} --file {{path/to/file}} up`
+`docker compose {{[-p|--project-name]}} {{project_name}} {{[-f|--file]}} {{path/to/file}} up`
 
 - Stop all running containers:
 
@@ -25,12 +25,12 @@
 
 - Stop and remove all containers, networks, images, and volumes:
 
-`docker compose down --rmi all --volumes`
+`docker compose down --rmi all {{[-v|--volumes]}}`
 
 - Follow logs for all containers:
 
-`docker compose logs --follow`
+`docker compose logs {{[-f|--follow]}}`
 
 - Follow logs for a specific container:
 
-`docker compose logs --follow {{container_name}}`
+`docker compose logs {{[-f|--follow]}} {{container_name}}`

--- a/pages/common/docker-cp.md
+++ b/pages/common/docker-cp.md
@@ -13,4 +13,4 @@
 
 - Copy a file or directory from the host to a container, following symlinks (copies the symlinked files directly, not the symlinks themselves):
 
-`docker cp --follow-link {{path/to/symlink_on_host}} {{container_name}}:{{path/to/file_or_directory_in_container}}`
+`docker cp {{[-L|--follow-link]}} {{path/to/symlink_on_host}} {{container_name}}:{{path/to/file_or_directory_in_container}}`

--- a/pages/common/docker-image.md
+++ b/pages/common/docker-image.md
@@ -14,7 +14,7 @@
 
 - Delete all unused images (not just those without a tag):
 
-`docker image prune --all`
+`docker image prune {{[-a|--all]}}`
 
 - Show the history of a local Docker image:
 

--- a/pages/common/docker-images.md
+++ b/pages/common/docker-images.md
@@ -25,4 +25,4 @@
 
 - Sort images by size:
 
-`docker images --format "\{\{.ID\}\}\t\{\{.Size\}\}\t\{\{.Repository\}\}:\{\{.Tag\}\}" | sort -k 2 -h`
+`docker images --format "\{\{.ID\}\}\t\{\{.Size\}\}\t\{\{.Repository\}\}:\{\{.Tag\}\}" | sort {{[-k|--key]}} 2 {{[-h|--human-numeric-sort]}}`

--- a/pages/common/docker-inspect.md
+++ b/pages/common/docker-inspect.md
@@ -13,20 +13,20 @@
 
 - Display a container's IP address:
 
-`docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{container}}`
+`docker inspect {{[-f|--format]}} '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{container}}`
 
 - Display the path to the container's log file:
 
-`docker inspect --format='\{\{.LogPath\}\}' {{container}}`
+`docker inspect {{[-f|--format]}} '\{\{.LogPath\}\}' {{container}}`
 
 - Display the image name of the container:
 
-`docker inspect --format='\{\{.Config.Image\}\}' {{container}}`
+`docker inspect {{[-f|--format]}} '\{\{.Config.Image\}\}' {{container}}`
 
 - Display the configuration information as JSON:
 
-`docker inspect --format='\{\{json .Config\}\}' {{container}}`
+`docker inspect {{[-f|--format]}} '\{\{json .Config\}\}' {{container}}`
 
 - Display all port bindings:
 
-`docker inspect --format='\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{container}}`
+`docker inspect {{[-f|--format]}} '\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{container}}`

--- a/pages/common/docker-load.md
+++ b/pages/common/docker-load.md
@@ -9,8 +9,8 @@
 
 - Load a Docker image from a specific file:
 
-`docker load --input {{path/to/image_file.tar}}`
+`docker load {{[-i|--input]}} {{path/to/image_file.tar}}`
 
 - Load a Docker image from a specific file in quiet mode:
 
-`docker load --quiet --input {{path/to/image_file.tar}}`
+`docker load {{[-q|--quiet]}} {{[-i|--input]}} {{path/to/image_file.tar}}`

--- a/pages/common/docker-login.md
+++ b/pages/common/docker-login.md
@@ -9,12 +9,12 @@
 
 - Log into a registry with a specific username (user will be prompted for a password):
 
-`docker login --username {{username}}`
+`docker login {{[-u|--username]}} {{username}}`
 
 - Log into a registry with username and password:
 
-`docker login --username {{username}} --password {{password}} {{server}}`
+`docker login {{[-u|--username]}} {{username}} {{[-p|--password]}} {{password}} {{server}}`
 
 - Log into a registry with password from `stdin`:
 
-`echo "{{password}}" | docker login --username {{username}} --password-stdin`
+`echo "{{password}}" | docker login {{[-u|--username]}} {{username}} --password-stdin`

--- a/pages/common/docker-network.md
+++ b/pages/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Create a user-defined network:
 
-`docker network create --driver {{driver_name}} {{network_name}}`
+`docker network create {{[-d|--driver]}} {{driver_name}} {{network_name}}`
 
 - Display detailed information about one or more networks:
 

--- a/pages/common/docker-rmi.md
+++ b/pages/common/docker-rmi.md
@@ -13,7 +13,7 @@
 
 - Force remove an image:
 
-`docker rmi --force {{image}}`
+`docker rmi {{[-f|--force]}} {{image}}`
 
 - Remove an image without deleting untagged parents:
 

--- a/pages/common/docker-save.md
+++ b/pages/common/docker-save.md
@@ -9,12 +9,12 @@
 
 - Save an image to a tar archive:
 
-`docker save --output {{path/to/file.tar}} {{image}}:{{tag}}`
+`docker save {{[-o|--output]}} {{path/to/file.tar}} {{image}}:{{tag}}`
 
 - Save all tags of the image:
 
-`docker save --output {{path/to/file.tar}} {{image_name}}`
+`docker save {{[-o|--output]}} {{path/to/file.tar}} {{image_name}}`
 
 - Cherry-pick particular tags of an image to save:
 
-`docker save --output {{path/to/file.tar}} {{image_name:tag1 image_name:tag2 ...}}`
+`docker save {{[-o|--output]}} {{path/to/file.tar}} {{image_name:tag1 image_name:tag2 ...}}`

--- a/pages/common/docker-stats.md
+++ b/pages/common/docker-stats.md
@@ -17,7 +17,7 @@
 
 - Display statistics for all containers (both running and stopped):
 
-`docker stats --all`
+`docker stats {{[-a|--all]}}`
 
 - Disable streaming stats and only pull the current stats:
 

--- a/pages/common/docker-system.md
+++ b/pages/common/docker-system.md
@@ -13,7 +13,7 @@
 
 - Show detailed information on disk usage:
 
-`docker system df --verbose`
+`docker system df {{[-v|--verbose]}}`
 
 - Remove unused data (append `--volumes` to remove unused volumes as well):
 
@@ -29,7 +29,7 @@
 
 - Display real-time events from containers streamed as valid JSON Lines:
 
-`docker system events --filter 'type=container' --format '{{json .}}'`
+`docker system events {{[-f|--filter]}} 'type=container' --format '{{json .}}'`
 
 - Display system-wide information:
 

--- a/pages/common/docker-volume.md
+++ b/pages/common/docker-volume.md
@@ -13,7 +13,7 @@
 
 - Create a `tmpfs` volume a size of 100 MiB and an uid of 1000:
 
-`docker volume create --opt {{type}}={{tmpfs}} --opt {{device}}={{tmpfs}} --opt {{o}}={{size=100m,uid=1000}} {{volume_name}}`
+`docker volume create {{[-o|--opt]}} {{type}}={{tmpfs}} {{[-o|--opt]}} {{device}}={{tmpfs}} {{[-o|--opt]}} {{o}}={{size=100m,uid=1000}} {{volume_name}}`
 
 - List all volumes:
 

--- a/pages/common/dolt-add.md
+++ b/pages/common/dolt-add.md
@@ -9,4 +9,4 @@
 
 - Stage all tables:
 
-`dolt add --all`
+`dolt add {{[-A|--all]}}`

--- a/pages/common/dolt-branch.md
+++ b/pages/common/dolt-branch.md
@@ -9,7 +9,7 @@
 
 - List all local and remote branches:
 
-`dolt branch --all`
+`dolt branch {{[-A|--all]}}`
 
 - Create a new branch based on the current branch:
 
@@ -21,15 +21,15 @@
 
 - Rename a branch:
 
-`dolt branch --move {{branch_name1}} {{branch_name2}}`
+`dolt branch {{[-m|--move]}} {{branch_name1}} {{branch_name2}}`
 
 - Duplicate a branch:
 
-`dolt branch --copy {{branch_name1}} {{branch_name2}}`
+`dolt branch {{[-c|--copy]}} {{branch_name1}} {{branch_name2}}`
 
 - Delete a branch:
 
-`dolt branch --delete {{branch_name}}`
+`dolt branch {{[-d|--delete]}} {{branch_name}}`
 
 - Display the name of the current branch:
 

--- a/pages/common/dolt-clone.md
+++ b/pages/common/dolt-clone.md
@@ -1,7 +1,7 @@
 # dolt clone
 
 > Clone a repository into a new directory.
-> More information: <https://docs.dolthub.com/interfaces/cli#dolt-clone>.
+> More information: <https://docs.dolthub.com/cli-reference/cli#dolt-clone>.
 
 - Clone an existing repository into a specific directory (defaults to the repository name):
 
@@ -13,7 +13,7 @@
 
 - Clone an existing repository only fetching a specific branch (defaults to all branches):
 
-`dolt clone --branch {{branch_name}} {{repository_url}}`
+`dolt clone {{[-b|--branch]}} {{branch_name}} {{repository_url}}`
 
 - Clone a repository, using an AWS region (uses the profile's default region if none is provided):
 

--- a/pages/common/dolt-commit.md
+++ b/pages/common/dolt-commit.md
@@ -9,11 +9,11 @@
 
 - Commit all staged changes with the specified message:
 
-`dolt commit --message "{{commit_message}}"`
+`dolt commit {{[-m|--message]}} "{{commit_message}}"`
 
 - Stage all unstaged changes to tables before committing:
 
-`dolt commit --all`
+`dolt commit {{[-a|--all]}}`
 
 - Use the specified ISO 8601 commit date (defaults to current date and time):
 
@@ -29,4 +29,4 @@
 
 - Ignore foreign key warnings:
 
-`dolt commit --force`
+`dolt commit {{[-f|--force]}}`

--- a/pages/common/dolt-gc.md
+++ b/pages/common/dolt-gc.md
@@ -9,4 +9,4 @@
 
 - Initiate a faster but less thorough garbage collection process:
 
-`dolt gc --shallow`
+`dolt gc {{[-s|--shallow]}}`

--- a/pages/common/dolt-init.md
+++ b/pages/common/dolt-init.md
@@ -9,4 +9,4 @@
 
 - Initialize a new Dolt data repository creating a commit with the specified metadata:
 
-`dolt init --name "{{name}}" --email "{{email}}" --date "{{2021-12-31T00:00:00}}" -b "{{branch_name}}"`
+`dolt init --name "{{name}}" --email "{{email}}" --date "{{2021-12-31T00:00:00}}" {{[-b|--initial-branch]}} "{{branch_name}}"`

--- a/pages/common/dolt-merge.md
+++ b/pages/common/dolt-merge.md
@@ -17,7 +17,7 @@
 
 - Merge a branch and create a merge commit with a specific commit message:
 
-`dolt merge --no-ff -m "{{message}}" {{branch_name}}`
+`dolt merge --no-ff {{[-m|--message]}} "{{message}}" {{branch_name}}`
 
 - Abort the current conflict resolution process:
 

--- a/pages/common/dolt-sql.md
+++ b/pages/common/dolt-sql.md
@@ -5,8 +5,8 @@
 
 - Run a single query:
 
-`dolt sql --query "{{INSERT INTO t values (1, 3);}}"`
+`dolt sql {{[-q|--query]}} "{{INSERT INTO t values (1, 3);}}"`
 
 - List all saved queries:
 
-`dolt sql --list-saved`
+`dolt sql {{[-l|--list-saved]}}`

--- a/pages/common/dotnet-add-package.md
+++ b/pages/common/dotnet-add-package.md
@@ -13,15 +13,15 @@
 
 - Add a specific version of a package to the project:
 
-`dotnet add package {{package}} --version {{1.0.0}}`
+`dotnet add package {{package}} {{[-v|--version]}} {{1.0.0}}`
 
 - Add a package using a specific NuGet source:
 
-`dotnet add package {{package}} --source {{https://api.nuget.org/v3/index.json}}`
+`dotnet add package {{package}} {{[-s|--source]}} {{https://api.nuget.org/v3/index.json}}`
 
 - Add a package only when targeting a specific framework:
 
-`dotnet add package {{package}} --framework {{net7.0}}`
+`dotnet add package {{package}} {{[-f|--framework]}} {{net7.0}}`
 
 - Add and specify the directory where to restore packages (`~/.nuget/packages` by default):
 

--- a/pages/common/dotnet-build.md
+++ b/pages/common/dotnet-build.md
@@ -13,7 +13,7 @@
 
 - Compile in release mode:
 
-`dotnet build --configuration {{Release}}`
+`dotnet build {{[-c|--configuration]}} {{Release}}`
 
 - Compile without restoring dependencies:
 
@@ -21,12 +21,12 @@
 
 - Compile with a specific verbosity level:
 
-`dotnet build --verbosity {{quiet|minimal|normal|detailed|diagnostic}}`
+`dotnet build {{[-v|--verbosity]}} {{quiet|minimal|normal|detailed|diagnostic}}`
 
 - Compile for a specific runtime:
 
-`dotnet build --runtime {{runtime_identifier}}`
+`dotnet build {{[-r|--runtime]}} {{runtime_identifier}}`
 
 - Specify the output directory:
 
-`dotnet build --output {{path/to/directory}}`
+`dotnet build {{[-o|--output]}} {{path/to/directory}}`

--- a/pages/common/dotnet-publish.md
+++ b/pages/common/dotnet-publish.md
@@ -5,19 +5,19 @@
 
 - Compile a .NET project in release mode:
 
-`dotnet publish --configuration Release {{path/to/project_file}}`
+`dotnet publish {{[-c|--configuration]}} Release {{path/to/project_file}}`
 
 - Publish the .NET Core runtime with your application for the specified runtime:
 
-`dotnet publish --self-contained true --runtime {{runtime_identifier}} {{path/to/project_file}}`
+`dotnet publish {{[-sc|--self-contained]}} true {{[-r|--runtime]}} {{runtime_identifier}} {{path/to/project_file}}`
 
 - Package the application into a platform-specific single-file executable:
 
-`dotnet publish --runtime {{runtime_identifier}} -p:PublishSingleFile=true {{path/to/project_file}}`
+`dotnet publish {{[-r|--runtime]}} {{runtime_identifier}} -p:PublishSingleFile=true {{path/to/project_file}}`
 
 - Trim unused libraries to reduce the deployment size of an application:
 
-`dotnet publish --self-contained true --runtime {{runtime_identifier}} -p:PublishTrimmed=true {{path/to/project_file}}`
+`dotnet publish {{[-sc|--self-contained]}} true {{[-r|--runtime]}} {{runtime_identifier}} -p:PublishTrimmed=true {{path/to/project_file}}`
 
 - Compile a .NET project without restoring dependencies:
 
@@ -25,4 +25,4 @@
 
 - Specify the output directory:
 
-`dotnet publish --output {{path/to/directory}} {{path/to/project_file}}`
+`dotnet publish {{[-o|--output]}} {{path/to/directory}} {{path/to/project_file}}`

--- a/pages/common/dotnet-restore.md
+++ b/pages/common/dotnet-restore.md
@@ -25,4 +25,4 @@
 
 - Restore dependencies with a specific verbosity level:
 
-`dotnet restore --verbosity {{quiet|minimal|normal|detailed|diagnostic}}`
+`dotnet restore {{[-v|--verbosity]}} {{quiet|minimal|normal|detailed|diagnostic}}`

--- a/pages/common/dotnet-run.md
+++ b/pages/common/dotnet-run.md
@@ -17,8 +17,8 @@
 
 - Run the project using a target framework moniker:
 
-`dotnet run --framework {{net7.0}}`
+`dotnet run {{[-f|--framework]}} {{net7.0}}`
 
 - Specify architecture and OS, available since .NET 6 (Don't use `--runtime` with these options):
 
-`dotnet run --arch {{x86|x64|arm|arm64}} --os {{win|win7|osx|linux|ios|android}}`
+`dotnet run {{[-a|--arch]}} {{x86|x64|arm|arm64}} --os {{win|win7|osx|linux|ios|android}}`

--- a/pages/common/dotnet-tool.md
+++ b/pages/common/dotnet-tool.md
@@ -5,7 +5,7 @@
 
 - Install a global tool (don't use `--global` for local tools):
 
-`dotnet tool install --global {{dotnetsay}}`
+`dotnet tool install {{[-g|--global]}} {{dotnetsay}}`
 
 - Install tools defined in the local tool manifest:
 
@@ -13,15 +13,15 @@
 
 - Update a specific global tool (don't use `--global` for local tools):
 
-`dotnet tool update --global {{tool_name}}`
+`dotnet tool update {{[-g|--global]}} {{tool_name}}`
 
 - Uninstall a global tool (don't use `--global` for local tools):
 
-`dotnet tool uninstall --global {{tool_name}}`
+`dotnet tool uninstall {{[-g|--global]}} {{tool_name}}`
 
 - List installed global tools (don't use `--global` for local tools):
 
-`dotnet tool list --global`
+`dotnet tool list {{[-g|--global]}}`
 
 - Search tools in NuGet:
 
@@ -29,4 +29,4 @@
 
 - Display help:
 
-`dotnet tool --help`
+`dotnet tool {{[-h|--help]}}`

--- a/pages/common/dub.md
+++ b/pages/common/dub.md
@@ -9,7 +9,7 @@
 
 - Non-interactively create a new D project:
 
-`dub init {{project_name}} -n`
+`dub init {{project_name}} {{[-n|--non-interactive]}}`
 
 - Build and run a D project:
 
@@ -25,4 +25,4 @@
 
 - Display help:
 
-`dub --help`
+`dub {{[-h|--help]}}`

--- a/pages/common/dumpcap.md
+++ b/pages/common/dumpcap.md
@@ -5,16 +5,16 @@
 
 - Display available interfaces:
 
-`dumpcap --list-interfaces`
+`dumpcap {{[-D|--list-interfaces]}}`
 
 - Capture packets on a specific interface:
 
-`dumpcap --interface {{1}}`
+`dumpcap {{[-i|--interface]}} {{1}}`
 
 - Capture packets to a specific location:
 
-`dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}}`
+`dumpcap {{[-i|--interface]}} {{1}} -w {{path/to/output_file.pcapng}}`
 
 - Write to a ring buffer with a specific max file limit of a specific size:
 
-`dumpcap --interface {{1}} -w {{path/to/output_file.pcapng}} --ring-buffer filesize:{{500000}} --ring-buffer files:{{10}}`
+`dumpcap {{[-i|--interface]}} {{1}} -w {{path/to/output_file.pcapng}} {{[-b|--ring-buffer]}} filesize:{{500000}} {{[-b|--ring-buffer]}} files:{{10}}`

--- a/pages/common/duplicacy.md
+++ b/pages/common/duplicacy.md
@@ -5,7 +5,7 @@
 
 - Use current directory as the repository, initialize a SFTP storage and encrypt the storage with a password:
 
-`duplicacy init -e {{snapshot_id}} {{sftp://user@192.168.2.100/path/to/storage/}}`
+`duplicacy init {{[-e|-encrypt]}} {{snapshot_id}} {{sftp://user@192.168.2.100/path/to/storage/}}`
 
 - Save a snapshot of the repository to the default storage:
 

--- a/pages/common/electrum.md
+++ b/pages/common/electrum.md
@@ -5,15 +5,15 @@
 
 - Create a new wallet:
 
-`electrum -w {{new_wallet.dat}} create`
+`electrum {{[-w|--wallet]}} {{path/to/new_wallet.dat}} create`
 
 - Restore an existing wallet from seed offline:
 
-`electrum -w {{recovery_wallet.dat}} restore -o`
+`electrum {{[-w|--wallet]}} {{path/to/recovery_wallet.dat}} restore {{[-o|--offline]}}`
 
 - Create a signed transaction offline:
 
-`electrum mktx {{recipient}} {{amount}} -f 0.0000001 -F {{from}} -o`
+`electrum mktx {{recipient}} {{amount}} {{[-f|--fee]}} 0.0000001 {{[-F|--from-addr]}} {{from}} {{[-o|--offline]}}`
 
 - Display all wallet receiving addresses:
 
@@ -29,4 +29,4 @@
 
 - Connect only to a specific electrum-server instance:
 
-`electrum -p socks5:{{127.0.0.1}}:9050 -s {{56ckl5obj37gypcu.onion}}:50001:t -1`
+`electrum {{[-p|--proxy]}} socks5:{{127.0.0.1}}:9050 {{[-s|--server]}} {{56ckl5obj37gypcu.onion}}:50001:t {{[-1|--oneserver]}}`

--- a/pages/common/elixir.md
+++ b/pages/common/elixir.md
@@ -9,4 +9,4 @@
 
 - Evaluate Elixir code by passing it as an argument:
 
-`elixir -e "{{code}}"`
+`elixir {{[-e|--eval]}} "{{code}}"`

--- a/pages/common/enca.md
+++ b/pages/common/enca.md
@@ -9,12 +9,12 @@
 
 - Detect file(s) encoding specifying a language in the POSIX/C locale format (e.g. zh_CN, en_US):
 
-`enca -L {{language}} {{path/to/file1 path/to/file2 ...}}`
+`enca {{[-L|--language]}} {{language}} {{path/to/file1 path/to/file2 ...}}`
 
 - Convert file(s) to a specific encoding:
 
-`enca -L {{language}} -x {{to_encoding}} {{path/to/file1 path/to/file2 ...}}`
+`enca {{[-L|--language]}} {{language}} {{[-x|--convert-to]}} {{to_encoding}} {{path/to/file1 path/to/file2 ...}}`
 
 - Create a copy of an existing file using a different encoding:
 
-`enca -L {{language}} -x {{to_encoding}} < {{original_file}} > {{new_file}}`
+`enca {{[-L|--language]}} {{language}} {{[-x|--convert-to]}} {{to_encoding}} < {{original_file}} > {{new_file}}`

--- a/pages/common/entr.md
+++ b/pages/common/entr.md
@@ -5,7 +5,7 @@
 
 - Rebuild with `make` if any file in any subdirectory changes:
 
-`{{ag -l}} | entr {{make}}`
+`{{ag --files-with-matches}} | entr {{make}}`
 
 - Rebuild and test with `make` if any `.c` source files in the current directory change:
 

--- a/pages/common/eslint.md
+++ b/pages/common/eslint.md
@@ -17,4 +17,4 @@
 
 - Lint using the specified configuration file:
 
-`eslint -c {{path/to/config_file}} {{path/to/file1.js path/to/file2.js}}`
+`eslint {{[-c|--config]}} {{path/to/config_file}} {{path/to/file1.js path/to/file2.js}}`

--- a/pages/common/exiftool.md
+++ b/pages/common/exiftool.md
@@ -25,7 +25,7 @@
 
 - Move the date at which all JPEG photos in the current directory were taken 1 day and 2 hours backward:
 
-`exiftool "-AllDates-=0:0:1 2:0:0" -ext jpg`
+`exiftool "-AllDates-=0:0:1 2:0:0" {{[-ext|-extension]}} jpg`
 
 - Only change the `DateTimeOriginal` field subtracting 1.5 hours, without keeping backups:
 
@@ -33,4 +33,4 @@
 
 - Recursively rename all JPEG photos in a directory based on the `DateTimeOriginal` field:
 
-`exiftool '-filename<DateTimeOriginal' -d %Y-%m-%d_%H-%M-%S%%lc.%%e {{path/to/directory}} -r -ext jpg`
+`exiftool '-filename<DateTimeOriginal' {{[-d|-dateFormat]}} %Y-%m-%d_%H-%M-%S%%lc.%%e {{path/to/directory}} {{[-r|-recurse]}} {{[-ext|-extension]}} jpg`

--- a/pages/common/exiv2.md
+++ b/pages/common/exiv2.md
@@ -9,20 +9,20 @@
 
 - Print all metadata (Exif, IPTC, XMP) with interpreted values:
 
-`exiv2 -P kt {{path/to/file}}`
+`exiv2 {{[-P|-Print]}} kt {{path/to/file}}`
 
 - Print all metadata with raw values:
 
-`exiv2 -P kv {{path/to/file}}`
+`exiv2 {{[-P|-Print]}} kv {{path/to/file}}`
 
 - Delete all metadata from an image:
 
-`exiv2 -d a {{path/to/file}}`
+`exiv2 {{[-d|--delete]}} a {{path/to/file}}`
 
 - Delete all metadata, preserving the file timestamp:
 
-`exiv2 -d a -k {{path/to/file}}`
+`exiv2 {{[-d|--delete]}} a {{[-k|--keep]}} {{path/to/file}}`
 
 - Rename the file, prepending the date and time from metadata (not from the file timestamp):
 
-`exiv2 -r {{'%Y%m%d_%H%M%S_:basename:'}} {{path/to/file}}`
+`exiv2 {{[-r|--rename]}} {{'%Y%m%d_%H%M%S_:basename:'}} {{path/to/file}}`

--- a/pages/common/fastd.md
+++ b/pages/common/fastd.md
@@ -7,15 +7,15 @@
 
 - Start `fastd` with a specific configuration file:
 
-`fastd --config {{path/to/fastd.conf}}`
+`fastd {{[-c|--config]}} {{path/to/fastd.conf}}`
 
 - Start a Layer 3 VPN with an MTU of 1400, loading the rest of the configuration parameters from a file:
 
-`fastd --mode {{tap}} --mtu {{1400}} --config {{path/to/fastd.conf}}`
+`fastd {{[-m|--mode]}} {{tap}} {{[-M|--mtu]}} {{1400}} {{[-c|--config]}} {{path/to/fastd.conf}}`
 
 - Validate a configuration file:
 
-`fastd --verify-config --config {{path/to/fastd.conf}}`
+`fastd --verify-config {{[-c|--config]}} {{path/to/fastd.conf}}`
 
 - Generate a new keypair:
 
@@ -23,8 +23,8 @@
 
 - Show the public key to a private key in a configuration file:
 
-`fastd --show-key --config {{path/to/fastd.conf}}`
+`fastd --show-key {{[-c|--config]}} {{path/to/fastd.conf}}`
 
 - Show the current version:
 
-`fastd -v`
+`fastd {{[-v|--version]}}`

--- a/pages/common/fc-cache.md
+++ b/pages/common/fc-cache.md
@@ -9,8 +9,8 @@
 
 - Force a rebuild of all font cache files, without checking if cache is up-to-date:
 
-`fc-cache -f`
+`fc-cache {{[-f|--force]}}`
 
 - Erase font cache files, then generate new font cache files:
 
-`fc-cache -r`
+`fc-cache {{[-r|--really-force]}}`

--- a/pages/common/fc-list.md
+++ b/pages/common/fc-list.md
@@ -13,7 +13,7 @@
 
 - Return the number of installed fonts in your system:
 
-`fc-list | wc -l`
+`fc-list | wc {{[-l|--lines]}}`
 
 - Return a list of installed fonts that support the language based on its locale code:
 

--- a/pages/common/fc-match.md
+++ b/pages/common/fc-match.md
@@ -5,4 +5,4 @@
 
 - Return a sorted list of best matching fonts:
 
-`fc-match -s '{{DejaVu Serif}}'`
+`fc-match {{[-s|--sort]}} '{{DejaVu Serif}}'`

--- a/pages/common/fc-pattern.md
+++ b/pages/common/fc-pattern.md
@@ -5,8 +5,8 @@
 
 - Display default information about a font:
 
-`fc-pattern --default '{{DejaVu Serif}}'`
+`fc-pattern {{[-d|--default]}} '{{DejaVu Serif}}'`
 
 - Display configuration information about a font:
 
-`fc-pattern --config '{{DejaVu Serif}}'`
+`fc-pattern {{[-c|--config]}} '{{DejaVu Serif}}'`

--- a/pages/common/fdupes.md
+++ b/pages/common/fdupes.md
@@ -13,20 +13,20 @@
 
 - Search a directory recursively:
 
-`fdupes -r {{path/to/directory}}`
+`fdupes {{[-r|--recurse]}} {{path/to/directory}}`
 
 - Search multiple directories, one recursively:
 
-`fdupes {{directory1}} -R {{directory2}}`
+`fdupes {{path/to/irectory1}} {{[-R|--recurse:]}} {{path/to/directory2}}`
 
 - Search recursively, considering hardlinks as duplicates:
 
-`fdupes -rH {{path/to/directory}}`
+`fdupes {{[-rH|--recurse --hardlinks]}} {{path/to/directory}}`
 
 - Search recursively for duplicates and display interactive prompt to pick which ones to keep, deleting the others:
 
-`fdupes -rd {{path/to/directory}}`
+`fdupes {{[-rd|--recurse --delete]}} {{path/to/directory}}`
 
 - Search recursively and delete duplicates without prompting:
 
-`fdupes -rdN {{path/to/directory}}`
+`fdupes {{[-rdN|--recurse --delete --noprompt]}} {{path/to/directory}}`

--- a/pages/common/ffe.md
+++ b/pages/common/ffe.md
@@ -6,24 +6,24 @@
 
 - Display all input data using the specified data configuration:
 
-`ffe --configuration={{path/to/config.ffe}} {{path/to/input}}`
+`ffe {{[-c|--configuration]}} {{path/to/config.ffe}} {{path/to/input}}`
 
 - Convert an input file to an output file in a new format:
 
-`ffe --output={{path/to/output}} -c {{path/to/config.ffe}} {{path/to/input}}`
+`ffe --output={{path/to/output}} {{[-c|--configuration]}} {{path/to/config.ffe}} {{path/to/input}}`
 
 - Select input structure and print format from definitions in `~/.fferc` configuration file:
 
-`ffe --structure={{structure}} --print={{format}} {{path/to/input}}`
+`ffe {{[-s|--structure]}} {{structure}} {{[-p|--print]}} {{format}} {{path/to/input}}`
 
 - Write only the selected fields:
 
-`ffe --field-list="{{FirstName,LastName,Age}}" -c {{path/to/config.ffe}} {{path/to/input}}`
+`ffe {{[-f|--field-list]}} "{{FirstName,LastName,Age}}" {{[-c|--configuration]}} {{path/to/config.ffe}} {{path/to/input}}`
 
 - Write only the records that match an expression:
 
-`ffe -e "{{LastName=Smith}}" -c {{path/to/config.ffe}} {{path/to/input}}`
+`ffe {{[-e|--expression]}} "{{LastName=Smith}}" {{[-c|--configuration]}} {{path/to/config.ffe}} {{path/to/input}}`
 
 - Display help:
 
-`ffe --help`
+`ffe {{[-?|--help]}}`

--- a/pages/common/ffprobe.md
+++ b/pages/common/ffprobe.md
@@ -5,20 +5,20 @@
 
 - Display all available stream info for a media file:
 
-`ffprobe -v error -show_streams {{input.mp4}}`
+`ffprobe {{[-v|-loglevel]}} error -show_streams {{input.mp4}}`
 
 - Display media duration:
 
-`ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
+`ffprobe  {{[-v|-loglevel]}} error -show_entries format=duration {{[-of|-output_format]}} default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
 
 - Display the frame rate of a video:
 
-`ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
+`ffprobe  {{[-v|-loglevel]}} error -select_streams v:0 -show_entries stream=avg_frame_rate {{[-of|-output_format]}} default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
 
 - Display the width or height of a video:
 
-`ffprobe -v error -select_streams v:0 -show_entries stream={{width|height}} -of default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
+`ffprobe  {{[-v|-loglevel]}} error -select_streams v:0 -show_entries stream={{width|height}} {{[-of|-output_format]}} default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
 
 - Display the average bit rate of a video:
 
-`ffprobe -v error -select_streams v:0 -show_entries stream=bit_rate -of default=noprint_wrappers=1:nokey=1 {{input.mp4}}`
+`ffprobe  {{[-v|-loglevel]}} error -select_streams v:0 -show_entries stream=bit_rate {{[-of|-output_format]}} default=noprint_wrappers=1:nokey=1 {{input.mp4}}`

--- a/pages/common/fiascotopnm.md
+++ b/pages/common/fiascotopnm.md
@@ -5,20 +5,20 @@
 
 - Convert a compressed FIASCO file to a PNM file or in the case of video streams multiple PNM files:
 
-`fiascotopnm {{path/to/file.fiasco}} -o {{output_file_basename}}`
+`fiascotopnm {{path/to/file.fiasco}} {{[-o|--output]}} {{output_file_basename}}`
 
 - Use fast decompression, resulting in a slightly decreased quality of the output file(s):
 
-`fiascotopnm --fast {{path/to/file.fiasco}} -o {{output_file_basename}}`
+`fiascotopnm {{[-z|--fast]}} {{path/to/file.fiasco}} {{[-o|--output]}} {{output_file_basename}}`
 
 - Load the options to be used from the specified configuration file:
 
-`fiascotopnm --config {{path/to/fiascorc}} {{path/to/file.fiasco}} -o {{output_file_basename}}`
+`fiascotopnm {{[-f|--config]}} {{path/to/fiascorc}} {{path/to/file.fiasco}} {{[-o|--output]}} {{output_file_basename}}`
 
 - Magnify the decompressed image(s) by a factor of 2^n:
 
-`fiascotopnm --magnify {{n}} {{path/to/file.fiasco}} -o {{output_file_basename}}`
+`fiascotopnm {{[-m|--magnify]}} {{n}} {{path/to/file.fiasco}} {{[-o|--output]}} {{output_file_basename}}`
 
 - Smooth the decompressed image by the specified amount:
 
-`fiascotopnm --smooth {{n}} {{path/to/file.fiasco}} -o {{output_file_basename}}`
+`fiascotopnm {{[-s|--smoothing]}} {{n}} {{path/to/file.fiasco}} {{[-o|--output]}} {{output_file_basename}}`

--- a/pages/common/fin.md
+++ b/pages/common/fin.md
@@ -21,4 +21,4 @@
 
 - Display logs of a specific container and follow the log:
 
-`fin logs -f {{container_name}}`
+`fin logs {{[-f|--follow]}} {{container_name}}`

--- a/pages/common/flac.md
+++ b/pages/common/flac.md
@@ -9,12 +9,12 @@
 
 - Encode a WAV file to FLAC, specifying the output file:
 
-`flac -o {{path/to/output.flac}} {{path/to/file.wav}}`
+`flac {{[-o|--output-name]}} {{path/to/output.flac}} {{path/to/file.wav}}`
 
 - Decode a FLAC file to WAV, specifying the output file:
 
-`flac -d -o {{path/to/output.wav}} {{path/to/file.flac}}`
+`flac {{[-d|--decode]}} {{[-o|--output-name]}} {{path/to/output.wav}} {{path/to/file.flac}}`
 
 - Test a FLAC file for the correct encoding:
 
-`flac -t {{path/to/file.flac}}`
+`flac {{[-t|--test]}} {{path/to/file.flac}}`

--- a/pages/common/fly.md
+++ b/pages/common/fly.md
@@ -5,7 +5,7 @@
 
 - Authenticate with and save concourse target:
 
-`fly --target {{target_name}} login --team-name {{team_name}} -c {{https://ci.example.com}}`
+`fly {{[-t|--target]}} {{target_name}} login {{[-n|--team-name]}} {{team_name}} {{[-c|--concourse-url]}} {{https://ci.example.com}}`
 
 - List targets:
 
@@ -13,24 +13,24 @@
 
 - List pipelines:
 
-`fly -t {{target_name}} pipelines`
+`fly {{[-t|--target]}} {{target_name}} pipelines`
 
 - Upload or update a pipeline:
 
-`fly -t {{target_name}} set-pipeline --config {{pipeline.yml}} --pipeline {{pipeline_name}}`
+`fly {{[-t|--target]}} {{target_name}} set-pipeline {{[-c|--config]}} {{pipeline.yml}} {{[-p|--pipeline]}} {{pipeline_name}}`
 
 - Unpause pipeline:
 
-`fly -t {{target_name}} unpause-pipeline --pipeline {{pipeline_name}}`
+`fly {{[-t|--target]}} {{target_name}} unpause-pipeline {{[-p|--pipeline]}} {{pipeline_name}}`
 
 - Show pipeline configuration:
 
-`fly -t {{target_name}} get-pipeline --pipeline {{pipeline_name}}`
+`fly {{[-t|--target]}} {{target_name}} get-pipeline {{[-p|--pipeline]}} {{pipeline_name}}`
 
 - Update local copy of fly:
 
-`fly -t {{target_name}} sync`
+`fly {{[-t|--target]}} {{target_name}} sync`
 
 - Destroy pipeline:
 
-`fly -t {{target_name}} destroy-pipeline --pipeline {{pipeline_name}}`
+`fly {{[-t|--target]}} {{target_name}} destroy-pipeline {{[-p|--pipeline]}} {{pipeline_name}}`

--- a/pages/common/fswatch.md
+++ b/pages/common/fswatch.md
@@ -5,16 +5,16 @@
 
 - Run a Bash command on file creation, update or deletion:
 
-`fswatch {{path/to/file}} | xargs -n 1 {{bash_command}}`
+`fswatch {{path/to/file}} | xargs {{[-n|--max-args]}} 1 {{bash_command}}`
 
 - Watch one or more files and/or directories:
 
-`fswatch {{path/to/file}} {{path/to/directory}} {{path/to/another_directory/**/*.js}} | xargs -n 1 {{bash_command}}`
+`fswatch {{path/to/file}} {{path/to/directory}} {{path/to/another_directory/**/*.js}} | xargs {{[-n|--max-args]}} 1 {{bash_command}}`
 
 - Print the absolute paths of the changed files:
 
-`fswatch {{path/to/directory}} | xargs -n 1 -I {} echo {}`
+`fswatch {{path/to/directory}} | xargs {{[-n|--max-args]}} 1 -I _ echo _`
 
 - Filter by event type:
 
-`fswatch --event {{Updated|Removed|Created|...}} {{path/to/directory}} | xargs -n 1 {{bash_command}}`
+`fswatch --event {{Updated|Removed|Created|...}} {{path/to/directory}} | xargs {{[-n|--max-args]}} 1 {{bash_command}}`

--- a/pages/common/fswebcam.md
+++ b/pages/common/fswebcam.md
@@ -9,11 +9,11 @@
 
 - Take a picture with custom resolution:
 
-`fswebcam -r {{width}}x{{height}} {{filename}}`
+`fswebcam {{[-r|--resolution]}} {{width}}x{{height}} {{filename}}`
 
 - Take a picture from selected device(Default is `/dev/video0`):
 
-`fswebcam -d {{device}} {{filename}}`
+`fswebcam {{[-d|--device]}} {{device}} {{filename}}`
 
 - Take a picture with timestamp(timestamp string is formatted by strftime):
 

--- a/pages/common/gdrive.md
+++ b/pages/common/gdrive.md
@@ -6,7 +6,7 @@
 
 - Upload a local path to the parent folder with the specified ID:
 
-`gdrive upload -p {{id}} {{path/to/file_or_folder}}`
+`gdrive upload {{[-p|--parent]}} {{id}} {{path/to/file_or_folder}}`
 
 - Download file or directory by ID to current directory:
 

--- a/pages/common/gendesk.md
+++ b/pages/common/gendesk.md
@@ -1,7 +1,7 @@
 # gendesk
 
 > Specifies the command to generate a `.desktop` file and a download icon with minimal information.
-> More information: <https://gendesk.roboticoverlords.org>.
+> More information: <https://manned.org/gendesk>.
 
 - Create a `.desktop` file named `app`:
 
@@ -13,4 +13,4 @@
 
 - Display help:
 
-`gendesk -h`
+`gendesk {{[-h|--help]}}`

--- a/pages/common/git-checkout.md
+++ b/pages/common/git-checkout.md
@@ -21,7 +21,7 @@
 
 - Switch to an existing remote branch:
 
-`git checkout --track {{remote_name}}/{{branch_name}}`
+`git checkout {{[-t|--track]}} {{remote_name}}/{{branch_name}}`
 
 - Discard all unstaged changes in the current directory (see `git reset` for more undo-like commands):
 

--- a/pages/common/git-force-clone.md
+++ b/pages/common/git-force-clone.md
@@ -10,8 +10,8 @@
 
 - Clone a Git repository into a new directory, checking out an specific branch:
 
-`git force-clone -b {{branch_name}} {{remote_repository_location}} {{path/to/directory}}`
+`git force-clone {{[-b|--branch]}} {{branch_name}} {{remote_repository_location}} {{path/to/directory}}`
 
 - Clone a Git repository into an existing directory of a Git repository, performing a force-reset to resemble it to the remote and checking out an specific branch:
 
-`git force-clone -b {{branch_name}} {{remote_repository_location}} {{path/to/directory}}`
+`git force-clone {{[-b|--branch]}} {{branch_name}} {{remote_repository_location}} {{path/to/directory}}`

--- a/pages/common/git-guilt.md
+++ b/pages/common/git-guilt.md
@@ -14,15 +14,15 @@
 
 - Show author emails instead of names:
 
-`git guilt --email`
+`git guilt {{[-e|--email]}}`
 
 - Ignore whitespace only changes when attributing blame:
 
-`git guilt --ignore-whitespace`
+`git guilt {{[-w|--ignore-whitespace]}}`
 
 - Find blame delta over the last three weeks:
 
-`git guilt 'git log --until="3 weeks ago" --format="%H" -n 1'`
+`git guilt 'git log --until="3 weeks ago" --format="%H" {{[-n|--max-count]}} 1'`
 
 - Find blame delta over the last three weeks (git 1.8.5+):
 

--- a/pages/common/git-sed.md
+++ b/pages/common/git-sed.md
@@ -2,7 +2,7 @@
 
 > Replace patterns in git-controlled files using sed.
 > Part of `git-extras`.
-> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-sed>.
+> More information: <https://manned.org/git-sed>.
 
 - Replace the specified text in the current repository:
 

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -21,7 +21,7 @@
 
 - Show a commit's message in a single line, suppressing the diff output:
 
-`git show --oneline -s {{commit}}`
+`git show --oneline {{[-s|--no-patch]}} {{commit}}`
 
 - Show only statistics (added/removed characters) about the changed files:
 

--- a/pages/common/git-standup.md
+++ b/pages/common/git-standup.md
@@ -2,7 +2,7 @@
 
 > See commits from a specified user.
 > Part of `git-extras`.
-> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-standup>.
+> More information: <https://manned.org/git-standup>.
 
 - Show a given author's commits from the last 10 days:
 

--- a/pages/common/git-subtree.md
+++ b/pages/common/git-subtree.md
@@ -1,24 +1,24 @@
 # git subtree
 
 > Manage project dependencies as subprojects.
-> More information: <https://manpages.debian.org/latest/git-man/git-subtree.1.html>.
+> More information: <https://manned.org/git-subtree>.
 
 - Add a Git repository as a subtree:
 
-`git subtree add --prefix={{path/to/directory/}} --squash {{repository_url}} {{branch_name}}`
+`git subtree add {{[-P|--prefix]}} {{path/to/directory/}} --squash {{repository_url}} {{branch_name}}`
 
 - Update subtree repository to its latest commit:
 
-`git subtree pull --prefix={{path/to/directory/}} {{repository_url}} {{branch_name}}`
+`git subtree pull {{[-P|--prefix]}} {{path/to/directory/}} {{repository_url}} {{branch_name}}`
 
 - Merge recent changes up to the latest subtree commit into the subtree:
 
-`git subtree merge --prefix={{path/to/directory/}} --squash {{repository_url}} {{branch_name}}`
+`git subtree merge {{[-P|--prefix]}} {{path/to/directory/}} --squash {{repository_url}} {{branch_name}}`
 
 - Push commits to a subtree repository:
 
-`git subtree push --prefix={{path/to/directory/}} {{repository_url}} {{branch_name}}`
+`git subtree push {{[-P|--prefix]}} {{path/to/directory/}} {{repository_url}} {{branch_name}}`
 
 - Extract a new project history from the history of a subtree:
 
-`git subtree split --prefix={{path/to/directory/}} {{repository_url}} -b {{branch_name}}`
+`git subtree split {{[-P|--prefix]}} {{path/to/directory/}} {{repository_url}} {{[-b|--branch]}} {{branch_name}}`

--- a/pages/common/git-symbolic-ref.md
+++ b/pages/common/git-symbolic-ref.md
@@ -17,8 +17,8 @@
 
 - Delete a reference by name:
 
-`git symbolic-ref --delete refs/{{name}}`
+`git symbolic-ref {{[-d|--delete]}} refs/{{name}}`
 
 - For scripting, hide errors with `--quiet` and use `--short` to simplify ("refs/heads/X" prints as "X"):
 
-`git symbolic-ref --quiet --short refs/{{name}}`
+`git symbolic-ref {{[-q|--quiet]}} --short refs/{{name}}`

--- a/pages/common/git-sync.md
+++ b/pages/common/git-sync.md
@@ -2,7 +2,7 @@
 
 > Sync local branches with remote branches.
 > Part of `git-extras`.
-> More information: <https://github.com/tj/git-extras/blob/master/Commands.md#git-sync>.
+> More information: <https://manned.org/git-sync>.
 
 - Sync the current local branch with its remote branch:
 
@@ -14,4 +14,4 @@
 
 - Sync without cleaning untracked files:
 
-`git sync -s {{remote_name}} {{branch_name}}`
+`git sync {{[-s|--soft]}} {{remote_name}} {{branch_name}}`

--- a/pages/common/git.md
+++ b/pages/common/git.md
@@ -18,7 +18,7 @@
 
 - Display help:
 
-`git --help`
+`git {{[-h|--help]}}`
 
 - Display help for a specific subcommand (like `clone`, `add`, `push`, `log`, etc.):
 
@@ -26,4 +26,4 @@
 
 - Display version:
 
-`git --version`
+`git {{[-v|--version]}}`

--- a/pages/common/glab-repo.md
+++ b/pages/common/glab-repo.md
@@ -13,12 +13,12 @@
 
 - Fork and clone a repository:
 
-`glab repo fork {{owner}}/{{repository}} --clone`
+`glab repo fork {{owner}}/{{repository}} {{[-c|--clone]}}`
 
 - View a repository in the default web browser:
 
-`glab repo view {{owner}}/{{repository}} --web`
+`glab repo view {{owner}}/{{repository}} {{[-w|--web]}}`
 
 - Search some repositories in the GitLab instance:
 
-`glab repo search -s {{search_string}}`
+`glab repo search {{[-s|--search]}} {{search_string}}`

--- a/pages/common/glow.md
+++ b/pages/common/glow.md
@@ -13,7 +13,7 @@
 
 - View a Markdown file using a paginator:
 
-`glow -p {{path/to/file}}`
+`glow {{[-p|--pager]}} {{path/to/file}}`
 
 - View a file from a URL:
 

--- a/pages/common/gnmic-get.md
+++ b/pages/common/gnmic-get.md
@@ -5,16 +5,16 @@
 
 - Get a snapshot of the device state at a specific path:
 
-`gnmic --address {{ip:port}} get --path {{path}}`
+`gnmic {{[-a|--address]}} {{ip:port}} get --path {{path}}`
 
 - Query the device state at multiple paths:
 
-`gnmic -a {{ip:port}} get --path {{path/to/file_or_directory1}} --path {{path/to/file_or_directory2}}`
+`gnmic {{[-a|--address]}} {{ip:port}} get --path {{path/to/file_or_directory1}} --path {{path/to/file_or_directory2}}`
 
 - Query the device state at multiple paths with a common prefix:
 
-`gnmic -a {{ip:port}} get --prefix {{prefix}} --path {{path/to/file_or_directory1}} --path {{path/to/file_or_directory2}}`
+`gnmic {{[-a|--address]}} {{ip:port}} get --prefix {{prefix}} --path {{path/to/file_or_directory1}} --path {{path/to/file_or_directory2}}`
 
 - Query the device state and specify response encoding (json_ietf):
 
-`gnmic -a {{ip:port}} get --path {{path}} --encoding json_ietf`
+`gnmic {{[-a|--address]}} {{ip:port}} get --path {{path}} {{[-e|--encoding]}} json_ietf`

--- a/pages/common/gnmic-set.md
+++ b/pages/common/gnmic-set.md
@@ -5,16 +5,16 @@
 
 - Update the value of a path:
 
-`gnmic --address {{ip:port}} set --update-path {{path}} --update-value {{value}}`
+`gnmic {{[-a|--address]}} {{ip:port}} set --update-path {{path}} --update-value {{value}}`
 
 - Update the value of a path to match the contents of a JSON file:
 
-`gnmic -a {{ip:port}} set --update-path {{path}} --update-file {{filepath}}`
+`gnmic {{[-a|--address]}} {{ip:port}} set --update-path {{path}} --update-file {{filepath}}`
 
 - Replace the value of a path to match the contents of a JSON file:
 
-`gnmic -a {{ip:port}} set --replace-path {{path}} --replace-file {{filepath}}`
+`gnmic {{[-a|--address]}} {{ip:port}} set --replace-path {{path}} --replace-file {{filepath}}`
 
 - Delete the node at a given path:
 
-`gnmic -a {{ip:port}} set --delete {{path}}`
+`gnmic {{[-a|--address]}} {{ip:port}} set --delete {{path}}`

--- a/pages/common/gnmic-subscribe.md
+++ b/pages/common/gnmic-subscribe.md
@@ -5,20 +5,20 @@
 
 - Subscribe to target state updates under the subtree of a specific path:
 
-`gnmic --address {{ip:port}} subscribe --path {{path}}`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}}`
 
 - Subscribe to a target with a sample interval of 30s (default is 10s):
 
-`gnmic -a {{ip:port}} subscribe --path {{path}} --sample-interval 30s`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}} --sample-interval 30s`
 
 - Subscribe to a target with sample interval and updates only on change:
 
-`gnmic -a {{ip:port}} subscribe --path {{path}} --stream-mode on-change --heartbeat-interval 1m`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}} --stream-mode on-change --heartbeat-interval 1m`
 
 - Subscribe to a target for only one update:
 
-`gnmic -a {{ip:port}} subscribe --path {{path}} --mode once`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}} --mode once`
 
 - Subscribe to a target and specify response encoding (json_ietf):
 
-`gnmic -a {{ip:port}} subscribe --path {{path}} --encoding json_ietf`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}} {{[-e|--encoding]}} json_ietf`

--- a/pages/common/gnmic.md
+++ b/pages/common/gnmic.md
@@ -6,20 +6,20 @@
 
 - Request device capabilities:
 
-`gnmic --address {{ip:port}} capabilities`
+`gnmic {{[-a|--address]}} {{ip:port}} capabilities`
 
 - Provide a username and password to fetch device capabilities:
 
-`gnmic --address {{ip:port}} --username {{username}} --password {{password}} capabilities`
+`gnmic {{[-a|--address]}} {{ip:port}} {{[-u|--username]}} {{username}} {{[-p|--password]}} {{password}} capabilities`
 
 - Get a snapshot of the device state at a specific path:
 
-`gnmic -a {{ip:port}} get --path {{path}}`
+`gnmic {{[-a|--address]}} {{ip:port}} get --path {{path}}`
 
 - Update device state at a specific path:
 
-`gnmic -a {{ip:port}} set --update-path {{path}} --update-value {{value}}`
+`gnmic {{[-a|--address]}} {{ip:port}} set --update-path {{path}} --update-value {{value}}`
 
 - Subscribe to target state updates under the subtree at a specific path:
 
-`gnmic -a {{ip:port}} subscribe --path {{path}}`
+`gnmic {{[-a|--address]}} {{ip:port}} subscribe --path {{path}}`

--- a/pages/common/godot.md
+++ b/pages/common/godot.md
@@ -9,11 +9,11 @@
 
 - Edit a project (the current directory must contain a `project.godot` file):
 
-`godot -e`
+`godot {{[-e|--editor]}}`
 
 - Open the project manager even if the current directory contains a `project.godot` file:
 
-`godot -p`
+`godot {{[-p|--project-manager]}}`
 
 - Export a project for a given export preset (the preset must be defined in the project):
 
@@ -21,4 +21,4 @@
 
 - Execute a standalone GDScript file (the script must inherit from `SceneTree` or `MainLoop`):
 
-`godot -s {{script.gd}}`
+`godot {{[-s|--script]}} {{script.gd}}`

--- a/pages/common/goreload.md
+++ b/pages/common/goreload.md
@@ -5,7 +5,7 @@
 
 - Watch a binary file (defaults to `.goreload`):
 
-`goreload -b {{path/to/binary}} {{path/to/file.go}}`
+`goreload {{[-b|--bin]}} {{path/to/binary}} {{path/to/file.go}}`
 
 - Set a custom log prefix (defaults to `goreload`):
 

--- a/pages/common/gotty.md
+++ b/pages/common/gotty.md
@@ -9,8 +9,8 @@
 
 - Share with write permission:
 
-`gotty -w {{shell}}`
+`gotty {{[-w|--permit-write]}} {{shell}}`
 
 - Share with credential (Basic Auth):
 
-`gotty -w -c {{username}}:{{password}} {{shell}}`
+`gotty {{[-w|--permit-write]}} {{[-c|--credential]}} {{username}}:{{password}} {{shell}}`

--- a/pages/common/gource.md
+++ b/pages/common/gource.md
@@ -12,10 +12,6 @@
 
 `gource -{{width}}x{{height}}`
 
-- Specify the timescale for the animation:
-
-`gource {{[-c|--time-scale]}} {{time_scale_multiplier}}`
-
 - Specify how long each day should be in the animation (this combines with -c, if provided):
 
 `gource {{[-s|--seconds-per-day]}} {{seconds}}`
@@ -31,6 +27,10 @@
 - Pause the animation:
 
 `<Space>`
+
+- Adjust simulation speed:
+
+`<{{+|-}}>`
 
 - Display help:
 

--- a/pages/common/gource.md
+++ b/pages/common/gource.md
@@ -14,16 +14,24 @@
 
 - Specify the timescale for the animation:
 
-`gource -c {{time_scale_multiplier}}`
+`gource {{[-c|--time-scale]}} {{time_scale_multiplier}}`
 
 - Specify how long each day should be in the animation (this combines with -c, if provided):
 
-`gource -s {{seconds}}`
+`gource {{[-s|--seconds-per-day]}} {{seconds}}`
 
 - Use fullscreen mode and a custom background color:
 
-`gource -f -b {{hex_color_code}}`
+`gource {{[-f|--fullscreen ]}} {{[-b|--background-colour]}} {{hex_color_code}}`
 
 - Specify the animation title:
 
 `gource --title {{title}}`
+
+- Pause the animation:
+
+`<Space>`
+
+- Display help:
+
+`gource {{[-h|--help]}}`

--- a/pages/common/gradle.md
+++ b/pages/common/gradle.md
@@ -9,7 +9,7 @@
 
 - Exclude test task:
 
-`gradle build -x {{test}}`
+`gradle build {{[-x|--exclude-task]}} {{test}}`
 
 - Run in offline mode to prevent Gradle from accessing the network during builds:
 

--- a/pages/common/grex.md
+++ b/pages/common/grex.md
@@ -9,20 +9,20 @@
 
 - Generate a case-insensitive regular expression:
 
-`grex -i {{space_separated_strings}}`
+`grex {{[-i|--ignore-case]}} {{space_separated_strings}}`
 
 - Replace digits with '\d':
 
-`grex -d {{space_separated_strings}}`
+`grex {{[-d|--digits]}} {{space_separated_strings}}`
 
 - Replace Unicode word character with '\w':
 
-`grex -w {{space_separated_strings}}`
+`grex {{[-w|--words]}} {{space_separated_strings}}`
 
 - Replace spaces with '\s':
 
-`grex -s {{space_separated_strings}}`
+`grex {{[-s|--spaces]}} {{space_separated_strings}}`
 
 - Add {min, max} quantifier representation for repeating sub-strings:
 
-`grex -r {{space_separated_strings}}`
+`grex {{[-r|--repetitions]}} {{space_separated_strings}}`

--- a/pages/common/hexyl.md
+++ b/pages/common/hexyl.md
@@ -9,7 +9,7 @@
 
 - Print the hexadecimal representation of the first n bytes of a file:
 
-`hexyl -n {{n}} {{path/to/file}}`
+`hexyl {{[-n|--length]}} {{n}} {{path/to/file}}`
 
 - Print bytes 512 through 1024 of a file:
 

--- a/pages/common/hive.md
+++ b/pages/common/hive.md
@@ -13,7 +13,7 @@
 
 - Run a HiveQL file with a variable substitution:
 
-`hive --define {{key}}={{value}} -f {{path/to/file.sql}}`
+`hive {{[-d|--define]}} {{key}}={{value}} -f {{path/to/file.sql}}`
 
 - Run a HiveQL with HiveConfig (e.g. `mapred.reduce.tasks=32`):
 

--- a/pages/common/hledger-accounts.md
+++ b/pages/common/hledger-accounts.md
@@ -5,31 +5,31 @@
 
 - Show all accounts used or declared in the default journal file:
 
-`hledger accounts`
+`hledger {{[acc|accounts]}}`
 
 - Show accounts used by transactions:
 
-`hledger accounts --used`
+`hledger {{[acc|accounts]}} {{[-u|--used]}}`
 
 - Show accounts declared with account directives:
 
-`hledger accounts --declared`
+`hledger {{[acc|accounts]}} {{[-d|--declared]}}`
 
 - Add new account directives, for accounts used but not declared, to the journal:
 
-`hledger accounts --undeclared --directives >> {{2024-accounts.journal}}`
+`hledger {{[acc|accounts]}} --undeclared --directives >> {{2024-accounts.journal}}`
 
 - Show accounts with `asset` in their name, and their declared/inferred types:
 
-`hledger accounts asset --types`
+`hledger {{[acc|accounts]}} asset --types`
 
 - Show accounts of the `Asset` type:
 
-`hledger accounts type:A`
+`hledger {{[acc|accounts]}} type:A`
 
 - Show the first two levels of the accounts hierarchy:
 
-`hledger accounts --tree --depth 2`
+`hledger {{[acc|accounts]}} {{[-t|--tree]}} --depth 2`
 
 - Short form of the above:
 

--- a/pages/common/hledger-add.md
+++ b/pages/common/hledger-add.md
@@ -9,7 +9,7 @@
 
 - Add transactions to `2024.journal`, but also load `2023.journal` for completions:
 
-`hledger add --file {{path/to/2024.journal}} --file {{path/to/2023.journal}}`
+`hledger add {{[-f|--file]}} {{path/to/2024.journal}} {{[-f|--file]}} {{path/to/2023.journal}}`
 
 - Provide answers for the first four prompts:
 
@@ -17,7 +17,7 @@
 
 - Show `add`'s options and documentation with `$PAGER`:
 
-`hledger add --help`
+`hledger add {{[-h|--help]}}`
 
 - Show `add`'s documentation with `info` or `man` if available:
 

--- a/pages/common/hledger-aregister.md
+++ b/pages/common/hledger-aregister.md
@@ -5,16 +5,16 @@
 
 - Show transactions and running balance in the `assets:bank:checking` account:
 
-`hledger aregister assets:bank:checking`
+`hledger {{[areg|aregister]}} assets:bank:checking`
 
 - Show transactions and running balance in the first account named `*savings*`:
 
-`hledger aregister savings`
+`hledger {{[areg|aregister]}} savings`
 
 - Show the checking account's cleared transactions, with a specified width:
 
-`hledger aregister checking --cleared --width {{120}}`
+`hledger {{[areg|aregister]}} checking {{[-C|--cleared]}} {{[-w|--width]}} {{120}}`
 
 - Show the checking register, including transactions from forecast rules:
 
-`hledger aregister checking --forecast`
+`hledger {{[areg|aregister]}} checking --forecast`

--- a/pages/common/hledger-balance.md
+++ b/pages/common/hledger-balance.md
@@ -6,15 +6,15 @@
 
 - Show the balance change in all accounts from all postings over all time:
 
-`hledger balance`
+`hledger {{[bal|balance]}}`
 
 - Show the balance change in accounts named `*expenses*`, as a tree, summarising the top two levels only:
 
-`hledger balance {{expenses}} --tree --depth {{2}}`
+`hledger {{[bal|balance]}} {{expenses}} {{[-t|--tree]}} --depth {{2}}`
 
 - Show expenses each month, and their totals and averages, sorted by total; and their monthly budget goals:
 
-`hledger balance {{expenses}} --monthly --row-total --average --sort-amount --budget`
+`hledger {{[bal|balance]}} {{expenses}} {{[-M|--monthly]}} {{[-T|--row-total]}} {{[-A|--average]}} {{[-S|--sort-amount]}} --budget`
 
 - Similar to the above, shorter form, matching accounts by `Expense` type, as a two level tree without squashing boring accounts:
 
@@ -22,7 +22,7 @@
 
 - Show end balances (including from postings before the start date), quarterly in 2024, in accounts named `*assets*` or `*liabilities*`:
 
-`hledger balance --historical --period '{{quarterly in 2024}}' {{assets}} {{liabilities}}`
+`hledger {{[bal|balance]}} {{[-H|--historical]}} {{[-p|--period]}} '{{quarterly in 2024}}' {{assets}} {{liabilities}}`
 
 - Similar to the above, shorter form; also show zero balances, sort by total and summarise to three levels:
 

--- a/pages/common/hledger-balancesheet.md
+++ b/pages/common/hledger-balancesheet.md
@@ -6,27 +6,27 @@
 
 - Show the current balances in `Asset` and `Liability` accounts, excluding zeros:
 
-`hledger balancesheet`
+`hledger {{[bs|balancesheet]}}`
 
 - Show just the liquid assets (`Cash` account type):
 
-`hledger balancesheet type:C`
+`hledger {{[bs|balancesheet]}} type:C`
 
 - Include accounts with zero balances, and show the account hierarchy:
 
-`hledger balancesheet --empty --tree`
+`hledger {{[bs|balancesheet]}} {{[-E|--empty]}} {{[-t|--tree]}}`
 
 - Show the balances at the end of each month:
 
-`hledger balancesheet --monthly`
+`hledger {{[bs|balancesheet]}} {{[-M|--monthly]}}`
 
 - Show the balances' market value in home currency at the end of each month:
 
-`hledger balancesheet --monthly -V`
+`hledger {{[bs|balancesheet]}} {{[-M|--monthly]}} {{[-V|--market]}}`
 
 - Show quarterly balances, with just the top two levels of account hierarchy:
 
-`hledger balancesheet --quarterly --tree --depth 2`
+`hledger {{[bs|balancesheet]}} {{[-Qt|--quarterly --tree]}} {{[-2|--depth 2]}}`
 
 - Short form of the above, and generate HTML output in `bs.html`:
 

--- a/pages/common/hledger-import.md
+++ b/pages/common/hledger-import.md
@@ -17,7 +17,7 @@
 
 - Show conversion errors or results while editing `bank.csv.rules`:
 
-`watchexec -- hledger -f {{path/to/bank.csv}} print`
+`watchexec -- hledger {{[-f|--file]}} {{path/to/bank.csv}} print`
 
 - Mark `bank.csv`'s current data as seen, as if already imported:
 
@@ -25,4 +25,4 @@
 
 - Mark `bank.csv` as all new, as if not yet imported:
 
-`rm -f .latest.bank.csv`
+`rm {{[-f|--force]}} .latest.bank.csv`

--- a/pages/common/hledger-incomestatement.md
+++ b/pages/common/hledger-incomestatement.md
@@ -6,15 +6,15 @@
 
 - Show revenues and expenses (changes in `Revenue` and `Expense` accounts):
 
-`hledger incomestatement`
+`hledger {{[is|incomestatement]}}`
 
 - Show revenues and expenses each month:
 
-`hledger incomestatement --monthly`
+`hledger {{[is|incomestatement]}} {{[-M|--monthly]}}`
 
 - Show monthly revenues/expenses/totals, largest first, summarised to 2 levels:
 
-`hledger incomestatement --monthly --row-total --average --sort --depth 2`
+`hledger {{[is|incomestatement]}} {{[-MTAS|--monthly --row-total --average --sort-amount]}} {{[-2|--depth 2]}}`
 
 - Short form of the above, and generate HTML output in `is.html`:
 

--- a/pages/common/hledger-print.md
+++ b/pages/common/hledger-print.md
@@ -9,11 +9,11 @@
 
 - Show transactions, with any implied amounts or costs made explicit:
 
-`hledger print --explicit --infer-costs`
+`hledger print {{[-x|--explicit]}} --infer-costs`
 
 - Show transactions from two specified files, with amounts converted to cost:
 
-`hledger print --file {{path/to/2023.journal}} --file {{path/to/2024.journal}} --cost`
+`hledger print {{[-f|--file]}} {{path/to/2023.journal}} {{[-f|--file]}} {{path/to/2024.journal}} {{[-B|--cost]}}`
 
 - Show `$` transactions in `*food*` but not `*groceries*` accounts this month:
 
@@ -25,8 +25,8 @@
 
 - Show cleared transactions, with `EUR` amounts rounded and with decimal commas:
 
-`hledger print --cleared --commodity '1000, EUR' --round hard`
+`hledger print {{[-C|--cleared]}} --commodity '1000, EUR' --round hard`
 
 - Write transactions from `foo.journal` as a CSV file:
 
-`hledger print --file {{path/to/foo.journal}} --output-file {{path/to/output_file.csv}}`
+`hledger print {{[-f|--file]}} {{path/to/foo.journal}} {{[-o|--output-file]}} {{path/to/output_file.csv}}`

--- a/pages/common/hledger-ui.md
+++ b/pages/common/hledger-ui.md
@@ -13,15 +13,15 @@
 
 - Start in the balance sheet accounts screen, showing hierarchy down to level 3:
 
-`hledger-ui --bs --tree --depth 3`
+`hledger-ui --bs {{[-t|--tree]}} --depth 3`
 
 - Start in this account's screen, showing cleared transactions, and reload on change:
 
-`hledger-ui --register {{assets:bank:checking}} --cleared --watch`
+`hledger-ui --register {{assets:bank:checking}} {{[-C|--cleared]}} {{[-w|--watch]}}`
 
 - Read two journal files, and show amounts as current value when known:
 
-`hledger-ui --file {{path/to/2024.journal}} --file {{path/to/2024-prices.journal}} --value now`
+`hledger-ui {{[-f|--file]}} {{path/to/2024.journal}} {{[-f|--file]}} {{path/to/2024-prices.journal}} --value now`
 
 - Show the manual in Info format, if possible:
 
@@ -29,4 +29,4 @@
 
 - Display help:
 
-`hledger-ui --help`
+`hledger-ui {{[-h|--help]}}`

--- a/pages/common/hledger-web.md
+++ b/pages/common/hledger-web.md
@@ -9,7 +9,7 @@
 
 - As above but with a specified file, and allow editing of existing data:
 
-`hledger-web --file {{path/to/file.journal}} --allow edit`
+`hledger-web {{[-f|--file]}} {{path/to/file.journal}} --allow edit`
 
 - Start just the web app, and accept incoming connections to the specified host and port:
 
@@ -29,4 +29,4 @@
 
 - Display help:
 
-`hledger-web --help`
+`hledger-web {{[-h|--help]}}`

--- a/pages/common/hledger.md
+++ b/pages/common/hledger.md
@@ -14,24 +14,24 @@
 
 - Print all transactions, reading from multiple specified journal files:
 
-`hledger print --file {{path/to/prices-2024.journal}} --file {{path/to/prices-2023.journal}}`
+`hledger print {{[-f|--file]}} {{path/to/prices-2024.journal}} {{[-f|--file]}} {{path/to/prices-2023.journal}}`
 
 - Show all accounts, as a hierarchy, and their types:
 
-`hledger accounts --tree --types`
+`hledger accounts {{[-t|--tree]}} --types`
 
 - Show asset and liability account balances, including zeros, hierarchically:
 
-`hledger balancesheet --empty --tree --no-elide`
+`hledger {{[bs|balancesheet]}} {{[-E|--empty]}} {{[-t|--tree]}} --no-elide`
 
 - Show monthly incomes/expenses/totals, largest first, summarised to 2 levels:
 
-`hledger incomestatement --monthly --row-total --average --sort --depth 2`
+`hledger {{[is|incomestatement]}} {{[-M|--monthly]}} {{[-T|--row-total]}} {{[-A|--average]}} --sort --depth 2`
 
 - Show the `assets:bank:checking` account's transactions and running balance:
 
-`hledger aregister assets:bank:checking`
+`hledger {{[areg|aregister]}} assets:bank:checking`
 
 - Show the amount spent on food from the `assets:cash` account:
 
-`hledger print assets:cash | hledger -f- -I aregister expenses:food`
+`hledger print assets:cash | hledger {{-f|--file}} - {{[-I|--ignore-assertions]}} aregister expenses:food`

--- a/pages/common/http-server.md
+++ b/pages/common/http-server.md
@@ -9,7 +9,7 @@
 
 - Start an HTTP server on a specific port to serve a specific directory:
 
-`http-server {{path/to/directory}} --port {{port}}`
+`http-server {{path/to/directory}} {{[-p|--port]}} {{port}}`
 
 - Start an HTTP server using basic authentication:
 
@@ -21,7 +21,7 @@
 
 - Start an HTTPS server on the default port using the specified certificate:
 
-`http-server --ssl --cert {{path/to/cert.pem}} --key {{path/to/key.pem}}`
+`http-server {{[-S|--ssl]}} {{[-C|--cert]}} {{path/to/cert.pem}} {{[-K|--key]}} {{path/to/key.pem}}`
 
 - Start an HTTP server and include the client's IP address in the output logging:
 
@@ -33,4 +33,4 @@
 
 - Start an HTTP server with logging disabled:
 
-`http-server --silent`
+`http-server {{[-s|--silent]}}`

--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -13,16 +13,16 @@
 
 - Change minimum number of benchmarking runs:
 
-`hyperfine --min-runs {{7}} '{{make}}'`
+`hyperfine {{[-m|--min-runs]}} {{7}} '{{make}}'`
 
 - Perform benchmark with warmup:
 
-`hyperfine --warmup {{5}} '{{make}}'`
+`hyperfine {{[-w|--warmup]}} {{5}} '{{make}}'`
 
 - Run a command before each benchmark run (to clear caches, etc.):
 
-`hyperfine --prepare '{{make clean}}' '{{make}}'`
+`hyperfine {{[-p|--prepare]}} '{{make clean}}' '{{make}}'`
 
 - Run a benchmark where a single parameter changes for each run:
 
-`hyperfine --prepare '{{make clean}}' --parameter-scan {{num_threads}} {{1}} {{10}} '{{make -j {num_threads}}}'`
+`hyperfine {{[-p|--prepare]}} '{{make clean}}' {{[-P|--parameter-scan]}} {{num_threads}} {{1}} {{10}} '{{make {{[-j|--jobs]}} {num_threads}}}'`

--- a/pages/common/iconv.md
+++ b/pages/common/iconv.md
@@ -5,12 +5,12 @@
 
 - Convert file to a specific encoding, and print to `stdout`:
 
-`iconv -f {{from_encoding}} -t {{to_encoding}} {{input_file}}`
+`iconv {{[-f|--from-code]}} {{from_encoding}} {{[-t|--to-code]}} {{to_encoding}} {{input_file}}`
 
 - Convert file to the current locale's encoding, and output to a file:
 
-`iconv -f {{from_encoding}} {{input_file}} > {{output_file}}`
+`iconv {{[-f|--from-code]}} {{from_encoding}} {{input_file}} > {{output_file}}`
 
 - List supported encodings:
 
-`iconv -l`
+`iconv {{[-l|--list]}}`

--- a/pages/common/in-toto-record.md
+++ b/pages/common/in-toto-record.md
@@ -5,8 +5,8 @@
 
 - Start the record (creates a preliminary link file):
 
-`in-toto-record start -n {{path/to/edit_file1 path/to/edit_file2 ...}} -k {{path/to/key_file}} -m {{.}}`
+`in-toto-record start {{[-n|--step-name]}} {{path/to/edit_file1 path/to/edit_file2 ...}} -k {{path/to/key_file}} {{[-m|--materials]}} {{.}}`
 
 - Stop the record (expects a preliminary link file):
 
-`in-toto-record stop -n {{path/to/edit_file1 path/to/edit_file2 ...}} -k {{path/to/key_file}} -p {{.}}`
+`in-toto-record stop {{[-n|--step-name]}} {{path/to/edit_file1 path/to/edit_file2 ...}} -k {{path/to/key_file}} {{[-p|--products]}} {{.}}`

--- a/pages/common/in-toto-run.md
+++ b/pages/common/in-toto-run.md
@@ -5,16 +5,16 @@
 
 - Tag a Git repo and signing the resulting link file:
 
-`in-toto-run -n {{tag}} --products {{.}} -k {{key_file}} -- {{git tag v1.0}}`
+`in-toto-run {{[-n|--step-name]}} {{tag}} {{[-p|--products]}} {{.}} -k {{key_file}} -- {{git tag v1.0}}`
 
 - Create a tarball, storing files as materials and the tarball as product:
 
-`in-toto-run -n {{package}} -m {{project}} -p {{project.tar.gz}} -- {{tar czf project.tar.gz project}}`
+`in-toto-run {{[-n|--step-name]}} {{package}} {{[-m|--materials]}} {{project}} {{[-p|--products]}} {{project.tar.gz}} -- {{tar czf project.tar.gz project}}`
 
 - Generate signed attestations for review work:
 
-`in-toto-run -n {{review}} -k {{key_file}} -m {{document.pdf}} -x`
+`in-toto-run {{[-n|--step-name]}} {{review}} -k {{key_file}} {{[-m|--materials]}} {{document.pdf}} {{[-x|--no-command]}}`
 
 - Scan the image using Trivy and generate link file:
 
-`in-toto-run -n {{scan}} -k {{key_file}} -p {{report.json}} -- {{/bin/sh -c "trivy -o report.json -f json <IMAGE>"}}`
+`in-toto-run {{[-n|--step-name]}} {{scan}} -k {{key_file}} {{[-p|--products]}} {{report.json}} -- {{/bin/sh -c "trivy {{[-o|--output]}} report.json {{[-f|--format]}} json <IMAGE>"}}`

--- a/pages/common/in-toto-sign.md
+++ b/pages/common/in-toto-sign.md
@@ -5,20 +5,20 @@
 
 - Sign 'unsigned.layout' with two keys and write it to 'root.layout':
 
-`in-toto-sign -f {{unsigned.layout}} -k {{priv_key1}} {{priv_key2}} -o {{root.layout}}`
+`in-toto-sign {{[-f|--file]}} {{unsigned.layout}} {{[-k|--keep]}} {{priv_key1}} {{priv_key2}} {{[-o|--output]}} {{root.layout}}`
 
 - Replace signature in link file and write to default filename:
 
-`in-toto-sign -f {{package.2f89b927.link}} -k {{priv_key}}`
+`in-toto-sign {{[-f|--file]}} {{package.2f89b927.link}} {{[-k|--keep]}} {{priv_key}}`
 
 - Verify a layout signed with 3 keys:
 
-`in-toto-sign -f {{root.layout}} -k {{pub_key0}} {{pub_key1}} {{pub_key2}} --verify`
+`in-toto-sign {{[-f|--file]}} {{root.layout}} {{[-k|--keep]}} {{pub_key0}} {{pub_key1}} {{pub_key2}} --verify`
 
 - Sign a layout with the default GPG key in default GPG keyring:
 
-`in-toto-sign -f {{root.layout}} --gpg`
+`in-toto-sign {{[-f|--file]}} {{root.layout}} {{[-g|--gpg]}}`
 
 - Verify a layout with a GPG key identified by keyid '...439F3C2':
 
-`in-toto-sign -f {{root.layout}} --verify --gpg {{...439F3C2}}`
+`in-toto-sign {{[-f|--file]}} {{root.layout}} --verify {{[-g|--gpg]}} {{...439F3C2}}`

--- a/pages/common/in2csv.md
+++ b/pages/common/in2csv.md
@@ -18,4 +18,4 @@
 
 - Pipe a JSON file to in2csv:
 
-`cat {{data.json}} | in2csv -f json > {{data.csv}}`
+`cat {{data.json}} | in2csv {{[-f|--format]}} json > {{data.csv}}`

--- a/pages/common/inkscape.md
+++ b/pages/common/inkscape.md
@@ -6,28 +6,28 @@
 
 - Open an SVG file in the Inkscape GUI:
 
-`inkscape {{path/to/filename.svg}}`
+`inkscape {{path/to/file.svg}}`
 
 - Export an SVG file into a bitmap with the default format (PNG) and the default resolution (96 DPI):
 
-`inkscape {{path/to/filename.svg}} -o {{path/to/filename.png}}`
+`inkscape {{path/to/file.svg}} {{[-o|--export-filename]}} {{path/to/filename.png}}`
 
 - Export an SVG file into a bitmap of 600x400 pixels (aspect ratio distortion may occur):
 
-`inkscape {{path/to/filename.svg}} -o {{path/to/filename.png}} -w {{600}} -h {{400}}`
+`inkscape {{path/to/file.svg}} {{[-o|--export-filename]}} {{path/to/filename.png}} {{[-w|--export-width]}} {{600}} {{[-h|--export-height]}} {{400}}`
 
 - Export the drawing (bounding box of all objects) of an SVG file into a bitmap:
 
-`inkscape {{path/to/filename.svg}} -o {{path/to/filename.png}} -D`
+`inkscape {{path/to/file.svg}} {{[-o|--export-filename]}} {{path/to/filename.png}} {{[-D|--export-area-drawing]}}`
 
 - Export a single object, given its ID, into a bitmap:
 
-`inkscape {{path/to/filename.svg}} -i {{id}} -o {{object.png}}`
+`inkscape {{path/to/file.svg}} {{[-i|--export-id]}} {{id}} {{[-o|--export-filename]}} {{object.png}}`
 
 - Export an SVG document to PDF, converting all texts to paths:
 
-`inkscape {{path/to/filename.svg}} -o {{path/to/filename.pdf}} --export-text-to-path`
+`inkscape {{path/to/file.svg}} {{[-o|--export-filename]}} {{path/to/filename.pdf}} {{[-T|--export-text-to-path]}}`
 
 - Duplicate the object with id="path123", rotate the duplicate 90 degrees, save the file, and quit Inkscape:
 
-`inkscape {{path/to/filename.svg}} --select=path123 --verb="{{EditDuplicate;ObjectRotate90;FileSave;FileQuit}}"`
+`inkscape {{path/to/file.svg}} --select=path123 --verb="{{EditDuplicate;ObjectRotate90;FileSave;FileQuit}}"`

--- a/pages/common/interdiff.md
+++ b/pages/common/interdiff.md
@@ -9,4 +9,4 @@
 
 - Compare diff files, ignoring whitespace:
 
-`interdiff -w {{old_file}} {{new_file}}`
+`interdiff {{[-w|--ignore-all-space]}} {{old_file}} {{new_file}}`

--- a/pages/common/ioping.md
+++ b/pages/common/ioping.md
@@ -9,12 +9,12 @@
 
 - Measure latency on /tmp using 10 requests of 1 megabyte each:
 
-`ioping -c 10 -s 1M /tmp`
+`ioping {{[-c|-count]}} 10 {{[-s|-size]}} 1M /tmp`
 
 - Measure disk seek rate on `/dev/sdX`:
 
-`ioping -R {{/dev/sdX}}`
+`ioping {{[-R|-rapid]}} {{/dev/sdX}}`
 
 - Measure disk sequential speed on `/dev/sdX`:
 
-`ioping -RL {{/dev/sdX}}`
+`ioping {{[-RL|-rapid -linear]}} {{/dev/sdX}}`

--- a/pages/common/ippfind.md
+++ b/pages/common/ippfind.md
@@ -6,16 +6,16 @@
 
 - List IPP printers registered on the network with their status:
 
-`ippfind --ls`
+`ippfind {{[-l|--ls]}}`
 
 - Send a specific PostScript document to every PostScript printer on the network:
 
-`ippfind --txt-pdl application/postscript --exec ipptool -f {{path/to/document.ps}} '{}' print-job.test \;`
+`ippfind --txt-pdl application/postscript {{[-x|--exec]}} ipptool -f {{path/to/document.ps}} '{}' print-job.test \;`
 
 - Send a PostScript test document to every PostScript printer on the network:
 
-`ippfind --txt-pdl application/postscript --exec ipptool -f onepage-letter.ps '{}' print-job.test \;`
+`ippfind --txt-pdl application/postscript {{[-x|--exec]}} ipptool -f onepage-letter.ps '{}' print-job.test \;`
 
 - Send a PostScript test document to every PostScript printer on the network, whose name matches a regular expression:
 
-`ippfind --txt-pdl application/postscript --host {{regex}} --exec ipptool -f onepage-letter.ps '{}' print-job.test \;`
+`ippfind --txt-pdl application/postscript {{[-h|--host]}} {{regex}} {{[-x|--exec]}} ipptool -f onepage-letter.ps '{}' print-job.test \;`

--- a/pages/common/irssi.md
+++ b/pages/common/irssi.md
@@ -5,15 +5,15 @@
 
 - Open Irssi and connect to a server with a nickname:
 
-`irssi -n {{nickname}} -c {{irc.example.com}}`
+`irssi {{[-n|--nick]}} {{nickname}} {{[-c|--connect]}} {{irc.example.com}}`
 
 - Open Irssi and connect with a specific server on a given port:
 
-`irssi -c {{irc.example.com}} -p {{port}}`
+`irssi {{[-c|--connect]}} {{irc.example.com}} {{[-p|--port]}} {{port}}`
 
 - Display help:
 
-`irssi --help`
+`irssi {{[-?|--help]}}`
 
 - Join a channel:
 

--- a/pages/common/jc.md
+++ b/pages/common/jc.md
@@ -13,8 +13,8 @@
 
 - Output pretty JSON via pipe:
 
-`{{ifconfig}} | jc {{--ifconfig}} -p`
+`{{ifconfig}} | jc {{--ifconfig}} {{[-p|--pretty]}}`
 
 - Output pretty JSON via magic syntax:
 
-`jc -p {{ifconfig}}`
+`jc {{[-p|--pretty]}} {{ifconfig}}`

--- a/pages/common/jhat.md
+++ b/pages/common/jhat.md
@@ -9,7 +9,7 @@
 
 - Analyze a heap dump, specifying an alternate port for the HTTP server:
 
-`jhat -p {{port}} {{dump_file.bin}}`
+`jhat {{[-p|-port]}} {{port}} {{dump_file.bin}}`
 
 - Analyze a dump letting `jhat` use up to 8 GB RAM (2-4x dump size recommended):
 

--- a/pages/common/jmtpfs.md
+++ b/pages/common/jmtpfs.md
@@ -13,7 +13,7 @@
 
 - List available MTP devices:
 
-`jmtpfs --listDevices`
+`jmtpfs {{[-l|--listDevices]}}`
 
 - If multiple devices are present, mount a specific device:
 

--- a/pages/common/jtbl.md
+++ b/pages/common/jtbl.md
@@ -13,8 +13,8 @@
 
 - Print a table and truncate rows instead of wrapping:
 
-`cat {{file.json}} | jtbl -t`
+`cat {{file.json}} | jtbl {{[-t|--truncate]}}`
 
 - Print a table and don't wrap or truncate rows:
 
-`cat {{file.json}} | jtbl -n`
+`cat {{file.json}} | jtbl {{[-n|--no-wrap]}}`

--- a/pages/common/just.1.md
+++ b/pages/common/just.1.md
@@ -13,11 +13,11 @@
 
 - Edit justfile in the default editor:
 
-`just -e`
+`just {{[-e|--edit]}}`
 
 - List available recipes in the justfile:
 
-`just -l`
+`just {{[-l|--list]}}`
 
 - Print justfile:
 

--- a/pages/common/jwt.md
+++ b/pages/common/jwt.md
@@ -10,12 +10,12 @@
 
 - Decode a JWT as a JSON string:
 
-`jwt decode -j {{jwt_string}}`
+`jwt decode {{[-j|--json]}} {{jwt_string}}`
 
 - Encode a JSON string to a JWT:
 
-`jwt encode --alg {{HS256}} --secret {{1234567890}} '{{json_string}}'`
+`jwt encode {{[-A|--alg]}} {{HS256}} {{[-S|--secret]}} {{1234567890}} '{{json_string}}'`
 
 - Encode key pair payload to JWT:
 
-`jwt encode --alg {{HS256}} --secret {{1234567890}} -P {{key=value}}`
+`jwt encode {{[-A|--alg]}} {{HS256}} {{[-S|--secret]}} {{1234567890}} {{[-P|--payload]}} {{key=value}}`

--- a/pages/common/k6.md
+++ b/pages/common/k6.md
@@ -9,15 +9,15 @@
 
 - Run load test locally with a given number of virtual users and duration:
 
-`k6 run --vus {{10}} --duration {{30s}} {{script.js}}`
+`k6 run {{[-u|--vus]}} {{10}} {{[-d|--duration]}} {{30s}} {{script.js}}`
 
 - Run load test locally with a given environment variable:
 
-`k6 run -e {{HOSTNAME=example.com}} {{script.js}}`
+`k6 run {{[-e|--env]}} {{HOSTNAME=example.com}} {{script.js}}`
 
 - Run load test locally using InfluxDB to store results:
 
-`k6 run --out influxdb={{http://localhost:8086/k6db}} {{script.js}}`
+`k6 run {{[-o|--out]}} influxdb={{http://localhost:8086/k6db}} {{script.js}}`
 
 - Run load test locally and discard response bodies (significantly faster):
 

--- a/pages/common/k8s-unused-secret-detector.md
+++ b/pages/common/k8s-unused-secret-detector.md
@@ -9,8 +9,8 @@
 
 - Detect unused secrets in a specific namespace:
 
-`k8s-unused-secret-detector -n {{namespace}}`
+`k8s-unused-secret-detector {{[-n|--namespace]}} {{namespace}}`
 
 - Delete unused secrets in a specific namespace:
 
-`k8s-unused-secret-detector -n {{namespace}} | kubectl delete secret -n {{namespace}}`
+`k8s-unused-secret-detector {{[-n|--namespace]}} {{namespace}} | kubectl delete secret {{[-n|--namespace]}} {{namespace}}`

--- a/pages/common/k8sec.md
+++ b/pages/common/k8sec.md
@@ -25,8 +25,8 @@
 
 - Load secrets from a file:
 
-`k8sec load -f {{path/to/file}} {{secret_name}}`
+`k8sec load {{[-f|--filename]}} {{path/to/file}} {{secret_name}}`
 
 - Dump secrets to a file:
 
-`k8sec dump -f {{path/to/file}} {{secret_name}}`
+`k8sec dump {{[-f|--filename]}} {{path/to/file}} {{secret_name}}`

--- a/pages/common/kaggle.md
+++ b/pages/common/kaggle.md
@@ -9,4 +9,4 @@
 
 - Download a specific file from a competition dataset:
 
-`kaggle competitions download {{competition}} -f {{filename}}`
+`kaggle competitions download {{competition}} {{[-f|--file]}} {{filename}}`

--- a/pages/common/kismet.md
+++ b/pages/common/kismet.md
@@ -17,7 +17,7 @@
 
 - Start Kismet with a specific configuration file:
 
-`sudo kismet -c {{wlan0}} -f {{path/to/config.conf}}`
+`sudo kismet -c {{wlan0}} {{[-f|--config-file]}} {{path/to/config.conf}}`
 
 - Monitor and log data to an SQLite database:
 

--- a/pages/common/kompose.md
+++ b/pages/common/kompose.md
@@ -5,12 +5,12 @@
 
 - Deploy a dockerized application to Kubernetes:
 
-`kompose up -f {{docker-compose.yml}}`
+`kompose up {{[-f|--file]}} {{docker-compose.yml}}`
 
 - Delete instantiated services/deployments from Kubernetes:
 
-`kompose down -f {{docker-compose.yml}}`
+`kompose down {{[-f|--file]}} {{docker-compose.yml}}`
 
 - Convert a docker-compose file into Kubernetes resources file:
 
-`kompose convert -f {{docker-compose.yml}}`
+`kompose convert {{[-f|--file]}} {{docker-compose.yml}}`

--- a/pages/common/kops.md
+++ b/pages/common/kops.md
@@ -5,11 +5,11 @@
 
 - Create a cluster from the configuration specification:
 
-`kops create cluster -f {{cluster_name.yaml}}`
+`kops create cluster {{[-f|--filename]}} {{cluster_name.yaml}}`
 
 - Create a new SSH public key:
 
-`kops create secret sshpublickey {{key_name}} -i {{~/.ssh/id_rsa.pub}}`
+`kops create sshpublickey {{key_name}} {{[-i|--ssh-public-key]}} {{~/.ssh/id_rsa.pub}}`
 
 - Export the cluster configuration to the `~/.kube/config` file:
 
@@ -17,11 +17,11 @@
 
 - Get the cluster configuration as YAML:
 
-`kops get cluster {{cluster_name}} -o yaml`
+`kops get cluster {{cluster_name}} {{[-o|--output]}} yaml`
 
 - Delete a cluster:
 
-`kops delete cluster {{cluster_name}} --yes`
+`kops delete cluster {{cluster_name}} {{[-y|--yes]}}`
 
 - Validate a cluster:
 

--- a/pages/common/kube-capacity.md
+++ b/pages/common/kube-capacity.md
@@ -10,8 +10,8 @@
 
 - Include pods:
 
-`kube-capacity -p`
+`kube-capacity {{[-p|--pods]}}`
 
 - Include utilization:
 
-`kube-capacity -u`
+`kube-capacity {{[-u|--util]}}`

--- a/pages/common/kubectl-apply.md
+++ b/pages/common/kubectl-apply.md
@@ -6,16 +6,16 @@
 
 - Apply a configuration to a resource by file name or `stdin`:
 
-`kubectl apply -f {{resource_filename}}`
+`kubectl apply {{[-f|--filename]}} {{resource_filename}}`
 
 - Edit the latest last-applied-configuration annotations of resources from the default editor:
 
-`kubectl apply edit-last-applied -f {{resource_filename}}`
+`kubectl apply edit-last-applied {{[-f|--filename]}} {{resource_filename}}`
 
 - Set the latest last-applied-configuration annotations by setting it to match the contents of a file:
 
-`kubectl apply set-last-applied -f {{resource_filename}}`
+`kubectl apply set-last-applied {{[-f|--filename]}} {{resource_filename}}`
 
 - View the latest last-applied-configuration annotations by type/name or file:
 
-`kubectl apply view-last-applied -f {{resource_filename}}`
+`kubectl apply view-last-applied {{[-f|--filename]}} {{resource_filename}}`

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -5,11 +5,11 @@
 
 - Create a resource using the resource definition file:
 
-`kubectl create -f {{path/to/file.yml}}`
+`kubectl create {{[-f|--filename]}} {{path/to/file.yml}}`
 
 - Create a resource from `stdin`:
 
-`kubectl create -f -`
+`kubectl create {{[-f|--filename]}} -`
 
 - Create a deployment:
 

--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -29,4 +29,4 @@
 
 - Delete resources defined in a YAML manifest:
 
-`kubectl delete --filename {{path/to/manifest.yaml}}`
+`kubectl delete {{[-f|--filename]}} {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-edit.md
+++ b/pages/common/kubectl-edit.md
@@ -21,4 +21,4 @@
 
 - Edit a resource in JSON format:
 
-`kubectl edit {{resource}}/{{resource_name}} --output json`
+`kubectl edit {{resource}}/{{resource_name}} {{[-o|--output]}} json`

--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -9,7 +9,7 @@
 
 - Create a service for a resource identified by a file:
 
-`kubectl expose -f {{path/to/file.yml}} --port={{node_port}} --target-port={{container_port}}`
+`kubectl expose {{[-f|--filename]}} {{path/to/file.yml}} --port={{node_port}} --target-port={{container_port}}`
 
 - Create a service with a name, to serve to a node port which will be same for container port:
 

--- a/pages/common/kubectl-label.md
+++ b/pages/common/kubectl-label.md
@@ -17,7 +17,7 @@
 
 - Label a pod identified by the pod definition file:
 
-`kubectl label -f {{pod_definition_file}} {{key}}={{value}}`
+`kubectl label {{[-f|--filename]}} {{pod_definition_file}} {{key}}={{value}}`
 
 - Remove the label from a pod:
 

--- a/pages/common/kubectl-logs.md
+++ b/pages/common/kubectl-logs.md
@@ -9,7 +9,7 @@
 
 - Show logs for a specified container in a pod:
 
-`kubectl logs --container {{container_name}} {{pod_name}}`
+`kubectl logs {{[-c|--container]}} {{container_name}} {{pod_name}}`
 
 - Show logs for all containers in a pod:
 
@@ -17,7 +17,7 @@
 
 - Stream pod logs:
 
-`kubectl logs --follow {{pod_name}}`
+`kubectl logs {{[-f|--follow]}} {{pod_name}}`
 
 - Show pod logs newer than a relative time like `10s`, `5m`, or `1h`:
 

--- a/pages/common/kubectl-replace.md
+++ b/pages/common/kubectl-replace.md
@@ -5,12 +5,12 @@
 
 - Replace the resource using the resource definition file:
 
-`kubectl replace -f {{path/to/file.yml}}`
+`kubectl replace {{[-f|--filename]}} {{path/to/file.yml}}`
 
 - Replace the resource using the input passed into `stdin`:
 
-`kubectl replace -f -`
+`kubectl replace {{[-f|--filename]}} -`
 
 - Force replace, delete and then re-create the resource:
 
-`kubectl replace --force -f {{path/to/file.yml}}`
+`kubectl replace --force {{[-f|--filename]}} {{path/to/file.yml}}`

--- a/pages/common/kubectl-scale.md
+++ b/pages/common/kubectl-scale.md
@@ -9,7 +9,7 @@
 
 - Scale a resource identified by a file:
 
-`kubectl scale --replicas={{number_of_replicas}} -f {{path/to/file.yml}}`
+`kubectl scale --replicas={{number_of_replicas}} {{[-f|--filename]}} {{path/to/file.yml}}`
 
 - Scale a deployment based on current number of replicas:
 

--- a/pages/common/kubectl.md
+++ b/pages/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - List information about a resource with more details:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - Update specified pod with the label 'unhealthy' and the value 'true':
 

--- a/pages/common/kubectx.md
+++ b/pages/common/kubectx.md
@@ -21,7 +21,7 @@
 
 - Show the current named context:
 
-`kubectx -c`
+`kubectx {{[-c|--current]}}`
 
 - Delete a named context:
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -9,11 +9,11 @@
 
 - Tail only a specific container from multiple pods:
 
-`kubetail {{my_app}} -c {{my_container}}`
+`kubetail {{my_app}} {{[-c|--container]}} {{my_container}}`
 
 - To tail multiple containers from multiple pods:
 
-`kubetail {{my_app}} -c {{my_container_1}} -c {{my_container_2}}`
+`kubetail {{my_app}} {{[-c|--container]}} {my_container_1}} {{[-c|--container]}} {my_container_2}}`
 
 - To tail multiple applications at the same time separate them by comma:
 

--- a/pages/common/kustomize.md
+++ b/pages/common/kustomize.md
@@ -9,7 +9,7 @@
 
 - Build a kustomization file and deploy it with `kubectl`:
 
-`kustomize build . | kubectl apply -f -`
+`kustomize build . | kubectl apply {{[-f|--filename]}} -`
 
 - Set an image in the kustomization file:
 

--- a/pages/common/ldapsearch.md
+++ b/pages/common/ldapsearch.md
@@ -5,32 +5,32 @@
 
 - Query an LDAP server for all items that are a member of the given group and return the object's displayName value:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} -b {{base_ou}} '{{memberOf=group1}}' displayName`
+`ldapsearch {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} {{[-b|--baseDN]}} {{base_ou}} '{{memberOf=group1}}' displayName`
 
 - Query an LDAP server with a no-newline password file for all items that are a member of the given group and return the object's displayName value:
 
-`ldapsearch -D '{{admin_DN}}' -y '{{password_file}}' -h {{ldap_host}} -b {{base_ou}} '{{memberOf=group1}}' displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-u|--keyStorePasswordFile]}} '{{password_file}}' {{[-h|--hostname]}} {{ldap_host}} {{[-b|--baseDN]}} {{base_ou}} '{{memberOf=group1}}' displayName`
 
 - Return 5 items that match the given filter:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} -b {{base_ou}} '{{memberOf=group1}}' -z 5 displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} {{[-b|--baseDN]}} {{base_ou}} '{{memberOf=group1}}' {{[-z|--sizeLimit]}} 5 displayName`
 
 - Wait up to 7 seconds for a response:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} -b {{base_ou}} '{{memberOf=group1}}' -l 7 displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} {{[-b|--baseDN]}} {{base_ou}} '{{memberOf=group1}}' {{[-l|--timeLimitSeconds]}} 7 displayName`
 
 - Invert the filter:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} -b {{base_ou}} '(!(memberOf={{group1}}))' displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} {{[-b|--baseDN]}} {{base_ou}} '(!(memberOf={{group1}}))' displayName`
 
 - Return all items that are part of multiple groups, returning the display name for each item:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} '(&({{memberOf=group1}})({{memberOf=group2}})({{memberOf=group3}}))' "displayName"`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} '(&({{memberOf=group1}})({{memberOf=group2}})({{memberOf=group3}}))' "displayName"`
 
 - Return all items that are members of at least 1 of the specified groups:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} '(|({{memberOf=group1}})({{memberOf=group1}})({{memberOf=group3}}))' displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} '(|({{memberOf=group1}})({{memberOf=group1}})({{memberOf=group3}}))' displayName`
 
 - Combine multiple boolean logic filters:
 
-`ldapsearch -D '{{admin_DN}}' -w '{{password}}' -h {{ldap_host}} '(&({{memberOf=group1}})({{memberOf=group2}})(!({{memberOf=group3}})))' displayName`
+`ldapsearch  {{[-D|--bindDN]}} '{{admin_DN}}' {{[-w|--bindPassword]}} '{{password}}' {{[-h|--hostname]}} {{ldap_host}} '(&({{memberOf=group1}})({{memberOf=group2}})(!({{memberOf=group3}})))' displayName`

--- a/pages/common/lilypond.md
+++ b/pages/common/lilypond.md
@@ -10,16 +10,16 @@
 
 - Compile into the specified format:
 
-`lilypond --formats={{format_dump}} {{path/to/file}}`
+`lilypond {{[-f|--format]}} {{format_dump}} {{path/to/file}}`
 
 - Compile the specified file, suppressing progress updates:
 
-`lilypond -s {{path/to/file}}`
+`lilypond {{[-s|--silent]}} {{path/to/file}}`
 
 - Compile the specified file, and also specify the output filename:
 
-`lilypond --output={{path/to/output_file}} {{path/to/input_file}}`
+`lilypond {{[-o|--output]}} {{path/to/output_file}} {{path/to/input_file}}`
 
 - Show the current version of lilypond:
 
-`lilypond --version`
+`lilypond {{[-v|--version]}}`

--- a/pages/common/loc.md
+++ b/pages/common/loc.md
@@ -17,4 +17,4 @@
 
 - Print lines of code without .gitignore (etc.) files (e.g. two -u flags will additionally count hidden files and dirs):
 
-`loc -u`
+`loc {{[-u|--unrestricted]}}`

--- a/pages/common/lolcat.md
+++ b/pages/common/lolcat.md
@@ -13,8 +13,8 @@
 
 - Print a file to the console with animated rainbow colors:
 
-`lolcat -a {{path/to/file}}`
+`lolcat {{[-a|--animate]}} {{path/to/file}}`
 
 - Print a file to the console with 24-bit (truecolor) rainbow colors:
 
-`lolcat -t {{path/to/file}}`
+`lolcat {{[-t|--truecolor]}} {{path/to/file}}`

--- a/pages/common/lsd.md
+++ b/pages/common/lsd.md
@@ -6,32 +6,32 @@
 
 - List files and directories, one per line:
 
-`lsd -1`
+`lsd {{[-1|--oneline]}}`
 
 - List all files and directories, including hidden ones, in the current directory:
 
-`lsd -a`
+`lsd {{[-a|--all]}}`
 
 - List files and directories with trailing `/` added to directory names:
 
-`lsd -F`
+`lsd {{[-F|--classify]}}`
 
 - List all files and directories in long format (permissions, ownership, size in human-readable format, and modification date):
 
-`lsd -lha`
+`lsd {{[-lha|--long --human-readable --all]}}`
 
 - List files and directories in long format, sorted by size (descending):
 
-`lsd -lS`
+`lsd {{[-lS|--long --sizesort]}}`
 
 - List files and directories in long format, sorted by modification date (oldest first):
 
-`lsd -ltr`
+`lsd {{[-ltr|--long --timesort --reverse]}}`
 
 - Only list directories:
 
-`lsd -d {{*/}}`
+`lsd {{[-d|--directory-only]}} {{*/}}`
 
 - Recursively list all directories in a tree format:
 
-`lsd --tree -d`
+`lsd --tree {{[-d|--directory-only]}}`

--- a/pages/common/lychee.md
+++ b/pages/common/lychee.md
@@ -17,7 +17,7 @@
 
 - Check files in a directory structure for any broken URLs:
 
-`grep -r "{{pattern}}" | lychee -`
+`grep {{[-r|--recursive]}} "{{pattern}}" | lychee -`
 
 - Display help:
 

--- a/pages/common/lz4.md
+++ b/pages/common/lz4.md
@@ -9,11 +9,11 @@
 
 - Decompress a file:
 
-`lz4 -d {{file.lz4}}`
+`lz4 {{[-d|--decompress]}} {{file.lz4}}`
 
 - Decompress a file and write to `stdout`:
 
-`lz4 -dc {{file.lz4}}`
+`lz4 {{[-dc|--decompress --stdout]}} {{file.lz4}}`
 
 - Package and compress a directory and its contents:
 
@@ -21,8 +21,8 @@
 
 - Decompress and unpack a directory and its contents:
 
-`lz4 -dc {{dir.tar.lz4}} | tar -xv`
+`lz4 {{[-dc|--decompress --stdout]}} {{dir.tar.lz4}} | tar -xv`
 
 - Compress a file using the best compression:
 
-`lz4 -9 {{path/to/file}}`
+`lz4 {{[-12|--best]}} {{path/to/file}}`

--- a/pages/common/lzop.md
+++ b/pages/common/lzop.md
@@ -9,8 +9,16 @@
 
 - Decompress a file:
 
-`lzop -d {{path/to/file.lzo}}`
+`lzop {{[-d|--decompress]}} {{path/to/file.lzo}}`
 
 - Compress a file, while specifying the compression level. 0 = Worst, 9 = Best (Default level is 3):
 
 `lzop -{{level}} {{path/to/file}}`
+
+- Compress a file with the best compression level:
+
+`lzop {{[-9|--best]}} {{[path/to/file]}}`
+
+- Compress a file with the fastest compression level:
+
+`lzop {{[-1|--fast]}} {{[path/to/file]}}`

--- a/pages/common/mailx.md
+++ b/pages/common/mailx.md
@@ -5,24 +5,24 @@
 
 - Send mail (the content should be typed after the command, and ended with `<Ctrl d>`):
 
-`mailx -s "{{subject}}" {{to_addr}}`
+`mailx {{[-s|--subject]}} "{{subject}}" {{to_addr}}`
 
 - Send mail with content passed from another command:
 
-`echo "{{content}}" | mailx -s "{{subject}}" {{to_addr}}`
+`echo "{{content}}" | mailx {{[-s|--subject]}} "{{subject}}" {{to_addr}}`
 
 - Send mail with content read from a file:
 
-`mailx -s "{{subject}}" {{to_addr}} < {{content.txt}}`
+`mailx {{[-s|--subject]}} "{{subject}}" {{to_addr}} < {{content.txt}}`
 
 - Send mail to a recipient and CC to another address:
 
-`mailx -s "{{subject}}" -c {{cc_addr}} {{to_addr}}`
+`mailx {{[-s|--subject]}} "{{subject}}" {{[-c|--cc]}} {{cc_addr}} {{to_addr}}`
 
 - Send mail specifying the sender address:
 
-`mailx -s "{{subject}}" -r {{from_addr}} {{to_addr}}`
+`mailx {{[-s|--subject]}} "{{subject}}" {{[-r|--from-address]}} {{from_addr}} {{to_addr}}`
 
 - Send mail with an attachment:
 
-`mailx -a {{path/to/file}} -s "{{subject}}" {{to_addr}}`
+`mailx {{[-a|--attach]}} {{path/to/file}} {{[-s|--subject]}} "{{subject}}" {{to_addr}}`

--- a/pages/common/mc.md
+++ b/pages/common/mc.md
@@ -11,4 +11,4 @@
 
 - Start Midnight Commander in black and white:
 
-`mc -b`
+`mc {{[-b|--nocolor]}}`

--- a/pages/common/minifab.md
+++ b/pages/common/minifab.md
@@ -5,7 +5,7 @@
 
 - Bring up the default Hyperledger Fabric network:
 
-`minifab up -i {{minifab_version}}`
+`minifab up {{[-i|--fabric-release]}} {{minifab_version}}`
 
 - Bring down the Hyperledger Fabric network:
 
@@ -13,11 +13,11 @@
 
 - Install chaincode onto a specified channel:
 
-`minifab install -n {{chaincode_name}}`
+`minifab install {{[-n|--chaincode-name]}} {{chaincode_name}}`
 
 - Install a specific chaincode version onto a channel:
 
-`minifab install -n {{chaincode_name}} -v {{chaincode_version}}`
+`minifab install {{[-n|--chaincode-name]}} {{chaincode_name}} {{[-v|--chaincode-version]}} {{chaincode_version}}`
 
 - Initialize the chaincode after installation/upgrade:
 
@@ -25,7 +25,7 @@
 
 - Invoke a chaincode method with the specified arguments:
 
-`minifab invoke -n {{chaincode_name}} -p '"{{method_name}}", "{{argument1}}", "{{argument2}}", ...'`
+`minifab invoke {{[-n|--chaincode-name]}} {{chaincode_name}} {{[-p|--chaincode-parameters]}} '"{{method_name}}", "{{argument1}}", "{{argument2}}", ...'`
 
 - Make a query on the ledger:
 
@@ -33,4 +33,4 @@
 
 - Quickly run an application:
 
-`minifab apprun -l {{app_programming_language}}`
+`minifab apprun {{[-l|--chaincode-language]}} {{app_programming_language}}`

--- a/pages/common/mitmdump.md
+++ b/pages/common/mitmdump.md
@@ -6,12 +6,12 @@
 
 - Start a proxy and save all output to a file:
 
-`mitmdump -w {{path/to/file}}`
+`mitmdump {{[-w|--wfile]}} {{path/to/file}}`
 
 - Filter a saved traffic file to just POST requests:
 
-`mitmdump -nr {{input_filename}} -w {{output_filename}} "{{~m post}}"`
+`mitmdump {{[-nr|--no-server --read-flows]}} {{input_filename}} {{[-w|--wfile]}} {{output_filename}} "{{~m post}}"`
 
 - Replay a saved traffic file:
 
-`mitmdump -nc {{path/to/file}}`
+`mitmdump {{[-nc|--no-server --client-replay]}} {{path/to/file}}`

--- a/pages/common/mktorrent.md
+++ b/pages/common/mktorrent.md
@@ -5,20 +5,20 @@
 
 - Create a torrent with 2^21 KB as the piece size:
 
-`mktorrent -a {{tracker_announce_url}} -l {{21}} -o {{path/to/example.torrent}} {{path/to/file_or_directory}}`
+`mktorrent {{[-a|--announce]}} {{tracker_announce_url}} {{[-l|--piece-length]}} {{21}} {{[-o|--output]}} {{path/to/example.torrent}} {{path/to/file_or_directory}}`
 
 - Create a private torrent with a 2^21 KB piece size:
 
-`mktorrent -p -a {{tracker_announce_url}} -l {{21}} -o {{path/to/example.torrent}} {{path/to/file_or_directory}}`
+`mktorrent {{[-p|--private]}} {{[-a|--announce]}} {{tracker_announce_url}} {{[-l|--piece-length]}} {{21}} {{[-o|--output]}} {{path/to/example.torrent}} {{path/to/file_or_directory}}`
 
 - Create a torrent with a comment:
 
-`mktorrent -c "{{comment}}" -a {{tracker_announce_url}} -l {{21}} -o {{path/to/example.torrent}} {{path/to/file_or_directory}}`
+`mktorrent {{[-c|--comment]}} "{{comment}}" {{[-a|--announce]}} {{tracker_announce_url}} {{[-l|--piece-length]}} {{21}} {{[-o|--output]}} {{path/to/example.torrent}} {{path/to/file_or_directory}}`
 
 - Create a torrent with multiple trackers:
 
-`mktorrent -a {{tracker_announce_url,tracker_announce_url_2}} -l {{21}} -o {{path/to/example.torrent}} {{path/to/file_or_directory}}`
+`mktorrent {{[-a|--announce]}} {{tracker_announce_url,tracker_announce_url_2}} {{[-l|--piece-length]}} {{21}} {{[-o|--output]}} {{path/to/example.torrent}} {{path/to/file_or_directory}}`
 
 - Create a torrent with web seed URLs:
 
-`mktorrent -a {{tracker_announce_url}} -w {{web_seed_url}} -l {{21}} -o {{path/to/example.torrent}} {{path/to/file_or_directory}}`
+`mktorrent {{[-a|--announce]}} {{tracker_announce_url}} -w {{web_seed_url}} {{[-l|--piece-length]}} {{21}} {{[-o|--output]}} {{path/to/example.torrent}} {{path/to/file_or_directory}}`

--- a/pages/common/mlr.md
+++ b/pages/common/mlr.md
@@ -27,6 +27,6 @@
 
 `echo '{"hello":"world", "foo":"bar"}' | mlr --ijson --ojson --jvstack cat`
 
-- Filter lines of a compressed CSV file treating numbers as strings:
+- Filter lines of a compressed CSV file treating numbers as [S]trings:
 
-`mlr --prepipe 'gunzip' --csv filter -S '${{fieldName}} =~ "{{regular_expression}}"' {{example.csv.gz}}`
+`mlr --prepipe 'gunzip' {{[-c|--csv]}} filter {{[-S|--infer-none]}} '${{fieldName}} =~ "{{regular_expression}}"' {{example.csv.gz}}`

--- a/pages/common/mmv.md
+++ b/pages/common/mmv.md
@@ -9,11 +9,11 @@
 
 - Copy `report6part4.txt` to `./french/rapport6partie4.txt` along with all similarly named files:
 
-`mmv -c "{{report*part*.txt}}" "{{./french/rapport#1partie#2.txt}}"`
+`mmv {{[-c|--copy]}} "{{report*part*.txt}}" "{{./french/rapport#1partie#2.txt}}"`
 
 - Append all `.txt` files into one file:
 
-`mmv -a "{{*.txt}}" "{{all.txt}}"`
+`mmv {{[-a|--append]}} "{{*.txt}}" "{{all.txt}}"`
 
 - Convert dates in filenames from "M-D-Y" format to "D-M-Y" format:
 

--- a/pages/common/monop.md
+++ b/pages/common/monop.md
@@ -17,15 +17,15 @@
 
 - Only show members defined in the specified Type:
 
-`monop -r:{{path/to/assembly.dll}} --only-declared {{Namespace.Path.To.Type}}`
+`monop -r:{{path/to/assembly.dll}} {{[-d|--declared-only]}} {{Namespace.Path.To.Type}}`
 
 - Show private members:
 
-`monop -r:{{path/to/assembly.dll}} --private {{Namespace.Path.To.Type}}`
+`monop -r:{{path/to/assembly.dll}} {{[-p|--private]}} {{Namespace.Path.To.Type}}`
 
 - Hide obsolete members:
 
-`monop -r:{{path/to/assembly.dll}} --filter-obsolete {{Namespace.Path.To.Type}}`
+`monop -r:{{path/to/assembly.dll}} {{[-f|--filter-obsolete]}} {{Namespace.Path.To.Type}}`
 
 - List the other assemblies that a specified assembly references:
 

--- a/pages/common/mosquitto_pub.md
+++ b/pages/common/mosquitto_pub.md
@@ -5,24 +5,24 @@
 
 - Publish a temperature value of 32 on the topic `sensors/temperature` to 192.168.1.1 (defaults to `localhost`) with Quality of Service (`QoS`) set to 1:
 
-`mosquitto_pub -h {{192.168.1.1}} -t {{sensors/temperature}} -m {{32}} -q {{1}}`
+`mosquitto_pub {{[-h|--host]}} {{192.168.1.1}} {{[-t|--topic]}} {{sensors/temperature}} {{[-m|--message]}} {{32}} {{[-q|--qos]}} {{1}}`
 
 - Publish timestamp and temperature data on the topic `sensors/temperature` to a remote host on a non-standard port:
 
-`mosquitto_pub -h {{192.168.1.1}} -p {{1885}} -t {{sensors/temperature}} -m "{{1266193804 32}}"`
+`mosquitto_pub {{[-h|--host]}} {{192.168.1.1}} {{[-p|--port]}} {{1885}} {{[-t|--topic]}} {{sensors/temperature}} {{[-m|--message]}} "{{1266193804 32}}"`
 
 - Publish light switch status and retain the message on the topic `switches/kitchen_lights/status` to a remote host because there may be a long period of time between light switch events:
 
-`mosquitto_pub -r -h "{{iot.eclipse.org}}" -t {{switches/kitchen_lights/status}} -m "{{on}}"`
+`mosquitto_pub {{[-r|--retain]}} {{[-h|--host]}} "{{iot.eclipse.org}}" {{[-t|--topic]}} {{switches/kitchen_lights/status}} {{[-m|--message]}} "{{on}}"`
 
 - Send the contents of a file (`data.txt`) as a message and publish it to `sensors/temperature` topic:
 
-`mosquitto_pub -t {{sensors/temperature}} -f {{data.txt}}`
+`mosquitto_pub {{[-t|--topic]}} {{sensors/temperature}} {{[-f|--file]}} {{data.txt}}`
 
 - Send the contents of a file (`data.txt`), by reading from `stdin` and send the entire input as a message and publish it to `sensors/temperature` topic:
 
-`mosquitto_pub -t {{sensors/temperature}} -s < {{data.txt}}`
+`mosquitto_pub {{[-t|--topic]}} {{sensors/temperature}} {{[-s|--stdin-file]}} < {{data.txt}}`
 
 - Read newline delimited data from `stdin` as a message and publish it to `sensors/temperature` topic:
 
-`{{echo data.txt}} | mosquitto_pub -t {{sensors/temperature}} -l`
+`{{echo data.txt}} | mosquitto_pub {{[-t|--topic]}} {{sensors/temperature}} {{[-l|--stdin-line]}}`

--- a/pages/common/mosquitto_sub.md
+++ b/pages/common/mosquitto_sub.md
@@ -5,12 +5,12 @@
 
 - Subscribe to the topic `sensors/temperature` information with Quality of Service (`QoS`) set to 1. (The default hostname is `localhost` and port 1883):
 
-`mosquitto_sub -t {{sensors/temperature}} -q {{1}}`
+`mosquitto_sub {{[-t|--topic]}} {{sensors/temperature}} {{[-q|--qos]}} {{1}}`
 
 - Subscribe to all broker status messages publishing on `iot.eclipse.org` port 1885 and print published messages verbosely:
 
-`mosquitto_sub -v -h "iot.eclipse.org" -p 1885 -t {{\$SYS/#}}`
+`mosquitto_sub {{[-v|--verbose]}} {{[-h|--host]}} "iot.eclipse.org" {{[-p|--port]}} 1885 {{[-t|--topic]}} {{\$SYS/#}}`
 
 - Subscribe to multiple topics matching a given pattern. (+ takes any metric name):
 
-`mosquitto_sub -t {{sensors/machines/+/temperature/+}}`
+`mosquitto_sub {{[-t|--topic]}} {{sensors/machines/+/temperature/+}}`

--- a/pages/common/mr.md
+++ b/pages/common/mr.md
@@ -9,7 +9,7 @@
 
 - Update repositories in 5 concurrent jobs:
 
-`mr -j{{5}} update`
+`mr {{[-j|--jobs]}} {{5}} update`
 
 - Print the status of all repositories:
 

--- a/pages/common/msedge.md
+++ b/pages/common/msedge.md
@@ -5,8 +5,8 @@
 
 - View the documentation for Microsoft Edge for Windows:
 
-`tldr -p windows msedge`
+`tldr {{[-p|--platform]}} windows msedge`
 
 - View the documentation for Microsoft Edge for other platforms:
 
-`tldr -p common microsoft-edge`
+`tldr {{[-p|--platform]}} common microsoft-edge`

--- a/pages/common/msfvenom.md
+++ b/pages/common/msfvenom.md
@@ -1,28 +1,28 @@
 # msfvenom
 
 > Manually generate payloads for metasploit.
-> More information: <https://github.com/rapid7/metasploit-framework/wiki/How-to-use-msfvenom>.
+> More information: <https://docs.metasploit.com/docs/using-metasploit/basics/how-to-use-msfvenom.html>.
 
 - List payloads:
 
-`msfvenom -l payloads`
+`msfvenom {{[-l|--list]}} payloads`
 
 - List formats:
 
-`msfvenom -l formats`
+`msfvenom {{[-l|--list]}} formats`
 
 - Show payload options:
 
-`msfvenom -p {{payload}} --list-options`
+`msfvenom {{[-p|--payload]}} {{payload}} --list-options`
 
 - Create an ELF binary with a reverse TCP handler:
 
-`msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST={{local_ip}} LPORT={{local_port}} -f elf -o {{path/to/binary}}`
+`msfvenom {{[-p|--payload]}} linux/x64/meterpreter/reverse_tcp LHOST={{local_ip}} LPORT={{local_port}} {{[-f|--format]}} elf {{[-o|--out]}} {{path/to/binary}}`
 
 - Create an EXE binary with a reverse TCP handler:
 
-`msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST={{local_ip}} LPORT={{local_port}} -f exe -o {{path/to/binary.exe}}`
+`msfvenom {{[-p|--payload]}} windows/x64/meterpreter/reverse_tcp LHOST={{local_ip}} LPORT={{local_port}} {{[-f|--format]}} exe {{[-o|--out]}} {{path/to/binary.exe}}`
 
 - Create a raw Bash with a reverse TCP handler:
 
-`msfvenom -p cmd/unix/reverse_bash LHOST={{local_ip}} LPORT={{local_port}} -f raw`
+`msfvenom {{[-p|--payload]}} cmd/unix/reverse_bash LHOST={{local_ip}} LPORT={{local_port}} {{[-f|--format]}} raw`

--- a/pages/common/multipass.md
+++ b/pages/common/multipass.md
@@ -9,7 +9,7 @@
 
 - Launch a new instance, set its name and use a cloud-init configuration file:
 
-`multipass launch -n {{instance_name}} --cloud-init {{configuration_file}}`
+`multipass launch {{[-n|--name]}} {{instance_name}} --cloud-init {{configuration_file}}`
 
 - List all the created instances and some of their properties:
 

--- a/pages/common/mysql.md
+++ b/pages/common/mysql.md
@@ -9,24 +9,24 @@
 
 - Connect to a database, user will be prompted for a password:
 
-`mysql -u {{user}} --password {{database_name}}`
+`mysql {{[-u|--user]}} {{user}} {{[-p|--password]}} {{database_name}}`
 
 - Connect to a database on another host:
 
-`mysql -h {{database_host}} {{database_name}}`
+`mysql {{[-h|--host]}} {{database_host}} {{database_name}}`
 
 - Connect to a database through a Unix socket:
 
-`mysql --socket {{path/to/socket.sock}}`
+`mysql {{[-S|--socket]}} {{path/to/socket.sock}}`
 
 - Execute SQL statements in a script file (batch file):
 
-`mysql -e "source {{filename.sql}}" {{database_name}}`
+`mysql {{[-e|--execute]}} "source {{filename.sql}}" {{database_name}}`
 
 - Restore a database from a backup created with `mysqldump` (user will be prompted for a password):
 
-`mysql --user {{user}} --password {{database_name}} < {{path/to/backup.sql}}`
+`mysql {{[-u|--user]}} {{user}} {{[-p|--password]}} {{database_name}} < {{path/to/backup.sql}}`
 
 - Restore all databases from a backup (user will be prompted for a password):
 
-`mysql --user {{user}} --password < {{path/to/backup.sql}}`
+`mysql {{[-u|--user]}} {{user}} {{[-p|--password]}} < {{path/to/backup.sql}}`

--- a/pages/common/pnmtofiasco.md
+++ b/pages/common/pnmtofiasco.md
@@ -13,7 +13,7 @@
 
 - Specify the compression quality:
 
-`pnmtofiasco {{[-qua|--quality]}} {{quality_level}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
+`pnmtofiasco {{[-q|--quality]}} {{quality_level}} {{path/to/file.pnm}} > {{path/to/file.fiasco}}`
 
 - Load the options to be used from the specified configuration file:
 

--- a/pages/common/sort.md
+++ b/pages/common/sort.md
@@ -13,7 +13,7 @@
 
 - Sort a file in case-insensitive way:
 
-`sort {{-f|--ignore-case}} {{path/to/file}}`
+`sort {{[-f|--ignore-case]}} {{path/to/file}}`
 
 - Sort a file using numeric rather than alphabetic order:
 

--- a/pages/common/trivy.md
+++ b/pages/common/trivy.md
@@ -9,7 +9,7 @@
 
 - Scan a Docker image filtering the output by severity:
 
-`trivy image --severity {{HIGH,CRITICAL}} {{alpine:3.15}}`
+`trivy image {{[-s|--severity]}} {{HIGH,CRITICAL}} {{alpine:3.15}}`
 
 - Scan a Docker image ignoring any unfixed/unpatched vulnerabilities:
 
@@ -33,4 +33,4 @@
 
 - Generate output with a SARIF template:
 
-`trivy image --format {{template}} --template "{{@sarif.tpl}}" -o {{path/to/report.sarif}} {{image:tag}}`
+`trivy image {{[-f|--format]}} {{template}} {{[-t|--template]}} "{{@sarif.tpl}}" {{[-o|--output]}} {{path/to/report.sarif}} {{image:tag}}`

--- a/pages/common/watchexec.md
+++ b/pages/common/watchexec.md
@@ -1,7 +1,7 @@
 # watchexec
 
 > Run arbitrary commands when files change.
-> More information: <https://github.com/watchexec/watchexec>.
+> More information: <https://manned.org/watchexec>.
 
 - Call `ls -la` when any file in the current directory changes:
 
@@ -9,12 +9,12 @@
 
 - Run `make` when any JavaScript, CSS and HTML file in the current directory changes:
 
-`watchexec --exts {{js,css,html}} make`
+`watchexec {{[-e|--exts]}} {{js,css,html}} make`
 
 - Run `make` when any file in the `lib` or `src` directory changes:
 
-`watchexec --watch {{lib}} --watch {{src}} {{make}}`
+`watchexec {{[-w|--watch]}} {{lib}} {{[-w|--watch]}} {{src}} {{make}}`
 
 - Call/restart `my_server` when any file in the current directory changes, sending `SIGKILL` to stop the child process:
 
-`watchexec --restart --stop-signal {{SIGKILL}} {{my_server}}`
+`watchexec {{[-r|--restart]}} --stop-signal {{SIGKILL}} {{my_server}}`

--- a/pages/linux/fuzzel.md
+++ b/pages/linux/fuzzel.md
@@ -25,9 +25,9 @@
 
 - Reset apps usage count (default cache directory: `$XDG_CACHE_HOME/fuzzel`):
 
-`rm -v $HOME/.cache/fuzzel`
+`rm {{[-v|--verbose]}} $HOME/.cache/fuzzel`
 
-- Launch `fuzzel` on a specific monitor, see `wlr-randr` or `swaymsg -t get_outputs`:
+- Launch `fuzzel` on a specific monitor, see `wlr-randr` or `swaymsg --type get_outputs`:
 
 `fuzzel {{[-o|--output]}} "{{DP-1}}"`
 


### PR DESCRIPTION
These were hunted down with `grep -rl " -[a-z][^a-z]"` to find lone short options and then checking documentation if there's existing long options. Couple of these were found because I noticed a group of pages from a project that consistently provides short and long options