### PR TITLE
ibmcloud-{api,config,logout,...}: add pages

### DIFF
--- a/pages/common/ibmcloud-account.md
+++ b/pages/common/ibmcloud-account.md
@@ -1,0 +1,28 @@
+# ibmcloud account
+
+> Manage IBM Cloud accounts and users.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- List all accounts:
+
+`ibmcloud account list`
+
+- Show details of the current account:
+
+`ibmcloud account show`
+
+- List users in the account:
+
+`ibmcloud account users`
+
+- Invite a user to the account:
+
+`ibmcloud account user-invite {{email}}`
+
+- List organizations in the account:
+
+`ibmcloud account orgs`
+
+- View documentation for account management subcommands:
+
+`tldr ibmcloud-account-{{subcommand}}`

--- a/pages/common/ibmcloud-api.md
+++ b/pages/common/ibmcloud-api.md
@@ -1,0 +1,24 @@
+# ibmcloud api
+
+> Set or view the IBM Cloud API endpoint.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli#ibmcloud_api>.
+
+- View the current API endpoint:
+
+`ibmcloud api`
+
+- Set the API endpoint to cloud.ibm.com:
+
+`ibmcloud api cloud.ibm.com`
+
+- Set a private API endpoint:
+
+`ibmcloud api private.cloud.ibm.com`
+
+- Use a VPC connection for a private endpoint:
+
+`ibmcloud api private.cloud.ibm.com --vpc`
+
+- Remove the API endpoint setting:
+
+`ibmcloud api --unset`

--- a/pages/common/ibmcloud-assist.md
+++ b/pages/common/ibmcloud-assist.md
@@ -1,0 +1,16 @@
+# ibmcloud assist
+
+> Get answers to IBM Cloud questions using AI assistant powered by watsonx.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Ask a question to the AI assistant:
+
+`ibmcloud assist "{{How do I create a Kubernetes cluster?}}"`
+
+- Get help about updating the CLI:
+
+`ibmcloud assist "How do I update the CLI?"`
+
+- Ask about resource management:
+
+`ibmcloud assist "How do I list my resources?"`

--- a/pages/common/ibmcloud-billing.md
+++ b/pages/common/ibmcloud-billing.md
@@ -1,0 +1,24 @@
+# ibmcloud billing
+
+> Retrieve usage and billing information for IBM Cloud.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- View account usage:
+
+`ibmcloud billing account-usage`
+
+- View resource group usage:
+
+`ibmcloud billing resource-group-usage {{resource_group_name}}`
+
+- View organization usage:
+
+`ibmcloud billing org-usage {{org_name}}`
+
+- View resource instances usage:
+
+`ibmcloud billing resource-instances-usage`
+
+- View billing information for a specific month:
+
+`ibmcloud billing account-usage -d {{YYYY-MM}}`

--- a/pages/common/ibmcloud-catalog.md
+++ b/pages/common/ibmcloud-catalog.md
@@ -1,0 +1,24 @@
+# ibmcloud catalog
+
+> Manage the IBM Cloud catalog.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- List all catalog entries:
+
+`ibmcloud catalog search`
+
+- Search for a specific service:
+
+`ibmcloud catalog search {{service_name}}`
+
+- Get details of a catalog entry:
+
+`ibmcloud catalog entry {{entry_id}}`
+
+- List all templates:
+
+`ibmcloud catalog templates`
+
+- Filter catalog by category:
+
+`ibmcloud catalog search --category {{compute}}`

--- a/pages/common/ibmcloud-cbr.md
+++ b/pages/common/ibmcloud-cbr.md
@@ -1,0 +1,24 @@
+# ibmcloud cbr
+
+> Manage Context Based Restrictions in IBM Cloud.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- List all network zones:
+
+`ibmcloud cbr zones`
+
+- Create a network zone:
+
+`ibmcloud cbr zone-create --name {{zone_name}}`
+
+- List all context-based restriction rules:
+
+`ibmcloud cbr rules`
+
+- Create a context-based restriction rule:
+
+`ibmcloud cbr rule-create`
+
+- Delete a network zone:
+
+`ibmcloud cbr zone-delete {{zone_id}}`

