### PR TITLE
common*: refresh old pages part 2

### DIFF
--- a/pages/common/dvc-commit.md
+++ b/pages/common/dvc-commit.md
@@ -13,4 +13,4 @@
 
 - Recursively commit all DVC-tracked files in a directory:
 
-`dvc commit --recursive {{path/to/directory}}`
+`dvc commit {{[-R|--recursive]}} {{path/to/directory}}`

--- a/pages/common/dvc-config.md
+++ b/pages/common/dvc-config.md
@@ -14,7 +14,7 @@
 
 - Unset the project's default remote:
 
-`dvc config --unset core.remote`
+`dvc config {{[-u|--unset]}} core.remote`
 
 - Get the configuration value for a specified key for the current project:
 
@@ -26,7 +26,7 @@
 
 - Unset a project level configuration value for a given key:
 
-`dvc config --unset {{key}}`
+`dvc config {{[-u|--unset]}} {{key}}`
 
 - Set a local, global, or system level configuration value:
 

--- a/pages/common/dvc-destroy.md
+++ b/pages/common/dvc-destroy.md
@@ -9,4 +9,4 @@
 
 - Force destroy the current project:
 
-`dvc destroy --force`
+`dvc destroy {{[-f|--force]}}`

--- a/pages/common/dvc-fetch.md
+++ b/pages/common/dvc-fetch.md
@@ -9,7 +9,7 @@
 
 - Fetch changes from a specific remote upstream repository:
 
-`dvc fetch --remote {{remote_name}}`
+`dvc fetch {{[-r|--remote]}} {{remote_name}}`
 
 - Fetch the latest changes for a specific target/s:
 
@@ -17,8 +17,8 @@
 
 - Fetch changes for all branch and tags:
 
-`dvc fetch --all-branches --all-tags`
+`dvc fetch {{[-a|--all-branches]}} {{[-T|--all-tags]}}`
 
 - Fetch changes for all commits:
 
-`dvc fetch --all-commits`
+`dvc fetch {{[-A|--all-commits]}}`

--- a/pages/common/dvc-gc.md
+++ b/pages/common/dvc-gc.md
@@ -5,16 +5,16 @@
 
 - Garbage collect from the cache, keeping only versions referenced by the current workspace:
 
-`dvc gc --workspace`
+`dvc gc {{[-w|--workspace]}}`
 
 - Garbage collect from the cache, keeping only versions referenced by branch, tags, and commits:
 
-`dvc gc --all-branches --all-tags --all-commits`
+`dvc gc {{[-a|--all-branches]}} {{[-T|--all-tags]}} {{[-a|--all-commits]}}`
 
 - Garbage collect from the cache, including the default cloud remote storage (if set):
 
-`dvc gc --all-commits --cloud`
+`dvc gc {{[-a|--all-commits]}} {{[-c|--cloud]}}`
 
 - Garbage collect from the cache, including a specific cloud remote storage:
 
-`dvc gc --all-commits --cloud --remote {{remote_name}}`
+`dvc gc {{[-a|--all-commits]}} {{[-c|--cloud]}} {{[-r|--remote]}} {{remote_name}}`

--- a/pages/common/dvc.md
+++ b/pages/common/dvc.md
@@ -2,7 +2,7 @@
 
 > Data Version Control: like `git` for data.
 > Some subcommands such as `commit` have their own usage documentation.
-> More information: <https://dvc.org/>.
+> More information: <https://dvc.org/doc/command-reference>.
 
 - Execute a DVC subcommand:
 
@@ -10,11 +10,11 @@
 
 - Display general help:
 
-`dvc --help`
+`dvc {{[-h|--help]}}`
 
 - Display help about a specific subcommand:
 
-`dvc {{subcommand}} --help`
+`dvc {{subcommand}} {{[-h|--help]}}`
 
 - Display version:
 

--- a/pages/common/env.md
+++ b/pages/common/env.md
@@ -25,4 +25,4 @@
 
 - Set one or more variables and run a program:
 
