### PR TITLE
mkdir: add --mode example

### DIFF
--- a/pages/common/mkdir.md
+++ b/pages/common/mkdir.md
@@ -18,3 +18,7 @@
 - Create multiple nested directories recursively:
 
 `mkdir {{[-p|--parents]}} {{path/to/{a,b}/{x,y,z}/{h,i,j}}}`
+
+- Create a directory with specific permissions (e.g., rwxr-xr-x):
+
+`mkdir --mode={{755}} {{directory_name}}`


### PR DESCRIPTION
Adds a common example for creating a directory with the --mode flag.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

**Version of the command being documented (if known):**
N/A (GNU coreutils)