### PR TITLE
jj-undo: add page

### DIFF
--- a/pages/common/jj-undo.md
+++ b/pages/common/jj-undo.md
@@ -1,0 +1,8 @@
+# jj undo
+
+> Undo the most recent recorded operation in a `jj` repository.
+> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-undo>.
+
+- Undo the last operation:
+
+`jj undo`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.34.0v

#17040

Please note - `jj undo` accepted the deprecated `jj undo <OPERATION>` form, but the recommended replacement is `jj op revert <operation>`. I omitted the deprecated form to match tldr style as I didn't find any examples in the repo that retain deprecated subcommands.