### PR TITLE
dosbox: add page

### DIFF
--- a/pages/common/dosbox.md
+++ b/pages/common/dosbox.md
@@ -13,7 +13,7 @@
 
 - Mount a folder as C: and run an executable:
 
-`dosbox -c "MOUNT C {{path/to/folder}} {{path/to/executable.exe}}"`
+`dosbox {{path/to/executable.exe}} -c "MOUNT C {{path/to/folder}}"`
 
 - Start DOSBox in fullscreen mode:
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  
  DOSBox 0.74-3

Solves issue #18373 
