### PR TITLE
codex: add page

### DIFF
--- a/pages/common/codex.md
+++ b/pages/common/codex.md
@@ -1,0 +1,33 @@
+# codex
+
+> Natural language code assistant for the terminal, powered by OpenAI.
+> Reads and edits files in your current directory to fulfill requests.
+> More information: <https://github.com/openai/codex>.
+
+- Start an interactive Codex session in the current directory:
+
+`codex`
+
+- Run a single Codex command using a prompt:
+
+`codex "{{your prompt}}"`
+
+- Run a prompt with automatic approval of all file edits and commands:
+
+`codex --approval-mode full-auto "{{your prompt}}"`
+
+- Use a specific provider and model:
+
+`codex --provider {{provider_name}} --model {{model_name}} "{{your prompt}}"`
+
+- Load the entire repository as context (experimental):
+
+`codex --full-context "{{your prompt}}"`
+
+- Show the resource usage for the current session (run this command inside a session):
+
+`/cost`
+
+- Show help and a summary of available options:
+
+`codex --help`


### PR DESCRIPTION
Add a new page for the `codex` command.

This page documents the OpenAI Codex CLI, a natural language code assistant for the terminal.
The page includes common usage examples, demonstrates how to use different providers and models, and covers experimental and session features. The examples follow tldr-pages style and keep new command-line users in mind.

References:
- https://github.com/openai/codex

- [x] Page is placed under `pages/common/` as the command is cross-platform.
- [x] Syntax, descriptions, and placeholders conform to the tldr style guide.
- [x] Checked for existing pages and PRs for this command.

Thank you for reviewing!
