### PR TITLE
curl: add example for custom output filename with -o flag

### DIFF
--- a/pages/common/curl.md
+++ b/pages/common/curl.md
@@ -16,6 +16,10 @@
 
 `curl {{[-O|--remote-name]}} {{https://example.com/filename.zip}}`
 
+- Download a file, saving the output under a custom filename:
+
+`curl {{[-o|--output]}} {{path/to/file}} {{https://example.com}}`
+
 - Send form-encoded data (POST request of type `application/x-www-form-urlencoded`). Use `--data @file_name` or `--data @'-'` to read from `stdin`:
 
 `curl {{[-X|--request]}} POST {{[-d|--data]}} {{'name=bob'}} {{http://example.com/form}}`
@@ -31,7 +35,3 @@
 - Pass client certificate and key for a resource, skipping certificate validation:
 
 `curl {{[-E|--cert]}} {{client.pem}} --key {{key.pem}} {{[-k|--insecure]}} {{https://example.com}}`
-
-- Resolve a hostname to a custom IP address, with verbose output (similar to editing the `/etc/hosts` file for custom DNS resolution):
-
-`curl {{[-v|--verbose]}} --resolve {{example.com}}:{{80}}:{{127.0.0.1}} {{http://example.com}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** curl 8.10.1

## Changes Made
This PR adds an important missing example to the `curl` page: downloading a file with a custom output filename using the `-o` / `--output` flag.

### What was added:
- New example: "Download a file, saving the output under a custom filename" using `curl -o path/to/file https://example.com`

### What was removed:
- Removed the advanced custom DNS resolution example (`--resolve` flag) to maintain the maximum of 8 examples per page

### Rationale:
The `-o` flag is one of the most commonly used curl options for downloading files with a specific name, distinct from `-O` which uses the remote filename. This feature is already documented in many translated versions of the page (French, German, Chinese, Japanese, etc.) but was missing from the English version. The removed DNS resolution example is more advanced and less frequently used, making it a good candidate for removal to stay within the 8-example limit.

This change improves the completeness and usefulness of the `curl` page for new users while following all contribution guidelines.