### PR TITLE
presenterm: add page

### DIFF
--- a/pages/common/presenterm.md
+++ b/pages/common/presenterm.md
@@ -1,7 +1,7 @@
 # presenterm
 
 > A terminal-based slideshow tool that renders markdown presentations.
-> More information: <https://github.com/mfontanini/presenterm>.
+> More information: <https://mfontanini.github.io/presenterm/>.
 
 - Display a presentation:
 


### PR DESCRIPTION
Add tldr page for presenterm, a terminal-based slideshow tool that renders markdown presentations.

## Checklist

- [x] Page doesn't already exist
- [x] Page is in the correct platform directory (`pages/common/`)
- [x] 8 or fewer examples
- [x] Follows style guide formatting
- [x] Description includes documentation link