### PR TITLE
rbw: add page

### DIFF
--- a/pages/common/rbw.md
+++ b/pages/common/rbw.md
@@ -1,0 +1,33 @@
+# rbw
+
+> Unofficial Bitwarden-compatible CLI password manager, written in Rust.
+> More information: <https://github.com/doy/rbw>.
+
+- Login and unlock the vault:
+
+`rbw login`
+`rbw unlock`
+
+- List all items in the vault:
+
+`rbw list`
+
+- Get a password for an entry:
+
+`rbw get {{"entry_name"}}`
+
+- Get a username for an entry:
+
+`rbw get {{[-f|--field]}} username {{"entry_name"}}`
+
+- Copy a password to the clipboard:
+
+`rbw get {{[-c|--clipboard]}} {{"entry_name"}}`
+
+- Generate a new password:
+
+`rbw generate {{--no-symbols}} {{--only-numbers}} {{--nonconfusables}} {{password_length}}`
+
+- Lock the vault:
+
+`rbw lock`


### PR DESCRIPTION
Added documentation for the rbw CLI password manager.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 1.14.1** 