-`env {{variable1}}={{value}} {{variable2}}={{value}} {{variable3}}={{value}} {{program}}`
+`env {{variable1=value variable2=value variable3=value ...}} {{program}}`

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -17,8 +17,8 @@
 
 - Also fetch tags from the remote upstream repository:
 
-`git fetch --tags`
+`git fetch {{[-t|--tags]}}`
 
 - Delete local references to remote branches that have been deleted upstream:
 
-`git fetch --prune`
+`git fetch {{[-p|--prune]}}`

--- a/pages/common/git-sizer.md
+++ b/pages/common/git-sizer.md
@@ -1,16 +1,16 @@
-# git sizer
+# git-sizer
 
 > Computes various Git repository size metrics and alerts you to any that might cause problems or inconvenience.
 > More information: <https://github.com/github/git-sizer>.
 
 - Report only statistics that have a level of concern greater than 0:
 
-`git sizer`
+`git-sizer`
 
 - Report all statistics:
 
-`git sizer -v`
+`git-sizer -v`
 
 - See additional options:
 
-`git sizer -h`
+`git-sizer -h`

--- a/pages/common/gocryptfs.md
+++ b/pages/common/gocryptfs.md
@@ -1,7 +1,7 @@
 # gocryptfs
 
 > Encrypted overlay filesystem written in Go.
-> More information: <https://github.com/rfjakob/gocryptfs>.
+> More information: <https://github.com/rfjakob/gocryptfs#use>.
 
 - Initialize an encrypted filesystem:
 

--- a/pages/common/gunicorn.md
+++ b/pages/common/gunicorn.md
@@ -1,7 +1,7 @@
 # gunicorn
 
 > Python WSGI HTTP Server.
-> More information: <https://gunicorn.org/>.
+> More information: <https://docs.gunicorn.org/en/latest/run.html>.
 
 - Run Python web app:
 
@@ -9,7 +9,7 @@
 
 - Listen on port 8080 on localhost:
 
-`gunicorn --bind {{localhost}}:{{8080}} {{import.path:app_object}}`
+`gunicorn {{[-b|--bind]}} {{localhost}}:{{8080}} {{import.path:app_object}}`
 
 - Turn on live reload:
 
@@ -17,7 +17,7 @@
 
 - Use 4 worker processes for handling requests:
 
-`gunicorn --workers {{4}} {{import.path:app_object}}`
+`gunicorn {{[-w|--workers]}} {{4}} {{import.path:app_object}}`
 
 - Use 4 worker threads for handling requests:
 

--- a/pages/common/hg-add.md
+++ b/pages/common/hg-add.md
@@ -9,16 +9,16 @@
 
 - Add all unstaged files matching a specified pattern:
 
-`hg add --include {{pattern}}`
+`hg add {{[-I|--include]}} {{pattern}}`
 
 - Add all unstaged files, excluding those that match a specified pattern:
 
-`hg add --exclude {{pattern}}`
+`hg add {{[-X|--exclude]}} {{pattern}}`
 
 - Recursively add sub-repositories:
 
-`hg add --subrepos`
+`hg add {{[-S|--subrepos]}}`
 
 - Perform a test-run without performing any actions:
 
-`hg add --dry-run`
+`hg add {{[-n|--dry-run]}}`

--- a/pages/common/hg-commit.md
+++ b/pages/common/hg-commit.md
@@ -13,16 +13,16 @@
 
 - Commit with a specific message:
 
-`hg commit --message {{message}}`
+`hg commit {{[-m|--message]}} {{message}}`
 
 - Commit all files matching a specified pattern:
 
-`hg commit --include {{pattern}}`
+`hg commit {{[-I|--include]}} {{pattern}}`
 
 - Commit all files, excluding those that match a specified pattern:
 
-`hg commit --exclude {{pattern}}`
+`hg commit {{[-X|--exclude]}} {{pattern}}`
 
 - Commit using the interactive mode:
 
