### PR TITLE
kubectl-*: update pages with better man page links

### DIFF
--- a/pages.de/common/kubectl-delete.md
+++ b/pages.de/common/kubectl-delete.md
@@ -1,7 +1,7 @@
 # kubectl delete
 
 > Lösche Kubernetes-Ressourcen.
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete>.
 
 - Lösche einen bestimmten Pod:
 

--- a/pages.de/common/kubectl-describe.md
+++ b/pages.de/common/kubectl-describe.md
@@ -1,7 +1,7 @@
 # kubectl describe
 
 > Details von Kubernetes-Objekten und -Ressourcen anzeigen.
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_describe>.
 
 - Zeige Details zu Pods in einem bestimmten [n]amespace an:
 

--- a/pages.de/common/kubectl-get.md
+++ b/pages.de/common/kubectl-get.md
@@ -1,7 +1,7 @@
 # kubectl get
 
 > Abfragen von Kubernetes Resourcen und Objekten.
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get>.
 
 - Zeige alle Namespaces im Cluster an:
 

--- a/pages.de/common/kubectl-logs.md
+++ b/pages.de/common/kubectl-logs.md
@@ -1,7 +1,7 @@
 # kubectl logs
 
 > Logs für Container in einem Pod anzeigen.
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs>.
 
 - Zeige Logs für einen Einzelcontainer-Pod an:
 

--- a/pages.de/common/kubectl-rollout.md
+++ b/pages.de/common/kubectl-rollout.md
@@ -1,7 +1,7 @@
 # kubectl rollout
 
 > Verwalten des Rollouts einer Kubernetes-Ressource (deployments, daemonsets, and statefulsets).
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout>.
 
 - Starte einen rollenden Neustart einer Ressource:
 

--- a/pages.de/common/kubectl-run.md
+++ b/pages.de/common/kubectl-run.md
@@ -1,7 +1,7 @@
 # kubectl run
 
 > Pods in Kubernetes ausführen. Gibt den Pod-Generator an, um einen deprecation Fehler in einigen Kubernetes Versionen zu vermeiden.
-> Weitere Informationen: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run>.
+> Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run>.
 
 - Starte einen nginx-Pod und gib Port 80 frei:
 

--- a/pages.es/common/kubectl-logs.md
+++ b/pages.es/common/kubectl-logs.md
@@ -1,7 +1,7 @@
 # kubectl logs
 
 > Muestra los registros de los contenedores de un pod.
-> Más información: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+> Más información: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs>.
 
 - Muestra los registros de un pod de un contenedor:
 

--- a/pages.es/common/kubectl-wait.md
+++ b/pages.es/common/kubectl-wait.md
@@ -1,7 +1,7 @@
 # kubectl wait
 
 > Espera a que los recursos alcancen un estado determinado.
-> Más información: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait>.
+> Más información: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_wait>.
 
 - Espera a que un despliegue esté disponible:
 

--- a/pages.ko/common/kubectl-apply.md
+++ b/pages.ko/common/kubectl-apply.md
@@ -2,7 +2,7 @@
 
 > Kubernetes 리소스를 정의하는 파일을 통해 애플리케이션을 관리하세요.
 > 클러스터에서 리소스를 생성하고 업데이트하세요.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply>.
 
 - 파일 이름이나 `stdin`으로 리소스에 설정 적용:
 

--- a/pages.ko/common/kubectl-config.md
+++ b/pages.ko/common/kubectl-config.md
@@ -3,7 +3,7 @@
 > Kubernetes 구성(kubeconfig) 파일을 관리하여 `kubectl` 또는 Kubernetes API를 통해 클러스터에 접근할 수 있도록 함.
 > 기본적으로 Kubernetes는 `${HOME}/.kube/config`에서 구성을 가져옵니다.
 > 같이 보기: `kubectx`, `kubens`.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config>.
 
 - 기본 kubeconfig 파일에서 모든 컨텍스트 가져오기:
 

--- a/pages.ko/common/kubectl-create.md
+++ b/pages.ko/common/kubectl-create.md
@@ -1,7 +1,7 @@
 # kubectl create
 
 > 파일 또는 `stdin`에서 리소스를 생성.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create>.
 
 - 리소스 정의 파일을 사용하여 리소스 생성:
 

--- a/pages.ko/common/kubectl-delete.md
+++ b/pages.ko/common/kubectl-delete.md
@@ -1,7 +1,7 @@
 # kubectl delete
 
 > Kubernetes 리소스 삭제.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete>.
 
 - 특정 포드 삭제:
 

