### PR TITLE
*: remove placeholders from descriptions

### DIFF
--- a/pages/common/crane-index-filter.md
+++ b/pages/common/crane-index-filter.md
@@ -7,7 +7,7 @@
 
 `crane index filter`
 
-- Specify the platform(s) to keep from base in the form os/arch{{/variant}}{{:osversion}}{{,<platform>}}:
+- Specify the platform(s) to keep from base in the form `os/arch/variant:osversion,platform`:
 
 `crane index filter --platform {{platform1 platform2 ...}}`
 

--- a/pages/common/crane-mutate.md
+++ b/pages/common/crane-mutate.md
@@ -16,7 +16,7 @@
 
 `crane mutate {{[-o|--output]}} {{path/to/tarball}}`
 
-- Repository in the form os/arch{{/variant}}{{:osversion}}{{,<platform>}} to push mutated image:
+- Repository in the form `os/arch/variant:osversion,platform` to push mutated image:
 
 `crane mutate --set-platform {{platform_name}}`
 

--- a/pages/common/crane.md
+++ b/pages/common/crane.md
@@ -16,7 +16,7 @@
 
 `crane --insecure {{subcommand}}`
 
-- Specify the platform in the form os/arch{{/variant}}{{:osversion}} (e.g. linux/amd64). (default all):
+- Specify the platform in the form `os/arch/variant:osversion` (e.g. `linux/amd64`). (default all):
 
 `crane --platform {{platform}} {{subcommand}}`
 

--- a/pages/common/gcrane.md
+++ b/pages/common/gcrane.md
@@ -18,7 +18,7 @@
 
 `gcrane --insecure {{subcommand}}`
 
-- Specify the platform in the form os/arch{{/variant}}{{:osversion}} (e.g. linux/amd64). (default all):
+- Specify the platform in the form `os/arch/variant:osversion` (e.g. `linux/amd64`). (default all):
 
 `gcrane --platform {{platform}} {{subcommand}}`
 

--- a/pages/linux/aide.md
+++ b/pages/linux/aide.md
@@ -19,7 +19,7 @@
 
 `sudo aide {{[-u|--update]}}`
 
-- Define a config file to override the default {{./aide.conf}}:
+- Define a config file to override the default `./aide.conf`:
 
 `sudo aide {{[-c|--config]}} {{path/to/config_file}}`
 


### PR DESCRIPTION
Found with ``grep -r {{ | grep -v '`'``
