### PR TITLE
vagrant-ssh: add page

### DIFF
--- a/pages/common/vagrant-ssh.md
+++ b/pages/common/vagrant-ssh.md
@@ -4,16 +4,21 @@
 > More information: <https://developer.hashicorp.com/vagrant/docs/cli/ssh>.
 
 - SSH into the default machine:
+
 `vagrant ssh`
 
 - SSH into a specific machine by name:
+
 `vagrant ssh {{machine_name}}`
 
 - Execute a single command over SSH and exit:
+
 `vagrant ssh --command "{{uname -a}}"`
 
 - Connect without automatic authentication:
+
 `vagrant ssh --plain`
 
 - Pass additional flags directly to the underlying SSH client:
+
 `vagrant ssh -- -L {{localhost:8080:localhost:80}}`


### PR DESCRIPTION
Adds a new TLDR page for vagrant ssh.

Refs tldr-pages#18895, tldr-pages#18405.

More information: https://developer.hashicorp.com/vagrant/docs/cli/ssh.
