### PR TITLE
restorecond: add page

### DIFF
--- a/pages/linux/restorecond.md
+++ b/pages/linux/restorecond.md
@@ -27,4 +27,4 @@
 
 - Enable restorecond to start at boot:
 
-`sudo systemctl enable --now restorecond`
+`sudo systemctl enable restorecond --now`


### PR DESCRIPTION
Adds documentation for the restorecond command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** policycoreutils-restorecond-3.7-8.fc41.x86_64