### PR TITLE
fzf: fix example

### DIFF
--- a/pages/common/fzf.md
+++ b/pages/common/fzf.md
@@ -24,6 +24,6 @@
 
 `fzf {{[-q|--query]}} "^core go$ | rb$ | py$"`
 
-- Start `fzf` on entries that not match `pyc` and match exactly `travis`:
+- Start `fzf` on entries that do not match `pyc` and contain `travis`:
 
-`fzf {{[-q|--query]}} "\!pyc 'travis'"`
+`fzf {{[-q|--query]}} '!pyc travis'`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.65.2 (416aff86)

The old example works for shells like Zsh, but not Bash. The description also did not accurately describe the command.
