### PR TITLE
in-toto-run, pueue-add, x8, ippeveps, pasuspender, screenkey: fix nested placeholders

### DIFF
--- a/pages/common/in-toto-run.md
+++ b/pages/common/in-toto-run.md
@@ -17,4 +17,4 @@
 
 - Scan the image using Trivy and generate link file:
 
-`in-toto-run {{[-n|--step-name]}} {{scan}} -k {{key_file}} {{[-p|--products]}} {{report.json}} -- {{/bin/sh -c "trivy {{[-o|--output]}} report.json {{[-f|--format]}} json <IMAGE>"}}`
+`in-toto-run {{[-n|--step-name]}} {{scan}} -k {{key_file}} {{[-p|--products]}} {{report.json}} -- {{/bin/sh -c "trivy --output report.json --format json <IMAGE>"}}`

--- a/pages/common/ippeveps.md
+++ b/pages/common/ippeveps.md
@@ -11,4 +11,4 @@
 
 - Print a file from `stdin` to `stdout`:
 
-`{{wget {{[-O|--output-document]}} - https://example.com/file}} | ippeveps`
+`{{wget --output-document - https://example.com/file}} | ippeveps`

--- a/pages/common/pueue-add.md
+++ b/pages/common/pueue-add.md
@@ -13,7 +13,7 @@
 
 - Add a command but do not start it if it's the first in a queue:
 
-`pueue add {{[-s|--stashed]}} -- {{rsync {{[-a|--archive]}} {{[-z|--compress]}} /local/directory /remote/directory}}`
+`pueue add {{[-s|--stashed]}} -- {{rsync --archive --compress /local/directory /remote/directory}}`
 
 - Add a command to a group and start it immediately, see `pueue group` to manage groups:
 

--- a/pages/common/x8.md
+++ b/pages/common/x8.md
@@ -13,7 +13,7 @@
 
 - Send parameters via POST body with JSON format:
 
-`x8 {{[-u|--url]}} {{https://example.com/}} {{[-X|--method]}} {{POST}} {{[-b|--body]}} {{'{"x":{%s}}'}} {{[-w|--wordlist]}} {{path/to/wordlist.txt}}`
+`x8 {{[-u|--url]}} {{https://example.com/}} {{[-X|--method]}} {{POST}} {{[-b|--body]}} {{'{"x":{%s\}\}'}} {{[-w|--wordlist]}} {{path/to/wordlist.txt}}`
 
 - Check parameters with a custom template (`%k` for key, `%v` for value):
 

--- a/pages/linux/pasuspender.md
+++ b/pages/linux/pasuspender.md
@@ -5,4 +5,4 @@
 
 - Suspend PulseAudio while running `jackd`:
 
-`pasuspender -- {{jackd {{[-d|--driver]}} alsa {{[-d|--device]}} hw:0}}`
+`pasuspender -- {{jackd --driver alsa --device hw:0}}`

--- a/pages/linux/screenkey.md
+++ b/pages/linux/screenkey.md
@@ -29,4 +29,4 @@
 
 - Drag and select a window on screen to display screenkey:
 
-`screenkey {{[-p|--position]}} fixed {{[-g|--geometry]}} {{$(slop {{[-n|--nodecorations]}} {{[-f|--format]}} '%g')}}`
+`screenkey {{[-p|--position]}} fixed {{[-g|--geometry]}} {{$(slop --nodecorations --format '%g')}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
