### PR TITLE
intercept, apparmor_parser, tspin: enclose stdout in backtics

### DIFF
--- a/pages/common/tspin.md
+++ b/pages/common/tspin.md
@@ -7,7 +7,7 @@
 
 `tspin {{path/to/application.log}}`
 
-- Read from another command and print to stdout:
+- Read from another command and print to `stdout`:
 
 `journalctl {{[-b|--boot]}} {{[-f|--follow]}} | tspin`
 

--- a/pages/linux/apparmor_parser.md
+++ b/pages/linux/apparmor_parser.md
@@ -23,7 +23,7 @@
 
 `apparmor_parser {{[-p|--preprocess]}} {{[-o|--ofile]}} {{path/to/output.cache}} {{[-Q|--skip-kernel-load]}} {{path/to/profile}}`
 
-- Preprocess and print binary profile to stdout without loading:
+- Preprocess and print binary profile to `stdout` without loading:
 
 `apparmor_parser {{[-p|--preprocess]}} {{[-S|--stdout]}} {{[-Q|--skip-kernel-load]}} {{path/to/profile}}`
 

--- a/pages/linux/intercept.md
+++ b/pages/linux/intercept.md
@@ -1,6 +1,6 @@
 # intercept
 
-> Read raw input events from a specified input event device and redirect it to stdout.
+> Read raw input events from a specified input event device and redirect it to `stdout`.
 > More information: <https://gitlab.com/interception/linux/tools/-/tree/master#intercept>.
 
 - Read and output raw input events from a given input device file (the system will not see any key presses):


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
