### PR TITLE
crush: add Italian translation

### DIFF
--- a/pages.it/common/crush.md
+++ b/pages.it/common/crush.md
@@ -1,0 +1,29 @@
+# crush
+
+> Assistente da terminale basato su IA per attività di sviluppo software.
+> Fornisce un'interfaccia di chat interattiva con funzionalità di intelligenza artificiale, analisi del codice e integrazione LSP.
+> Maggiori informazioni: <https://github.com/charmbracelet/crush>.
+
+- Avvia la modalità interattiva:
+
+`crush`
+
+- Esegui con log di debug attivi:
+
+`crush {{[-d|--debug]}}`
+
+- Esegui con log di debug in una directory specifica:
+
+`crush {{[-d|--debug]}} {{[-c|--cwd]}} {{percorso/al/progetto}}`
+
+- Esegui un prompt singolo in modalità non interattiva:
+
+`crush run "{{Spiega l'uso del contesto in Go}}"`
+
+- Esegui in modalità pericolosa (accetta automaticamente tutti i permessi):
+
+`crush {{[-y|--yolo]}}`
+
+- Mostra la versione:
+
+`crush {{[-v|--version]}}`


### PR DESCRIPTION
### Add Italian translation for crush (common)

- Added `pages.it/common/crush.md` with Italian translation.  
- Preserved structure and examples from the English page.  

- [x] The page is in the correct platform directory: `common`.  
- [x] The page has at most 8 examples.  
- [x] The page description has links to documentation.  
- [x] The page follows the content guidelines.  
- [x] The page follows the style guide.  
- [x] The PR title follows the recommended template.
