### PR TITLE
common/h~m*: fix outdated Brazilian Portuguese pages

### DIFF
--- a/pages.pt_BR/common/history.md
+++ b/pages.pt_BR/common/history.md
@@ -11,6 +11,10 @@
 
 `history {{20}}`
 
+- Exibe histórico com data e hora em diferentes formatos (diponível apenas em Zsh):
+
+`history -{{d|f|i|E}}`
+
 - Limpa a lista do histórico de comandos (apenas para o shell Bash atual):
 
 `history -c`

--- a/pages.pt_BR/common/htop.md
+++ b/pages.pt_BR/common/htop.md
@@ -11,6 +11,10 @@
 
 `htop {{[-u|--user]}} {{nome_usuário}}`
 
+- Apresenta os processos de forma hierárquica em uma visão de árvore para mostrar relações de pai-filho:
+
+`htop --tree`
+
 - Ordena processos por um `item_de_ordenação` (utilize `htop --sort help` para ver as opções disponíveis):
 
 `htop {{[-s|--sort]}} {{item_de_ordenação}}`

--- a/pages.pt_BR/common/htop.md
+++ b/pages.pt_BR/common/htop.md
@@ -13,7 +13,7 @@
 
 - Apresenta os processos de forma hierárquica em uma visão de árvore para mostrar relações de pai-filho:
 
-`htop --tree`
+`htop {{[-t|--tree]}}`
 
 - Ordena processos por um `item_de_ordenação` (utilize `htop --sort help` para ver as opções disponíveis):
 
@@ -23,7 +23,7 @@
 
 `htop {{[-d|--delay]}} {{50}}`
 
-- Vê comandos interativos enquanto roda `htop`:
+- Vê comandos interativos enquanto roda htop:
 
 `<?>`
 

--- a/pages.pt_BR/common/id.md
+++ b/pages.pt_BR/common/id.md
@@ -7,9 +7,17 @@
 
 `id`
 
+- Exibe a identidade do usuário atual:
+
+`id -un`
+
 - Exibe a identidade do usuário atual como um número:
 
 `id {{[-u|--user]}}`
+
+- Exibe a identidade do grupo primário atual:
+
+`id -gn`
 
 - Exibe a identidade do grupo atual como um número:
 
@@ -17,4 +25,4 @@
 
 - Exibe o ID de um usuário arbitrário (UID), ID do grupo (GID) e grupos aos quais eles pertencem:
 
-`id {{nomedeusuario}}`
+`id {{nome_de_usuário}}`

--- a/pages.pt_BR/common/id.md
+++ b/pages.pt_BR/common/id.md
@@ -9,7 +9,7 @@
 
 - Exibe a identidade do usuário atual:
 
-`id -un`
+`id {{[-un|--user --name]}}`
 
 - Exibe a identidade do usuário atual como um número:
 
@@ -17,7 +17,7 @@
 
 - Exibe a identidade do grupo primário atual:
 
-`id -gn`
+`id {{[-gn|--group --name]}}`
 
 - Exibe a identidade do grupo atual como um número:
 

--- a/pages.pt_BR/common/join.md
+++ b/pages.pt_BR/common/join.md
@@ -5,16 +5,20 @@
 
 - Junta dois arquivos no primeiro campo (padrão):
 
-`join {{arquivo1}} {{arquivo2}}`
+`join {{caminho/para/arquivo1}} {{caminho/para/arquivo2}}`
 
 - Junta dois arquivos usando uma vírgula (em vez de um espaço) como separador de campo:
 
-`join -t {{','}} {{arquivo1}} {{arquivo2}}`
+`join -t {{','}} {{caminho/para/arquivo1}} {{caminho/para/arquivo2}}`
 
 - Junta campo3 do arquivo1 ao campo1 do arquivo2:
 
-`join -1 {{3}} -2 {{1}} {{arquivo1}} {{arquivo2}}`
+`join -1 {{3}} -2 {{1}} {{caminho/para/arquivo1}} {{caminho/para/arquivo2}}`
 
 - Produz uma linha para cada linha que não pode ser pareada para o arquivo1:
 
