### PR TITLE
style-guide: adjust suggested repetition syntax

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -49,7 +49,7 @@ Example:
 
 - Open specific files:
 
-`krita {{path/to/image1 path/to/image2 ...}}`
+`krita {{path/to/image_1 path/to/image_2 ...}}`
 
 - Start without a splash screen:
 
@@ -515,9 +515,9 @@ Keep the following guidelines in mind when choosing placeholders:
 
 #### Grouping placeholders
 
-- If a command can optionally take 1 or more arguments of the same kind, use an ellipsis: `{{placeholder1 placeholder2 ...}}`.
-  For instance, if multiple paths are expected, use `{{path/to/directory1 path/to/directory2 ...}}`.
-- If only one of the multiple options is possible, write it as: `{{placeholder1|placeholder2|placeholder3}}`. If there are more than 3 possible values, you can use `|...` after the last item.
+- If a command can optionally take 1 or more arguments of the same kind, use an ellipsis: `{{placeholder_1 placeholder_2 ...}}`.
+  For instance, if multiple paths are expected, use `{{path/to/directory_1 path/to/directory_2 ...}}`.
+- If only one of the multiple options is possible, write it as: `{{placeholder_1|placeholder_2|placeholder_3}}`. If there are more than 3 possible values, you can use `|...` after the last item.
 - Use two dots to mark a range of possible values, for example `{{1..5}}` or `{{a..z}}`.
 
 #### Optional placeholders


### PR DESCRIPTION
The variant with an underscore looks marginally more readable as was discussed in Matrix today.
Both are fine to use, but this should be the suggested variant.
Good exaple of why:
<img width="354" height="88" alt="image" src="https://github.com/user-attachments/assets/1de980df-4b9b-4bd6-8030-c327abb8490d" />
<img width="272" height="92" alt="image" src="https://github.com/user-attachments/assets/97427fdb-298f-4469-9f5d-6df7f6f8d4d1" />
