### PR TITLE
mktemp: document dry-run flag

### DIFF
--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -29,4 +29,4 @@
 
 - Print the name of a temporary file or directory without actually creating it:
 
-`mktemp {{--dry-run}}`
+`mktemp --dry-run`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -29,4 +29,4 @@
 
 - Print the name of a temporary file or directory without actually creating it:
 
-`mktemp --dry-run`
+`mktemp {{[-u|--dry-run]}}`

--- a/pages/linux/mktemp.md
+++ b/pages/linux/mktemp.md
@@ -26,3 +26,7 @@
 - Create an empty temporary directory and print its absolute path:
 
 `mktemp {{[-d|--directory]}}`
+
+- Print the name of a temporary file or directory without actually creating it:
+
+`mktemp {{--dry-run}}`


### PR DESCRIPTION
I wanted to use a similar feature where i wanted to create a temporary filename but not create the file yet. After a bit of searching, i realised `mktemp` had that built-in functionality. So, i thought it would be a good idea to add this as an example to the `mktemp` page.

Translations required.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
  mktemp (GNU coreutils) 9.7
  Copyright (C) 2025 Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
  This is free software: you are free to change and redistribute it.
  There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering and Eric Blake.
