### PR TITLE
bun-init: add page

### DIFF
--- a/pages/common/bun-init.md
+++ b/pages/common/bun-init.md
@@ -1,0 +1,20 @@
+# bun init
+
+> Initialize a new Bun project with default configuration files.
+> More information: <https://bun.com/docs/cli/init>.
+
+- Initialize a new Bun project in the current directory:
+
+`bun init`
+
+- Initialize without prompts (use all defaults):
+
+`bun init -y`
+
+- Initialize with a specific project name:
+
+`bun init --name {{project_name}}`
+
+- Initialize in a specific directory:
+
+`bun init {{path/to/directory}}`


### PR DESCRIPTION
Adds documentation for the `bun init` command as part of issue #19127.

## Changes
- New page: `pages/common/bun-init.md`
- 4 clear examples for project initialization
- Follows tldr format and style guidelines

## Examples included
- Basic initialization
- Skip prompts with defaults
- Custom project name
- Initialize in specific directory

Addresses #19127