### PR TITLE
kubectl-cluster-info: add page

### DIFF
--- a/pages/common/kubectl-cluster-info.md
+++ b/pages/common/kubectl-cluster-info.md
@@ -17,4 +17,4 @@
 
 - Use a specific kubeconfig context:
 
-`kubectl --context {{context_name}} cluster-info`
+`kubectl cluster-info --context {{context_name}}`


### PR DESCRIPTION
Adds documentation for the `kubectl cluster-info` subcommand.

Closes part of #17606 (kubectl cluster management commands).

### Changes
- Created `pages/common/kubectl-cluster-info.md` with 4 useful examples
- Covers basic cluster info display and debugging dump operations
- Follows style guide conventions

### Examples
- Show basic cluster information
- Dump cluster state to stdout
- Dump to a directory
- Use specific kubeconfig context