### PR TITLE
nix-collect-garbage: remove `sudo`

### DIFF
--- a/pages.de/common/nix-collect-garbage.md
+++ b/pages.de/common/nix-collect-garbage.md
@@ -6,12 +6,12 @@
 
 - Lösche alle Speicherpfade, die von den aktuellen Generationen der einzelnen Profile nicht verwendet werden:
 
-`sudo nix-collect-garbage --delete-old`
+`nix-collect-garbage --delete-old`
 
 - Simuliere die Löschung alter Speicherpfade:
 
-`sudo nix-collect-garbage --delete-old --dry-run`
+`nix-collect-garbage --delete-old --dry-run`
 
 - Lösche alle Speicherpfade, die älter als 30 Tage sind:
 
-`sudo nix-collect-garbage --delete-older-than 30d`
+`nix-collect-garbage --delete-older-than 30d`

--- a/pages.es/common/nix-collect-garbage.md
+++ b/pages.es/common/nix-collect-garbage.md
@@ -6,12 +6,12 @@
 
 - Elimina todas las rutas del almacén desusados por las generaciones actuales de cada perfil:
 
-`sudo nix-collect-garbage {{[-d|--delete-old]}}`
+`nix-collect-garbage {{[-d|--delete-old]}}`
 
 - Simula la eliminación de rutas del almacén antiguas:
 
-`sudo nix-collect-garbage {{[-d|--delete-old]}} --dry-run`
+`nix-collect-garbage {{[-d|--delete-old]}} --dry-run`
 
 - Elimina todas las rutas del almacén más antiguas que 30 días:
 
-`sudo nix-collect-garbage --delete-older-than 30d`
+`nix-collect-garbage --delete-older-than 30d`

--- a/pages.ko/common/nix-collect-garbage.md
+++ b/pages.ko/common/nix-collect-garbage.md
@@ -6,12 +6,12 @@
 
 - 각 프로필의 현재 세대에서 사용되지 않는 모든 저장소 경로 삭제:
 
-`sudo nix-collect-garbage --delete-old`
+`nix-collect-garbage --delete-old`
 
 - 오래된 저장소 경로 삭제 시뮬레이션:
 
-`sudo nix-collect-garbage --delete-old --dry-run`
+`nix-collect-garbage --delete-old --dry-run`
 
 - 30일보다 오래된 모든 저장소 경로 삭제:
 
-`sudo nix-collect-garbage --delete-older-than 30d`
+`nix-collect-garbage --delete-older-than 30d`

--- a/pages/common/nix-collect-garbage.md
+++ b/pages/common/nix-collect-garbage.md
@@ -6,12 +6,12 @@
 
 - Delete all store paths unused by current generations of each profile:
 
-`sudo nix-collect-garbage {{[-d|--delete-old]}}`
+`nix-collect-garbage {{[-d|--delete-old]}}`
 
 - Simulate the deletion of old store paths:
 
-`sudo nix-collect-garbage {{[-d|--delete-old]}} --dry-run`
+`nix-collect-garbage {{[-d|--delete-old]}} --dry-run`
 
 - Delete all store paths older than 30 days:
 
-`sudo nix-collect-garbage --delete-older-than 30d`
+`nix-collect-garbage --delete-older-than 30d`


### PR DESCRIPTION
It works without `sudo` on a single-user installation of Nix.