### PR TITLE
cargo-msrv: add page

### DIFF
--- a/pages/common/cargo-msrv.md
+++ b/pages/common/cargo-msrv.md
@@ -1,0 +1,24 @@
+# cargo msrv
+
+> Manage the Minimum Supported Rust Version (MSRV) of a project.
+> More information: <https://gribnau.dev/cargo-msrv>.
+
+- Display the MSRVs of dependencies (as specified in their `Cargo.toml`):
+
+`cargo msrv list`
+
+- Find the MSRV of the project by trying to compile it with various toolchains:
+
+`cargo msrv find`
+
+- Show the MSRV of the project as specified in `Cargo.toml`:
+
+`cargo msrv show`
+
+- Set the MSRV in `Cargo.toml` to a given Rust version:
+
+`cargo msrv set {{version}}`
+
+- Verify whether the MSRV is satisfyable by compiling the project using the specified version of Rust:
+
+`cargo msrv verify`

--- a/pages/common/cargo-msrv.md
+++ b/pages/common/cargo-msrv.md
@@ -19,6 +19,6 @@
 
 `cargo msrv set {{version}}`
 
-- Verify whether the MSRV is satisfyable by compiling the project using the specified version of Rust:
+- Verify whether the MSRV is satisfiable by compiling the project using the specified version of Rust:
 
 `cargo msrv verify`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).