### PR TITLE
sc-*: remove subcommand pages marked as alias to the main command

### DIFF
--- a/pages/windows/sc-config.md
+++ b/pages/windows/sc-config.md
@@ -1,7 +1,0 @@
-# sc config
-
-> This command is an alias of `sc.exe config`.
-
-- View documentation for the original command:
-
-`tldr sc`

--- a/pages/windows/sc-create.md
+++ b/pages/windows/sc-create.md
@@ -1,7 +1,0 @@
-# sc create
-
-> This command is an alias of `sc.exe create`.
-
-- View documentation for the original command:
-
-`tldr sc`

--- a/pages/windows/sc-delete.md
+++ b/pages/windows/sc-delete.md
@@ -1,7 +1,0 @@
-# sc delete
-
-> This command is an alias of `sc.exe delete`.
-
-- View documentation for the original command:
-
-`tldr sc`

--- a/pages/windows/sc-query.md
+++ b/pages/windows/sc-query.md
@@ -1,7 +1,0 @@
-# sc query
-
-> This command is an alias of `sc.exe query`.
-
-- View documentation for the original command:
-
-`tldr sc`


### PR DESCRIPTION
These subcommands were marked as aliases to the main command, which can't be the case. I guess it was made by mistake. These subcommands don't have many different use-cases, so it should be reasonable to keep them all in the main comand's page. 

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
