### PR TITLE
ausearch: add page

### DIFF
--- a/pages/linux/ausearch.md
+++ b/pages/linux/ausearch.md
@@ -7,28 +7,28 @@
 
 - Search for all SELinux AVC denial events:
 
-`sudo ausearch -m avc`
+`sudo ausearch {{[-m|--message]}} avc`
 
 - Search for events related to a specific executable:
 
-`sudo ausearch -c {{httpd}}`
+`sudo ausearch {{[-c|--comm]}} {{httpd}}`
 
 - Search for events from a specific user:
 
-`sudo ausearch -ui {{1000}}`
+`sudo ausearch {{[-ui|--uid]}} {{1000}}`
 
 - Search for events in the last 10 minutes:
 
-`sudo ausearch -ts recent`
+`sudo ausearch {{[-ts|--start]}} recent`
 
 - Search for failed login attempts:
 
-`sudo ausearch -m user_login -sv no`
+`sudo ausearch {{[-m|--message]}} user_login {{[-sv|--success]}} no`
 
 - Search for events related to a specific file:
 
-`sudo ausearch -f {{path/to/file}}`
+`sudo ausearch {{[-f|--file]}} {{path/to/file}}`
 
 - Display results in raw format for further processing:
 
-`sudo ausearch -m avc --raw`
+`sudo ausearch {{[-m|--message]}} avc --raw`


### PR DESCRIPTION
Adds documentation for the ausearch command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  audit-4.1.1-1.fc41.x86_64