### PR TITLE
trufflehog: remove `=` from options

### DIFF
--- a/pages/common/trufflehog.md
+++ b/pages/common/trufflehog.md
@@ -9,7 +9,7 @@
 
 - Scan a GitHub organization for verified secrets:
 
-`trufflehog github --org={{trufflesecurity}} --only-verified`
+`trufflehog github --org {{trufflesecurity}} --only-verified`
 
 - Scan a GitHub repository for verified keys and get JSON output:
 
@@ -17,15 +17,15 @@
 
 - Scan a GitHub repository along with its Issues and Pull Requests:
 
-`trufflehog github --repo={{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
+`trufflehog github --repo {{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
 
 - Scan an S3 bucket for verified keys:
 
-`trufflehog s3 --bucket={{bucket name}} --only-verified`
+`trufflehog s3 --bucket {{bucket name}} --only-verified`
 
 - Scan S3 buckets using IAM Roles:
 
-`trufflehog s3 --role-arn={{iam-role-arn}}`
+`trufflehog s3 --role-arn {{iam-role-arn}}`
 
 - Scan individual files or directories:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
