### PR TITLE
gc: add page

### DIFF
--- a/pages/common/gc.md
+++ b/pages/common/gc.md
@@ -1,7 +1,6 @@
 # gc
 
 > Count nodes, edges, connected components, or clusters in Graphviz `.dot` files.
-> By default, prints number of nodes and edges.
 > More information: <https://graphviz.org/pdf/gc.1.pdf>.
 
 - Count nodes and edges in a file:


### PR DESCRIPTION
Please see issue: #2580 

This PR adds `gc` command which helps ount nodes, edges, connected components, or clusters in Graphviz `.dot` files

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
