### PR TITLE
openrgb: add page

### DIFF
--- a/pages/common/openrgb.md
+++ b/pages/common/openrgb.md
@@ -3,11 +3,11 @@
 > Control RGB lighting.
 > More information: <https://gitlab.com/OpenRGBDevelopers/OpenRGB-Wiki/-/blob/stable/User-Documentation/Using-OpenRGB.md>.
 
-- Start the `openrgb` GUI:
+- Start the OpenRGB GUI:
 
 `openrgb`
 
-- List devices supported by `openrgb`:
+- List devices supported by OpenRGB:
 
 `openrgb --noautoconnect {{[-l|--list-devices]}}`
 


### PR DESCRIPTION
I wasn't about to find documentation that directly addresses CLI usage. If someone knows where to find that, let me know.
Only place where CLI was addressed was in `openrgb -h`

Closes #13656