### PR TITLE
nix-{why-depends, classoc, store}: use a more explicit package name instead of ellipsis

### DIFF
--- a/pages/common/nix-classic.md
+++ b/pages/common/nix-classic.md
@@ -19,7 +19,7 @@
 
 - Show all dependencies of a store path (package), in a tree format:
 
-`nix-store {{[-q|--query]}} --tree {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --tree /nix/store/{{checksum-package-version.ext}}`
 
 - Update the channels (repositories):
 

--- a/pages/common/nix-store.2.md
+++ b/pages/common/nix-store.2.md
@@ -14,16 +14,16 @@
 
 - Delete a specific store path (must be unused):
 
-`nix-store --delete {{/nix/store/...}}`
+`nix-store --delete /nix/store/{{checksum-package-version.ext}}`
 
 - Show all dependencies of a store path (package), in a tree format:
 
-`nix-store {{[-q|--query]}} --tree {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --tree /nix/store/{{checksum-package-version.ext}}`
 
 - Calculate the total size of a certain store path with all the dependencies:
 
-`du {{[-cLsh|--total --dereference --summarize --human-readable]}} $(nix-store {{[-q|--query]}} --references {{/nix/store/...}})`
+`du {{[-cLsh|--total --dereference --summarize --human-readable]}} $(nix-store {{[-q|--query]}} --references /nix/store/{{checksum-package-version.ext}})`
 
 - Show all dependents of a particular store path:
 
-`nix-store {{[-q|--query]}} --referrers {{/nix/store/...}}`
+`nix-store {{[-q|--query]}} --referrers /nix/store/{{checksum-package-version.ext}}`

--- a/pages/common/nix-store.3.md
+++ b/pages/common/nix-store.3.md
@@ -14,12 +14,12 @@
 
 - Delete a specific store path (most be unused):
 
-`nix store delete {{/nix/store/...}}`
+`nix store delete /nix/store/{{checksum-package-version.ext}}`
 
 - List a contents of the store path, on a remote store:
 
-`nix store --store {{https://cache.nixos.org}} ls {{/nix/store/...}}`
+`nix store --store {{https://cache.nixos.org}} ls /nix/store/{{checksum-package-version.ext}}`
 
 - Show the differences in versions between two store paths, with their respective dependencies:
 
-`nix store diff-closures {{/nix/store/...}} {{/nix/store/...}}`
+`nix store diff-closures /nix/store/{{checksum-package-version.ext}} /nix/store/{{checksum-package-version.ext}}`

--- a/pages/common/nix-why-depends.md
+++ b/pages/common/nix-why-depends.md
@@ -5,7 +5,7 @@
 
 - Show why the currently running NixOS system requires a certain store path:
 
-`nix why-depends {{/run/current-system}} {{/nix/store/...}}`
+`nix why-depends {{/run/current-system}} /nix/store/{{checksum-package-version.ext}}`
 
 - Show why a package from nixpkgs requires another package as a _build-time_ dependency:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
