### PR TITLE
nix-flake: update deprecated `lock --update-input` example

### DIFF
--- a/pages.es/common/nix-flake.md
+++ b/pages.es/common/nix-flake.md
@@ -13,7 +13,7 @@
 
 - Actualiza una entrada específica (dependencia) del flake en el directorio actual:
 
-`nix flake lock --update-input {{entrada}}`
+`nix flake update {{entrada}}`
 
 - Muestra todas the salidas de un flake en github:
 

--- a/pages.ko/common/nix-flake.md
+++ b/pages.ko/common/nix-flake.md
@@ -13,7 +13,7 @@
 
 - 현재 디렉토리의 플레이크의 특정 입력(의존성) 업데이트:
 
-`nix flake lock --update-input {{입력}}`
+`nix flake update {{입력}}`
 
 - GitHub에 있는 플레이크의 모든 출력 표시:
 

--- a/pages/common/nix-flake.md
+++ b/pages/common/nix-flake.md
@@ -13,7 +13,7 @@
 
 - Update a specific input (dependency) of the flake in the current directory:
 
-`nix flake lock --update-input {{input}}`
+`nix flake update {{input}}`
 
 - Show all the outputs of a flake on github:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** nix (Nix) 2.28.3

> warning: '--update-input' is a deprecated alias for 'flake update' and will be removed in a future version.

Replace the example for `nix flake lock --update-input` to point to `nix flake update {{input}}` for all languages.