### PR TITLE
Expand-Archive: add page

### DIFF
--- a/pages/windows/expand-archive.md
+++ b/pages/windows/expand-archive.md
@@ -5,12 +5,12 @@
 
 - Extract a ZIP file to a folder:
 
-`Expand-Archive -Path "{{path\to\example.zip}}" -DestinationPath "{{path\to\extracted_files}}"`
+`Expand-Archive -Path {{path\to\example.zip}} -DestinationPath {{path\to\extracted_files}}`
 
 - Overwrite existing files:
 
-`Expand-Archive -Path "{{path\to\example.zip}}" -DestinationPath "{{path\to\extracted_files}}" -Force`
+`Expand-Archive -Path {{path\to\example.zip}} -DestinationPath {{path\to\extracted_files}} -Force`
 
 - Preview without extracting:
 
-`Expand-Archive -Path "{{path\to\example.zip}}" -DestinationPath "{{path\to\extracted_files}}" -WhatIf`
+`Expand-Archive -Path {{path\to\example.zip}} -DestinationPath {{path\to\extracted_files}} -WhatIf`


### PR DESCRIPTION
This PR adds a new tldr page for the PowerShell cmdlet Expand-Archive which is used to extract files from a compressed archive (ZIP) to a specified directory.

Includes examples for:
- Extracting a ZIP file to a folder
- Overwriting existing files 
- Previewing extraction 