### PR TITLE
kill: fix typo in French translation

### DIFF
--- a/pages.fr/common/kill.md
+++ b/pages.fr/common/kill.md
@@ -6,7 +6,7 @@
 
 - Termine un processus avec le signal SIGTERM (terminaison) par défaut :
 
-`kill {{indentifiant_processus}}`
+`kill {{identifiant_processus}}`
 
 - Liste les noms des signaux disponibles (à utiliser sans leurs préfixes `SIG`) :
 
@@ -18,19 +18,19 @@
 
 - Termine un processus avec le signal SIGHUP ("raccrocher"). Beaucoup de daemons se rafraîchissent au lieu de terminer :
 
-`kill -{{1|HUP}} {{indentifiant_processus}}`
+`kill -{{1|HUP}} {{identifiant_processus}}`
 
 - Termine un processus avec le signal SIGINT ("interruption"). Généralement initié par l'utilisateur appuyant sur `<Ctrl c>` :
 
-`kill -{{2|INT}} {{indentifiant_processus}}`
+`kill -{{2|INT}} {{identifiant_processus}}`
 
 - Demande au système d'exploitation de mettre fin à un processus immédiatement (sans possibilité d'intercepter le signal) :
 
-`kill -{{9|KILL}} {{indentifiant_processus}}`
+`kill -{{9|KILL}} {{identifiant_processus}}`
 
 - Demande au système d'exploitation de suspendre un processus jusqu'à recevoir le signal SIGCONT ("continue") :
 
-`kill -{{17|STOP}} {{indentifiant_processus}}`
+`kill -{{17|STOP}} {{identifiant_processus}}`
 
 - Envoie le signal SIGUSR1 à tous les processus dans le groupe avec l'identifiant indiqué :
 


### PR DESCRIPTION
Typo: "identifiant" and not "indentifiant"

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
