### PR TITLE
kubectl-{exec, delete}: fix typos

### DIFF
--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -21,7 +21,7 @@
 
 - Delete all deployments and services in a specified namespace:
 
-`kubectl delete {{[deploy|deployment]}},{{[svcľservices]}} --all {{[-n|--namespace]}} {{namespace}}`
+`kubectl delete {{[deploy|deployment]}},{{[svc|services]}} --all {{[-n|--namespace]}} {{namespace}}`
 
 - Delete all nodes:
 

--- a/pages/common/kubectl-exec.md
+++ b/pages/common/kubectl-exec.md
@@ -5,4 +5,4 @@
 
 - Open Bash in a pod, using the first container by default:
 
-`kubectl exec {{pod_name}} {{-it|--stdin --tty]}} -- bash`
+`kubectl exec {{pod_name}} {{[-it|--stdin --tty]}} -- bash`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
