### PR TITLE
chcat: add page

### DIFF
--- a/pages/linux/chcat.md
+++ b/pages/linux/chcat.md
@@ -1,0 +1,30 @@
+# chcat
+
+> Change SELinux security category for files.
+> Categories provide an additional level of access control based on MCS (Multi-Category Security).
+> See also: `chcon`, `semanage`.
+> More information: <https://manned.org/chcat>.
+
+- List all available categories:
+
+`sudo chcat -L`
+
+- Add a category to a file:
+
+`sudo chcat +{{CategoryName}} {{path/to/file}}`
+
+- Remove a category from a file:
+
+`sudo chcat -- -{{CategoryName}} {{path/to/file}}`
+
+- Set specific categories for a file (replacing existing ones):
+
+`sudo chcat {{CategoryName1,CategoryName2}} {{path/to/file}}`
+
+- Display the categories of a file:
+
+`ls -Z {{path/to/file}}`
+
+- Remove all categories from a file:
+
+`sudo chcat -d {{path/to/file}}`


### PR DESCRIPTION
Adds documentation for the chcat command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-python-utils-3.7-8.fc41.noarch