### PR TITLE
mysql_secure_installation, mysqlbinlog: replace broken links

### DIFF
--- a/pages.ko/common/mysql_secure_installation.md
+++ b/pages.ko/common/mysql_secure_installation.md
@@ -1,7 +1,7 @@
 # mysql_secure_installation
 
 > MySQL을 보다 안전하게 설정.
-> 더 많은 정보: <https://dev.mysql.com/doc/refman/en/mysql-secure-installation.html>.
+> 더 많은 정보: <https://dev.mysql.com/doc/refman/8.4/en/mysql-secure-installation.html>.
 
 - 대화형 설정 시작:
 

--- a/pages.ko/common/mysqlbinlog.md
+++ b/pages.ko/common/mysqlbinlog.md
@@ -1,7 +1,7 @@
 # mysqlbinlog
 
 > MySQL 바이너리 로그 파일을 처리하는 도구.
-> 더 많은 정보: <https://dev.mysql.com/doc/refman/en/mysqlbinlog.html>.
+> 더 많은 정보: <https://dev.mysql.com/doc/refman/8.4/en/mysqlbinlog.html>.
 
 - 특정 바이너리 로그 파일에서 이벤트 표시:
 

--- a/pages/common/mysql_secure_installation.md
+++ b/pages/common/mysql_secure_installation.md
@@ -1,7 +1,7 @@
 # mysql_secure_installation
 
 > Set up MySQL to have better security.
-> More information: <https://dev.mysql.com/doc/refman/en/mysql-secure-installation.html>.
+> More information: <https://dev.mysql.com/doc/refman/8.4/en/mysql-secure-installation.html>.
 
 - Start an interactive setup:
 

--- a/pages/common/mysqlbinlog.md
+++ b/pages/common/mysqlbinlog.md
@@ -1,7 +1,7 @@
 # mysqlbinlog
 
 > Utility for processing MySQL binary log files.
-> More information: <https://dev.mysql.com/doc/refman/en/mysqlbinlog.html>.
+> More information: <https://dev.mysql.com/doc/refman/8.4/en/mysqlbinlog.html>.
 
 - Show events from a specific binary log file:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (mysql_secure_installation, mysqlbinlog) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.