### PR TITLE
pages*: replaced invocations of `cat` with shell redirection

### DIFF
--- a/pages/common/ajson.md
+++ b/pages/common/ajson.md
@@ -9,7 +9,7 @@
 
 - Read JSON from `stdin` and execute a specified JSONPath expression:
 
-`cat {{path/to/file.json}} | ajson '{{$..json[?(@.path)]}}'`
+`ajson '{{$..json[?(@.path)]}}' < {{path/to/file.json}}`
 
 - Read JSON from a URL and evaluate a specified JSONPath expression:
 

--- a/pages/common/argos-translate.md
+++ b/pages/common/argos-translate.md
@@ -13,7 +13,7 @@
 
 - Translate a text file from English to Hindi:
 
-`cat {{path/to/file.txt}} | argos-translate --from-lang en --to-lang hi`
+`argos-translate --from-lang en --to-lang hi < {{path/to/file.txt}}`
 
 - List all installed translation pairs:
 

--- a/pages/common/aspell.md
+++ b/pages/common/aspell.md
@@ -9,7 +9,7 @@
 
 - List misspelled words from `stdin`:
 
-`cat {{path/to/file}} | aspell list`
+`aspell list < {{path/to/file}}`
 
 - Show available dictionary languages:
 
@@ -21,4 +21,4 @@
 
 - List misspelled words from `stdin` and ignore words from personal word list:
 
-`cat {{path/to/file}} | aspell --personal {{personal-word-list.pws}} list`
+`aspell --personal {{personal-word-list.pws}} list < {{path/to/file}}`

--- a/pages/common/bzgrep.md
+++ b/pages/common/bzgrep.md
@@ -29,4 +29,4 @@
 
 - Search `stdin` for lines that do not match a pattern:
 
-`cat {{/path/to/bz/compressed/file}} | bzgrep {{[-v|--invert-match]}} "{{search_pattern}}"`
+`bzgrep {{[-v|--invert-match]}} "{{search_pattern}}" < {{/path/to/bz/compressed/file}}`

--- a/pages/common/cariddi.md
+++ b/pages/common/cariddi.md
@@ -5,23 +5,23 @@
 
 - Hunt for secrets using custom regexes and output results in JSON:
 
-`cat {{path/to/urls.txt}} | cariddi -s -sf {{path/to/custom_secrets.txt}} -json`
+`cariddi -s -sf {{path/to/custom_secrets.txt}} -json < {{path/to/urls.txt}}`
 
 - Hunt for juicy endpoints with high concurrency and timeout with plain output results:
 
-`cat {{path/to/urls.txt}} | cariddi -e -c {{250}} -t {{15}} -plain`
+`cariddi -e -c {{250}} -t {{15}} -plain < {{path/to/urls.txt}}`
 
 - Crawl with debug mode and store HTTP responses and output results in `txt` file:
 
-`cat {{path/to/urls.txt}} | cariddi -debug -sr -ot {{path/to/debug_output.txt}}`
+`cariddi -debug -sr -ot {{path/to/debug_output.txt}} < {{path/to/urls.txt}}`
 
 - Perform an intensive crawl with a proxy and random user agent and output results in `html` file:
 
-`cat {{path/to/urls.txt}} | cariddi -intensive -proxy {{http://127.0.0.1:8080}} -rua -oh {{path/to/intensive_crawl.html}}`
+`cariddi -intensive -proxy {{http://127.0.0.1:8080}} -rua -oh {{path/to/intensive_crawl.html}} < {{path/to/urls.txt}}`
 
 - Hunt for errors and useful information with a custom delay and use `.cariddi_cache` folder as cache:
 
-`cat {{path/to/urls.txt}} | cariddi -err -info -d {{3}} -cache`
+`cariddi -err -info -d {{3}} -cache < {{path/to/urls.txt}}`
 
 - Show example uses:
 

--- a/pages/common/comm.md
+++ b/pages/common/comm.md
@@ -13,7 +13,7 @@
 
 - Print only lines common to both files, reading one file from `stdin`:
 
-`cat {{file1}} | comm -12 - {{file2}}`
+`comm -12 - {{file2}} < {{file1}}`
 
 - Get lines only found in first file, saving the result to a third file:
 

--- a/pages/common/duckdb.md
+++ b/pages/common/duckdb.md
@@ -29,7 +29,7 @@
 
 - Read CSV from `stdin` and write CSV to `stdout`:
 
-`cat {{path/to/source.csv}} | duckdb -c "{{COPY (FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}"`
+`duckdb -c "{{COPY (FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)}}" < {{path/to/source.csv}}`
 
 - Start the DuckDB UI, a web interface with notebooks:
 

