### PR TITLE
transport: add example

### DIFF
--- a/pages/cisco-ios/transport.md
+++ b/pages/cisco-ios/transport.md
@@ -7,3 +7,7 @@
 - Restrict line protocols to `ssh`:
 
 `transport input ssh`
+
+- Restrict line protocols to `telnet`:
+
+`transport input telnet`


### PR DESCRIPTION
Added an example that show how to configure the line communication protocol to Telnet. Even if Telnet isn't recommended today, one may want to know how to configure it for specific or testing purpose.


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).