### PR TITLE
bluetoothctl: Minor Czech word corrections

### DIFF
--- a/pages.cs/linux/bluetoothctl.md
+++ b/pages.cs/linux/bluetoothctl.md
@@ -7,7 +7,7 @@
 
 `bluetoothctl`
 
-- Vypsat všechny známe zařízení:
+- Vypsat všechna známá zařízení:
 
 `bluetoothctl devices`
 
@@ -15,7 +15,7 @@
 
 `bluetoothctl power {{on|off}}`
 
-- Spárovat se s zařízením:
+- Spárovat se zařízením:
 
 `bluetoothctl pair {{mac_adresa}}`
 
@@ -23,7 +23,7 @@
 
 `bluetoothctl remove {{mac_adresa}}`
 
-- Připojit se ke spárovanému zařízení:
+- Připojit se k spárovanému zařízení:
 
 `bluetoothctl connect {{mac_adresa}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**