### PR TITLE
CODEOWNERS: remove @tricantivu, @vitorhcl, and @waldyrious

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /contributing-guides/translation-templates/ @kbdharun @sebastiaanspeck
 /contributing-guides/*.ar.md @MachiavelliII
 /contributing-guides/*.de.md @pixelcmtd @gutjuri
-/contributing-guides/*.es.md @kant @tricantivu @ikks
+/contributing-guides/*.es.md @kant @ikks
 /contributing-guides/*.fa.md @MrMw3
 /contributing-guides/*.fr.md @Nico385412 @nicokosi @noraj
 /contributing-guides/*.hi.md @kbdharun @debghs @karthik-script

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 /pages.ar/ @MachiavelliII
 /pages.de/ @pixelcmtd @gutjuri
-/pages.es/ @kant @tricantivu @ikks
+/pages.es/ @kant @ikks
 /pages.fa/ @MrMw3
 /pages.fi/ @Managor
 /pages.fr/ @Nico385412 @nicokosi @noraj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /pages.nl/ @sebastiaanspeck @leonvsc @Waples @dmmqz
 /pages.pl/ @acuteenvy @spageektti
 /pages.pt_BR/ @isaacvicente @renie
-/pages.pt_PT/ @waldyrious
+/pages.pt_PT/ 
 /pages.ta/ @kbdharun
 /pages.tr/ @tansiret
 /pages.zh/ @blueskyson @einverne
@@ -40,7 +40,7 @@
 /contributing-guides/*.nl.md @sebastiaanspeck @leonvsc @Waples @dmmqz
 /contributing-guides/*.pl.md @acuteenvy @spageektti
 /contributing-guides/*.pt_BR.md @isaacvicente @renie
-/contributing-guides/*.pt_PT.md @waldyrious
+/contributing-guides/*.pt_PT.md 
 /contributing-guides/*.ta.md @kbdharun
 /contributing-guides/*.tr.md @tansiret
 /contributing-guides/*.zh.md @blueskyson @einverne

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /pages.ko/ @IMHOJEONG @Zamoca42 @CodePsy-2001
 /pages.nl/ @sebastiaanspeck @leonvsc @Waples @dmmqz
 /pages.pl/ @acuteenvy @spageektti
-/pages.pt_BR/ @isaacvicente @vitorhcl @renie
+/pages.pt_BR/ @isaacvicente @renie
 /pages.pt_PT/ @waldyrious
 /pages.ta/ @kbdharun
 /pages.tr/ @tansiret
@@ -39,7 +39,7 @@
 /contributing-guides/*.ko.md @IMHOJEONG @Zamoca42 @CodePsy-2001
 /contributing-guides/*.nl.md @sebastiaanspeck @leonvsc @Waples @dmmqz
 /contributing-guides/*.pl.md @acuteenvy @spageektti
-/contributing-guides/*.pt_BR.md @isaacvicente @vitorhcl @renie
+/contributing-guides/*.pt_BR.md @isaacvicente @renie
 /contributing-guides/*.pt_PT.md @waldyrious
 /contributing-guides/*.ta.md @kbdharun
 /contributing-guides/*.tr.md @tansiret


### PR DESCRIPTION
To reduce false hope of a translation getting reviewed, I removed people with no involvement with tldr for a year. This was done with a search query `is:closed commenter:username`. 

Please voice yourself if you would like to keep yourself in the CODEOWNERS file.