### PR TITLE
matlab: replace broken link

### DIFF
--- a/pages.fr/common/matlab.md
+++ b/pages.fr/common/matlab.md
@@ -1,7 +1,7 @@
 # matlab
 
 > Environnement de calcul numérique créé par MathWorks.
-> Plus d'informations : <https://se.mathworks.com/help/matlab/matlab_env/startup-options.html>.
+> Plus d'informations : <https://www.mathworks.com/help/matlab/matlab_env/startup-options.html>.
 
 - Lance MATLAB sans afficher l'écran de démarrage :
 

--- a/pages.ko/common/matlab.md
+++ b/pages.ko/common/matlab.md
@@ -1,7 +1,7 @@
 # matlab
 
 > MathWorks의 수치 계산 환경.
-> 더 많은 정보: <https://se.mathworks.com/help/matlab/matlab_env/startup-options.html>.
+> 더 많은 정보: <https://www.mathworks.com/help/matlab/matlab_env/startup-options.html>.
 
 - 시작 시 스플래시 화면 없이 실행:
 

--- a/pages.zh/common/matlab.md
+++ b/pages.zh/common/matlab.md
@@ -1,7 +1,7 @@
 # matlab
 
 > MathWorks 制作的数值计算环境。
-> 更多信息：<https://se.mathworks.com/help/matlab/matlab_env/startup-options.html>.
+> 更多信息：<https://www.mathworks.com/help/matlab/matlab_env/startup-options.html>.
 
 - 在启动过程中，运行时不出现闪屏：
 

--- a/pages/common/matlab.md
+++ b/pages/common/matlab.md
@@ -1,7 +1,7 @@
 # matlab
 
 > Numerical computation environment by MathWorks.
-> More information: <https://se.mathworks.com/help/matlab/matlab_env/startup-options.html>.
+> More information: <https://www.mathworks.com/help/matlab/matlab_env/startup-options.html>.
 
 - Run without splash screen during startup:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (matlab) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.