### PR TITLE
common/*: reduce usage of "command-line" (part 2)

### DIFF
--- a/pages/common/phpunit.md
+++ b/pages/common/phpunit.md
@@ -1,6 +1,6 @@
 # phpunit
 
-> PHPUnit command-line test runner.
+> PHPUnit test runner.
 > More information: <https://phpunit.de>.
 
 - Run tests in the current directory. Note: Expects you to have a 'phpunit.xml':

--- a/pages/common/piactl.md
+++ b/pages/common/piactl.md
@@ -1,6 +1,6 @@
 # piactl
 
-> The command-line tool for Private Internet Access, a commercial VPN provider.
+> The tool for Private Internet Access, a commercial VPN provider.
 > More information: <https://helpdesk.privateinternetaccess.com/kb/articles/pia-desktop-command-line-interface-part-1>.
 
 - Log in to Private Internet Access:

--- a/pages/common/pprof.md
+++ b/pages/common/pprof.md
@@ -1,6 +1,6 @@
 # pprof
 
-> Command-line tool for visualization and analysis of profile data.
+> Tool for visualization and analysis of profile data.
 > More information: <https://github.com/google/pprof>.
 
 - Generate a text report from a specific profiling file, on fibbo binary:

--- a/pages/common/pup.md
+++ b/pages/common/pup.md
@@ -1,6 +1,6 @@
 # pup
 
-> Command-line HTML parsing tool.
+> HTML parsing tool.
 > More information: <https://github.com/ericchiang/pup>.
 
 - Transform a raw HTML file into a cleaned, indented, and colored format:

--- a/pages/common/pwsh.md
+++ b/pages/common/pwsh.md
@@ -1,6 +1,6 @@
 # pwsh
 
-> Command-line shell and scripting language designed especially for system administration.
+> Shell and scripting language designed especially for system administration.
 > This command refers to PowerShell version 6 and above (also known as PowerShell Core and cross-platform PowerShell).
 > To use the original Windows version (5.1 and below, also known as the legacy Windows PowerShell), use `powershell` instead of `pwsh`.
 > More information: <https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh>.

--- a/pages/common/rbt.md
+++ b/pages/common/rbt.md
@@ -1,6 +1,6 @@
 # rbt
 
-> RBTools is a set of command-line tools for working with Review Board and RBCommons.
+> RBTools, a set of tools for working with Review Board and RBCommons.
 > More information: <https://www.reviewboard.org/docs/rbtools/dev/>.
 
 - Post changes to Review Board:

--- a/pages/common/satis.md
+++ b/pages/common/satis.md
@@ -1,6 +1,6 @@
 # satis
 
-> The command-line utility for the Satis static Composer repository.
+> The utility for the Satis static Composer repository.
 > More information: <https://github.com/composer/satis>.
 
 - Initialize a Satis configuration:

--- a/pages/common/scan-build.md
+++ b/pages/common/scan-build.md
@@ -1,6 +1,6 @@
 # scan-build
 
-> Command-line utility to run a static analyzer over a codebase as part of performing a regular build.
+> Utility to run a static analyzer over a codebase as part of performing a regular build.
 > More information: <https://clang-analyzer.llvm.org/scan-build.html>.
 
 - Build and analyze the project in the current directory:

--- a/pages/common/sdcv.md
+++ b/pages/common/sdcv.md
@@ -1,6 +1,6 @@
 # sdcv
 
-> StarDict, a command-line dictionary client.
+> StarDict, a dictionary client.
 > Dictionaries are provided separately from the client.
 > More information: <https://manned.org/sdcv>.
 

--- a/pages/common/sgpt.md
+++ b/pages/common/sgpt.md
@@ -1,6 +1,6 @@
 # sgpt
 
-> Command-line productivity tool powered by OpenAI's GPT models.
+> Productivity tool powered by OpenAI's GPT models.
 > More information: <https://github.com/TheR1D/shell_gpt#readme>.
 
 - Use it as a search engine, asking for the mass of the sun:

--- a/pages/common/snowsql.md
+++ b/pages/common/snowsql.md
@@ -1,6 +1,6 @@
 # snowsql
 
-> SnowSQL command-line client for Snowflake's Data Cloud.
+> SnowSQL client for Snowflake's Data Cloud.
 > More information: <https://docs.snowflake.com/en/user-guide/snowsql.html>.
 
 - Connect to a specific instance at <https://account.snowflakecomputing.com> (password can be provided in prompt or configuration file):

--- a/pages/common/spark.md
+++ b/pages/common/spark.md
@@ -1,6 +1,6 @@
 # spark
 
-> The Laravel Spark command-line tool.
+> The Laravel Spark tool.
 > More information: <https://spark.laravel.com>.
 
 - Register your API token:

--- a/pages/common/sqsc.md
+++ b/pages/common/sqsc.md
@@ -1,6 +1,6 @@
 # sqsc
 
-> A command-line AWS Simple Queue Service client.
+> An AWS Simple Queue Service client.
 > More information: <https://github.com/yongfei25/sqsc>.
 
 - List all queues:

--- a/pages/common/supervisorctl.md
+++ b/pages/common/supervisorctl.md
@@ -1,6 +1,6 @@
 # supervisorctl
 
-> Supervisor is a client/server system that allows its users to control a number of processes on UNIX-like operating systems.
+> Supervisor, a client/server system that allows its users to control a number of processes on UNIX-like operating systems.
 > Supervisorctl is the command-line client piece of the supervisor which provides a shell-like interface.
 > More information: <http://supervisord.org>.
 

--- a/pages/common/svn.md
+++ b/pages/common/svn.md
@@ -1,6 +1,6 @@
 # svn
 
-> Subversion command-line client tool.
+> Subversion client tool.
 > More information: <https://subversion.apache.org>.
 
 - Check out a working copy from a repository:

--- a/pages/common/task.md
+++ b/pages/common/task.md
@@ -1,6 +1,6 @@
 # task
 
-> Command-line to-do list manager.
+> To-do list manager.
 > More information: <https://taskwarrior.org/docs/>.
 
 - Add a new task which is due tomorrow:

--- a/pages/common/termdown.md
+++ b/pages/common/termdown.md
@@ -1,6 +1,6 @@
 # termdown
 
-> Countdown timer and stopwatch for the command-line.
+> Countdown timer and stopwatch.
 > More information: <https://github.com/trehn/termdown>.
 
 - Start a stopwatch:

--- a/pages/common/timetrap.md
+++ b/pages/common/timetrap.md
@@ -1,6 +1,6 @@
 # timetrap
 
-> Simple command-line time tracker written in Ruby.
+> Simple time tracker written in Ruby.
 > More information: <https://github.com/samg/timetrap>.
 
 - Create a new timesheet:

--- a/pages/common/tmsu.md
+++ b/pages/common/tmsu.md
@@ -1,6 +1,6 @@
 # tmsu
 
-> Simple command-line tool for tagging files.
+> Simple tool for tagging files.
 > More information: <https://tmsu.org>.
 
 - Tag a specific file with multiple tags:

--- a/pages/common/transfersh.md
+++ b/pages/common/transfersh.md
@@ -1,6 +1,6 @@
 # transfersh
 
-> An unofficial command-line client for transfer.sh.
+> An unofficial client for transfer.sh.
 > More information: <https://github.com/AlpixTM/transfersh>.
 
 - Upload a file to transfer.sh:

--- a/pages/common/travis.md
+++ b/pages/common/travis.md
@@ -1,6 +1,6 @@
 # travis
 
-> Command-line client to interface with Travis CI.
+> Interface with Travis CI.
 > More information: <https://github.com/travis-ci/travis.rb>.
 
 - Display the client version:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
