### PR TITLE
stty: add size display example

### DIFF
--- a/pages/common/stty.md
+++ b/pages/common/stty.md
@@ -3,6 +3,10 @@
 > Set options for a terminal device interface.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/stty-invocation.html>.
 
+- Display current terminal size:
+
+`stty size`
+
 - Display all settings for the current terminal:
 
 `stty {{[-a|--all]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