--- a/pages/common/egrep.md
+++ b/pages/common/egrep.md
@@ -13,7 +13,7 @@
 
 - Search `stdin` for a pattern:
 
-`cat {{path/to/file}} | egrep {{search_pattern}}`
+`egrep {{search_pattern}} < {{path/to/file}}`
 
 - Print file name and line number for each match:
 

--- a/pages/common/exo-iam.md
+++ b/pages/common/exo-iam.md
@@ -13,7 +13,7 @@
 
 - Create a new IAM role:
 
-`cat {{/path/to/policy.json}} | exo iam role create {{iam_role_name}} --editable --policy -`
+`exo iam role create {{iam_role_name}} --editable --policy - < {{/path/to/policy.json}}`
 
 - Show the policy of an existing IAM role:
 
@@ -21,4 +21,4 @@
 
 - Update the default Organization policy (the default Organization policy will be applied to all of the API keys within the Organization):
 
-`cat {{/path/to/policy.json}} | exo iam org-policy update -`
+`exo iam org-policy update - < {{/path/to/policy.json}}`

--- a/pages/common/git-hash-object.md
+++ b/pages/common/git-hash-object.md
@@ -17,4 +17,4 @@
 
 - Compute the object ID from `stdin`:
 
-`cat {{path/to/file}} | git hash-object --stdin`
+`git hash-object --stdin < {{path/to/file}}`

--- a/pages/common/git-stripspace.md
+++ b/pages/common/git-stripspace.md
@@ -5,11 +5,11 @@
 
 - Trim whitespace from a file:
 
-`cat {{path/to/file}} | git stripspace`
+`git stripspace < {{path/to/file}}`
 
 - Trim whitespace and Git comments from a file:
 
-`cat {{path/to/file}} | git stripspace {{[-s|--strip-comments]}}`
+`git stripspace {{[-s|--strip-comments]}} < {{path/to/file}}`
 
 - Convert all lines in a file into Git comments:
 

--- a/pages/common/gml2gv.md
+++ b/pages/common/gml2gv.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.gml}} | gml2gv > {{output.gv}}`
+`gml2gv > {{output.gv}} < {{input.gml}}`
 
 - Display help:
 

--- a/pages/common/graphml2gv.md
+++ b/pages/common/graphml2gv.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.gml}} | graphml2gv > {{output.gv}}`
+`graphml2gv > {{output.gv}} < {{input.gml}}`
 
 - Display help:
 

--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -33,4 +33,4 @@
 
 - Search `stdin` for lines that do not match a pattern:
 
-`cat {{path/to/file}} | grep {{[-v|--invert-match]}} "{{search_pattern}}"`
+`grep {{[-v|--invert-match]}} "{{search_pattern}}" < {{path/to/file}}`

--- a/pages/common/gunzip.md
+++ b/pages/common/gunzip.md
@@ -21,4 +21,4 @@
 
 - Decompress an archive from `stdin`:
 
-`cat {{path/to/archive.gz}} | gunzip`
+`gunzip < {{path/to/archive.gz}}`

--- a/pages/common/gv2gml.md
+++ b/pages/common/gv2gml.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.gv}} | gv2gml > {{output.gml}}`
+`gv2gml > {{output.gml}} < {{input.gv}}`
 
 - Display help:
 

--- a/pages/common/gv2gxl.md
+++ b/pages/common/gv2gxl.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.gv}} | gv2gxl > {{output.gxl}}`
+`gv2gxl > {{output.gxl}} < {{input.gv}}`
 
 - Display help:
 

