### PR TITLE
kubectl-cordon: add page

### DIFF
--- a/pages/common/kubectl-cordon.md
+++ b/pages/common/kubectl-cordon.md
@@ -10,8 +10,8 @@
 
 - Mark multiple nodes as unschedulable:
 
-`kubectl cordon {{node_name1}} {{node_name2}} {{...}}`
+`kubectl cordon {{node_name1 node_name2 ...}}`
 
 - Mark a node using a specific kubeconfig context as unschedulable:
 
-`kubectl --context {{context_name}} cordon {{node_name}}`
+`kubectl cordon --context {{context_name}} {{node_name}}`


### PR DESCRIPTION
Adds documentation for the `kubectl cordon` subcommand that marks nodes as unschedulable.

Closes part of #17606 (kubectl cluster management commands).

### Changes
- Created `pages/common/kubectl-cordon.md` with 3 common examples
- Follows style guide: imperative mood, GNU-style long options, placeholder syntax
- Includes cross-reference to `kubectl uncordon` in description

### Examples
- Mark a node as unschedulable
- Mark multiple nodes
- Use a specific kubeconfig context