### PR TITLE
prowler, prowler-{aws,azure,gcp,kubernetes,m365,github}: add pages

### DIFF
--- a/pages/common/prowler-aws.md
+++ b/pages/common/prowler-aws.md
@@ -1,0 +1,29 @@
+# prowler aws
+
+> Run Prowler to assess AWS security best practices, perform audits, compliance checks, and generate reports.
+> See also: `prowler`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run the default set of checks on the AWS account:
+
+`prowler aws`
+
+- Use a custom AWS profile and filter audited regions:
+
+`prowler aws --profile {{custom-profile}} --filter-region {{us-east-1}} {{eu-south-2}}`
+
+- Show verbose debug output:
+
+`prowler aws -D`
+
+- Run checks for selected AWS services:
+
+`prowler aws {{[-s|--services]}} {{s3}} {{ec2}}`
+
+- Run a specific AWS check:
+
+`prowler aws {{[-c|--checks]}} {{s3_bucket_public_access}}`
+
+- Exclude specific checks or services:
+
+`prowler aws {{[-e|--excluded-checks]}} {{s3_bucket_public_access}} --exclude-services {{s3}} {{ec2}}`

--- a/pages/common/prowler-aws.md
+++ b/pages/common/prowler-aws.md
@@ -1,6 +1,6 @@
 # prowler aws
 
-> Run Prowler to assess AWS security best practices, perform audits, compliance checks, and generate reports.
+> Assess AWS security best practices, perform audits, compliance checks, and generate reports.
 > See also: `prowler`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -10,15 +10,11 @@
 
 - Use a custom AWS profile and filter audited regions:
 
-`prowler aws --profile {{custom-profile}} --filter-region {{us-east-1}} {{eu-south-2}}`
-
-- Show verbose debug output:
-
-`prowler aws -D`
+`prowler aws {{[-p|--profile]}} {{custom-profile}} {{[-f|--filter-region]}} {{us-east-1 eu-south-2 ...}}`
 
 - Run checks for selected AWS services:
 
-`prowler aws {{[-s|--services]}} {{s3}} {{ec2}}`
+`prowler aws {{[-s|--services]}} {{s3 ec2 ...}}`
 
 - Run a specific AWS check:
 
@@ -26,4 +22,4 @@
 
 - Exclude specific checks or services:
 
-`prowler aws {{[-e|--excluded-checks]}} {{s3_bucket_public_access}} --exclude-services {{s3}} {{ec2}}`
+`prowler aws {{[-e|--excluded-checks]}} {{s3_bucket_public_access}} --exclude-services {{s3 ec2 ...}}`

--- a/pages/common/prowler-azure.md
+++ b/pages/common/prowler-azure.md
@@ -1,0 +1,37 @@
+# prowler azure
+
+> Run Prowler to assess Azure security best practices, perform audits, compliance checks, and generate reports.
+> See also: `prowler`, `prowler-aws`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run the default set of checks on the current Azure account using Azure CLI authentication:
+
+`prowler azure --az-cli-auth`
+
+- Run checks for specific Azure subscriptions:
+
+`prowler azure --az-cli-auth --subscription-ids {{subscription_id1}} {{subscription_id2}}`
+
+- Authenticate using a service principal via environment variables:
+
+`prowler azure --sp-env-auth`
+
+- Authenticate using browser login and specify a tenant ID:
+
+`prowler azure --browser-auth --tenant-id {{"XXXXXXXX"}}`
+
+- Authenticate using a managed identity (e.g. for Azure VM):
+
+`prowler azure --managed-identity-auth`
+
+- Run checks for selected Azure services:
+
+`prowler azure {{[-s|--services]}} {{defender}} {{iam}}`
+
+- Run a specific Azure check:
+
+`prowler azure {{[-c|--checks]}} {{storage_blob_public_access_level_is_disabled}}`
+
+- Exclude specific checks or services:
+
+`prowler azure {{[-e|--excluded-checks]}} {{storage_blob_public_access_level_is_disabled}} --exclude-services {{defender}} {{iam}}`

--- a/pages/common/prowler-azure.md
+++ b/pages/common/prowler-azure.md
@@ -1,6 +1,6 @@
 # prowler azure
 
-> Run Prowler to assess Azure security best practices, perform audits, compliance checks, and generate reports.
+> Assess Azure security best practices, perform audits, compliance checks, and generate reports.
 > See also: `prowler`, `prowler-aws`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -10,7 +10,7 @@
 
 - Run checks for specific Azure subscriptions:
 
