### PR TITLE
pdf-parser: generalize /Font example

### DIFF
--- a/pages/common/pdf-parser.md
+++ b/pages/common/pdf-parser.md
@@ -7,9 +7,9 @@
 
 `pdf-parser {{[-a|--stats]}} {{path/to/file.pdf}}`
 
-- Display objects of type `/Font` in a PDF file:
+- Display objects of a specific type (`/Font`, `/URI`, ...) in a PDF file:
 
-`pdf-parser {{[-t|--type]}} {{/Font}} {{path/to/file.pdf}}`
+`pdf-parser {{[-t|--type]}} {{/object_type}} {{path/to/file.pdf}}`
 
 - Search for strings in indirect objects:
 


### PR DESCRIPTION
The previous example was confusing, as it was unclear whether /Font should be treated as a literal or a placeholder. I have generalized the example to clarify this.
