### PR TITLE
qmake: add Spanish translation

### DIFF
--- a/pages.es/common/qmake.md
+++ b/pages.es/common/qmake.md
@@ -1,0 +1,28 @@
+# qmake
+
+> Genera archivos Makefile a partir de archivos de proyecto Qt.
+> Más información: <https://doc.qt.io/qt-6/qmake-running.html>.
+
+- Genera un archivo `Makefile` a partir de un archivo de proyecto en el directorio actual:
+
+`qmake`
+
+- Especifica las ubicaciones del archivo `Makefile` y del archivo de proyecto:
+
+`qmake -o {{ruta/a/Makefile}} {{ruta/para/archivo_de_proyecto.pro}}`
+
+- Genera un archivo de proyecto predeterminado:
+
+`qmake -project`
+
+- Compila un proyecto:
+
+`qmake && make`
+
+- Habilita el modo de depuración:
+
+`qmake -d`
+
+- Muestra la ayuda:
+
+`qmake -help`


### PR DESCRIPTION
Add documentation for qmake usage in Spanish.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
-->

### Checklist

- x ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
-x[ ] The page description(s) have links to documentation or a homepage.
x [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).x- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.mdx.
- [x] The PR contains at most 5 new pagex.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Reference issue: #
