### PR TITLE
msedge: remove '=' from long options

### DIFF
--- a/pages/windows/msedge.md
+++ b/pages/windows/msedge.md
@@ -19,19 +19,19 @@
 
 - Open in application mode (without toolbars, URL bar, buttons, etc.):
 
-`msedge --app={{https://example.com}}`
+`msedge --app {{https://example.com}}`
 
 - Use a proxy server:
 
-`msedge --proxy-server="{{socks5://hostname:66}}" {{example.com}}`
+`msedge --proxy-server "{{socks5://hostname:66}}" {{example.com}}`
 
 - Open with a custom profile directory:
 
-`msedge --user-data-dir={{path/to/directory}}`
+`msedge --user-data-dir {{path/to/directory}}`
 
 - Open without CORS validation (useful to test an API):
 
-`msedge --user-data-dir={{path/to/directory}} --disable-web-security`
+`msedge --user-data-dir {{path/to/directory}} --disable-web-security`
 
 - Open with a DevTools window for each tab opened:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