-`hg commit --interactive`
+`hg commit {{[-i|--interactive]}}`

--- a/pages/common/hg-log.md
+++ b/pages/common/hg-log.md
@@ -9,28 +9,28 @@
 
 - Display the revision history with an ASCII graph:
 
-`hg log --graph`
+`hg log {{[-G|--graph]}}`
 
 - Display the revision history with file names matching a specified pattern:
 
-`hg log --include {{pattern}}`
+`hg log {{[-I|--include]}} {{pattern}}`
 
 - Display the revision history, excluding file names that match a specified pattern:
 
-`hg log --exclude {{pattern}}`
+`hg log {{[-X|--exclude]}} {{pattern}}`
 
 - Display the log information for a specific revision:
 
-`hg log --rev {{revision}}`
+`hg log {{[-r|--rev]}} {{revision}}`
 
 - Display the revision history for a specific branch:
 
-`hg log --branch {{branch}}`
+`hg log {{[-b|--branch]}} {{branch}}`
 
 - Display the revision history for a specific date:
 
-`hg log --date {{date}}`
+`hg log {{[-d|--date]}} {{date}}`
 
 - Display revisions committed by a specific user:
 
-`hg log --user {{user}}`
+`hg log {{[-u|--user]}} {{user}}`

--- a/pages/common/hg-pull.md
+++ b/pages/common/hg-pull.md
@@ -13,20 +13,20 @@
 
 - Update the local repository to the head of the remote:
 
-`hg pull --update`
+`hg pull {{[-u|--update]}}`
 
 - Pull changes even when the remote repository is unrelated:
 
-`hg pull --force`
+`hg pull {{[-f|--force]}}`
 
 - Specify a specific revision changeset to pull up to:
 
-`hg pull --rev {{revision}}`
+`hg pull {{[-r|--rev]}} {{revision}}`
 
 - Specify a specific branch to pull:
 
-`hg pull --branch {{branch}}`
+`hg pull {{[-b|--branch]}} {{branch}}`
 
 - Specify a specific bookmark to pull:
 
-`hg pull --bookmark {{bookmark}}`
+`hg pull {{[-B|--bookmark]}} {{bookmark}}`

--- a/pages/common/hg-push.md
+++ b/pages/common/hg-push.md
@@ -17,12 +17,12 @@
 
 - Specify a specific revision changeset to push:
 
-`hg push --rev {{revision}}`
+`hg push {{[-r|--rev]}} {{revision}}`
 
 - Specify a specific branch to push:
 
-`hg push --branch {{branch}}`
+`hg push {{[-b|--branch]}} {{branch}}`
 
 - Specify a specific bookmark to push:
 
-`hg push --bookmark {{bookmark}}`
+`hg push {{[-B|--bookmark]}} {{bookmark}}`

--- a/pages/common/hg-remove.md
+++ b/pages/common/hg-remove.md
@@ -9,16 +9,16 @@
 
 - Remove all staged files matching a specified pattern:
 
-`hg remove --include {{pattern}}`
+`hg remove {{[-I|--include]}} {{pattern}}`
 
 - Remove all staged files, excluding those that match a specified pattern:
 
-`hg remove --exclude {{pattern}}`
+`hg remove {{[-X|--exclude]}} {{pattern}}`
 
 - Recursively remove sub-repositories:
 
-`hg remove --subrepos`
+`hg remove {{[-S|--subrepos]}}`
 
 - Remove files from the repository that have been physically removed:
 
-`hg remove --after`
+`hg remove {{[-A|--after]}}`

--- a/pages/common/hg-serve.md
+++ b/pages/common/hg-serve.md
@@ -9,15 +9,15 @@
 
 - Start a web server instance on the specified port:
 
-`hg serve --port {{port}}`
+`hg serve {{[-p|--port]}} {{port}}`
 
 - Start a web server instance on the specified listening address:
 
-`hg serve --address {{address}}`
+`hg serve {{[-a|--address]}} {{address}}`
 
 - Start a web server instance with a specific identifier:
 
