### PR TITLE
kde-builder: add hint for desktop compilation

### DIFF
--- a/pages/linux/kde-builder.md
+++ b/pages/linux/kde-builder.md
@@ -8,7 +8,7 @@
 
 `kde-builder --initial-setup`
 
-- Compile a KDE component and its dependencies from the source:
+- Compile a KDE component and its dependencies from the source (use `workspace` to compile Plasma desktop):
 
 `kde-builder {{component_name}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
