### PR TITLE
chpass: use chpass in man page link instead of the alias chsh

### DIFF
--- a/pages.nl/netbsd/chpass.md
+++ b/pages.nl/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Gebruikersdatabase informatie toevoegen of wijzigen, inclusief login shell en wachtwoord.
 > Bekijk ook: `passwd`.
-> Meer informatie: <https://man.netbsd.org/common>.
+> Meer informatie: <https://man.netbsd.org/chpass>.
 
 - Stel interactief een specifieke login shell in voor de huidige gebruiker:
 

--- a/pages.nl/netbsd/chpass.md
+++ b/pages.nl/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Gebruikersdatabase informatie toevoegen of wijzigen, inclusief login shell en wachtwoord.
 > Bekijk ook: `passwd`.
-> Meer informatie: <https://man.netbsd.org/chsh>.
+> Meer informatie: <https://man.netbsd.org/common>.
 
 - Stel interactief een specifieke login shell in voor de huidige gebruiker:
 

--- a/pages.nl/openbsd/chpass.md
+++ b/pages.nl/openbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Gebruikersdatabase informatie toevoegen of wijzigen, inclusief login shell en wachtwoord.
 > Bekijk ook: `passwd`.
-> Meer informatie: <https://man.openbsd.org/common>.
+> Meer informatie: <https://man.openbsd.org/chpass>.
 
 - Stel interactief een specifieke login shell in voor de huidige gebruiker:
 

--- a/pages.nl/openbsd/chpass.md
+++ b/pages.nl/openbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Gebruikersdatabase informatie toevoegen of wijzigen, inclusief login shell en wachtwoord.
 > Bekijk ook: `passwd`.
-> Meer informatie: <https://man.openbsd.org/chsh>.
+> Meer informatie: <https://man.openbsd.org/common>.
 
 - Stel interactief een specifieke login shell in voor de huidige gebruiker:
 

--- a/pages.pl/netbsd/chpass.md
+++ b/pages.pl/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Dodaj lub zmień informacje w bazie danych użytkowników, w tym powłokę logowania i hasło.
 > Zobacz także: `passwd`.
-> Więcej informacji: <https://man.netbsd.org/chsh>.
+> Więcej informacji: <https://man.netbsd.org/chpass>.
 
 - Ustaw określoną powłokę logowania dla bieżącego użytkownika w sposób interaktywny:
 

--- a/pages.pl/openbsd/chpass.md
+++ b/pages.pl/openbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Dodaj lub zmień informacje o użytkowniku w bazie danych, w tym powłoki logowania i hasła.
 > Zobacz także: `passwd`.
-> Więcej informacji: <https://man.openbsd.org/chsh>.
+> Więcej informacji: <https://man.openbsd.org/chpass>.
 
 - Interaktywnie ustaw określoną powłokę logowania dla bieżącego użytkownika:
 

--- a/pages/netbsd/chpass.md
+++ b/pages/netbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Add or change user database information, including login shell and password.
 > See also: `passwd`.
-> More information: <https://man.netbsd.org/chsh>.
+> More information: <https://man.netbsd.org/chpass>.
 
 - Set a specific login shell for the current user interactively:
 

--- a/pages/openbsd/chpass.md
+++ b/pages/openbsd/chpass.md
@@ -2,7 +2,7 @@
 
 > Add or change user database information, including login shell and password.
 > See also: `passwd`.
-> More information: <https://man.openbsd.org/chsh>.
+> More information: <https://man.openbsd.org/chpass>.
 
 - Set a specific login shell for the current user interactively:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

