### PR TITLE
lsfd: remove leading slash in file path

### DIFF
--- a/pages/linux/lsfd.md
+++ b/pages/linux/lsfd.md
@@ -13,7 +13,7 @@
 
 - Check what program has a specific file open:
 
-`lsfd {{[-Q|--filter]}} "NAME == '{{/path/to/file}}'"`
+`lsfd {{[-Q|--filter]}} "NAME == '{{path/to/file}}'"`
 
 - List open IPv4 or IPv6 sockets:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
