### PR TITLE
flex: add Spanish translation

### DIFF
--- a/pages.es/linux/flex.md
+++ b/pages.es/linux/flex.md
@@ -1,0 +1,25 @@
+# flex
+
+> Generador de analizadores léxicos.
+> Dada la especificación de un analizador léxico, genera código C para su implementación.
+> Más información: <https://manned.org/lex.1>.
+
+- Genera un analizador a partir de un fichero Lex, almacenándolo en el archivo `lex.yy.c`:
+
+`flex {{analyzer.l}}`
+
+- Escribe el analizador en `stdout`:
+
+`flex {{[-t|--stdout]}} {{analyzer.l}}`
+
+- Especifica el archivo de salida:
+
+`flex {{analyzer.l}} {{[-o|--outfile]}} {{analyzer.c}}`
+
+- Genera un analizador por lotes en lugar de un analizador interactivo:
+
+`flex {{[-B|--batch]}} {{analyzer.l}}`
+
+- Compila un archivo C generado por Lex:
+
+`cc {{ruta/a/lex.yy.c}} -o {{ejecutable}}`


### PR DESCRIPTION
Added documentation for the flex lexical analyzer generator.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->x
- [ x The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
