### PR TITLE
bn: correct translation of the path/to/file and all related items in the common-arguments file

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -10,7 +10,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 
 | en    | path/to/file          | path/to/directory        | path/to/file_or_directory            | package       | username           |
 |-------|-----------------------|--------------------------|--------------------------------------|---------------|--------------------|
-| bn    | পাথ/টু/ফাইল           | পাথ/টু/ডিরেক্টরি         | পথ/থেকে/ফাইল_অথবা_ডিরেক্টরি          | প্যাকেজ       | ইউজারনেম           |
+| bn    | ফাইল/এর/পাথ           | ডিরেক্টরি/এর/পাথ         | ফাইল_অথবা_ডিরেক্টরি/এর/পাথ          | প্যাকেজ       | ইউজারনেম           |
 | bs    | put/do/datoteke       | put/do/direktorija       | put/do/datoteke_ili_direktorija      | paket         | korisničko_ime     |
 | ca    | camí/al/fitxer        | camí/al/directori        | camí/al/fitxer_o_directori           | paquet        | nom_usuari         |
 | cs    | cesta/k/souboru       | cesta/k/adresari         | cesta/k/souboru_ci_adresari          | balíček       | jmeno_uzivatele    |

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -64,7 +64,7 @@ Some subcommands such as `example command` have their own usage documentation.
 ### bn
 
 ```markdown
-কিছু উপ-কমান্ড যেমন `example command` স্বতন্ত্র ব্যবহার নির্দেশনা রয়েছে.
+কিছু উপ-কমান্ড যেমন `example command` স্বতন্ত্র ব্যবহার নির্দেশনা রয়েছে।
 ```
 
 ---


### PR DESCRIPTION
## Description

I changed the Bangla translation of `path/to/file`, `path/to/directory`, and `path/to/file_or_directory` in the common-arguments file. I will gradually convert all the Bangla (bn) files to this format to maintain consistency in the translations. I have also added the correct Bangla full stop in the subcommand-mention file.

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

## Pages Modified

1. `contributing-guides/translation-templates/common-arguments.md`
2. `contributing-guides/translation-templates/subcommand-mention.md`