--- a/pages/common/gxl2gv.md
+++ b/pages/common/gxl2gv.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.gxl}} | gxl2gv > {{output.gv}}`
+`gxl2gv > {{output.gv}} < {{input.gxl}}`
 
 - Display help:
 

--- a/pages/common/htmlq.md
+++ b/pages/common/htmlq.md
@@ -5,19 +5,19 @@
 
 - Return all elements of class `card`:
 
-`cat {{path/to/file.html}} | htmlq '.card'`
+`htmlq '.card' < {{path/to/file.html}}`
 
 - Get the text content of the first paragraph:
 
-`cat {{path/to/file.html}} | htmlq --text 'p:first-of-type'`
+`htmlq --text 'p:first-of-type' < {{path/to/file.html}}`
 
 - Find all the links in a page:
 
-`cat {{path/to/file.html}} | htmlq --attribute href 'a'`
+`htmlq --attribute href 'a' < {{path/to/file.html}}`
 
 - Remove all images and SVGs from a page:
 
-`cat {{path/to/file.html}} | htmlq --remove-nodes 'img' --remove-nodes 'svg'`
+`htmlq --remove-nodes 'img' --remove-nodes 'svg' < {{path/to/file.html}}`
 
 - Pretty print and write the output to a file:
 

--- a/pages/common/httprobe.md
+++ b/pages/common/httprobe.md
@@ -5,15 +5,15 @@
 
 - Probe a list of domains from a text file:
 
-`cat {{input_file}} | httprobe`
+`httprobe < {{input_file}}`
 
 - Only check for HTTP if HTTPS is not working:
 
-`cat {{input_file}} | httprobe --prefer-https`
+`httprobe --prefer-https < {{input_file}}`
 
 - Probe additional ports with a given protocol:
 
-`cat {{input_file}} | httprobe -p {{https:2222}}`
+`httprobe -p {{https:2222}} < {{input_file}}`
 
 - Display help:
 

--- a/pages/common/in2csv.md
+++ b/pages/common/in2csv.md
@@ -18,4 +18,4 @@
 
 - Pipe a JSON file to in2csv:
 
-`cat {{data.json}} | in2csv {{[-f|--format]}} json > {{data.csv}}`
+`in2csv {{[-f|--format]}} json > {{data.csv}} < {{data.json}}`

--- a/pages/common/jello.md
+++ b/pages/common/jello.md
@@ -5,28 +5,28 @@
 
 - Pretty-print JSON or JSON-Lines data from `stdin` to `stdout`:
 
-`cat {{file.json}} | jello`
+`jello < {{file.json}}`
 
 - Output a schema of JSON or JSON Lines data from `stdin` to `stdout` (useful for grep):
 
-`cat {{file.json}} | jello -s`
+`jello -s < {{file.json}}`
 
 - Output all elements from arrays (or all the values from objects) in JSON or JSON-Lines data from `stdin` to `stdout`:
 
-`cat {{file.json}} | jello -l`
+`jello -l < {{file.json}}`
 
 - Output the first element in JSON or JSON-Lines data from `stdin` to `stdout`:
 
-`cat {{file.json}} | jello _[0]`
+`jello _[0] < {{file.json}}`
 
 - Output the value of a given key of each element in JSON or JSON-Lines data from `stdin` to `stdout`:
 
-`cat {{file.json}} | jello '[i.{{key_name}} for i in _]'`
+`jello '[i.{{key_name}} for i in _]' < {{file.json}}`
 
 - Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name1` and `key_name2`):
 
-`cat {{file.json}} | jello '{"{{key1}}": _.{{key_name1}}, "{{key_name}}": _.{{key_name2}}}'`
+`jello '{"{{key1}}": _.{{key_name1}}, "{{key_name}}": _.{{key_name2}}}' < {{file.json}}`
 
 - Output the value of a given key to a string (and disable JSON output):
 
-`cat {{file.json}} | jello -r '"{{some text}}: " + _.{{key_name}}'`
+`jello -r '"{{some text}}: " + _.{{key_name}}' < {{file.json}}`

--- a/pages/common/join.md
+++ b/pages/common/join.md
@@ -21,4 +21,4 @@
 
 - Join a file from `stdin`:
 
-`cat {{path/to/file1}} | join - {{path/to/file2}}`
+`join - {{path/to/file2}} < {{path/to/file1}}`

--- a/pages/common/jtbl.md
+++ b/pages/common/jtbl.md
@@ -5,16 +5,16 @@
 
 - Print a table from JSON or JSON Lines input:
 
-`cat {{file.json}} | jtbl`
+`jtbl < {{file.json}}`
 
 - Print a table and specify the column width for wrapping:
 
-`cat {{file.json}} | jtbl --cols={{width}}`
+`jtbl --cols={{width}} < {{file.json}}`
 
 - Print a table and truncate rows instead of wrapping:
 
-`cat {{file.json}} | jtbl {{[-t|--truncate]}}`
+`jtbl {{[-t|--truncate]}} < {{file.json}}`
 
 - Print a table and don't wrap or truncate rows:
 
-`cat {{file.json}} | jtbl {{[-n|--no-wrap]}}`
+`jtbl {{[-n|--no-wrap]}} < {{file.json}}`

--- a/pages/common/kate.md
+++ b/pages/common/kate.md
@@ -25,7 +25,7 @@
 
 - Create a file from `stdin`:
 
-`cat {{path/to/file}} | kate {{[-i|--stdin]}}`
+`kate {{[-i|--stdin]}} < {{path/to/file}}`
 
 - Display help:
 

