### PR TITLE
kubectl: add long and short options to commands in translations

### DIFF
--- a/pages.de/common/kubectl.md
+++ b/pages.de/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - Liste Informationen über eine Ressource mit weiteren Details auf:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - Aktualisiere die angegebenen Pods mit dem Label 'unhealthy' und dem Wert 'true':
 

--- a/pages.it/common/kubectl.md
+++ b/pages.it/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - Elenca le informazioni su una risorsa in maniera dettagliata:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - Aggiorna il pod specificato con l'etichetta 'unhealthy' e il valore 'true':
 

--- a/pages.ja/common/kubectl.md
+++ b/pages.ja/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - リソースに関する情報をより詳細に一覧表示する:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - 指定したポッドにラベル 'unhealthy' と値 'true' を付けて更新する:
 

--- a/pages.ko/common/kubectl.md
+++ b/pages.ko/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - 리소스에 대한 정보를 자세히 나열:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - 지정된 포드에 'unhealthy' 레이블과 'true' 값을 추가:
 

--- a/pages.pt_BR/common/kubectl.md
+++ b/pages.pt_BR/common/kubectl.md
@@ -6,7 +6,7 @@
 
 - Lista toda a informação sobre um recurso em detalhes:
 
-`kubectl get {{pod|service|deployment|ingress|...}} -o wide`
+`kubectl get {{pod|service|deployment|ingress|...}} {{[-o|--output]}} wide`
 
 - Atualiza um pod específico com o label 'unhealthy' e o valor 'true':
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

