### PR TITLE
gettext: added disambiguation

### DIFF
--- a/pages/common/gettext.md
+++ b/pages/common/gettext.md
@@ -10,3 +10,11 @@
 - Display help:
 
 `gettext {{[-h|--help]}}`
+
+- Use context to disambiguate
+
+`gettext {{[-c context|--context=context]}}`
+
+- Specify domain (e.g., package, program, module)
+
+`gettext {{[-d textdomain|--domain=textdomain]}}`


### PR DESCRIPTION
Updating gettext to include disambiguation options

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 0.25**
