### PR TITLE
systemctl-mount-image: fix wrong apostrophe

### DIFF
--- a/pages/linux/systemctl-mount-image.md
+++ b/pages/linux/systemctl-mount-image.md
@@ -8,7 +8,7 @@
 
 `systemctl mount-image {{unit}} /{{path/to/image}} /{{path/to/directory_inside_unit}}`
 
-- Mount the image’s `root` partition with read-only and no-setuid options:
+- Mount the image's `root` partition with read-only and no-setuid options:
 
 `systemctl mount-image {{unit}} /{{path/to/image}} /{{path/to/directory_inside_unit}} root:ro,nosuid`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
