### PR TITLE
nl: don't need `-`

### DIFF
--- a/pages/common/nl.md
+++ b/pages/common/nl.md
@@ -9,7 +9,7 @@
 
 - Read from `stdin`:
 
-`{{command}} | nl -`
+`{{command}} | nl`
 
 - Number [a]ll [b]ody lines including blank lines or do [n]ot number [b]ody lines:
 


### PR DESCRIPTION
Only tested on linux: nl don't need `-`