--- a/pages/common/keep-header.md
+++ b/pages/common/keep-header.md
@@ -13,7 +13,7 @@
 
 - Read from `stdin`, sorting all except the first line:
 
-`cat {{path/to/file}} | keep-header -- {{command}}`
+`keep-header -- {{command}} < {{path/to/file}}`
 
 - Grep a file, keeping the first line regardless of the search pattern:
 

--- a/pages/common/llm.md
+++ b/pages/common/llm.md
@@ -13,7 +13,7 @@
 
 - Run a system prompt against a file:
 
-`cat {{path/to/file.py}} | llm {{[-s|--system]}} "{{Explain this code}}"`
+`llm {{[-s|--system]}} "{{Explain this code}}" < {{path/to/file.py}}`
 
 - Install packages from PyPI into the same environment as LLM:
 

--- a/pages/common/llvm-as.md
+++ b/pages/common/llvm-as.md
@@ -13,4 +13,4 @@
 
 - Read an IR file from `stdin` and assemble it:
 
-`cat {{path/to/source.ll}} | llvm-as -o {{path/to/out.bc}}`
+`llvm-as -o {{path/to/out.bc}} < {{path/to/source.ll}}`

--- a/pages/common/llvm-bcanalyzer.md
+++ b/pages/common/llvm-bcanalyzer.md
@@ -13,4 +13,4 @@
 
 - Read a Bitcode file from `stdin` and analyze it:
 
-`cat {{path/to/file.bc}} | llvm-bcanalyzer`
+`llvm-bcanalyzer < {{path/to/file.bc}}`

--- a/pages/common/mm2gv.md
+++ b/pages/common/mm2gv.md
@@ -10,7 +10,7 @@
 
 - Convert a graph using `stdin` and `stdout`:
 
-`cat {{input.mm}} | mm2gv > {{output.gv}}`
+`mm2gv > {{output.gv}} < {{input.mm}}`
 
 - Display help:
 

--- a/pages/common/nms.md
+++ b/pages/common/nms.md
@@ -13,7 +13,7 @@
 
 - Decrypt the content of a file, with a custom output color:
 
-`cat {{path/to/file}} | nms -a -f {{blue|white|yellow|black|magenta|green|red}}`
+`nms -a -f {{blue|white|yellow|black|magenta|green|red}} < {{path/to/file}}`
 
 - Clear the screen before decrypting:
 

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -21,7 +21,7 @@
 
 - Break `stdin` into ~1M blocks, feed each block to `stdin` of new command:
 
-`cat {{big_file.txt}} | parallel --pipe --block 1M {{command}}`
+`parallel --pipe --block 1M {{command}} < {{big_file.txt}}`
 
 - Run on multiple machines via SSH:
 

--- a/pages/common/pngcheck.md
+++ b/pages/common/pngcheck.md
@@ -18,7 +18,7 @@
 
 - Receive an image from `stdin` and display detailed information:
 
-`cat {{path/to/image.png}} | pngcheck -cvt`
+`pngcheck -cvt < {{path/to/image.png}}`
 
 - [s]earch for PNGs within a specific file and display information about them:
 

--- a/pages/common/pulumi-config.md
+++ b/pages/common/pulumi-config.md
@@ -21,7 +21,7 @@
 
 - Set a value for a configuration key from a file:
 
-`cat {{path/to/file}} | pulumi config set {{key}}`
+`pulumi config set {{key}} < {{path/to/file}}`
 
 - Set a secret value (e.g. API key) for a configuration key and store/display as ciphertext:
 

--- a/pages/common/pup.md
+++ b/pages/common/pup.md
@@ -5,24 +5,24 @@
 
 - Transform a raw HTML file into a cleaned, indented, and colored format:
 
-`cat {{index.html}} | pup --color`
+`pup --color < {{index.html}}`
 
 - Filter HTML by element tag name:
 
-`cat {{index.html}} | pup '{{tag}}'`
+`pup '{{tag}}' < {{index.html}}`
 
 - Filter HTML by ID:
 
-`cat {{index.html}} | pup '{{div#id}}'`
+`pup '{{div#id}}' < {{index.html}}`
 
 - Filter HTML by attribute value:
 
-`cat {{index.html}} | pup '{{input[type="text"]}}'`
+`pup '{{input[type="text"]}}' < {{index.html}}`
 
 - Print all text from the filtered HTML elements and their children:
 
-`cat {{index.html}} | pup '{{div}} text{}'`
+`pup '{{div}} text{}' < {{index.html}}`
 
 - Print HTML as JSON:
 
