### PR TITLE
GetNPUsers.py: translate placeholders to Dutch

### DIFF
--- a/pages.nl/common/getnpusers.py.md
+++ b/pages.nl/common/getnpusers.py.md
@@ -14,11 +14,11 @@
 
 - Authenticeer met valide credentials (als anonieme binding is uitgeschakeld):
 
-`GetNPUsers.py {{domein}}/{{username}}:{{password}} -usersfile {{pad/naar/gebruikerslijst}} -dc-ip {{domain_controller_ip}}`
+`GetNPUsers.py {{domein}}/{{gebruikersnaam}}:{{wachtwoord}} -usersfile {{pad/naar/gebruikerslijst}} -dc-ip {{domain_controller_ip}}`
 
 - Gebruik pass-the-hash authenticatie in plaats van een wachtwoord:
 
-`GetNPUsers.py {{domein}}/{{username}} -hashes {{LM_Hash}}:{{NT_Hash}} -usersfile {{pad/naar/gebruikerslijst}} -dc-ip {{domain_controller_ip}}`
+`GetNPUsers.py {{domein}}/{{gebruikersnaam}} -hashes {{LM_Hash}}:{{NT_Hash}} -usersfile {{pad/naar/gebruikerslijst}} -dc-ip {{domain_controller_ip}}`
 
 - Sla de output op in een bestand:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message). 