-`prowler azure --az-cli-auth --subscription-ids {{subscription_id1}} {{subscription_id2}}`
+`prowler azure --az-cli-auth --subscription-ids {{subscription_id1 subscription_id2 ...}}`
 
 - Authenticate using a service principal via environment variables:
 
@@ -18,7 +18,7 @@
 
 - Authenticate using browser login and specify a tenant ID:
 
-`prowler azure --browser-auth --tenant-id {{"XXXXXXXX"}}`
+`prowler azure --browser-auth --tenant-id "{{XXXXXXXX}}"`
 
 - Authenticate using a managed identity (e.g. for Azure VM):
 
@@ -26,7 +26,7 @@
 
 - Run checks for selected Azure services:
 
-`prowler azure {{[-s|--services]}} {{defender}} {{iam}}`
+`prowler azure {{[-s|--services]}} {{defender iam ...}}`
 
 - Run a specific Azure check:
 
@@ -34,4 +34,4 @@
 
 - Exclude specific checks or services:
 
-`prowler azure {{[-e|--excluded-checks]}} {{storage_blob_public_access_level_is_disabled}} --exclude-services {{defender}} {{iam}}`
+`prowler azure {{[-e|--excluded-checks]}} {{storage_blob_public_access_level_is_disabled}} --exclude-services {{defender iam ...}}`

--- a/pages/common/prowler-gcp.md
+++ b/pages/common/prowler-gcp.md
@@ -1,6 +1,6 @@
 # prowler gcp
 
-> Run Prowler to assess Google Cloud Platform (GCP) security best practices, audits, and compliance checks.
+> Assess Google Cloud Platform (GCP) security best practices, audits, and compliance checks.
 > See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -10,15 +10,15 @@
 
 - Authenticate using a service account credentials file:
 
-`prowler gcp --credentials-file {{/path/to/credentials.json}}`
+`prowler gcp --credentials-file {{path/to/credentials.json}}`
 
 - Scan specific GCP projects by ID:
 
-`prowler gcp --project-ids {{project_id1}} {{project_id2}}`
+`prowler gcp --project-ids {{project_id1 project_id2 ...}}`
 
 - Run checks for selected GCP services:
 
-`prowler gcp {{[-s|--services]}} {{iam}} {{compute}}`
+`prowler gcp {{[-s|--services]}} {{iam compute ...}}`
 
 - Run a specific GCP check:
 
@@ -26,4 +26,4 @@
 
 - Exclude specific checks or services:
 
-`prowler gcp {{[-e|--excluded-checks]}} {{gcp_storage_bucket_logging_enabled}} --exclude-services {{iam}} {{compute}}`
+`prowler gcp {{[-e|--excluded-checks]}} {{gcp_storage_bucket_logging_enabled}} --exclude-services {{iam compute ...}}`

--- a/pages/common/prowler-gcp.md
+++ b/pages/common/prowler-gcp.md
@@ -1,0 +1,29 @@
+# prowler gcp
+
+> Run Prowler to assess Google Cloud Platform (GCP) security best practices, audits, and compliance checks.
+> See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run the default set of checks on all accessible GCP projects using default user credentials:
+
+`prowler gcp`
+
+- Authenticate using a service account credentials file:
+
+`prowler gcp --credentials-file {{/path/to/credentials.json}}`
+
+- Scan specific GCP projects by ID:
+
+`prowler gcp --project-ids {{project_id1}} {{project_id2}}`
+
+- Run checks for selected GCP services:
+
+`prowler gcp {{[-s|--services]}} {{iam}} {{compute}}`
+
+- Run a specific GCP check:
+
+`prowler gcp {{[-c|--checks]}} {{gcp_storage_bucket_logging_enabled}}`
+
+- Exclude specific checks or services:
+
+`prowler gcp {{[-e|--excluded-checks]}} {{gcp_storage_bucket_logging_enabled}} --exclude-services {{iam}} {{compute}}`

--- a/pages/common/prowler-github.md
+++ b/pages/common/prowler-github.md
@@ -1,6 +1,6 @@
 # prowler github
 
-> Run Prowler to assess GitHub account, repository, and organization security best practices.
+> Assess GitHub account, repository, and organization security best practices.
 > See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 

