### PR TITLE
fzf: add long and short options to commands in translations

### DIFF
--- a/pages.ar/common/fzf.md
+++ b/pages.ar/common/fzf.md
@@ -14,16 +14,16 @@
 
 - تحديد ملفات متعددة باستخدام `<Shift Tab>` وحفظها في ملف:
 
-`find {{path/to/directory}} -type f | fzf --multi > {{path/to/file}}`
+`find {{path/to/directory}} -type f | fzf {{[-m|--multi]}} > {{path/to/file}}`
 
 - تشغيل `fzf` مع نص بحثي محدد:
 
-`fzf --query "{{query}}"`
+`fzf {{[-q|--query]}} "{{query}}"`
 
 - تشغيل `fzf` على الإدخالات التي تبدأ بـ "core" وتنتهي بـ "go" أو "rb" أو "py":
 
-`fzf --query "^core go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
 - تشغيل `fzf` على الإدخالات التي لا تطابق "pyc" وتطابق تمامًا "travis":
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`

--- a/pages.es/common/fzf.md
+++ b/pages.es/common/fzf.md
@@ -14,16 +14,16 @@
 
 - Selecciona varios archivos con `<Shift Tab>` y los escribe a un archivo:
 
-`find {{ruta/al/directorio}} -type f | fzf --multi > {{ruta/al/archivo}}`
+`find {{ruta/al/directorio}} -type f | fzf {{[-m|--multi]}} > {{ruta/al/archivo}}`
 
 - Aplica `fzf` con una consulta especificada:
 
-`fzf --query "{{consulta}}"`
+`fzf {{[-q|--query]}} "{{consulta}}"`
 
 - Aplica `fzf` en las entradas que comienzan con `programa` y finalizan con `go`, `rb`, o `py`:
 
-`fzf --query "^programa go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^programa go$ | rb$ | py$"`
 
 - Aplica `fzf` en entradas que no coinciden con `pyc` y coinciden exactamente con `travis`:
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`

--- a/pages.fr/common/fzf.md
+++ b/pages.fr/common/fzf.md
@@ -14,16 +14,16 @@
 
 - Sélectionne plusieurs fichiers avec `<Shift Tab>` et écrit dans un fichier :
 
-`find {{chemin/vers/répertoire}} -type f | fzf --multi > {{chemin/vers/fichier}}`
+`find {{chemin/vers/répertoire}} -type f | fzf {{[-m|--multi]}} > {{chemin/vers/fichier}}`
 
 - Lance `fzf` avec une requête donnée :
 
-`fzf --query "{{query}}"`
+`fzf {{[-q|--query]}} "{{query}}"`
 
 - Lance `fzf` sur les entrées qui commencent par core et se terminent par go, rb, ou py :
 
-`fzf --query "^core go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
 - Lance `fzf` sur les entrées qui ne correspondent pas à pyc et qui correspondent exactement à travis :
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`

--- a/pages.ko/common/fzf.md
+++ b/pages.ko/common/fzf.md
@@ -14,16 +14,16 @@
 
 - `<Shift Tab>`을 사용해 여러 파일을 선택하고 파일에 작성:
 
-`find {{경로/대상/디렉터리}} -type f | fzf --multi > {{경로/대상/파일}}`
+`find {{경로/대상/디렉터리}} -type f | fzf {{[-m|--multi]}} > {{경로/대상/파일}}`
 
 - 지정된 쿼리로 `fzf`를 시작:
 
-`fzf --query "{{쿼리}}"`
+`fzf {{[-q|--query]}} "{{쿼리}}"`
 
 - core로 시작하고 go, rb 또는 py로 끝나는 항목에서 `fzf`를 시작:
 
-`fzf --query "^core go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
 - pvc와 일치하지 않고 travis와 정확히 일치하는 항목에 대해 `fzf`를 시작:
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`

--- a/pages.tr/common/fzf.md
+++ b/pages.tr/common/fzf.md
@@ -14,16 +14,16 @@
 
 - `<Shift Tab>` ile birden çok dosya seç ve bir dosyaya yaz:
 
-`find {{dosya/yolu/dizin}} -type f | fzf --multi > {{dosya/yolu/dosya}}`
+`find {{dosya/yolu/dizin}} -type f | fzf {{[-m|--multi]}} > {{dosya/yolu/dosya}}`
 
 - fzf'yi belirli bir sorgu ile başlat:
 
-`fzf --query "{{sorgu}}"`
+`fzf {{[-q|--query]}} "{{sorgu}}"`
 
 - Core ile başlayan ve Go, RB veya PY ile biten girişlerde fzf'yi başlat:
 
-`fzf --query "^core go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
 - PYC ile eşleşmeyen ve Travis'e tam olarak eşleşen girişlerde fzf'yi başlat:
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`

--- a/pages.zh/common/fzf.md
+++ b/pages.zh/common/fzf.md
@@ -14,16 +14,16 @@
 
 - 使用 `<Shift Tab>` 选择多个文件并将结果写入文件：
 
-`find {{路径/到/目录}} -type f | fzf --multi > {{路径/到/文件}}`
+`find {{路径/到/目录}} -type f | fzf {{[-m|--multi]}} > {{路径/到/文件}}`
 
 - 使用指定查询词启动 `fzf`:
 
-`fzf --query "{{查询词}}"`
+`fzf {{[-q|--query]}} "{{查询词}}"`
 
 - 对以 core 开头、以 go, rb 或 py 结尾的条目启动 `fzf`:
 
-`fzf --query "^core go$ | rb$ | py$"`
+`fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
 - 对不匹配 pyc 且完全匹配 travis 的条目启动 `fzf`:
 
-`fzf --query "!pyc 'travis"`
+`fzf {{[-q|--query]}} "!pyc 'travis"`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

