### PR TITLE
show: fix example

### DIFF
--- a/pages/cisco-ios/show.md
+++ b/pages/cisco-ios/show.md
@@ -5,20 +5,20 @@
 
 - Show switch IP addresses:
 
-`{{[s|show]}} ip interface brief`
+`{{[sh|show]}} ip interface brief`
 
 - Show specific interface configuration:
 
-`{{[s|show]}} ip interface {{vlan1}}`
+`{{[sh|show]}} ip interface {{vlan1}}`
 
 - Show vlan configuration:
 
-`{{[s|show]}} vlan`
+`{{[sh|show]}} vlan`
 
 - Show currently running configuration:
 
-`{{[s|show]}} running-config`
+`{{[sh|show]}} running-config`
 
 - Show SSH configuration:
 
-`{{[s|show]}} ip ssh`
+`{{[sh|show]}} ip ssh`


### PR DESCRIPTION
Changed the `s` command shortcut to `sh` in the examples since using only `s` produce an error :
```cisco
Switch#s ip interface brief
% Ambiguous command: "s ip interface brief"
```

Working example with `sh` :
```cisco
Switch#sh ip interface brief
Interface              IP-Address      OK? Method Status                Protocol 
FastEthernet0/1        unassigned      YES manual down                  down
...
```

This has been tested on a Cisco Switch Catalyst 2960 and a Cisco Router 1941

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).