### PR TITLE
dependabot: migrate reviewers to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,9 @@
 /.devcontainer/* @kbdharun @sebastiaanspeck
 /.github/workflows/* @sbrl @kbdharun @sebastiaanspeck
 /scripts/* @sebastiaanspeck @kbdharun
+/package.json @kbdharun @sebastiaanspeck
+/package-lock.json @kbdharun @sebastiaanspeck
+/requirements.txt @kbdharun @sebastiaanspeck
 
 /contributing-guides/maintainers-guide.md @sbrl @kbdharun
 /contributing-guides/style-guide.md @sbrl @kbdharun

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-    - "kbdharun"
-    - "sebastiaanspeck"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-    - "kbdharun"
-    - "sebastiaanspeck"
 
   - package-ecosystem: "pip"
     directory: "/scripts/pdf"


### PR DESCRIPTION
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

> To improve reliability and reduce review assignment conflicts, we’re removing the [Dependabot reviewers configuration option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--) on Tuesday, May 27, 2025.

>
> We’re retiring this dependabot.yml configuration option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners). This has caused issues in the past, and it’s duplicated effort to maintain the same functionality.
> 
> Moving forward, we recommend relying solely on code owners for assigning pull request reviewers. You can use a CODEOWNERS file to define individuals or teams responsible for code in a repository. GitHub natively supports code owners, ensuring more consistent and streamlined behavior. This change simplifies your configuration by having all your review requests come from one configuration file.