-`join -a {{1}} {{arquivo1}} {{arquivo2}}`
+`join -a {{1}} {{caminho/para/arquivo1}} {{caminho/para/arquivo2}}`
+
+- Junta aquivo da entrada padrão (`stdin`):
+
+`cat {{caminho/para/arquivo1}} | join - {{caminho/para/arquivo2}}`

--- a/pages.pt_BR/common/kill.md
+++ b/pages.pt_BR/common/kill.md
@@ -4,17 +4,13 @@
 > Todos os sinais exceto pelo SIGKILL e SIGSTOP podem ser interceptados pelo processo para finalizar de forma limpa.
 > Mais informações: <https://manned.org/kill.1posix>.
 
-- Finaliza um programa usando o sinal default SIGTERM (terminate):
+- Finaliza um programa usando o sinal padrão SIGTERM (terminate):
 
 `kill {{id_do_processo}}`
 
-- Lista todos os nomes dos sinais disponíveis (para serem usados sem o prefixo `SIG`):
+- Lista todos os nomes de sinais disponíveis (para serem usados sem o prefixo `SIG`):
 
 `kill -l`
-
-- Finaliza um processo em background:
-
-`kill %{{id_do_processo}}`
 
 - Finaliza um programa usando o sinal SIGHUP. Muitos daemons vão recarregar ao invés de finalizar:
 
@@ -24,11 +20,11 @@
 
 `kill -{{2|INT}} {{id_do_processo}}`
 
-- Envia sinal para o sistema operacional para finalizar imediatamente o programa (quem não tem chance de capturar o sinal):
+- Envia sinal para o sistema operacional para finalizar imediatamente o programa (que não tem chance de capturar o sinal):
 
 `kill -{{9|KILL}} {{id_do_processo}}`
 
-- Envia sinal para o sistema operacional para pausar o programa até um sinal SIGCONT ("continue") seja recebido:
+- Envia sinal para o sistema operacional para pausar o programa até que um sinal SIGCONT ("continue") seja recebido:
 
 `kill -{{17|STOP}} {{id_do_processo}}`
 

--- a/pages.pt_BR/common/magick-convert.md
+++ b/pages.pt_BR/common/magick-convert.md
@@ -1,28 +1,37 @@
 # magick convert
 
-> Ferramenta de conversão de imagens da ImageMagick.
+> Converte formatos de imagem, escala, adiciona, e cria imagens, e muito mais.
+> Nota: Essa ferramenta (previamente conhecida como `convert`) foi substituída por `magick` no ImageMagick 7+.
 > Mais informações: <https://imagemagick.org/script/convert.php>.
 
 - Converte uma imagem do formato JPEG para o formato PNG:
 
-`magick convert {{imagem.jpg}} {{imagem.png}}`
+`magick convert {{caminho/para/imagem_de_entrada.jpg}} {{caminho/para/imagem_de_saida.png}}`
 
 - Escala uma imagem para 50% do seu tamanho original:
 
-`magick convert {{imagem.png}} -resize 50% {{nova_imagem.png}}`
+`magick convert {{caminho/para/imagem_de_entrada.png}} -resize 50% {{caminho/para/imagem_de_saida.png}}`
 
 - Escala uma imagem, mantendo as suas proporções originais, para uma dimensão máxima de 640x480:
 
-`magick convert {{imagem.png}} -resize 640x480 {{nova_imagem.png}}`
+`magick convert {{caminho/para/imagem_de_entrada.png}} -resize 640x480 {{caminho/para/imagem_de_saida.png}}`
 
-- Junta várias imagens horizontalmente:
+- Escala uma imagem para ter oum tamanho de arquivo específico:
 
-`magick convert {{imagem1.png}} {{imagem2.png}} {{imagem3.png}} +append {{nova_imagem.png}}`
+`magick convert {{caminho/para/imagem_de_entrada.png}} -define jpeg:extent=512kb {{caminho/para/imagem_de_saida.jpg}}`
+
+- Junta imagens verticalmente/horizontalmente e deixa o espaço vazio transparente:
+
+`magick convert -background none {{caminho/para/imagem1.png caminho/para/imagem2.png ...}} {{-append|+append}} {{caminho/para/imagem_de_saida.png}}`
 
 - Cria um GIF a partir de uma série de imagens, com um intervalo de 100ms entre elas:
 
