### PR TITLE
docker-compose-up: add page

### DIFF
--- a/pages/common/docker-compose-up.md
+++ b/pages/common/docker-compose-up.md
@@ -1,36 +1,36 @@
-# docker-compose up
+# docker compose up
 
 > Start and run Docker services defined in a Compose file.
 > More information: <https://docs.docker.com/compose/reference/up/>.
 
 - Start all services defined in the docker-compose file:
 
-`docker-compose up`
+`docker compose up`
 
 - Start services in the background (detached mode):
 
-`docker-compose up {{[-d|--detach]}}`
+`docker compose up {{[-d|--detach]}}`
 
 - Start services and rebuild images before starting:
 
-`docker-compose up --build`
+`docker compose up --build`
 
 - Start specific services only:
 
-`docker-compose up {{service1 service2 ...}}`
+`docker compose up {{service1 service2 ...}}`
 
 - Start services with custom compose file:
 
-`docker-compose {{[-f|--file]}} {{path/to/docker-compose.yml}} up`
+`docker compose {{[-f|--file]}} {{path/to/docker-compose.yml}} up`
 
 - Start services and remove orphaned containers:
 
-`docker-compose up --remove-orphans`
+`docker compose up --remove-orphans`
 
 - Start services with scaled instances:
 
-`docker-compose up --scale {{service}}={{count}}`
+`docker compose up --scale {{service}}={{count}}`
 
 - Start services and show logs with timestamps:
 
-`docker-compose up --timestamps`
+`docker compose up --timestamps`


### PR DESCRIPTION
Add page for `docker-compose up` command - start and run Docker services defined in a Compose file.
This is a commonly used Docker Compose command that was missing from the tldr collection.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
