### PR TITLE
systemctl-*: add user unit examples

### DIFF
--- a/pages/linux/systemctl-cat.md
+++ b/pages/linux/systemctl-cat.md
@@ -14,3 +14,7 @@
 - Show the contents of a unit file for a template:
 
 `systemctl cat {{template@}}`
+
+- Show the contents of a user unit file:
+
+`systemctl cat --user {{unit}}`

--- a/pages/linux/systemctl-disable.md
+++ b/pages/linux/systemctl-disable.md
@@ -10,3 +10,7 @@
 - Stop a service from running on boot and stop its current execution:
 
 `systemctl disable {{unit}} --now`
+
+- Stop a user service from running on login:
+
+`systemctl disable --user {{unit}}`

--- a/pages/linux/systemctl-edit.md
+++ b/pages/linux/systemctl-edit.md
@@ -3,7 +3,7 @@
 > Edit systemd unit files.
 > More information: <https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#edit%20UNIT%E2%80%A6>.
 
-- Replace a unit file non-destructively:
+- Overlay a unit file non-destructively:
 
 `sudo systemctl edit {{unit_file}}`
 
@@ -14,3 +14,7 @@
 - Create a new unit file:
 
 `sudo systemctl edit {{[-lf|--full --force]}} {{unit_file}}`
+
+- Overlay a user unit file:
+
+`systemctl edit --user {{unit_file}}`

--- a/pages/linux/systemctl-enable.md
+++ b/pages/linux/systemctl-enable.md
@@ -11,6 +11,6 @@
 
 `systemctl enable {{unit}} --now`
 
-- Enable a user unit:
+- Enable a user unit to run on login:
 
 `systemctl enable --user {{unit}}`

--- a/pages/linux/systemctl-enable.md
+++ b/pages/linux/systemctl-enable.md
@@ -10,3 +10,7 @@
 - Enable a service to run on boot and start it now:
 
 `systemctl enable {{unit}} --now`
+
+- Enable a user unit:
+
+`systemctl enable --user {{unit}}`

--- a/pages/linux/systemctl-mask.md
+++ b/pages/linux/systemctl-mask.md
@@ -10,3 +10,7 @@
 - Ensure that the service is shut down while masking:
 
 `systemctl mask {{service_name}} --now`
+
+- Mask a user service:
+
+`sysemctl mask --user {{service_name}}`

--- a/pages/linux/systemctl-restart.md
+++ b/pages/linux/systemctl-restart.md
@@ -11,3 +11,7 @@
 - Restart more than one unit:
 
 `systemctl restart {{unit1 unit2 ...}}`
+
+- Restart a user unit:
+
+`systemctl restart --user {{unit}}`

--- a/pages/linux/systemctl-start.md
+++ b/pages/linux/systemctl-start.md
@@ -6,3 +6,7 @@
 - Start a unit:
 
 `systemctl start {{unit}}`
+
+- Start a user unit:
+
+`systemctl start --user {{unit}}`

--- a/pages/linux/systemctl-status.md
+++ b/pages/linux/systemctl-status.md
@@ -26,3 +26,7 @@
 - List all units with a specific state:
 
 `systemctl status --state {{active|inactive|failed}}`
+
+- Show the status of a user unit:
+
+`systemctl status --user {{unit}}`

--- a/pages/linux/systemctl-stop.md
+++ b/pages/linux/systemctl-stop.md
@@ -10,3 +10,7 @@
 - Stop a service and suppress warnings:
 
 `systemctl stop --no-warn {{unit}}`
+
+- Stop a user unit:
+
+`systemctl stop --user {{unit}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
