### PR TITLE
poetry-export: add page

### DIFF
--- a/pages/common/poetry-export.md
+++ b/pages/common/poetry-export.md
@@ -1,0 +1,28 @@
+# poetry export
+
+> Export Poetry's lock file to other formats.
+> More information: <https://python-poetry.org/docs/cli/#export>.
+
+- Export dependencies to a requirements.txt file:
+
+`poetry export --output {{requirements.txt}}`
+
+- Export dependencies including development dependencies:
+
+`poetry export --dev --output {{requirements-dev.txt}}`
+
+- Export dependencies without hashes:
+
+`poetry export --without-hashes --output {{requirements.txt}}`
+
+- Export dependencies for a specific format:
+
+`poetry export --format {{requirements.txt}} --output {{requirements.txt}}`
+
+- Export only specific dependency groups:
+
+`poetry export --only {{main}} --output {{requirements.txt}}`
+
+- Display help:
+
+`poetry export --help`


### PR DESCRIPTION
Adds documentation for `poetry export` command.

**Examples included:**
- Export dependencies to requirements.txt
- Export with hashes
- Export development dependencies
- Export without hashes
- Export specific extras group
- Export to custom file

#18042