### PR TITLE
xhost: add page

### DIFF
--- a/pages/linux/xhost.md
+++ b/pages/linux/xhost.md
@@ -1,7 +1,6 @@
 # xhost
 
 > Manage access control lists for X server connections.
-> Adds or removes hosts and users allowed to connect to the X server.
 > More information: <https://manned.org/xhost>.
 
 - Display the current access control list:

--- a/pages/linux/xhost.md
+++ b/pages/linux/xhost.md
@@ -1,0 +1,29 @@
+# xhost
+
+> Manage access control lists for X server connections.
+> Adds or removes hosts and users allowed to connect to the X server.
+> More information: <https://manned.org/xhost>.
+
+- Display the current access control list:
+
+`xhost`
+
+- Allow a specific host to connect to the X server:
+
+`xhost +{{hostname}}`
+
+- Deny a specific host from connecting to the X server:
+
+`xhost -{{hostname}}`
+
+- Allow all hosts to connect (disable access control — insecure):
+
+`xhost +`
+
+- Deny all hosts except those explicitly allowed (enable access control):
+
+`xhost -`
+
+- Remove a specific user or address using a family prefix (like `inet:hostname` or `si:localuser:username`):
+
+`xhost -{{family:name}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Version of the command being documented (if known): 1.0.10
---
Adds a TLDR page for `xhost`, the X server access control utility.
Includes examples for displaying, allowing, denying hosts and users.

