### PR TITLE
vagrant-status: update verbiage to clarify command scope

### DIFF
--- a/pages/common/vagrant-status.md
+++ b/pages/common/vagrant-status.md
@@ -1,7 +1,7 @@
 # vagrant status
 
 > Display the state of machines in the current Vagrant environment.
-> See also: `vagrant`.
+> See also: `vagrant`, `vagrant global-status`.
 > More information: <https://developer.hashicorp.com/vagrant/docs/cli/status>.
 
 - View status of the machines in the current directory:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

#### If you are a new contributor to the project, do not use AI to generate pages. We will close any PR with a suspicion of AI usage.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

initially I followed the verbiage from the [documentation](https://developer.hashicorp.com/vagrant/docs/cli/status) for this page, but I think this version may be more clear particularly with the addition of `vagrant global-status` in #19035