### PR TITLE
astroterm: add page

### DIFF
--- a/pages/common/astroterm.md
+++ b/pages/common/astroterm.md
@@ -9,16 +9,16 @@
 
 - Display constellations, use colour, and render the simulation at the given frame rate:
 
-`astroterm --constellations --color --fps={{60}}`
+`astroterm {{[-C|--constellations]}} {{[-c|--color]}} {{[-f|--fps]}} {{60}}`
 
 - Use unicode characters instead of the basic ASCII characters, and only render stars brighter than the given magnitude:
 
-`astroterm --unicode --threshold={{2.0}}`
+`astroterm {{[-u|--unicode]}} {{[-t|--threshold]}} {{2.0}}`
 
 - Use a given latitude, longitude and datetime:
 
-`astroterm --latitude={{90.0}} --longitude={{-180.0}} --datetime={{2025-08-04T12:00:00}}`
+`astroterm {{[-a|--latitude]}} {{90.0}} {{[-o|--longitude]}} {{-180.0}} {{[-d|--datetime]}} {{2025-08-04T12:00:00}}`
 
 - Use the longitude and latitude of a given city, and set the speed of the simulation to a given factor:
 
-`astroterm --city={{Singapore}} --speed={{1000.0}}`
+`astroterm {{[-i|--city]}} {{Singapore}} {{[-s|--speed]}} {{1000.0}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** astroterm 1.0.8

Not sure if it's too many arguments per example, but let me know and I can make changes. Just felt everything mentioned here was important for customisation.