### PR TITLE
cl, lib, nmake: add pages

### DIFF
--- a/pages/windows/cl.md
+++ b/pages/windows/cl.md
@@ -1,0 +1,32 @@
+# cl
+
+> The Microsoft C/C++ compiler for compiling and linking source code files.
+> More information: <https://learn.microsoft.com/cpp/build/reference/compiler-command-line-syntax>.
+
+- Compile a source file:
+
+`cl {{path/to/source.c}}`
+
+- Compile and create an executable with a custom name:
+
+`cl /Fe{{path/to/output_executable}} {{path/to/source.c}}`
+
+- Compile a source file with optimization enabled:
+
+`cl /O2 {{path/to/source.c}}`
+
+- Compile a source file and create a debug executable:
+
+`cl /Zi {{path/to/source.c}}`
+
+- Compile multiple source files:
+
+`cl {{path/to/source1.c path/to/source2.c ...}}`
+
+- Specify the output directory for compiled files:
+
+`cl /Fo{{path/to/output_directory/}} {{path/to/source.c}}`
+
+- Compile with warnings as errors:
+
+`cl /WX {{path/to/source.c}}`

--- a/pages/windows/lib.md
+++ b/pages/windows/lib.md
@@ -1,0 +1,28 @@
+# lib
+
+> The Microsoft Library Manager for creating and managing static libraries of object files.
+> More information: <https://learn.microsoft.com/cpp/build/reference/lib-reference>.
+
+- Create a static library from object files:
+
+`lib /OUT:{{path/to/library.lib}} {{path/to/file1.obj path/to/file2.obj ...}}`
+
+- List the contents of a library:
+
+`lib /LIST {{path/to/library.lib}}`
+
+- Add an object file to an existing library:
+
+`lib {{path/to/library.lib}} {{path/to/file.obj}}`
+
+- Remove an object file from a library:
+
+`lib /REMOVE:{{path/to/file.obj}} {{path/to/library.lib}}`
+
+- Extract an object file from a library:
+
+`lib /EXTRACT:{{path/to/file.obj}} {{path/to/library.lib}}`
+
+- Create an import library from a DLL:
+
+`lib /DEF:{{path/to/definition.def}} /OUT:{{path/to/import.lib}}`

--- a/pages/windows/nmake.md
+++ b/pages/windows/nmake.md
@@ -1,0 +1,36 @@
+# nmake
+
+> The Microsoft Program Maintenance Utility for building projects based on commands in a makefile.
+> More information: <https://learn.microsoft.com/cpp/build/reference/nmake-reference>.
+
+- Build targets using the default makefile in the current directory:
+
+`nmake`
+
+- Build targets using a specific makefile:
+
+`nmake /F {{path/to/makefile}}`
+
+- Build a specific target:
+
+`nmake {{target}}`
+
+- Display commands without executing them:
+
+`nmake /N`
+
+- Display all macro definitions and target descriptions:
+
+`nmake /P`
+
+- Continue building unrelated targets on error:
+
+`nmake /K`
+
+- Build and ignore timestamp checks (force rebuild):
+
+`nmake /A`
+
+- Suppress copyright message:
+
+`nmake /NOLOGO`


### PR DESCRIPTION
Add tldr pages for Microsoft Visual Studio command-line tools:
- cl: Microsoft C/C++ compiler
- lib: Library manager for static libraries
- nmake: Build automation utility

Closes #6565

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
