### PR TITLE
qm-cloud-init: rename to qm-cloudinit and fix typos

### DIFF
--- a/pages/linux/qm-cloudinit.md
+++ b/pages/linux/qm-cloudinit.md
@@ -1,24 +1,24 @@
-# qm cloud init
+# qm cloudinit
 
 > Configure cloudinit settings for virtual machines managed by Proxmox Virtual Environment (PVE).
 > More information: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
 - Configure cloudinit settings for a specific user and set password for the user:
 
-`qm cloud-init {{vm_id}} -user={{user}} -password={{password}}`
+`qm cloudinit {{vm_id}} -user={{user}} -password={{password}}`
 
 - Configure cloudinit settings for a specific user and set password for the user with a specific SSH key:
 
-`qm cloud-init {{vm_id}} -user={{user}} -password={{password}} -sshkey={{ssh_key}}`
+`qm cloudinit {{vm_id}} -user={{user}} -password={{password}} -sshkey={{ssh_key}}`
 
 - Set the hostname for a specific virtual machine:
 
-`qm cloud-init {{vm_id}} -hostname={{hostname}}`
+`qm cloudinit {{vm_id}} -hostname={{hostname}}`
 
 - Configure the network interface settings for a specific virtual machine:
 
-`qm cloud-init {{vm_id}} -ipconfig {{ipconfig}}`
+`qm cloudinit {{vm_id}} -ipconfig {{ipconfig}}`
 
 - Configure a shell script to execute before `cloud-ini` is run on a virtual machine:
 
-`qm cloud-init {{vm_id}} -pre {{script}}`
+`qm cloudinit {{vm_id}} -pre {{script}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
