### PR TITLE
kubectl-uncordon: add page

### DIFF
--- a/pages/common/kubectl-uncordon.md
+++ b/pages/common/kubectl-uncordon.md
@@ -9,8 +9,8 @@
 
 - Make multiple nodes schedulable again:
 
-`kubectl uncordon {{node_name1}} {{node_name2}} {{...}}`
+`kubectl uncordon {{node_name1 node_name2 ...}}`
 
 - Use a specific kubeconfig context when uncordoning:
 
-`kubectl --context {{context_name}} uncordon {{node_name}}`
+`kubectl uncordon {{node_name}} --context {{context_name}}`


### PR DESCRIPTION
Adds documentation for the `kubectl uncordon` subcommand that marks nodes as schedulable again.

Closes part of #17606 (kubectl cluster management commands).

### Changes
- Created `pages/common/kubectl-uncordon.md` with 3 common examples
- Complements the `kubectl cordon` page
- Follows repository style guide conventions

### Examples
- Make a node schedulable again
- Make multiple nodes schedulable
- Use a specific kubeconfig context