### PR TITLE
powercfg: add page

### DIFF
--- a/pages/windows/powercfg.md
+++ b/pages/windows/powercfg.md
@@ -1,0 +1,36 @@
+# powercfg
+
+> Configure power settings and manage power schemes.
+> More information: <https://learn.microsoft.com/windows-hardware/design/device-experiences/powercfg-command-line-options>.
+
+- Display the current power scheme:
+
+`powercfg /getactivescheme`
+
+- List all available power schemes:
+
+`powercfg /list`
+
+- Set the active power scheme by its GUID:
+
+`powercfg /setactive {{GUID}}`
+
+- Turn off the display after a specific number of minutes on AC power:
+
+`powercfg /change monitor-timeout-ac {{minutes}}`
+
+- Turn off the display after a specific number of minutes on battery power:
+
+`powercfg /change monitor-timeout-dc {{minutes}}`
+
+- Put the system to sleep after a specific number of minutes on AC power:
+
+`powercfg /change standby-timeout-ac {{minutes}}`
+
+- Generate a system sleep diagnostics report and save it to a file:
+
+`powercfg /sleepstudy /output {{path\to\report.html}}`
+
+- Generate a full power efficiency report and save it to a file:
+
+`powercfg /energy /output {{path\to\report.html}}`


### PR DESCRIPTION
## Add `powercfg` page to Windows section

This PR introduces a new TLDR page for the `powercfg` command, a Windows utility used to manage and configure power settings, including sleep, display timeout, and power schemes.  

The page provides **8 concise examples** covering the most common use cases:  

- Viewing and listing power schemes  
- Setting the active power scheme  
- Configuring display and sleep timeouts for AC and battery power  
- Generating sleep diagnostics and power efficiency reports  

All examples follow TLDR formatting rules with clear placeholders and imperative style, making it easy for users to quickly reference common `powercfg` tasks.  

This addition improves TLDR coverage of Windows-specific power management commands and complements existing pages like `bcdboot` and `choco`.
