### PR TITLE
modprobe: replace deprecated option

### DIFF
--- a/pages.es/linux/modprobe.md
+++ b/pages.es/linux/modprobe.md
@@ -18,7 +18,7 @@
 
 - Elimina un módulo y los que dependen de él desde el núcleo:
 
-`sudo modprobe --remove-dependencies {{nombre_del_módulo}}`
+`sudo modprobe {{[-r|--remove]}} --remove-holders {{nombre_del_módulo}}`
 
 - Muestra las dependencias de un módulo del kernel:
 

--- a/pages.it/linux/modprobe.md
+++ b/pages.it/linux/modprobe.md
@@ -17,7 +17,7 @@
 
 - Rimuove dal kernel un modulo e quelli che dipendono da quest'ultimo:
 
-`sudo modprobe --remove-dependencies {{nome_del_modulo}}`
+`sudo modprobe {{[-r|--remove]}} --remove-holders {{nome_del_modulo}}`
 
 - Mostra le dipendenza di un modulo del kernel:
 

--- a/pages.ko/linux/modprobe.md
+++ b/pages.ko/linux/modprobe.md
@@ -17,7 +17,7 @@
 
 - 모듈과 해당 모듈에 의존하는 모듈을 커널에서 제거:
 
-`sudo modprobe --remove-dependencies {{모듈_이름}}`
+`sudo modprobe {{[-r|--remove]}} --remove-holders {{모듈_이름}}`
 
 - 커널 모듈의 의존성 표시:
 

--- a/pages/linux/modprobe.md
+++ b/pages/linux/modprobe.md
@@ -18,7 +18,7 @@
 
 - Remove a module and those that depend on it from the kernel:
 
-`sudo modprobe --remove-dependencies {{module_name}}`
+`sudo modprobe {{[-r|--remove]}} --remove-holders {{module_name}}`
 
 - Show a kernel module's dependencies:
 


### PR DESCRIPTION
From `modprobe --help`:

```
--remove-dependencies   Deprecated: use --remove-holders
--remove-holders        Also remove module holders (use together with -r)
```

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 34.2
