### PR TITLE
cargo*: add option placeholders and fix some syntax

### DIFF
--- a/pages/common/cargo-add.md
+++ b/pages/common/cargo-add.md
@@ -13,7 +13,7 @@
 
 - Add a dependency and enable one or more specific features:
 
-`cargo add {{dependency}} --features {{feature_1}},{{feature_2}}`
+`cargo add {{dependency}} {{[-F|--features]}} {{feature_1}},{{feature_2}}`
 
 - Add an optional dependency, which then gets exposed as a feature of the crate:
 

--- a/pages/common/cargo-clean.md
+++ b/pages/common/cargo-clean.md
@@ -13,7 +13,7 @@
 
 - Remove release artifacts (the `target/release` directory):
 
-`cargo clean --release`
+`cargo clean {{[-r|--release]}}`
 
 - Remove artifacts in the directory of the given profile (in this case, `target/debug`):
 

--- a/pages/common/cargo-clippy.md
+++ b/pages/common/cargo-clippy.md
@@ -21,15 +21,15 @@
 
 - Run checks for a lint group (see <https://rust-lang.github.io/rust-clippy/stable/index.html#?groups=cargo,complexity,correctness,deprecated,nursery,pedantic,perf,restriction,style,suspicious>):
 
-`cargo clippy -- --warn clippy::{{lint_group}}`
+`cargo clippy -- {{[-W|--warn]}} clippy::{{lint_group}}`
 
 - Treat warnings as errors:
 
-`cargo clippy -- --deny warnings`
+`cargo clippy -- {{[-D|--deny]}} warnings`
 
 - Run checks and ignore warnings:
 
-`cargo clippy -- --allow warnings`
+`cargo clippy -- {{[-A|--allow]}} warnings`
 
 - Apply Clippy suggestions automatically:
 

--- a/pages/common/cargo-owner.md
+++ b/pages/common/cargo-owner.md
@@ -5,15 +5,15 @@
 
 - Invite the given user or team as an owner:
 
-`cargo owner --add {{username|github:org_name:team_name}} {{crate}}`
+`cargo owner {{[-a|--add]}} {{username|github:org_name:team_name}} {{crate}}`
 
 - Remove the given user or team as an owner:
 
-`cargo owner --remove {{username|github:org_name:team_name}} {{crate}}`
+`cargo owner {{[-r|--remove]}} {{username|github:org_name:team_name}} {{crate}}`
 
 - List owners of a crate:
 
-`cargo owner --list {{crate}}`
+`cargo owner {{[-l|--list]}} {{crate}}`
 
 - Use the specified registry (registry names can be defined in the configuration - the default is <https://crates.io>):
 

--- a/pages/common/cargo-package.md
+++ b/pages/common/cargo-package.md
@@ -10,4 +10,4 @@
 
 - Display what files would be included in the tarball without actually creating it:
 
-`cargo package --list`
+`cargo package {{[-l|--list]}}`

--- a/pages/common/cargo-publish.md
+++ b/pages/common/cargo-publish.md
@@ -10,7 +10,7 @@
 
 - Perform checks, create a `.crate` file but don't upload it (equivalent of `cargo package`):
 
-`cargo publish --dry-run`
+`cargo publish {{[-n|--dry-run]}}`
 
 - Use the specified registry (registry names can be defined in the configuration - the default is <https://crates.io>):
 

--- a/pages/common/cargo-report.md
+++ b/pages/common/cargo-report.md
@@ -5,12 +5,12 @@
 
 - Display a report:
 
-`cargo report {{future-incompatibilities|...}}`
+`cargo report future-incompatibilities`
 
 - Display a report with the specified Cargo-generated ID:
 
-`cargo report {{future-incompatibilities|...}} --id {{id}}`
+`cargo report future-incompatibilities --id {{id}}`
 
 - Display a report for the specified package:
 
-`cargo report {{future-incompatibilities|...}} --package {{package}}`
+`cargo report future-incompatibilities {{[-p|--package]}} {{package}}`

--- a/pages/common/cargo-tree.md
+++ b/pages/common/cargo-tree.md
@@ -22,4 +22,4 @@
 
 - Only show normal/build/development dependencies:
 
-`cargo tree --edges {{normal|build|dev}}`
+`cargo tree {{[-e|--edges]}} {{normal|build|dev}}`

--- a/pages/common/cargo-update.md
+++ b/pages/common/cargo-update.md
@@ -9,7 +9,7 @@
 
 - Display what would be updated, but don't actually write the lockfile:
 
-`cargo update --dry-run`
+`cargo update {{[-n|--dry-run]}}`
 
 - Update only the specified dependencies:
 

--- a/pages/common/cargo-version.md
+++ b/pages/common/cargo-version.md
@@ -9,4 +9,4 @@
 
 - Display additional build information:
 
-`cargo version --verbose`
+`cargo version {{[-v|--verbose]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
