### PR TITLE
Tldr limine add

### DIFF
--- a/pages/common/limine.md
+++ b/pages/common/limine.md
@@ -35,4 +35,3 @@
 - Update the Limine installation (refresh bootloader files):
 
 `limine update`
-

--- a/pages/common/limine.md
+++ b/pages/common/limine.md
@@ -4,41 +4,35 @@
 > Provides tools for installing, scanning, and managing Limine boot entries.
 > More information: <https://limine-bootloader.org/docs/latest/>.
 
-- Display help information:
-`limine --help`
+- Show installed Limine version:
 
-- Show the installed Limine version:
 `limine --version`
 
 - Install Limine to the default target (auto-detect disk or EFI partition):
+
 `limine install`
 
 - Install Limine to a specific disk device:
-`limine install {{/dev/sdX}}`
+
+`limine install /dev/{{sdX}}`
 
 - Install Limine into a specific EFI directory:
+
 `limine install --efi-dir {{/boot/efi}}`
 
 - Scan system for Limine-compatible boot entries:
+
 `limine scan`
 
-- Enroll a configuration file into the firmware (secure boot):
+- Enroll a configuration file into firmware (Secure Boot):
+
 `limine enroll-config {{/boot/limine.conf}}`
 
 - Reset Limine configuration enrollment:
+
 `limine reset-enroll`
 
-- Generate or update a Limine configuration template:
-`limine config --generate`
-
 - Update the Limine installation (refresh bootloader files):
+
 `limine update`
 
-- View or edit existing boot entries interactively:
-`limine entry-tool --edit`
-
-- Create a new Limine initramfs preset for mkinitcpio:
-`limine mkinitcpio --preset {{preset_name}}`
-
-- Display all Limine subcommands and their usage:
-`limine help`

--- a/pages/common/limine.md
+++ b/pages/common/limine.md
@@ -1,0 +1,44 @@
+# limine
+
+> Limine Bootloader — modular BIOS/UEFI bootloader manager.
+> Provides tools for installing, scanning, and managing Limine boot entries.
+> More information: <https://limine-bootloader.org/docs/latest/>.
+
+- Display help information:
+`limine --help`
+
+- Show the installed Limine version:
+`limine --version`
+
+- Install Limine to the default target (auto-detect disk or EFI partition):
+`limine install`
+
+- Install Limine to a specific disk device:
+`limine install {{/dev/sdX}}`
+
+- Install Limine into a specific EFI directory:
+`limine install --efi-dir {{/boot/efi}}`
+
+- Scan system for Limine-compatible boot entries:
+`limine scan`
+
+- Enroll a configuration file into the firmware (secure boot):
+`limine enroll-config {{/boot/limine.conf}}`
+
+- Reset Limine configuration enrollment:
+`limine reset-enroll`
+
+- Generate or update a Limine configuration template:
+`limine config --generate`
+
+- Update the Limine installation (refresh bootloader files):
+`limine update`
+
+- View or edit existing boot entries interactively:
+`limine entry-tool --edit`
+
+- Create a new Limine initramfs preset for mkinitcpio:
+`limine mkinitcpio --preset {{preset_name}}`
+
+- Display all Limine subcommands and their usage:
+`limine help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page is in the correct platform directory: `pages/common/`.
- [x] The page has at most 8 examples.
- [x] The page description includes a link to the official documentation.
- [x] The page follows the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented :** Latest (`v8.0.0` as per [Limine Docs](https://limine-bootloader.org/docs/latest/))

---

### Summary

Adds a new TLDR page for the **`limine`** bootloader CLI tool.

Includes 8 concise examples covering installation, scanning, configuration enrollment, and update commands.  
References the latest documentation:  
🔗 https://limine-bootloader.org/docs/latest/

---

###  Related Issue
Closes #18405  <!-- This links it directly to the Hacktoberfest master issue -->

---

###  Notes

Limine is a modular BIOS/UEFI bootloader written in C, providing commands for installation, EFI enrollment, scanning boot entries, and system updates.  
This page serves as a general overview for the `limine` command, with subcommands (`limine-install`, `limine-scan`, etc.) to be documented in future pages.