### PR TITLE
semanage-login: add page

### DIFF
--- a/pages/linux/semanage-login.md
+++ b/pages/linux/semanage-login.md
@@ -1,0 +1,29 @@
+# semanage-login
+
+> Manage SELinux login mappings between Linux users and SELinux users.
+> See also: `semanage`, `semanage-user`.
+> More information: <https://manned.org/semanage-login>.
+
+- List all login mappings:
+
+`sudo semanage login {{[-l|--list]}}`
+
+- Add a login mapping (map Linux user to SELinux user):
+
+`sudo semanage login {{[-a|--add]}} {{[-s|--seuser]}} {{user_u}} {{username}}`
+
+- Delete a login mapping:
+
+`sudo semanage login {{[-d|--delete]}} {{username}}`
+
+- Modify an existing login mapping:
+
+`sudo semanage login {{[-m|--modify]}} {{[-s|--seuser]}} {{staff_u}} {{username}}`
+
+- Add a login mapping with a specific MLS/MCS range:
+
+`sudo semanage login {{[-a|--add]}} {{[-s|--seuser]}} {{user_u}} {{[-r|--range]}} {{s0-s0:c0.c1023}} {{username}}`
+
+- List only customized login mappings:
+
+`sudo semanage login {{[-l|--list]}} {{[-C|--locallist]}}`


### PR DESCRIPTION
Adds documentation for the semanage-login command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-python-utils-3.7-8.fc41.noarch