### PR TITLE
pw-link: fix typo in id option

### DIFF
--- a/pages.ko/linux/pw-link.md
+++ b/pages.ko/linux/pw-link.md
@@ -5,7 +5,7 @@
 
 - 모든 오디오 출력 및 입력 포트와 해당 ID 나열:
 
-`pw-link --output --input --id`
+`pw-link {{[-oiI|--output --input --id]}}`
 
 - 출력 포트와 입력 포트 간 링크 생성:
 

--- a/pages.ko/linux/pw-link.md
+++ b/pages.ko/linux/pw-link.md
@@ -5,7 +5,7 @@
 
 - 모든 오디오 출력 및 입력 포트와 해당 ID 나열:
 
-`pw-link --output --input --ids`
+`pw-link --output --input --id`
 
 - 출력 포트와 입력 포트 간 링크 생성:
 
@@ -17,7 +17,7 @@
 
 - 모든 링크와 해당 ID 나열:
 
-`pw-link {{[-lI|--links --ids]}}`
+`pw-link {{[-lI|--links --id]}}`
 
 - 도움말 표시:
 

--- a/pages.pt_BR/linux/pw-link.md
+++ b/pages.pt_BR/linux/pw-link.md
@@ -5,7 +5,7 @@
 
 - Lista todos as saídas e entradas de áudio com seus IDs:
 
-`pw-link {{[-oiI|--output --input --ids]}}`
+`pw-link {{[-oiI|--output --input --id]}}`
 
 - Cria uma conexão entre uma porta de entrada e uma porta de saída:
 
@@ -17,7 +17,7 @@
 
 - Lista todas as conexões com seus IDs:
 
-`pw-link {{[-lI|--links --ids]}}`
+`pw-link {{[-lI|--links --id]}}`
 
 - Exibe ajuda:
 

--- a/pages/linux/pw-link.md
+++ b/pages/linux/pw-link.md
@@ -5,7 +5,7 @@
 
 - List all audio output and input ports with their IDs:
 
-`pw-link {{[-oiI|--output --input --ids]}}`
+`pw-link {{[-oiI|--output --input --id]}}`
 
 - Create a link between an output and an input port:
 
@@ -17,7 +17,7 @@
 
 - List all links with their IDs:
 
-`pw-link {{[-lI|--links --ids]}}`
+`pw-link {{[-lI|--links --id]}}`
 
 - Display help:
 


### PR DESCRIPTION
`pw-link` pages listed `--ids` as availabe option, however actual option is spelled `--id`. Using `--ids` fails with:

```
$ pw-link --links --ids
pw-link: unrecognized option '--ids'
```

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `1.4.6`
