### PR TITLE
MAINTAINERS: add @badhon495 as repository collaborator and Bengali codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 /pages.ar/ @MachiavelliII @ali90h
+/pages.bn/ @badhon495
 /pages.cs/ @Sarijen
 /pages.de/ @pixelcmtd @gutjuri
 /pages.es/ @kant

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -106,6 +106,8 @@ If you are an owner of the organization, you can see an automated list [here](ht
   [04 November 2025](https://github.com/tldr-pages/tldr/issues/19189) — present
 - **Meinard Francisco ([@znarfm](https://github.com/znarfm))**:
   [04 November 2025](https://github.com/tldr-pages/tldr/issues/19190) — present
+- **Md Sakib Sadman Badhon ([@badhon495](https://github.com/badhon495))**:
+  [06 November 2025](https://github.com/tldr-pages/tldr/issues/19235) — present
 - Owen Voke ([@owenvoke](https://github.com/owenvoke)):
   [11 January 2018](https://github.com/tldr-pages/tldr/issues/1885) — [26 August 2018](https://github.com/tldr-pages/tldr/issues/2258)
 - Marco Bonelli ([@mebeim](https://github.com/mebeim)):


### PR DESCRIPTION
## Description

This pull request adds **Md Sakib Sadman Badhon** ([@badhon495](https://github.com/badhon495)) as a repository collaborator to the tldr-pages project and assigns them as codeowner for Bengali translations.

## Changes Made

1. **MAINTAINERS.md**: Added @badhon495 to the "Repository collaborators" section
   - Start date: 06 November 2025
   - Reference issue: #19235

2. **CODEOWNERS**: Added @badhon495 as codeowner for Bengali translations
   - `/pages.bn/` - Bengali language pages