### PR TITLE
bun-feedback: add new page

### DIFF
--- a/pages/common/bun-feedback.md
+++ b/pages/common/bun-feedback.md
@@ -1,0 +1,22 @@
+# bun feedback
+
+> Sends feedback to `Bun`.
+> More information: <https://bun.com/docs/feedback>.
+
+- Send feedback interactively:
+`bun feedback`
+
+- Send feedback from a file:
+`bun feedback {{path/to/file}}`
+
+- Send feedback with a description:
+`bun feedback -m "{{your_message}}"`
+
+- Send feedback anonymously:
+`bun feedback --anonymous`
+
+- Send feedback with a category:
+`bun feedback --category {{bug|feature|performance}}`
+
+- Show help for feedback command:
+`bun feedback --help`


### PR DESCRIPTION
This PR adds a new TLDR page for the `bun feedback` command.

The `bun feedback` command allows users to send feedback directly to Bun, either interactively or from a file.

Closes #<your-issue-number>.

