### PR TITLE
apt-install: add Bengali translation

### DIFF
--- a/pages.bn/linux/apt-install.md
+++ b/pages.bn/linux/apt-install.md
@@ -9,4 +9,4 @@
 
 - ইনস্টল বা আপডেটের সময় বিস্তারিত ভার্সন তথ্য (verbose version info) দেখতে:
 
-`sudo apt install {{[-V|--verbose-versions]}} {{package}}`
+`sudo apt install {{[-V|--verbose-versions]}} {{প্যাকেজ}}`


### PR DESCRIPTION
## Description

I have localized apt-install command to Bengali (বাংলা). All markdown formatting issues have been fixed to comply with the tldr-pages style guide.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** apt 2.x (Debian/Ubuntu package manager)


## Pages Added

1. `pages.bn/linux/apt-install.md`