### PR TITLE
microsoft-edge, msedge: replace broken links

### DIFF
--- a/pages.es/windows/microsoft-edge.md
+++ b/pages.es/windows/microsoft-edge.md
@@ -1,7 +1,7 @@
 # microsoft-edge
 
 > La utilidad de línea de comandos de Microsoft Edge está disponible como `msedge` en Windows y `microsoft-edge` para otras plataformas.
-> Más información: <https://microsoft.com/edge>.
+> Más información: <https://www.microsoft.com/edge/>.
 
 - Ver la documentación para Microsoft Edge en Windows:
 

--- a/pages.es/windows/msedge.md
+++ b/pages.es/windows/msedge.md
@@ -3,7 +3,7 @@
 > Navegador web moderno desarrollado por Microsoft basado en el navegador web Chromium desarrollado por Google.
 > Este comando está disponible como `microsoft-edge` en otras plataformas.
 > Nota: Argumentos adicionales del comando de `chromium` también pueden ser utilizables para controlar Microsoft Edge.
-> Más información: <https://microsoft.com/edge>.
+> Más información: <https://www.microsoft.com/edge/>.
 
 - Abrir una URL o archivo específico:
 

--- a/pages.id/windows/microsoft-edge.md
+++ b/pages.id/windows/microsoft-edge.md
@@ -1,7 +1,7 @@
 # microsoft-edge
 
 > Perintah Microsoft Edge tersedia sebagai `msedge` untuk platform Windows dan `microsoft-edge` untuk platform lainnya.
-> Informasi lebih lanjut: <https://microsoft.com/edge>.
+> Informasi lebih lanjut: <https://www.microsoft.com/edge/>.
 
 - Lihat dokumentasi untuk perintah Microsoft Edge untuk Windows:
 

--- a/pages.id/windows/msedge.md
+++ b/pages.id/windows/msedge.md
@@ -3,7 +3,7 @@
 > Aplikasi peramban web (web browser) dari Microsoft yang dibangun berdasarkan peramban Chromium yang dikembangkan oleh Google.
 > Perintah ini tersedia sebagai `microsoft-edge` dalam perangkat selain Windows.
 > Catatan: Anda mungkin dapat menggunakan argumen perintah `chromium` lainnya untuk dapat mengatur jalannya Microsoft Edge.
-> Informasi lebih lanjut: <https://microsoft.com/edge>.
+> Informasi lebih lanjut: <https://www.microsoft.com/edge/>.
 
 - Buka suatu URL atau berkas:
 

--- a/pages.ko/windows/microsoft-edge.md
+++ b/pages.ko/windows/microsoft-edge.md
@@ -1,7 +1,7 @@
 # microsoft-edge
 
 > Microsoft Edge 명령줄 유틸리티는 Windows에서 `msedge`로 사용할 수 있으며 다른 플랫폼에서는 `microsoft-edge`로 사용할 수 있습니다.
-> 더 많은 정보: <https://microsoft.com/edge>.
+> 더 많은 정보: <https://www.microsoft.com/edge/>.
 
 - Windows용 Microsoft Edge 문서 보기:
 

--- a/pages.ko/windows/msedge.md
+++ b/pages.ko/windows/msedge.md
@@ -3,7 +3,7 @@
 > 마이크로소프트에서 개발한 최신 웹 브라우저로, 구글에서 개발한 크로미움 웹 브라우저를 기반으로 합니다.
 > 이 명령어는 다른 플랫폼에서는 `microsoft-edge`로 사용할 수 있습니다.
 > 참고: `chromium`에서 추가 명령어 인수로 Microsoft Edge를 제어할 수 있습니다.
-> 더 많은 정보: <https://microsoft.com/edge>.
+> 더 많은 정보: <https://www.microsoft.com/edge/>.
 
 - 특정 URL 또는 파일 열기:
 

--- a/pages.nl/common/msedge.md
+++ b/pages.nl/common/msedge.md
@@ -1,7 +1,7 @@
 # msedge
 
 > De command-line utility van Microsoft Edge is beschikbaar als `msedge` op Windows en `microsoft-edge` op andere platforms.
-> Meer informatie: <https://microsoft.com/edge>.
+> Meer informatie: <https://www.microsoft.com/edge/>.
 
 - Bekijk de documentatie van Microsoft Edge op Windows:
 

--- a/pages/common/microsoft-edge.md
+++ b/pages/common/microsoft-edge.md
@@ -3,7 +3,7 @@
 > Modern web browser developed by Microsoft based on the Chromium web browser developed by Google.
 > This command is available instead as `msedge` for Windows.
 > Note: Additional command arguments from `chromium` may also be usable to control Microsoft Edge.
-> More information: <https://microsoft.com/edge>.
+> More information: <https://www.microsoft.com/edge/>.
 
 - Open a specific URL or file:
 

--- a/pages/common/msedge.md
+++ b/pages/common/msedge.md
@@ -1,7 +1,7 @@
 # msedge
 
 > The Microsoft Edge command-line utility is available as `msedge` on Windows and `microsoft-edge` for other platforms.
-> More information: <https://microsoft.com/edge>.
+> More information: <https://www.microsoft.com/edge/>.
 
 - View the documentation for Microsoft Edge for Windows:
 

--- a/pages/windows/microsoft-edge.md
+++ b/pages/windows/microsoft-edge.md
@@ -1,7 +1,7 @@
 # microsoft-edge
 
 > The Microsoft Edge command-line utility is available as `msedge` on Windows and `microsoft-edge` for other platforms.
-> More information: <https://microsoft.com/edge>.
+> More information: <https://www.microsoft.com/edge/>.
 
 - View the documentation for Microsoft Edge for Windows:
 

--- a/pages/windows/msedge.md
+++ b/pages/windows/msedge.md
@@ -3,7 +3,7 @@
 > Modern web browser developed by Microsoft based on the Chromium web browser developed by Google.
 > This command is available instead as `microsoft-edge` for other platforms.
 > Note: Additional command arguments from `chromium` may also be usable to control Microsoft Edge.
-> More information: <https://microsoft.com/edge>.
+> More information: <https://www.microsoft.com/edge/>.
 
 - Open a specific URL or file:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (microsoft-edge, msedge) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.