### PR TITLE
docs: clean nvm disambiguation page (fixes #19193)

### DIFF
--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -1,34 +1,14 @@
 # nvm
 
-> Install, uninstall or switch between Node.js versions.
-> Supports version numbers like "12.8" or "v16.13.1", and labels like "stable", "system", etc.
-> See also: `asdf`.
-> More information: <https://github.com/creationix/nvm>.
+> Disambiguation for different implementations of Node Version Manager (NVM).
 
-- Install a specific version of Node.js:
+- Original NVM for POSIX/Linux/macOS:
+  `nvm`
 
-`nvm install {{node_version}}`
+- Windows version of NVM:
+  `nvm-windows`
 
-- Use a specific version of Node.js in the current shell:
+- Fish shell version of NVM:
+  `nvm.fish`
 
-`nvm use {{node_version}}`
-
-- Set the default Node.js version:
-
-`nvm alias default {{node_version}}`
-
-- List all available Node.js versions and highlight the default one:
-
-`nvm list`
-
-- Uninstall a given Node.js version:
-
-`nvm uninstall {{node_version}}`
-
-- Launch the REPL of a specific version of Node.js:
-
-`nvm run {{node_version}} --version`
-
-- Execute a script in a specific version of Node.js:
-
-`nvm exec {{node_version}} node {{app.js}}`
+> More information: <https://github.com/nvm-sh/nvm>


### PR DESCRIPTION
Clean and corrected disambiguation page for nvm as requested in #19193.
All formatting follows TLDR guidelines.
Fixes #19193
