### PR TITLE
lsblk: add page

### DIFF
--- a/pages/common/lsblk.md
+++ b/pages/common/lsblk.md
@@ -1,0 +1,36 @@
+# lsblk
+
+> List information about block devices.
+> More information: <https://man7.org/linux/man-pages/man8/lsblk.8.html>.
+
+- List all block devices in a tree format:
+
+`lsblk`
+
+- List all block devices including empty ones:
+
+`lsblk -a`
+
+- Show filesystem information:
+
+`lsblk -f`
+
+- Use ASCII characters for tree formatting:
+
+`lsblk -i`
+
+- Show block device owner, group and mode:
+
+`lsblk -m`
+
+- Show device full path:
+
+`lsblk -p`
+
+- Show size in bytes rather than human-readable format:
+
+`lsblk -b`
+
+- Display information about a specific device:
+
+`lsblk {{/dev/sda}}`


### PR DESCRIPTION
Add page for `lsblk` command - lists information about block devices.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
