### PR TITLE
Added a tldr page for 'micromamba'

### DIFF
--- a/pages/common/micromamba.md
+++ b/pages/common/micromamba.md
@@ -8,10 +8,6 @@
 
 `micromamba create -p {{/path/to/env}} {{python=3.11 numpy}}`
 
-- Create a new environment by name:
-
-`micromamba create -n {{env_name}} {{python=3.11 matplotlib}}`
-
 - Activate an environment by name or path:
 
 `micromamba activate {{env_name}}`
@@ -26,21 +22,9 @@
 
 `micromamba install {{scipy pandas}}`
 
-- Update packages in the current environment:
-
-`micromamba update {{package_name}}`
-
-- Remove packages from the current environment:
-
-`micromamba remove {{package_name}}`
-
 - List all installed packages in the current environment:
 
 `micromamba list`
-
-- List all environments:
-
-`micromamba env list`
 
 - Search for packages in channels or current environment:
 
@@ -50,18 +34,6 @@
 
 `micromamba repoquery depends -t {{package_name}}`
 
-- Clean unused packages and caches:
-
-`micromamba clean --all`
-
-- Generate shell init scripts for activation support (e.g., for bash):
-
-`micromamba shell init -s {{bash}} -p {{~/.micromamba}}`
-
 - Show information about the current micromamba setup:
 
 `micromamba info`
-
-- Update micromamba itself:
-
-`micromamba self-update`

--- a/pages/common/micromamba.md
+++ b/pages/common/micromamba.md
@@ -1,0 +1,67 @@
+# micromamba
+
+> A fast, minimal, standalone package and environment manager for conda packages.
+> Drop-in replacement for conda, ideal for CI, Docker, and lightweight setups.
+> More information: <https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html>.
+
+- Create a new environment at a specific path, installing named packages into it:
+
+`micromamba create -p {{/path/to/env}} {{python=3.11 numpy}}`
+
+- Create a new environment by name:
+
+`micromamba create -n {{env_name}} {{python=3.11 matplotlib}}`
+
+- Activate an environment by name or path:
+
+`micromamba activate {{env_name}}`
+`micromamba activate -p {{/path/to/env}}`
+
+- Run a command inside an environment without activating it in the shell:
+
+`micromamba run -n {{env_name}} {{python script.py}}`
+`micromamba run -p {{/path/to/env}} {{pytest tests/}}`
+
+- Install packages into the currently active environment:
+
+`micromamba install {{scipy pandas}}`
+
+- Update packages in the current environment:
+
+`micromamba update {{package_name}}`
+
+- Remove packages from the current environment:
+
+`micromamba remove {{package_name}}`
+
+- List all installed packages in the current environment:
+
+`micromamba list`
+
+- List all environments:
+
+`micromamba env list`
+
+- Search for packages in channels or current environment:
+
+`micromamba search {{package_name}}`
+
+- Query tree-like dependencies of a package:
+
+`micromamba repoquery depends -t {{package_name}}`
+
+- Clean unused packages and caches:
+
+`micromamba clean --all`
+
+- Generate shell init scripts for activation support (e.g., for bash):
+
+`micromamba shell init -s {{bash}} -p {{~/.micromamba}}`
+
+- Show information about the current micromamba setup:
+
+`micromamba info`
+
+- Update micromamba itself:
+
+`micromamba self-update`


### PR DESCRIPTION
Added a tldr page for the command 'micromamba' (conda replacement)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ x] The page(s) have at most 8 examples.
- [x ] The page description(s) have links to documentation or a homepage.
- [x ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