--- a/pages/common/prowler-github.md
+++ b/pages/common/prowler-github.md
@@ -1,0 +1,21 @@
+# prowler github
+
+> Run Prowler to assess GitHub account, repository, and organization security best practices.
+> See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run all default GitHub security checks:
+
+`prowler github`
+
+- Authenticate using a GitHub Personal Access Token:
+
+`prowler github --personal-access-token {{pat}}`
+
+- Authenticate using a GitHub OAuth App Token:
+
+`prowler github --oauth-app-token {{oauth_token}}`
+
+- Authenticate using a GitHub App ID and private key:
+
+`prowler github --github-app-id {{app_id}} --github-app-key {{app_key}}`

--- a/pages/common/prowler-kubernetes.md
+++ b/pages/common/prowler-kubernetes.md
@@ -1,0 +1,33 @@
+# prowler kubernetes
+
+> Run Prowler to assess Kubernetes cluster security best practices and configurations.
+> See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-m365`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run the default checks using the default KubeConfig location:
+
+`prowler kubernetes`
+
+- Specify a custom KubeConfig file for scanning:
+
+`prowler kubernetes --kubeconfig-file {{/path/to/kubeconfig}}`
+
+- Specify a specific Kubernetes context to scan:
+
+`prowler kubernetes --context {{my-context}}`
+
+- Scan specific namespaces only:
+
+`prowler kubernetes --namespaces {{default}} {{kube-system}}`
+
+- Run checks for selected Kubernetes services:
+
+`prowler kubernetes {{[-s|--services]}} {{ietcd}} {{apiserver}}`
+
+- Run a specific Kubernetes check:
+
+`prowler kubernetes {{[-c|--checks]}} {{etcd_encryption}}`
+
+- Exclude specific checks or services:
+
+`prowler kubernetes {{[-e|--excluded-checks]}} {{etcd_encryption}} --exclude-services {{ietcd}} {{apiserver}}`

--- a/pages/common/prowler-kubernetes.md
+++ b/pages/common/prowler-kubernetes.md
@@ -1,6 +1,6 @@
 # prowler kubernetes
 
-> Run Prowler to assess Kubernetes cluster security best practices and configurations.
+> Assess Kubernetes cluster security best practices and configurations.
 > See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -10,7 +10,7 @@
 
 - Specify a custom KubeConfig file for scanning:
 
-`prowler kubernetes --kubeconfig-file {{/path/to/kubeconfig}}`
+`prowler kubernetes --kubeconfig-file {{path/to/kubeconfig}}`
 
 - Specify a specific Kubernetes context to scan:
 
@@ -22,7 +22,7 @@
 
 - Run checks for selected Kubernetes services:
 
-`prowler kubernetes {{[-s|--services]}} {{ietcd}} {{apiserver}}`
+`prowler kubernetes {{[-s|--services]}} {{ietcd apiserver ...}}`
 
 - Run a specific Kubernetes check:
 
@@ -30,4 +30,4 @@
 
 - Exclude specific checks or services:
 
-`prowler kubernetes {{[-e|--excluded-checks]}} {{etcd_encryption}} --exclude-services {{ietcd}} {{apiserver}}`
+`prowler kubernetes {{[-e|--excluded-checks]}} {{etcd_encryption}} --exclude-services {{ietcd apiserver ...}}`

--- a/pages/common/prowler-kubernetes.md
+++ b/pages/common/prowler-kubernetes.md
@@ -4,11 +4,11 @@
 > See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
-- Run the default checks using the default KubeConfig location:
+- Run the default checks using the default kubeconfig location:
 
 `prowler kubernetes`
 
-- Specify a custom KubeConfig file for scanning:
+- Specify a custom kubeconfig file for scanning:
 
 `prowler kubernetes --kubeconfig-file {{path/to/kubeconfig}}`
 

--- a/pages/common/prowler-m365.md
+++ b/pages/common/prowler-m365.md
@@ -1,0 +1,29 @@
+# prowler m365
+
+> Run Prowler to assess Microsoft 365 (M365) security configurations and best practices.
+> See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Run Prowler with combined service principal and user credentials:
+
+`prowler m365 --env-auth`
+
+- Authenticate using a service principal:
+
+`prowler m365 --sp-env-auth`
+
+- Authenticate using the Azure CLI:
+
+`prowler m365 --az-cli-auth`
+
+- Authenticate using a browser and specify the tenant ID:
+
+`prowler m365 --browser-auth --tenant-id {{"XXXXXXXX"}}`
+
+- Run a specific Microsoft 365 check:
+
+`prowler m365 {{[-c|--checks]}} {{etcd_enm365_onedrive_sharing_enabledcryption}}`
+
+- Exclude specific checks:
+
+`prowler m365 {{[-e|--excluded-checks]}} {{m365_onedrive_sharing_enabled}}`

--- a/pages/common/prowler-m365.md
+++ b/pages/common/prowler-m365.md
@@ -1,6 +1,6 @@
 # prowler m365
 
-> Run Prowler to assess Microsoft 365 (M365) security configurations and best practices.
+> Assess Microsoft 365 (M365) security configurations and best practices.
 > See also: `prowler`, `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -18,7 +18,7 @@
 
 - Authenticate using a browser and specify the tenant ID:
 
