### PR TITLE
bash: update documentation links

### DIFF
--- a/pages.de/common/bash.md
+++ b/pages.de/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell.
 > `sh`-kompatibler Kommandozeilen-Interpreter.
-> Weitere Informationen: <https://www.gnu.org/software/bash/>.
+> Weitere Informationen: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Interaktive Shell starten:
 

--- a/pages.fr/common/bash.md
+++ b/pages.fr/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, un interpréteur de ligne de commande compatible avec `sh`.
 > Voir aussi `histexpand` pour l'expansion de l'historique.
-> Plus d'informations : <https://www.gnu.org/software/bash/>.
+> Plus d'informations : <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Démarre une session shell interactive :
 

--- a/pages.it/common/bash.md
+++ b/pages.it/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell.
 > Interprete da linea di comando compatibile con `sh`.
-> Maggiori informazioni: <https://www.gnu.org/software/bash/>.
+> Maggiori informazioni: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Avvia una shell interattiva:
 

--- a/pages.ko/common/bash.md
+++ b/pages.ko/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, an `sh`- 호환 명령 행 인터프리터.
 > 참조: `zsh`, `histexpand` (history 확장).
-> 더 많은 정보: <https://www.gnu.org/software/bash/>.
+> 더 많은 정보: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - 대화형 쉘 시작하기:
 

--- a/pages.pl/common/bash.md
+++ b/pages.pl/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, interpreter komend powłoki systemowej kompatybilny z `sh`.
 > Zobacz także: `zsh`, `histexpand`.
-> Więcej informacji: <https://www.gnu.org/software/bash/>.
+> Więcej informacji: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Rozpocznij interaktywną sesję powłoki:
 

--- a/pages.pt_BR/common/bash.md
+++ b/pages.pt_BR/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell, um interpretador de linha de comando compatível com `sh`.
 > Veja também: `zsh`, `histexpand` (expansão do histórico).
-> Mais informações: <https://www.gnu.org/software/bash/>.
+> Mais informações: <https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - Inicia uma sessão interativa do shell:
 

--- a/pages.zh/common/bash.md
+++ b/pages.zh/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell，兼容 `sh` 的命令行解释器。
 > 此外请参阅：`zsh`，`histexpand`（历史展开）。
-> 更多信息：<https://www.gnu.org/software/bash/>.
+> 更多信息：<https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - 启动交互式 shell：
 

--- a/pages.zh_TW/common/bash.md
+++ b/pages.zh_TW/common/bash.md
@@ -2,7 +2,7 @@
 
 > Bourne-Again SHell. 一個與 `sh` 相容的命令列。
 > 參照 `histexpand` 以使用 history expansion 特性。
-> 更多資訊：<https://www.gnu.org/software/bash/>.
+> 更多資訊：<https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html>.
 
 - 開啟互動式 shell：
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This PR makes the information link consistent among all `bash.md` pages.
