### PR TITLE
grep: adjust options

### DIFF
--- a/pages/common/grep.md
+++ b/pages/common/grep.md
@@ -21,7 +21,7 @@
 
 - Print 3 lines of [C]ontext around, [B]efore or [A]fter each match:
 
-`grep --{{context|before-context|after-context}} 3 "{{search_pattern}}" {{path/to/file}}`
+`grep {{--context|--before-context|--after-context}} 3 "{{search_pattern}}" {{path/to/file}}`
 
 - Print file name and line number for each match with color output:
 


### PR DESCRIPTION
As much as I like DRY, the more I see this when opening the grep page, the less I like it. This would make it more self-explanatory