### PR TITLE
uname: fix typo

### DIFF
--- a/pages/common/uname.md
+++ b/pages/common/uname.md
@@ -14,7 +14,7 @@
 
 - Print system architecture and processor information:
 
-`uname {{[-mp|--machine --processsor]}}`
+`uname {{[-mp|--machine --processor]}}`
 
 - Print kernel name, kernel release and kernel version:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) have at most 8 examples.
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 9.7
- fixed a minor typo in `uname` command in the `common` page.
