### PR TITLE
ruff: fix typo

### DIFF
--- a/pages/common/ruff.md
+++ b/pages/common/ruff.md
@@ -5,8 +5,8 @@
 
 - View documentation for the Ruff linter:
 
-`tldr ruff check`
+`ruff check`
 
 - View documentation for the Ruff code formatter:
 
-`tldr ruff format`
+`ruff format`


### PR DESCRIPTION

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** ruff
