### PR TITLE
counter-strike-2, openocd: fix double space

### DIFF
--- a/pages/common/openocd.md
+++ b/pages/common/openocd.md
@@ -13,7 +13,7 @@
 
 - Attach OpenOCD session to a board with configuration files and a list of commands to be executed on server startup:
 
-`openocd {{[-f|--file]}} {{config_file.cfg}}  {{[-c|--command]}} "{{command}}"`
+`openocd {{[-f|--file]}} {{config_file.cfg}} {{[-c|--command]}} "{{command}}"`
 
 - Use configuration files in the specified path:
 

--- a/pages/linux/counter-strike-2.md
+++ b/pages/linux/counter-strike-2.md
@@ -9,7 +9,7 @@
 
 - Run a game with specified maximum number of players:
 
-`{{path/to/cs2}}  -dedicated +map {{de_dust2}} -maxplayers {{64}}`
+`{{path/to/cs2}} -dedicated +map {{de_dust2}} -maxplayers {{64}}`
 
 - Run a game with specified server IP and port:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
