### PR TITLE
gst-inspect-1.0: fix typo

### DIFF
--- a/pages/common/gst-inspect-1.0.md
+++ b/pages/common/gst-inspect-1.0.md
@@ -13,7 +13,7 @@
 
 - List available container plugins:
 
-`gst-inspect-10 {{matroska|avi|ogg|isomp4}}`
+`gst-inspect-1.0 {{matroska|avi|ogg|isomp4}}`
 
 - List available audio codecs:
 


### PR DESCRIPTION
Found with
```
grep -r '`' | grep 'md:`' | sed "s/-/ /g" | grep -vEi '/([a-zA-Z0-9+_ \.\^,!~%\[]+)\.md:`.*\1' | grep -v tldr | grep -v "<" | grep -v "pacman" | grep -vEi ' ([a-zA-Z0-9+_ \.]+)\.md:`.*\1\]}}' | cut -d ":" -f 1 | uniq -u
```