### PR TITLE
git-blame: add an example to blame similar to github UI

### DIFF
--- a/pages/common/git-blame.md
+++ b/pages/common/git-blame.md
@@ -19,6 +19,10 @@
 
 `git blame {{commit}}~ {{path/to/file}}`
 
+- Jump to the parent of a specific commit and track a specific text and 10 of its following lines:
+
+`git blame -L '/{{text}}/',+10 {{a82812aa}}^ tldr.py`
+
 - Print author name and commit hash information for a specific line range:
 
 `git blame -L {{start_line}},{{end_line}} {{path/to/file}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
