### PR TITLE
firewall-cmd: remove `=`

### DIFF
--- a/pages/linux/firewall-cmd.md
+++ b/pages/linux/firewall-cmd.md
@@ -10,19 +10,19 @@
 
 - Permanently move the interface into the block zone, effectively blocking all communication:
 
-`firewall-cmd --permanent --zone={{block}} --change-interface={{enp1s0}}`
+`firewall-cmd --permanent --zone {{block}} --change-interface {{enp1s0}}`
 
 - Permanently open the port for a service in the specified zone (like port 443 when in the `public` zone):
 
-`firewall-cmd --permanent --zone={{public}} --add-service={{https}}`
+`firewall-cmd --permanent --zone {{public}} --add-service {{https}}`
 
 - Permanently close the port for a service in the specified zone (like port 80 when in the `public` zone):
 
-`firewall-cmd --permanent --zone={{public}} --remove-service={{http}}`
+`firewall-cmd --permanent --zone {{public}} --remove-service {{http}}`
 
 - Permanently forward a port for incoming packets in the specified zone (like port 443 to 8443 when entering the `public` zone):
 
-`firewall-cmd --permanent --zone={{public}} --add-rich-rule='rule family="{{ipv4|ipv6}}" forward-port port="{{443}}" protocol="{{udp|tcp}}" to-port="{{8443}}"'`
+`firewall-cmd --permanent --zone {{public}} --add-rich-rule 'rule family "{{ipv4|ipv6}}" forward-port port "{{443}}" protocol "{{udp|tcp}}" to-port "{{8443}}"'`
 
 - Reload firewalld to lose any runtime changes and force the permanent configuration to take effect immediately:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
