### PR TITLE
sc: update page

### DIFF
--- a/pages/windows/sc.md
+++ b/pages/windows/sc.md
@@ -5,16 +5,24 @@
 
 - Show the status of a service (no service name will list all services):
 
-`sc.exe query {{service_name}}`
+`sc query {{service_name}}`
 
 - Start a service asynchronously:
 
-`sc.exe create {{service_name}} binpath= {{path\to\service_binary_file}}`
+`sc start {{service_name}}`
 
 - Stop a service asynchronously:
 
-`sc.exe delete {{service_name}}`
+`sc stop {{service_name}}`
+
+- Create a service:
+
+`sc create {{service_name}} binpath= {{path\to\service_binary_file}}`
+
+- Delete a service:
+
+`sc delete {{service_name}}`
 
 - Set the type of a service:
 
-`sc.exe config {{service_name}} type= {{service_type}}`
+`sc config {{service_name}} type= {{service_type}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

This partially reverts 905f5f4da0a3df5cc818b2fd5af78b40fc7bff83. The part about `sc` was messed up a little bit. This command has all these subcommands (start, stop, create, delete) and many others, in fact. And there's no need to use the `.exe` file extension in the command name.