### PR TITLE
apt-show: add page

### DIFF
--- a/pages/linux/apt-show.md
+++ b/pages/linux/apt-show.md
@@ -1,0 +1,36 @@
+# apt show
+
+> Display detailed information about packages.
+> More information: <https://manpages.ubuntu.com/manpages/jammy/man8/apt.8.html>.
+
+- Show information about a package:
+
+`apt show {{package}}`
+
+- Show information about multiple packages:
+
+`apt show {{package1 package2}}`
+
+- Show information about all available versions of a package:
+
+`apt show {{package}} -a`
+
+- Show only the package description:
+
+`apt show {{package}} | grep -A5 "Description"`
+
+- Show package information without asking for confirmation:
+
+`apt show {{package}} -qq`
+
+- Show information about an installed package:
+
+`apt show {{package}} --installed`
+
+- Show package information and dependencies:
+
+`apt show {{package}} | grep -E "(Depends|Recommends|Suggests)"`
+
+- Show package size information:
+
+`apt show {{package}} | grep -E "(Download-Size|Installed-Size)"`


### PR DESCRIPTION
Add page for `apt show` command - display detailed information about packages.

This command is commonly used by Ubuntu/Debian users to get package details before installation and was missing from the tldr collection.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
