### PR TITLE
enable: Changed information link pointing to a mostly unrelated page

### DIFF
--- a/pages/cisco-ios/enable.md
+++ b/pages/cisco-ios/enable.md
@@ -1,7 +1,7 @@
 # enable
 
 > Enter privileged execution mode.
-> More information: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ios_shl/command/ios-shell-cr-book/ios-shell-cr-a1.html>.
+> More information: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/security/d1/sec-d1-cr-book/sec-cr-e1.html#wp3307186499>.
 
 - Enter privileged execution mode:
 


### PR DESCRIPTION
The previous link to the documentation page was pointing to a page for another command that was only mentionning `enable` as an example, not the actual documentation for the `enable` command.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).