### PR TITLE
grub-probe: add page

### DIFF
--- a/pages/linux/grub-probe.md
+++ b/pages/linux/grub-probe.md
@@ -29,4 +29,4 @@
 
 - Probe using a custom device map:
 
-`sudo grub-probe {{[-m|--device-map]}} {{path/to/custom_device.map}} {{[-t|--target]}} drive {{/boot/grub}}`
+`sudo grub-probe {{[-t|--target]}} drive {{/boot/grub}} {{[-m|--device-map]}} {{path/to/custom_device.map}}`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).