### PR TITLE
duckdb: add direct querying option

### DIFF
--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -11,9 +11,13 @@
 
 `duckdb {{path/to/dbfile}}`
 
-- Directly query a CSV, JSON, or Parquet file:
+- Query a CSV, JSON, or Parquet file using SQL:
 
 `duckdb -c "{{SELECT * FROM 'data_source.[csv|csv.gz|json|json.gz|parquet]'}}"`
+
+- Directly query a CSV, JSON, or Parquet file using the `file` view:
+
+`duckdb {{data_source.[csv|csv.gz|json|json.gz|parquet]}} -c "{{ SELECT * FROM file }}"`
 
 - Run an SQL script:
 
@@ -22,10 +26,6 @@
 - Run query on database file and keep the interactive shell open:
 
 `duckdb {{path/to/dbfile}} -cmd "{{SELECT DISTINCT * FROM tbl}}"`
-
-- Run SQL queries in file on database and keep the interactive shell open:
-
-`duckdb {{path/to/dbfile}} -init {{path/to/script.sql}}`
 
 - Read CSV from `stdin` and write CSV to `stdout`:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.3.0

This PR add a new CLI feature introduced in DuckDB 1.3.0 (https://duckdb.org/2025/05/21/announcing-duckdb-130).
