### PR TITLE
yay: add cache cleaning command

### DIFF
--- a/pages/linux/yay.md
+++ b/pages/linux/yay.md
@@ -32,6 +32,10 @@
 
 `yay -Yc`
 
+- Clean pacman and yay caches (old package versions kept for rollback and downgrade purposes):
+
+`yay -Scc`
+
 - Show statistics for installed packages and system health:
 
 `yay -Ps`


### PR DESCRIPTION
I realise this is getting rather long and is growing the list one example beyond eight.

However, all examples so far are essential; and cleaning your pacman and yay caches is mandatory every once in a while for any user since the caches grow indefinitely in size. Unfortunately this is not very well documented in yay --help as of right now.

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
