### PR TITLE
docker-compose-logs: add page

### DIFF
--- a/pages/common/docker-compose-logs.md
+++ b/pages/common/docker-compose-logs.md
@@ -11,7 +11,7 @@
 
 `docker compose logs {{service_name}}`
 
-- View logs and follow new output (like `tail -f`):
+- View logs and follow new output (like `tail --follow`):
 
 `docker compose logs {{[-f|--follow]}}`
 


### PR DESCRIPTION
Add page for docker-compose logs command to view output from containers.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

#### If you are a new contributor to the project, do not use AI to generate pages. We will close any PR with a suspicion of AI usage.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
