### PR TITLE
dkms: add italian translation

### DIFF
--- a/pages.it/linux/dkms.md
+++ b/pages.it/linux/dkms.md
@@ -1,0 +1,20 @@
+# dkms
+
+> Un framework che permette la compilazione dinamica di moduli del kernel.
+> Maggiori informazioni: <https://manned.org/dkms>.
+
+- Elenca i moduli attualmente installati:
+
+`dkms status`
+
+- Ricompila tutti i moduli per il kernel in esecuzione:
+
+`sudo dkms autoinstall`
+
+- Installa la versione 1.2.1 del modulo acpi_call per il kernel in esecuzione:
+
+`sudo dkms install -m {{acpi_call}} -v {{1.2.1}}`
+
+- Rimuovi la versione 1.2.1 del modulo acpi_call da tutti i kernel:
+
+`sudo dkms remove -m {{acpi_call}} -v {{1.2.1}} --all`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `linux`.
- [x] The page has at most 8 examples.
- [x] The page description has a link to documentation.
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR title follows the recommended template.

- Added `pages.it/linux/dkms.md` with Italian translation.
- Preserved structure and examples from the English page.
- Verified that examples remain consistent and functional.