### PR TITLE
sudo: Use imperative mood in description

### DIFF
--- a/pages/common/sudo.md
+++ b/pages/common/sudo.md
@@ -1,6 +1,6 @@
 # sudo
 
-> Executes a single command as the superuser or another user.
+> Execute a single command as the superuser or another user.
 > More information: <https://www.sudo.ws/sudo.html>.
 
 - Run a command as the superuser:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

In PR #18104, it was pointed out that page descriptions should use the imperative mood (e.g., "Execute" instead of "Executes").
This PR applies that style fix to the English page for sudo.