### PR TITLE
pages.nl/*: translate 'command' like 'commando'

### DIFF
--- a/pages.nl/common/$.md
+++ b/pages.nl/common/$.md
@@ -21,7 +21,7 @@
 
 - Breid uit met de uitvoer van `command` en voer het uit. Hetzelfde als het commando tussen backticks plaatsen:
 
-`$({{command}})`
+`$({{commando}})`
 
 - Toon hoeveel argumenten de huidige context heeft:
 

--- a/pages.nl/common/,.md
+++ b/pages.nl/common/,.md
@@ -9,7 +9,7 @@
 
 - Voeg een commando toe aan een child shell:
 
-`, {{[-s|--shell]}} {{command}}`
+`, {{[-s|--shell]}} {{commando}}`
 
 - Wis de cache:
 

--- a/pages.nl/common/b2sum.md
+++ b/pages.nl/common/b2sum.md
@@ -13,7 +13,7 @@
 
 - Bereken de BLAKE2 checksum voor `stdin`:
 
-`{{command}} | b2sum`
+`{{commando}} | b2sum`
 
 - Lees een bestand van BLAKE2 sums en bestandsnamen en verifieer dat alle bestanden overeenkomende checksums hebben:
 

--- a/pages.nl/common/basenc.md
+++ b/pages.nl/common/basenc.md
@@ -13,8 +13,8 @@
 
 - Encodeer `stdin` met base32 encoding met 42 kolommen:
 
-`{{command}} | basenc --base32 {{[-w|--wrap]}} 42`
+`{{commando}} | basenc --base32 {{[-w|--wrap]}} 42`
 
 - Encodeer `stdin` met base32 encoding:
 
-`{{command}} | basenc --base32`
+`{{commando}} | basenc --base32`

--- a/pages.nl/common/gcrane-help.md
+++ b/pages.nl/common/gcrane-help.md
@@ -5,7 +5,7 @@
 
 - Toon help voor een subcommando:
 
-`gcrane help {{command}}`
+`gcrane help {{commando}}`
 
 - Toon de help:
 

--- a/pages.nl/linux/distrobox-host-exec.md
+++ b/pages.nl/linux/distrobox-host-exec.md
@@ -5,7 +5,7 @@
 
 - Voer een commando uit op de host vanuit de Distrobox container:
 
-`distrobox-host-exec "{{command}}"`
+`distrobox-host-exec "{{commando}}"`
 
 - Voer het `ls` commando uit op de host vanuit de Distrobox container:
 

--- a/pages.nl/linux/tftp.md
+++ b/pages.nl/linux/tftp.md
@@ -9,7 +9,7 @@
 
 - Maak verbinding met een TFTP-server en voer een TFTP-[c]ommand uit:
 
-`tftp {{server_ip}} -c {{command}}`
+`tftp {{server_ip}} -c {{commando}}`
 
 - Maak verbinding met een TFTP-server met IPv6 en forceer dat de oorspronkelijke poort binnen een [R]ange ligt:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 