### PR TITLE
kubectl-delete: add Portuguese (Brazil) translation

### DIFF
--- a/pages.pt_BR/common/kubectl-delete.md
+++ b/pages.pt_BR/common/kubectl-delete.md
@@ -18,3 +18,15 @@
 - Excluir todos os recursos em um determinado namespace:
 
 `kubectl delete all --all -n {{namespace}}`
+
+- Excluir todos os deployments e services em um namespace especificado:
+
+`kubectl delete {{[deploy|deployments]}},{{[svc|services]}} --all {{[-n|--namespace]}} {{namespace}}`
+
+- Excluir todos os nodes:
+
+`kubectl delete {{[no|nodes]}} --all`
+
+- Excluir recursos definidos em um manifesto YAML:
+
+`kubectl delete {{[-f|--filename]}} {{path/to/manifest.yaml}}`


### PR DESCRIPTION
Tradução da página kubectl-delete.md para o Português do Brasil (pt_BR), seguindo as diretrizes de estilo.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Não se aplica, é uma tradução.

Reference issue: #