### PR TITLE
partclone: fix manpage link

### DIFF
--- a/pages/linux/partclone.md
+++ b/pages/linux/partclone.md
@@ -1,7 +1,7 @@
 # partclone
 
 > Copy and restore partitions to and from an image while disregarding empty blocks.
-> More information: <https://manned.org/a2disconf.8>.
+> More information: <https://manned.org/partclone.8>.
 
 - Copy a partition into an image:
 

--- a/pages/linux/partclone.md
+++ b/pages/linux/partclone.md
@@ -1,7 +1,7 @@
 # partclone
 
 > Copy and restore partitions to and from an image while disregarding empty blocks.
-> More information: <https://manned.org/partclone.8>.
+> More information: <https://manned.org/partclone>.
 
 - Copy a partition into an image:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
