### PR TITLE
lvextend: fix improper flag usage, add additional example

### DIFF
--- a/pages/linux/lvextend.md
+++ b/pages/linux/lvextend.md
@@ -2,16 +2,20 @@
 
 > Increase the size of a logical volume.
 > See also: `lvm`.
-> More information: <https://manned.org/lvextend.8>.
+> More information: <https://linux.die.net/man/8/lvextend>.
 
 - Increase a volume's size to 120 GB:
 
-`lvextend {{[-L|--size]}} {{120G}} {{logical_volume}}`
+`sudo lvextend {{[-L|--size]}} {{120G}} {{logical_volume}}`
 
 - Increase a volume's size by 40 GB as well as the underlying filesystem:
 
-`lvextend {{[-L|--size]}} +{{40G}} {{[-r|--resizefs]}} {{logical_volume}}`
+`sudo lvextend {{[-L|--size]}} +{{40G}} {{[-r|--resizefs]}} {{logical_volume}}`
 
 - Increase a volume's size to 100% of the free physical volume space:
 
-`lvextend {{[-L|--size]}} +{{100}}%FREE {{logical_volume}}`
+`sudo lvextend {{[-l|--extents]}} +{{100}}%FREE {{logical_volume}}`
+
+- Increase a volume's size to 100% of the free physical volume space and resize the underlying filesystem:
+
+`sudo lvextend {{[-l|--extents]}} +{{100}}%FREE {{[-r|--resizefs]}} {{logical_volume}}`

--- a/pages/linux/lvextend.md
+++ b/pages/linux/lvextend.md
@@ -2,7 +2,7 @@
 
 > Increase the size of a logical volume.
 > See also: `lvm`.
-> More information: <https://linux.die.net/man/8/lvextend>.
+> More information: <https://manned.org/lvextend.8>.
 
 - Increase a volume's size to 120 GB:
 


### PR DESCRIPTION
Updated upstream link to a more verbose man page

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**


Closes #15379
