### PR TITLE
PULL_REQUEST_TEMPLATE: add a warning for good faith submitters

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thank you for contributing!
 Please fill in the following checklist, removing items that do not apply.
 See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
 
-Sign the CLA before submitting a pull request or it can be closed after 15 minutes!!!
+Sign the CLA before submitting a pull request or it will be closed after some time.
 https://cla-assistant.io/tldr-pages/tldr
 -->
 


### PR DESCRIPTION
This seems to be a common theme among these poor quality PRs that they never followup by signing the CLA or interacting with the bot errors. This would give a warning to people who actually care. Once https://github.com/tldr-pages/tldr-bot/issues/20 has been implemented, the "can" should be renamed to "will".

Any opinions on the 15 minutes? Reduce it to 5-10? Increase it to 30?