### PR TITLE
Add example to extract specific files from tar archive

### DIFF
--- a/pages/common/tar.md
+++ b/pages/common/tar.md
@@ -35,3 +35,7 @@
 - E[x]tract files matching a pattern from an archive [f]ile:
 
 `tar xf {{path/to/source.tar}} --wildcards "{{*.html}}"`
+
+- Extract only specific files from an archive:
+`tar xf {{source.tar}} {{path/to/file1}} {{path/to/file2}}`
+    


### PR DESCRIPTION
Added an additional example in `tar.md` showing how to extract specific files from a tar archive using wildcard patterns.

This improves usability for users who only need to extract a subset of files from a compressed archive.
