### PR TITLE
systemd-cat: add examples

### DIFF
--- a/pages/linux/systemd-cat.md
+++ b/pages/linux/systemd-cat.md
@@ -14,3 +14,11 @@
 - Use the specified identifier (default: `cat` when reading from a pipeline, executable name otherwise):
 
 `{{command}} | systemd-cat {{[-t|--identifier]}} {{id}}`
+
+- Use the specified default priority level for all logged messages:
+
+`systemd-cat {{[-p|--priority]}} {{emerg|alert|crit|err|warning|notice|info|debug}} {{command}}`
+
+- Use the specified default priority level for the logged messages from the command's `stderr`:
+
+`systemd-cat --stderr-priority {{emerg|alert|crit|err|warning|notice|info|debug}} {{command}}`

--- a/pages/linux/systemd-cat.md
+++ b/pages/linux/systemd-cat.md
@@ -10,3 +10,7 @@
 - Write the output of a pipeline to the journal (`stderr` stays connected to the terminal):
 
 `{{command}} | systemd-cat`
+
+- Use the specified identifier (default: `cat` when reading from a pipeline, executable name otherwise):
+
+`{{command}} | systemd-cat {{[-t|--identifier]}} {{id}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).