### PR TITLE
zstd: add ultra-fast compression level

### DIFF
--- a/pages/common/zstd.md
+++ b/pages/common/zstd.md
@@ -19,6 +19,10 @@
 
 `zstd -{{level}} {{path/to/file}}`
 
+- Compress a file using an ultra-fast compression level, where 1=default:
+
+`zstd --fast={{level}} {{path/to/file}}`
+
 - Unlock higher compression levels (up to 22) using more memory (both for compression and decompression):
 
 `zstd --ultra -{{level}} {{path/to/file}}`


### PR DESCRIPTION
Can speed up compression in exchange for compression ratio 
https://github.com/facebook/zstd?tab=readme-ov-file#benchmarks

Is this the right format for `--fast[=#]` as in the manpage?

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** all
- Reference issue: none
