### PR TITLE
dir: add sort example

### DIFF
--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -23,6 +23,6 @@
 
 `dir /b`
 
-- Sort results by date/time, oldest first
+- Sort results by date/time, oldest first:
 
 `dir /o:d`

--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -22,3 +22,7 @@
 - Show a bare list of directories and files, with no additional information:
 
 `dir /b`
+
+- Sort results by size, date, name, etc. (e.g., by date/time):
+
+`dir /o:d`

--- a/pages/windows/dir.md
+++ b/pages/windows/dir.md
@@ -23,6 +23,6 @@
 
 `dir /b`
 
-- Sort results by size, date, name, etc. (e.g., by date/time):
+- Sort results by date/time, oldest first
 
 `dir /o:d`


### PR DESCRIPTION
Add "dir /o:d" to the cheat sheet. It is quite useful for creating sort/order by size, date, name, etc.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
