### PR TITLE
mullvad: add example

### DIFF
--- a/pages/common/mullvad.md
+++ b/pages/common/mullvad.md
@@ -19,3 +19,7 @@
 - Check status of VPN tunnel:
 
 `mullvad status`
+
+- Check expire date of account and obtain device name:
+
+`mullvad account get`

--- a/pages/common/mullvad.md
+++ b/pages/common/mullvad.md
@@ -20,6 +20,6 @@
 
 `mullvad status`
 
-- Check expire date of account and obtain device name:
+- Check the account expiration date and obtain the device name:
 
 `mullvad account get`


### PR DESCRIPTION
# Add `mullvad account get` command to mullvad page

The `mullvad account get` command provides essential information for Mullvad VPN CLI users by displaying both the account expiration date and the current device's auto-generated name in a single command.

This addition is particularly valuable for users who:
- Need to quickly check when their VPN subscription expires
- Want to identify their current device's name when managing multiple devices
- Are approaching Mullvad's 5-device limit and need to make informed decisions about which devices to keep connected

The command complements the existing `mullvad status` command by providing account-specific information rather than just connection status.

## Example output:
```
$ mullvad account get
Account number: XXXX XXXX XXXX XXXX
Paid until: 2026-03-15
Device: Monkey Ship
```


<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
mullvad-cli 2025.5