### PR TITLE
st-util: remove gdb prompt

### DIFF
--- a/pages/common/st-util.md
+++ b/pages/common/st-util.md
@@ -7,10 +7,10 @@
 
 `st-util {{[-p|--listen_port]}} {{4500}}`
 
-- Connect to GDB server:
+- Connect to GDB server within `gdb`:
 
-`(gdb) target extended-remote {{localhost}}:{{4500}}`
+`target extended-remote {{localhost}}:{{4500}}`
 
 - Write firmware to device:
 
-`(gdb) load {{firmware.elf}}`
+`load {{firmware.elf}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
