### PR TITLE
git-get-tar-commit-id: add page

### DIFF
--- a/pages/common/git-get-tar-commit-id.md
+++ b/pages/common/git-get-tar-commit-id.md
@@ -5,4 +5,4 @@
 
 - Extract commit hash ID or quietly exit with a return code of 1:
 
-`git get-tar-commit-id < {{path/to/archive.tar}}`
+`git < {{path/to/archive.tar}} get-tar-commit-id`


### PR DESCRIPTION
Addresses #3953 .

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): git-get-tar-commit-id last updated in 2.43.0**
