### PR TITLE
bluetoothctl: fix documentation link

### DIFF
--- a/pages.hi/linux/bluetoothctl.md
+++ b/pages.hi/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > ब्लूटूथ उपकरणों का प्रबंधन करें।
-> अधिक जानकारी: <https://bitbucket.org/serkanp/bluetoothctl>।
+> अधिक जानकारी: <https://manned.org/bluetoothctl>।
 
 - `bluetoothctl` शैल में प्रवेश करें:
 

--- a/pages.ko/linux/bluetoothctl.md
+++ b/pages.ko/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > 블루투스 장치를 관리합니다.
-> 더 많은 정보: <https://bitbucket.org/serkanp/bluetoothctl>.
+> 더 많은 정보: <https://manned.org/bluetoothctl>.
 
 - `bluetoothctl` 셸에 진입:
 

--- a/pages.ml/linux/bluetoothctl.md
+++ b/pages.ml/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > കമാൻഡ് ലൈനിൽ നിന്ന് ബ്ലൂടൂത്ത് ഉപകരണങ്ങൾ മാനേജുചെയ്യുക.
-> കൂടുതൽ വിവരങ്ങൾ: <https://bitbucket.org/serkanp/bluetoothctl>.
+> കൂടുതൽ വിവരങ്ങൾ: <https://manned.org/bluetoothctl>.
 
 - ബ്ലൂടൂത്ത്സിറ്റിഎൽ ഷെല്ലിൽ കേറാൻ:
 

--- a/pages.pt_BR/linux/bluetoothctl.md
+++ b/pages.pt_BR/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > Gerencia dispositivos Bluetooth a partir da linha de comando.
-> Mais informações: <https://bitbucket.org/serkanp/bluetoothctl>.
+> Mais informações: <https://manned.org/bluetoothctl>.
 
 - Inicia o shell `bluetoothctl`:
 

--- a/pages.zh/linux/bluetoothctl.md
+++ b/pages.zh/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > 从命令行管理蓝牙设备。
-> 更多信息：<https://bitbucket.org/serkanp/bluetoothctl>.
+> 更多信息：<https://manned.org/bluetoothctl>.
 
 - 进入 bluetoothctl 外壳程序：
 

--- a/pages/linux/bluetoothctl.md
+++ b/pages/linux/bluetoothctl.md
@@ -1,7 +1,7 @@
 # bluetoothctl
 
 > Manage Bluetooth devices.
-> More information: <https://bitbucket.org/serkanp/bluetoothctl>.
+> More information: <https://manned.org/bluetoothctl>.
 
 - Enter the `bluetoothctl` shell:
 


### PR DESCRIPTION
The old link points to some NodeJS library.