### PR TITLE
netplan: refresh documentation link and remove `=`

### DIFF
--- a/pages/linux/netplan.md
+++ b/pages/linux/netplan.md
@@ -1,7 +1,7 @@
 # netplan
 
 > Network configuration utility using YAML.
-> More information: <https://netplan.io/>.
+> More information: <https://netplan.readthedocs.io/en/stable/cli/>.
 
 - Apply a network configuration and make it persistent:
 
@@ -17,7 +17,7 @@
 
 - Try configuration changes without applying them permanently:
 
-`sudo netplan try --timeout={{seconds}}`
+`sudo netplan try --timeout {{seconds}}`
 
 - Return to previous working configuration after failed apply:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
