### PR TITLE
vagrant-global-status: add page

### DIFF
--- a/pages/common/vagrant-global-status.md
+++ b/pages/common/vagrant-global-status.md
@@ -4,13 +4,17 @@
 > More information: <https://developer.hashicorp.com/vagrant/docs/cli/global-status>.
 
 - List all known Vagrant environments:
+
 `vagrant global-status`
 
 - Remove invalid entries from the status cache:
+
 `vagrant global-status --prune`
 
 - Prune the cache and filter results for a specific machine name:
+
 `vagrant global-status --prune | grep {{machine_name}}`
 
 - Output only the machine IDs for scripting:
+
 `vagrant global-status | awk 'NR>2 && $1 !~ /^---/ {print $1}'`


### PR DESCRIPTION
Adds a new TLDR page for vagrant global-status.

Refs tldr-pages#18895, tldr-pages#18405.

More information: https://developer.hashicorp.com/vagrant/docs/cli/global-status.
