### PR TITLE
style-guide: define environment variable usage

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -323,7 +323,7 @@ When describing an environment variable for UNIX platforms, prepend the variable
 
 For Windows command prompt, prepend and append the environment variable with a percent sign and enclose it with backticks (`%VARIABLE_NAME%`). For example: "Manage the `%JAVA_HOME%` environment variable".
 
-Whereas for Powershell,  prepend the environment variable with a dollar sign, Env and a colon then enclose it with backticks (`$Env:VARIABLE_NAME`). For example: "Manage the `$Env:JAVA_HOME` environment variable".
+Whereas for Powershell, prepend the environment variable with a dollar sign, Env and a colon, then enclose it with backticks (`$Env:VARIABLE_NAME`). For example: "Manage the `$Env:JAVA_HOME` environment variable".
 
 ### Standardized Terms
 


### PR DESCRIPTION
I noticed that there was inconsistencies when describing environment variables