### PR TITLE
docs: Convert nvm page into a disambiguation (fixes #19193)

### DIFF
--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -1,34 +1,15 @@
 # nvm
 
-> Install, uninstall or switch between Node.js versions.
-> Supports version numbers like "12.8" or "v16.13.1", and labels like "stable", "system", etc.
-> See also: `asdf`.
-> More information: <https://github.com/creationix/nvm>.
+> Disambiguation: Multiple implementations of Node Version Manager exist.
+> Use the appropriate page below depending on your shell or operating system.
 
-- Install a specific version of Node.js:
+- **nvm (POSIX/Linux/macOS)** — Original Node Version Manager:
+  `nvm`
 
-`nvm install {{node_version}}`
+- **nvm-windows** — Windows alternative Node Version Manager:
+  `nvm-windows`
 
-- Use a specific version of Node.js in the current shell:
+- **nvm.fish** — Fish shell version of Node Version Manager:
+  `nvm.fish`
 
-`nvm use {{node_version}}`
-
-- Set the default Node.js version:
-
-`nvm alias default {{node_version}}`
-
-- List all available Node.js versions and highlight the default one:
-
-`nvm list`
-
-- Uninstall a given Node.js version:
-
-`nvm uninstall {{node_version}}`
-
-- Launch the REPL of a specific version of Node.js:
-
-`nvm run {{node_version}} --version`
-
-- Execute a script in a specific version of Node.js:
-
-`nvm exec {{node_version}} node {{app.js}}`
+> More information: https://github.com/nvm-sh/nvm


### PR DESCRIPTION
This PR updates the `nvm` tldr page to a disambiguation page as requested in issue #19193.

The current `pages/common/nvm.md` file describes only one implementation of NVM, but multiple implementations exist across different platforms and shells. This PR replaces the content with a short, clear disambiguation that links to the appropriate pages:

- `nvm` (POSIX/Linux/macOS)
- `nvm-windows` (Windows)
- `nvm.fish` (Fish shell)

This follows the TLDR design guidelines for disambiguation pages and helps users find the correct command page depending on their environment.

Fixes #19193
