### PR TITLE
factorio, terraria, counter-strike-2, minecraft: capitalize title

### DIFF
--- a/pages/common/minecraft.md
+++ b/pages/common/minecraft.md
@@ -1,4 +1,4 @@
-# minecraft
+# Minecraft
 
 > Run a headless Minecraft server.
 > More information: <https://minecraft.wiki/w/Tutorial:Setting_up_a_Java_Edition_server>.

--- a/pages/linux/counter-strike-2.md
+++ b/pages/linux/counter-strike-2.md
@@ -1,4 +1,4 @@
-# counter strike 2
+# Counter Strike 2
 
 > Host a headless Counter Strike 2 server.
 > More information: <https://developer.valvesoftware.com/wiki/Counter-Strike_2/Dedicated_Servers>.

--- a/pages/linux/factorio.md
+++ b/pages/linux/factorio.md
@@ -1,4 +1,4 @@
-# factorio
+# Factorio
 
 > Create and start a headless Factorio server.
 > More information: <https://wiki.factorio.com/Multiplayer>.

--- a/pages/linux/terraria.md
+++ b/pages/linux/terraria.md
@@ -1,4 +1,4 @@
-# terraria
+# Terraria
 
 > Create and start a headless Terraria server.
 > More information: <https://terraria.wiki.gg/wiki/Server>.


### PR DESCRIPTION
Since the title is already the game name instead of the binary name, I think it should be properly capitalized. Only exception I took was openttd since the game can be installed with a package manager to your $PATH and the binary matches the filename of the page.