### PR TITLE
run-mailcap: conform with style guide

### DIFF
--- a/pages/linux/run-mailcap.md
+++ b/pages/linux/run-mailcap.md
@@ -10,16 +10,16 @@
 
 - In simple language:
 
-`run-mailcap --action={{action}} {{filename}}`
+`run-mailcap --action={{action}} {{path/to/file}}`
 
 - Turn on extra information:
 
-`run-mailcap --action={{action}} --debug {{filename}}`
+`run-mailcap --action={{action}} --debug {{path/to/file}}`
 
 - Ignore any "copiousoutput" directive and forward output to `stdout`:
 
-`run-mailcap --action={{action}} --nopager {{filename}}`
+`run-mailcap --action={{action}} --nopager {{path/to/file}}`
 
 - Display the found command without actually executing it:
 
-`run-mailcap --action={{action}} --norun {{filename}}`
+`run-mailcap --action={{action}} --norun {{path/to/file}}`

--- a/pages/linux/run-mailcap.md
+++ b/pages/linux/run-mailcap.md
@@ -6,20 +6,20 @@
 
 - Individual actions/programs on run-mailcap can be invoked with action flag:
 
-`run-mailcap --action=ACTION [--option[=value]]`
+`run-mailcap --action={{view|cat|compose|composetyped|edit|print}}`
 
 - In simple language:
 
-`run-mailcap --action=ACTION {{filename}}`
+`run-mailcap --action={{action}} {{filename}}`
 
 - Turn on extra information:
 
-`run-mailcap --action=ACTION --debug {{filename}}`
+`run-mailcap --action={{action}} --debug {{filename}}`
 
 - Ignore any "copiousoutput" directive and forward output to `stdout`:
 
-`run-mailcap --action=ACTION --nopager {{filename}}`
+`run-mailcap --action={{action}} --nopager {{filename}}`
 
 - Display the found command without actually executing it:
 
-`run-mailcap --action=ACTION --norun {{filename}}`
+`run-mailcap --action={{action}} --norun {{filename}}`

--- a/pages/linux/run-mailcap.md
+++ b/pages/linux/run-mailcap.md
@@ -4,13 +4,9 @@
 > Run mailcap view, see, edit, compose, print - execute programs via entries in the mailcap file (or any of its aliases) will use the given action to process each mime-type/file.
 > More information: <https://manned.org/run-mailcap>.
 
-- Individual actions/programs on run-mailcap can be invoked with action flag:
+- Invoke individual actions/programs on run-mailcap:
 
-`run-mailcap --action={{view|cat|compose|composetyped|edit|print}}`
-
-- In simple language:
-
-`run-mailcap --action={{action}} {{path/to/file}}`
+`run-mailcap --action={{view|cat|compose|composetyped|edit|print}} {{path/to/file}}`
 
 - Turn on extra information:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
