### PR TITLE
*: fix curly brace syntax, nested placeholders and mismatched brackets

### DIFF
--- a/pages/common/aws-eks.md
+++ b/pages/common/aws-eks.md
@@ -6,7 +6,7 @@
 
 - Create an EKS Cluster:
 
-`aws eks create-cluster --name {{cluster_name}} --role-arn {{eks_service_role_arn}} --resources-vpc-config {{subnetIds={{subnet_ids}},securityGroupIds={{security_group_ids}}}}`
+`aws eks create-cluster --name {{cluster_name}} --role-arn {{eks_service_role_arn}} --resources-vpc-config subnetIds={{subnet_ids}},securityGroupIds={{security_group_ids}}`
 
 - Update kubeconfig to connect to the EKS Cluster:
 

--- a/pages/common/coproc.md
+++ b/pages/common/coproc.md
@@ -13,11 +13,11 @@
 
 - Write to a specific coprocess `stdin`:
 
-`echo "{{input}}" >&"$\{{{name}}[1]}"`
+`echo "{{input}}" >&"${{{name[1]}}}"`
 
 - Read from a specific coprocess `stdout`:
 
-`read {{variable}} <&"$\{{{name}}[0]}"`
+`read {{variable}} <&"${{{name[0]}}}"`
 
 - Create a coprocess which repeatedly reads `stdin` and runs some commands on the input:
 

--- a/pages/common/coproc.md
+++ b/pages/common/coproc.md
@@ -13,11 +13,11 @@
 
 - Write to a specific coprocess `stdin`:
 
-`echo "{{input}}" >&"${{{name}}[1]}"`
+`echo "{{input}}" >&"$\{{{name}}[1]}"`
 
 - Read from a specific coprocess `stdout`:
 
-`read {{variable}} <&"${{{name}}[0]}"`
+`read {{variable}} <&"$\{{{name}}[0]}"`
 
 - Create a coprocess which repeatedly reads `stdin` and runs some commands on the input:
 

--- a/pages/common/d8.md
+++ b/pages/common/d8.md
@@ -13,4 +13,4 @@
 
 - Evaluate a JavaScript expression:
 
-`d8 -e "{{code}}`
+`d8 -e "{{code}}"`

--- a/pages/common/dropdb.md
+++ b/pages/common/dropdb.md
@@ -18,7 +18,7 @@
 
 - Force a password prompt before connecting to the database:
 
-`dropdb {{[-W|--password]}} {{dbname}}}}`
+`dropdb {{[-W|--password]}} {{dbname}}`
 
 - Suppress a password prompt before connecting to the database:
 

--- a/pages/common/for.md
+++ b/pages/common/for.md
@@ -13,7 +13,7 @@
 
 - Iterate over a given range of numbers:
 
-`for {{variable}} in {{{from}}..{{to}}..{{step}}}; do {{echo "Loop is executed"}}; done`
+`for {{variable}} in {{{from..to..step}}}; do {{echo "Loop is executed"}}; done`
 
 - Iterate over a given list of files:
 

--- a/pages/common/for.md
+++ b/pages/common/for.md
@@ -13,7 +13,7 @@
 
 - Iterate over a given range of numbers:
 
-`for {{variable}} in {{{from}}..{{to}}..{{step}}}; do {{echo "Loop is executed"}}; done`
+`for {{variable}} in \{{{from}}..{{to}}..{{step}}\}; do {{echo "Loop is executed"}}; done`
 
 - Iterate over a given list of files:
 

--- a/pages/common/for.md
+++ b/pages/common/for.md
@@ -13,7 +13,7 @@
 
 - Iterate over a given range of numbers:
 
-`for {{variable}} in \{{{from}}..{{to}}..{{step}}\}; do {{echo "Loop is executed"}}; done`
+`for {{variable}} in {{{from}}..{{to}}..{{step}}}; do {{echo "Loop is executed"}}; done`
 
 - Iterate over a given list of files:
 

--- a/pages/common/highlight.md
+++ b/pages/common/highlight.md
@@ -21,4 +21,4 @@
 
 - Print a CSS stylesheet for a theme:
 
-`highlight {{[-o|--out-format]}} {{html}} --print-style {{[-s|--style]}} {{theme_name}} {{[-S|--syntax]}} {{language}}] --stdout`
+`highlight {{[-o|--out-format]}} {{html}} --print-style {{[-s|--style]}} {{theme_name}} {{[-S|--syntax]}} {{language}} --stdout`

--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -25,4 +25,4 @@
 
 - Run a benchmark where a single parameter changes for each run:
 
-`hyperfine {{[-p|--prepare]}} '{{make clean}}' {{[-P|--parameter-scan]}} {{num_threads}} {{1}} {{10}} 'make {{[-j|--jobs]}} {{num_threads}}'`
+`hyperfine {{[-p|--prepare]}} '{{make clean}}' {{[-P|--parameter-scan]}} {{num_threads}} {{1}} {{10}} '{{make --jobs {num_threads}}}'`

