### PR TITLE
sequin: add page

### DIFF
--- a/pages/common/sequin.md
+++ b/pages/common/sequin.md
@@ -14,7 +14,7 @@
 
 - Examine a file containing ANSI sequences (e.g., a TUI golden file):
 
-`cat {{./testdata/MyCuteApp.golden}} | sequin`
+`cat {{path/to/file.golden}} | sequin`
 
 - Execute a command directly within a fake TTY to inspect its output:
 


### PR DESCRIPTION
Add TLDR page for `sequin`, the Charmbracelet CLI tool that makes ANSI escape sequences human-readable.

- Added examples directly from the official documentation.
- Included examples for printf, colorized command output, golden files, fake TTY usage, and raw highlighting.
- Page located under `pages/common/sequin.md`.

**Checklist**
- [x] Follows TLDR style and content guidelines.
- [x] Includes link to official documentation.
- [x] Contains fewer than 8 examples.