### PR TITLE
systemctl-show: add page

### DIFF
--- a/pages/linux/systemctl-show.md
+++ b/pages/linux/systemctl-show.md
@@ -1,0 +1,28 @@
+# systemctl show
+
+> Show properties of units or systemd itself.
+> More information: <https://www.freedesktop.org/software/systemd/man/systemctl.html#show%20PATTERN%E2%80%A6%7CJOB%E2%80%A6>.
+
+- Show properties of the system service manager:
+
+`systemctl show`
+
+- Show properties of the user service manager:
+
+`systemctl show --user`
+
+- Show properties of a specific unit:
+
+`systemctl show {{unit}}`
+
+- Show properties of a specific user unit:
+
+`systemctl show --user {{unit}}`
+
+- Include empty properties in the list:
+
+`systemctl show {{[-a|--all]}}`
+
+- Only show the specified properties:
+
+`systemctl show {{[-p|--property]}} {{Wants,Conflicts,...}} {{unit}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).