### PR TITLE
vela, whatweb: replace broken links

### DIFF
--- a/pages.es/common/whatweb.md
+++ b/pages.es/common/whatweb.md
@@ -1,7 +1,7 @@
 # whatweb
 
 > Escáner web de nueva generación.
-> Más información: <https://morningstarsecurity.com/research/whatweb>.
+> Más información: <https://github.com/urbanadventurer/WhatWeb/>.
 
 - Escanea sitios web/objetivos en busca de tecnologías web:
 

--- a/pages.ko/common/vela.md
+++ b/pages.ko/common/vela.md
@@ -1,7 +1,7 @@
 # vela
 
 > Vela 파이프라인을 위한 명령줄 도구.
-> 더 많은 정보: <https://go-vela.github.io/docs/reference/cli/>.
+> 더 많은 정보: <https://go-vela.github.io/docs/reference/cli>.
 
 - Git 브랜치, 커밋 또는 태그에서 파이프라인 실행 트리거:
 

--- a/pages/common/vela.md
+++ b/pages/common/vela.md
@@ -1,7 +1,7 @@
 # vela
 
 > Tools for the Vela pipeline.
-> More information: <https://go-vela.github.io/docs/reference/cli/>.
+> More information: <https://go-vela.github.io/docs/reference/cli>.
 
 - Trigger a pipeline to run from a Git branch, commit or tag:
 

--- a/pages/common/whatweb.md
+++ b/pages/common/whatweb.md
@@ -1,7 +1,7 @@
 # whatweb
 
 > Next-generation web scanner.
-> More information: <https://morningstarsecurity.com/research/whatweb>.
+> More information: <https://github.com/urbanadventurer/WhatWeb/>.
 
 - Scan websites/targets for web technologies:
 


### PR DESCRIPTION
## Summary

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Description

Replaced broken links (vela, whatweb) as of https://github.com/tldr-pages/tldr-maintenance/issues/129 with updated, working links.