### PR TITLE
pages/*: fix colon typo

### DIFF
--- a/pages/common/ipmitool.md
+++ b/pages/common/ipmitool.md
@@ -3,7 +3,7 @@
 > Interface with the Intelligent Platform Management Interface (IPMI).
 > More information: <https://manned.org/ipmitool>.
 
-- Open IPMI shell on the local hardware :
+- Open IPMI shell on the local hardware:
 
 `sudo ipmitool shell`
 

--- a/pages/freebsd/ipmitool.md
+++ b/pages/freebsd/ipmitool.md
@@ -7,7 +7,7 @@
 
 `kldload ipmi.ko`
 
-- Open IPMI shell on the local hardware :
+- Open IPMI shell on the local hardware:
 
 `ipmitool shell`
 

--- a/pages/linux/distrobox-export.md
+++ b/pages/linux/distrobox-export.md
@@ -11,7 +11,7 @@
 
 `distrobox-export {{[-b|--bin]}} {{path/to/binary}} {{[-ep|--export-path]}} {{path/to/binary_on_host}}`
 
-- Export a binary from the container to the host (i.e.`$HOME/.local/bin`) :
+- Export a binary from the container to the host (i.e.`$HOME/.local/bin`):
 
 `distrobox-export {{[-b|--bin]}} {{path/to/binary}} {{[-ep|--export-path]}} {{path/to/export}}`
 

--- a/pages/linux/ipmitool.md
+++ b/pages/linux/ipmitool.md
@@ -7,7 +7,7 @@
 
 `systemctl start ipmidrv`
 
-- Open IPMI shell on the local hardware :
+- Open IPMI shell on the local hardware:
 
 `sudo ipmitool shell`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 