### PR TITLE
rpm-ostree: add Italian translation

### DIFF
--- a/pages.it/linux/rpm-ostree.md
+++ b/pages.it/linux/rpm-ostree.md
@@ -1,0 +1,25 @@
+# rpm-ostree
+
+> Un sistema ibrido immagine/pacchetto.
+> Gestisce i deployment ostree, i layer di pacchetti, gli overlay del filesystem e la configurazione di boot.
+> Maggiori informazioni: <https://coreos.github.io/rpm-ostree/administrator-handbook/>.
+
+- Mostra i deployment rpm-ostree nell’ordine in cui appariranno nel bootloader:
+
+`rpm-ostree status`
+
+- Mostra i pacchetti obsoleti che possono essere aggiornati:
+
+`rpm-ostree upgrade --preview`
+
+- Prepara un nuovo deployment ostree con i pacchetti aggiornati e riavvia in esso:
+
+`rpm-ostree upgrade {{[-r|--reboot]}}`
+
+- Riavvia nel deployment ostree precedente:
+
+`rpm-ostree rollback {{[-r|--reboot]}}`
+
+- Installa un pacchetto in un nuovo deployment ostree e riavvia in esso:
+
+`rpm-ostree install {{package}} {{[-r|--reboot]}}`


### PR DESCRIPTION
- [x] The page is in the correct platform directory: `linux`.
- [x] The page has at most 8 examples.
- [x] The page description has links to documentation.
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR title follows the recommended template.

- Added `pages.it/linux/rpm-ostree.md` with Italian translation.
- Preserved structure and examples from the English page.