### PR TITLE
rustup-toolchain: fix missing toolchain subcommand in all commands

### DIFF
--- a/pages.ko/common/rustup-toolchain.md
+++ b/pages.ko/common/rustup-toolchain.md
@@ -6,16 +6,16 @@
 
 - 주어진 툴체인 설치 또는 업데이트:
 
-`rustup install {{툴체인}}`
+`rustup toolchain install {{툴체인}}`
 
 - 툴체인 제거:
 
-`rustup uninstall {{툴체인}}`
+`rustup toolchain uninstall {{툴체인}}`
 
 - 설치된 툴체인 나열:
 
-`rustup list`
+`rustup toolchain list`
 
 - 디렉토리에 대한 심볼릭 링크를 통해 사용자 지정 툴체인 생성:
 
-`rustup link {{사용자_지정_툴체인_이름}} {{경로/대상/폴더}}`
+`rustup toolchain link {{사용자_지정_툴체인_이름}} {{경로/대상/폴더}}`

--- a/pages/common/rustup-toolchain.md
+++ b/pages/common/rustup-toolchain.md
@@ -6,16 +6,16 @@
 
 - Install or update a given toolchain:
 
-`rustup install {{toolchain}}`
+`rustup toolchain install {{toolchain}}`
 
 - Uninstall a toolchain:
 
-`rustup uninstall {{toolchain}}`
+`rustup toolchain uninstall {{toolchain}}`
 
 - List installed toolchains:
 
-`rustup list`
+`rustup toolchain list`
 
 - Create a custom toolchain by symlinking to a directory:
 
-`rustup link {{custom_toolchain_name}} {{path/to/directory}}`
+`rustup toolchain link {{custom_toolchain_name}} {{path/to/directory}}`


### PR DESCRIPTION
Was not working for list and link without `toolchain` before it. Seems to have worked for install and uninstall as a shortcut, but not really how the commands of the toolchain subcommand are supposed to look.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** rustup 1.28.1 (2025-03-05)
