### PR TITLE
rankmirrors: add Italian translation

### DIFF
--- a/pages.it/linux/rankmirrors.md
+++ b/pages.it/linux/rankmirrors.md
@@ -1,0 +1,25 @@
+# rankmirrors
+
+> Classifica una lista di mirror di Pacman in base alla velocità di connessione e apertura.
+> Scrive la nuova lista di mirror su `stdout`.
+> Maggiori informazioni: <https://manned.org/rankmirrors>.
+
+- Classifica una lista di mirror:
+
+`rankmirrors {{/etc/pacman.d/mirrorlist}}`
+
+- Mostra solo un certo numero di server con il punteggio più alto:
+
+`rankmirrors -n {{numero}} {{/etc/pacman.d/mirrorlist}}`
+
+- Mostra output dettagliato durante la generazione della lista di mirror:
+
+`rankmirrors {{[-v|--verbose]}} {{/etc/pacman.d/mirrorlist}}`
+
+- Verifica solo un URL specifico:
+
+`rankmirrors {{[-u|--url]}} {{url}}`
+
+- Mostra solo i tempi di risposta invece della lista completa:
+
+`rankmirrors {{[-t|--times]}} {{/etc/pacman.d/mirrorlist}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `linux`.
- [x] The page has at most 8 examples.
- [x] The page description has a link to documentation.
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR title follows the recommended template.

- Added `pages.it/linux/rankmirrors.md` with Italian translation.
- Preserved structure and examples from the English page.