### PR TITLE
French translation template update

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -207,7 +207,7 @@ The templates can be changed when necessary.
 
 > Cette commande est un alias de `example`.
 
-- Voir la documentation de la commande originale :
+- Affiche la documentation de la commande originale :
 
 `tldr example`
 ```


### PR DESCRIPTION
The [French-Specific Rules](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#french-specific-rules) of the Style guide asks that command and example descriptions on pages in French must use the third person singular present indicative tense (présent de l'indicatif à la troisième personne du singulier). For example, use `Extrait une archive` rather than `Extraire une archive` or `Extrais une archive`.

However, this French translation alias page template recommends `Voir` (infinitif présent) instead of `voit` (présent de l'indicatif à la troisième personne du singulier). However, the third person singular present indicative tense `voit` doesn't make sense in this contexte, so it must be replace with another similar verb like `Afficher`. That's why I propose to replace `Voir` with `Affiche` so it avoids making people following the template breaking this rule.

It would also align with the translation in [Common descriptions](https://github.com/tldr-pages/tldr/blob/6f23f4516b9747485f820915b3df83e47d5aeaf4/contributing-guides/translation-templates/common-descriptions.md)

> Display help -> Affiche l'aide (and not voir l'aide)
>
> Display version -> Affiche la version (and not voir la version)