### PR TITLE
nix: align examples of translations

### DIFF
--- a/pages.de/common/nix.md
+++ b/pages.de/common/nix.md
@@ -1,24 +1,34 @@
 # nix
 
-> Dienstprogramme für die Nix-Sprache und den Nix-Speicher.
+> Ein leistungsfähiger Paketmanager, der das Paketmanagement zuverlässig, reproduzierbar und deklarativ macht.
+> `nix` ist experimentell und muss gesondert aktiviert werden. Für die klassische, stabile Schnittstelle siehe `tldr nix classic`.
+> Einige Unterbefehle wie `build`, `develop`, `flake`, `registry`, `profile`, `search`, `repl`, `store`, `edit`, `why-depends` usw. haben ihre eigene Dokumentation.
 > Weitere Informationen: <https://nix.dev/manual/nix/stable/command-ref/new-cli/nix>.
 
-- Suche nach einem Paket über seinen Namen oder seine Beschreibung:
+- Aktiviere den `nix` Befehl:
 
-`nix search {{suchbegriff}}`
+`mkdir {{[-p|--parents]}} ~/.config/nix; echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf`
 
-- Starte eine Nix-Shell, die die angegebenen Pakete zur Verfügung stellt:
+- Suche ein Paket in nixpkgs nach Namen oder Beschreibung:
 
-`nix run {{nixpkgs.pkg1 nixpkgs.pkg2 ...}}`
+`nix search nixpkgs {{suchbegriff}}`
 
-- Optimiere die Festplattennutzung des Nix-Speichers durch Zusammenfassen doppelter Dateien:
+- Starte eine Shell und stelle die angegebenen Pakete von nixpkgs darin bereit:
 
-`nix store optimise`
+`nix shell {{nixpkgs#pkg1 nixpkgs#pkg2 nixpkgs#pkg3 ...}}`
 
-- Starte eine interaktive Umgebung zum Ausführen von Nix-Ausdrücken:
+- Installiere einige Pakete von nixpkgs dauerhaft:
+
+`nix profile install {{nixpkgs#pkg1 nixpkgs#pkg2 nixpkgs#pkg3 ...}}`
+
+- Entferne ungenutzte Pfade aus dem Nix-Store, um Speicherplatz freizugeben:
+
+`nix store gc`
+
+- Starte eine interaktive Umgebung zur Auswertung von Nix-Ausdrücken:
 
 `nix repl`
 
-- Upgrade Nix auf die neueste stabile Version:
+- Zeige Hilfe für einen bestimmten Unterbefehl an:
 
-`nix upgrade-nix`
+`nix help {{unterbefehl}}`

--- a/pages.ko/common/nix.md
+++ b/pages.ko/common/nix.md
@@ -7,7 +7,7 @@
 
 - `nix` 명령 활성화:
 
-`mkdir -p ~/.config/nix; echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf`
+`mkdir {{[-p|--parents]}} ~/.config/nix; echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf`
 
 - nixpkgs에서 이름이나 설명으로 패키지 검색:
 


### PR DESCRIPTION
Aligns the German and Korean translations with the English original. Addresses the bot comments from https://github.com/tldr-pages/tldr/pull/16286#issuecomment-2835285356.

> - The page `pages.de/common/nix.md` is outdated, based on number of commands, compared to the English page.
> - The page `pages.ko/common/nix.md` is outdated, based on the command contents itself, compared to the English page.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** nix (Nix) 2.28.2
