### PR TITLE
docker-login: add long & short options to commands in translations

### DIFF
--- a/pages.de/common/docker-login.md
+++ b/pages.de/common/docker-login.md
@@ -9,12 +9,12 @@
 
 - Einloggen mit einem angegebenen Benutzernamen (fragt nach dem Passwort):
 
-`docker login --username {{benutzername}}`
+`docker login {{[-u|--username]}} {{benutzername}}`
 
 - Einloggen mit einem angegebenen Benutzernamen und Passwort:
 
-`docker login --username {{benutzername}} --password {{passwort}} {{server}}`
+`docker login {{[-u|--username]}} {{benutzername}} {{[-p|--password]}} {{passwort}} {{server}}`
 
 - Einloggen mit einem Passwort, welches von `stdin` gelesen wird:
 
-`echo "{{passwort}}" | docker login --username {{benutzername}} --password-stdin`
+`echo "{{passwort}}" | docker login {{[-u|--username]}} {{benutzername}} --password-stdin`

--- a/pages.fr/common/docker-login.md
+++ b/pages.fr/common/docker-login.md
@@ -9,12 +9,12 @@
 
 - Se connecter à un registre avec un nom d'utilisateur spécifique (l'utilisateur sera invité à saisir un mot de passe) :
 
-`docker login --username {{nom_d_utilisateur}}`
+`docker login {{[-u|--username]}} {{nom_d_utilisateur}}`
 
 - Se connecter à un registre avec un nom d'utilisateur et un mot de passe spécifiques :
 
-`docker login --username {{nom_d_utilisateur}} --password {{mot_de_passe}} {{serveur}}`
+`docker login {{[-u|--username]}} {{nom_d_utilisateur}} {{[-p|--password]}} {{mot_de_passe}} {{serveur}}`
 
 - Se connecter à un registre avec un mot de passe depuis l'entrée standard :
 
-`echo "{{mot_de_passe}}" | docker login --username {{nom_d_utilisateur}} --password-stdin`
+`echo "{{mot_de_passe}}" | docker login {{[-u|--username]}} {{nom_d_utilisateur}} --password-stdin`

--- a/pages.ko/common/docker-login.md
+++ b/pages.ko/common/docker-login.md
@@ -9,12 +9,12 @@
 
 - 특정 사용자 명으로 레지스트리에 로그인 (사용자는 비밀번호를 입력하라는 메시지를 받음):
 
-`docker login --username {{사용자_명}}`
+`docker login {{[-u|{{[-u|--username]}}]}} {{사용자_명}}`
 
 - 사용자 명과 비밀번호로 레지스트리에 로그인:
 
-`docker login --username {{사용자_명}} --password {{비밀번호}} {{서버}}`
+`docker login {{[-u|--username]}} {{사용자_명}} {{[-p|--password]}} {{비밀번호}} {{서버}}`
 
 - `stdin`에서 비밀번호를 받아 레지스트리에 로그인:
 
-`echo "{{비밀번호}}" | docker login --username {{사용자_명}} --password-stdin`
+`echo "{{비밀번호}}" | docker login {{[-u|--username]}} {{사용자_명}} --password-stdin`

--- a/pages.pt_BR/common/docker-login.md
+++ b/pages.pt_BR/common/docker-login.md
@@ -9,12 +9,12 @@
 
 - Faz login em um registro com um nome de usuário específico (será solicitada a senha):
 
-`docker login --username {{nome_de_usuário}}`
+`docker login {{[-u|--username]}} {{nome_de_usuário}}`
 
 - Faz login em um registro com nome de usuário e senha:
 
-`docker login --username {{nome_de_usuário}} --password {{senha}} {{servidor}}`
+`docker login {{[-u|--username]}} {{nome_de_usuário}} {{[-p|--password]}} {{senha}} {{servidor}}`
 
 - Faz login em um registro com a senha vinda do `stdin`:
 
-`echo "{{senha}}" | docker login --username {{nome_de_usuário}} --password-stdin`
+`echo "{{senha}}" | docker login {{[-u|--username]}} {{nome_de_usuário}} --password-stdin`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

