### PR TITLE
linux/f*: add option placeholders and mnemonics

### DIFF
--- a/pages/linux/fakeroot.md
+++ b/pages/linux/fakeroot.md
@@ -11,7 +11,7 @@
 
 `fakeroot -- {{command}} {{command_arguments}}`
 
-- Run a command as fakeroot and save the environment to a file on exit:
+- Run a command as fakeroot and [s]ave the environment to a file on exit:
 
 `fakeroot -s {{path/to/file}} -- {{command}} {{command_arguments}}`
 

--- a/pages/linux/flameshot.md
+++ b/pages/linux/flameshot.md
@@ -2,7 +2,7 @@
 
 > Screenshot utility with a GUI.
 > Supports basic image editing, such as text, shapes, colors, and imgur.
-> More information: <https://flameshot.org>.
+> More information: <https://flameshot.org/docs/advanced/commandline-options/>.
 
 - Create a fullscreen screenshot:
 

--- a/pages/linux/fprintd-verify.md
+++ b/pages/linux/fprintd-verify.md
@@ -25,4 +25,4 @@
 
 - Display help:
 
-`fprintd-verify --help`
+`fprintd-verify {{[-h|--help]}}`

--- a/pages/linux/fsck.md
+++ b/pages/linux/fsck.md
@@ -11,6 +11,6 @@
 
 `sudo fsck -r {{/dev/sdXN}}`
 
-- Check filesystem `/dev/sdXN`, reporting any damaged blocks and automatically repairing them:
+- Check filesystem `/dev/sdXN`, reporting any damaged blocks and [a]utomatically repairing them:
 
 `sudo fsck -a {{/dev/sdXN}}`

--- a/pages/linux/fuser.md
+++ b/pages/linux/fuser.md
@@ -9,20 +9,20 @@
 
 - Show more fields (`USER`, `PID`, `ACCESS` and `COMMAND`):
 
-`fuser --verbose {{path/to/file_or_directory}}`
+`fuser {{[-v|--verbose]}} {{path/to/file_or_directory}}`
 
 - Identify processes using a TCP socket:
 
-`fuser --namespace tcp {{port}}`
+`fuser {{[-n|--namespace]}} tcp {{port}}`
 
 - Kill all processes accessing a file or directory (sends the `SIGKILL` signal):
 
-`fuser --kill {{path/to/file_or_directory}}`
+`fuser {{[-k|--kill]}} {{path/to/file_or_directory}}`
 
 - Find which processes are accessing the filesystem containing a specific file or directory:
 
-`fuser --mount {{path/to/file_or_directory}}`
+`fuser {{[-m|--mount]}} {{path/to/file_or_directory}}`
 
 - Kill all processes with a TCP connection on a specific port:
 
-`fuser --kill {{port}}/tcp`
+`fuser {{[-k|--kill]}} {{port}}/tcp`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
