### PR TITLE
ip, nmcli, nmcli-device, nmcli-general, nmcli-monitor: add Czech translation

### DIFF
--- a/pages.cs/linux/ip.md
+++ b/pages.cs/linux/ip.md
@@ -1,0 +1,37 @@
+# ip
+
+> Ukazuje/nastavuje routování, zařízení, pravidla routování a tunely.
+> Některé dílčí příkazy jako je `address` mají svou vlastní dokumentaci.
+> Více informací: <https://www.manned.org/ip.8>.
+
+- Vypsat rozhraní s podrobnými informacemi:
+
+`ip {{[a|address]}}`
+
+- Vypsat rozhraní se stručnými informacemi o síťové vrstvě:
+
+`ip {{[-br|-brief]}} {{[a|address]}}`
+
+- Vypsat rozhraní se stručnými informacemi o linkové vrstvě:
+
+`ip {{[-br|-brief]}} {{[l|link]}}`
+
+- Zobrazit routovací tabulku:
+
+`ip {{[r|route]}}`
+
+- Ukázat sousedy (ARP tabulka):
+
+`ip {{[n|neighbour]}}`
+
+- Změnit rozhraní nahoru/dolů:
+
+`sudo ip {{[l|link]}} {{[s|set]}} {{ethX}} {{up|down}}`
+
+- Přidat/Smazat IP adresu k rozhraní:
+
+`sudo ip {{[a|address]}} {{add|delete}} {{ip}}/{{maska}} dev {{ethX}}`
+
+- Přidat výchozí cestu:
+
+`sudo ip {{[r|route]}} {{[a|add]}} default via {{ip}} dev {{ethX}}`

--- a/pages.cs/linux/nmcli-device.md
+++ b/pages.cs/linux/nmcli-device.md
@@ -1,0 +1,21 @@
+# nmcli device
+
+> Spravuje síťové rozhraní a navazuje nové Wi-Fi spojení pomocí NetworkManageru.
+> Tento dílčí příkaz může být zvolán také pomocí `nmcli d`.
+> Více informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
+
+- Vypsat stav všech síťových rozhraní:
+
+`nmcli device status`
+
+- Vypsat všechny dostupné přístupové body Wi-Fi:
+
+`nmcli device wifi`
+
+- Připojit se k Wi-Fi síťi s uvedeným SSID (budete vyzváni k zadání hesla):
+
+`nmcli --ask device wifi connect {{ssid}}`
+
+- Vypsat heslo a QR kód pro aktuální Wi-Fi síť:
+
+`nmcli device wifi show-password`

--- a/pages.cs/linux/nmcli-device.md
+++ b/pages.cs/linux/nmcli-device.md
@@ -6,16 +6,16 @@
 
 - Vypsat stav všech síťových rozhraní:
 
-`nmcli device status`
+`nmcli {{[d|device]}}`
 
 - Vypsat všechny dostupné přístupové body Wi-Fi:
 
-`nmcli device wifi`
+`nmcli {{[d|device]}} {{[w|wifi]}}`
 
 - Připojit se k Wi-Fi síťi s uvedeným SSID (budete vyzváni k zadání hesla):
 
-`nmcli --ask device wifi connect {{ssid}}`
+`nmcli {{[d|device]}} {{[w|wifi]}} {{[c|connect]}} {{ssid}} {{[-a|--ask]}}`
 
 - Vypsat heslo a QR kód pro aktuální Wi-Fi síť:
 
-`nmcli device wifi show-password`
+`nmcli {{[d|device]}} {{[w|wifi]}} {{[s|show-password]}}`

--- a/pages.cs/linux/nmcli-general.md
+++ b/pages.cs/linux/nmcli-general.md
@@ -6,24 +6,24 @@
 
 - Zobrazit obecný stav NetworkManageru:
 
-`nmcli general`
+`nmcli {{[g|general]}}`
 
 - Zobrazit hostitelské jméno aktuálního zařízení:
 
-`nmcli general hostname`
+`nmcli {{[g|general]}} {{[h|hostname]}}`
 
 - Změnit hostitelské jméno aktuálního zařízení:
 
-`sudo nmcli general hostname {{nove_hostitelske_jmeno}}`
+`sudo nmcli {{[g|general]}} {{[h|hostname]}} {{nove_hostitelske_jmeno}}`
 
 - Zobrazit oprávění NetworkManageru:
 
-`nmcli general permissions`
+`nmcli {{[g|general]}} {{[p|permissions]}}`
 
 - Zobrazit aktuální úroveň logů a domén:
 
-`nmcli general logging`
+`nmcli {{[g|general]}} {{[l|logging]}}`
 
 - Nastavit úroveň logů a/nebo domén (všechny dostupné domény najdete pomocí `man NetworkManager.conf`):
 
