### PR TITLE
grub-mkrescue: add page

### DIFF
--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -19,6 +19,10 @@
 
 `grub-mkrescue --disable-cli --output {{grub.iso}} {{path/to/source}}`
 
+- Preload specific GRUB modules into the image (quote when specifying multiple modules):
+
+`grub-mkrescue --modules "{{part_gpt iso9660}}" --output {{grub.iso}} {{path/to/source}}`
+
 - Pass additional options directly to xorriso (use `--` to switch to xorriso mode):
 
 `grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{volume_name}} {{path/to/source}}`
@@ -29,4 +33,4 @@
 
 - Display version:
 
-`grub-mkrescue {{[-V|--version]}}`
+`grub-mkrescue {{--version}}`

--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -1,0 +1,32 @@
+# grub-mkrescue
+
+> Make a GRUB CD/USB/floppy bootable image.
+> More information: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dmkrescue>.
+
+- Create a bootable ISO from the current directory and save it as `grub.iso`:
+
+`grub-mkrescue --output {{grub.iso}} .`
+
+- Create an ISO using GRUB files from a custom directory:
+
+`grub-mkrescue --directory {{/usr/lib/grub/i386-pc}} --output {{grub.iso}} {{path/to/source}}`
+
+- Use XZ compression for GRUB files when building the image:
+
+`grub-mkrescue --compress {{xz}} --output {{grub.iso}} {{path/to/source}}`
+
+- Disable the GRUB command-line interface in the generated image:
+
+`grub-mkrescue --disable-cli --output {{grub.iso}} {{path/to/source}}`
+
+- Pass additional options directly to xorriso (use `--` to switch to xorriso mode):
+
+`grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{volume_name}} {{path/to/source}}`
+
+- Display help:
+
+`grub-mkrescue {{[-?|--help]}}`
+
+- Display version:
+
+`grub-mkrescue {{[-V|--version]}}`

--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -23,7 +23,7 @@
 
 `grub-mkrescue --modules "{{part_gpt iso9660}}" --output {{grub.iso}} {{path/to/source}}`
 
-- Pass additional options directly to xorriso:
+- Pass additional options directly to `xorriso`:
 
 `grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{volume_name}} {{path/to/source}}`
 

--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -11,9 +11,9 @@
 
 `grub-mkrescue --directory {{/usr/lib/grub/i386-pc}} --output {{grub.iso}} {{path/to/source}}`
 
-- Use XZ compression for GRUB files when building the image:
+- Use compression for GRUB files when building the image:
 
-`grub-mkrescue --compress xz --output {{grub.iso}} {{path/to/source}}`
+`grub-mkrescue --compress {{no|xz|gz|lzo}} --output {{grub.iso}} {{path/to/source}}`
 
 - Disable the GRUB command-line interface in the generated image:
 

--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -11,7 +11,7 @@
 
 `grub-mkrescue --directory {{/usr/lib/grub/i386-pc}} --output {{grub.iso}} {{path/to/source}}`
 
-- Use compression for GRUB files when building the image:
+- Use compression for GRUB files when building the image, setting `no` disables compression:
 
 `grub-mkrescue --compress {{no|xz|gz|lzo}} --output {{grub.iso}} {{path/to/source}}`
 

--- a/pages/linux/grub-mkrescue.md
+++ b/pages/linux/grub-mkrescue.md
@@ -13,17 +13,17 @@
 
 - Use XZ compression for GRUB files when building the image:
 
-`grub-mkrescue --compress {{xz}} --output {{grub.iso}} {{path/to/source}}`
+`grub-mkrescue --compress xz --output {{grub.iso}} {{path/to/source}}`
 
 - Disable the GRUB command-line interface in the generated image:
 
 `grub-mkrescue --disable-cli --output {{grub.iso}} {{path/to/source}}`
 
-- Preload specific GRUB modules into the image (quote when specifying multiple modules):
+- Preload specific GRUB modules into the image:
 
 `grub-mkrescue --modules "{{part_gpt iso9660}}" --output {{grub.iso}} {{path/to/source}}`
 
-- Pass additional options directly to xorriso (use `--` to switch to xorriso mode):
+- Pass additional options directly to xorriso:
 
 `grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{volume_name}} {{path/to/source}}`
 
@@ -33,4 +33,4 @@
 
 - Display version:
 
-`grub-mkrescue {{--version}}`
+`grub-mkrescue --version`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** grub-mkrescue (GRUB) 2:2.12.r359.g19c698d12-1

Part of #8080 
