### PR TITLE
cargo-verify-project: add deprecation notice

### DIFF
--- a/pages/common/cargo-verify-project.md
+++ b/pages/common/cargo-verify-project.md
@@ -1,7 +1,8 @@
 # cargo verify-project
 
 > Check the correctness of the `Cargo.toml` manifest and print the result as a JSON object.
-> More information: <https://doc.rust-lang.org/cargo/commands/cargo-verify-project.html>.
+> Note: this command is deprecated and may be removed in the future.
+> More information: <https://doc.rust-lang.org/cargo/commands/deprecated-and-removed.html>.
 
 - Check the correctness of the current project's manifest:
 


### PR DESCRIPTION
The previous more info link redirects to https://doc.rust-lang.org/cargo/commands/deprecated-and-removed.html.