### PR TITLE
wol, bzip3, gh-api, lzop, pct: fix typos

### DIFF
--- a/pages/common/bzip3.md
+++ b/pages/common/bzip3.md
@@ -25,7 +25,7 @@
 
 - Decompress a file overwriting existing files:
 
-`bzip3 {{[-d|--decode]}} {{[-f--force]}} {{path/to/compressed_file.bz3}}`
+`bzip3 {{[-d|--decode]}} {{[-f|--force]}} {{path/to/compressed_file.bz3}}`
 
 - Display help:
 

--- a/pages/common/gh-api.md
+++ b/pages/common/gh-api.md
@@ -21,7 +21,7 @@
 
 - Include the HTTP response headers in the output:
 
-`gh api {{[--include]}} {{endpoint}}`
+`gh api {{[-i|--include]}} {{endpoint}}`
 
 - Do not print the response body:
 

--- a/pages/common/lzop.md
+++ b/pages/common/lzop.md
@@ -17,8 +17,8 @@
 
 - Compress a file with the best compression level:
 
-`lzop {{[-9|--best]}} {{[path/to/file]}}`
+`lzop {{[-9|--best]}} {{path/to/file}}`
 
 - Compress a file with the fastest compression level:
 
-`lzop {{[-1|--fast]}} {{[path/to/file]}}`
+`lzop {{[-1|--fast]}} {{path/to/file}}`

--- a/pages/linux/pct.md
+++ b/pages/linux/pct.md
@@ -21,7 +21,7 @@
 
 - Resize the container's disk to 20G:
 
-`pct {{[resi|resize]]} {{100}} {{rootfs|mpX}} {{20G}}`
+`pct {{[resi|resize]}} {{100}} {{rootfs|mpX}} {{20G}}`
 
 - Show the configuration of a container, specifying its ID:
 

--- a/pages/linux/wol.md
+++ b/pages/linux/wol.md
@@ -21,7 +21,7 @@
 
 - Read hardware addresses, IP addresses/hostnames, optional ports and SecureON passwords from a file:
 
-`wol {{[-f|--file]]} {{path/to/file}}`
+`wol {{[-f|--file]}} {{path/to/file}}`
 
 - Turn on verbose output:
 


### PR DESCRIPTION
I ran through some of the commands in #17107