### PR TITLE
docs: add examples for gh pr create with reviewers, assignees and labels

### DIFF
--- a/pages/common/gh-pr-create.md
+++ b/pages/common/gh-pr-create.md
@@ -11,6 +11,7 @@
 
 `gh pr create {{[-f|--fill]}}`
 
+
 - Create a draft pull request:
 
 `gh pr create {{[-d|--draft]}}`
@@ -22,3 +23,27 @@
 - Start opening a pull request in the default web browser:
 
 `gh pr create {{[-w|--web]}}`
+
+- 基于当前分支创建PR，与基础分支比较，并在编辑器中填写PR信息：
+  gh pr create
+
+- 创建PR并指定标题和描述：
+  gh pr create --title "标题" --body "描述"
+
+- 创建PR并指定目标分支：
+  gh pr create --base 目标分支 --head 源分支
+
+- 创建PR并指定审核者：
+  gh pr create --reviewer username1,username2
+
+- 创建PR并指定负责人：
+  gh pr create --assignee username1,username2
+
+- 创建PR并添加标签：
+  gh pr create --label bug,enhancement
+
+- 创建PR并同时指定审核者、负责人和标签：
+  gh pr create --reviewer team-name,username --assignee username --label "priority: high"
+
+- 在浏览器中创建PR：
+  gh pr create --web


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
