### PR TITLE
htop: add readonly example

### DIFF
--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -34,4 +34,3 @@
 - Switch to a different tab:
 
 `<Tab>`
-

--- a/pages/common/htop.md
+++ b/pages/common/htop.md
@@ -23,14 +23,15 @@
 
 `htop {{[-d|--delay]}} {{50}}`
 
+- Disable all system and process changing features:
+
+`htop --readonly`
+
 - See interactive commands while running htop:
 
-`<?>`
+`{{<F1>|<?>}}`
 
 - Switch to a different tab:
 
 `<Tab>`
 
-- Display help:
-
-`htop {{[-h|--help]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
