### PR TITLE
setfacl: fix incorrect shorthand argument for --remove-all

### DIFF
--- a/pages/linux/setfacl.md
+++ b/pages/linux/setfacl.md
@@ -17,4 +17,4 @@
 
 - Remove all ACL entries of a file:
 
-`setfacl {{[-X|--remove-all]}} {{path/to/file_or_directory}}`
+`setfacl {{[-b|--remove-all]}} {{path/to/file_or_directory}}`


### PR DESCRIPTION
The shorthand for --remove-all is -b, and not -X

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

setfacl 2.3.2
