### PR TITLE
cli53: add proper option placeholders and fix example link

### DIFF
--- a/pages/common/cli53.md
+++ b/pages/common/cli53.md
@@ -21,7 +21,7 @@
 
 - Create a `www` subdomain pointing to an external address (must end with a dot):
 
-`cli53 {{[rc|rrcreate]}} {{example.com}} {{'www 300 CNAME lb.externalhost.com.'}}`
+`cli53 {{[rc|rrcreate]}} {{example.com}} {{'www 300 CNAME lb.example.com.'}}`
 
 - Create a `www` subdomain pointing to an IP address:
 

--- a/pages/common/cli53.md
+++ b/pages/common/cli53.md
@@ -9,23 +9,23 @@
 
 - Create a domain:
 
-`cli53 create {{mydomain.com}} --comment "{{comment}}"`
+`cli53 create {{example.com}} --comment "{{comment}}"`
 
 - Export a bind zone file to `stdout`:
 
-`cli53 export {{mydomain.com}}`
+`cli53 export {{example.com}}`
 
 - Create a `www` subdomain pointing to a relative record in the same zone:
 
-`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 CNAME lb'}}`
+`cli53 {{[rc|rrcreate]}} {{example.com}} {{'www 300 CNAME lb'}}`
 
 - Create a `www` subdomain pointing to an external address (must end with a dot):
 
-`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 CNAME lb.externalhost.com.'}}`
+`cli53 {{[rc|rrcreate]}} {{example.com}} {{'www 300 CNAME lb.externalhost.com.'}}`
 
 - Create a `www` subdomain pointing to an IP address:
 
-`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 A 150.130.110.1'}}`
+`cli53 {{[rc|rrcreate]}} {{example.com}} {{'www 300 A 150.130.110.1'}}`
 
 - Replace a `www` subdomain pointing to a different IP:
 
@@ -33,4 +33,4 @@
 
 - Delete a record A:
 
-`cli53 {{[rd|rrdelete]}} {{mydomain.com}} {{www}} {{A}}`
+`cli53 {{[rd|rrdelete]}} {{example.com}} {{www}} {{A}}`

--- a/pages/common/cli53.md
+++ b/pages/common/cli53.md
@@ -17,20 +17,20 @@
 
 - Create a `www` subdomain pointing to a relative record in the same zone:
 
-`cli53 {{rc|rrcreate}} {{mydomain.com}} {{'www 300 CNAME lb'}}`
+`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 CNAME lb'}}`
 
 - Create a `www` subdomain pointing to an external address (must end with a dot):
 
-`cli53 {{rc|rrcreate}} {{mydomain.com}} {{'www 300 CNAME lb.externalhost.com.'}}`
+`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 CNAME lb.externalhost.com.'}}`
 
 - Create a `www` subdomain pointing to an IP address:
 
-`cli53 {{rc|rrcreate}} {{mydomain.com}} {{'www 300 A 150.130.110.1'}}`
+`cli53 {{[rc|rrcreate]}} {{mydomain.com}} {{'www 300 A 150.130.110.1'}}`
 
 - Replace a `www` subdomain pointing to a different IP:
 
-`cli53 {{rc|rrcreate}} --replace {{'www 300 A 150.130.110.2'}}`
+`cli53 {{[rc|rrcreate]}} --replace {{'www 300 A 150.130.110.2'}}`
 
 - Delete a record A:
 
-`cli53 {{rd|rrdelete}} {{mydomain.com}} {{www}} {{A}}`
+`cli53 {{[rd|rrdelete]}} {{mydomain.com}} {{www}} {{A}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
