### PR TITLE
duti: add reference to osascript

### DIFF
--- a/pages/osx/duti.md
+++ b/pages/osx/duti.md
@@ -26,3 +26,7 @@
 - Display all handlers of a given UTI:
 
 `duti -l {{uti}}`
+
+- Find out bundle id:
+
+`osascript -e 'id of app "App Name"'`

--- a/pages/osx/duti.md
+++ b/pages/osx/duti.md
@@ -29,4 +29,4 @@
 
 - Find out bundle id:
 
-`osascript -e 'id of app "App Name"'`
+`osascript -e 'id of app "{{App Name}}"'`

--- a/pages/osx/duti.md
+++ b/pages/osx/duti.md
@@ -1,6 +1,7 @@
 # duti
 
 > Set default applications for document types and URL schemes on macOS.
+> See also: `osascript`.
 > More information: <https://github.com/moretension/duti>.
 
 - Set Safari as the default handler for HTML documents:
@@ -26,7 +27,3 @@
 - Display all handlers of a given UTI:
 
 `duti -l {{uti}}`
-
-- Find out bundle id:
-
-`osascript -e 'id of app "{{App Name}}"'`


### PR DESCRIPTION
Added command to find bundle ID using AppleScript. Because i have to google it every time and tldr is for me the solution to not have to google irregularly used commands.