### PR TITLE
pacinfo: add page

### DIFF
--- a/pages/linux/pacinfo.md
+++ b/pages/linux/pacinfo.md
@@ -1,9 +1,9 @@
 # pacinfo
 
-> Query information about installed packages.
+> Display information about installed packages.
 > More information: <https://github.com/andrewgregory/pacutils/blob/master/doc/pacinfo.pod>.
 
-- Query information about a specific package:
+- Display information about a specific package:
 
 `pacinfo {{package_name}}`
 


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
