### PR TITLE
zbarimg: fix link

### DIFF
--- a/pages/common/zbarimg.md
+++ b/pages/common/zbarimg.md
@@ -1,7 +1,7 @@
 # zbarimg
 
 > Scan and decode bar codes from image file(s).
-> More information: <https://github.com/mchehab/zbar>.
+> More information: <https://manned.org/zbarimg>.
 
 - Process an image file:
 


### PR DESCRIPTION
The existing link points to ZBar's original site where the development stopped in 2012.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

<!--
- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
-->