-`hg serve --name {{name}}`
+`hg serve {{[-n|--name]}} {{name}}`
 
 - Start a web server instance using the specified theme (see the templates directory):
 

--- a/pages/common/hg-status.md
+++ b/pages/common/hg-status.md
@@ -9,19 +9,19 @@
 
 - Display only modified files:
 
-`hg status --modified`
+`hg status {{[-m|--modified]}}`
 
 - Display only added files:
 
-`hg status --added`
+`hg status {{[-a|--added]}}`
 
 - Display only removed files:
 
-`hg status --removed`
+`hg status {{[-r|--removed]}}`
 
 - Display only deleted (but tracked) files:
 
-`hg status --deleted`
+`hg status {{[-d|--deleted]}}`
 
 - Display changes in the working directory compared to a specified changeset:
 
@@ -29,8 +29,8 @@
 
 - Display only files matching a specified glob pattern:
 
-`hg status --include {{pattern}}`
+`hg status {{[-I|--include]}} {{pattern}}`
 
 - Display files, excluding those that match a specified glob pattern:
 
-`hg status --exclude {{pattern}}`
+`hg status {{[-X|--exclude]}} {{pattern}}`

--- a/pages/common/hg-update.md
+++ b/pages/common/hg-update.md
@@ -9,12 +9,12 @@
 
 - Update to the specified revision:
 
-`hg update --rev {{revision}}`
+`hg update {{[-r|--rev]}} {{revision}}`
 
 - Update and discard uncommitted changes:
 
-`hg update --clean`
+`hg update {{[-C|--clean]}}`
 
 - Update to the last commit matching a specified date:
 
-`hg update --date {{dd-mm-yyyy}}`
+`hg update {{[-d|--date]}} {{dd-mm-yyyy}}`

--- a/pages/common/hostapd.md
+++ b/pages/common/hostapd.md
@@ -1,7 +1,7 @@
 # hostapd
 
 > Start an access point using a wireless interface.
-> More information: <https://w1.fi/hostapd/>.
+> More information: <https://manned.org/hostapd>.
 
 - Start an access point:
 

--- a/pages/common/jdupes.md
+++ b/pages/common/jdupes.md
@@ -1,7 +1,7 @@
 # jdupes
 
 > A powerful duplicate file finder and an enhanced fork of fdupes.
-> More information: <https://codeberg.org/jbruchon/jdupes>.
+> More information: <https://codeberg.org/jbruchon/jdupes#usage>.
 
 - Search a single directory:
 
@@ -25,4 +25,4 @@
 
 - Search multiple directories and keep the directory order in result:
 
-`jdupes -O {{directory1}} {{directory2}} {{directory3}}`
+`jdupes -O {{directory1 directory2 directory3 ...}}`

--- a/pages/common/nvidia-smi.md
+++ b/pages/common/nvidia-smi.md
@@ -9,7 +9,7 @@
 
 - Display more detailed GPU information:
 
-`nvidia-smi --query`
+`nvidia-smi {{[-q|--query]}}`
 
 - Monitor overall GPU usage with 1-second update interval:
 

--- a/pages/common/pamixer.md
+++ b/pages/common/pamixer.md
@@ -1,7 +1,7 @@
 # pamixer
 
 > A simple command-line mixer for PulseAudio.
-> More information: <https://github.com/cdemoulins/pamixer>.
+> More information: <https://github.com/cdemoulins/pamixer#installation>.
 
 - List all sinks and sources with their corresponding IDs:
 
@@ -17,11 +17,11 @@
 
 - Increase the volume on default sink by 5%:
 
-`pamixer --increase {{5}}`
+`pamixer {{[-i|--increase]}} {{5}}`
 
 - Decrease the volume on a source by 5%:
 
-`pamixer --decrease {{5}} --source {{ID}}`
+`pamixer {{[-d|--decrease]}} {{5}} --source {{ID}}`
 
 - Use the allow boost option to increase, decrease, or set the volume above 100%:
 
