### PR TITLE
grub-editenv: remove functionality that doesn't exist

### DIFF
--- a/pages/linux/grub-editenv.md
+++ b/pages/linux/grub-editenv.md
@@ -7,14 +7,11 @@
 
 `grub-editenv /boot/grub/grubenv set default={{Ubuntu}}`
 
-- Display the current value of the `timeout` variable:
+- Display the GRUB environment variables:
 
-`grub-editenv /boot/grub/grubenv list timeout`
+`grub-editenv /boot/grub/grubenv list`
 
 - Reset the `saved_entry` variable to the default:
 
 `grub-editenv /boot/grub/grubenv unset saved_entry`
 
-- Append "quiet splash" to the kernel command-line:
-
-`grub-editenv /boot/grub/grubenv list kernel_cmdline`


### PR DESCRIPTION
It doesn't seem like `list` does anything past listing all variables.