### PR TITLE
style-guide: adjust mandatory slash style

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -468,8 +468,8 @@ Keep the following guidelines in mind when choosing placeholders:
   except when the location is implicit.
 - When the path cannot be relative
   and has to start at the root of the filesystem,
-  prefix it with a slash,
-  such as `get {{/path/to/remote_file}}`.
+  prefix it with a slash outside the placeholder,
+  such as `get /{{path/to/remote_file}}`.
 - In case of a possible reference both to a file or a directory,
   use `{{path/to/file_or_directory}}`.
 


### PR DESCRIPTION
I'm looking for opinions on making this a standard. Since this is mandatory, it makes sense to leave it outside the placeholder.
Looking at grep, nearly every occurence of this is `{{/path`, but this change would make more logical sense.
This should also apply to trailing slashes for `directory}}/`
An added benefit to this would be that the non-placeholder character catches the eye, indicating that it's important
<img width="450" height="147" alt="image" src="https://github.com/user-attachments/assets/9d2c2954-b75e-4b04-9946-8544bdde8617" />
