### PR TITLE
adb-disconnect: delete page

### DIFF
--- a/pages/common/adb-disconnect.md
+++ b/pages/common/adb-disconnect.md
@@ -1,7 +1,0 @@
-# adb disconnect
-
-> This command has been moved to `adb connect`.
-
-- View documentation for `adb disconnect`:
-
-`tldr adb connect`


### PR DESCRIPTION
Delete adb-disconnect file, as the command has already been moved to adb-connect.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
Relates to adb-connect and adb-disconnect in #13997 