### PR TITLE
bash-it: add Italian translation

### DIFF
--- a/pages.it/common/bash-it.md
+++ b/pages.it/common/bash-it.md
@@ -1,0 +1,32 @@
+# bash-it
+
+> Una collezione di comandi e script Bash contribuiti dalla community per Bash 3.2+.
+> Maggiori informazioni: <https://bash-it.readthedocs.io/en/latest/>.
+
+- Aggiorna Bash-it all’ultima versione stabile/sviluppo:
+
+`bash-it update {{stable|dev}}`
+
+- Ricarica il profilo di Bash (impostare `BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE` a un valore non vuoto per un ricaricamento automatico):
+
+`bash-it reload`
+
+- Riavvia Bash:
+
+`bash-it restart`
+
+- Ricarica il profilo di Bash con log di errori e avvisi abilitati:
+
+`bash-it doctor`
+
+- Ricarica il profilo di Bash con log di errori/avvisi/completo abilitati:
+
+`bash-it doctor {{errors|warnings|all}}`
+
+- Cerca alias/plugin/completamenti di Bash-it:
+
+`bash-it search {{alias|plugin|completion}}`
+
+- Cerca alias/plugin/completamenti di Bash-it ed abilita/disabilita tutti gli elementi trovati:
+
+`bash-it search --{{enable|disable}} {{alias|plugin|completion}}`


### PR DESCRIPTION
* [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
* [x] The page(s) have at most 8 examples.
* [x] The page description(s) have links to documentation or a homepage.
* [x] The page(s) follow the [[content guidelines](https://chatgpt.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines)](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
* [x] The page(s) follow the [[style guide](https://chatgpt.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
* [x] The PR title conforms to the recommended [[templates](https://chatgpt.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title)](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
* **Version of the command being documented (if known):** N/A

This PR adds the Italian translation for the [`[bash-it](https://bash-it.readthedocs.io/en/latest/)`](https://bash-it.readthedocs.io/en/latest/) command.