--- a/pages/common/ibmcloud-config.md
+++ b/pages/common/ibmcloud-config.md
@@ -1,0 +1,28 @@
+# ibmcloud config
+
+> Modify or read out values in the IBM Cloud CLI configuration.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Set HTTP request timeout to 30 seconds:
+
+`ibmcloud config --http-timeout 30`
+
+- Enable trace output for HTTP requests:
+
+`ibmcloud config --trace true`
+
+- Trace HTTP requests to a specific file:
+
+`ibmcloud config --trace {{path/to/trace_file}}`
+
+- Disable color output:
+
+`ibmcloud config --color false`
+
+- Set the locale to a specific language:
+
+`ibmcloud config --locale {{zh_Hans}}`
+
+- Enable automatic SSO one-time passcode acceptance:
+
+`ibmcloud config --sso-otp auto`

--- a/pages/common/ibmcloud-help.md
+++ b/pages/common/ibmcloud-help.md
@@ -1,0 +1,16 @@
+# ibmcloud help
+
+> Display help information for IBM Cloud CLI commands.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Display general help for the IBM Cloud CLI:
+
+`ibmcloud help`
+
+- Display help for a specific command:
+
+`ibmcloud help {{command}}`
+
+- Display help for a specific namespace:
+
+`ibmcloud help {{namespace}}`

--- a/pages/common/ibmcloud-logout.md
+++ b/pages/common/ibmcloud-logout.md
@@ -1,0 +1,8 @@
+# ibmcloud logout
+
+> Log out of the IBM Cloud CLI.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Log out of the current session:
+
+`ibmcloud logout`

--- a/pages/common/ibmcloud-plugin.md
+++ b/pages/common/ibmcloud-plugin.md
@@ -1,0 +1,28 @@
+# ibmcloud plugin
+
+> Manage plugins and plugin repositories for the IBM Cloud CLI.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- List all installed plugins:
+
+`ibmcloud plugin list`
+
+- Install a plugin from a repository:
+
+`ibmcloud plugin install {{plugin_name}}`
+
+- Uninstall a plugin:
+
+`ibmcloud plugin uninstall {{plugin_name}}`
+
+- Update all plugins:
+
+`ibmcloud plugin update --all`
+
+- List available plugins in repositories:
+
+`ibmcloud plugin repo-plugins`
+
+- Add a plugin repository:
+
+`ibmcloud plugin repo-add {{repo_name}} {{repo_url}}`

--- a/pages/common/ibmcloud-regions.md
+++ b/pages/common/ibmcloud-regions.md
@@ -1,0 +1,8 @@
+# ibmcloud regions
+
+> List all available regions on IBM Cloud.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- View information for all regions:
+
+`ibmcloud regions`

--- a/pages/common/ibmcloud-target.md
+++ b/pages/common/ibmcloud-target.md
@@ -1,0 +1,28 @@
+# ibmcloud target
+
+> Set or view the target account, region, or resource group.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- View the current target account and region:
+
+`ibmcloud target`
+
+- Set the target account:
+
+`ibmcloud target -c {{account_id}}`
+
+- Switch to a specific region:
+
+`ibmcloud target -r {{region_name}}`
+
+- Set the target resource group:
+
+`ibmcloud target -g {{resource_group_name}}`
+
+- Clear the targeted region:
+
+`ibmcloud target --unset-region`
+
+- Clear the targeted resource group:
+
+`ibmcloud target --unset-resource-group`

--- a/pages/common/ibmcloud-update.md
+++ b/pages/common/ibmcloud-update.md
@@ -1,0 +1,12 @@
+# ibmcloud update
+
+> Update the IBM Cloud CLI to the most recent version.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Update the CLI:
+
+`ibmcloud update`
+
+- Force an update without confirmation:
+
+`ibmcloud update -f`

--- a/pages/common/ibmcloud-version.md
+++ b/pages/common/ibmcloud-version.md
@@ -1,0 +1,8 @@
+# ibmcloud version
+
+> Print the version of the IBM Cloud CLI.
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+- Display the CLI version:
+
+`ibmcloud version`

