### PR TITLE
zerotier-{cli, idtool, one}: add pages

### DIFF
--- a/pages/common/zerotier-cli.md
+++ b/pages/common/zerotier-cli.md
@@ -1,6 +1,7 @@
 # zerotier-cli
 
 > Manage a local ZeroTier node and its network memberships.
+> Most of these commands require `sudo`.
 > More information: <https://docs.zerotier.com/cli/>.
 
 - Show node status:

--- a/pages/common/zerotier-idtool.md
+++ b/pages/common/zerotier-idtool.md
@@ -1,7 +1,7 @@
 # zerotier-idtool
 
 > Manage ZeroTier identities (public/private keys, addresses).
-> More information: <https://man.archlinux.org/man/zerotier-idtool.1.en>.
+> More information: <https://github.com/zerotier/ZeroTierOne/blob/dev/doc/zerotier-idtool.1.md>.
 
 - Generate a new identity pair and write to two files:
 

--- a/pages/common/zerotier-one.md
+++ b/pages/common/zerotier-one.md
@@ -1,7 +1,8 @@
 # zerotier-one
 
 > ZeroTier service daemon.
-> More information: <https://docs.zerotier.com/>.
+> Most of these commands require `sudo`.
+> More information: <https://github.com/zerotier/ZeroTierOne/blob/dev/doc/zerotier-one.8.md>.
 
 - Start the daemon in the foreground:
 


### PR DESCRIPTION
This pull request adds new TLDR pages for the following ZeroTier utilities:

zerotier-cli

zerotier-idtool

zerotier-one

Each page follows the standard TLDR markdown format and provides clear, concise examples of commonly used commands.
The examples are based on the official ZeroTier documentation and Linux man pages.

References:

[https://docs.zerotier.com/cli/](https://docs.zerotier.com/cli/?utm_source=chatgpt.com)

https://man.archlinux.org/man/zerotier-idtool.1.en

Closes #19113

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x ] The page description(s) have links to documentation or a homepage.
- [ x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ x] The PR contains at most 5 new pages.
- [ x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Reference issue: #
