### PR TITLE
melt: add page

### DIFF
--- a/pages/common/melt.md
+++ b/pages/common/melt.md
@@ -1,20 +1,20 @@
 # melt
 
 > Backup and restore Ed25519 SSH keys using memorizable seed phrases.
-> More information: <https://github.com/charmbracelet/melt>.
+> More information: <https://github.com/charmbracelet/melt#usage>.
 
 - Generate a seed phrase from an existing Ed25519 private key:
 
 `melt {{~/.ssh/id_ed25519}}`
 
-- Generate a seed phrase from standard input:
+- Generate a seed phrase from `stdin`:
 
-`cat {{~/.ssh/id_ed25519}} | melt`
+`{{cat ~/.ssh/id_ed25519}} | melt`
 
 - Restore an SSH key from a seed phrase:
 
-`melt restore {{./my-key}} --seed "{{seed phrase}}"`
+`melt restore {{path/to/key}} --seed "{{seed_phrase}}"`
 
-- Restore an SSH key from a seed phrase via standard input:
+- Restore an SSH key from a seed phrase via `stdin`:
 
-`cat {{words}} | melt restore -`
+`{{cat path/to/file}} | melt restore -`


### PR DESCRIPTION
Add TLDR page for `melt`, the Charmbracelet CLI tool for backing up and restoring Ed25519 SSH keys using seed phrases.

- Added examples for generating and restoring keys.
- Linked to official documentation.
- Page located under `pages/common/melt.md`.

**Checklist**
- [x] The page follows TLDR style and content guidelines.
- [x] Contains fewer than 8 examples.
- [x] The page includes a documentation link.