--- a/pages/common/script.py
+++ b/pages/common/script.py
@@ -1,0 +1,57 @@
+
+# Create all IBM Cloud CLI tldr pages based on the command list
+
+commands = {
+    "Command Line": {
+        "ibmcloud-api": "Set or view target API endpoint",
+        "ibmcloud-config": "Modify or read out values in the config",
+        "ibmcloud-logout": "Log user out",
+        "ibmcloud-plugin": "Manage plug-ins and plug-in repositories",
+        "ibmcloud-regions": "List all the regions",
+        "ibmcloud-target": "Set or view the targeted region, account or resource group",
+        "ibmcloud-update": "Update CLI to the latest version",
+        "ibmcloud-version": "Print the version",
+        "ibmcloud-help": "Show help"
+    },
+    "Platform": {
+        "ibmcloud-account": "Manage accounts and users",
+        "ibmcloud-assist": "Get answers to IBM Cloud questions by searching documentation, tutorials, and other IBM sources",
+        "ibmcloud-billing": "Retrieve usage and billing information",
+        "ibmcloud-catalog": "Manage catalog",
+        "ibmcloud-cbr": "Manage Context Based Restrictions",
+        "ibmcloud-enterprise": "Manage enterprise, account groups and accounts",
+        "ibmcloud-iam": "Manage identities and access to resources",
+        "ibmcloud-resource": "Manage resource groups and resources",
+        "ibmcloud-resources": "List all resources",
+        "ibmcloud-sat": "Manage IBM Cloud Satellite clusters"
+    },
+    "Containers": {
+        "ibmcloud-cr": "Manage IBM Cloud Container Registry content and configuration",
+        "ibmcloud-ks": "Manage Kubernetes and OpenShift clusters in IBM Cloud"
+    },
+    "Databases": {
+        "ibmcloud-cloud-databases": "Manage IBM Cloud Databases"
+    },
+    "Infrastructure": {
+        "ibmcloud-cos": "Interact with IBM Cloud Object Storage services",
+        "ibmcloud-sl": "Manage Classic infrastructure services"
+    },
+    "Security": {
+        "ibmcloud-key-protect": "Manage IBM Key Protect API",
+        "ibmcloud-pag": "Manage Privileged Access Gateway",
+        "ibmcloud-secrets-manager": "Manage IBM Cloud Secrets Manager API"
+    },
+    "Additional Services": {
+        "ibmcloud-logging": "Manage IBM Cloud logging"
+    }
+}
+
+# Display the commands to be created
+print("IBM Cloud CLI tldr Pages to Create\n")
+print("=" * 70)
+for category, cmds in commands.items():
+    print(f"\n{category}:")
+    for cmd, desc in cmds.items():
+        print(f"  - {cmd}.md")
+
+print(f"\n\nTotal pages to create: {sum(len(cmds) for cmds in commands.values())}")

