### PR TITLE
docker-network: add long and short options to commands in translations

### DIFF
--- a/pages.de/common/docker-network.md
+++ b/pages.de/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Erzeuge ein benutzerdefiniertes Netzwerk:
 
-`docker network create --driver {{treiber_name}} {{netzwerk_name}}`
+`docker network create {{[-d|--driver]}} {{treiber_name}} {{netzwerk_name}}`
 
 - Zeige detaillierte Informationen der mit Leerzeichen separierten Netzwerke an:
 

--- a/pages.fr/common/docker-network.md
+++ b/pages.fr/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Créer un réseau défini par l'utilisateur :
 
-`docker network create --driver {{nom_du_driver}} {{nom_du_reseau}}`
+`docker network create {{[-d|--driver]}} {{nom_du_driver}} {{nom_du_reseau}}`
 
 - Afficher les informations détaillées des réseaux séparés par des espaces :
 

--- a/pages.it/common/docker-network.md
+++ b/pages.it/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Crea una rete definita da un utente:
 
-`docker network create --driver {{nome_del_driver}} {{nome_rete}}`
+`docker network create {{[-d|--driver]}} {{nome_del_driver}} {{nome_rete}}`
 
 - Mostra informazioni dettagliate su una lista di reti (separata da spazi):
 

--- a/pages.ko/common/docker-network.md
+++ b/pages.ko/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - 사용자 정의 네트워크 생성:
 
-`docker network create --driver {{드라이버_이름}} {{네트워크_이름}}`
+`docker network create {{[-d|--driver]}} {{드라이버_이름}} {{네트워크_이름}}`
 
 - 하나 이상의 네트워크에 대한 자세한 정보 표시:
 

--- a/pages.pt_BR/common/docker-network.md
+++ b/pages.pt_BR/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Cria uma rede definida pelo usuário:
 
-`docker network create --driver {{nome_do_driver}} {{nome_da_rede}}`
+`docker network create {{[-d|--driver]}} {{nome_do_driver}} {{nome_da_rede}}`
 
 - Exibe informações detalhadas de uma lista separada por espaços de redes:
 

--- a/pages.tr/common/docker-network.md
+++ b/pages.tr/common/docker-network.md
@@ -9,7 +9,7 @@
 
 - Kullanıcı tarafından belirtilmiş bir ağ oluştur:
 
-`docker network create --driver {{driver_name}} {{ağ_ismi}}`
+`docker network create {{[-d|--driver]}} {{driver_name}} {{ağ_ismi}}`
 
 - Boşluk ile ayrılmış bir ağ listesinin detaylı bilgisini görüntüle:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

