### PR TITLE
Fix #16827: Remove redundant mode from libtool

### DIFF
--- a/pages/linux/libtool.md
+++ b/pages/linux/libtool.md
@@ -5,28 +5,28 @@
 
 - Compile a source file into a `libtool` object:
 
-`libtool --mode=compile gcc {{[-c|--compile]}} {{path/to/source.c}} {{[-o|--output]}} {{path/to/source.lo}}`
+`libtool compile gcc {{[-c|--compile]}} {{path/to/source.c}} {{[-o|--output]}} {{path/to/source.lo}}`
 
 - Create a library or an executable:
 
-`libtool --mode=link gcc {{[-o|--output]}} {{path/to/library.lo}} {{path/to/source.lo}}`
+`libtool link gcc {{[-o|--output]}} {{path/to/library.lo}} {{path/to/source.lo}}`
 
 - Automatically set the library path so that another program can use uninstalled `libtool` generated programs or libraries:
 
-`libtool --mode=execute gdb {{path/to/program}}`
+`libtool execute gdb {{path/to/program}}`
 
 - Install a shared library:
 
-`libtool --mode=install cp {{path/to/library.la}} {{path/to/installation_directory}}`
+`libtool install cp {{path/to/library.la}} {{path/to/installation_directory}}`
 
 - Complete the installation of `libtool` libraries on the system:
 
-`libtool --mode=finish {{path/to/installation_dir}}`
+`libtool finish {{path/to/installation_dir}}`
 
 - Delete installed libraries or executables:
 
-`libtool --mode=uninstall {{path/to/installed_library.la}}`
+`libtool uninstall {{path/to/installed_library.la}}`
 
 - Delete uninstalled libraries or executables:
 
-`libtool --mode=clean rm {{path/to/source.lo}} {{path/to/library.la}}`
+`libtool clean rm {{path/to/source.lo}} {{path/to/library.la}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

mode is redundant and therefore can be removed from libtool. 

<img width="863" alt="Screenshot 2025-06-26 at 5 36 00 PM" src="https://github.com/user-attachments/assets/df8072d7-833c-49e5-b122-d8328bf8c803" />
