### PR TITLE
intercept, mux, udevmon, uinput: prune info link

### DIFF
--- a/pages/linux/intercept.md
+++ b/pages/linux/intercept.md
@@ -1,7 +1,7 @@
 # intercept
 
 > Read raw input events from a specified input event device and redirect it to stdout.
-> More information: <https://gitlab.com/interception/linux/tools/-/tree/master?ref_type=heads#intercept>.
+> More information: <https://gitlab.com/interception/linux/tools/-/tree/master#intercept>.
 
 - Read and output raw input events from a given input device file (the system will not see any key presses):
 

--- a/pages/linux/mux.md
+++ b/pages/linux/mux.md
@@ -1,7 +1,7 @@
 # mux
 
 > Intercept and multiplex streams of input events.
-> More information: <https://gitlab.com/interception/linux/tools/-/tree/master?ref_type=heads#mux>.
+> More information: <https://gitlab.com/interception/linux/tools/-/tree/master#mux>.
 
 - Create a new muxer with a specified name:
 

--- a/pages/linux/udevmon.md
+++ b/pages/linux/udevmon.md
@@ -2,7 +2,7 @@
 
 > Intercept and monitor input devices for launching tasks.
 > Filters or modifies events according to configuration file(s) (default: `/etc/interception/udevmon.d/*.yaml`).
-> More information: <https://gitlab.com/interception/linux/tools/-/tree/master?ref_type=heads#udevmon>.
+> More information: <https://gitlab.com/interception/linux/tools/-/tree/master#udevmon>.
 
 - Start udevmon with specified configuration file:
 

--- a/pages/linux/uinput.md
+++ b/pages/linux/uinput.md
@@ -1,7 +1,7 @@
 # uinput
 
 > Intercept and write input events to a virtual keyboard device using /dev/uinput.
-> More information: <https://gitlab.com/interception/linux/tools/-/tree/master?ref_type=heads#uinput>.
+> More information: <https://gitlab.com/interception/linux/tools/-/tree/master#uinput>.
 
 - Show resulting YAML device description merge and exit (dry-run):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
