### PR TITLE
adb-forward, adb-reverse: improve command description, add -s option for selecting devices

### DIFF
--- a/pages/common/adb-forward.md
+++ b/pages/common/adb-forward.md
@@ -1,11 +1,15 @@
 # adb forward
 
-> Connect to an Android device wirelessly.
+> Forward socket connections to a connected Android device or emulator.
 > More information: <https://developer.android.com/tools/adb>.
 
-- Forward a TCP port:
+- Forward a TCP port to the only connected emulator or device:
 
 `adb forward tcp:{{local_port}} tcp:{{remote_port}}`
+
+- Forward a TCP port to a specific emulator or device (by device ID / [s]erial number):
+
+`adb -s {{device_ID}} forward tcp:{{local_port}} tcp:{{remote_port}}`
 
 - List all forwardings:
 

--- a/pages/common/adb-reverse.md
+++ b/pages/common/adb-reverse.md
@@ -7,9 +7,13 @@
 
 `adb reverse --list`
 
-- Reverse a TCP port from an emulator or device to localhost:
+- Reverse a TCP port from the only connected emulator or device to localhost:
 
 `adb reverse tcp:{{remote_port}} tcp:{{local_port}}`
+
+- Reverse a TCP port from a specific emulator or device (by device ID / [s]erial number) to localhost:
+
+`adb -s {{device_ID}} adb reverse tcp:{{remote_port}} tcp:{{local_port}}`
 
 - Remove a reverse socket connections from an emulator or device:
 


### PR DESCRIPTION
…for selecting devices

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

#### If you are a new contributor to the project, do not use AI to generate pages. We will close any PR with a suspicion of AI usage.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

The current command description for `adb-forward` is not relevant. Port forwarding does not always relate with connecting an Android device wirelessly (that's the role of `adb connect`).

The command examples also did not mention how to explicitly select a device (using `-s`) to forward or reverse the connections, since that will be important for dealing with more than one connected Android emulators or devices.