### PR TITLE
Add sudo prefix to commands requiring elevated privileges

### DIFF
--- a/pages/common/arp.md
+++ b/pages/common/arp.md
@@ -9,8 +9,8 @@
 
 - [d]elete a specific entry:
 
-`arp -d {{address}}`
+`sudo arp -d {{address}}`
 
 - [s]et up a new entry in the ARP table:
 
-`arp -s {{address}} {{mac_address}}`
+`sudo arp -s {{address}} {{mac_address}}`

--- a/pages/linux/apt-get.md
+++ b/pages/linux/apt-get.md
@@ -11,28 +11,28 @@
 
 - Install a package, or update it to the latest available version:
 
-`apt-get install {{package}}`
+`sudo apt-get install {{package}}`
 
 - Remove a package:
 
-`apt-get remove {{package}}`
+`sudo apt-get remove {{package}}`
 
 - Remove a package and its configuration files:
 
-`apt-get purge {{package}}`
+`sudo apt-get purge {{package}}`
 
 - Upgrade all installed packages to their newest available versions:
 
-`apt-get upgrade`
+`sudo apt-get upgrade`
 
 - Clean the local repository - removing package files (`.deb`) from interrupted downloads that can no longer be downloaded:
 
-`apt-get autoclean`
+`sudo apt-get autoclean`
 
 - Remove all packages that are no longer needed:
 
-`apt-get autoremove`
+`sudo apt-get autoremove`
 
 - Upgrade installed packages (like `upgrade`), but remove obsolete packages and install additional packages to meet new dependencies:
 
-`apt-get dist-upgrade`
+`sudo apt-get dist-upgrade`

--- a/pages/linux/aptitude.md
+++ b/pages/linux/aptitude.md
@@ -9,7 +9,7 @@
 
 - Install a new package and its dependencies:
 
-`aptitude install {{package}}`
+`sudo aptitude install {{package}}`
 
 - Search for a package:
 
@@ -21,16 +21,16 @@
 
 - Remove a package and all packages depending on it:
 
-`aptitude remove {{package}}`
+`sudo aptitude remove {{package}}`
 
 - Upgrade installed packages to the newest available versions:
 
-`aptitude upgrade`
+`sudo aptitude upgrade`
 
 - Upgrade installed packages (like `aptitude upgrade`) including removing obsolete packages and installing additional packages to meet new package dependencies:
 
-`aptitude full-upgrade`
+`sudo aptitude full-upgrade`
 
 - Put an installed package on hold to prevent it from being automatically upgraded:
 
-`aptitude hold '?installed({{package}})'`
+`sudo aptitude hold '?installed({{package}})'`

--- a/pages/linux/dd.md
+++ b/pages/linux/dd.md
@@ -6,11 +6,11 @@
 
 - Make a bootable USB drive from an isohybrid file (such as `archlinux-xxx.iso`) and show the progress:
 
-`dd if={{path/to/file.iso}} of={{/dev/usb_drive}} status=progress`
+`sudo dd if={{path/to/file.iso}} of={{/dev/usb_drive}} status=progress`
 
 - Clone a drive to another drive with 4 MiB block size and flush writes before the command terminates:
 
-`dd bs=4M conv=fsync if={{/dev/source_drive}} of={{/dev/dest_drive}}`
+`sudo dd bs=4M conv=fsync if={{/dev/source_drive}} of={{/dev/dest_drive}}`
 
 - Generate a file with a specific number of random bytes by using kernel random driver:
 
@@ -18,11 +18,11 @@
 
 - Benchmark the write performance of a disk:
 
-`dd bs={{1M}} count={{1024}} if=/dev/zero of={{path/to/file_1GB}}`
+`sudo dd bs={{1M}} count={{1024}} if=/dev/zero of={{path/to/file_1GB}}`
 
 - Create a system backup, save it into an IMG file (can be restored later by swapping `if` and `of`), and show the progress:
 
-`dd if={{/dev/drive_device}} of={{path/to/file.img}} status=progress`
+`sudo dd if={{/dev/drive_device}} of={{path/to/file.img}} status=progress`
 
 - Check the progress of an ongoing `dd` operation (run this command from another shell):
 

--- a/pages/linux/dpkg.md
+++ b/pages/linux/dpkg.md
@@ -7,11 +7,11 @@
 
 - Install a package:
 
-`dpkg {{[-i|--install]}} {{path/to/file.deb}}`
+`sudo dpkg {{[-i|--install]}} {{path/to/file.deb}}`
 
 - Remove a package:
 
-`dpkg {{[-r|--remove]}} {{package}}`
+`sudo dpkg {{[-r|--remove]}} {{package}}`
 
 - List installed packages:
 
@@ -31,4 +31,4 @@
 
 - Purge an installed or already removed package, including configuration:
 
-`dpkg {{[-P|--purge]}} {{package}}`
+`sudo dpkg {{[-P|--purge]}} {{package}}`

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -5,28 +5,28 @@
 
 - Start tracing a specific process by its PID:
 
-`strace {{[-p|--attach]}} {{pid}}`
+`sudo strace {{[-p|--attach]}} {{pid}}`
 
 - Trace a process and filter output by system call [e]xpression:
 
-`strace {{[-p|--attach]}} {{pid}} -e {{system_call,system_call2,...}}`
+`sudo strace {{[-p|--attach]}} {{pid}} -e {{system_call,system_call2,...}}`
 
 - Count time, calls, and errors for each system call and report a summary on program exit:
 
-`strace {{[-p|--attach]}} {{pid}} {{[-c|--summary-only]}}`
+`sudo strace {{[-p|--attach]}} {{pid}} {{[-c|--summary-only]}}`
 
 - Show the time spent in every system call and specify the maximum string size to print:
 
-`strace {{[-p|--attach]}} {{pid}} {{[-T|--syscall-times]}} {{[-s|--string-limit]}} {{32}}`
+`sudo strace {{[-p|--attach]}} {{pid}} {{[-T|--syscall-times]}} {{[-s|--string-limit]}} {{32}}`
 
 - Start tracing a program by executing it:
 
-`strace {{program}}`
+`sudo strace {{program}}`
 
 - Start tracing file operations of a program:
 
-`strace -e trace=file {{program}}`
+`sudo strace -e trace=file {{program}}`
 
 - Start tracing network operations of a program as well as all its forked and child processes, saving the output to a file:
 
-`strace {{[-f|--follow-forks]}} -e trace=network {{[-o|--output]}} {{trace.txt}} {{program}}`
+`sudo strace {{[-f|--follow-forks]}} -e trace=network {{[-o|--output]}} {{trace.txt}} {{program}}`


### PR DESCRIPTION
This PR addresses issue #19270 by adding the `sudo` prefix to various command examples that require elevated privileges to function properly. This change improves clarity and prevents potential permission errors when users follow the examples.

The changes affect the following pages:

- `arp.md`: Added `sudo` to `arp -d` and `arp -s` commands
- `apt-get.md`: Added `sudo` to all apt-get commands that modify the system (install, remove, purge, upgrade, autoclean, autoremove, dist-upgrade)
- `aptitude.md`: Added `sudo` to aptitude commands that modify the system (install, remove, upgrade, full-upgrade, hold)
- `dd.md`: Added `sudo` to dd commands that perform disk operations
- `dpkg.md`: Added `sudo` to dpkg commands that modify the system (install, remove, purge)
- `strace.md`: Added `sudo` to strace commands that attach to processes or require elevated privileges

This is a documentation improvement that ensures users have the correct command examples for system administration tasks.