### PR TITLE
dnsmasq: add page

### DIFF
--- a/pages/common/dnsmasq.md
+++ b/pages/common/dnsmasq.md
@@ -1,0 +1,28 @@
+# dnsmasq
+
+> Lightweight DNS, DHCP, TFTP, and PXE server.
+> More information: <https://manned.org/dnsmasq>
+
+- Start dnsmasq with default configuration:
+
+`dnsmasq`
+
+- Run dnsmasq in the foreground (for debugging):
+
+`dnsmasq --no-daemon`
+
+- Specify a custom configuration file:
+
+`dnsmasq --conf-file={{/path/to/config.conf}}`
+
+- Enable verbose logging:
+
+`dnsmasq --log-queries --log-facility=-`
+
+- Set a DHCP range and lease time:
+
+`dnsmasq --dhcp-range=192.168.0.50,192.168.0.150,12h`
+
+- Print dnsmasq version:
+
+`dnsmasq --version`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `common`
- [x] The page has at most 8 examples
- [x] The page description has a link to documentation
- [x] The page follows the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines)
- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- **Version of the command being documented (if known):** `2.89`

This PR adds a new tldr page for the `dnsmasq` utility, which provides lightweight DNS, DHCP, TFTP, and PXE services.

Closes #17309.
