### PR TITLE
pwd: add Italian translation

### DIFF
--- a/pages.it/common/pwd.md
+++ b/pages.it/common/pwd.md
@@ -1,0 +1,16 @@
+# pwd
+
+> Mostra il nome della directory corrente/di lavoro.
+> Maggiori informazioni: <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+
+- Mostra la directory corrente:
+
+`pwd`
+
+- Mostra la directory corrente e risolve tutti i collegamenti simbolici (cioè mostra il percorso "fisico"):
+
+`pwd {{[-P|--physical]}}`
+
+- Mostra l'aiuto:
+
+`pwd --help`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `common`.
- [x] The page has at most 8 examples.
- [x] The page description has a link to documentation.
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR title follows the recommended template.

- Added `pages.it/common/pwd.md` with Italian translation.
- Preserved structure and examples from the English page.