### PR TITLE
style(aspell): remove equals signs in --lang and --personal options

### DIFF
--- a/pages/common/aspell.md
+++ b/pages/common/aspell.md
@@ -17,8 +17,8 @@
 
 - Run `aspell` with a different language (takes two-letter ISO 639 language code):
 
-`aspell --lang={{cs}}`
+`aspell --lang {{cs}}`
 
 - List misspelled words from `stdin` and ignore words from personal word list:
 
-`cat {{path/to/file}} | aspell --personal={{personal-word-list.pws}} list`
+`cat {{path/to/file}} | aspell --personal {{personal-word-list.pws}} list`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** aspell 0.60.8.1
