### PR TITLE
busybox, clangd, valac, x8: replace broken links

### DIFF
--- a/pages/common/busybox.md
+++ b/pages/common/busybox.md
@@ -3,7 +3,7 @@
 > A collection of small system utilities in a single executable.
 > Executing `busybox` via a symlink is equivalent to running `busybox symlink_name`.
 > Linux distributions that use BusyBox will usually provide symlinks for all programs.
-> More information: <https://www.busybox.net/downloads/BusyBox.html>.
+> More information: <https://busybox.net>.
 
 - Execute a BusyBox function:
 

--- a/pages/common/clangd.md
+++ b/pages/common/clangd.md
@@ -2,7 +2,7 @@
 
 > Language server that provides IDE-like features to editors.
 > It should be used via an editor plugin rather than invoked directly.
-> More information: <https://manpages.ubuntu.com/manpages/focal/man1/clangd.1.html>.
+> More information: <https://manpages.ubuntu.com/manpages/noble/en/man1/clangd.1.html>.
 
 - Display available options:
 

--- a/pages/common/valac.md
+++ b/pages/common/valac.md
@@ -2,7 +2,7 @@
 
 > Vala code compiler.
 > Tutorial: <https://wiki.gnome.org/Projects/Vala/Tutorial>.
-> More information: <https://docs.vala.dev/tutorials/programming-language/main/07-00-tools/07-01-valac.html/>.
+> More information: <https://docs.vala.dev/tutorials/programming-language/main/07-00-tools/07-01-valac.html>.
 
 - Compile a vala file, with gtk+:
 

--- a/pages/common/x8.md
+++ b/pages/common/x8.md
@@ -1,7 +1,7 @@
 # x8
 
 > A hidden parameters discovery suite for identifying vulnerable or interesting web parameters.
-> More information: <https://sh1yo.art/x8docs/>.
+> More information: <https://github.com/Sh1Yo/x8/>.
 
 - Check hidden parameters in a URL query:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (busybox, clangd, valac, x8) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.