### PR TITLE
grub-install: add simplified example, sudo, and help

### DIFF
--- a/pages/linux/grub-install.md
+++ b/pages/linux/grub-install.md
@@ -5,6 +5,10 @@
 
 - Install GRUB on a BIOS system:
 
+`sudo grub-install {{path/to/device}}`
+
+- Install GRUB on a BIOS system while specifying architecture:
+
 `sudo grub-install --target {{i386-pc}} {{path/to/device}}`
 
 - Install GRUB on an UEFI system:

--- a/pages/linux/grub-install.md
+++ b/pages/linux/grub-install.md
@@ -18,3 +18,7 @@
 - Install GRUB pre-loading specific modules:
 
 `sudo grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --modules "{{part_gpt part_msdos}}"`
+
+- Display help:
+
+`grub-install {{[-?|--help]}}`

--- a/pages/linux/grub-install.md
+++ b/pages/linux/grub-install.md
@@ -9,6 +9,10 @@
 
 - Install GRUB on an UEFI system:
 
+`grub-install --efi-directory {{path/to/efi_directory}}`
+
+- Install GRUB on an UEFI system while specifying architecture and boot menu text:
+
 `grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --bootloader-id {{GRUB}}`
 
 - Install GRUB pre-loading specific modules:

--- a/pages/linux/grub-install.md
+++ b/pages/linux/grub-install.md
@@ -5,16 +5,16 @@
 
 - Install GRUB on a BIOS system:
 
-`grub-install --target {{i386-pc}} {{path/to/device}}`
+`sudo grub-install --target {{i386-pc}} {{path/to/device}}`
 
 - Install GRUB on an UEFI system:
 
-`grub-install --efi-directory {{path/to/efi_directory}}`
+`sudo grub-install --efi-directory {{path/to/efi_directory}}`
 
 - Install GRUB on an UEFI system while specifying architecture and boot menu text:
 
-`grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --bootloader-id {{GRUB}}`
+`sudo grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --bootloader-id {{GRUB}}`
 
 - Install GRUB pre-loading specific modules:
 
-`grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --modules "{{part_gpt part_msdos}}"`
+`sudo grub-install --target {{x86_64-efi}} --efi-directory {{path/to/efi_directory}} --modules "{{part_gpt part_msdos}}"`


### PR DESCRIPTION
Seems to be possible to do this with less effort.