### PR TITLE
base64: update documentation link

### DIFF
--- a/pages.es/osx/base64.md
+++ b/pages.es/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codifica o decodifica un archivo o `stdin` a/desde base64, a `stdout` o a otro archivo.
-> Más información: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> Más información: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Codifica un archivo a `stdout`:
 

--- a/pages.hi/osx/base64.md
+++ b/pages.hi/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > बेस 64 प्रस्तुतीकरण का उपयोग करके कोड और डिकोड करें।
-> अधिक जानकारी: <https://keith.github.io/xcode-man-pages/base64.1.html>।
+> अधिक जानकारी: <https://keith.github.io/xcode-man-pages/bintrans.1>।
 
 - फ़ाइल को कोड करें:
 

--- a/pages.id/osx/base64.md
+++ b/pages.id/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Lakukan pengodean dan pendekodean terhadap suatu berkas atau `stdin` dari/menuju format Base64, menuju `stdout` atau berkas lainnya.
-> Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Kodekan isi suatu berkas menuju format Base64, dan keluarkan hasil menuju `stdout`:
 

--- a/pages.it/osx/base64.md
+++ b/pages.it/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codifica e decodifica utilizzando la rappresentazione in base64.
-> Maggiori informazioni: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> Maggiori informazioni: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Codifica un file:
 

--- a/pages.ko/osx/base64.md
+++ b/pages.ko/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > 파일 또는 `stdin`을 base64로 인코딩하거나 디코딩하여 `stdout` 또는 다른 파일로 출력.
-> 더 많은 정보: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> 더 많은 정보: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - 파일을 `stdout`으로 인코딩:
 

--- a/pages.nl/osx/base64.md
+++ b/pages.nl/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Encodeer of decodeer een bestand of `stdin` van/naar base64, naar `stdout` of een ander bestand.
-> Meer informatie: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> Meer informatie: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Encodeer een bestand naar `stdout`:
 

--- a/pages.pt_BR/osx/base64.md
+++ b/pages.pt_BR/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Codifica e decodifica usando a representação Base64.
-> Mais informações: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> Mais informações: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Codifica um arquivo:
 

--- a/pages.zh/osx/base64.md
+++ b/pages.zh/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > 使用 Base64 来进行编码和解码。
-> 更多信息：<https://keith.github.io/xcode-man-pages/base64.1.html>.
+> 更多信息：<https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - 编码目标文件：
 

--- a/pages/osx/base64.md
+++ b/pages/osx/base64.md
@@ -1,7 +1,7 @@
 # base64
 
 > Encode or decode file or `stdin` to/from base64, to `stdout` or another file.
-> More information: <https://keith.github.io/xcode-man-pages/base64.1.html>.
+> More information: <https://keith.github.io/xcode-man-pages/bintrans.1>.
 
 - Encode a file to `stdout`:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

The documentation link for the OSX version of `base64` is outdated. Instructions for `base64` have been merged into the [bintrans](https://keith.github.io/xcode-man-pages/bintrans.1) page.
