### PR TITLE
vagrant-up: add page

### DIFF
--- a/pages/common/vagrant-up.md
+++ b/pages/common/vagrant-up.md
@@ -4,22 +4,29 @@
 > More information: <https://developer.hashicorp.com/vagrant/docs/cli/up>.
 
 - Boot and provision all machines defined in the Vagrantfile:
+
 `vagrant up`
 
 - Boot a specific machine by name:
+
 `vagrant up {{machine_name}}`
 
 - Boot using a specific provider:
+
 `vagrant up --provider {{virtualbox}}`
 
 - Force all provisioners to run on boot:
+
 `vagrant up --provision`
 
 - Run only selected provisioners during boot:
+
 `vagrant up --provision-with {{shell}}`
 
 - Disable parallel boot for multi-machine environments:
+
 `vagrant up --no-parallel`
 
 - Destroy a machine automatically if an error occurs during the initial boot:
+
 `vagrant up --destroy-on-error`


### PR DESCRIPTION
Adds a new TLDR page for vagrant up.

Refs tldr-pages#18895, tldr-pages#18405.

More information: https://developer.hashicorp.com/vagrant/docs/cli/up.
