### PR TITLE
scripts/check-pr: expand sed command to cover edge cases

### DIFF
--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -95,7 +95,7 @@ function strip_commands() {
 
   mapfile -t stripped_commands < <(
     grep "$regex" "$file" | 
-    sed -E 's/\{\{([^{}]|(\{[^}]*\}))*\}\}/{{}}/g' | 
+    sed -E 's/\{\{([^}]|(\{[^}]*\}))*\}\}/{{}}/g' | 
     sed 's/<[^>]*>//g' | 
     sed 's/([^)]*)//g' | 
     sed 's/"[^"]*"/""/g' | 


### PR DESCRIPTION
As described in #17198. I have ran into this being an issue a few times now (#17189, #17661, and #18106), so I think it should be addressed. I avoided using `perl`, as [it isn't POSIX-compliant](https://en.wikipedia.org/wiki/List_of_POSIX_commands).

Closes #17198 