-`cat {{index.html}} | pup '{{div}} json{}'`
+`pup '{{div}} json{}' < {{index.html}}`

--- a/pages/common/sponge.md
+++ b/pages/common/sponge.md
@@ -5,7 +5,7 @@
 
 - Append file content to the source file:
 
-`cat {{path/to/file}} | sponge -a {{path/to/file}}`
+`sponge -a {{path/to/file}} < {{path/to/file}}`
 
 - Remove all lines starting with # in a file:
 

--- a/pages/common/tex-fmt.md
+++ b/pages/common/tex-fmt.md
@@ -13,4 +13,4 @@
 
 - Format a file read from `stdin` and print to `stdout`:
 
-`cat {{path/to/file.tex}} | tex-fmt --stdin`
+`tex-fmt --stdin < {{path/to/file.tex}}`

--- a/pages/common/textql.md
+++ b/pages/common/textql.md
@@ -17,7 +17,7 @@
 
 - Read data from `stdin`:
 
-`cat {{path/to/file}} | textql -sql "{{SELECT * FROM stdin}}"`
+`textql -sql "{{SELECT * FROM stdin}}" < {{path/to/file}}`
 
 - Join two files on a specified common column:
 

--- a/pages/common/tlmgr-key.md
+++ b/pages/common/tlmgr-key.md
@@ -13,7 +13,7 @@
 
 - Add a key from `stdin`:
 
-`cat {{path/to/key.gpg}} | sudo tlmgr key add -`
+`sudo tlmgr key add - < {{path/to/key.gpg}}`
 
 - Remove a specific key by its ID:
 

--- a/pages/common/ts.md
+++ b/pages/common/ts.md
@@ -17,4 +17,4 @@
 
 - Convert existing timestamps in a text file (eg. a log file) into [r]elative format:
 
-`cat {{path/to/file}} | ts -r`
+`ts -r < {{path/to/file}}`

--- a/pages/common/vale.md
+++ b/pages/common/vale.md
@@ -21,7 +21,7 @@
 
 - Check the style from `stdin`, specifying markup format:
 
-`cat {{file.md}} | vale --ext=.md`
+`vale --ext=.md < {{file.md}}`
 
 - List the current configuration:
 

--- a/pages/common/xml-depyx.md
+++ b/pages/common/xml-depyx.md
@@ -9,7 +9,7 @@
 
 - Convert a PYX document from `stdin` to XML format:
 
-`cat {{path/to/input.pyx}} | xml {{[p2x|depyx]}} > {{path/to/output.xml}}`
+`xml {{[p2x|depyx]}} > {{path/to/output.xml}} < {{path/to/input.pyx}}`
 
 - Display help:
 

--- a/pages/common/xml-format.md
+++ b/pages/common/xml-format.md
@@ -17,7 +17,7 @@
 
 - Format an XML document from `stdin`, removing the `DOCTYPE` declaration:
 
-`cat {{path\to\input.xml}} | xml {{[fo|format]}} {{[-D|--dropdtd]}} > {{path/to/output.xml}}`
+`xml {{[fo|format]}} {{[-D|--dropdtd]}} > {{path/to/output.xml}} < {{path\to\input.xml}}`
 
 - Format an XML document, omitting the XML declaration:
 

--- a/pages/common/xml-pyx.md
+++ b/pages/common/xml-pyx.md
@@ -9,7 +9,7 @@
 
 - Convert an XML document from `stdin` to PYX format:
 
-`cat {{path/to/input.xml}} | xml pyx > {{path/to/output.pyx}}`
+`xml pyx > {{path/to/output.pyx}} < {{path/to/input.xml}}`
 
 - Display help:
 

--- a/pages/common/zek.md
+++ b/pages/common/zek.md
@@ -5,7 +5,7 @@
 
 - Generate a Go struct from a given XML from `stdin` and display output on `stdout`:
 
-`cat {{path/to/input.xml}} | zek`
+`zek < {{path/to/input.xml}}`
 
 - Generate a Go struct from a given XML from `stdin` and send output to a file:
 
@@ -13,4 +13,4 @@
 
 - Generate an example Go program from a given XML from `stdin` and send output to a file:
 
-`cat {{path/to/input.xml}} | zek -p -o {{path/to/output.go}}`
+`zek -p -o {{path/to/output.go}} < {{path/to/input.xml}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

In general, there's no need to pipe the output of `cat` into another command just to operate on the contents of a file. A shell redirection serves that exact purpose and does not include the overhead of spawning a new process. Given the fact that one of the goals of `tldr` is to ease new users into the world of the command-line, it is best not to instill bad practices on new users.