### PR TITLE
grep: fix wrong terms in zh_TW translation

### DIFF
--- a/pages.zh_TW/common/grep.md
+++ b/pages.zh_TW/common/grep.md
@@ -1,36 +1,36 @@
 # grep
 
-> 使用正則表達式在文件中查找字符串。
+> 使用正則表達式在文件中查找字串。
 > 更多資訊：<https://www.gnu.org/software/grep/manual/grep.html>.
 
-- 在檔案中尋找字符：
+- 在檔案中尋找字串：
 
-`grep "{{字符串}}" {{檔案/完整/路徑}}`
+`grep "{{字串}}" {{檔案/完整/路徑}}`
 
-- 搜索確切的字符串(禁用正則表達式)：
+- 搜索確切的字串(停用正則表達式)：
 
-`grep {{[-F|--fixed-strings]}} "{{精確字符串}}" {{檔案/完整/路徑}}`
+`grep {{[-F|--fixed-strings]}} "{{精確字串}}" {{檔案/完整/路徑}}`
 
-- 在目錄中遞歸搜索模式，顯示匹配行的行號並忽略二進制文件：
+- 在目錄中遞迴搜尋模式，顯示相符行的行號並忽略二進位文件：
 
-`grep {{[-rnI|--recursive --line-number --binary-files=without-match]}} "{{字符串}}" {{檔案/完整/路徑}}`
+`grep {{[-rnI|--recursive --line-number --binary-files=without-match]}} "{{字串}}" {{檔案/完整/路徑}}`
 
-- 使用擴展正則表達式(支持 `?`, `+`, `{}`, `()`, 和 `|`)，並啟用不區分大小寫的模式：
+- 使用擴充正則表達式(支援 `?`, `+`, `{}`, `()`, 和 `|`)，並啟用不區分大小寫的模式：
 
-`grep {{[-Ei|--extended-regexp --ignore-case]}} "{{字符串}}" {{檔案/完整/路徑}}`
+`grep {{[-Ei|--extended-regexp --ignore-case]}} "{{字串}}" {{檔案/完整/路徑}}`
 
-- 打印每次匹配的上下文、之前或之後的 3 行：
+- 印出每次相符的上下文、之前或之後的 3 行：
 
-`grep {{--context|--before-context|--after-context}} 3 "{{字符串}}" {{檔案/完整/路徑}}`
+`grep {{--context|--before-context|--after-context}} 3 "{{字串}}" {{檔案/完整/路徑}}`
 
-- 打印包含匹配結果的文件名和行號，並啟用彩色輸出：
+- 印出包含相符結果的文件名和行號，並啟用彩色輸出：
 
-`grep {{[-Hn|--with-filename --line-number]}} --color=always "{{字符串}}" {{檔案/完整/路徑}}`
+`grep {{[-Hn|--with-filename --line-number]}} --color=always "{{字串}}" {{檔案/完整/路徑}}`
 
-- 搜索與模式匹配的行，僅打印匹配的文本：
+- 搜尋與模式相符的行，僅印出相符的文字：
 
-`grep {{[-o|--only-matching]}} "{{字符串}}" {{檔案/完整/路徑}}`
+`grep {{[-o|--only-matching]}} "{{字串}}" {{檔案/完整/路徑}}`
 
-- 在標準輸入中搜索不匹配模式的行：
+- 在標準輸入中搜尋不相符模式的行：
 
-`cat {{檔案/完整/路徑}} | grep {{[-v|--invert-match]}} "{{字符串}}"`
+`cat {{檔案/完整/路徑}} | grep {{[-v|--invert-match]}} "{{字串}}"`


### PR DESCRIPTION
string => "字串"
search => "搜尋"
recursion => "遞迴"
disable => "停用"
match => "相符"
binary => "二進位"
extended => "擴充"
support => "支援"
print => "列印" or "印出" depends on context
text => "文字"

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
