### PR TITLE
pve*, qm*: add missing option placeholders

### DIFF
--- a/pages/linux/pct-clone.md
+++ b/pages/linux/pct-clone.md
@@ -5,4 +5,4 @@
 
 - Clone a container with a custom name:
 
-`pct clone {{template_id}} {{copy_id}} --hostname {{host_name}}`
+`pct {{[cl|clone]}} {{template_id}} {{copy_id}} --hostname {{host_name}}`

--- a/pages/linux/pct-template.md
+++ b/pages/linux/pct-template.md
@@ -5,4 +5,4 @@
 
 - Convert a container into a template:
 
-`pct template {{100}}`
+`pct {{[t|template]}} {{100}}`

--- a/pages/linux/pve-firewall.md
+++ b/pages/linux/pve-firewall.md
@@ -5,15 +5,15 @@
 
 - Compile and print all firewall rules:
 
-`pve-firewall compile`
+`pve-firewall {{[c|compile]}}`
 
 - Show information about the local network:
 
-`pve-firewall localnet`
+`pve-firewall {{[l|localnet]}}`
 
 - Restart the Proxmox VE Firewall service:
 
-`pve-firewall restart`
+`pve-firewall {{[r|restart]}}`
 
 - Start the Proxmox VE Firewall service:
 
@@ -25,7 +25,7 @@
 
 - Simulate all firewall rules:
 
-`pve-firewall simulate`
+`pve-firewall {{[si|simulate]}}`
 
 - Show the status of Proxmox VE Firewall:
 

--- a/pages/linux/pveam.md
+++ b/pages/linux/pveam.md
@@ -5,16 +5,16 @@
 
 - Update container template database:
 
-`pveam update`
+`pveam {{[u|update]}}`
 
 - List available templates:
 
-`pveam available`
+`pveam {{[a|available]}}`
 
 - Download a template:
 
-`pveam download {{local}} {{template_name}}`
+`pveam {{[d|download]}} {{local}} {{template_name}}`
 
 - List downloaded templates:
 
-`pveam list {{local}}`
+`pveam {{[l|list]}} {{local}}`

--- a/pages/linux/pvecm.md
+++ b/pages/linux/pvecm.md
@@ -9,24 +9,24 @@
 
 - Add a node to the cluster configuration (internal use):
 
-`pvecm addnode {{node}}`
+`pvecm {{[addn|addnode]}} {{node}}`
 
 - Display the version of the cluster join API available on this node:
 
-`pvecm apiver`
+`pvecm {{[ap|apiver]}}`
 
 - Generate new cluster configuration:
 
-`pvecm create {{clustername}}`
+`pvecm {{[c|create]}} {{clustername}}`
 
 - Remove a node from the cluster configuration:
 
-`pvecm delnode {{node}}`
+`pvecm {{[d|delnode]}} {{node}}`
 
 - Display the local view of the cluster nodes:
 
-`pvecm nodes`
+`pvecm {{[n|nodes]}}`
 
 - Display the local view of the cluster status:
 
-`pvecm status`
+`pvecm {{[s|status]}}`

--- a/pages/linux/pvesh.md
+++ b/pages/linux/pvesh.md
@@ -5,8 +5,8 @@
 
 - List available nodes:
 
-`pvesh get /nodes`
+`pvesh {{[g|get]}} /nodes`
 
 - Discover API paths:
 
-`pvesh ls {{/}}`
+`pvesh {{[l|ls]}} {{/}}`

--- a/pages/linux/pvesm.md
+++ b/pages/linux/pvesm.md
@@ -5,16 +5,16 @@
 
 - Get status for all datastores:
 
-`pvesm status`
+`pvesm {{[st|status]}}`
 
 - List storage contents:
 
-`pvesm list {{storage_name}}`
+`pvesm {{[l|list]}} {{storage_name}}`
 
 - Add a directory storage:
 
-`pvesm add dir {{storage_name}} --path {{path/to/directory}}`
+`pvesm add {{[d|dir]}} {{storage_name}} --path {{path/to/directory}}`
 
 - Remove a storage:
 
-`pvesm remove {{storage_name}}`
+`pvesm {{[r|remove]}} {{storage_name}}`

--- a/pages/linux/pveum.md
+++ b/pages/linux/pveum.md
@@ -5,12 +5,12 @@
 
 - List users:
 
-`pveum user list`
+`pveum {{[u|user]}} {{[l|list]}}`
 
 - Add a user:
 
-`pveum user add {{username}}@pve`
+`pveum {{[u|user]}} {{[a|add]}} {{username}}@pve`
 
 - Delete a user:
 
-`pveum user delete {{username}}@pve`
+`pveum {{[u|user]}} {{[d|delete]}} {{username}}@pve`

--- a/pages/linux/qm-disk-rescan.md
+++ b/pages/linux/qm-disk-rescan.md
@@ -5,8 +5,8 @@
 
 - Rescan all storages and update disk sizes and unused disk images of a specific virtual machine:
 
-`qm disk rescan {{vm_id}}`
+`qm {{[di|disk]}} {{[resc|rescan]}} {{vm_id}}`
 
 - Perform a dry-run of rescan on a specific virtual machine and do not write any changes to configurations:
 
-`qm disk rescan --dryrun {{true}} {{vm_id}}`
+`qm {{[di|disk]}} {{[resc|rescan]}} --dryrun {{true}} {{vm_id}}`

--- a/pages/linux/qm-list.md
+++ b/pages/linux/qm-list.md
@@ -5,8 +5,8 @@
 
 - List all virtual machines:
 
-`qm list`
+`qm {{[l|list]}}`
 
 - List all virtual machines with a full status about the ones which are currently running:
 
-`qm list --full 1`
+`qm {{[l|list]}} --full 1`

--- a/pages/linux/qm-terminal.md
+++ b/pages/linux/qm-terminal.md
@@ -5,7 +5,7 @@
 
 - Attach to a terminal:
 
-`qm terminal {{100}}`
+`qm {{[ter|terminal]}} {{100}}`
 
 - Detach from a terminal:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
