### PR TITLE
pbpaste: update docs link

### DIFF
--- a/pages.de/osx/pbpaste.md
+++ b/pages.de/osx/pbpaste.md
@@ -1,7 +1,7 @@
 # pbpaste
 
 > Sende den Inhalt der Zwischenablage zum Standardoutput.
-> Weitere Informationen: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> Weitere Informationen: <https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - Schreibe den Inhalt der Zwischenablage in eine Datei:
 

--- a/pages.es/osx/pbpaste.md
+++ b/pages.es/osx/pbpaste.md
@@ -2,7 +2,7 @@
 
 > Envía el contenido del portapapeles a la salida estándar.
 > Comparable a pulsar `<Cmd v>` en el teclado.
-> Más información: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> Más información: <https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - Escribe el contenido del portapapeles en un archivo:
 

--- a/pages.id/osx/pbpaste.md
+++ b/pages.id/osx/pbpaste.md
@@ -1,7 +1,7 @@
 # pbpaste
 
 > Kirim isi papan klip (clipboard) ke output standar.
-> Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> Informasi lebih lanjut: <https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - Tulis konten papan klip ke dalam sebuah file:
 

--- a/pages.ko/osx/pbpaste.md
+++ b/pages.ko/osx/pbpaste.md
@@ -2,7 +2,7 @@
 
 > 클립보드의 내용을 `stdout`으로 전송.
 > 키보드에서 `<Cmd v>`를 누르는 것과 유사.
-> 더 많은 정보: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> 더 많은 정보: <https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - 클립보드의 내용을 [f]파일에 쓰기:
 

--- a/pages.th/osx/pbpaste.md
+++ b/pages.th/osx/pbpaste.md
@@ -2,7 +2,7 @@
 
 > ส่งเนื้อหาของคลิปบอร์ดไปยังผลผลิตมาตรฐาน (`stdout`)
 > เทียบได้กับการกดปุ่ม `<Cmd v>` บนแป้นพิมพ์
-> ข้อมูลเพิ่มเติม: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>
+> ข้อมูลเพิ่มเติม: <https://keith.github.io/xcode-man-pages/pbcopy.1>
 
 - เขียนเนื้อหาของคลิปบอร์ดไปยังไฟล์:
 

--- a/pages.zh/osx/pbpaste.md
+++ b/pages.zh/osx/pbpaste.md
@@ -2,7 +2,7 @@
 
 > 将剪贴板的内容发送到标准输出。
 > 相当于在键盘上按下 `<Cmd v>`.
-> 更多信息：<https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> 更多信息：<https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - 将剪贴板的内容写入文件：
 

--- a/pages/osx/pbpaste.md
+++ b/pages/osx/pbpaste.md
@@ -2,7 +2,7 @@
 
 > Send the contents of the clipboard to `stdout`.
 > Comparable to pressing `<Cmd v>` on the keyboard.
-> More information: <https://keith.github.io/xcode-man-pages/pbpaste.1.html>.
+> More information: <https://keith.github.io/xcode-man-pages/pbcopy.1>.
 
 - Write the contents of the clipboard to a file:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Documentation for `pbpaste` is combined with `pbcopy`'s 