--- a/pages/common/script_1.py
+++ b/pages/common/script_1.py
@@ -1,0 +1,88 @@
+
+import os
+
+# Create directory structure for the pages
+os.makedirs("pages/common", exist_ok=True)
+
+# Template for creating tldr pages
+def create_tldr_page(command, description, examples):
+    """Generate tldr page content"""
+    content = f"""# {command}
+
+> {description}
+> More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
+
+"""
+    for example_desc, example_cmd in examples:
+        content += f"- {example_desc}:\n\n`{example_cmd}`\n\n"
+    
+    return content.strip() + "\n"
+
+# Create all the command pages
+pages_created = []
+
+# 1. ibmcloud-api
+content = create_tldr_page(
+    "ibmcloud api",
+    "Set or view the IBM Cloud API endpoint.",
+    [
+        ("View the current API endpoint", "ibmcloud api"),
+        ("Set the API endpoint to cloud.ibm.com", "ibmcloud api cloud.ibm.com"),
+        ("Set a private API endpoint", "ibmcloud api private.cloud.ibm.com"),
+        ("Use a VPC connection for a private endpoint", "ibmcloud api private.cloud.ibm.com --vpc"),
+        ("Bypass SSL validation of HTTP requests", "ibmcloud api https://cloud.ibm.com --skip-ssl-validation"),
+        ("Remove the API endpoint setting", "ibmcloud api --unset")
+    ]
+)
+with open("pages/common/ibmcloud-api.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-api.md")
+
+# 2. ibmcloud-config
+content = create_tldr_page(
+    "ibmcloud config",
+    "Modify or read out values in the IBM Cloud CLI configuration.",
+    [
+        ("Set HTTP request timeout to 30 seconds", "ibmcloud config --http-timeout 30"),
+        ("Enable trace output for HTTP requests", "ibmcloud config --trace true"),
+        ("Trace HTTP requests to a specific file", "ibmcloud config --trace {{path/to/trace_file}}"),
+        ("Disable color output", "ibmcloud config --color false"),
+        ("Set the locale to a specific language", "ibmcloud config --locale {{zh_Hans}}"),
+        ("Enable automatic SSO one-time passcode acceptance", "ibmcloud config --sso-otp auto")
+    ]
+)
+with open("pages/common/ibmcloud-config.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-config.md")
+
+# 3. ibmcloud-logout
+content = create_tldr_page(
+    "ibmcloud logout",
+    "Log out of the IBM Cloud CLI.",
+    [
+        ("Log out of the current session", "ibmcloud logout")
+    ]
+)
+with open("pages/common/ibmcloud-logout.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-logout.md")
+
+# 4. ibmcloud-plugin
+content = create_tldr_page(
+    "ibmcloud plugin",
+    "Manage plugins and plugin repositories for the IBM Cloud CLI.",
+    [
+        ("List all installed plugins", "ibmcloud plugin list"),
+        ("Install a plugin from a repository", "ibmcloud plugin install {{plugin_name}}"),
+        ("Uninstall a plugin", "ibmcloud plugin uninstall {{plugin_name}}"),
+        ("Update all plugins", "ibmcloud plugin update --all"),
+        ("List available plugins in repositories", "ibmcloud plugin repo-plugins"),
+        ("Add a plugin repository", "ibmcloud plugin repo-add {{repo_name}} {{repo_url}}")
+    ]
+)
+with open("pages/common/ibmcloud-plugin.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-plugin.md")
+
+print(f"Created {len(pages_created)} pages so far...")
+print("Files created:", ", ".join(pages_created))

--- a/pages/common/script_2.py
+++ b/pages/common/script_2.py
@@ -1,0 +1,75 @@
+
+# Continue creating remaining Command Line pages
+
+pages_created = []
+
+# 5. ibmcloud-regions
+content = create_tldr_page(
+    "ibmcloud regions",
+    "List all available regions on IBM Cloud.",
+    [
+        ("View information for all regions", "ibmcloud regions")
+    ]
+)
+with open("pages/common/ibmcloud-regions.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-regions.md")
+
+# 6. ibmcloud-target
+content = create_tldr_page(
+    "ibmcloud target",
+    "Set or view the target account, region, or resource group.",
+    [
+        ("View the current target account and region", "ibmcloud target"),
+        ("Set the target account", "ibmcloud target -c {{account_id}}"),
+        ("Switch to a specific region", "ibmcloud target -r {{region_name}}"),
+        ("Set the target resource group", "ibmcloud target -g {{resource_group_name}}"),
+        ("Clear the targeted region", "ibmcloud target --unset-region"),
+        ("Clear the targeted resource group", "ibmcloud target --unset-resource-group")
+    ]
+)
+with open("pages/common/ibmcloud-target.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-target.md")
+
+# 7. ibmcloud-update
+content = create_tldr_page(
+    "ibmcloud update",
+    "Update the IBM Cloud CLI to the most recent version.",
+    [
+        ("Update the CLI", "ibmcloud update"),
+        ("Force an update without confirmation", "ibmcloud update -f")
+    ]
+)
+with open("pages/common/ibmcloud-update.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-update.md")
+
+# 8. ibmcloud-version
+content = create_tldr_page(
+    "ibmcloud version",
+    "Print the version of the IBM Cloud CLI.",
+    [
+        ("Display the CLI version", "ibmcloud version")
+    ]
+)
+with open("pages/common/ibmcloud-version.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-version.md")
+
+# 9. ibmcloud-help
+content = create_tldr_page(
+    "ibmcloud help",
+    "Display help information for IBM Cloud CLI commands.",
+    [
+        ("Display general help for the IBM Cloud CLI", "ibmcloud help"),
+        ("Display help for a specific command", "ibmcloud help {{command}}"),
+        ("Display help for a specific namespace", "ibmcloud help {{namespace}}")
+    ]
+)
+with open("pages/common/ibmcloud-help.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-help.md")
+
+print(f"Command Line pages completed: {len(pages_created)} pages")
+print("Files created:", ", ".join(pages_created))