--- a/pages/common/hyperfine.md
+++ b/pages/common/hyperfine.md
@@ -25,4 +25,4 @@
 
 - Run a benchmark where a single parameter changes for each run:
 
-`hyperfine {{[-p|--prepare]}} '{{make clean}}' {{[-P|--parameter-scan]}} {{num_threads}} {{1}} {{10}} '{{make {{[-j|--jobs]}} {num_threads}}}'`
+`hyperfine {{[-p|--prepare]}} '{{make clean}}' {{[-P|--parameter-scan]}} {{num_threads}} {{1}} {{10}} 'make {{[-j|--jobs]}} {{num_threads}}'`

--- a/pages/common/jello.md
+++ b/pages/common/jello.md
@@ -25,7 +25,7 @@
 
 - Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name1` and `key_name2`):
 
-`cat {{file.json}} | jello '{"{{key1}}": _.{{key_name1}}, "{{key_name}}": _.{{key_name2}}}'`
+`cat {{file.json}} | jello '{"{{key1}}": _.{{key_name1}}, "{{key2}}": _.{{key_name2}}\}'`
 
 - Output the value of a given key to a string (and disable JSON output):
 

--- a/pages/common/jello.md
+++ b/pages/common/jello.md
@@ -25,7 +25,7 @@
 
 - Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name1` and `key_name2`):
 
-`cat {{file.json}} | jello '{"{{key1}}": _.{{key_name1}}, "{{key2}}": _.{{key_name2}}\}'`
+`cat {{file.json}} | jello '{{{"key1": _.key_name1, "key2": _.key_name2, ...}}}'`
 
 - Output the value of a given key to a string (and disable JSON output):
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -13,7 +13,7 @@
 
 - To tail multiple containers from multiple pods:
 
-`kubetail {{my_app}} {{[-c|--container]}} {my_container_1}} {{[-c|--container]}} {my_container_2}}`
+`kubetail {{my_app}} {{[-c|--container]}} {my_container_1}} {{[-c|--container]}} {{my_container_2}}`
 
 - To tail multiple applications at the same time separate them by comma:
 

--- a/pages/common/kubetail.md
+++ b/pages/common/kubetail.md
@@ -13,7 +13,7 @@
 
 - To tail multiple containers from multiple pods:
 
-`kubetail {{my_app}} {{[-c|--container]}} {my_container_1}} {{[-c|--container]}} {{my_container_2}}`
+`kubetail {{my_app}} {{[-c|--container]}} {{my_container_1}} {{[-c|--container]}} {{my_container_2}}`
 
 - To tail multiple applications at the same time separate them by comma:
 

--- a/pages/common/linode-cli-linodes.md
+++ b/pages/common/linode-cli-linodes.md
@@ -18,7 +18,7 @@
 
 - Update settings for a Linode:
 
-`linode-cli linodes update {{linode_id}} --label {{[new_label}}`
+`linode-cli linodes update {{linode_id}} --label {{new_label}}`
 
 - Delete a Linode:
 

--- a/pages/common/mamba-repoquery.md
+++ b/pages/common/mamba-repoquery.md
@@ -9,7 +9,7 @@
 
 - Search for all packages satisfying specific constraints:
 
-`mamba repoquery search {{sphinx<5}}`
+`mamba repoquery search "{{sphinx<5}}"`
 
 - List the dependencies of a package installed in the currently activated environment, in a tree format:
 

--- a/pages/common/phpcbf.md
+++ b/pages/common/phpcbf.md
@@ -21,7 +21,7 @@
 
 - A comma-separated list of files to load before processing:
 
-`phpcbf {{path/to/directory}} --bootstrap {{path/to/file1,path/to/file2,...)}}`
+`phpcbf {{path/to/directory}} --bootstrap {{path/to/file1,path/to/file2,...}}`
 
 - Don't recurse into subdirectories:
 

--- a/pages/common/quarto.md
+++ b/pages/common/quarto.md
@@ -13,7 +13,7 @@
 
 - Render input file(s) to different formats:
 
-`quarto render {{path/to/file.{{qmd|rmd|ipynb}}}} --to {{html|pdf|docx}}`
+`quarto render {{path/to/file.[qmd|rmd|ipynb]}} --to {{html|pdf|docx}}`
 
 - Render and preview a document or a website:
 

--- a/pages/common/swig.md
+++ b/pages/common/swig.md
@@ -1,7 +1,7 @@
 # swig
 
 > Generate bindings between C/C++ code and various high level languages such as JavaScript, Python, C#, and more.
