### PR TITLE
semanage-interface: add page

### DIFF
--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -10,7 +10,7 @@
 
 - Add a network interface type definition:
 
-`sudo semanage interface -a -t {{netif_t}} {{eth0}}`
+`sudo semanage interface {{[-a|--add]}} {{[-t|--type]}} {{netif_t}} {{eth0}}`
 
 - Delete a network interface type definition:
 

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -22,4 +22,4 @@
 
 - List interface type definitions in a customized format:
 
-`sudo semanage interface -l -C`
+`sudo semanage interface {{[-l|--list]}} {{[-C|--locallist]}}`

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -6,7 +6,7 @@
 
 - List all interface type definitions:
 
-`sudo semanage interface -l`
+`sudo semanage interface {{[-l|--list]}}`
 
 - Add a network interface type definition:
 

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -10,15 +10,15 @@
 
 - Add a network interface type definition:
 
-`sudo semanage interface {{[-a|--add]}} {{[-t|--type]}} {{netif_t}} {{eth0}}`
+`sudo semanage interface {{[-a|--add]}} {{[-t|--type]}} {{type_name}} {{interface_name}}`
 
 - Delete a network interface type definition:
 
-`sudo semanage interface {{[-d|--delete]}} {{eth0}}`
+`sudo semanage interface {{[-d|--delete]}} {{interface_name}}`
 
 - Modify a network interface type definition:
 
-`sudo semanage interface {{[-m|--modify]}} {{[-t|--type]}} {{ipsec_spd_t}} {{eth1}}`
+`sudo semanage interface {{[-m|--modify]}} {{[-t|--type]}} {{type_name}} {{interface_name}}`
 
 - List interface type definitions in a customized format:
 

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -1,4 +1,4 @@
-# semanage-interface
+# semanage interface
 
 > Manage SELinux network interface type definitions.
 > See also: `semanage`, `semanage-port`.

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -18,7 +18,7 @@
 
 - Modify a network interface type definition:
 
-`sudo semanage interface -m -t {{ipsec_spd_t}} {{eth1}}`
+`sudo semanage interface {{[-m|--modify]}} {{[-t|--type]}} {{ipsec_spd_t}} {{eth1}}`
 
 - List interface type definitions in a customized format:
 

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -14,7 +14,7 @@
 
 - Delete a network interface type definition:
 
-`sudo semanage interface -d {{eth0}}`
+`sudo semanage interface {{[-d|--delete]}} {{eth0}}`
 
 - Modify a network interface type definition:
 

--- a/pages/linux/semanage-interface.md
+++ b/pages/linux/semanage-interface.md
@@ -1,0 +1,25 @@
+# semanage-interface
+
+> Manage SELinux network interface type definitions.
+> See also: `semanage`, `semanage-port`.
+> More information: <https://manned.org/semanage-interface>.
+
+- List all interface type definitions:
+
+`sudo semanage interface -l`
+
+- Add a network interface type definition:
+
+`sudo semanage interface -a -t {{netif_t}} {{eth0}}`
+
+- Delete a network interface type definition:
+
+`sudo semanage interface -d {{eth0}}`
+
+- Modify a network interface type definition:
+
+`sudo semanage interface -m -t {{ipsec_spd_t}} {{eth1}}`
+
+- List interface type definitions in a customized format:
+
+`sudo semanage interface -l -C`


### PR DESCRIPTION
Adds documentation for the semanage-interface command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-python-utils-3.7-8.fc41.noarch