### PR TITLE
dnf-search: add page

### DIFF
--- a/pages/linux/dnf-search.md
+++ b/pages/linux/dnf-search.md
@@ -1,0 +1,36 @@
+# dnf search
+
+> Search for packages in repositories using DNF package manager.
+> More information: <https://dnf.readthedocs.io/en/latest/command_ref.html#search-command>.
+
+- Search for packages by name:
+
+`dnf search {{package_name}}`
+
+- Search for packages by name or summary:
+
+`dnf search {{keyword}}`
+
+- Search in all fields including description:
+
+`dnf search --all {{keyword}}`
+
+- Search for packages with exact name match:
+
+`dnf search --exact {{package_name}}`
+
+- Search for packages in a specific repository:
+
+`dnf search --repo {{repository_name}} {{package_name}}`
+
+- Search for packages and show detailed information:
+
+`dnf search --verbose {{package_name}}`
+
+- Search for packages containing specific files:
+
+`dnf search --file {{/path/to/file}}`
+
+- Search for packages but only display package names:
+
+`dnf search --quiet {{package_name}}`


### PR DESCRIPTION
Add page for dnf search command to search for packages in repositories.

This command is commonly used by Fedora/RHEL/CentOS users to find packages before installation and was missing from the tldr collection.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
