### PR TITLE
apt-search: add page

### DIFF
--- a/pages/linux/apt-search.md
+++ b/pages/linux/apt-search.md
@@ -1,0 +1,36 @@
+# apt search
+
+> Search for packages in repositories using APT package manager.
+> More information: <https://manpages.ubuntu.com/manpages/jammy/man8/apt.8.html>.
+
+- Search for packages by name:
+
+`apt search {{package_name}}`
+
+- Search for packages by name or description:
+
+`apt search {{keyword}}`
+
+- Search for packages with exact name match:
+
+`apt search {{^package_name$}}`
+
+- Search for packages and show only package names:
+
+`apt search {{keyword}} --names-only`
+
+- Search for packages in a specific section:
+
+`apt search {{keyword}} | grep "{{section}}"`
+
+- Search for packages and show detailed information:
+
+`apt search {{keyword}} --full`
+
+- Search for packages using regular expressions:
+
+`apt search "{{pattern.*}}`
+
+- Search for installed packages only:
+
+`apt search {{keyword}} --installed`


### PR DESCRIPTION
Add page for `apt search` command - search for packages in repositories using APT package manager.

This command is commonly used by Ubuntu/Debian users to find packages before installation and complements the existing apt-show page.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
