### PR TITLE
reuse: add page

### DIFF
--- a/pages/common/reuse.md
+++ b/pages/common/reuse.md
@@ -1,0 +1,20 @@
+# reuse
+
+> Tool for compliance with the REUSE recommendations.
+> More information: <https://reuse.readthedocs.io/en/stable/man/index.html>.
+
+- Lint for REUSE compliance for the current project (version control aware):
+
+`reuse lint`
+
+- Lint for REUSE compliance from the specified directory:
+
+`reuse --root {{path/to/directory}} lint`
+
+- Download a license by its SPDX identifier and place it in the LICENSES directory:
+
+`reuse download {{spdx-identifier}}`
+
+- Download all missing licenses detected in the project:
+
+`reuse download --all`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 5.0.2

---

Just used this in one of the projects I maintain, so figured I'd document it here.

TL;DR: It's a tool by the FSFE for managing license compliance, particularly useful when a project pulls in code from a variety of sources and so a single `LICENSE` file in the project root isn't good enough to properly denote the license of all distributed files.