### PR TITLE
fix: correct placeholder syntax in zypper tldr page

### DIFF
--- a/pages/linux/zypper.md
+++ b/pages/linux/zypper.md
@@ -7,6 +7,24 @@
 - Synchronize list of packages and versions available:
 
 `sudo zypper {{[ref|refresh]}}`
+- Synchronize list of packages and versions available:
+  `zypper {{ref|refresh}}`
+  `sudo zypper {{ref|refresh}}`
+
+- Install a new package:
+  `zypper {{in|install}} {{package}}`
+  `sudo zypper {{in|install}} {{package}}`
+
+- Remove a package:
+  `zypper {{rm|remove}} {{package}}`
+  `sudo zypper {{rm|remove}} {{package}}`
+
+- Upgrade installed packages to the newest available versions:
+  `zypper {{up|update}}`
+  `sudo zypper {{up|update}}`
+
+- Search for a package via keyword:
+  `zypper search {{keyword}}`
 
 - Install a new package:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Reference issue: #
