### PR TITLE
docs(kubectl): point More information to generated man pages

### DIFF
--- a/pages/common/kubectl-api-resources.md
+++ b/pages/common/kubectl-api-resources.md
@@ -1,7 +1,7 @@
 # kubectl api-resources
 
 > Print the supported API resources on the server.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#api-resources>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_api-resources/>.
 
 - Print the supported API resources:
 

--- a/pages/common/kubectl-apply.md
+++ b/pages/common/kubectl-apply.md
@@ -2,7 +2,7 @@
 
 > Manage applications through files defining Kubernetes resources.
 > Create and update resources in a cluster.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/>.
 
 - Apply a configuration to a resource by file name:
 

--- a/pages/common/kubectl-auth.md
+++ b/pages/common/kubectl-auth.md
@@ -1,7 +1,7 @@
 # kubectl auth
 
 > Inspect access permissions in a Kubernetes cluster.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#auth>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_auth/>.
 
 - Check if the current user can perform all actions on all resources in a specific namespace:
 

--- a/pages/common/kubectl-autoscale.md
+++ b/pages/common/kubectl-autoscale.md
@@ -1,7 +1,7 @@
 # kubectl autoscale
 
 > Create an autoscaler to intelligently scale pod count based on kubernetes cluster demands.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#autoscale>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_autoscale/>.
 
 - Auto scale a deployment with no target CPU utilization specified:
 

--- a/pages/common/kubectl-config.md
+++ b/pages/common/kubectl-config.md
@@ -3,7 +3,7 @@
 > Manage Kubernetes configuration (kubeconfig) files for accessing clusters via `kubectl` or the Kubernetes API.
 > By default, the Kubernetes will get its configuration from `${HOME}/.kube/config`.
 > See also: `kubectx`, `kubens`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/>.
 
 - Get all contexts in the default kubeconfig file:
 

--- a/pages/common/kubectl-create.md
+++ b/pages/common/kubectl-create.md
@@ -1,7 +1,7 @@
 # kubectl create
 
 > Create a resource from a file or from `stdin`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/>.
 
 - Create a resource using the resource definition file:
 

--- a/pages/common/kubectl-delete.md
+++ b/pages/common/kubectl-delete.md
@@ -1,7 +1,7 @@
 # kubectl delete
 
 > Delete Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/>.
 
 - Delete a specific pod:
 

--- a/pages/common/kubectl-describe.md
+++ b/pages/common/kubectl-describe.md
@@ -1,7 +1,7 @@
 # kubectl describe
 
 > Show details of Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_describe/>.
 
 - Show details of pods in a namespace:
 

--- a/pages/common/kubectl-edit.md
+++ b/pages/common/kubectl-edit.md
@@ -1,7 +1,7 @@
 # kubectl edit
 
 > Edit Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#edit>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_edit/>.
 
 - Edit a pod in the default namespace:
 

--- a/pages/common/kubectl-exec.md
+++ b/pages/common/kubectl-exec.md
@@ -1,7 +1,7 @@
 # kubectl exec
 
 > Execute a command in a container.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#exec>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/>.
 
 - Open Bash in a pod, using the first container by default:
 

--- a/pages/common/kubectl-expose.md
+++ b/pages/common/kubectl-expose.md
@@ -1,7 +1,7 @@
 # kubectl expose
 
 > Expose a resource as a new Kubernetes service.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_expose/>.
 
 - Create a service for a resource, which will be served from container port to node port:
 

--- a/pages/common/kubectl-get.md
+++ b/pages/common/kubectl-get.md
@@ -1,7 +1,7 @@
 # kubectl get
 
 > Get Kubernetes objects and resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get/>.
 
 - Get all namespaces in the current cluster:
 

--- a/pages/common/kubectl-label.md
+++ b/pages/common/kubectl-label.md
@@ -1,7 +1,7 @@
 # kubectl label
 
 > Label Kubernetes resources.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label/>.
 
 - Label a pod:
 

--- a/pages/common/kubectl-logs.md
+++ b/pages/common/kubectl-logs.md
@@ -1,7 +1,7 @@
 # kubectl logs
 
 > Show logs for containers in a pod.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs/>.
 
 - Show logs for a single-container pod:
 

--- a/pages/common/kubectl-replace.md
+++ b/pages/common/kubectl-replace.md
@@ -1,7 +1,7 @@
 # kubectl replace
 
 > Replace a resource by file or `stdin`.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#replace>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_replace/>.
 
 - Replace the resource using the resource definition file:
 

--- a/pages/common/kubectl-rollout.md
+++ b/pages/common/kubectl-rollout.md
@@ -1,7 +1,7 @@
 # kubectl rollout
 
 > Manage the rollout of a Kubernetes resource (deployments, daemonsets, and statefulsets).
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout/>.
 
 - Start a rolling restart of a resource:
 

--- a/pages/common/kubectl-run.md
+++ b/pages/common/kubectl-run.md
@@ -1,7 +1,7 @@
 # kubectl run
 
 > Run pods in Kubernetes. Specifies pod generator to avoid deprecation error in some K8S versions.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run/>.
 
 - Run an nginx pod and expose port 80:
 

--- a/pages/common/kubectl-scale.md
+++ b/pages/common/kubectl-scale.md
@@ -1,7 +1,7 @@
 # kubectl scale
 
 > Set a new size for a deployment, replica set, replication controller, or stateful set.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_scale/>.
 
 - Scale a replica set:
 

--- a/pages/common/kubectl-taint.md
+++ b/pages/common/kubectl-taint.md
@@ -1,7 +1,7 @@
 # kubectl taint
 
 > Update the taints on nodes.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_taint/>.
 
 - Apply taint to a node:
 

--- a/pages/common/kubectl-wait.md
+++ b/pages/common/kubectl-wait.md
@@ -1,7 +1,7 @@
 # kubectl wait
 
 > Wait for resource(s) to reach a certain state.
-> More information: <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait>.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_wait/>.
 
 - Wait for a deployment to become available:
 


### PR DESCRIPTION
## Summary
Updates kubectl command pages to link to the new generated man pages instead of the old `kubectl-commands` summary page.

Related to #17606

## Changes
- Updated 20 kubectl subcommand pages
- Changed links from `https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#<command>` 
- To: `https://kubernetes.io/docs/reference/kubectl/generated/kubectl_<command>/`

## Validation
- ✅ All pages pass `tldr-lint` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)