### PR TITLE
adb-connect, adb-disconnect, adb-forward, adb-pair, adb-uninstall, adguardhome, age-keygen, airdecap-ng, airshare, androguard, animdl, ansible-galaxy, ansible-lin, ansible-playbook: add Spanish translation

### DIFF
--- a/pages.es/common/adb-connect.md
+++ b/pages.es/common/adb-connect.md
@@ -1,0 +1,16 @@
+# adb connect
+
+> Permite establecer una conexión a un dispositivo Android de forma inalámbrica.
+> Más información: <https://developer.android.com/tools/adb>.
+
+- Empareja con un dispositivo Android (los códigos de dirección y emparejamiento se pueden encontrar en las opciones de desarrollador):
+
+`adb pair {{dirección_ip}}:{{puerto}}`
+
+- Conecta con un dispositvo Android (el puerto será diferente del de emparejamiento):
+
+`adb connect {{dirección_ip}}:{{puerto}}`
+
+- Desconecta un dispositivo:
+
+`adb disconnect {{dirección_ip}}:{{puerto}}`

--- a/pages.es/common/adb-disconnect.md
+++ b/pages.es/common/adb-disconnect.md
@@ -1,0 +1,7 @@
+# adb disconnect
+
+> Este comando ha sido movido a `adb connect`.
+
+- Ver documentación para `adb disconnect`:
+
+`tldr adb connect`

--- a/pages.es/common/adb-forward.md
+++ b/pages.es/common/adb-forward.md
@@ -1,0 +1,20 @@
+# adb forward
+
+> Permite conectarse a un dispositivo Android de forma inalámbrica.
+> Más información: <https://developer.android.com/tools/adb>.
+
+- Reenviar un puerto TCP:
+
+`adb forward tcp:{{puerto_local}} tcp:{{puerto_remoto}}`
+
+- Enumera todos los reenvíos:
+
+`adb forward --list`
+
+- Elimina una regla de reenvío:
+
+`adb forward --remove tcp:{{puerto_local}}`
+
+- Elimina todas las reglas de reenvío:
+
+`adb forward --remove-all`

--- a/pages.es/common/adb-pair.md
+++ b/pages.es/common/adb-pair.md
@@ -1,0 +1,7 @@
+# adb pair
+
+> Este comando ha sido movido a `adb connect`.
+
+- Ver documentación para `adb pair`:
+
+`tldr adb connect`

--- a/pages.es/common/adb-uninstall.md
+++ b/pages.es/common/adb-uninstall.md
@@ -1,0 +1,15 @@
+# adb uninstall
+
+> Desinstala un paquete.
+> Más información: <https://manned.org/adb>.
+
+- Desinstalar un paquete:
+
+`adb uninstall {{com.ejemplo.app}}`
+
+- Desinstalar un paquete, pero conservarndo los datos del usuario:
+
+`adb uninstall -k {{com.ejemplo.app}}`
+
+
+

--- a/pages.es/common/adguardhome.md
+++ b/pages.es/common/adguardhome.md
@@ -1,0 +1,34 @@
+# AdGuardHome
+
+> Software de red completa para bloquear anuncios y el rastreo.
+> Más información: <https://github.com/AdguardTeam/AdGuardHome>.
+
+- Corre AdGuard Home:
+
+`AdGuardHome`
+
+- Específica un archivo de configuración:
+
+`AdGuardHome --config {{ruta/al/AdGuardHome.yaml}}`
+
+- Almacena la información en un directorio de trabajo específico:
+
+`AdGuardHome --work-dir {{ruta/al/directorio}}`
+
+- Instala o desinstala AdGuard Home como servicio:
+
+`AdGuardHome --service {{install|uninstall}}`
+
+- Inicia el servicio de AdGuard Home:
+
+`AdGuardHome --service start`
+
+- Recarga la configuración para el servicio de AdGuard Home:
+
+`AdGuardHome --service reload`
+
+- Detén o reinicia el servicio de AdGuard Home:
+
+`AdGuardHome --service {{stop|restart}}`
+
+

--- a/pages.es/common/age-keygen.md
+++ b/pages.es/common/age-keygen.md
@@ -1,0 +1,13 @@
+# age-keygen
+
+> Genera pares de claves `age`.
+> Consulta también: `age` para cifrar/descifrar archivos.
+> Más información: <https://manned.org/age-keygen>.
+
+- Generar un par de claves, guardarlas en un archivo sin cifrar, y mostrar la clave pública con `stdout`:
+
+`age-keygen {{[-o|--output]}} {{ruta/al/archivo}}`
+
+- Convertir una identidad en un destinatario y mostrar la clave pública con `stdout`:
+
+`age-keygen -y {{ruta/al/archivo}}`

