### PR TITLE
setfacl: fix flag order when modifying defaults

### DIFF
--- a/pages/linux/setfacl.md
+++ b/pages/linux/setfacl.md
@@ -9,7 +9,7 @@
 
 - Modify default ACL of a file for all users:
 
-`setfacl {{[-m|--modify]}} {{[-d|--default]}} u::rw {{path/to/file_or_directory}}`
+`setfacl {{[-d|--default]}} {{[-m|--modify]}} u::rw {{path/to/file_or_directory}}`
 
 - Remove ACL of a file for a user:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) have at most 8 examples.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

If we run the `setfacl` command with the flags in the order given in the example, we get an invalid argument error on the `-m` option. Swapping the order works as expected.

```
[jwlodek@rocky-dev tldr]$ getfacl .
# file: .
# owner: jwlodek
# group: jwlodek
user::rwx
group::r-x
other::r-x

[jwlodek@rocky-dev tldr]$ setfacl -m -d u::rw .
setfacl: Option -m: Invalid argument near character 1
[jwlodek@rocky-dev tldr]$ setfacl -d -m u::rw .
[jwlodek@rocky-dev tldr]$ getfacl .
# file: .
# owner: jwlodek
# group: jwlodek
user::rwx
group::r-x
other::r-x
default:user::rw-
default:group::r-x
default:other::r-x
```
