### PR TITLE
jj-evolog: Update revisions option to preferred canonical

### DIFF
--- a/pages/common/jj-evolog.md
+++ b/pages/common/jj-evolog.md
@@ -5,12 +5,12 @@
 
 - Show how a revision has evolved over time:
 
-`jj evolog {{[-r|--revision]}} {{revset}}`
+`jj evolog {{[-r|--revisions]}} {{revsets}}`
 
 - Show diff statistics in the evolution log:
 
-`jj evolog {{[-r|--revision]}} {{revset}} --stat`
+`jj evolog {{[-r|--revisions]}} {{revsets}} --stat`
 
 - Show summary of each change in the evolution log:
 
-`jj evolog {{[-r|--revision]}} {{revset}} {{[-s|--summary]}}`
+`jj evolog {{[-r|--revisions]}} {{revsets}} {{[-s|--summary]}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** v0.30.0

v0.29.0 had it as `--revision` while `v0.30.0` added support for multiple revisions (https://github.com/jj-vcs/jj/pull/6756).
It updated the option name to `revisions`, and added the previous `revision` as an alias.
The tldr page for it should use the updated name, instead of the alias added for backward compatibility.