### PR TITLE
common/*: use "configuration" instead of "config"

### DIFF
--- a/pages/common/bitcoind.md
+++ b/pages/common/bitcoind.md
@@ -16,6 +16,6 @@
 
 `bitcoind -chain={{main|test|signet|regtest}}`
 
-- Start the Bitcoin Core daemon using specific config file and data directory:
+- Start the Bitcoin Core daemon using specific configuration file and data directory:
 
 `bitcoind -conf={{path/to/bitcoin.conf}} -datadir={{path/to/directory}}`

--- a/pages/common/bpython.md
+++ b/pages/common/bpython.md
@@ -16,6 +16,6 @@
 
 `bpython {{[-i|--interactive]}} {{path/to/file.py}}`
 
-- Use the specified config file instead of the default config:
+- Use the specified configuration file instead of the default configuration:
 
 `bpython --config {{path/to/file.conf}}`

--- a/pages/common/crane-index-append.md
+++ b/pages/common/crane-index-append.md
@@ -2,7 +2,7 @@
 
 > Append manifest to a remote index.
 > This sub-command pushes an index based on an (optional) base index, with appended manifests.
-> The platform for appended manifests is inferred from the config file or omitted if that is infeasible.
+> The platform for appended manifests is inferred from the configuration file or omitted if that is infeasible.
 > More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_index_append.md>.
 
 - Append manifest to a remote index:

--- a/pages/common/doppler.md
+++ b/pages/common/doppler.md
@@ -8,7 +8,7 @@
 
 `doppler setup`
 
-- Setup Doppler project and config in current directory:
+- Setup Doppler project and configuration in current directory:
 
 `doppler setup`
 

--- a/pages/common/flexget.md
+++ b/pages/common/flexget.md
@@ -15,6 +15,6 @@
 
 `flexget series list`
 
-- Run a task from a config file:
+- Run a task from a configuration file:
 
 `flexget -c {{path/to/config.yml}} execute --task {{task_name}}`

--- a/pages/common/frps.md
+++ b/pages/common/frps.md
@@ -12,7 +12,7 @@
 
 `frps {{[-c|--config]}} ./frps.toml`
 
-- Start the service, using a specified config file:
+- Start the service, using a specified configuration file:
 
 `frps {{[-c|--config]}} {{path/to/file}}`
 

--- a/pages/common/immich-go.md
+++ b/pages/common/immich-go.md
@@ -12,7 +12,7 @@
 
 `immich-go -server={{server_url}} -key={{server_key}} upload -create-albums -google-photos -date={{2019-06}} {{path/to/takeout_file.zip}}`
 
-- Upload a takeout file using server and key from a config file:
+- Upload a takeout file using server and key from a configuration file:
 
 `immich-go -use-configuration={{~/.immich-go/immich-go.json}} upload {{path/to/takeout_file.zip}}`
 

--- a/pages/common/kubie.md
+++ b/pages/common/kubie.md
@@ -23,6 +23,6 @@
 
 `kubie exec {{context}} {{namespace}} {{command}}`
 
-- Check the Kubernetes config files for issues:
+- Check the Kubernetes configuration files for issues:
 
 `kubie lint`

--- a/pages/common/piper.md
+++ b/pages/common/piper.md
@@ -4,7 +4,7 @@
 > Try out and download speech models from <https://rhasspy.github.io/piper-samples>.
 > More information: <https://github.com/rhasspy/piper>.
 
-- Output a WAV [f]ile using a text-to-speech [m]odel (assuming a config file at model_path + .json):
+- Output a WAV [f]ile using a text-to-speech [m]odel (assuming a configuration file at model_path + .json):
 
 `echo {{Thing to say}} | piper -m {{path/to/model.onnx}} -f {{outputfile.wav}}`
 

--- a/pages/common/pre-commit.md
+++ b/pages/common/pre-commit.md
@@ -19,6 +19,6 @@
 
 `pre-commit clean`
 
-- Update pre-commit config file to the latest repos' versions:
+- Update pre-commit configuration file to the latest repos' versions:
 
 `pre-commit autoupdate`

--- a/pages/common/rage.md
+++ b/pages/common/rage.md
@@ -1,6 +1,6 @@
 # rage
 
-> A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability.
+> A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no configuration options, and UNIX-style composability.
 > Rust implementation of `age`.
 > More information: <https://github.com/str4d/rage>.
 

--- a/pages/common/secrethub.md
+++ b/pages/common/secrethub.md
@@ -1,6 +1,6 @@
 # secrethub
 
-> Keep secrets out of config files.
+> Keep secrets out of configuration files.
 > More information: <https://github.com/secrethub/secrethub-cli>.
 
 - Print a secret to `stdout`:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
