### PR TITLE
expect: add page

### DIFF
--- a/pages/common/expect.md
+++ b/pages/common/expect.md
@@ -1,0 +1,37 @@
+# expect
+
+> Automate interactive command-line programs with scripted responses.
+> Commonly used to automate SSH, FTP, or installer prompts.
+> More information: <https://core.tcl-lang.org/expect/>.
+
+- Run an Expect script file:
+
+`expect {{path/to/script.exp}}`
+
+- Run inline Expect commands:
+
+`expect -c '{{commands}}'`
+
+- Enable debug output to print interactions:
+
+`expect -d {{path/to/script.exp}}`
+
+- Start interactive debugging mode:
+
+`expect -D 1 {{path/to/script.exp}}`
+
+- Read and execute a script in buffered mode:
+
+`expect -b {{path/to/script.exp}}`
+
+- Automate a password prompt (example using `spawn`, `expect`, `send`, `interact`):
+
+`expect -c 'spawn ssh {{user}}@{{host}}; expect "password:"; send "{{password}}\r"; interact'`
+
+- Set a timeout within a script (common pattern):
+
+`expect -c 'set timeout 5; spawn ./script; expect "prompt" { send "reply\r" }'`
+
+- Display help or version information:
+
+`expect --help`


### PR DESCRIPTION


- [x] The page is in the correct platform directory: `pages/common/`.
- [x] The page has at  8 examples.
- [x] The page description includes a link to the official documentation.
- [x] The page follows the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).


---

### Summary
Adds a new TLDR page for the **`expect`** automation tool.

Includes 8 concise examples covering running scripts, inline commands, debugging, passing arguments, and automating password prompts.  
References the official Expect documentation:  
<https://core.tcl-lang.org/expect/>

### Related issue
Related to [#18405](https://github.com/tldr-pages/tldr/issues/18405)

### Notes
`expect` automates interactive command-line programs such as SSH, FTP, or telnet by scripting expected prompts and sending responses.  
This page follows all TLDR contributing guidelines:
- Long-form options where possible  
- Placeholders in `{{curly braces}}` syntax  
- Maximum of 8 examples for readability  

It is placed in the `pages/common/` directory because `expect` is available on most Unix-like systems.  
Official documentation is available at:  
<https://core.tcl-lang.org/expect/>