### PR TITLE
retroarch: add italian translation

### DIFF
--- a/pages.it/linux/retroarch.md
+++ b/pages.it/linux/retroarch.md
@@ -1,0 +1,29 @@
+# retroarch
+
+> Un frontend per emulatori, motori di gioco e lettori multimediali.
+> L'implementazione di riferimento dell'API libretro.
+> Maggiori informazioni: <https://github.com/libretro/RetroArch>.
+
+- Avvia in modalità menu:
+
+`retroarch`
+
+- Avvia in modalità schermo intero:
+
+`retroarch --fullscreen`
+
+- Elenca tutte le funzionalità compilate:
+
+`retroarch --features`
+
+- Imposta il percorso di un file di configurazione:
+
+`retroarch --config={{percorso/al/file_di_configurazione}}`
+
+- Mostra l'aiuto:
+
+`retroarch --help`
+
+- Mostra la versione:
+
+`retroarch --version`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `common`.
- [x] The page has at most 8 examples.
- [x] The page description has a link to documentation.
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR title follows the recommended template.

- Added `pages.it/linux/retroarch.md` with Italian translation.
- Preserved structure and examples from the English page.