### PR TITLE
semanage-user: add page

### DIFF
--- a/pages/linux/semanage-user.md
+++ b/pages/linux/semanage-user.md
@@ -1,0 +1,29 @@
+# semanage-user
+
+> Manage SELinux user mappings.
+> See also: `semanage`, `semanage-login`.
+> More information: <https://manned.org/semanage-user>.
+
+- List all SELinux users:
+
+`sudo semanage user {{[-l|--list]}}`
+
+- Add a new SELinux user:
+
+`sudo semanage user {{[-a|--add]}} {{[-R|--roles]}} "{{staff_r sysadm_r}}" {{myuser_u}}`
+
+- Delete a SELinux user:
+
+`sudo semanage user {{[-d|--delete]}} {{myuser_u}}`
+
+- Modify an existing SELinux user's roles:
+
+`sudo semanage user {{[-m|--modify]}} {{[-R|--roles]}} "{{staff_r}}" {{user_u}}`
+
+- Add a SELinux user with a specific MLS/MCS range:
+
+`sudo semanage user {{[-a|--add]}} {{[-R|--roles]}} {{user_r}} {{[-r|--range]}} {{s0-s0:c0.c1023}} {{guest_u}}`
+
+- List only customized SELinux users:
+
+`sudo semanage user {{[-l|--list]}} {{[-C|--locallist]}}`


### PR DESCRIPTION
Adds documentation for the semanage-user command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-python-utils-3.7-8.fc41.noarch