### PR TITLE
nix: update more information link to be more precise

### DIFF
--- a/pages.de/common/nix.md
+++ b/pages.de/common/nix.md
@@ -1,7 +1,7 @@
 # nix
 
 > Dienstprogramme für die Nix-Sprache und den Nix-Speicher.
-> Weitere Informationen: <https://nixos.org/manual/nix>.
+> Weitere Informationen: <https://nix.dev/manual/nix/stable/command-ref/new-cli/nix>.
 
 - Suche nach einem Paket über seinen Namen oder seine Beschreibung:
 

--- a/pages.ko/common/nix.md
+++ b/pages.ko/common/nix.md
@@ -3,7 +3,7 @@
 > 패키지 관리를 신뢰성 있고, 재현 가능하며, 선언적으로 만드는 강력한 패키지 관리자.
 > `nix`는 실험적이며 실험적 기능 사용을 활성화해야 합니다. 안정적인 인터페이스를 원하면 `tldr nix classic`을 참조하세요.
 > `build`, `develop`, `flake`, `registry`, `profile`, `search`, `repl`, `store`, `edit`, `why-depends` 등의 일부 하위 명령에는 자체 사용 설명서가 있습니다.
-> 더 많은 정보: <https://nixos.org/manual/nix>.
+> 더 많은 정보: <https://nix.dev/manual/nix/stable/command-ref/new-cli/nix>.
 
 - `nix` 명령 활성화:
 

--- a/pages/common/nix.md
+++ b/pages/common/nix.md
@@ -3,7 +3,7 @@
 > A powerful package manager that makes package management reliable, reproducible, and declarative.
 > `nix` is experimental and requires enabling experimental features. For a classic, stable interface, see `tldr nix classic`.
 > Some subcommands such as `build`, `develop`, `flake`, `registry`, `profile`, `search`, `repl`, `store`, `edit`, `why-depends`, etc. have their own usage documentation.
-> More information: <https://nixos.org/manual/nix>.
+> More information: <https://nix.dev/manual/nix/stable/command-ref/new-cli/nix>.
 
 - Enable the `nix` command:
 


### PR DESCRIPTION
Update the "More infos" link to point directly to the online documentation of the `nix` command (instead of the Nix landing page).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.

Fixes #16274