### PR TITLE
style-guide: add file extension instructions

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -325,7 +325,7 @@ For Windows command prompt, prepend and append the environment variable with a p
 
 Whereas for Powershell, prepend the environment variable with a dollar sign, Env and a colon, then enclose it with backticks (`$Env:VARIABLE_NAME`). For example: "Manage the `$Env:JAVA_HOME` environment variable".
 
-When describing file formats, primarily use the brand name like JSON, or prepend the file extensions with a dot like `.txt`.
+When describing file formats, primarily use the brand name in plain text (e.g. JSON, SQLite), or use the file extension preceded by a dot, wrapped in backticks (e.g. `.txt`).
 
 ### Standardized Terms
 


### PR DESCRIPTION
The Special Cases category is starting to feel a bit bloated. If anyone wants, they can take similar instructions and put them under their own category.