### PR TITLE
linux/{h, i}*: add option placeholders

### DIFF
--- a/pages/linux/hlint.md
+++ b/pages/linux/hlint.md
@@ -9,7 +9,7 @@
 
 - Check all Haskell files and generate a report:
 
-`hlint {{path/to/directory}} --report`
+`hlint {{path/to/directory}} {{[-r|--report]}}`
 
 - Automatically apply most suggestions:
 

--- a/pages/linux/homectl.md
+++ b/pages/linux/homectl.md
@@ -33,4 +33,4 @@
 
 - Display help:
 
-`homectl --help`
+`homectl {{[-h|--help]}}`

--- a/pages/linux/id3v2.md
+++ b/pages/linux/id3v2.md
@@ -5,11 +5,11 @@
 
 - List all genres:
 
-`id3v2 --list-genres`
+`id3v2 {{-L|--list-genres}}`
 
 - List all tags of specific files:
 
-`id3v2 --list {{path/to/file1 path/to/file2 ...}}`
+`id3v2 {{[-l|--list]}} {{path/to/file1 path/to/file2 ...}}`
 
 - Delete all `id3v2` or `id3v1` tags of specific files:
 
@@ -17,8 +17,8 @@
 
 - Display help:
 
-`id3v2 --help`
+`id3v2 {{[-h|--help]}}`
 
 - Display version:
 
-`id3v2 --version`
+`id3v2 {{[-v|--version]}}`

--- a/pages/linux/img2txt.md
+++ b/pages/linux/img2txt.md
@@ -5,20 +5,20 @@
 
 - Set output column count to a specific value:
 
-`img2txt --width={{10}}`
+`img2txt {{[-W|--width]}} {{10}} {{path/to/image}}`
 
 - Set output line count to a specific value:
 
-`img2txt --height={{5}}`
+`img2txt {{[-H|--height]}} {{5}} {{path/to/image}}`
 
 - Set output font width to a specific value:
 
-`img2txt --font-width={{12}}`
+`img2txt {{[-x|--font-width]}} {{12}} {{path/to/image}}`
 
 - Set output font height to a specific value:
 
-`img2txt --font-height={{14}}`
+`img2txt {{[-y|--font-height]}} {{14}} {{path/to/image}}`
 
 - Set image brightness to a specific value:
 
-`img2txt --brightness={{2}}`
+`img2txt {{[-b|--brightness]}} {{2}} {{path/to/image}}`

--- a/pages/linux/inotifywait.md
+++ b/pages/linux/inotifywait.md
@@ -9,28 +9,28 @@
 
 - Continuously watch a specific file for events without exiting:
 
-`inotifywait --monitor {{path/to/file}}`
+`inotifywait {{[-m|--monitor]}} {{path/to/file}}`
 
 - Watch a directory recursively for events:
 
-`inotifywait --monitor --recursive {{path/to/directory}}`
+`inotifywait {{[-m|--monitor]}} {{[-r|--recursive]}} {{path/to/directory}}`
 
 - Watch a directory for changes, excluding files, whose names match a regular expression:
 
-`inotifywait --monitor --recursive --exclude "{{regular_expression}}" {{path/to/directory}}`
+`inotifywait {{[-m|--monitor]}} {{[-r|--recursive]}} --exclude "{{regular_expression}}" {{path/to/directory}}`
 
 - Watch a file for changes, exiting when no event occurs for 30 seconds:
 
-`inotifywait --monitor --timeout {{30}} {{path/to/file}}`
+`inotifywait {{[-m|--monitor]}} {{[-t|--timeout]}} {{30}} {{path/to/file}}`
 
 - Only watch a file for file modification events:
 
-`inotifywait --event {{modify}} {{path/to/file}}`
+`inotifywait {{[-e|--event]}} {{modify}} {{path/to/file}}`
 
 - Watch a file printing only events, and no status messages:
 
-`inotifywait --quiet {{path/to/file}}`
+`inotifywait {{[-q|--quiet]}} {{path/to/file}}`
 
 - Run a command when a file is accessed:
 
-`inotifywait --event {{access}} {{path/to/file}} && {{command}}`
+`inotifywait {{[-e|--event]}} {{access}} {{path/to/file}} && {{command}}`

--- a/pages/linux/instaloader.md
+++ b/pages/linux/instaloader.md
@@ -2,7 +2,7 @@
 
 > Download pictures, videos, captions, and other metadata from Instagram.
 > Note: You will need to provide Instagram login information if you want high-quality media downloads.
-> More information: <https://instaloader.github.io>.
+> More information: <https://instaloader.github.io/cli-options.html>.
 
 - Download a profile:
 
@@ -14,7 +14,7 @@
 
 - Download posts with geotags (if available), suppressing any user interaction:
 
-`instaloader --quiet --geotags {{profile_name}}`
+`instaloader {{[-q|--quiet]}} {{[-G|--geotags]}} {{profile_name}}`
 
 - Specify a user agent for HTTP requests:
 
@@ -22,16 +22,16 @@
 
 - Specify login info and download posts (useful for private profiles):
 
-`instaloader --login {{username}} --password {{password}} {{profile_name}}`
+`instaloader {{[-l|--login]}} {{username}} {{[-p|--password]}} {{password}} {{profile_name}}`
 
 - Skip a target if the first downloaded file has been found (useful for updating Instagram archives):
 
-`instaloader --fast-update {{profile_name}}`
+`instaloader {{[-F|--fast-update]}} {{profile_name}}`
 
 - Download stories and IGTV videos (login required):
 
-`instaloader --login {{username}} --password {{password}} --stories --igtv {{profile_name}}`
+`instaloader {{[-l|--login]}} {{username}} {{[-p|--password]}} {{password}} {{[-s|--stories]}} --igtv {{profile_name}}`
 
 - Download all types of posts (login required):
 
-`instaloader --login {{username}} --password {{password}} --stories --igtv --highlights {{profile_name}}`
+`instaloader {{[-l|--login]}} {{username}} {{[-p|--password]}} {{password}} {[-s|--stories]}} --igtv --highlights {{profile_name}}`

--- a/pages/linux/ipcmk.md
+++ b/pages/linux/ipcmk.md
@@ -5,16 +5,16 @@
 
 - Create a shared memory segment:
 
-`ipcmk --shmem {{segment_size_in_bytes}}`
+`ipcmk {{[-M|--shmem]}} {{segment_size_in_bytes}}`
 
 - Create a semaphore:
 
-`ipcmk --semaphore {{element_size}}`
+`ipcmk {{[-S|--semaphore]}} {{element_size}}`
 
 - Create a message queue:
 
-`ipcmk --queue`
+`ipcmk {{[-Q|--queue]}}`
 
 - Create a shared memory segment with specific permissions (default is 0644):
 
-`ipcmk --shmem {{segment_size_in_bytes}} {{octal_permissions}}`
+`ipcmk {{[-M|--shmem]}} {{segment_size_in_bytes}} {{octal_permissions}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
