### PR TITLE
linux/a*: add option placeholders

### DIFF
--- a/pages/linux/a2disconf.md
+++ b/pages/linux/a2disconf.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2disconf --quiet {{configuration_file}}`
+`sudo a2disconf {{[-q|--quiet]}} {{configuration_file}}`

--- a/pages/linux/a2dismod.md
+++ b/pages/linux/a2dismod.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2dismod --quiet {{module}}`
+`sudo a2dismod {{[-q|--quiet]}} {{module}}`

--- a/pages/linux/a2dissite.md
+++ b/pages/linux/a2dissite.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2dissite --quiet {{virtual_host}}`
+`sudo a2dissite {{[-q|--quiet]}} {{virtual_host}}`

--- a/pages/linux/a2enconf.md
+++ b/pages/linux/a2enconf.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2enconf --quiet {{configuration_file}}`
+`sudo a2enconf {{[-q|--quiet]}} {{configuration_file}}`

--- a/pages/linux/a2enmod.md
+++ b/pages/linux/a2enmod.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2enmod --quiet {{module}}`
+`sudo a2enmod {{[-q|--quiet]}} {{module}}`

--- a/pages/linux/a2ensite.md
+++ b/pages/linux/a2ensite.md
@@ -9,4 +9,4 @@
 
 - Don't show informative messages:
 
-`sudo a2ensite --quiet {{virtual_host}}`
+`sudo a2ensite {{[-q|--quiet]}} {{virtual_host}}`

--- a/pages/linux/aa-complain.md
+++ b/pages/linux/aa-complain.md
@@ -10,4 +10,4 @@
 
 - Set policies to complain mode:
 
-`sudo aa-complain --dir {{path/to/profiles}}`
+`sudo aa-complain {{[-d|--dir]}} {{path/to/profiles}}`

--- a/pages/linux/aa-enforce.md
+++ b/pages/linux/aa-enforce.md
@@ -6,7 +6,7 @@
 
 - Enable profile:
 
-`sudo aa-enforce --dir {{path/to/profile}}`
+`sudo aa-enforce {{[-d|--dir]}} {{path/to/profile}}`
 
 - Enable profiles:
 

--- a/pages/linux/abroot.md
+++ b/pages/linux/abroot.md
@@ -34,4 +34,4 @@
 
 - Display help:
 
-`abroot --help`
+`abroot {{[-h|--help]}}`

--- a/pages/linux/add-apt-repository.md
+++ b/pages/linux/add-apt-repository.md
@@ -1,7 +1,20 @@
 # add-apt-repository
 
-> This command is an alias of `apt-add-repository`.
+> Manage `apt` repository definitions.
+> More information: <https://manned.org/add-apt-repository>.
 
-- View documentation for the original command:
+- Add a new `apt` repository:
 
-`tldr apt-add-repository`
+`add-apt-repository {{repository_spec}}`
+
+- Remove an `apt` repository:
+
+`add-apt-repository {{[-r|--remove]}} {{repository_spec}}`
+
+- Update the package cache after adding a repository:
+
+`add-apt-repository --update {{repository_spec}}`
+
+- Enable source packages:
+
+`add-apt-repository {{[-s|--enable-source]}} {{repository_spec}}`

--- a/pages/linux/add-apt-repository.md
+++ b/pages/linux/add-apt-repository.md
@@ -15,6 +15,6 @@
 
 `add-apt-repository --update {{repository_spec}}`
 
-- Enable source packages:
+- Allow source packages to be downloaded from the repository:
 
 `add-apt-repository {{[-s|--enable-source]}} {{repository_spec}}`

--- a/pages/linux/add-apt-repository.md
+++ b/pages/linux/add-apt-repository.md
@@ -1,20 +1,7 @@
 # add-apt-repository
 
-> Manage `apt` repository definitions.
-> More information: <https://manned.org/apt-add-repository>.
+> This command is an alias of `apt-add-repository`.
 
-- Add a new `apt` repository:
+- View documentation for the original command:
 
-`add-apt-repository {{repository_spec}}`
-
-- Remove an `apt` repository:
-
-`add-apt-repository --remove {{repository_spec}}`
-
-- Update the package cache after adding a repository:
-
-`add-apt-repository --update {{repository_spec}}`
-
-- Allow source packages to be downloaded from the repository:
-
-`add-apt-repository --enable-source {{repository_spec}}`
+`tldr apt-add-repository`

--- a/pages/linux/alien.md
+++ b/pages/linux/alien.md
@@ -6,16 +6,16 @@
 
 - Convert a specific installation file to Debian format (`.deb` extension):
 
-`sudo alien --to-deb {{path/to/file}}`
+`sudo alien {{[-d|--to-deb]}} {{path/to/file}}`
 
 - Convert a specific installation file to Red Hat format (`.rpm` extension):
 
-`sudo alien --to-rpm {{path/to/file}}`
+`sudo alien {{[-r|--to-rpm]}} {{path/to/file}}`
 
 - Convert a specific installation file to a Slackware installation file (`.tgz` extension):
 
-`sudo alien --to-tgz {{path/to/file}}`
+`sudo alien {{[-t|--to-tgz]}} {{path/to/file}}`
 
 - Convert a specific installation file to Debian format and install on the system:
 
-`sudo alien --to-deb --install {{path/to/file}}`
+`sudo alien {{[-d|--to-deb]}} {{[-i|--install]}} {{path/to/file}}`

--- a/pages/linux/alpine.md
+++ b/pages/linux/alpine.md
@@ -14,4 +14,4 @@
 
 - Quit alpine:
 
-`q + y`
+`<q><y>`

--- a/pages/linux/apt-add-repository.md
+++ b/pages/linux/apt-add-repository.md
@@ -1,20 +1,7 @@
 # apt-add-repository
 
-> Manage `apt` repository definitions.
-> More information: <https://manned.org/apt-add-repository.1>.
+> This command is an alias of `add-apt-repository`.
 
-- Add a new `apt` repository:
+- View documentation for the original command:
 
-`apt-add-repository {{repository_spec}}`
-
-- Remove an `apt` repository:
-
-`apt-add-repository {{[-r|--remove]}} {{repository_spec}}`
-
-- Update the package cache after adding a repository:
-
-`apt-add-repository --update {{repository_spec}}`
-
-- Enable source packages:
-
-`apt-add-repository {{[-s|--enable-source]}} {{repository_spec}}`
+`tldr add-apt-repository`

--- a/pages/linux/ark.md
+++ b/pages/linux/ark.md
@@ -5,12 +5,12 @@
 
 - Extract a specific archive into the current directory:
 
-`ark --batch {{path/to/archive}}`
+`ark {{[-b|--batch]}} {{path/to/archive}}`
 
 - Extract an archive into a specific directory:
 
-`ark --batch --destination {{path/to/directory}} {{path/to/archive}}`
+`ark {{[-b|--batch]}} {{[-o|--destination]}} {{path/to/directory}} {{path/to/archive}}`
 
 - Create an archive if it does not exist and add specific files to it:
 
-`ark --add-to {{path/to/archive}} {{path/to/file1 path/to/file2 ...}}`
+`ark {{[-t|--add-to]}} {{path/to/archive}} {{path/to/file1 path/to/file2 ...}}`

--- a/pages/linux/auracle.md
+++ b/pages/linux/auracle.md
@@ -1,6 +1,6 @@
 # auracle
 
-> Command-line tool used to interact with Arch Linux's User Repository, commonly referred to as the AUR.
+> Interact with Arch Linux's User Repository, commonly referred to as the AUR.
 > More information: <https://github.com/falconindy/auracle>.
 
 - Display AUR packages that match a regular expression:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
