### PR TITLE
aplay, wol, unlzma: remove `=` and add short options

### DIFF
--- a/pages/common/unlzma.md
+++ b/pages/common/unlzma.md
@@ -1,6 +1,6 @@
 # unlzma
 
-> This command is an alias of `xz --format=lzma --decompress`.
+> This command is an alias of `xz --format lzma --decompress`.
 
 - View documentation for the original command:
 

--- a/pages/linux/aplay.md
+++ b/pages/linux/aplay.md
@@ -9,8 +9,8 @@
 
 - Play the first 10 seconds of a specific file at 2500 Hz:
 
-`aplay --duration {{10}} --rate {{2500}} {{path/to/file}}`
+`aplay {{[-d|--duration]}} {{10}} {{[-r|--rate]}} {{2500}} {{path/to/file}}`
 
 - Play the raw file as a 22050 Hz, mono, 8-bit, Mu-Law `.au` file:
 
-`aplay --channels {{1}} --file-type {{raw}} --rate {{22050}} --format {{mu_law}} {{path/to/file}}`
+`aplay {{[-c|--channels]}} {{1}} {{[-t|--file-type]}} {{raw}} {{[-r|--rate]}} {{22050}} {{[-f|--format]}} {{mu_law}} {{path/to/file}}`

--- a/pages/linux/aplay.md
+++ b/pages/linux/aplay.md
@@ -9,8 +9,8 @@
 
 - Play the first 10 seconds of a specific file at 2500 Hz:
 
-`aplay --duration={{10}} --rate={{2500}} {{path/to/file}}`
+`aplay --duration {{10}} --rate {{2500}} {{path/to/file}}`
 
 - Play the raw file as a 22050 Hz, mono, 8-bit, Mu-Law `.au` file:
 
-`aplay --channels={{1}} --file-type {{raw}} --rate={{22050}} --format={{mu_law}} {{path/to/file}}`
+`aplay --channels {{1}} --file-type {{raw}} --rate {{22050}} --format {{mu_law}} {{path/to/file}}`

--- a/pages/linux/wol.md
+++ b/pages/linux/wol.md
@@ -9,19 +9,19 @@
 
 - Send a WoL packet to a device in another subnet based on its IP:
 
-`wol --ipaddr {{ip_address}} {{mac_address}}`
+`wol {{[-i|--ipaddr]}} {{ip_address}} {{mac_address}}`
 
 - Send a WoL packet to a device in another subnet based on its hostname:
 
-`wol --host {{hostname}} {{mac_address}}`
+`wol {{[-h|--host]}} {{hostname}} {{mac_address}}`
 
 - Send a WoL packet to a specific port on a host:
 
-`wol --port {{port_number}} {{mac_address}}`
+`wol {{[-p|--port]}} {{port_number}} {{mac_address}}`
 
 - Read hardware addresses, IP addresses/hostnames, optional ports and SecureON passwords from a file:
 
-`wol --file {{path/to/file}}`
+`wol {{[-f|--file]]} {{path/to/file}}`
 
 - Turn on verbose output:
 

--- a/pages/linux/wol.md
+++ b/pages/linux/wol.md
@@ -9,19 +9,19 @@
 
 - Send a WoL packet to a device in another subnet based on its IP:
 
-`wol --ipaddr={{ip_address}} {{mac_address}}`
+`wol --ipaddr {{ip_address}} {{mac_address}}`
 
 - Send a WoL packet to a device in another subnet based on its hostname:
 
-`wol --host={{hostname}} {{mac_address}}`
+`wol --host {{hostname}} {{mac_address}}`
 
 - Send a WoL packet to a specific port on a host:
 
-`wol --port={{port_number}} {{mac_address}}`
+`wol --port {{port_number}} {{mac_address}}`
 
 - Read hardware addresses, IP addresses/hostnames, optional ports and SecureON passwords from a file:
 
-`wol --file={{path/to/file}}`
+`wol --file {{path/to/file}}`
 
 - Turn on verbose output:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
