### PR TITLE
CODEOWNERS: remove @ikks as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 /pages.ar/ @MachiavelliII @ali90h
 /pages.cs/ @Sarijen
 /pages.de/ @pixelcmtd @gutjuri
-/pages.es/ @kant @ikks
+/pages.es/ @kant
 /pages.fa/ @MrMw3
 /pages.fi/ @Managor
 /pages.fr/ @Nico385412 @nicokosi @noraj
@@ -30,7 +30,7 @@
 /contributing-guides/translation-templates/ @kbdharun @sebastiaanspeck
 /contributing-guides/*.ar.md @MachiavelliII @ali90h
 /contributing-guides/*.de.md @pixelcmtd @gutjuri
-/contributing-guides/*.es.md @kant @ikks
+/contributing-guides/*.es.md @kant
 /contributing-guides/*.fa.md @MrMw3
 /contributing-guides/*.fr.md @Nico385412 @nicokosi @noraj
 /contributing-guides/*.hi.md @kbdharun @debghs @karthik-script


### PR DESCRIPTION
@ikks hasn't participated in tldr in a long while. To not give any false hope that spanish pages would be reviewed, I'm removing them from codeowners.