--- a/pages.ko/common/kubectl-describe.md
+++ b/pages.ko/common/kubectl-describe.md
@@ -1,7 +1,7 @@
 # kubectl describe
 
 > Kubernetes 객체 및 리소스의 세부 정보 표시.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_describe>.
 
 - [n]amespace의 포드 세부 정보 표시:
 

--- a/pages.ko/common/kubectl-edit.md
+++ b/pages.ko/common/kubectl-edit.md
@@ -1,7 +1,7 @@
 # kubectl edit
 
 > Kubernetes 리소스를 편집.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#edit>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_edit>.
 
 - Pod 편집:
 

--- a/pages.ko/common/kubectl-expose.md
+++ b/pages.ko/common/kubectl-expose.md
@@ -1,7 +1,7 @@
 # kubectl expose
 
 > 리소스를 새로운 Kubernetes 서비스로 노출.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_expose>.
 
 - 컨테이너 포트에서 노드 포트로 제공될 리소스에 대한 서비스 생성:
 

--- a/pages.ko/common/kubectl-get.md
+++ b/pages.ko/common/kubectl-get.md
@@ -1,7 +1,7 @@
 # kubectl get
 
 > Kubernetes 객체 및 리소스 가져오기.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get>.
 
 - 현재 클러스터의 모든 네임스페이스 가져오기:
 

--- a/pages.ko/common/kubectl-label.md
+++ b/pages.ko/common/kubectl-label.md
@@ -1,7 +1,7 @@
 # kubectl label
 
 > Kubernetes 리소스에 레이블 지정.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label>.
 
 - 포드에 레이블 지정:
 

--- a/pages.ko/common/kubectl-logs.md
+++ b/pages.ko/common/kubectl-logs.md
@@ -1,7 +1,7 @@
 # kubectl logs
 
 > 컨테이너의 로그를 조회하는 도구.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs>.
 
 - 단일 컨테이너가 있는 파드의 로그 조회:
 

--- a/pages.ko/common/kubectl-replace.md
+++ b/pages.ko/common/kubectl-replace.md
@@ -1,7 +1,7 @@
 # kubectl replace
 
 > 파일 또는 `stdin`을 통해 리소스를 교체.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#replace>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_replace>.
 
 - 리소스 정의 파일을 사용하여 리소스 교체:
 

--- a/pages.ko/common/kubectl-rollout.md
+++ b/pages.ko/common/kubectl-rollout.md
@@ -1,7 +1,7 @@
 # kubectl rollout
 
 > Kubernetes 리소스(배포, 데몬셋, 스테이트풀셋)의 롤아웃 관리.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout>.
 
 - 리소스의 롤링 재시작 시작:
 

--- a/pages.ko/common/kubectl-run.md
+++ b/pages.ko/common/kubectl-run.md
@@ -1,7 +1,7 @@
 # kubectl run
 
 > Kubernetes에서 파드를 실행. 일부 K8S 버전에서 경고 메시지를 피하기 위해 파드 생성기를 지정.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run>.
 
 - nginx 파드를 실행하고 포트 80을 노출:
 

--- a/pages.ko/common/kubectl-scale.md
+++ b/pages.ko/common/kubectl-scale.md
@@ -1,7 +1,7 @@
 # kubectl scale
 
 > 배포, 레플리카 세트, 복제 컨트롤러 또는 스테이트풀 세트의 크기를 조정.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_scale>.
 
 - 레플리카 세트 크기 조정:
 

--- a/pages.ko/common/kubectl-taint.md
+++ b/pages.ko/common/kubectl-taint.md
@@ -1,7 +1,7 @@
 # kubectl taint
 
 > 노드에 taint 업데이트.
-> 더 많은 정보: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint>.
+> 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_taint>.
 
 - 노드에 taint 적용:
 

--- a/pages/common/kubectl-api-resources.md
+++ b/pages/common/kubectl-api-resources.md
@@ -1,7 +1,7 @@
 # kubectl api-resources
 
 > Print the supported API resources on the server.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#api-resources>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_api-resources>.
 
 - Print the supported API resources:
 

--- a/pages/common/kubectl-apply.md
+++ b/pages/common/kubectl-apply.md
@@ -2,7 +2,7 @@
 
 > Manage applications through files defining Kubernetes resources.
 > Create and update resources in a cluster.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply>.
 
 - Apply a configuration to a resource by file name:
 

--- a/pages/common/kubectl-auth.md
+++ b/pages/common/kubectl-auth.md
@@ -1,7 +1,7 @@
 # kubectl auth
 
 > Inspect access permissions in a Kubernetes cluster.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#auth>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_auth>.
 
 - Check if the current user can perform all actions on all resources in a specific namespace:
 

