### PR TITLE
hg: update page

### DIFF
--- a/pages/common/hg.md
+++ b/pages/common/hg.md
@@ -4,18 +4,34 @@
 > Some subcommands such as `commit` have their own usage documentation.
 > More information: <https://www.mercurial-scm.org/help/commands>.
 
-- Execute a Mercurial command:
+- Create an empty Mercurial repository:
 
-`hg {{command}}`
+`hg init`
 
-- Display help:
+- Clone a remote Mercurial repository from the internet:
 
-`hg help`
+`hg clone {{https://example.com/repo}}`
 
-- Display help for a specific command:
+- View the status of a local repository:
 
-`hg help {{command}}`
+`hg status`
 
-- Display version:
+- Add all new files to the next commit:
 
-`hg --version`
+`hg add`
+
+- Commit changes to version history:
+
+`hg commit {{[-m|--message]}} {{message_text}}`
+
+- Push local changes to a remote repository:
+
+`hg push`
+
+- Pull any changes made to a remote:
+
+`hg pull`
+
+- Reset everything the way it was in the latest commit:
+
+`hg update {{[-C|--clean]}}; hg purge`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

Makes the `hg` page very similar to `git`, as described in #18255.