### PR TITLE
Update virtualboxvm.md

### DIFF
--- a/pages/windows/virtualboxvm.md
+++ b/pages/windows/virtualboxvm.md
@@ -1,24 +1,23 @@
-# virtualboxvm
+## virtualboxvm
 
-> Manage VirtualBox virtual machines.
-> More information: <https://www.virtualbox.org>.
+> VirtualBox VM launcher (Windows) — **deprecated or non-standard** in VirtualBox CLI.
+> More information: https://www.virtualbox.org/
 
-- Start a virtual machine:
+- Start a VM by name / UUID:  
+  `virtualboxvm --startvm {{name|uuid}}`
 
-`virtualboxvm --startvm {{name|uuid}}`
+- Start in fullscreen:  
+  `virtualboxvm --startvm {{name|uuid}} --fullscreen`
 
-- Start a virtual machine in fullscreen mode:
+- Mount a DVD image:  
+  `virtualboxvm --startvm {{name|uuid}} --dvd {{path\to\image_file}}`
 
-`virtualboxvm --startvm {{name|uuid}} --fullscreen`
+- Debug with command-line window:  
+  `virtualboxvm --startvm {{name|uuid}} --debug-command-line`
 
-- Mount the specified DVD image file:
+- Start a VM in a paused state:  
+  `virtualboxvm --startvm {{name|uuid}} --start-paused`
 
-`virtualboxvm --startvm {{name|uuid}} --dvd {{path\to\image_file}}`
-
-- Display a command-line window with debug information:
-
-`virtualboxvm --startvm {{name|uuid}} --debug-command-line`
-
-- Start a virtual machine in a paused state:
-
-`virtualboxvm --startvm {{name|uuid}} --start-paused`
+> **Note:** This command is not part of the standard `VBoxManage` CLI. Users are encouraged to use `VBoxManage` for full CLI functionality:
+> - List VMs: `VBoxManage list vms` :contentReference[oaicite:4]{index=4}  
+> - Start VM: `VBoxManage startvm {{name|uuid}}` :contentReference[oaicite:5]{index=5}  


### PR DESCRIPTION
fix(virtualbox): clarify or deprecate virtualboxvm command

Remove or update the TLDR page for virtualboxvm because there is no sufficient evidence that this command is officially supported by modern VirtualBox CLI.

Add a note explaining that VBoxManage is the recommended, documented way to manage VMs via command line.

Link to Oracle VirtualBox manual showing the VBoxManage subcommands.  virtualbox.org
+1

This change improves accuracy for Windows users and reduces confusion for contributors / users who find virtualboxvm in TLDR but not in VirtualBox documentation.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
