### PR TITLE
netbsd/chpass: use path/to/shell instead of path/to/file

### DIFF
--- a/pages/netbsd/chpass.md
+++ b/pages/netbsd/chpass.md
@@ -18,7 +18,7 @@
 
 - Specify a user database entry in the `passwd` file format:
 
-`su -c 'chpass -a {{username:encrypted_password:uid:gid:...}} -s {{path/to/file}}' {{username}}`
+`su -c 'chpass -a {{username:encrypted_password:uid:gid:...}} -s {{path/to/shell}}' {{username}}`
 
 - Only update the [l]ocal password file:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

#### If you are a new contributor to the project, do not use AI to generate pages. We will close any PR with a suspicion of AI usage.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

The [manpage](https://man.netbsd.org/chpass.1)'s definition for `-s` is clearly to _change a new shell_, and other command examples have clearly used `{{path/to/shell}}` instead of `{{path/to/file}}`.

Since this example command's intent to wrap the entire `chpass` command inside a `su -c '...'`, so it's better to use `{{path/to/shell}}` for consistency.