### PR TITLE
zoxide: refresh page

### DIFF
--- a/pages/common/zoxide.md
+++ b/pages/common/zoxide.md
@@ -24,6 +24,6 @@
 
 `zoxide remove {{path/to/directory}}`
 
-- Generate shell configuration for command aliases (`z`, `za`, `zi`, `zq`, `zr`):
+- Generate shell configuration for command aliases (`z`, `zi`):
 
-`zoxide init {{bash|fish|zsh}}`
+`zoxide init {{bash|elvish|fish|nushell|posix|powershell|tcsh|xonsh|zsh}}`


### PR DESCRIPTION
This PR removes the aliases `za`, `zq`, `zr`, that have not been bundled with zoxide for years.

It also adds some new shells supported by the current version of zoxide.