### PR TITLE
ip-monitor, rtmon: add page

### DIFF
--- a/pages/linux/ip-monitor.md
+++ b/pages/linux/ip-monitor.md
@@ -9,7 +9,7 @@
 
 - Specify the type to monitor:
 
-`ip {{[mo|monitor]}} {{link|address|route||neigh|rule|maddress|...}}`
+`ip {{[mo|monitor]}} {{link|address|route|neigh|rule|maddress|...}}`
 
 - Replay an event file (can be generated with `rtmon`):
 

--- a/pages/linux/ip-monitor.md
+++ b/pages/linux/ip-monitor.md
@@ -1,0 +1,16 @@
+# ip monitor
+
+> Monitor network for state changes.
+> More information: <https://manned.org/ip-monitor>.
+
+- Monitor the whole network for state changes:
+
+`ip {{[mo|monitor]}}`
+
+- Specify the type to monitor:
+
+`ip {{[mo|monitor]}} {{link|address|route||neigh|rule|maddress|...}}`
+
+- Replay an event file (can be generated with `rtmon`):
+
+`ip {{[mo|monitor]}} {{[f|file]}} {{path/to/file}}`

--- a/pages/linux/rtmon.md
+++ b/pages/linux/rtmon.md
@@ -1,0 +1,12 @@
+# rtmon
+
+> Save network state changes to a file.
+> More information: <https://manned.org/rtmon>.
+
+- Save all network state changes to a file:
+
+`sudo rtmon {{[f|file]}} {{path/to/file}}`
+
+- Specify the type of change to log:
+
+`sudo rtmon {{[f|file}} {{link|address|route}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
