### PR TITLE
basenc: add Italian translation

### DIFF
--- a/pages.it/common/basenc.md
+++ b/pages.it/common/basenc.md
@@ -1,0 +1,20 @@
+# basenc
+
+> Codifica o decodifica un file o `stdin` usando una codifica specificata, inviando il risultato a `stdout`.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/basenc-invocation.html>.
+
+- Codifica un file con codifica base64:
+
+`basenc --base64 {{percorso/del/file}}`
+
+- Decodifica un file con codifica base64:
+
+`basenc {{[-d|--decode]}} --base64 {{percorso/del/file}}`
+
+- Codifica da `stdin` con codifica base32 e 42 colonne:
+
+`{{comando}} | basenc --base32 {{[-w|--wrap]}} 42`
+
+- Codifica da `stdin` con codifica base32:
+
+`{{comando}} | basenc --base32`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.  
- [x] The page(s) have at most 8 examples.  
- [x] The page description(s) have links to documentation or a homepage.  
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).  
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).  
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).  

**Version of the command being documented (if known):** GNU coreutils (basenc)  

This PR adds the Italian translation for `basenc`.  
