### PR TITLE
kubectl-*: change `--file` to `--filename`

### DIFF
--- a/pages.de/common/kubectl-describe.md
+++ b/pages.de/common/kubectl-describe.md
@@ -21,4 +21,4 @@
 
 - Zeige Details zu Ressourcen, die in einer YAML Datei definiert sind, an:
 
-`kubectl describe {{[-f|--file]}} {{pfad/zu/manifest.yaml}}`
+`kubectl describe {{[-f|--filename]}} {{pfad/zu/manifest.yaml}}`

--- a/pages.de/common/kubectl-get.md
+++ b/pages.de/common/kubectl-get.md
@@ -9,24 +9,24 @@
 
 - Frage alle Nodes in einem bestimmten [n]amespace ab:
 
-`kubectl get nodes --namespace {{namespace}}`
+`kubectl get nodes {{[-n|--namespace]}} {{namespace}}`
 
 - Frage alle Pods in einem bestimmten [n]amespace ab:
 
-`kubectl get pods --namespace {{namespace}}`
+`kubectl get pods {{[-n|--namespace]}} {{namespace}}`
 
 - Frage alle Deployments in einem bestimmten [n]amespace ab:
 
-`kubectl get deployments --namespace {{namespace}}`
+`kubectl get deployments {{[-n|--namespace]}} {{namespace}}`
 
 - Frage alle Services in einem bestimmten [n]amespace ab:
 
-`kubectl get services --namespace {{namespace}}`
+`kubectl get services {{[-n|--namespace]}} {{namespace}}`
 
 - Frage alle Resourcen in einem bestimmten [n]amespace ab:
 
-`kubectl get all --namespace {{namespace}}`
+`kubectl get all {{[-n|--namespace]}} {{namespace}}`
 
 - Frage alle Ressourcen ab, die in einer YAML Datei definiert sind:
 
-`kubectl get --file {{pfad/zu/manifest.yaml}}`
+`kubectl get {{[-f|--filename]}} {{pfad/zu/manifest.yaml}}`

--- a/pages.ko/common/kubectl-describe.md
+++ b/pages.ko/common/kubectl-describe.md
@@ -21,4 +21,4 @@
 
 - YAML 매니페스트 [f]ile에 정의된 Kubernetes 객체의 세부 정보 표시:
 
-`kubectl describe {{[-f|--file]}} {{경로/대상/manifest.yaml}}`
+`kubectl describe {{[-f|--filename]}} {{경로/대상/manifest.yaml}}`

--- a/pages.ko/common/kubectl-get.md
+++ b/pages.ko/common/kubectl-get.md
@@ -9,24 +9,24 @@
 
 - 지정된 [n]amespace의 노드 가져오기:
 
-`kubectl get nodes --namespace {{네임스페이스}}`
+`kubectl get nodes {{[-n|--namespace]}} {{네임스페이스}}`
 
 - 지정된 [n]amespace의 파드 가져오기:
 
-`kubectl get pods --namespace {{네임스페이스}}`
+`kubectl get pods {{[-n|--namespace]}} {{네임스페이스}}`
 
 - 지정된 [n]amespace의 배포 가져오기:
 
-`kubectl get deployments --namespace {{네임스페이스}}`
+`kubectl get deployments {{[-n|--namespace]}} {{네임스페이스}}`
 
 - 지정된 [n]amespace의 서비스 가져오기:
 
-`kubectl get services --namespace {{네임스페이스}}`
+`kubectl get services {{[-n|--namespace]}} {{네임스페이스}}`
 
 - 지정된 [n]amespace의 모든 리소스 가져오기:
 
-`kubectl get all --namespace {{네임스페이스}}`
+`kubectl get all {{[-n|--namespace]}} {{네임스페이스}}`
 
 - YAML 매니페스트 [f]ile에 정의된 Kubernetes 객체 가져오기:
 
-`kubectl get --file {{경로/대상/매니페스트.yaml}}`
+`kubectl get {{[-f|--filename]}} {{경로/대상/매니페스트.yaml}}`

--- a/pages/common/kubectl-describe.md
+++ b/pages/common/kubectl-describe.md
@@ -21,4 +21,4 @@
 
 - Show details of Kubernetes objects defined in a YAML manifest file:
 
-`kubectl describe {{[-f|--file]}} {{path/to/manifest.yaml}}`
+`kubectl describe {{[-f|--filename]}} {{path/to/manifest.yaml}}`

--- a/pages/common/kubectl-get.md
+++ b/pages/common/kubectl-get.md
@@ -29,4 +29,4 @@
 
 - Get Kubernetes objects defined in a YAML manifest file:
 
-`kubectl get {{[-f|--file]}} {{path/to/manifest.yaml}}`
+`kubectl get {{[-f|--filename]}} {{path/to/manifest.yaml}}`


### PR DESCRIPTION
Some `kubectl` pages were using `--file` which is invalid. This PR fixes that. Also took the opportunity to add short and long options as needed.