### PR TITLE
poetry-env: change virtualenv verbiage

### DIFF
--- a/pages/common/poetry-env.md
+++ b/pages/common/poetry-env.md
@@ -14,11 +14,11 @@
 
 - Display the path of the current environment:
 
-`poetry env info {{-p|--path}}`
+`poetry env info {{[-p|--path]}}`
 
 - Display the path of the current environment's Python executable:
 
-`poetry env info {{-e|--executable}}`
+`poetry env info {{[-e|--executable]}}`
 
 - List all virtual environments associated with the current project (optionally showing the full path):
 

--- a/pages/common/poetry-env.md
+++ b/pages/common/poetry-env.md
@@ -8,9 +8,17 @@
 
 `poetry env activate`
 
-- Display information about the current environment (`-p` or `-e` will display the environment's path or executable):
+- Display information about the current environment:
 
-`poetry env info {{[-p|--path]}} {{[-e|--executable]}}`
+`poetry env info`
+
+- Display the path of the current environment:
+
+`poetry env info {{-p|--path}}`
+
+- Display the path of the current environment's Python executable:
+
+`poetry env info {{-e|--executable}}`
 
 - List all virtual environments associated with the current project (optionally showing the full path):
 

--- a/pages/common/poetry-env.md
+++ b/pages/common/poetry-env.md
@@ -1,10 +1,10 @@
 # poetry-env
 
-> Manage virtualenvs associated with a Poetry project.
+> Manage virtual environments associated with a Poetry project.
 > See also: `asdf`.
 > More information: <https://python-poetry.org/docs/cli/#env>.
 
-- Print the command to activate a virtualenv:
+- Print the command to activate a virtual environment:
 
 `poetry env activate`
 
@@ -12,14 +12,14 @@
 
 `poetry env info {{[-p|--path]}} {{[-e|--executable]}}`
 
-- List all virtualenvs associated with the current project (optionally showing the full path):
+- List all virtual environments associated with the current project (optionally showing the full path):
 
 `poetry env list --full-path`
 
-- Remove specific or all virtualenvs associated with the current project:
+- Remove specific or all virtual environments associated with the current project:
 
 `poetry env remove python {{path/to/executable|environment_name}} | poetry env remove --all`
 
-- Activate or create a virtualenv for the project using the specified python executable:
+- Activate or create a virtual environment for the project using the specified python executable:
 
 `poetry env use python {{path/to/executable}}`

--- a/pages/common/poetry-env.md
+++ b/pages/common/poetry-env.md
@@ -8,7 +8,7 @@
 
 `poetry env activate`
 
-- Display information about the current environment (-p or -e will display the environment's path or executable):
+- Display information about the current environment (`-p` or `-e` will display the environment's path or executable):
 
 `poetry env info {{[-p|--path]}} {{[-e|--executable]}}`
 
@@ -20,6 +20,6 @@
 
 `poetry env remove python {{path/to/executable|environment_name}} | poetry env remove --all`
 
-- Activate or create a virtual environment for the project using the specified python executable:
+- Activate or create a virtual environment for the project using the specified Python executable:
 
 `poetry env use python {{path/to/executable}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Changing `virtualenv` -> `virtual environment` per discussion on https://github.com/tldr-pages/tldr/pull/17960#pullrequestreview-3197950104 