-`prowler m365 --browser-auth --tenant-id {{"XXXXXXXX"}}`
+`prowler m365 --browser-auth --tenant-id "{{XXXXXXXX}}"`
 
 - Run a specific Microsoft 365 check:
 

--- a/pages/common/prowler.md
+++ b/pages/common/prowler.md
@@ -1,29 +1,29 @@
 # prowler
 
-> Prowler is a security tool to perform security best practices assessments, audits and compliance checks across AWS, Azure, Google Cloud, and Kubernetes.
+> A security tool to perform security best practices assessments, audits and compliance checks across AWS, Azure, Google Cloud, and Kubernetes.
 > See also: `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
-- Show help for the `prowler` command:
-
-`prowler --help`
-
-- Show the [v]ersion of Prowler:
-
-`prowler -v`
-
 - Run an AWS, Azure, GCP, Kubernetes - as provider - audit with default checks:
 
-`prowler {{<provider>}}`
+`prowler {{provider}}`
 
 - Show all available checks for a specific provider:
 
-`prowler {{<provider>}} {{[-l|--list-checks]}}`
+`prowler {{provider}} {{[-l|--list-checks]}}`
 
 - Show all available services for a specific provider:
 
-`prowler {{<provider>}} --list-services`
+`prowler {{provider}} --list-services`
 
 - Generate output in multiple formats, including JSON-ASFF for AWS Security Hub:
 
-`prowler {{<provider>}} --output-modes {{csv}} {{json-asff}} {{html}}`
+`prowler {{provider}} --output-modes {{csv,json-asff,html,...}}`
+
+- Display help:
+
+`prowler --help`
+
+- Display version:
+
+`prowler -v`

--- a/pages/common/prowler.md
+++ b/pages/common/prowler.md
@@ -1,6 +1,6 @@
 # prowler
 
-> A security tool to perform security best practices assessments, audits and compliance checks across AWS, Azure, Google Cloud, and Kubernetes.
+> Performs security best practices assessments, audits and compliance checks across AWS, Azure, Google Cloud, and Kubernetes.
 > See also: `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
 > More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
 
@@ -20,10 +20,18 @@
 
 `prowler {{provider}} --output-modes {{csv,json-asff,html,...}}`
 
+- Execute in verbose mode:
+
+`prowler {{provider}} --verbose`
+
+- Filter findings by status:
+
+`prowler {{provider}} --status {{PASS,FAIL,MANUAL}}`
+
 - Display help:
 
 `prowler --help`
 
 - Display version:
 
-`prowler -v`
+`prowler {{[-v|--version]}}`

--- a/pages/common/prowler.md
+++ b/pages/common/prowler.md
@@ -1,0 +1,29 @@
+# prowler
+
+> Prowler is a security tool to perform security best practices assessments, audits and compliance checks across AWS, Azure, Google Cloud, and Kubernetes.
+> See also: `prowler-aws`, `prowler-azure`, `prowler-gcp`, `prowler-kubernetes`, `prowler-m365`, `prowler-github`.
+> More information: <https://docs.prowler.com/projects/prowler-open-source/en/latest/>.
+
+- Show help for the `prowler` command:
+
+`prowler --help`
+
+- Show the [v]ersion of Prowler:
+
+`prowler -v`
+
+- Run an AWS, Azure, GCP, Kubernetes - as provider - audit with default checks:
+
+`prowler {{<provider>}}`
+
+- Show all available checks for a specific provider:
+
+`prowler {{<provider>}} {{[-l|--list-checks]}}`
+
+- Show all available services for a specific provider:
+
+`prowler {{<provider>}} --list-services`
+
+- Generate output in multiple formats, including JSON-ASFF for AWS Security Hub:
+
+`prowler {{<provider>}} --output-modes {{csv}} {{json-asff}} {{html}}`


### PR DESCRIPTION
Added a new main page for prowler, a cloud security assessment tool, as well as subcommand pages for the following providers:

- prowler-aws
- prowler-azure
- prowler-gcp
- prowler-kubernetes
- prowler-m365
- prowler-github

Issue: #13453 