### PR TITLE
jj-absorb: clarify move semantics

### DIFF
--- a/pages/common/jj-absorb.md
+++ b/pages/common/jj-absorb.md
@@ -1,6 +1,7 @@
 # jj absorb
 
-> Split changes in the source revision and move each change to the closest mutable ancestor where the corresponding lines were modified last. Changes that have zero or multiple matching regions in ancestral revisions won't be moved.
+> Split changes in the source revision and move each change to the closest mutable ancestor where the corresponding lines were modified last.
+> Changes that have zero or multiple matching regions in ancestral revisions won't be moved.
 > More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-absorb>.
 
 - Move all eligible and unambiguous changes from a revision to other revisions automatically:

--- a/pages/common/jj-absorb.md
+++ b/pages/common/jj-absorb.md
@@ -1,9 +1,9 @@
 # jj absorb
 
-> Split changes in the source revision and move each change to the closest mutable ancestor where the corresponding lines were modified last.
+> Split changes in the source revision and move each change to the closest mutable ancestor where the corresponding lines were modified last. Changes that have zero or multiple matching regions in ancestral revisions won't be moved.
 > More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-absorb>.
 
-- Move all changes from a revision to other revisions automatically:
+- Move all eligible and unambiguous changes from a revision to other revisions automatically:
 
 `jj absorb {{[-f|--from]}} {{revset}} {{[-t|--into]}} {{revsets}}`
 


### PR DESCRIPTION
This change makes it clear that running `jj absorb` on a revision will only move eligible and unambiguous changes to ancestral revisions, not just a blanket "move all changes".

See also: https://github.com/tldr-pages/tldr/pull/17129#discussion_r2190398185

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** v0.30.0