-`magick convert {{imagem1.png}} {{imagem2.png}} {{imagem3.png}} -delay {{100}} {{nova_imagem.gif}}`
+`magick convert {{caminho/para/imagem1.png}} {{caminho/para/imagem2.png}} {{caminho/para/imagem3.png}} -delay {{100}} {{caminho/para/animacao.gif}}`
 
-- Cria uma nova imagem de tamanho 800x600 com apenas um fundo sólido vermelho:
+- Cria uma imagem de tamanho 800x600 com apenas um fundo sólido vermelho:
 
-`magick convert -size {{800x600}} "xc:{{#ff0000}}" {{imagem.png}}`
+`magick convert -size {{800x600}} "xc:{{#ff0000}}" {{caminho/para/imagem.png}}`
+
+- Cria um favicon de várias imagens de tamanhos diferentes:
+
+`magick convert {{caminho/para/imagem1.png caminho/para/imagem2.png ...}} {{caminho/para/favicon.ico}}`

--- a/pages.pt_BR/common/magick-convert.md
+++ b/pages.pt_BR/common/magick-convert.md
@@ -26,9 +26,9 @@
 
 - Cria um GIF a partir de uma série de imagens, com um intervalo de 100ms entre elas:
 
-`magick convert {{caminho/para/imagem1.png}} {{caminho/para/imagem2.png}} {{caminho/para/imagem3.png}} -delay {{100}} {{caminho/para/animacao.gif}}`
+`magick convert {{caminho/para/imagem1.png caminho/para/imagem2.png ...}} -delay {{10}} {{caminho/para/animacao.gif}}`
 
-- Cria uma imagem de tamanho 800x600 com apenas um fundo sólido vermelho:
+- Cria uma imagem apenas com um fundo sólido vermelho:
 
 `magick convert -size {{800x600}} "xc:{{#ff0000}}" {{caminho/para/imagem.png}}`
 

--- a/pages.pt_BR/common/man.md
+++ b/pages.pt_BR/common/man.md
@@ -7,26 +7,30 @@
 
 `man {{comando}}`
 
+- Abre uma página de manua para um comando em um navegadore de internet (a variável de ambiente `BROWSER` pode subistituir `=nome_do_navegador`):
+
+`man {{[-Hnome_do_navegador|--html=nome_do_navegador]}} {{command}}`
+
 - Exibe a página de manual de um comando da seção 7:
 
 `man {{7}} {{comando}}`
 
 - Lista todas as seções disponíveis para um comando:
 
-`man -f {{comando}}`
+`man {{[-f|--whatis]}} {{comando}}`
 
 - Exibe o caminho procurado pelas páginas de manual:
 
-`man --path`
+`man {{[-w|--path]}}`
 
 - Exibe a localização de uma página de manual em vez da própria página de manual:
 
-`man -w {{comando}}`
+`man {{[-w|--where]}} {{comando}}`
 
 - Exibe a página de manual usando uma localidade específica:
 
-`man {{comando}} --locale={{localidade}}`
+`man {{[-L|--locale]}} {{localicade}} {{comando}}`
 
 - Procura páginas de manual contendo um termo de pesquisa:
 
-`man -k "{{termo_de_pesquisa}}"`
+`man {{[-k|--apropos]}} "{{termo_de_pesquisa}}"`

--- a/pages/common/magick-convert.md
+++ b/pages/common/magick-convert.md
@@ -26,7 +26,7 @@
 
 - Create a GIF from a series of images with 100ms delay between them:
 
-`magick convert {{path/to/image1.png path/to/image2.png ...}} -delay {{10}} {{path/to/animation.gif}}`
+`magick convert {{path/to/image1.png path/to/image2.png ...}} -delay {{100}} {{path/to/animation.gif}}`
 
 - Create an image with nothing but a solid red background:
 

--- a/pages/common/magick-convert.md
+++ b/pages/common/magick-convert.md
@@ -26,7 +26,7 @@
 
 - Create a GIF from a series of images with 100ms delay between them:
 
-`magick convert {{path/to/image1.png path/to/image2.png ...}} -delay {{100}} {{path/to/animation.gif}}`
+`magick convert {{path/to/image1.png path/to/image2.png ...}} -delay {{10}} {{path/to/animation.gif}}`
 
 - Create an image with nothing but a solid red background:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
