### PR TITLE
hexyl: remove unsupported examples

### DIFF
--- a/pages/common/hexyl.md
+++ b/pages/common/hexyl.md
@@ -11,11 +11,3 @@
 - Print the hexadecimal representation of the first n bytes of a file:
 
 `hexyl {{[-n|--length]}} {{n}} {{path/to/file}}`
-
-- Print bytes 512 through 1024 of a file:
-
-`hexyl -r {{512}}:{{1024}} {{path/to/file}}`
-
-- Print 512 bytes starting at the 1024th byte:
-
-`hexyl -r {{1024}}:+{{512}} {{path/to/file}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
