### PR TITLE
kaggle-config: add page

### DIFF
--- a/pages/common/kaggle-config.md
+++ b/pages/common/kaggle-config.md
@@ -1,0 +1,24 @@
+# kaggle config
+
+> View and edit Kaggle CLI configuration values.
+> More information: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#config>.
+
+- Display the current configuration:
+
+`kaggle config view`
+
+- Set the default competition:
+
+`kaggle config set -n {{competition}} -v {{competition_name}}`
+
+- Set the default download directory:
+
+`kaggle config set -n {{path}} -v {{path/to/directory}}`
+
+- Configure a proxy for API requests:
+
+`kaggle config set -n {{proxy}} -v {{http://proxy:port}}`
+
+- Unset a configuration value:
+
+`kaggle config unset -n {{configuration_name}}`


### PR DESCRIPTION
Adds a new TLDR page for kaggle config.

Refs tldr-pages#18897, tldr-pages#18405.

More information: https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#config.