--- a/pages.es/common/airdecap-ng.md
+++ b/pages.es/common/airdecap-ng.md
@@ -1,0 +1,25 @@
+# airdecap-ng
+
+> Descifra un archivo de captura cifrado (WEP, WPA o WPA2).
+> Parte del paquete de software de red de Aircrack-ng.
+> Más información: <https://www.aircrack-ng.org/doku.php?id=airdecap-ng>.
+
+- Elimina encabezados inalámbricos de una red abierta de archivos de captura y utiliza los puntos de acceso con dirección MAC para filtrar:
+
+`airdecap-ng -b {{ap_mac}} {{ruta/al/archivo_de_captura.cap}}`
+
+- Descifra un archivo de captura [w]EP cifrado usando la clave en formato hexadecimal:
+
+`airdecap-ng -w {{clave_hex}} {{ruta/al/archivo_de_captura.cap}}`
+
+- Descifra un archivo de captura WPA/WPA2 cifrado usando los puntos de acceso [e]ssid y [p]contraseña:
+
+`airdecap-ng -e {{essid}} -p {{contraseña}} {{ruta/al/archivo_de_captura.cap}}`
+
+- Descifra un archivo de captura WPA/WPA2 cifrado preservando los encabezados usando los puntos de acceso [e]ssid y [p]contraseña:
+
+`airdecap-ng -l -e {{essid}} -p {{contraseña}} {{ruta/al/archivo_de_captura.cap}}`
+
+- Descifra un archivo de captura WPA/WPA2 cifrado usando los puntos de acceso [e]ssid y [p]contraseña, así como su dirección MAC para filtrar:
+
+`airdecap-ng -b {{ap_mac}} -e {{essid}} -p {{contraseña}} {{ruta/al/archivo_de_captura.cap}}`

--- a/pages.es/common/airshare.md
+++ b/pages.es/common/airshare.md
@@ -1,0 +1,27 @@
+# airshare
+
+> Transfiere datos entre dos máquinas en una red local.
+> Más información: <https://airshare.rtfd.io/en/latest/cli.html>.
+
+- Comparte archivos o directorios:
+
+`airshare {{code}} {{ruta/al/archivo_o_directorio1 ruta/al/archivo_o_directorio2 ...}}`
+- Recibe un archivo:
+
+`airshare {{code}}`
+
+- Aloja un servidor receptor (usa esto para poder cargar archivos usando la interfaz web):
+
+`airshare --upload {{code}}`
+
+- Envía archivos o directorios a un servidor receptor:
+
+`airshare --upload {{code}} {{ruta/al/archivo_o_directorio1 ruta/al/archivo_o_directorio2 ...}}`
+
+- Envía archivos cuyas rutas han sido copiadas al portapapeles:
+
+`airshare --file-path {{code}}`
+
+- Recive un archivo y cópialo al portapapeles:
+
+`airshare --clip-receive {{code}}`

--- a/pages.es/common/androguard.md
+++ b/pages.es/common/androguard.md
@@ -1,0 +1,16 @@
+# androguard
+
+> Obtiene información o un diseño a partir de una aplicación de Android. Escrito en Python.
+> Más información: <https://github.com/androguard/androguard>.
+
+- Despliega el manifiesto de la aplicación Android:
+
+`androguard axml {{ruta/al/app.apk}}`
+
+- Despliega metadatos de la aplicación (versión y ID de la app):
+
+`androguard apkid {{ruta/al/app.apk}}`
+
+- Descompila el código en Java de una aplicación:
+
+`androguard decompile {{ruta/al/app.apk}} --output {{ruta/al/directorio_de_salida}}`

--- a/pages.es/common/animdl.md
+++ b/pages.es/common/animdl.md
@@ -1,0 +1,37 @@
+# animdl
+
+> Recolector eficiente y veloz de datos de anime.
+> Consultar también: `ani-cli`.
+> Más información: <https://github.com/justfoolingaround/animdl>.
+
+- Descarga un anime específico:
+
+`animdl download {{nombre_anime}}`
+
+- Descarga un anime específico, específicando un rango de episodios:
+
+`animdl download {{nombre_anime}} {{[-r|--range]}} {{episodio_inicial}}-{{episodio_final}}`
+
+- Descarga un anime específico, específicando un directorio de descarga:
+
+`animdl download {{nombre_anime}} {{[-d|--download-dir]}} {{ruta/al/directorio_de_descargas}}`
+
+- Obtener la URL de transmisión de un anime específico:
+
+`animdl grab {{nombre_anime}}`
+
+- Desplegar el cronograma de los próximos animes para la siguiente semana:
+
+`animdl schedule`
+
+- Busca un anime en específico:
+
+`animdl search {{nombre_anime}}`
+
+- Ver un anime específico en transmisión:
+
+`animdl stream {{nombre_anime}}`
+
+- Ver la transmisión del último episodio de un anime específico:
+
+`animdl stream {{nombre_anime}} {{[-s|--special]}} latest`

