### PR TITLE
dirname: clarify description of first example

### DIFF
--- a/pages/common/dirname.md
+++ b/pages/common/dirname.md
@@ -3,7 +3,7 @@
 > Calculates the parent directory of a file or directory path.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/dirname-invocation.html>.
 
-- Calculate the parent directory of a given path:
+- Calculate the parent directory of a given file or directory path:
 
 `dirname {{path/to/file_or_directory}}`
 


### PR DESCRIPTION
This updates the description of the first example to clarify that `dirname` accepts both file and directory paths. The change improves clarity and consistency with other examples in the page, while keeping the page compliant with the style guide.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**

Reference issue: #
