### PR TITLE
trufflehog: remove unnecessary `=` sign

### DIFF
--- a/pages.es/common/trufflehog.md
+++ b/pages.es/common/trufflehog.md
@@ -9,7 +9,7 @@
 
 - Escanea una organización de GitHub en busca de secretos verificados:
 
-`trufflehog github --org={{trufflesecurity}} --only-verified`
+`trufflehog github --org {{trufflesecurity}} --only-verified`
 
 - Escanea un repositorio de GitHub en busca de claves verificadas y genera un archivo de salida JSON:
 
@@ -17,15 +17,15 @@
 
 - Escanea un repositorio de GitHub junto con sus incidencias y solicitudes de extracción:
 
-`trufflehog github --repo={{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
+`trufflehog github --repo {{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
 
 - Escanea un cubo S3 en busca de claves verificadas:
 
-`trufflehog s3 --bucket={{nombre_del_cubo}} --only-verified`
+`trufflehog s3 --bucket {{nombre_del_cubo}} --only-verified`
 
 - Escanea cubos S3 utilizando roles IAM:
 
-`trufflehog s3 --role-arn={{iam-role-arn}}`
+`trufflehog s3 --role-arn {{iam-role-arn}}`
 
 - Escanea archivos o directorios individuales:
 

--- a/pages.ko/common/trufflehog.md
+++ b/pages.ko/common/trufflehog.md
@@ -9,7 +9,7 @@
 
 - GitHub 조직에서 검증된 비밀 검색:
 
-`trufflehog github --org={{trufflesecurity}} --only-verified`
+`trufflehog github --org {{trufflesecurity}} --only-verified`
 
 - GitHub 저장소에서 검증된 키 검색 및 JSON 출력 받기:
 
@@ -17,15 +17,15 @@
 
 - GitHub 저장소와 그 이슈 및 풀 리퀘스트 검색:
 
-`trufflehog github --repo={{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
+`trufflehog github --repo {{https://github.com/trufflesecurity/test_keys}} --issue-comments --pr-comments`
 
 - S3 버킷에서 검증된 키 검색:
 
-`trufflehog s3 --bucket={{버킷 이름}} --only-verified`
+`trufflehog s3 --bucket {{버킷 이름}} --only-verified`
 
 - IAM 역할을 사용하여 S3 버킷 검색:
 
-`trufflehog s3 --role-arn={{iam-role-arn}}`
+`trufflehog s3 --role-arn {{iam-role-arn}}`
 
 - 개별 파일 또는 디렉터리 검색:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

