### PR TITLE
Add improved sgdisk page and fix formatting

### DIFF
--- a/pages/linux/sgdisk.md
+++ b/pages/linux/sgdisk.md
@@ -1,19 +1,26 @@
 # sgdisk
 
-> A command-line partitioning tool for GPT disks.
-> Part of the `gdisk` package.
+> Create and modify partition tables on disks that use the GUID Partition Table (GPT) format.
+> This tool is part of the `gdisk` family of utilities.
+> More information: <https://manpages.org/sgdisk>.
 
-- Show partition table:
+- Display the current GPT partition table of a device:
+
 `sgdisk -p {{/dev/sdX}}`
 
-- Create a new partition:
-`sgdisk -n {{1}}:{{start}}:{{end}} {{/dev/sdX}}`
+- Create a new partition with a specified number, start sector, and end sector:
 
-- Delete a partition:
+`sgdisk -n {{1}}:{{start_sector}}:{{end_sector}} {{/dev/sdX}}`
+
+- Delete a specific partition:
+
 `sgdisk -d {{1}} {{/dev/sdX}}`
 
-- Backup the GPT table:
+- Back up the entire GPT partition table to a file:
+
 `sgdisk -b {{backup.img}} {{/dev/sdX}}`
 
-- Restore the GPT table:
+- Restore the GPT partition table from a backup file:
+
 `sgdisk -l {{backup.img}} {{/dev/sdX}}`
+


### PR DESCRIPTION
This PR adds a corrected and improved TLDR page for the `sgdisk` command.
It replaces the previous submission that failed lint checks. All formatting and style issues have been fixed according to TLDR guidelines.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
-->

### Checklist

- [x] The page is in the correct platform directory: `linux`.
- [x] The page description includes a link to documentation (`manpages.org`).
- [x] The page follows the content guidelines.
- [x] The page follows the style guide.
- [x] The PR contains only 1 new page.
- [x] The PR is authored by me, and manually written/reviewed.
- [x] The PR title follows TLDR naming conventions.
- **Version of the command being documented:** `sgdisk` from the `gdisk` package (commonly available on Linux)

Reference issue: #19275
