### PR TITLE
semodule: add page

### DIFF
--- a/pages/linux/semodule.md
+++ b/pages/linux/semodule.md
@@ -6,28 +6,28 @@
 
 - List all installed policy modules:
 
-`sudo semodule -l`
+`sudo semodule {{[-l|--list]}}`
 
 - Install a new policy module:
 
-`sudo semodule -i {{path/to/module.pp}}`
+`sudo semodule {{[-i|--install]}} {{path/to/module.pp}}`
 
 - Remove a policy module:
 
-`sudo semodule -r {{module_name}}`
+`sudo semodule {{[-r|--remove]}} {{module_name}}`
 
 - Enable a policy module:
 
-`sudo semodule -e {{module_name}}`
+`sudo semodule {{[-e|--enable]}} {{module_name}}`
 
 - Disable a policy module:
 
-`sudo semodule -d {{module_name}}`
+`sudo semodule {{[-d|--disable]}} {{module_name}}`
 
 - Reload all policy modules:
 
-`sudo semodule -R`
+`sudo semodule {{[-R|--reload]}}`
 
 - Display the version of installed policy modules:
 
-`sudo semodule -l -v`
+`sudo semodule {{[-l|--list]}} {{[-v|--verbose]}}`

--- a/pages/linux/semodule.md
+++ b/pages/linux/semodule.md
@@ -1,0 +1,33 @@
+# semodule
+
+> Manage SELinux policy modules.
+> See also: `audit2allow`, `semanage`.
+> More information: <https://manned.org/semodule>.
+
+- List all installed policy modules:
+
+`sudo semodule -l`
+
+- Install a new policy module:
+
+`sudo semodule -i {{path/to/module.pp}}`
+
+- Remove a policy module:
+
+`sudo semodule -r {{module_name}}`
+
+- Enable a policy module:
+
+`sudo semodule -e {{module_name}}`
+
+- Disable a policy module:
+
+`sudo semodule -d {{module_name}}`
+
+- Reload all policy modules:
+
+`sudo semodule -R`
+
+- Display the version of installed policy modules:
+
+`sudo semodule -l -v`


### PR DESCRIPTION
Adds documentation for the semodule command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  libsemanage-3.7-3.fc41.x86_64