### PR TITLE
poetry-build: add page

### DIFF
--- a/pages/common/poetry-build.md
+++ b/pages/common/poetry-build.md
@@ -1,0 +1,24 @@
+# poetry build
+
+> Build a Poetry package as a tarball and a wheel.
+> More information: <https://python-poetry.org/docs/cli/#build>.
+
+- Build the package in the default format (sdist and wheel):
+
+`poetry build`
+
+- Build only the wheel package:
+
+`poetry build --format {{wheel}}`
+
+- Build only the source distribution (sdist):
+
+`poetry build --format {{sdist}}`
+
+- Build the package and output to a specific directory:
+
+`poetry build --output {{path/to/directory}}`
+
+- Display help:
+
+`poetry build --help`


### PR DESCRIPTION
Adds documentation for `poetry build` command.

**Examples included:**
- Build package in both formats (wheel and sdist)
- Build only wheel format
- Build only sdist format
- Build with verbose output
- Build using specific format

#18042