### PR TITLE
k9s: add short options

### DIFF
--- a/pages/common/k9s.md
+++ b/pages/common/k9s.md
@@ -13,8 +13,8 @@
 
 - Manage a cluster using a given kubernetes namespace:
 
-`k9s --namespace {{kubernetes_namespace}} --cluster {{cluster_name}}`
+`k9s {{[-n|--namespace]}} {{kubernetes_namespace}} --cluster {{cluster_name}}`
 
 - Manage a cluster launching k9s in the pod view and enable debug logging:
 
-`k9s --command {{pod}} --logLevel debug --cluster {{cluster_name}}`
+`k9s {{[-c|--command]}} {{pod}} {{[-l|--logLevel]}} debug --cluster {{cluster_name}}`


### PR DESCRIPTION
Not found in official documentation. Only found in `k9s -h`