### PR TITLE
ss: add page

### DIFF
--- a/pages/common/ss.md
+++ b/pages/common/ss.md
@@ -1,0 +1,37 @@
+# ss
+
+> Display socket statistics.
+> A modern replacement for netstat.
+> More information: <https://man7.org/linux/man-pages/man8/ss.8.html>.
+
+- Display all TCP sockets:
+
+`ss -t`
+
+- Display all listening sockets:
+
+`ss -l`
+
+- Display all TCP sockets with process names:
+
+`ss -tp`
+
+- Display listening TCP and UDP sockets with numeric addresses:
+
+`ss -tuln`
+
+- Display only IPv4 sockets:
+
+`ss -4`
+
+- Display only IPv6 sockets:
+
+`ss -6`
+
+- Display sockets using a specific port:
+
+`ss -at '( dport = :{{port}} or sport = :{{port}} )'`
+
+- Display summary statistics:
+
+`ss -s`


### PR DESCRIPTION
Add page for `ss` command - socket statistics utility and modern netstat replacement.

Related to util-linux commands missing from tldr.
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
