### PR TITLE
kubectl-completion: add page

### DIFF
--- a/pages/common/kubectl-completion.md
+++ b/pages/common/kubectl-completion.md
@@ -1,0 +1,28 @@
+# kubectl completion
+
+> Generate shell completion scripts for kubectl commands.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/>.
+
+- Generate Bash completion script:
+
+`kubectl completion bash`
+
+- Load Bash completions in the current shell session:
+
+`source <(kubectl completion bash)`
+
+- Generate Zsh completion script:
+
+`kubectl completion zsh`
+
+- Load Zsh completions in the current shell session:
+
+`source <(kubectl completion zsh)`
+
+- Generate Fish completion script:
+
+`kubectl completion fish`
+
+- Generate PowerShell completion script:
+
+`kubectl completion powershell`


### PR DESCRIPTION
Adds documentation for `kubectl completion` command.

**Examples included:**
- Generate bash completion
- Generate zsh completion
- Generate fish completion
- Generate PowerShell completion
- Load bash completion immediately
- Load zsh completion immediately

#17606