### PR TITLE
scripts/_common.py: exclude symlinks when obtaining pages directories

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -102,7 +102,9 @@ def get_pages_dir(root: Path) -> list[Path]:
     list (list of Path's): Path's of page entry and platform, e.g. "page.fr/common".
     """
 
-    return [d for d in root.iterdir() if d.name.startswith("pages") and not d.is_symlink()]
+    return [
+        d for d in root.iterdir() if d.name.startswith("pages") and not d.is_symlink()
+    ]
 
 
 def test_get_pages_dir():


### PR DESCRIPTION
Fixes #18653. This change doesn't affect `set-more-info-link.py` and `set-page-title.py` (where this function is also used),  because the [`Path.exists()`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.exists) method that is (indirectly) being used in these scripts resolves symlinks by default. 