### PR TITLE
sesearch: add page

### DIFF
--- a/pages/linux/sesearch.md
+++ b/pages/linux/sesearch.md
@@ -1,0 +1,30 @@
+# sesearch
+
+> Search SELinux policy rules.
+> Part of the `setools` package.
+> See also: `seinfo`, `semodule`.
+> More information: <https://manned.org/sesearch>.
+
+- Search for all allow rules:
+
+`sesearch --allow`
+
+- Search for rules related to a specific type:
+
+`sesearch --allow -t {{httpd_t}}`
+
+- Search for rules related to a specific source type:
+
+`sesearch --allow -s {{user_t}}`
+
+- Search for rules that allow a specific class and permission:
+
+`sesearch --allow -c {{file}} -p {{read}}`
+
+- Search for rules with a specific target type and class:
+
+`sesearch --allow -t {{shadow_t}} -c {{file}}`
+
+- Display more detailed information about matched rules:
+
+`sesearch --allow -t {{httpd_t}} -v`


### PR DESCRIPTION
Adds documentation for the sesearch command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  setools-console-4.5.1-6.fc41.x86_64