### PR TITLE
pages.nl/*: add missing Dutch alias pages

### DIFF
--- a/pages.nl/common/impacket-mqtt_check.md
+++ b/pages.nl/common/impacket-mqtt_check.md
@@ -1,0 +1,7 @@
+# impacket-mqtt_check
+
+> Dit commando is een alias van `mqtt_check.py`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr mqtt_check.py`

--- a/pages.nl/common/j.md
+++ b/pages.nl/common/j.md
@@ -1,0 +1,7 @@
+# j
+
+> Dit commando is een alias van `autojump`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr autojump`

--- a/pages.nl/common/jco.md
+++ b/pages.nl/common/jco.md
@@ -1,0 +1,7 @@
+# jco
+
+> Dit commando is een alias van `autojump`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr autojump`

--- a/pages.nl/common/jo.md
+++ b/pages.nl/common/jo.md
@@ -1,0 +1,7 @@
+# jo
+
+> Dit commando is een alias van `autojump`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr autojump`

--- a/pages.nl/common/netexec.md
+++ b/pages.nl/common/netexec.md
@@ -1,0 +1,7 @@
+# netexec
+
+> Dit commando is een alias van `nxc`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr nxc`

--- a/pages.nl/linux/lrunzip.md
+++ b/pages.nl/linux/lrunzip.md
@@ -1,0 +1,7 @@
+# lrunzip
+
+> Dit commando is een alias van `lrzip -d`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr lrzip`

--- a/pages.nl/linux/lrzuntar.md
+++ b/pages.nl/linux/lrzuntar.md
@@ -1,0 +1,7 @@
+# lrzuntar
+
+> Dit commando is een alias van `lrztar -d`.
+
+- Bekijk de documentatie van het originele commando:
+
+`tldr lrztar`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).