### PR TITLE
 dnf-versionlock: add page

### DIFF
--- a/pages/linux/dnf-versionlock.md
+++ b/pages/linux/dnf-versionlock.md
@@ -5,6 +5,10 @@
 > See also: `dnf`.
 > More information: <https://dnf-plugins-core.readthedocs.io/en/latest/versionlock.html>.
 
+- List the current versionlock entries:
+
+`dnf versionlock`
+
 - Add a versionlock for all available packages matching the spec:
 
 `dnf versionlock add {{package}}`
@@ -12,10 +16,6 @@
 - Add an exclude (within versionlock) for the available packages matching the spec:
 
 `dnf versionlock exclude {{package}}`
-
-- List the current versionlock entries.:
-
-`dnf versionlock list`
 
 - Remove any matching versionlock entries:
 


### PR DESCRIPTION
Added dnf versionlock


-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
