### PR TITLE
mise: adds plugin options example

### DIFF
--- a/pages/common/mise.md
+++ b/pages/common/mise.md
@@ -31,6 +31,6 @@
 
 `mise set {{variable}}={{value}}`
 
-- Pass plugin options
+- Pass plugin options:
 
 `mise use {{name}}\[{{option1}}={{option1_value}},{{option2}}={{option2_value}}\]@{{version}}`

--- a/pages/common/mise.md
+++ b/pages/common/mise.md
@@ -31,11 +31,6 @@
 
 `mise set {{variable}}={{value}}`
 
-- Pass an option
-
-`mise install {{name}}\[{{option}}={{option_value}}\]@{{version}}`
-`mise use {{name}}\[{{option}}={{option_value}}\]@{{version}}`
-
-- Multiple options
+- Pass plugin options
 
 `mise use {{name}}\[{{option1}}={{option1_value}},{{option2}}={{option2_value}}\]@{{version}}`

--- a/pages/common/mise.md
+++ b/pages/common/mise.md
@@ -1,6 +1,6 @@
 # mise
 
-> Manage language runtimes like Node.js, Python, Ruby, Go, Java, etc and developemnt tools.
+> Manage language runtimes like Node.js, Python, Ruby, Go, Java, etc and various tools.
 > More information: <https://mise.jdx.dev>.
 
 - List all available plugins:

--- a/pages/common/mise.md
+++ b/pages/common/mise.md
@@ -1,6 +1,6 @@
 # mise
 
-> Manage versions of different packages.
+> Manage language runtimes like Node.js, Python, Ruby, Go, Java, etc and developemnt tools.
 > More information: <https://mise.jdx.dev>.
 
 - List all available plugins:

--- a/pages/common/mise.md
+++ b/pages/common/mise.md
@@ -30,3 +30,12 @@
 - Set environment variable in configuration:
 
 `mise set {{variable}}={{value}}`
+
+- Pass an option
+
+`mise install {{name}}\[{{option}}={{option_value}}\]@{{version}}`
+`mise use {{name}}\[{{option}}={{option_value}}\]@{{version}}`
+
+- Multiple options
+
+`mise use {{name}}\[{{option1}}={{option1_value}},{{option2}}={{option2_value}}\]@{{version}}`


### PR DESCRIPTION
Adds plugin options syntax.

<img width="579" alt="image" src="https://github.com/user-attachments/assets/b7c00d32-f0c0-490d-af16-9116ac189721" />

E.g. for java release type:

```sh
mise use java[release_type=ea]@openjdk-25
```

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
