### PR TITLE
style-guide: refine argument order

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -449,11 +449,12 @@ Try to keep the following order:
 - Program name
 - Input redirection from a file
 - All subcommands
-- Options/Flags
 - Positional arguments/Packages/Data/...
+- Option flags
+- Options with arguments
 - Output redirection to a file
 
-For example: `systemctl < input_file.txt status --user pipewire > output_file.txt`
+For example: `systemctl < input_file.txt status pipewire --user > output_file.txt`
 
 This is only a suggestion and should be disregarded when program functionality or readability dictates otherwise.
 


### PR DESCRIPTION
As was discussed in https://github.com/tldr-pages/tldr/pull/18484#discussion_r2404785339, it is hard to differentiate between positional arguments and options with arguments when they were mixed like this. This new order does away with that issue.