### PR TITLE
chpasswd: add Italian translation

### DIFF
--- a/pages.it/linux/chpasswd.md
+++ b/pages.it/linux/chpasswd.md
@@ -1,0 +1,20 @@
+# chpasswd
+
+> Cambia le password di più utenti utilizzando `stdin`.
+> Maggiori informazioni: <https://manned.org/chpasswd.8>.
+
+- Cambia la password di un utente specifico:
+
+`printf "{{username}}:{{new_password}}" | sudo chpasswd`
+
+- Cambia le password di più utenti (il testo in input non deve contenere spazi):
+
+`printf "{{username_1}}:{{new_password_1}}\n{{username_2}}:{{new_password_2}}" | sudo chpasswd`
+
+- Cambia la password di un utente specifico, specificandola in forma crittografata:
+
+`printf "{{username}}:{{new_encrypted_password}}" | sudo chpasswd --encrypted`
+
+- Cambia la password di un utente specifico e utilizza un metodo di crittografia specifico:
+
+`printf "{{username}}:{{new_password}}" | sudo chpasswd --crypt-method {{NONE|DES|MD5|SHA256|SHA512}}`


### PR DESCRIPTION
### Add Italian translation for chpasswd (linux)

- Added `pages.it/linux/chpasswd.md` with Italian translation.  
- Preserved structure and examples from the English page.  

- [x] The page is in the correct platform directory: `linux`.  
- [x] The page has at most 8 examples.  
- [x] The page description has links to documentation.  
- [x] The page follows the content guidelines.  
- [x] The page follows the style guide.  
- [x] The PR title follows the recommended template.
