### PR TITLE
setfiles: add page

### DIFF
--- a/pages/linux/setfiles.md
+++ b/pages/linux/setfiles.md
@@ -11,16 +11,16 @@
 
 - Set file contexts recursively and show changes:
 
-`sudo setfiles {{[-v|--verbose]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+`sudo setfiles /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}} {{[-v|--verbose]}}`
 
 - Preview what would be changed without actually modifying contexts:
 
-`sudo setfiles {{[-n|--nochange]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+`sudo setfiles /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}} {{[-n|--nochange]}}`
 
 - Set file contexts and verify them:
 
-`sudo setfiles {{[-v|--verbose]}} {{[-F|--force]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+`sudo setfiles /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}} {{[-v|--verbose]}} {{[-F|--force]}}`
 
 - Use a specific root path for context matching:
 
-`sudo setfiles {{[-r|--rootpath]}} {{path/to/old_directory}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/new_directory}}`
+`sudo setfiles /etc/selinux/targeted/contexts/files/file_contexts {{path/to/new_directory}} {{[-r|--rootpath]}} {{path/to/old_directory}}`

--- a/pages/linux/setfiles.md
+++ b/pages/linux/setfiles.md
@@ -23,4 +23,4 @@
 
 - Use a specific root path for context matching:
 
-`sudo setfiles {{[-r|--rootpath]}} {{/old/path}} /etc/selinux/targeted/contexts/files/file_contexts {{/new/path}}`
+`sudo setfiles {{[-r|--rootpath]}} {{path/to/old_directory}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/new_directory}}`

--- a/pages/linux/setfiles.md
+++ b/pages/linux/setfiles.md
@@ -1,0 +1,26 @@
+# setfiles
+
+> Set SELinux file security contexts based on policy rules.
+> Similar to `restorecon` but reads contexts from a file_contexts file.
+> See also: `restorecon`, `semanage-fcontext`, `fixfiles`.
+> More information: <https://manned.org/setfiles>.
+
+- Set file contexts according to the default policy file:
+
+`sudo setfiles /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+
+- Set file contexts recursively and show changes:
+
+`sudo setfiles {{[-v|--verbose]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+
+- Preview what would be changed without actually modifying contexts:
+
+`sudo setfiles {{[-n|--nochange]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+
+- Set file contexts and verify them:
+
+`sudo setfiles {{[-v|--verbose]}} {{[-F|--force]}} /etc/selinux/targeted/contexts/files/file_contexts {{path/to/directory}}`
+
+- Use a specific root path for context matching:
+
+`sudo setfiles {{[-r|--rootpath]}} {{/old/path}} /etc/selinux/targeted/contexts/files/file_contexts {{/new/path}}`


### PR DESCRIPTION
Adds documentation for the setfiles command.

Contributes to #11896

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  policycoreutils-3.7-8.fc41.x86_64