### PR TITLE
pip: add long and short options to commands in translations

### DIFF
--- a/pages.ar/common/pip.md
+++ b/pages.ar/common/pip.md
@@ -14,7 +14,7 @@
 
 - تحديث حزمة مثبتة:
 
-`pip install --upgrade {{package}}`
+`pip install {{[-U|--upgrade]}} {{package}}`
 
 - إزالة تثبيت حزمة:
 
@@ -30,4 +30,4 @@
 
 - تثبيت الحزم من ملف متطلبات:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.de/common/pip.md
+++ b/pages.de/common/pip.md
@@ -14,7 +14,7 @@
 
 - Aktualisiere ein Paket:
 
-`pip install --upgrade {{paketname}}`
+`pip install {{[-U|--upgrade]}} {{paketname}}`
 
 - Deinstalliere ein Paket:
 
@@ -30,4 +30,4 @@
 
 - Installiere Pakete, die in einer Datei gelistet sind:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.fr/common/pip.md
+++ b/pages.fr/common/pip.md
@@ -18,7 +18,7 @@
 
 - Met à jour un paquet :
 
-`pip install --upgrade {{paquet}}`
+`pip install {{[-U|--upgrade]}} {{paquet}}`
 
 - Désinstalle un paquet :
 
@@ -30,7 +30,7 @@
 
 - Installe des paquets à partir d'un fichier :
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`
 
 - Affiche les informations d'un paquet installé :
 

--- a/pages.id/common/pip.md
+++ b/pages.id/common/pip.md
@@ -14,7 +14,7 @@
 
 - Tingkatkan suatu paket ke versi terbaru:
 
-`pip install --upgrade {{nama_paket}}`
+`pip install {{[-U|--upgrade]}} {{nama_paket}}`
 
 - Copot pemasangan suatu paket:
 
@@ -30,4 +30,4 @@
 
 - Pasang kumpulan paket dari suatu berkas:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.ko/common/pip.md
+++ b/pages.ko/common/pip.md
@@ -14,7 +14,7 @@
 
 - 패키지 업그레이드:
 
-`pip install --upgrade {{패키지}}`
+`pip install {{[-U|--upgrade]}} {{패키지}}`
 
 - 패키지 제거:
 
@@ -30,4 +30,4 @@
 
 - 파일에서 패키지 설치:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.pt_BR/common/pip.md
+++ b/pages.pt_BR/common/pip.md
@@ -14,7 +14,7 @@
 
 - Atualiza um pacote:
 
-`pip install --upgrade {{nome_pacote}}`
+`pip install {{[-U|--upgrade]}} {{nome_pacote}}`
 
 - Desinstala um pacote:
 
@@ -30,4 +30,4 @@
 
 - Instala pacotes a partir de um arquivo:
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.zh/common/pip.md
+++ b/pages.zh/common/pip.md
@@ -13,7 +13,7 @@
 
 - 升级包：
 
-`pip install --upgrade {{包名}}`
+`pip install {{[-U|--upgrade]}} {{包名}}`
 
 - 卸载包：
 
@@ -29,4 +29,4 @@
 
 - 通过依赖文件（如 requirements.txt）来进行安装：
 
-`pip install --requirement {{requirements.txt}}`
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
