### PR TITLE
sqlx: add page

### DIFF
--- a/pages/common/sqlx.md
+++ b/pages/common/sqlx.md
@@ -1,0 +1,24 @@
+# sqlx
+
+> Command-line utility for SQLx, the Rust SQL toolkit.
+> More information: <https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md>.
+
+- Create the database specified in the DATABASE_URL environment variable:
+
+`sqlx database create`
+
+- Drop the specified database:
+
+`sqlx database drop --database-url {{database_url}}`
+
+- Create a new pair of up and down migration files with the given description in the "migrations" directory:
+
+`sqlx migrate add -r {{migration_description}}`
+
+- Run all pending migrations for the specified database:
+
+`sqlx migrate run --database_url {{database_url}}`
+
+- Revert the latest migration for the specified database:
+
+`sqlx migrate revert --database_url {{database_url}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `sqlx-cli 0.8.3`

This is a CLI that's needed when working with [sqlx](https://github.com/launchbadge/sqlx) for Rust, manages databases + migrations.