### PR TITLE
dnf-reposync: add page

### DIFF
--- a/pages/linux/dnf-reposync.md
+++ b/pages/linux/dnf-reposync.md
@@ -5,7 +5,7 @@
 > See also: `dnf`.
 > More information: <https://dnf-plugins-core.readthedocs.io/en/latest/reposync.html>.
 
-- Synchronize all packages from the repository with id `repo_name`. The synchronized copy is saved in `repo_name` subdirectory of the current working directory:
+- Synchronize all packages from the repository with id `repo_name` to a subdirectory `repo_name` of the current working directory:
 
 `dnf reposync --repoid {{repo_name}}`
 
@@ -21,7 +21,7 @@
 
 `dnf reposync --repoid {{repo_name}} {{[-n|--newest-only]}}`
 
-- Print just urls of what would be downloaded, don’t download:
+- Just print URLs of what would be downloaded, don’t download:
 
 `dnf reposync --repoid {{repo_name}} {{[-u|--urls]}}`
 


### PR DESCRIPTION
Added dnf-reposync


- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
