### PR TITLE
licensor, reuse: fix wrong spelling of license

### DIFF
--- a/pages/common/licensor.md
+++ b/pages/common/licensor.md
@@ -15,7 +15,7 @@
 
 `licensor {{MIT}} "{{Bobby Tables}}" > {{LICENSE}}`
 
-- Specify licence exceptions with a WITH expression:
+- Specify license exceptions with a WITH expression:
 
 `licensor "{{Apache-2.0 WITH LLVM-exception}}" > {{LICENSE}}`
 

--- a/pages/common/reuse.md
+++ b/pages/common/reuse.md
@@ -15,7 +15,7 @@
 
 `reuse annotate {{[-c|--copyright]}} "{{your_name}} <{{your_email}}>" --fallback-dot-license {{path/to/file}}`
 
-- Add licence information to file:
+- Add license information to file:
 
 `reuse annotate {{[-l|--license]}} {{spdx_identifier}} --fallback-dot-license {{path/to/file}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
