### PR TITLE
cargo-deb: add page

### DIFF
--- a/pages/common/cargo-deb.md
+++ b/pages/common/cargo-deb.md
@@ -11,9 +11,9 @@
 
 `cargo deb {{[-o|--output]}} {{path/to/file_or_directory}}`
 
-- Compile for the specified Rust target:
+- Compile for the specified Rust target triple:
 
-`cargo deb --target {{target_triple}}`
+`cargo deb --target {{x86_64-unknown-linux-gnu}}`
 
 - Select which package to use in a Cargo workspace:
 

--- a/pages/common/cargo-deb.md
+++ b/pages/common/cargo-deb.md
@@ -1,0 +1,24 @@
+# cargo deb
+
+> Create Debian packages from Cargo projects.
+> More information: <https://github.com/kornelski/cargo-deb>.
+
+- Create a Debian package from a project:
+
+`cargo deb`
+
+- Write the `.deb` file to the specified file or directory:
+
+`cargo deb {{[-o|--output]}} {{path/to/file_or_directory}}`
+
+- Compile for the specified Rust target:
+
+`cargo deb --target {{target_triple}}`
+
+- Select which package to use in a Cargo workspace:
+
+`cargo deb {{[-p|--package]}} {{package_name}}`
+
+- Immediately install the created package:
+
+`cargo deb --install`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).