### PR TITLE
GNU software: use direct documentation link

### DIFF
--- a/pages/common/cpio.md
+++ b/pages/common/cpio.md
@@ -2,7 +2,7 @@
 
 > Copy files in and out of archives.
 > Supports the following archive formats: cpio's custom binary, old ASCII, new ASCII, crc, HPUX binary, HPUX old ASCII, old tar, and POSIX.1 tar.
-> More information: <https://www.gnu.org/software/cpio>.
+> More information: <https://www.gnu.org/software/cpio/manual/cpio.html#Invoking-cpio>.
 
 - Take a list of file names from `stdin` and add them onto an archive (copy-[o]ut) in cpio's binary forma:
 

--- a/pages/common/g++.md
+++ b/pages/common/g++.md
@@ -2,7 +2,7 @@
 
 > Compile C++ source files.
 > Part of GCC (GNU Compiler Collection).
-> More information: <https://gcc.gnu.org>.
+> More information: <https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html>.
 
 - Compile a source code file into an executable binary:
 

--- a/pages/common/gcal.md
+++ b/pages/common/gcal.md
@@ -1,7 +1,7 @@
 # gcal
 
 > Display calendar.
-> More information: <https://www.gnu.org/software/gcal>.
+> More information: <https://www.gnu.org/software/gcal/manual/gcal.html#Invoking-Gcal>.
 
 - Display calendar for the current month:
 

--- a/pages/common/gcc.md
+++ b/pages/common/gcc.md
@@ -2,7 +2,7 @@
 
 > Preprocess and compile C and C++ source files, then assemble and link them together.
 > Part of GCC (GNU Compiler Collection).
-> More information: <https://gcc.gnu.org>.
+> More information: <https://gcc.gnu.org/onlinedocs/gcc/>.
 
 - Compile multiple source files into an executable:
 

--- a/pages/common/gdb.md
+++ b/pages/common/gdb.md
@@ -1,7 +1,7 @@
 # gdb
 
 > The GNU Debugger.
-> More information: <https://www.gnu.org/software/gdb>.
+> More information: <https://sourceware.org/gdb/current/onlinedocs/gdb#Invocation>.
 
 - Debug an executable:
 

--- a/pages/common/guile.md
+++ b/pages/common/guile.md
@@ -1,7 +1,7 @@
 # guile
 
 > Guile Scheme interpreter.
-> More information: <https://www.gnu.org/software/guile>.
+> More information: <https://www.gnu.org/software/guile/manual/guile.html#Invoking-Guile>.
 
 - Start a REPL (interactive shell):
 

--- a/pages/common/help2man.md
+++ b/pages/common/help2man.md
@@ -1,7 +1,7 @@
 # help2man
 
 > Produce simple man pages from an executable's `--help` and `--version` output.
-> More information: <https://www.gnu.org/software/help2man>.
+> More information: <https://www.gnu.org/software/help2man/#Invoking-help2man>.
 
 - Generate a man page for an executable:
 

--- a/pages/common/lzip.md
+++ b/pages/common/lzip.md
@@ -2,7 +2,7 @@
 
 > A lossless data compressor with a user interface similar to `gzip` or `bzip2`.
 > Lzip uses a simplified form of the "Lempel-Ziv-Markovchain-Algorithm" (LZMA) stream format and provides 3-factor integrity checking to maximize interoperability and optimize safety.
-> More information: <https://www.nongnu.org/lzip>.
+> More information: <https://www.nongnu.org/lzip/manual/lzip_manual.html#Invoking-lzip>.
 
 - Archive a file, replacing it with with a compressed version:
 

--- a/pages/common/m4.md
+++ b/pages/common/m4.md
@@ -1,7 +1,7 @@
 # m4
 
 > Macro processor.
-> More information: <www.gnu.org/software/m4/manual/m4.html#Invoking-m4>.
+> More information: <https://www.gnu.org/software/m4/manual/m4.html#Invoking-m4>.
 
 - Process macros in a file:
 

--- a/pages/common/m4.md
+++ b/pages/common/m4.md
@@ -1,7 +1,7 @@
 # m4
 
 > Macro processor.
-> More information: <https://www.gnu.org/software/m4>.
+> More information: <www.gnu.org/software/m4/manual/m4.html#Invoking-m4>.
 
 - Process macros in a file:
 

--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -1,7 +1,7 @@
 # parallel
 
 > Run commands on multiple CPU cores.
-> More information: <https://www.gnu.org/software/parallel>.
+> More information: <https://www.gnu.org/software/parallel/man.html>.
 
 - Gzip several files at once, using all cores:
 

--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -2,7 +2,7 @@
 
 > Archiving utility.
 > Often combined with a compression method, such as `gzip` or `bzip2`.
-> More information: <https://www.gnu.org/software/tar>.
+> More information: <https://www.gnu.org/software/tar/manual/tar.html>.
 
 - [c]reate an archive and write it to a [f]ile:
 

--- a/pages/common/units.md
+++ b/pages/common/units.md
@@ -1,7 +1,7 @@
 # units
 
 > Convert between two units of measure.
-> More information: <https://www.gnu.org/software/units/>.
+> More information: <https://www.gnu.org/software/units/manual/units.html>.
 
 - Run in interactive mode:
 

--- a/pages/linux/zile.md
+++ b/pages/linux/zile.md
@@ -1,7 +1,7 @@
 # zile
 
 > A lightweight clone of the Emacs text editor.
-> More information: <https://www.gnu.org/software/zile/>.
+> More information: <https://manned.org/zile>.
 
 - Start a buffer for temporary notes, which won't be saved:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
