### PR TITLE
cl, git-{fast-export, sparse-checkout}, systemctl-exit: fix style issues

### DIFF
--- a/pages/common/git-fast-export.md
+++ b/pages/common/git-fast-export.md
@@ -19,6 +19,6 @@
 
 `git fast-export --progress {{n}} --all > {{path/to/file}}`
 
-- Export only a specific subdirectory’s history:
+- Export only a specific subdirectory's history:
 
 `git fast-export --all -- {{path/to/directory}} > {{path/to/file}}`

--- a/pages/common/git-sparse-checkout.md
+++ b/pages/common/git-sparse-checkout.md
@@ -1,6 +1,6 @@
 # git sparse-checkout
 
-> Check out only part of a repository’s files instead of cloning or checking out everything.
+> Check out only part of a repository's files instead of cloning or checking out everything.
 > More information: <https://manned.org/git-sparse-checkout>.
 
 - Enable sparse checkout:

--- a/pages/linux/systemctl-exit.md
+++ b/pages/linux/systemctl-exit.md
@@ -11,6 +11,6 @@
 
 `systemctl --user exit {{code}}`
 
-- Ask the container’s service manager to exit (equivalent of `systemctl poweroff` if not in a container):
+- Ask the container's service manager to exit (equivalent of `systemctl poweroff` if not in a container):
 
 `systemctl exit`

--- a/pages/windows/cl.md
+++ b/pages/windows/cl.md
@@ -25,7 +25,7 @@
 
 - Specify the output directory for compiled files:
 
-`cl /Fo {{path/to/output_directory/}} {{path/to/source.c}}`
+`cl /Fo {{path/to/output_directory}}/ {{path/to/source.c}}`
 
 - Compile with warnings as errors:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
