### PR TITLE
uname: remove redundant example for --nodename

### DIFF
--- a/pages/common/uname.md
+++ b/pages/common/uname.md
@@ -28,10 +28,6 @@
 
 `uname {{[-o|--operating-system]}}`
 
-- Print the current network node host name:
-
-`uname {{[-n|--nodename]}}`
-
 - Display help:
 
 `uname --help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

The page for `uname` contains two identical examples for the `-n|--nodename` flag with slightly different descriptions. Since "system hostname" and "network node hostname" refer to the same thing on modern systems, one of these examples is redundant.
