### PR TITLE
ntp-ctl: add page

### DIFF
--- a/pages/common/ntp-ctl.md
+++ b/pages/common/ntp-ctl.md
@@ -1,0 +1,16 @@
+# ntp-ctl
+
+> Management client for the `ntpd-rs` daemon.
+> More information: <https://docs.ntpd-rs.pendulum-project.org/man/ntp-ctl.8>.
+
+- Display information about the current state of the NTP daemon:
+
+`ntp-ctl status`
+
+- Check if the specified configuration file (default: `/etc/ntpd-rs/ntp.toml`) is valid:
+
+`ntp-ctl {{[-c|--config]}} {{path/to/config}} validate`
+
+- Interactively run a single synchronization of the clock:
+
+`sudo ntp-ctl force-sync`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).