### PR TITLE
newrole: add page

### DIFF
--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -15,7 +15,7 @@
 
 - Start a new shell with a specific SELinux level:
 
-`newrole -l {{s0-s0:c0.c1023}}`
+`newrole {{[-l|--level]}} {{s0-s0:c0.c1023}}`
 
 - Display the current SELinux context:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -11,7 +11,7 @@
 
 - Start a new shell with a specific SELinux type:
 
-`newrole -t {{type_name}}`
+`newrole {{[-t|--type]}} {{type_name}}`
 
 - Start a new shell with a specific SELinux level:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -7,7 +7,7 @@
 
 - Start a new shell with a specific SELinux role:
 
-`newrole -r {{role_name}}`
+`newrole {{[-r|--role]}} {{role_name}}`
 
 - Start a new shell with a specific SELinux type:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -13,9 +13,9 @@
 
 `newrole {{[-t|--type]}} {{type_name}}`
 
-- Start a new shell with a specific SELinux level:
+- Start a new shell with a specific SELinux level (levels range from `s0` to `s15`, `-` indicates level range, categories start with `c`, `:` separates level from categories, `.` indicates category range):
 
-`newrole {{[-l|--level]}} {{s0-s0:c0.c1023}}`
+`newrole {{[-l|--level]}} {{level_range}}`
 
 - Display the current SELinux context:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -23,4 +23,4 @@
 
 - Start a new shell with both role and type:
 
-`newrole -r {{role_name}} -t {{type_name}}`
+`newrole {{[-r|--role]}} {{role_name}} {{[-t|--type]}} {{type_name}}`

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -13,9 +13,9 @@
 
 `newrole {{[-t|--type]}} {{type_name}}`
 
-- Start a new shell with a specific SELinux level (levels range from `s0` to `s15`, `-` indicates level range, categories start with `c`, `:` separates level from categories, `.` indicates category range):
+- Start a new shell with a specific SELinux level (format: `s0-s0:c0.c1023` where levels range from `s0` to `s15`, `-` indicates level range, categories start with `c`, `:` separates level from categories, `.` indicates category range):
 
-`newrole {{[-l|--level]}} {{level_range}}`
+`newrole {{[-l|--level]}} {{s0-s0:c0.c1023}}`
 
 - Display the current SELinux context:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -19,7 +19,7 @@
 
 - Display the current SELinux context:
 
-`id -Z`
+`id {{[-Z|--context]}}`
 
 - Start a new shell with both role and type:
 

--- a/pages/linux/newrole.md
+++ b/pages/linux/newrole.md
@@ -1,0 +1,26 @@
+# newrole
+
+> Run a new shell with a different SELinux role.
+> Allows users to switch to a different SELinux security context.
+> See also: `runcon`, `semanage-user`.
+> More information: <https://manned.org/newrole>.
+
+- Start a new shell with a specific SELinux role:
+
+`newrole -r {{role_name}}`
+
+- Start a new shell with a specific SELinux type:
+
+`newrole -t {{type_name}}`
+
+- Start a new shell with a specific SELinux level:
+
+`newrole -l {{s0-s0:c0.c1023}}`
+
+- Display the current SELinux context:
+
+`id -Z`
+
+- Start a new shell with both role and type:
+
+`newrole -r {{role_name}} -t {{type_name}}`


### PR DESCRIPTION
Adds documentation for the newrole command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-newrole-3.7-8.fc41.x86_64