### PR TITLE
pyats: update page

### DIFF
--- a/pages/common/pyats.md
+++ b/pages/common/pyats.md
@@ -9,16 +9,16 @@
 
 - Parse the output of a show command from a device:
 
-  `pyats parse "show version" --testbed {{path/to/testbed.yaml}}`
+`pyats parse "show version" --testbed {{path/to/testbed.yaml}}`
 
 - List all available parsers or testbeds:
 
-  `pyats list`
+`pyats list`
 
 - Check the current version:
 
-  `pyats version check`
+`pyats version check`
 
 - Display help for a subcommand:
 
-  `pyats {{subcommand}} --help`
+`pyats {{subcommand}} --help`

--- a/pages/common/pyats.md
+++ b/pages/common/pyats.md
@@ -1,20 +1,24 @@
 # pyats
 
-> A vendor agnostic test automation framework by Cisco Systems, used for network and systems testing.
+> Cisco's vendor-agnostic test automation framework for network and systems validation.
 > More information: <https://developer.cisco.com/pyats/>.
 
-- Run a `pyATS` subcommand:
+- Run a test job from a Python file:
 
-`pyats {{subcommand}}`
+  `pyats run job {{path/to/job_file.py}}`
 
-- Display help:
+- Parse the output of a show command from a device:
 
-`pyats --help`
+  `pyats parse "show version" --testbed {{path/to/testbed.yaml}}`
 
-- Display help about a specific subcommand:
+- List all available parsers or testbeds:
 
-`pyats {{subcommand}} --help`
+  `pyats list`
 
-- Display version:
+- Check the current version:
 
-`pyats version check`
+  `pyats version check`
+
+- Display help for a subcommand:
+
+  `pyats {{subcommand}} --help`

--- a/pages/common/pyats.md
+++ b/pages/common/pyats.md
@@ -5,7 +5,7 @@
 
 - Run a test job from a Python file:
 
-  `pyats run job {{path/to/job_file.py}}`
+`pyats run job {{path/to/job_file.py}}`
 
 - Parse the output of a show command from a device:
 

--- a/pages/common/pyats.md
+++ b/pages/common/pyats.md
@@ -1,7 +1,7 @@
 # pyats
 
 > Cisco's vendor-agnostic test automation framework for network and systems validation.
-> More information: <https://developer.cisco.com/pyats/>.
+> More information: <https://developer.cisco.com/docs/pyats/api/>.
 
 - Run a test job from a Python file:
 


### PR DESCRIPTION
Updated the pyats base page to include clearer usage examples and align with the goal of #18255. I tried multiple cleanup methods (sed, perl, awk), but a few trailing whitespace flags remain — hopefully a quick fix on merge. Thanks!