### PR TITLE
ssh-keygen: provide hint for ssh-copy-id

### DIFF
--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -1,7 +1,7 @@
 # ssh-keygen
 
 > Generate SSH keys used for authentication, password-less logins, and other things.
-> See also: `tldr ssh-copy-id` for installing ssh keys on remote hosts.
+> See also: `ssh-copy-id` for installing SSH keys on remote hosts.
 > More information: <https://man.openbsd.org/ssh-keygen>.
 
 - Generate a key interactively:

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -1,7 +1,7 @@
 # ssh-keygen
 
 > Generate SSH keys used for authentication, password-less logins, and other things.
-> See `tldr ssh-copy-id` for installing ssh keys on remote hosts.
+> See also: `tldr ssh-copy-id` for installing ssh keys on remote hosts.
 > More information: <https://man.openbsd.org/ssh-keygen>.
 
 - Generate a key interactively:

--- a/pages/common/ssh-keygen.md
+++ b/pages/common/ssh-keygen.md
@@ -1,6 +1,7 @@
 # ssh-keygen
 
 > Generate SSH keys used for authentication, password-less logins, and other things.
+> See `tldr ssh-copy-id` for installing ssh keys on remote hosts.
 > More information: <https://man.openbsd.org/ssh-keygen>.
 
 - Generate a key interactively:


### PR DESCRIPTION
Users would mostly install ssh-keys into servers after generating them
using ssh-keygen. Provide hint for ssh-copy-id in the current page.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

Inspiration:
I used ssh-keygen to generate a key pair, and then I wanted to copy the public key. But i didn't know about ssh-copy-id, so after some fiddling around, i ultimately searched for it using the internet. I think it would be helpful to have a hint about ssh-copy-id in the ssh-keygen page, given that a common workflow is to generate a key pair and then copy the public key to a server.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
  OpenSSH_10.0p2, OpenSSL 3.5.0 8 Apr 2025
