### PR TITLE
audit2why: add page

### DIFF
--- a/pages/linux/audit2why.md
+++ b/pages/linux/audit2why.md
@@ -1,0 +1,22 @@
+# audit2why
+
+> Explain SELinux denials from audit logs.
+> Part of the `policycoreutils-python-utils` package.
+> See also: `audit2allow`, `ausearch`, `sealert`.
+> More information: <https://manned.org/audit2why>.
+
+- Explain the most recent SELinux denial:
+
+`sudo audit2why`
+
+- Explain SELinux denials from a specific audit log file:
+
+`sudo audit2why -i {{path/to/audit.log}}`
+
+- Explain all SELinux denials from the audit log:
+
+`sudo ausearch -m avc | audit2why`
+
+- Explain denials for a specific service:
+
+`sudo ausearch -m avc -c {{httpd}} | audit2why`


### PR DESCRIPTION
Adds documentation for the audit2why command.

Contributes to #11896

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-python-utils-3.7-5.fc41.x86_64