### PR TITLE
sealert: add page

### DIFF
--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -7,7 +7,7 @@
 
 - Analyze all recent SELinux denials:
 
-`sudo sealert -a /var/log/audit/audit.log`
+`sudo sealert {{[-a|--analyze]}} {{/var/log/audit/audit.log}}`
 
 - Analyze a specific alert ID from system logs:
 

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -11,7 +11,7 @@
 
 - Analyze a specific alert ID from system logs:
 
-`sudo sealert -l {{alert_id}}`
+`sudo sealert {{[-l|--lookupid]}} {{alert_id}}`
 
 - Display a summary of recent SELinux alerts:
 

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -1,0 +1,26 @@
+# sealert
+
+> Analyze and explain SELinux AVC denial messages.
+> Part of the `setroubleshoot-server` package.
+> See also: `audit2why`, `ausearch`, `audit2allow`.
+> More information: <https://manned.org/sealert>.
+
+- Analyze all recent SELinux denials:
+
+`sudo sealert -a /var/log/audit/audit.log`
+
+- Analyze a specific alert ID from system logs:
+
+`sudo sealert -l {{alert_id}}`
+
+- Display a summary of recent SELinux alerts:
+
+`sudo sealert -b`
+
+- Analyze SELinux denials and show detailed recommendations:
+
+`sudo sealert -a /var/log/audit/audit.log -v`
+
+- Monitor audit log in real-time for new alerts:
+
+`sudo tail -f /var/log/audit/audit.log | sealert -l -`

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -23,4 +23,4 @@
 
 - Monitor audit log in real-time for new alerts:
 
-`sudo tail -f /var/log/audit/audit.log | sealert -l -`
+`sudo tail {{[-f|--follow]}} {{/var/log/audit/audit.log}} | sealert {{[-l|--lookupid]}} -`

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -19,7 +19,7 @@
 
 - Analyze SELinux denials and show detailed recommendations:
 
-`sudo sealert -a /var/log/audit/audit.log -v`
+`sudo sealert {{[-a|--analyze]}} {{/var/log/audit/audit.log}} -v`
 
 - Monitor audit log in real-time for new alerts:
 

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -15,7 +15,7 @@
 
 - Display a summary of recent SELinux alerts:
 
-`sudo sealert -b`
+`sudo sealert {{[-b|--browser]}}`
 
 - Analyze SELinux denials and show detailed recommendations:
 

--- a/pages/linux/sealert.md
+++ b/pages/linux/sealert.md
@@ -17,10 +17,6 @@
 
 `sudo sealert {{[-b|--browser]}}`
 
-- Analyze SELinux denials and show detailed recommendations:
-
-`sudo sealert {{[-a|--analyze]}} {{/var/log/audit/audit.log}} -v`
-
 - Monitor audit log in real-time for new alerts:
 
 `sudo tail {{[-f|--follow]}} {{/var/log/audit/audit.log}} | sealert {{[-l|--lookupid]}} -`


### PR DESCRIPTION
Adds documentation for the sealert command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  setroubleshoot-server-3.3.35-4.fc41.x86_64