### PR TITLE
git-bisect: shorten description of "bisect run" example

### DIFF
--- a/pages/common/git-bisect.md
+++ b/pages/common/git-bisect.md
@@ -24,9 +24,9 @@
 
 `git bisect start {{bad_commit}} {{good_commit}} -- {{path/to/file_or_directory}}`
 
-- Automate the bisect process using a test script that `exit`s with 0 for "good" and non-zero for "bad" (script arguments are optional):
+- Automate the bisect process using a test script that `exit`s with 0 for "good" and non-zero for "bad":
 
-`git bisect run {{path/to/test_script}} {{script_arguments}}`
+`git bisect run {{path/to/test_script}} {{optional_script_arguments}}`
 
 - Display a log of what has been done so far:
 


### PR DESCRIPTION
Instead of a long example description line, this PR changes the parameter name itself to convey the information more compactly.

I would have proposed this [here](https://github.com/tldr-pages/tldr/pull/19154#discussion_r2492077420), but was not able to react before the PR got merged :sweat_smile: Sorry for the delay, @acuteenvy!