### PR TITLE
rustfmt: add examples

### DIFF
--- a/pages/common/rustfmt.md
+++ b/pages/common/rustfmt.md
@@ -17,8 +17,8 @@
 
 - Format code using a specific Rust style edition (formatting rules) verbosely:
 
-`rustfmt --style-edition {{2015|2018|2021|2024}} {{[-v|--verbose]}} {{path/to/source.rs}}`
+`rustfmt --style-edition {{2015|2018|2021|2024}} {{[-v|--verbose]}} {{path/to/source1.rs path/to/source2.rs ...}}`
 
 - Format code using a specific Rust edition (language features and parsing):
 
-`rustfmt --edition {{2015|2018|2021|2024}} {{path/to/source.rs}}`
+`rustfmt --edition {{2015|2018|2021|2024}} {{path/to/source1.rs path/to/source2.rs ...}}`

--- a/pages/common/rustfmt.md
+++ b/pages/common/rustfmt.md
@@ -14,3 +14,11 @@
 - Backup any modified files before formatting (the original file is renamed with a `.bk` extension):
 
 `rustfmt --backup {{path/to/source.rs}}`
+
+- Format code using a specific Rust style edition (formatting rules) verbosely:
+
+`rustfmt --style-edition {{2015|2018|2021|2024}} {{[-v|--verbose]}} {{path/to/source.rs}}`
+
+- Format code using a specific Rust edition (language features and parsing):
+
+`rustfmt --edition {{2015|2018|2021|2024}} {{path/to/source.rs}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 1.8.0**
