### PR TITLE
style(man): Improve argument syntax for clarity

### DIFF
--- a/pages/common/man.md
+++ b/pages/common/man.md
@@ -9,11 +9,11 @@
 
 - Open the man page for a command in a browser (`BROWSER` environment variable can replace `=browser_name`):
 
-`man {{[-Hbrowser_name|--html=browser_name]}} {{command}}`
+`man {{[-H|--html=]}}{{browser_name}} {{command}}`
 
 - Display the man page for a command from section 7:
 
-`man {{7}} {{command}}`
+`man 7 {{command}}`
 
 - List all available sections for a command:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

> Following the review in PR #18105, this PR applies the same style improvements to the English page for `man`:
>
> - Separates the browser flag from its placeholder value.
> - Removes curly braces from the section number, as it's a literal value, not a placeholder.
