### PR TITLE
systemctl-list-timers: add page

### DIFF
--- a/pages/linux/systemctl-list-timers.md
+++ b/pages/linux/systemctl-list-timers.md
@@ -15,6 +15,6 @@
 
 `systemctl list-timers {{pattern}}`
 
-- List timers matching a specific state (e.g., active, failed):
+- List timers matching a specific state:
 
-`systemctl list-timers --state {{state}}`
+`systemctl list-timers --state {{active|inactive|failed|...}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
