### PR TITLE
kubectl-kustomize: add page

### DIFF
--- a/pages/common/kubectl-kustomize.md
+++ b/pages/common/kubectl-kustomize.md
@@ -11,10 +11,6 @@
 
 `kubectl kustomize {{path/to/directory}}`
 
-- Build resources and display the output:
-
-`kubectl kustomize {{path/to/directory}} | less`
-
 - Build resources from a remote URL:
 
 `kubectl kustomize {{https://github.com/user/repo/path}}`
@@ -25,4 +21,4 @@
 
 - Build resources with load restrictor disabled:
 
-`kubectl kustomize --load-restrictor={{LoadRestrictionsNone}} {{path/to/directory}}`
+`kubectl kustomize --load-restrictor {{LoadRestrictionsNone}} {{path/to/directory}}`


### PR DESCRIPTION
Adds documentation for the `kubectl kustomize` command.

This command builds Kubernetes resources using a kustomization file, which is essential for managing configurations across different environments.

**Examples included:**
- Build resources from current/specific directory
- Display output with pipe to less
- Build from remote URLs
- Save output to file
- Use load restrictor options

**Documentation reference:** https://kubernetes.io/docs/reference/kubectl/generated/kubectl_kustomize/