### PR TITLE
scrun: add page

### DIFF
--- a/pages/linux/scrun.md
+++ b/pages/linux/scrun.md
@@ -1,0 +1,36 @@
+# scrun
+
+> An OCI runtime proxy for Slurm that runs containers as jobs.
+> More information: <https://slurm.schedmd.com/scrun.html>.
+
+- Create a new container with a specific ID:
+
+`scrun create {{container_id}}`
+
+- Start a previously created container:
+
+`scrun start {{container_id}}`
+
+- Query the state of a container:
+
+`scrun state {{container_id}}`
+
+- Send a signal to a container (default: SIGTERM):
+
+`scrun kill {{container_id}}`
+
+- Send a specific signal to a container:
+
+`scrun kill {{container_id}} {{SIGKILL}}`
+
+- Delete a container and release its resources:
+
+`scrun delete {{container_id}}`
+
+- Enable debug logging:
+
+`scrun --debug {{create|start|kill|delete}} {{container_id}}`
+
+- Display version information:
+
+`scrun --version`


### PR DESCRIPTION
Add tldr page for scrun - Slurm's OCI runtime proxy for containers.

scrun acts as an interface between Docker/Podman and Slurm, allowing containers to be executed as Slurm jobs on compute nodes.

Closes #11991
scrun: add page
## Command Added
- **scrun**: An OCI runtime proxy that runs Docker/Podman containers as Slurm jobs

## Features Documented
- Container lifecycle operations (create, start, state, delete)
- Sending signals to containers
- Debug logging
- Version information

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
