### PR TITLE
PULL_REQUEST_TEMPLATE: add a section to put issue number in

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,5 @@ See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
 - [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
 - [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
 - **Version of the command being documented (if known):**
+
+Reference issue: #


### PR DESCRIPTION
It's always nice when you can navigate to the issue directly from the PR.
This will also reduce the amount of Closes: usage in the OP by those that don't know that it has a special purpose.