### PR TITLE
windows: add netsh-wlan command for managing wireless networks

### DIFF
--- a/pages/common/scrun.md
+++ b/pages/common/scrun.md
@@ -1,0 +1,19 @@
+# scrun
+
+> Run a command under the Slurm workload manager.
+> More information: <https://slurm.schedmd.com/srun.html>.
+
+- Run a simple command interactively:
+`srun hostname`
+
+- Run a job with 4 CPUs:
+`srun -n 4 my_program`
+
+- Allocate memory for a job:
+`srun --mem=8G my_program`
+
+- Run a job on a specific partition:
+`srun -p gpu my_program`
+
+- Run a job and save output to a file:
+`srun my_program > output.txt`

--- a/pages/windows/netsh-wlan.md
+++ b/pages/windows/netsh-wlan.md
@@ -15,7 +15,7 @@
 
 `netsh wlan disconnect`
 
-- Show the current wireless network profile:
+- Show current wireless network interfaces and status:
 
 `netsh wlan show interfaces`
 
@@ -27,10 +27,6 @@
 
 `netsh wlan delete profile name="{{SSID}}"`
 
-- Add a new wireless network profile from an XML file:
-
-`netsh wlan add profile filename="{{profile.xml}}"`
-
 - Enable hosted network (turn PC into Wi-Fi hotspot):
 
 `netsh wlan set hostednetwork mode=allow ssid="{{SSID}}" key="{{password}}"`
@@ -38,7 +34,3 @@
 - Start the hosted network:
 
 `netsh wlan start hostednetwork`
-
-- Stop the hosted network:
-
-`netsh wlan stop hostednetwork`

--- a/pages/windows/netsh-wlan.md
+++ b/pages/windows/netsh-wlan.md
@@ -1,0 +1,44 @@
+# netsh wlan
+
+> Manage wireless networks on Windows using the command line.
+> More information: <https://docs.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-wlan>.
+
+- Show all available wireless networks:
+
+`netsh wlan show networks`
+
+- Connect to a wireless network with a specific SSID:
+
+`netsh wlan connect name="{{SSID}}"`
+
+- Disconnect from the current wireless network:
+
+`netsh wlan disconnect`
+
+- Show the current wireless network profile:
+
+`netsh wlan show interfaces`
+
+- Export a wireless network profile to an XML file:
+
+`netsh wlan export profile name="{{SSID}}" folder="{{C:\path\to\folder}}" key=clear`
+
+- Delete a saved wireless network profile:
+
+`netsh wlan delete profile name="{{SSID}}"`
+
+- Add a new wireless network profile from an XML file:
+
+`netsh wlan add profile filename="{{profile.xml}}"`
+
+- Enable hosted network (turn PC into Wi-Fi hotspot):
+
+`netsh wlan set hostednetwork mode=allow ssid="{{SSID}}" key="{{password}}"`
+
+- Start the hosted network:
+
+`netsh wlan start hostednetwork`
+
+- Stop the hosted network:
+
+`netsh wlan stop hostednetwork`


### PR DESCRIPTION
## This contribution adds a new tldr page for the Windows `netsh wlan` command. 
### It provides concise examples for common wireless network management tasks such as:

- Viewing available networks
- Connecting to or disconnecting from a network
- Managing network profiles
- Setting up and controlling a hosted network (Wi-Fi hotspot)

The page follows the tldr-pages style guide with placeholders for user-specific values. 
This addition aims to simplify network management on Windows for quick CLI reference.