### PR TITLE
speedtest: remove `=` and add short options

### DIFF
--- a/pages/common/speedtest.md
+++ b/pages/common/speedtest.md
@@ -11,24 +11,24 @@
 
 - Run a speed test and specify the unit of the output:
 
-`speedtest --unit={{auto-decimal-bits|auto-decimal-bytes|auto-binary-bits|auto-binary-bytes}}`
+`speedtest {{[-u|--unit]}} {{auto-decimal-bits|auto-decimal-bytes|auto-binary-bits|auto-binary-bytes}}`
 
 - Run a speed test and specify the output format:
 
-`speedtest --format={{human-readable|csv|tsv|json|jsonl|json-pretty}}`
+`speedtest {{[-f|--format]}} {{human-readable|csv|tsv|json|jsonl|json-pretty}}`
 
 - Run a speed test and specify the number of decimal points to use (0 to 8, defaults to 2):
 
-`speedtest --precision={{precision}}`
+`speedtest {{[-P|--precision]}} {{precision}}`
 
 - Run a speed test and print its progress (only available for output format `human-readable` and `json`):
 
-`speedtest --progress={{yes|no}}`
+`speedtest {{[-p|--progress]}} {{yes|no}}`
 
 - List all `speedtest.net` servers, sorted by distance:
 
-`speedtest --servers`
+`speedtest {{[-L|--servers]}}`
 
 - Run a speed test to a specific `speedtest.net` server:
 
-`speedtest --server-id={{server_id}}`
+`speedtest {{[-s|--server-id]}} {{server_id}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
