### PR TITLE
ps: remove option placeholder

### DIFF
--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -29,4 +29,4 @@
 
 - Sort processes by memory consumption:
 
-`ps {{[k|--sort]}} size`
+`ps --sort size`


### PR DESCRIPTION
The manual claims that these two are identical but in testing they are not. Reverted to the previous state