### PR TITLE
emaint: add example

### DIFF
--- a/pages/linux/emaint.md
+++ b/pages/linux/emaint.md
@@ -13,7 +13,7 @@
 
 - Synchronize all repositories:
 
-`sudo emaint sync --allrepos`
+`sudo emaint sync {{[-A|--allrepos]}}`
 
 - Clear the Portage resume list:
 


### PR DESCRIPTION
This PR adds examples for emaint sync commands (including --allrepos) directly into the existing emaint.md page instead of a separate file.


