### PR TITLE
docker-compose-up: add page

### DIFF
--- a/pages/common/docker-compose-up.md
+++ b/pages/common/docker-compose-up.md
@@ -21,7 +21,7 @@
 
 - Start services with custom compose file:
 
-`docker compose {{[-f|--file]}} {{path/to/docker-compose.yml}} up`
+`docker compose {{[-f|--file]}} {{path/to/config}} up`
 
 - Start services and remove orphaned containers:
 


### PR DESCRIPTION
Add page for docker-compose up command - start and run Docker services defined in a Compose file.
This is a commonly used Docker Compose command that was missing from the tldr collection.

 The page(s) are in the correct platform directories: common, linux, osx, windows, sunos, android, etc.
 The page description(s) have links to documentation or a homepage.
 The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
 The page(s) follow the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
 The PR contains at most 5 new pages.
 The PR title conforms to the recommended [templates](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
Version of the command being documented (if known):