### PR TITLE
qemu-system-{i386, x86_64}: fix messup

### DIFF
--- a/pages/common/qemu-system-i386.md
+++ b/pages/common/qemu-system-i386.md
@@ -25,4 +25,4 @@
 
 - List the supported machine types:
 
-`qemu-system-x86_64 {{[-M|-machine]}} help`
+`qemu-system-i386 {{[-M|-machine]}} help`

--- a/pages/common/qemu-system-x86_64.md
+++ b/pages/common/qemu-system-x86_64.md
@@ -17,7 +17,7 @@
 
 - Do not launch a VNC server:
 
-`qemu-system-i386 -hda {{image_name.img}} -m {{4096}} -nographic`
+`qemu-system-x86_64 -hda {{image_name.img}} -m {{4096}} -nographic`
 
 - Exit non-graphical QEMU:
 


### PR DESCRIPTION
Found with 
```
grep -r '`' | grep 'md:`' | sed "s/-/ /g" | grep -vEi '/([a-zA-Z0-9+_ \.\^,!~%\[]+)\.md:`.*\1' | grep -v tldr | grep -v "<" | grep -v "pacman" | grep -vEi ' ([a-zA-Z0-9+_ \.]+)\.md:`.*\1\]}}' | cut -d ":" -f 1 | uniq -u
```