### PR TITLE
wget: update 'More information' link to official manual

### DIFF
--- a/pages/common/wget.md
+++ b/pages/common/wget.md
@@ -2,7 +2,7 @@
 
 > Download files from the Web.
 > Supports HTTP, HTTPS, and FTP.
-> More information: <https://www.gnu.org/software/wget>.
+> More information: <https://www.gnu.org/software/wget/manual/>.
 
 - Download the contents of a URL to a file (named "foo" in this case):
 

--- a/pages/common/wget.md
+++ b/pages/common/wget.md
@@ -2,7 +2,7 @@
 
 > Download files from the Web.
 > Supports HTTP, HTTPS, and FTP.
-> More information: <https://www.gnu.org/software/wget/manual/>.
+> More information: <https://www.gnu.org/software/wget/manual/wget.html>.
 
 - Download the contents of a URL to a file (named "foo" in this case):
 


### PR DESCRIPTION
### Description

This PR updates the "More information" link in the `wget` page to point to the official GNU Wget manual instead of the previous reference.  
This ensures users always get the most accurate and up-to-date documentation directly from the official source.



