### PR TITLE
nixos-*: add italian translation

### DIFF
--- a/pages.it/linux/nixos-container.md
+++ b/pages.it/linux/nixos-container.md
@@ -1,0 +1,28 @@
+# nixos-container
+
+> Avvia container NixOS usando container Linux.
+> Maggiori informazioni: <https://nixos.org/manual/nixos/stable/#ch-containers>.
+
+- Elenca i container in esecuzione:
+
+`sudo nixos-container list`
+
+- Crea un container NixOS con un file di configurazione specifico:
+
+`sudo nixos-container create {{nome_container}} --config-file {{percorso_file_configurazione_nix}}`
+
+- Avvia, ferma, termina o elimina uno specifico container:
+
+`sudo nixos-container {{start|stop|terminate|destroy|status}} {{nome_container}}`
+
+- Esegue un comando all'interno di un container in esecuzione:
+
+`sudo nixos-container run {{nome_container}} -- {{comando}} {{argomenti}}`
+
+- Aggiorna la configurazione di un container:
+
+`sudo $EDITOR /var/lib/container/{{nome_container}}/etc/nixos/configuration.nix && sudo nixos-container update {{nome_container}}`
+
+- Entra in una sessione shell interattiva in un container già in esecuzione:
+
+`sudo nixos-container root-login {{nome_container}}`

--- a/pages.it/linux/nixos-option.md
+++ b/pages.it/linux/nixos-option.md
@@ -1,0 +1,28 @@
+# nixos-option
+
+> Ispeziona una configurazione NixOS.
+> Maggiori informazioni: <https://nixos.org/manual/nixos/stable/index.html#sec-modularity>.
+
+- Elenca tutte le sottochiavi di una data opzione:
+
+`nixos-option {{opzione}}`
+
+- Elenca tutti i moduli del kernel corrente:
+
+`nixos-option boot.kernelModules`
+
+- Elenca le chiavi di autorizzazioni per uno specifico utente:
+
+`nixos-option users.users.{{utente}}.openssh.authorizedKeys.{{keyFiles|keys}}`
+
+- Elenca tutte le macchine di compilazione remote:
+
+`nixos-option nix.buildMachines`
+
+- Elenca tutte le sottochiavi di una data opzione di un'altra configurazione NixOS:
+
+`NIXOS_CONFIG={{percorso_per_configuration.nix}} nixos-option {{opzione}}`
+
+- Visualizza ricorsivamente tutti i valori per un utente:
+
+`nixos-option {{[-r|--recursive]}} users.users.{{utente}}`

--- a/pages.it/linux/nixos-rebuild.md
+++ b/pages.it/linux/nixos-rebuild.md
@@ -1,0 +1,36 @@
+# nixos-rebuild
+
+> Riconfigura una macchina NixOS.
+> Maggiori informazioni: <https://nixos.org/nixos/manual/#sec-changing-config>.
+
+- Compila e passa alla nuova configurazione, rendendola quella predefinita all'avvio:
+
+`sudo nixos-rebuild switch`
+
+- Compila e passa alla nuova configurazione, rendendola quella predefinita all'avvio e assegnando un nome alla voce del menù di avvio:
+
+`sudo nixos-rebuild switch {{[-p|--profile-name]}} {{nome}}`
+
+- Compila e passa alla nuova configurazione, rendendola quella predefinita all'avvio e installando gli aggiornamenti:
+
+`sudo nixos-rebuild switch --upgrade`
+
+- Annulla le modifiche alla configurazione, passando alla generazione precedente:
+
+`sudo nixos-rebuild switch --rollback`
+
+- Compila la nuova configurazione rendendola quella predefinita all'avvio, senza passare ad essa:
+
+`sudo nixos-rebuild boot`
+
+- Compila e passa alla nuova configurazione senza aggiungere la voce al menù di avvio (a scopo di test):
+
+`sudo nixos-rebuild test`
+
+- Compila la configurazione e la apre in una macchina virtuale:
+
+`sudo nixos-rebuild build-vm`
+
+- Elenca le generazioni disponibili in modo simile al menù di avvio:
+
+`nixos-rebuild list-generations`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