--- a/pages/common/script_3.py
+++ b/pages/common/script_3.py
@@ -1,0 +1,86 @@
+
+# Create Platform category pages
+
+pages_created = []
+
+# 10. ibmcloud-account
+content = create_tldr_page(
+    "ibmcloud account",
+    "Manage IBM Cloud accounts and users.",
+    [
+        ("List all accounts", "ibmcloud account list"),
+        ("Show details of the current account", "ibmcloud account show"),
+        ("List users in the account", "ibmcloud account users"),
+        ("Invite a user to the account", "ibmcloud account user-invite {{email}}"),
+        ("List organizations in the account", "ibmcloud account orgs"),
+        ("View documentation for account management subcommands", "tldr ibmcloud-account-{{subcommand}}")
+    ]
+)
+with open("pages/common/ibmcloud-account.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-account.md")
+
+# 11. ibmcloud-assist
+content = create_tldr_page(
+    "ibmcloud assist",
+    "Get answers to IBM Cloud questions using AI assistant powered by watsonx.",
+    [
+        ("Ask a question to the AI assistant", 'ibmcloud assist "{{How do I create a Kubernetes cluster?}}"'),
+        ("Get help about updating the CLI", 'ibmcloud assist "How do I update the CLI?"'),
+        ("Ask about resource management", 'ibmcloud assist "How do I list my resources?"')
+    ]
+)
+with open("pages/common/ibmcloud-assist.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-assist.md")
+
+# 12. ibmcloud-billing
+content = create_tldr_page(
+    "ibmcloud billing",
+    "Retrieve usage and billing information for IBM Cloud.",
+    [
+        ("View account usage", "ibmcloud billing account-usage"),
+        ("View resource group usage", "ibmcloud billing resource-group-usage {{resource_group_name}}"),
+        ("View organization usage", "ibmcloud billing org-usage {{org_name}}"),
+        ("View resource instances usage", "ibmcloud billing resource-instances-usage"),
+        ("View billing information for a specific month", "ibmcloud billing account-usage -d {{YYYY-MM}}")
+    ]
+)
+with open("pages/common/ibmcloud-billing.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-billing.md")
+
+# 13. ibmcloud-catalog
+content = create_tldr_page(
+    "ibmcloud catalog",
+    "Manage the IBM Cloud catalog.",
+    [
+        ("List all catalog entries", "ibmcloud catalog search"),
+        ("Search for a specific service", "ibmcloud catalog search {{service_name}}"),
+        ("Get details of a catalog entry", "ibmcloud catalog entry {{entry_id}}"),
+        ("List all templates", "ibmcloud catalog templates"),
+        ("Filter catalog by category", "ibmcloud catalog search --category {{compute}}")
+    ]
+)
+with open("pages/common/ibmcloud-catalog.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-catalog.md")
+
+# 14. ibmcloud-cbr
+content = create_tldr_page(
+    "ibmcloud cbr",
+    "Manage Context Based Restrictions in IBM Cloud.",
+    [
+        ("List all network zones", "ibmcloud cbr zones"),
+        ("Create a network zone", "ibmcloud cbr zone-create --name {{zone_name}}"),
+        ("List all context-based restriction rules", "ibmcloud cbr rules"),
+        ("Create a context-based restriction rule", "ibmcloud cbr rule-create"),
+        ("Delete a network zone", "ibmcloud cbr zone-delete {{zone_id}}")
+    ]
+)
+with open("pages/common/ibmcloud-cbr.md", "w") as f:
+    f.write(content)
+pages_created.append("ibmcloud-cbr.md")
+
+print(f"Platform pages (1-5): {len(pages_created)} pages")
+print("Files created:", ", ".join(pages_created))


### PR DESCRIPTION
Add tldr pages for IBM Cloud CLI core commands including:
- Command line operations (api, config, logout, plugin, regions, target, update, version, help)
- Platform commands (account, assist, billing, catalog, cbr)
- Utility scripts for page generation

Related to issue documenting IBM Cloud CLI commands. 
Fixes #18416

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
