### PR TITLE
docker-compose-down: add page

### DIFF
--- a/pages/common/docker-compose-down.md
+++ b/pages/common/docker-compose-down.md
@@ -25,7 +25,7 @@
 
 - Stop and remove containers using an alternate compose file:
 
-`docker compose {{[-f|--file]}} {{path/to/file.yml}} down`
+`docker compose {{[-f|--file]}} {{path/to/config}} down`
 
 - Stop and remove containers with a custom timeout in seconds:
 


### PR DESCRIPTION
Add page for docker-compose down command to stop and remove containers, networks, images, and volumes.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

#### If you are a new contributor to the project, do not use AI to generate pages. We will close any PR with a suspicion of AI usage.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
