### PR TITLE
kaggle-models: add page

### DIFF
--- a/pages/common/kaggle-models.md
+++ b/pages/common/kaggle-models.md
@@ -1,0 +1,28 @@
+# kaggle models
+
+> Manage Kaggle models and their instances.
+> More information: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#models>.
+
+- List models filtered by a search term and sort by download count:
+
+`kaggle models list -s {{search_term}} --sort-by {{downloadCount}}`
+
+- Download a model's metadata into a directory:
+
+`kaggle models get {{owner/model_name}} -p {{path/to/directory}}`
+
+- Initialize model metadata in the current directory:
+
+`kaggle models init`
+
+- Create a new model using the prepared metadata:
+
+`kaggle models create -p {{path/to/model_directory}}`
+
+- Update an existing model with edited metadata:
+
+`kaggle models update -p {{path/to/model_directory}}`
+
+- Delete a model by its owner and slug:
+
+`kaggle models delete {{owner/model_name}}`


### PR DESCRIPTION
Adds a new TLDR page for kaggle models.

Refs tldr-pages#18897, tldr-pages#18405.

More information: https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#models.
