### PR TITLE
run_init: add page

### DIFF
--- a/pages/linux/run_init.md
+++ b/pages/linux/run_init.md
@@ -1,0 +1,22 @@
+# run_init
+
+> Run init scripts in the proper SELinux context.
+> Typically used to run system service scripts with correct SELinux domains.
+> See also: `runcon`, `semanage`.
+> More information: <https://manned.org/run_init>.
+
+- Run a script in the init script context:
+
+`sudo run_init {{path/to/script}}`
+
+- Run a script with arguments:
+
+`sudo run_init {{path/to/script}} {{start|stop|restart}}`
+
+- Run a script and specify the init script context explicitly:
+
+`sudo run_init -t {{initrc_t}} {{path/to/script}}`
+
+- Display the context that would be used without running the script:
+
+`sudo run_init -n {{path/to/script}}`

--- a/pages/linux/run_init.md
+++ b/pages/linux/run_init.md
@@ -15,7 +15,7 @@
 
 - Run a script and specify the init script context explicitly:
 
-`sudo run_init {{[-t|--type]}} {{initrc_t}} {{path/to/script}}`
+`sudo run_init {{[-t|--type]}} {{context_type}} {{path/to/script}}`
 
 - Display the context that would be used without running the script:
 

--- a/pages/linux/run_init.md
+++ b/pages/linux/run_init.md
@@ -15,8 +15,8 @@
 
 - Run a script and specify the init script context explicitly:
 
-`sudo run_init -t {{initrc_t}} {{path/to/script}}`
+`sudo run_init {{[-t|--type]}} {{initrc_t}} {{path/to/script}}`
 
 - Display the context that would be used without running the script:
 
-`sudo run_init -n {{path/to/script}}`
+`sudo run_init {{[-n|--dry-run]}} {{path/to/script}}`


### PR DESCRIPTION
Adds documentation for the run_init command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).