### PR TITLE
pbzip2: add --use-compress-program with tar

### DIFF
--- a/pages/common/pbzip2.md
+++ b/pages/common/pbzip2.md
@@ -12,9 +12,9 @@
 
 `pbzip2 -p{{4}} {{path/to/file}}`
 
-- Compress in combination with tar (remove `-pN` to use all CPUs`):
+- Compress in combination with tar (options can be passed to `pbzip2`):
 
-`tar -cf {{path/to/compressed_file}}.tar.bz2 {{[-I|--use-compress-program]}} "pbzip2 -pN" {{path/to/file}}`
+`tar -cf {{path/to/compressed_file}}.tar.bz2 {{[-I|--use-compress-program]}} "pbzip2 {{-option1 -option2 ...}}" {{path/to/file}}`
 
 - Decompress a file:
 


### PR DESCRIPTION
Add an example to create a tar.bz2 file using a tar one-liner and the option --use-compress-program.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.1.13