### PR TITLE
dlv: fix typo

### DIFF
--- a/pages/common/dlv.md
+++ b/pages/common/dlv.md
@@ -21,7 +21,7 @@
 
 - Attach to a running process and begin debugging:
 
-`div attach {{pid}}`
+`dlv attach {{pid}}`
 
 - Compile and begin tracing a program:
 


### PR DESCRIPTION
I assume this is a typo
Found with ``grep -r '`' | grep 'md:`' | sed "s/-/ /g" | grep -vEi '/([a-zA-Z0-9+_ \.\^,!~%\[]+)\.md:`.*\1' | grep -v tldr | grep -v "<" | grep -vEi ' ([a-zA-Z0-9+_ \.]+)\.md:`.*\1]}}'``