### PR TITLE
kubectl-proxy: add page

### DIFF
--- a/pages/common/kubectl-proxy.md
+++ b/pages/common/kubectl-proxy.md
@@ -1,0 +1,24 @@
+# kubectl proxy
+
+> Create a proxy server between localhost and the Kubernetes API server.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_proxy/>.
+
+- Start a proxy server on the default port (8001):
+
+`kubectl proxy`
+
+- Start a proxy server on a specific port:
+
+`kubectl proxy --port {{9000}}`
+
+- Accept connections from all interfaces (not just localhost):
+
+`kubectl proxy --address {{0.0.0.0}} --accept-hosts '{{.*}}'`
+
+- Start proxy and reject paths matching a regex:
+
+`kubectl proxy --reject-paths {{'^/api/.*/pods/.*'}}`
+
+- Start proxy with a specific API prefix:
+
+`kubectl proxy --api-prefix {{/custom/}}`


### PR DESCRIPTION
Adds documentation for `kubectl proxy` command.

**Examples included:**
- Start proxy on default port
- Start proxy on custom port
- Accept connections from all addresses
- Reject non-localhost requests
- Set custom API prefix

Fixes #17606