-`nmcli general logging level {{INFO|OFF|ERR|WARN|DEBUG|TRACE}} domain {{domena_1,domena_2,...}}`
+`sudo nmcli {{[g|general]}} {{[l|logging]}} {{[l|level]}} {{INFO|OFF|ERR|WARN|DEBUG|TRACE}} domain {{domena_1,domena_2,...}}`

--- a/pages.cs/linux/nmcli-general.md
+++ b/pages.cs/linux/nmcli-general.md
@@ -1,0 +1,29 @@
+# nmcli general
+
+> Spravuje obecné nastavení NetworkManageru.
+> Tento dílčí příkaz může být zvolán také pomocí `nmcli g`.
+> Více informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
+
+- Zobrazit obecný stav NetworkManageru:
+
+`nmcli general`
+
+- Zobrazit hostitelské jméno aktuálního zařízení:
+
+`nmcli general hostname`
+
+- Změnit hostitelské jméno aktuálního zařízení:
+
+`sudo nmcli general hostname {{nove_hostitelske_jmeno}}`
+
+- Zobrazit oprávění NetworkManageru:
+
+`nmcli general permissions`
+
+- Zobrazit aktuální úroveň logů a domén:
+
+`nmcli general logging`
+
+- Nastavit úroveň logů a/nebo domén (všechny dostupné domény najdete pomocí `man NetworkManager.conf`):
+
+`nmcli general logging level {{INFO|OFF|ERR|WARN|DEBUG|TRACE}} domain {{domena_1,domena_2,...}}`

--- a/pages.cs/linux/nmcli-monitor.md
+++ b/pages.cs/linux/nmcli-monitor.md
@@ -6,4 +6,4 @@
 
 - Spustit monitorování změn NetworkManageru:
 
-`nmcli monitor`
+`nmcli {{[m|monitor]}}`

--- a/pages.cs/linux/nmcli-monitor.md
+++ b/pages.cs/linux/nmcli-monitor.md
@@ -1,0 +1,9 @@
+# nmcli monitor
+
+> Monitoruje změny stavu připojení NetworkManageru.
+> Tento dílčí příkaz může být zvolán také pomocí `nmcli m`.
+> Více informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
+
+- Spustit monitorování změn NetworkManageru:
+
+`nmcli monitor`

--- a/pages.cs/linux/nmcli.md
+++ b/pages.cs/linux/nmcli.md
@@ -1,0 +1,32 @@
+# nmcli
+
+> Spravuje síťovou konfiguraci pomocí NetworkManageru.
+> Více Informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
+
+- Zobrazit dokumentaci pro běžící `nmcli` jako skrytý/polkit NetworkManager agent:
+
+`tldr nmcli agent`
+
+- Zobrazit dokumentaci pro správu síťových spojení:
+
+`tldr nmcli connection`
+
+- Zobrazit dokumentaci pro správu síťových rozhraní a navázání nových Wi-Fi připojení:
+
+`tldr nmcli device`
+
+- Zobrazit dokumentaci pro správu obecných nastavení NetworkManageru:
+
+`tldr nmcli general`
+
+- Zobrazit dokumentaci pro monitor aktivity NetworkManageru:
+
+`tldr nmcli monitor`
+
+- Zobrazit dokumentaci pro povolování/zakázání a kontrolovat stav sítě:
+
+`tldr nmcli networking`
+
+- Zobrazit dokumentaci pro správu rádiových přepínačů:
+
+`tldr nmcli radio`

--- a/pages.cs/linux/nmcli.md
+++ b/pages.cs/linux/nmcli.md
@@ -1,19 +1,19 @@
 # nmcli
 
 > Spravuje síťovou konfiguraci pomocí NetworkManageru.
-> Více Informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
+> Více informací: <https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html>.
 
-- Zobrazit dokumentaci pro běžící `nmcli` jako skrytý/polkit NetworkManager agent:
+- Zobrazit dokumentaci pro správu síťových rozhraní a navázání nových Wi-Fi připojení:
 
-`tldr nmcli agent`
+`tldr nmcli device`
 
 - Zobrazit dokumentaci pro správu síťových spojení:
 
 `tldr nmcli connection`
 
-- Zobrazit dokumentaci pro správu síťových rozhraní a navázání nových Wi-Fi připojení:
+- Zobrazit dokumentaci pro běžící `nmcli` jako skrytý/polkit NetworkManager agent:
 
-`tldr nmcli device`
+`tldr nmcli agent`
 
 - Zobrazit dokumentaci pro správu obecných nastavení NetworkManageru:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**