### PR TITLE
login: update description

### DIFF
--- a/pages/cisco-ios/login.md
+++ b/pages/cisco-ios/login.md
@@ -1,6 +1,6 @@
 # login
 
-> Manage line transport protocols.
+> Manage console and virtual line authentification.
 > Accessed in configuration mode under `line`.
 > More information: <https://www.cisco.com/c/en/us/td/docs/routers/sdwan/command/iosxe/qualified-cli-command-reference-guide/m-line-commands.pdf>.
 


### PR DESCRIPTION
Changed the command description which was based on the `transport` command description.


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).