### PR TITLE
p7zip: fix typo for --keep flag

### DIFF
--- a/pages/common/p7zip.md
+++ b/pages/common/p7zip.md
@@ -10,7 +10,7 @@
 
 - Archive a file keeping the input file:
 
-`p7zip {{[-k|--heep]}} {{path/to/file}}`
+`p7zip {{[-k|--keep]}} {{path/to/file}}`
 
 - Decompress a file, replacing it with the original uncompressed version:
 
@@ -18,7 +18,7 @@
 
 - Decompress a file keeping the input file:
 
-`p7zip {{[-d|--decompress]}} {{[-k|--heep]}} {{compressed.ext}}.7z`
+`p7zip {{[-d|--decompress]}} {{[-k|--keep]}} {{compressed.ext}}.7z`
 
 - Skip some checks and force compression or decompression:
 


### PR DESCRIPTION
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

- **Version of the command being documented (if known):**

![image](https://github.com/user-attachments/assets/203b3e43-412f-445a-ae93-6c0bdf01b3aa)

Relevant issue: #16856 