### PR TITLE
mysqldump: replace broken links

### DIFF
--- a/pages.es/common/mysqldump.md
+++ b/pages.es/common/mysqldump.md
@@ -2,7 +2,7 @@
 
 > Crea una copia de seguridad (backup) de bases de datos MySQL.
 > Vea también `mysql` para restaurar bases de datos.
-> Más información: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+> Más información: <https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html>.
 
 - Crea un backup (se le pedirá la contraseña al usuario):
 

--- a/pages.ko/common/mysqldump.md
+++ b/pages.ko/common/mysqldump.md
@@ -2,7 +2,7 @@
 
 > MySQL 데이터베이스 백업.
 > 데이터베이스 복원에 대해서는 `mysql`을 참조하세요.
-> 더 많은 정보: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+> 더 많은 정보: <https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html>.
 
 - 백업 생성 (사용자에게 비밀번호가 요청됨):
 

--- a/pages.pt_BR/common/mysqldump.md
+++ b/pages.pt_BR/common/mysqldump.md
@@ -1,7 +1,7 @@
 # mysqldump
 
 > Realizar e restaurar backups no MySQL.
-> Mais informações: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+> Mais informações: <https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html>.
 
 - Cria o backup do banco de dados em arquivo de saída (será solicitada a senha de acesso do usuário):
 

--- a/pages/common/mysqldump.md
+++ b/pages/common/mysqldump.md
@@ -2,7 +2,7 @@
 
 > Backups MySQL databases.
 > See also: `mysql` for restoring databases.
-> More information: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+> More information: <https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html>.
 
 - Create a backup (user will be prompted for a password):
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (mysqldump) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.