### PR TITLE
apt: revised all descriptions

### DIFF
--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -25,7 +25,7 @@
 
 `sudo apt install {{package}}`
 
-- Remove a package (use `purge` instead to remove config files too):
+- Remove a package (use `purge` instead to also remove configuration files):
 
 `sudo apt remove {{package}}`
 

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -13,7 +13,7 @@
 
 `apt search {{package}}`
 
-- Search packages by name only (supports wildcards like "*"):
+- Search packages by name only (supports wildcards like `*`):
 
 `apt list {{package}}`
 

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -1,38 +1,39 @@
 # apt
 
-> Package management utility for Debian based distributions.
-> Recommended replacement for `apt-get` when used interactively in Ubuntu versions 16.04 and later.
+> Command-line package manager for Debian-based distributions.
+> Intended as a user-friendly alternative to `apt-get` for interactive use.
 > For equivalent commands in other package managers, see <https://wiki.archlinux.org/title/Pacman/Rosetta>.
 > More information: <https://manned.org/apt.8>.
 
-- Update the list of available packages and versions (it's recommended to run this before other `apt` commands):
+- Update the list of available packages and versions (recommended before running other `apt` commands):
 
 `sudo apt update`
 
-- Search for a given package (use `apt search --name-only package` to search within package name only):
+- Search packages by name or description:
 
 `apt search {{package}}`
 
-- Show information for a package:
+- Search packages by name only (supports wildcards like "*"):
+
+`apt list {{package}}`
+
+- Show detailed information about a package:
 
 `apt show {{package}}`
 
-- Install a package, or update it to the latest available version:
+- Install a package, or update it to latest:
 
 `sudo apt install {{package}}`
 
-- Remove a package (using `purge` instead also removes its configuration files):
+- Remove a package (keep configs), or purge (remove config files too):
 
 `sudo apt remove {{package}}`
+`sudo apt purge {{package}}`
 
-- Upgrade all installed packages to their newest available versions:
+- Upgrade all installed packages to their latest versions:
 
 `sudo apt upgrade`
 
-- List all packages:
-
-`apt list`
-
-- List installed packages:
+- List all installed packages:
 
 `apt list {{[-i|--installed]}}`

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -21,7 +21,7 @@
 
 `apt show {{package}}`
 
-- Install a package, or update it to latest version:
+- Install a package, or update it to the latest version:
 
 `sudo apt install {{package}}`
 

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -25,10 +25,9 @@
 
 `sudo apt install {{package}}`
 
-- Remove a package (keep configs), or purge (remove config files too):
+- Remove a package (use `purge` instead to remove config files too):
 
 `sudo apt remove {{package}}`
-`sudo apt purge {{package}}`
 
 - Upgrade all installed packages to their latest versions:
 

--- a/pages/linux/apt.md
+++ b/pages/linux/apt.md
@@ -1,6 +1,6 @@
 # apt
 
-> Command-line package manager for Debian-based distributions.
+> Package manager for Debian-based distributions.
 > Intended as a user-friendly alternative to `apt-get` for interactive use.
 > For equivalent commands in other package managers, see <https://wiki.archlinux.org/title/Pacman/Rosetta>.
 > More information: <https://manned.org/apt.8>.
@@ -21,7 +21,7 @@
 
 `apt show {{package}}`
 
-- Install a package, or update it to latest:
+- Install a package, or update it to latest version:
 
 `sudo apt install {{package}}`
 


### PR DESCRIPTION
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `apt 2.7.14 (amd64)`

---

The descriptions on the page looked clunky so I took the liberty to revise most of them.

I couldn't find a mention of multiline commands in guidelines. ~~If this would break anything, please feel free to edit this PR~~ yes it breaks, thanks @tldr-bot :]

Two major fixes are:
- `--names-only` gives error since the flag is actually from [`apt-cache`](https://linux.die.net/man/8/apt-cache). Apt instead uses the `apt list` subcommand
- Removed `apt list` entry as nobody would want to dump the entire apt repository into their terminal