### PR TITLE
scripts/set-alias-page: default page title to filename

### DIFF
--- a/scripts/set-alias-page.py
+++ b/scripts/set-alias-page.py
@@ -374,9 +374,14 @@ def prompt_alias_page_info(page_path: str) -> AliasPageContent:
         )
     )
     print(create_colored_line(Colors.GREEN, "Example: npm run-script"))
-    title = input(create_colored_line(Colors.CYAN, "Enter page title: ")).strip()
+    page_name = Path(page_path).stem
+    title = input(
+        create_colored_line(
+            Colors.CYAN, f"Enter page title (press Enter to use {page_name}): "
+        )
+    ).strip()
     if not title:
-        raise SystemExit(create_colored_line(Colors.RED, "Title cannot be empty"))
+        title = page_name
 
     print(
         create_colored_line(


### PR DESCRIPTION
Currently, the user must type the page title when creating a new alias page with `set-alias-page.py`. Most of the time the title is just the filename, so I've modified this script to default to the filename when no title is provided.