### PR TITLE
doc: avoid using `npm install --global` which may fail when not root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,17 +217,19 @@ Of course, this shouldn't sacrifice content clarity, such as when documenting to
 
 Once you have written a `tldr` page, you can test its syntax locally using [`tldr-lint`](https://github.com/tldr-pages/tldr-lint).
 
-The latest version of [NodeJS](https://nodejs.org) is required to install `tldr-lint` with the following command:
+You can install it by running this command in the tldr repository folder:
 
 ```sh
-npm install --global tldr-lint
+npm install tldr-lint
 ```
 
 Once it is installed, you can test your page by running the following command:
 
 ```sh
-tldr-lint {{path/to/page.md}}
+npm run tool:tldr-lint {{path/to/page.md}}
 ```
+
+
 
 Now, you are ready to submit a pull request!
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "husky": "^9.1.7"
   },
   "scripts": {
+    "tool:tldr-lint": "tldr-lint",
     "lint-markdown": "markdownlint pages*/**/*.md",
     "lint-tldr-pages": "tldr-lint ./pages",
     "test": "bash scripts/test.sh",


### PR DESCRIPTION
This PR improves the contributing guide. You currently recommand to use the command `npm install --global tldr-lint`, but this command may fail on some systems. Here is the error, tested on Fedora 42 & ArchLinux:

```
npm install --global tldr-lint
npm error code EACCES
npm error syscall mkdir
npm error path /usr/lib/node_modules/tldr-lint
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/lib/node_modules/tldr-lint'
npm error     at async mkdir (node:internal/fs/promises:860:10)
npm error     at async /usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:576:20
npm error     at async Promise.allSettled (index 0)
npm error     at async [reifyPackages] (/usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:313:11)
npm error     at async Arborist.reify (/usr/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:125:5)
npm error     at async Install.exec (/usr/lib/node_modules/npm/lib/commands/install.js:150:5)
npm error     at async Npm.exec (/usr/lib/node_modules/npm/lib/npm.js:208:9)
npm error     at async module.exports (/usr/lib/node_modules/npm/lib/cli/entry.js:67:5) {
npm error   errno: -13,
npm error   code: 'EACCES',
npm error   syscall: 'mkdir',
npm error   path: '/usr/lib/node_modules/tldr-lint'
npm error }
npm error
npm error The operation was rejected by your operating system.
npm error It is likely you do not have the permissions to access this file as the current user
npm error
npm error If you believe this might be a permissions issue, please double-check the
npm error permissions of the file and its containing directories, or try running
npm error the command again as root/Administrator.
npm error A complete log of this run can be found in: /home/itrooz/.npm/_logs/2025-10-28T19_03_43_767Z-debug-0.log
```

This PR changes this by recommending to install the command directly into the local repository, and running it through npm.

I also removed the latest nodejs version requirement, since I was able to run the command on NodeJS 20. I'm not sure why this was here, the command seems simple enough to work on old node versions ?

### Checklist

- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
