### PR TITLE
poetry-new: add page

### DIFF
--- a/pages/common/poetry-new.md
+++ b/pages/common/poetry-new.md
@@ -1,0 +1,24 @@
+# poetry new
+
+> Create a new Python project with a standard project structure.
+> More information: <https://python-poetry.org/docs/cli/#new>.
+
+- Create a new project with the standard layout:
+
+`poetry new {{project_name}}`
+
+- Create a new project with a source layout (src/ directory):
+
+`poetry new {{project_name}} --src`
+
+- Create a new project with a specific name (different from the directory):
+
+`poetry new {{project_name}} --name {{package_name}}`
+
+- Create a new project and include a README file in a specific format:
+
+`poetry new {{project_name}} --readme {{md}}`
+
+- Display help:
+
+`poetry new --help`


### PR DESCRIPTION
Adds documentation for `poetry new` command.

**Examples included:**
- Create new project with default structure
- Create new project with src layout
- Create project with specific name
- Create project without tests
- Create project with custom readme

#18042