### PR TITLE
docs: update obsolete --cycle-once flag in feh example

### DIFF
--- a/pages/common/feh.md
+++ b/pages/common/feh.md
@@ -15,9 +15,9 @@
 
 `feh --borderless {{path/to/images}}`
 
-- Exit after the last image:
+- Set the behavior when reaching the beginnig or end of the image list:
 
-`feh --cycle-once {{path/to/images}}`
+`feh --on-last-slide {{hold|quit|resume}} {{path/to/images}}`
 
 - Use a specific slideshow cycle delay:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