--- a/pages/common/kubectl-autoscale.md
+++ b/pages/common/kubectl-autoscale.md
@@ -1,7 +1,7 @@
 # kubectl autoscale
 
 > Create an autoscaler to intelligently scale pod count based on kubernetes cluster demands.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#autoscale>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_autoscale>.
 
 - Auto scale a deployment with no target CPU utilization specified:
 

--- a/pages/common/kubectl-config.md
+++ b/pages/common/kubectl-config.md
@@ -3,7 +3,7 @@
 > Manage Kubernetes configuration (kubeconfig) files for accessing clusters via `kubectl` or the Kubernetes API.
 > By default, the Kubernetes will get its configuration from `${HOME}/.kube/config`.
 > See also: `kubectx`, `kubens`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config>.
 
 - Get all contexts in the default kubeconfig file:
 

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -1,7 +1,7 @@
 # kubectl create
 
 > Create a resource from a file or from `stdin`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create>.
 
 - Create a resource using the resource definition file:
 

--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -1,7 +1,7 @@
 # kubectl delete
 
 > Delete Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete>.
 
 - Delete a specific pod:
 

--- a/pages/common/kubectl-describe.md
+++ b/pages/common/kubectl-describe.md
@@ -1,7 +1,7 @@
 # kubectl describe
 
 > Show details of Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_describe>.
 
 - Show details of pods in a namespace:
 

--- a/pages/common/kubectl-edit.md
+++ b/pages/common/kubectl-edit.md
@@ -1,7 +1,7 @@
 # kubectl edit
 
 > Edit Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#edit>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_edit>.
 
 - Edit a pod in the default namespace:
 

--- a/pages/common/kubectl-exec.md
+++ b/pages/common/kubectl-exec.md
@@ -1,7 +1,7 @@
 # kubectl exec
 
 > Execute a command in a container.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#exec>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec>.
 
 - Open Bash in a pod, using the first container by default:
 

--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -1,7 +1,7 @@
 # kubectl expose
 
 > Expose a resource as a new Kubernetes service.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_expose>.
 
 - Create a service for a resource, which will be served from container port to node port:
 

--- a/pages/common/kubectl-get.md
+++ b/pages/common/kubectl-get.md
@@ -1,7 +1,7 @@
 # kubectl get
 
 > Get Kubernetes objects and resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get>.
 
 - Get all namespaces in the current cluster:
 

--- a/pages/common/kubectl-label.md
+++ b/pages/common/kubectl-label.md
@@ -1,7 +1,7 @@
 # kubectl label
 
 > Label Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label>.
 
 - Label a pod:
 

--- a/pages/common/kubectl-logs.md
+++ b/pages/common/kubectl-logs.md
@@ -1,7 +1,7 @@
 # kubectl logs
 
 > Show logs for containers in a pod.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs>.
 
 - Show logs for a single-container pod:
 

--- a/pages/common/kubectl-replace.md
+++ b/pages/common/kubectl-replace.md
@@ -1,7 +1,7 @@
 # kubectl replace
 
 > Replace a resource by file or `stdin`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#replace>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_replace>.
 
 - Replace the resource using the resource definition file:
 

--- a/pages/common/kubectl-rollout.md
+++ b/pages/common/kubectl-rollout.md
@@ -1,7 +1,7 @@
 # kubectl rollout
 
 > Manage the rollout of a Kubernetes resource (deployments, daemonsets, and statefulsets).
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout>.
 
 - Start a rolling restart of a resource:
 

--- a/pages/common/kubectl-run.md
+++ b/pages/common/kubectl-run.md
@@ -1,7 +1,7 @@
 # kubectl run
 
 > Run pods in Kubernetes. Specifies pod generator to avoid deprecation error in some K8S versions.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run>.
 
 - Run an nginx pod and expose port 80:
 

--- a/pages/common/kubectl-scale.md
+++ b/pages/common/kubectl-scale.md
@@ -1,7 +1,7 @@
 # kubectl scale
 
 > Set a new size for a deployment, replica set, replication controller, or stateful set.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_scale>.
 
 - Scale a replica set:
 

--- a/pages/common/kubectl-taint.md
+++ b/pages/common/kubectl-taint.md
@@ -1,7 +1,7 @@
 # kubectl taint
 
 > Update the taints on nodes.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_taint>.
 
 - Apply taint to a node:
 

--- a/pages/common/kubectl-wait.md
+++ b/pages/common/kubectl-wait.md
@@ -1,7 +1,7 @@
 # kubectl wait
 
 > Wait for resource(s) to reach a certain state.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_wait>.
 
 - Wait for a deployment to become available:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
