### PR TITLE
virt-{viewer, xml}: add missing backticks

### DIFF
--- a/pages/linux/virt-viewer.md
+++ b/pages/linux/virt-viewer.md
@@ -1,7 +1,7 @@
 # virt-viewer
 
 > Minimal graphical interface for a virtual machine (VM).
-> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
+> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: `tldr virsh`).
 > More information: <https://manned.org/virt-viewer>.
 
 - Launch `virt-viewer` with a prompt to select running virtual machines:

--- a/pages/linux/virt-xml.md
+++ b/pages/linux/virt-xml.md
@@ -1,7 +1,7 @@
 # virt-xml
 
 > Edit libvirt Domain XML files with explicit command-line options.
-> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: tldr virsh).
+> Note: 'domain' refers to the name, UUID or ID for the existing VMs (See: `tldr virsh`).
 > More information: <https://github.com/virt-manager/virt-manager/blob/main/man/virt-xml.rst>.
 
 - List all the suboptions for a specific option:
@@ -24,6 +24,6 @@
 
 `virt-xml {{domain}} --edit --boot bootmenu={{on|off}}`
 
-- Attach host USB hub to a running VM (See: tldr lsusb):
+- Attach host USB hub to a running VM (See: `tldr lsusb`):
 
 `virt-xml {{domain}} --update --add-device --hostdev {{bus}}.{{device}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
