### PR TITLE
git-authors: update more information links

### DIFF
--- a/pages.id/common/git-authors.md
+++ b/pages.id/common/git-authors.md
@@ -2,7 +2,7 @@
 
 > Buat daftar pelaku komit pada suatu repositori Git.
 > Bagian dari `git-extras`.
-> Informasi lebih lanjut: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+> Informasi lebih lanjut: <https://manned.org/git-authors>.
 
 - Tampilkan daftar pelaku komit menuju `stdout` daripada menuju ke file `AUTHORS`:
 

--- a/pages.ko/common/git-authors.md
+++ b/pages.ko/common/git-authors.md
@@ -2,7 +2,7 @@
 
 > Git 저장소의 커밋 작성자 목록을 생성.
 > `git-extras`의 일부.
-> 더 많은 정보: <https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+> 더 많은 정보: <https://manned.org/git-authors>.
 
 - 커밋 작성자 목록을 `AUTHORS` 파일 대신 `stdout`에 출력:
 

--- a/pages.zh/common/git-authors.md
+++ b/pages.zh/common/git-authors.md
@@ -2,7 +2,7 @@
 
 > 生成 Git 仓库的提交者列表。
 > 属于 `git-extras`的一部分。
-> 更多信息：<https://github.com/tj/git-extras/blob/master/Commands.md#git-authors>.
+> 更多信息：<https://manned.org/git-authors>.
 
 - 将完整的提交者列表输出到标准输出，而不是写入到 `AUTHORS` 文件：
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

