### PR TITLE
pygbag: add page

### DIFF
--- a/pages/common/pygbag.md
+++ b/pages/common/pygbag.md
@@ -1,0 +1,29 @@
+# pygbag
+
+> Build and serve Python projects for the web (WebAssembly) using Emscripten.
+> Used mainly with pygame-based applications.
+> More information: <https://pygame-web.github.io/wiki/pygbag/>.
+
+- Build the current Python project into a web bundle:
+`pygbag build`
+
+- Serve the web bundle locally on port 8000:
+`pygbag serve --port {{8000}}`
+
+- Specify a different directory to serve:
+`pygbag serve {{path/to/build_directory}}`
+
+- Clean previously generated build artifacts:
+`pygbag clean`
+
+- Enable debug mode while serving:
+`pygbag serve --debug`
+
+- Export a project to a distributable zip file:
+`pygbag export`
+
+- Show available templates for web packaging:
+`pygbag --template`
+
+- Display help for all commands:
+`pygbag --help`


### PR DESCRIPTION

- [x] The page is in the correct platform directory: `pages/common/`.
- [x] The page has at most 8 examples.
- [x] The page description includes a link to official documentation.
- [x] The page follows the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** unknown

---

### Summary
Adds a new page for the **`pygbag`** Python-to-WebAssembly bundler.

Includes 8 concise examples for building, serving, cleaning, and exporting projects.  
References the official docs: https://pygame-web.github.io/wiki/pygbag/

### Related issue
Related to #18405

### Notes
`pygbag` converts Python projects (often pygame apps) into WebAssembly to run directly in browsers.  
This TLDR page covers its primary developer commands.