-> It uses special `.i` or `.swg` files to generate the bindings (C/C++ with SWIG directives, then outputs a C/C++ file that contains all the wrapper code needed to build an extension module.
+> It uses special `.i` or `.swg` files to generate the bindings (C/C++ with SWIG directives), then outputs a C/C++ file that contains all the wrapper code needed to build an extension module.
 > More information: <https://www.swig.org>.
 
 - Generate a binding between C++ and Python:

--- a/pages/common/trdsql.md
+++ b/pages/common/trdsql.md
@@ -9,7 +9,7 @@
 
 - Interpret JSON list as a table and put objects inside as columns (path/to/file.json: `{"list":[{"age":"26","name":"Tanaka"}]}`):
 
-`trdsql "SELECT * FROM {{path/to/file.json}}::.list`
+`trdsql "SELECT * FROM {{path/to/file.json}}::.list"`
 
 - Manipulate complex SQL query with data from multiple CSV files with first line is header (`-ih`):
 

--- a/pages/common/vagrant-validate.md
+++ b/pages/common/vagrant-validate.md
@@ -10,4 +10,4 @@
 
 - Ensure that the Vagrantfile is correctly structured while ignoring provider-specific configuration options:
 
-`vagrant validate {{[-p|--ignore-provider]}} {{docker|hypervlibvirt|parallels|qemu|virtualbox|vmware_desktop}`
+`vagrant validate {{[-p|--ignore-provider]}} {{docker|hypervlibvirt|parallels|qemu|virtualbox|vmware_desktop}}`

--- a/pages/linux/keyd.md
+++ b/pages/linux/keyd.md
@@ -21,4 +21,4 @@
 
 - Create a temporary binding:
 
-`sudo keyd bind "{{pressed_key}} = {{output_key}}`
+`sudo keyd bind "{{pressed_key}} = {{output_key}}"`

--- a/pages/linux/pstoedit.md
+++ b/pages/linux/pstoedit.md
@@ -5,7 +5,7 @@
 
 - Convert a PDF page to PNG or JPEG format:
 
-`pstoedit -page {{page_number}} -f magick {{path/to/file.pdf}} {{page.png|page.jpg]}}`
+`pstoedit -page {{page_number}} -f magick {{path/to/file.pdf}} {{page.png|page.jpg}}`
 
 - Convert multiple PDF pages to numbered images:
 

--- a/pages/linux/rpicam-still.md
+++ b/pages/linux/rpicam-still.md
@@ -5,7 +5,7 @@
 
 - Capture a photo with different encoding:
 
-`rpicam-still {{[-e|--encoding]}} {{bmp|png|rgb|yuv420}} {{[-o|--output]}} {{path/to/file.{{bmp|png|rgb|yuv420}}}}`
+`rpicam-still {{[-e|--encoding]}} {{bmp|png|rgb|yuv420}} {{[-o|--output]}} {{path/to/file.[bmp|png|rgb|yuv420]}}`
 
 - Capture a raw image:
 

--- a/pages/linux/sfdisk.md
+++ b/pages/linux/sfdisk.md
@@ -13,7 +13,7 @@
 
 - Set the type of a partition:
 
-`sfdisk --part-type {{path/to/device}}} {{partition_number}} {{swap}}`
+`sfdisk --part-type {{path/to/device}} {{partition_number}} {{swap}}`
 
 - Delete a partition:
 

--- a/pages/linux/unzipsfx.md
+++ b/pages/linux/unzipsfx.md
@@ -9,16 +9,16 @@
 
 - Extract a self-extracting binary in the current directory:
 
-`{{./path/to/binary)}}`
+`{{./path/to/binary}}`
 
 - Test a self-extracting binary for errors:
 
-`{{./path/to/binary)}} -t`
+`{{./path/to/binary}} -t`
 
 - Print content of a file in the self-extracting binary without extraction:
 
-`{{./path/to/binary)}} -c {{path/to/filename}}`
+`{{./path/to/binary}} -c {{path/to/filename}}`
 
 - Print comments on Zip archive in the self-extracting binary:
 
-`{{./path/to/binary)}} -z`
+`{{./path/to/binary}} -z`


### PR DESCRIPTION
These were found by running `grep -r {{{` and `grep -r }}}` in the project 
#17107

Even more found with 
`find . -type f -print0 | xargs -0 awk '{ o=gsub(/{/,"&"); c=gsub(/}/,"&"); if(o!=c) print FILENAME ": " $0 }'`
`find . -type f -print0 | xargs -0 awk '{ o=gsub(/\[/,"&"); c=gsub(/\]/,"&"); if(o!=c) print FILENAME ": " $0 }'`
`find . -type f -print0 | xargs -0 awk '{ o=gsub(/\(/,"&"); c=gsub(/\)/,"&"); if(o!=c) print FILENAME ": " $0 }'`
`find . -type f -print0 | xargs -0 awk '{ q=gsub(/"/,"&"); if(q % 2 != 0) print FILENAME ": " $0 }'`

Also found an interesting case where a `<` was not inside `" "` with this
`find . -type f -print0 | xargs -0 awk '{ o=gsub(/</,"&"); c=gsub(/>/,"&"); if(o!=c) print FILENAME ": " $0 }' | cut -d : -f 2- | grep -v '\.' | grep "[a-zA-Z]<"`