### PR TITLE
hyprctl, hyprpm: replace broken links

### DIFF
--- a/pages.de/linux/hyprctl.md
+++ b/pages.de/linux/hyprctl.md
@@ -1,7 +1,7 @@
 # hyprctl
 
 > Steuere Teile des Hyprland Wayland-Compositors.
-> Weitere Informationen: <https://wiki.hyprland.org/Configuring/Using-hyprctl>.
+> Weitere Informationen: <https://wiki.hypr.land/Configuring/Using-hyprctl/>.
 
 - Lade die Hyprland-Konfiguration neu:
 

--- a/pages.es/linux/hyprctl.md
+++ b/pages.es/linux/hyprctl.md
@@ -1,7 +1,7 @@
 # hyprctl
 
 > Controla partes del compositor Hyprland Wayland.
-> Más información: <https://wiki.hyprland.org/Configuring/Using-hyprctl>.
+> Más información: <https://wiki.hypr.land/Configuring/Using-hyprctl/>.
 
 - Recarga la configuración de Hyprland:
 

--- a/pages.es/linux/hyprpm.md
+++ b/pages.es/linux/hyprpm.md
@@ -1,7 +1,7 @@
 # hyprpm
 
 > Complementos de control para el compositor Hyprland Wayland.
-> Más información: <https://wiki.hyprland.org/Plugins/Using-Plugins/#hyprpm>.
+> Más información: <https://wiki.hypr.land/Plugins/Using-Plugins/#hyprpm>.
 
 - Añade un complemento:
 

--- a/pages.ko/linux/hyprctl.md
+++ b/pages.ko/linux/hyprctl.md
@@ -1,7 +1,7 @@
 # hyprctl
 
 > Hyprland Wayland 컴포지터의 일부를 제어.
-> 더 많은 정보: <https://wiki.hyprland.org/Configuring/Using-hyprctl>.
+> 더 많은 정보: <https://wiki.hypr.land/Configuring/Using-hyprctl/>.
 
 - Hyprland 구성 파일 다시 로드:
 

--- a/pages.ko/linux/hyprpm.md
+++ b/pages.ko/linux/hyprpm.md
@@ -1,7 +1,7 @@
 # hyprpm
 
 > Hyprland Wayland 컴포지터의 플러그인을 제어.
-> 더 많은 정보: <https://wiki.hyprland.org/Plugins/Using-Plugins/#hyprpm>.
+> 더 많은 정보: <https://wiki.hypr.land/Plugins/Using-Plugins/#hyprpm>.
 
 - 플러그인 추가:
 

--- a/pages/linux/hyprctl.md
+++ b/pages/linux/hyprctl.md
@@ -1,7 +1,7 @@
 # hyprctl
 
 > Control parts of the Hyprland Wayland compositor.
-> More information: <https://wiki.hyprland.org/Configuring/Using-hyprctl>.
+> More information: <https://wiki.hypr.land/Configuring/Using-hyprctl/>.
 
 - Reload Hyprland configuration:
 

--- a/pages/linux/hyprpm.md
+++ b/pages/linux/hyprpm.md
@@ -1,7 +1,7 @@
 # hyprpm
 
 > Control plugins for the Hyprland Wayland compositor.
-> More information: <https://wiki.hyprland.org/Plugins/Using-Plugins/#hyprpm>.
+> More information: <https://wiki.hypr.land/Plugins/Using-Plugins/#hyprpm>.
 
 - Add a plugin:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (hyprctl, hyprpm) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.