### PR TITLE
squid: add page

### DIFF
--- a/pages/common/squid.md
+++ b/pages/common/squid.md
@@ -1,0 +1,36 @@
+# squid
+
+> A high-performance caching and forwarding HTTP web proxy.
+> More information: <https://manned.org/squid>.
+
+- Start the Squid daemon:
+
+`squid`
+
+- Start Squid daemon with a specific configuration file:
+
+`squid -f {{path/to/squid.conf}}`
+
+- Parse and test the configuration file for errors:
+
+`squid -k parse`
+
+- Reconfigure Squid (reload configuration file without stopping):
+
+`squid -k reconfigure`
+
+- Gracefully shutdown Squid:
+
+`squid -k shutdown`
+
+- Immediately shutdown Squid:
+
+`squid -k kill`
+
+- Rotate log files:
+
+`squid -k rotate`
+
+- Check the status of the running Squid process:
+
+`squid -k check`


### PR DESCRIPTION
This PR adds a new tldr page for the `squid` command - a high-performance caching and forwarding HTTP web proxy.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Squid 6.x
- Reference issue: #19493