@@ -29,4 +29,4 @@
 
 - Mute the default sink (use `--unmute` instead to unmute):
 
-`pamixer --mute`
+`pamixer {{[-m|--mute]}}`

--- a/pages/common/pdftk.md
+++ b/pages/common/pdftk.md
@@ -1,7 +1,7 @@
 # pdftk
 
 > PDF toolkit.
-> More information: <https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit>.
+> More information: <https://www.pdflabs.com/docs/pdftk-man-page/>.
 
 - Extract pages 1-3, 5 and 6-10 from a PDF file and save them as another one:
 

--- a/pages/common/qmv.md
+++ b/pages/common/qmv.md
@@ -13,7 +13,7 @@
 
 - Move multiple directories:
 
-`qmv {{[-d|--directory]}} {{path/to/directory1}} {{path/to/directory2}} {{path/to/directory3}}`
+`qmv {{[-d|--directory]}} {{path/to/directory1 path/to/directory2 path/to/directory3 ...}}`
 
 - Move all files and directories inside a directory:
 

--- a/pages/common/r2e.md
+++ b/pages/common/r2e.md
@@ -2,7 +2,7 @@
 
 > Forwards RSS feeds to an email address.
 > Requires a configured `sendmail` or smtp setup.
-> More information: <https://github.com/rss2email/rss2email>.
+> More information: <https://manned.org/r2e>.
 
 - Create a new feed database that sends email to an email address:
 

--- a/pages/common/rar.md
+++ b/pages/common/rar.md
@@ -5,7 +5,7 @@
 
 - Archive 1 or more files:
 
-`rar a {{path/to/archive_name.rar}} {{path/to/file1}} {{path/to/file2}} {{path/to/file3}}`
+`rar a {{path/to/archive_name.rar}} {{path/to/file1 path/to/file2 path/to/file3 ...}}`
 
 - Archive a directory:
 

--- a/pages/common/symfony.md
+++ b/pages/common/symfony.md
@@ -1,7 +1,7 @@
 # symfony
 
 > The console component for the Symfony framework.
-> More information: <https://symfony.com>.
+> More information: <https://symfony.com/doc/current/setup.html>.
 
 - Create a new Symfony project:
 

--- a/pages/common/zopflipng.md
+++ b/pages/common/zopflipng.md
@@ -9,4 +9,4 @@
 
 - Optimize several PNGs and save with given prefix:
 
-`zopflipng --prefix={{prefix}} {{image1.png}} {{image2.png}} {{image3.png}}`
+`zopflipng --prefix={{prefix}} {{image1.png image2.png image3.png ...}}`

--- a/pages/linux/netselect.md
+++ b/pages/linux/netselect.md
@@ -5,19 +5,19 @@
 
 - Choose the server with the lowest latency:
 
-`sudo netselect {{host_1}} {{host_2}}`
+`sudo netselect {{host_1 host_2 ...}}`
 
 - Display nameserver resolution and statistics:
 
-`sudo netselect -vv {{host_1}} {{host_2}}`
+`sudo netselect -vv {{host_1 host_2 ...}}`
 
 - Define maximum TTL (time to live):
 
-`sudo netselect -m {{10}} {{host_1}} {{host_2}}`
+`sudo netselect -m {{10}} {{host_1 host_2 ...}}`
 
 - Print `n` fastest servers among the hosts:
 
-`sudo netselect -s {{n}} {{host_1}} {{host_2}} {{host_3}}`
+`sudo netselect -s {{n}} {{host_1 host_2 host_3 ...}}`
 
 - Display help:
 


### PR DESCRIPTION
By using `git ls-files -z | xargs -0 -n1 -I{} -- git log -1 --format="%ai {}" {} | sort -r` I was able to sort files by their last modification date. Then I just took the oldest files with no changes and updated them.

I also used `grep -r "{{.*1.*}} {{.*2.*}} {{.*3.*}}"` to find pages that didn't use ellipses to indicate one or more placeholders.