### PR TITLE
cargo-binstall: add page

### DIFF
--- a/pages/common/cargo-binstall.md
+++ b/pages/common/cargo-binstall.md
@@ -8,7 +8,7 @@
 
 `cargo binstall {{package}}`
 
-- Install a specific version of a package from (latest by default):
+- Install a specific version of a package (latest by default):
 
 `cargo binstall {{package}}@{{version}}`
 

--- a/pages/common/cargo-binstall.md
+++ b/pages/common/cargo-binstall.md
@@ -1,0 +1,17 @@
+# cargo binstall
+
+> Install Rust binaries from CI artifacts.
+> Falls back to `cargo install` (from source code) if there are no binaries available.
+> More information: <https://github.com/cargo-bins/cargo-binstall>.
+
+- Install a package from <https://crates.io>:
+
+`cargo binstall {{package}}`
+
+- Install a specific version of a package from (latest by default):
+
+`cargo binstall {{package}}@{{version}}`
+
+- Install a package and disable confirmation prompts:
+
+`cargo binstall {{[-y|--no-confirm]}} {{package}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).