### PR TITLE
mitmproxy: add examples

### DIFF
--- a/pages/common/mitmproxy.md
+++ b/pages/common/mitmproxy.md
@@ -27,3 +27,11 @@
 - Set the console layout:
 
 `mitmproxy --console-layout {{horizontal|single|vertical}}`
+
+- Save all proxied traffic to a file for later analysis:
+
+`mitmproxy {{[-w|--save-stream-file]}} {{path/to/dump.mitm}}`
+
+- Replay a previously saved HTTP flow file:
+
+`mitmproxy {{[-nr|--no-server --rfile]}} {{path/to/dump.mitm}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 11.0.2**
