### PR TITLE
sqlmap: remove extra spaces in english page, add option placeholders in korean page

### DIFF
--- a/pages.ko/common/sqlmap.md
+++ b/pages.ko/common/sqlmap.md
@@ -5,20 +5,20 @@
 
 - 단일 대상 URL에 대해 sqlmap 실행:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php?id=1}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php?id=1}}"`
 
 - POST 요청으로 데이터 전송 (`--data`는 POST 요청을 의미):
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --data="{{id=1}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{id=1}}"`
 
 - 매개변수 구분자 변경 (기본값은 &):
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
 
 - `./txt/user-agents.txt`에서 무작위 `User-Agent` 선택 및 사용:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --random-agent`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --random-agent`
 
 - HTTP 프로토콜 인증을 위한 사용자 자격 증명 제공:
 
-`python sqlmap.py -u "{{http://www.target.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`

--- a/pages/common/sqlmap.md
+++ b/pages/common/sqlmap.md
@@ -9,16 +9,16 @@
 
 - Send data in a POST request (`--data` implies POST request):
 
-`python sqlmap.py  {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{id=1}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{id=1}}"`
 
 - Change the parameter delimiter (& is the default):
 
-`python sqlmap.py  {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --data="{{query=foobar;id=1}}" --param-del="{{;}}"`
 
 - Select a random `User-Agent` from `./txt/user-agents.txt` and use it:
 
-`python sqlmap.py  {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --random-agent`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --random-agent`
 
 - Provide user credentials for HTTP protocol authentication:
 
-`python sqlmap.py  {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`
+`python sqlmap.py {{[-u|--url]}} "{{http://www.example.com/vuln.php}}" --auth-type {{Basic}} --auth-cred "{{testuser:testpass}}"`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

