### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/monthly-check.yml
+++ b/.github/workflows/monthly-check.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-usernames:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr/security/code-scanning/2](https://github.com/tldr-pages/tldr/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for accessing repository files.
- `issues: write` for creating and updating issues.
- `pull-requests: read` for reading pull request data (if applicable).
- `actions: read` for interacting with GitHub Actions artifacts (if needed).

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
