### PR TITLE
arc: add Italian translation

### DIFF
--- a/pages.it/common/arc.md
+++ b/pages.it/common/arc.md
@@ -1,0 +1,20 @@
+# arc
+
+> Arcanist: una CLI per Phabricator.
+> Maggiori informazioni: <https://secure.phabricator.com/book/phabricator/article/arcanist/>.
+
+- Invia le modifiche a Differential per la revisione:
+
+`arc diff`
+
+- Mostra le informazioni sulle revisioni in sospeso:
+
+`arc list`
+
+- Aggiorna i messaggi dei commit Git dopo la revisione:
+
+`arc amend`
+
+- Esegui il push delle modifiche Git:
+
+`arc land`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Arcanist (version depends on Phabricator installation)

This PR adds the Italian translation for the `arc` command:

- Placed under `pages.it/common/`
- Contains 4 usage examples (well below the 8-example limit)
- Provides a link to the official Arcanist documentation
