### PR TITLE
flock: improvements and fix of misleading wording

### DIFF
--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -22,4 +22,4 @@
 
 - Backup a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file (can be used in a cronjob that runs often):
 
-`flock {{/tmp/backup.lock}} {{tar -cvf ./backup.tar ./data/}}`
+`flock {{path/to/backup.lock}} {{tar -cvf path/to/backup.tar path/to/data/}}`

--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -20,6 +20,6 @@
 
 `flock {{path/to/lock.lock}} {{[-w|--timeout]}} 10 {{command}}`
 
-- Backup a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file (can be used in a cronjob that runs often):
+- Backup a bunch of files, waiting for the previous `tar` command to finish if it's still running elsewhere and holding the same lock file (can be used in a `cronjob` that runs often):
 
 `flock {{path/to/backup.lock}} {{tar -cvf path/to/backup.tar path/to/data/}}`

--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -1,17 +1,25 @@
 # flock
 
-> Manage locks from shell scripts.
-> It can be used to ensure that only one process of a command is running.
+> Manage file locks from shell scripts.
+> It can be used to ensure that only one instance of a command is running.
 > More information: <https://manned.org/flock>.
 
-- Run a command with a file lock as soon as the lock is not required by others:
+- Run a command with a file lock as soon as the lock is available:
 
-`flock {{path/to/lock.lock}} {{[-c|--command]}} "{{command}}"`
+`flock {{path/to/lock.lock}} {{command}}`
 
-- Run a command with a file lock, and exit if the lock doesn't exist:
+- Run a command with a file lock, or exit if the lock is currently being held (with exit code 1):
 
-`flock {{path/to/lock.lock}} {{[-n|--nonblock]}} {{[-c|--command]}} "{{command}}"`
+`flock {{path/to/lock.lock}} {{[-n|--nonblock]}} {{command}}`
 
-- Run a command with a file lock, and exit with a specific error code if the lock doesn't exist:
+- Run a command with a file lock, or exit with a specific error code if the lock is currently being held:
 
-`flock {{path/to/lock.lock}} {{[-n|--nonblock]}} {{[-E|--conflict-exit-code]}} {{error_code}} {{[-c|--command]}} "{{command}}"`
+`flock {{path/to/lock.lock}} {{[-n|--nonblock]}} {{[-E|--conflict-exit-code]}} {{123}} {{command}}`
+
+- Run a command with a file lock, waiting up to 10 seconds for the lock to be available before giving up:
+
+`flock {{path/to/lock.lock}} {{[-w|--timeout]}} 10 {{command}}`
+
+- Archive a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file:
+
+`flock {{/tmp/backup.lock}} {{tar -cvf ./backup.tar ./data}}`

--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -20,6 +20,6 @@
 
 `flock {{path/to/lock.lock}} {{[-w|--timeout]}} 10 {{command}}`
 
-- Archive a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file:
+- Backup a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file (can be used in a cronjob that runs often):
 
 `flock {{/tmp/backup.lock}} {{tar -cvf ./backup.tar ./data/}}`

--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -22,4 +22,4 @@
 
 - Archive a bunch of files, waiting for the previous tar command to finish if it's still running elsewhere and holding the same lock file:
 
-`flock {{/tmp/backup.lock}} {{tar -cvf ./backup.tar ./data}}`
+`flock {{/tmp/backup.lock}} {{tar -cvf ./backup.tar ./data/}}`

--- a/pages/linux/flock.md
+++ b/pages/linux/flock.md
@@ -20,6 +20,6 @@
 
 `flock {{path/to/lock.lock}} {{[-w|--timeout]}} 10 {{command}}`
 
-- Backup a bunch of files, waiting for the previous `tar` command to finish if it's still running elsewhere and holding the same lock file (can be used in a `cronjob` that runs often):
+- Backup a bunch of files, waiting for the previous `tar` command to finish if it's still running elsewhere and holding the same lock file (can be used in a `cron` job that runs often):
 
 `flock {{path/to/backup.lock}} {{tar -cvf path/to/backup.tar path/to/data/}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** flock from util-linux 2.41.1

Changes:
- don't use `{{[-c|--command]}}` since that didn't allow passing arguments to the command being executed, so why use it?
- improve wording for clarity (previous one was so misleading that the man page was much clearer at that point, plus the desc for `--nonblock` was straight up lying due to being the other way around than how it actually works)
- added missing form `--nb` to `--nonblock`
- changed `{{error_code}}` to `{{123}}` to make it clear how the exit code should be specified (that it's not some kind of text code)
- added a pretty useful/common example with wait/timeout for lock before exiting and giving up
- added a practical example with actual command (tar, you don't want to run two tars at once into a single destination, tar might take a long time and exceed into the next time it tries to be ran)