### PR TITLE
style(ss): Use placeholders in kill example for safety

### DIFF
--- a/pages/linux/ss.md
+++ b/pages/linux/ss.md
@@ -31,6 +31,6 @@
 
 `ss {{[-4t|--ipv4 --tcp]}} src {{192.168/16}}`
 
-- Kill IPv4 or IPv6 Socket Connection with destination IP 192.168.1.17 and destination port 8080:
+- Kill IPv4 or IPv6 Socket Connection with a specific destination IP and port:
 
-`ss {{[-K|--kill]}} dst {{192.168.1.17}} dport = {{8080}}`
+`ss {{[-K|--kill]}} dst {{ip_address}} dport = {{port}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Hello!
While working on the Russian translation for `ss` (in PR #18248), I noticed that the last example with the `-K|--kill` flag uses a specific IP address and port.
According to the style guide's rule for potentially destructive commands, it's better to use placeholders to prevent accidental copy-pasting.
This PR applies that rule to the English page for consistency and safety.