--- a/pages.es/common/ansible-galaxy.md
+++ b/pages.es/common/ansible-galaxy.md
@@ -1,0 +1,33 @@
+# ansible-galaxy
+
+> Realiza varias operaciones de Ansible Role y algunas relacionadas a Collection.
+> Más información: <https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html>.
+
+- Enumera roles instalados o colecciones:
+
+`ansible-galaxy {{role|collection}} list`
+
+- Busca un rol con varios niveles de verbosidad (`-v` debe ser específicado al final):
+
+`ansible-galaxy role search {{keyword}} -v{{vvvvv}}`
+
+- Instala o elimina roles:
+
+`ansible-galaxy role {{install|remove}} {{rol_nombre1 rol_nombre2 ...}}`
+
+- Crea un nuevo rol:
+
+`ansible-galaxy role init {{rol_nombre}}`
+
+- Obten información acerca de un rol:
+
+`ansible-galaxy role info {{rol_nombre}}`
+
+- Instala o elimina colecciones:
+
+`ansible-galaxy collection {{install|remove}} {{colección_nombre1 colección_nombre2 ...}}`
+
+- Despliega más información (ayuda) acerca de roles o colecciones:
+
+`ansible-galaxy {{role|collection}} {{[-h|--help]}}`
+

--- a/pages.es/common/ansible-lint.md
+++ b/pages.es/common/ansible-lint.md
@@ -1,0 +1,24 @@
+# ansible-lint
+
+> Aplica reglas y sigue las mejores prácticas en la automatización de tu contenido.
+> Más información: <https://ansible.readthedocs.io/projects/lint/>.
+
+- Analizar un playbook (archivo de tareas) específico y un directorio de roles con Lint.
+
+`ansible-lint {{ruta/al/playbook}} {{ruta/al/directorio_de_roles}}`
+
+- Analizar un playbook mientras se excluyen reglas específicas:
+
+`ansible-lint {{[-x|--exclude-rules]}} {{regla1, regla2,...}} {ruta/al/archivo_playbook}`
+
+- Analizar un playbook en modo sin conexión y darle como formato de salida PEP8:
+
+`ansible-lint {{[-o|--offline]}} {{[-p|--parseable]}} {{ruta/al/archivo_playbook}}`
+
+- Analizar un playboo usando un directorio de reglas personalizadas:
+
+`ansible-lint {{[-r|--rules]}} {{ruta/al/directorio_de_reglas_personalizadas}} {{ruta/al/archivo_playbook}}`
+
+- Analizar todo el contenido Ansible de manerea recursiva en un directorio dado:
+
+`ansible-lint {{ruta/al/directorio_del_proyecto}}`

--- a/pages.es/common/ansible-playbook.md
+++ b/pages.es/common/ansible-playbook.md
@@ -1,0 +1,32 @@
+# ansible-playbook
+
+> Ejecuta tareas definidas en un playbook (archivo de tareas) en máquinas remotas sobre SSH.
+> Más información: <https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html>.
+
+- Corre tareas en el playbook dado:
+
+`ansible-playbook {{playbook}}`
+
+- Corre tareas en el playbook dado con inventario de host personalizado:
+
+`ansible-playbook {{playbook}} {{[-i|--inventory]}} {{inventory_file}}`
+
+- Corre tareas en el playbook dado con variables extra definidas con la línea de comandos:
+
+`ansible-playbook {{playbook}} {{[-e|--extra-vars]}} "{{variable1}}={{valor1}} {{variable2}}={{valor2}}"`
+
+- Corre tareas en el playbook dado con variables extra definidas en un archivo JSON:
+
+`ansible-playbook {{playbook}} {{[-e|extra-vars]}} "@{{variables.json}}"`
+
+- Corre tareas en el playbook dado con tags específicos:
+
+`ansible-playbook {{playbook}} {{[-t|--tags]}} {{tag1,tag2}}`
+
+- Corre tareas en el playbook dado empezando por una tarea en específico:
+
+`ansible-playbook {{playbook}} --start-at {{tarea_nombre}}`
+
+- Corre tareas en el playbook dado sin realizar ningún cambio (dry-run):
+
+`ansible-playbook {{playbook}} {{[-C|--check]}} {{[-D|--diff]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
