### PR TITLE
mysqlcheck, mysqld: replace broken links

### DIFF
--- a/pages.ko/common/mysqlcheck.md
+++ b/pages.ko/common/mysqlcheck.md
@@ -1,7 +1,7 @@
 # mysqlcheck
 
 > MySQL 테이블 검사 및 복구.
-> 더 많은 정보: <https://dev.mysql.com/doc/refman/en/mysqlcheck.html>.
+> 더 많은 정보: <https://dev.mysql.com/doc/refman/8.4/en/mysqlcheck.html>.
 
 - 테이블 검사:
 

--- a/pages.ko/common/mysqld.md
+++ b/pages.ko/common/mysqld.md
@@ -1,7 +1,7 @@
 # mysqld
 
 > MySQL 데이터베이스 서버 시작.
-> 더 많은 정보: <https://dev.mysql.com/doc/refman/en/mysqld.html>.
+> 더 많은 정보: <https://dev.mysql.com/doc/refman/8.4/en/mysqld.html>.
 
 - MySQL 데이터베이스 서버 시작:
 

--- a/pages/common/mysqlcheck.md
+++ b/pages/common/mysqlcheck.md
@@ -1,7 +1,7 @@
 # mysqlcheck
 
 > Check and repair MySQL tables.
-> More information: <https://dev.mysql.com/doc/refman/en/mysqlcheck.html>.
+> More information: <https://dev.mysql.com/doc/refman/8.4/en/mysqlcheck.html>.
 
 - Check a table:
 

--- a/pages/common/mysqld.md
+++ b/pages/common/mysqld.md
@@ -1,7 +1,7 @@
 # mysqld
 
 > Start the MySQL database server.
-> More information: <https://dev.mysql.com/doc/refman/en/mysqld.html>.
+> More information: <https://dev.mysql.com/doc/refman/8.4/en/mysqld.html>.
 
 - Start the MySQL database server:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (mysqlcheck, mysqld) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.