### PR TITLE
kubectl-drain: add page

### DIFF
--- a/pages/common/kubectl-drain.md
+++ b/pages/common/kubectl-drain.md
@@ -22,4 +22,4 @@
 
 - Drain nodes selected by a label selector:
 
-`kubectl drain --selector {{key}}={{value}}`
+`kubectl drain {{[-l|--selector]}} {{key}}={{value}}`


### PR DESCRIPTION
Adds documentation for the `kubectl drain` subcommand used for node maintenance.

Closes part of #17606 (kubectl cluster management commands).

### Changes
- Created `pages/common/kubectl-drain.md` with 5 practical examples
- Covers common maintenance scenarios: basic drain, force delete, emptyDir handling
- Includes control-plane node example and label selector usage
- Follows style guide: imperative mood, clear descriptions, proper placeholder syntax

### Examples
- Drain a node with PodDisruptionBudgets
- Force delete standalone pods
- Delete pods using emptyDir volumes
- Drain control-plane nodes
- Drain by label selector