### PR TITLE
objdump: add --visualize-jumps --disassembler-color example

### DIFF
--- a/pages/common/objdump.md
+++ b/pages/common/objdump.md
@@ -23,7 +23,7 @@
 
 `objdump {{[-d|--disassemble]}} {{path/to/binary}} --visualize-jumps={{color|extended-color}} --disassembler-color={{color|extended-color}}`
 
-- Display the symbol table:
+- Display the symbol [t]able:
 
 `objdump {{[-t|--syms]}} {{path/to/binary}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

I've added an example with jump/control flow visualization and syntax highlighting (which can be really useful when someone is reading the disassembled output of `objdump`). I reordered the arguments of the Intel syntax example so that all disassembly examples [align vertically](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#argument-order).

I also added a [mnemonic](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#short-option-mnemonics) for the symbol table example.

The difference between the output of `objdump` with `--visualize-jumps=extended-color --disassembler-color=extended-color` and without is the difference between:

<img width="1159" height="972" alt="image" src="https://github.com/user-attachments/assets/f0952151-52fa-4091-beb8-2d940dd69213" />

<br/>
and:

<img width="1159" height="972" alt="image" src="https://github.com/user-attachments/assets/74f4f4a3-9e36-4326-88a5-fd7d013b7d2c" />




### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `GNU objdump (GNU Binutils for Ubuntu) 2.42`
