### PR TITLE
agg: add --font-size example

### DIFF
--- a/pages/common/agg.md
+++ b/pages/common/agg.md
@@ -11,6 +11,10 @@
 
 `agg --cols 80 --rows 25 {{path/to/demo.cast}} {{path/to/demo.gif}}`
 
+- Create a GIF with a font size of 24 pixels:
+
+`agg --font-size 24 {{path/to/demo.cast}} {{path/to/demo.gif}}`
+
 - Display help:
 
 `agg {{[-h|--help]}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

