### PR TITLE
bluetoothctl: add Italian translation

### DIFF
--- a/pages.it/linux/bluetoothctl.md
+++ b/pages.it/linux/bluetoothctl.md
@@ -1,0 +1,37 @@
+# bluetoothctl
+
+> Gestisce i dispositivi Bluetooth.
+> Vedi anche: `bluetui`.
+> Maggiori informazioni: <https://manned.org/bluetoothctl>.
+
+- Entra nella shell `bluetoothctl`:
+
+`bluetoothctl`
+
+- Elenca tutti i dispositivi conosciuti:
+
+`bluetoothctl devices`
+
+- Accende o spegne il controller Bluetooth:
+
+`bluetoothctl power {{on|off}}`
+
+- Effettua il pairing con un dispositivo:
+
+`bluetoothctl pair {{mac_address}}`
+
+- Rimuove un dispositivo:
+
+`bluetoothctl remove {{mac_address}}`
+
+- Connetti a un dispositivo associato:
+
+`bluetoothctl connect {{mac_address}}`
+
+- Disconnetti da un dispositivo associato:
+
+`bluetoothctl disconnect {{mac_address}}`
+
+- Mostra l'aiuto:
+
+`bluetoothctl help`


### PR DESCRIPTION
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).