### PR TITLE
vagrant-provision: add page

### DIFF
--- a/pages/common/vagrant-provision.md
+++ b/pages/common/vagrant-provision.md
@@ -4,13 +4,17 @@
 > More information: <https://developer.hashicorp.com/vagrant/docs/cli/provision>.
 
 - Run all provisioners for the default machine:
+
 `vagrant provision`
 
 - Run provisioners for a specific machine:
+
 `vagrant provision {{machine_name}}`
 
 - Run only the specified provisioners (comma-separated):
+
 `vagrant provision --provision-with {{shell}}`
 
 - Run a subset of provisioners in order:
+
 `vagrant provision --provision-with {{shell,ansible_local}}`


### PR DESCRIPTION
Adds a new TLDR page for vagrant provision.

Refs tldr-pages#18895, tldr-pages#18405.

More information: https://developer.hashicorp.com/vagrant/docs/cli/provision.
