### PR TITLE
Add tealdeer page

### DIFF
--- a/pages/common/bottom.md
+++ b/pages/common/bottom.md
@@ -1,0 +1,36 @@
+# bottom
+
+> A graphical process and system monitor with a customizable interface.
+> More information: <https://clementtsang.github.io/bottom>.
+
+- Start bottom with default settings:
+
+`btm`
+
+- Start bottom in basic mode (similar to htop):
+
+`btm --basic`
+
+- Start bottom with a specific refresh rate in milliseconds:
+
+`btm --rate {{1000}}`
+
+- Start bottom with CPU usage shown as a percentage per core:
+
+`btm --cpu_left_legend`
+
+- Start bottom with the process widget in tree mode:
+
+`btm --tree`
+
+- Start bottom and show only CPU, memory, and process widgets:
+
+`btm --default_widget_type {{cpu}} --default_widget_count {{3}}`
+
+- Start bottom with a custom configuration file:
+
+`btm --config {{path/to/config.toml}}`
+
+- Display help:
+
+`btm --help`

--- a/pages/common/tealdeer.md
+++ b/pages/common/tealdeer.md
@@ -1,0 +1,36 @@
+# tealdeer
+
+> A fast implementation of tldr, providing simplified command-line help pages.
+> More information: <https://github.com/dbrgn/tealdeer>.
+
+- Get help for a specific command:
+
+`tldr {{command}}`
+
+- Get help for a specific subcommand:
+
+`tldr {{command}}-{{subcommand}}`
+
+- Update the local cache of tldr pages:
+
+`tldr --update`
+
+- List all available pages:
+
+`tldr --list`
+
+- Search for a specific keyword in all pages:
+
+`tldr --search "{{keyword}}"`
+
+- Show the file path of a specific page:
+
+`tldr --render {{path/to/page.md}}`
+
+- Clear the local cache:
+
+`tldr --clear-cache`
+
+- Print the current cache directory path:
+
+`tldr --config-path`


### PR DESCRIPTION
Adds documentation for `tealdeer`, a fast Rust implementation of the tldr client.

This page covers:
- Getting help for commands and subcommands
- Updating the local page cache
- Listing available pages
- Searching across all pages
- Rendering custom pages
- Cache management

Tealdeer is a popular alternative tldr client known for its speed and offline-first approach. All examples follow tldr guidelines and reference the official repository.