### PR TITLE
spotify_player: add page

### DIFF
--- a/pages/common/spotify_player.md
+++ b/pages/common/spotify_player.md
@@ -1,0 +1,28 @@
+# spotify_player
+
+> A TUI Spotify client that implements all features of the official Spotify app.
+> More information: <https://github.com/aome510/spotify-player#commands>.
+
+- Start a daemon that plays music in the background:
+
+`spotify_player {{[-d|--daemon]}}`
+
+- Start the TUI (controls the daemon if available, otherwise starts its own client):
+
+`spotify_player`
+
+- Use the specified theme:
+
+`spotify_player {{[-t|--theme]}} {{theme_name}}`
+
+- Use configuration files (`app.toml`, `keymap.toml` and `theme.toml`) in the specified directory:
+
+`spotify_player {{[-c|--config-folder]}} {{path/to/directory}}`
+
+- Like the currently playing track:
+
+`spotify_player like`
+
+- Display a list of keybindings:
+
+`<?>`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).