### PR TITLE
alacritty: remove nonexistant command

### DIFF
--- a/pages/common/alacritty.md
+++ b/pages/common/alacritty.md
@@ -19,7 +19,7 @@
 
 `alacritty --working-directory {{path/to/directory}}`
 
-- execute a command in a new Alacritty window (also works with `alacritty msg create-window`):
+- Execute a command in a new Alacritty window (also works with `alacritty msg create-window`):
 
 `alacritty {{[-e|--command]}} {{command}}`
 

--- a/pages/common/alacritty.md
+++ b/pages/common/alacritty.md
@@ -19,14 +19,10 @@
 
 `alacritty --working-directory {{path/to/directory}}`
 
-- [e]xecute a command in a new Alacritty window (also works with `alacritty msg create-window`):
+- execute a command in a new Alacritty window (also works with `alacritty msg create-window`):
 
 `alacritty {{[-e|--command]}} {{command}}`
 
 - Use an alternative configuration file (defaults to `$XDG_CONFIG_HOME/alacritty/alacritty.toml`):
 
 `alacritty --config-file {{path/to/config.toml}}`
-
-- Run with live configuration reload enabled (can also be enabled by default in `alacritty.toml`):
-
-`alacritty --live-config-reload --config-file {{path/to/config.toml}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.15.1 (0c405d53)

```
$ alacritty --live-config-reload --config-file ~/.config/alacritty/alacritty.toml
error: unexpected argument '--live-config-reload' found

Usage: alacritty [OPTIONS] [COMMAND]

For more information, try '--help'.
```