### PR TITLE
pytest: Add verbosity flag

### DIFF
--- a/pages/common/pytest.md
+++ b/pages/common/pytest.md
@@ -26,3 +26,7 @@
 - Run tests without capturing output:
 
 `pytest --capture=no`
+
+- Run tests with increased [v]erbosity, displaying individual test names:
+
+`pytest -v`


### PR DESCRIPTION
Add command for running tests with increased verbosity.

https://docs.pytest.org/en/stable/how-to/output.html#verbosity

`--verbose` works, but the docs only show `-v`

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** all

Reference issue: 
