### PR TITLE
ghq: add page

### DIFF
--- a/pages/common/ghq.md
+++ b/pages/common/ghq.md
@@ -1,0 +1,52 @@
+# ghq
+
+> Manage remote repository clones organized by hostname and path.
+> More information: <https://github.com/x-motemen/ghq>.
+
+- Clone a repository under the ghq root directory (default is `~/ghq`):
+
+`ghq get {{repository_url}}`
+
+- Clone a repository from a user/project format (defaults to GitHub):
+
+`ghq get {{user}}/{{project}}`
+
+- Clone a repository and cd into it:
+
+`ghq get -look {{repository_url}}`
+
+- Clone a repository via SSH using the `-p` flag:
+
+`ghq get -p {{user}}/{{project}}`
+
+- Clone a repository with a shallow clone (Git only):
+
+`ghq get --shallow {{repository_url}}`
+
+- Update an existing repository to the latest version:
+
+`ghq get -u {{repository_url}}`
+
+- List all locally cloned repositories:
+
+`ghq list`
+
+- List all locally cloned repositories with full paths:
+
+`ghq list --full-path`
+
+- List locally cloned repositories matching a query:
+
+`ghq list {{query}}`
+
+- Remove a locally cloned repository:
+
+`ghq rm {{user}}/{{project}}`
+
+- Display the path to the ghq root directory:
+
+`ghq root`
+
+- Create a new repository in the ghq root:
+
+`ghq create {{user}}/{{project}}`


### PR DESCRIPTION
Add tldr page for ghq - a tool for managing remote repository clones.

ghq organizes Git repositories in a structured directory hierarchy based on the repository URL's hostname and path.

Closes #6118

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
