### PR TITLE
llvm-diff: add page

### DIFF
--- a/pages/common/llvm-diff.md
+++ b/pages/common/llvm-diff.md
@@ -1,0 +1,24 @@
+# llvm-diff
+
+> Compare the structure of two LLVM modules.
+> More information: <https://llvm.org/docs/CommandGuide/llvm-diff.html>.
+
+- Compare two LLVM assembly files:
+
+`llvm-diff {{path/to/file1.ll}} {{path/to/file2.ll}}`
+
+- Compare two LLVM bitcode files:
+
+`llvm-diff {{path/to/file1.bc}} {{path/to/file2.bc}}`
+
+- Compare specific functions between two modules:
+
+`llvm-diff {{path/to/file1.ll}} {{path/to/file2.ll}} --function={{function_name}}`
+
+- Compare all global values between two modules:
+
+`llvm-diff {{path/to/file1.ll}} {{path/to/file2.ll}} --globals`
+
+- Display help:
+
+`llvm-diff --help`


### PR DESCRIPTION
This PR adds documentation for the `llvm-diff` command as requested in issue #6367.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** LLVM 19 (latest)

Fixes #6367 (partial - documents llvm-diff from the LLVM command list)