### PR TITLE
elasticsearch-keystore: add page

### DIFF
--- a/pages/common/elasticsearch-keystore.md
+++ b/pages/common/elasticsearch-keystore.md
@@ -1,6 +1,6 @@
 # elasticsearch-keystore
 
-> Manage secure settings (passwords, tokens, credentials) used by Elasticsearch.
+> Manage secure settings (e.g., passwords, tokens, and credentials) used by Elasticsearch..
 > More information: <https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-keystore.html>.
 
 - Create a new keystore (not password-protected):

--- a/pages/common/elasticsearch-keystore.md
+++ b/pages/common/elasticsearch-keystore.md
@@ -1,6 +1,6 @@
 # elasticsearch-keystore
 
-> Manage secure settings (e.g., passwords, tokens, and credentials) used by Elasticsearch..
+> Manage secure settings (e.g., passwords, tokens, and credentials) used by Elasticsearch.
 > More information: <https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-keystore.html>.
 
 - Create a new keystore (not password-protected):

--- a/pages/common/elasticsearch-keystore.md
+++ b/pages/common/elasticsearch-keystore.md
@@ -1,0 +1,36 @@
+# elasticsearch-keystore
+
+> Manage secure settings (passwords, tokens, credentials) used by Elasticsearch.
+> More information: <https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-keystore.html>.
+
+- Create a new keystore (not password-protected):
+
+`elasticsearch-keystore create`
+
+- Create a new password-protected keystore:
+
+`elasticsearch-keystore create -p`
+
+- Add a setting interactively:
+
+`elasticsearch-keystore add {{setting_name}}`
+
+- Add a setting from standard input:
+
+`echo "{{setting_value}}" | elasticsearch-keystore add --stdin {{setting_name}}`
+
+- Remove a setting from the keystore:
+
+`elasticsearch-keystore remove {{setting_name}}`
+
+- Change the keystore password:
+
+`elasticsearch-keystore passwd`
+
+- List all settings stored in the keystore:
+
+`elasticsearch-keystore list`
+
+- Upgrade the keystore format (after an Elasticsearch upgrade):
+
+`elasticsearch-keystore upgrade`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
