### PR TITLE
CODEOWNERS: remove inactive codeowners and those who have not removed sms two-factor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 /pages.es/ @kant
 /pages.fa/ @MrMw3
 /pages.fi/ @Managor
-/pages.fr/ @Nico385412 @nicokosi @noraj
-/pages.hi/ @kbdharun @debghs @karthik-script
+/pages.fr/ @nicokosi @noraj
+/pages.hi/ @kbdharun @debghs
 /pages.id/ @reinhart1010
 /pages.it/ @mebeim @tansiret @Magrid0 @SpikeTheDragon40k
 /pages.nl/ @sebastiaanspeck @leonvsc @Waples @dmmqz


### PR DESCRIPTION
@Zamoca42 is no longer active on github and @IMHOJEONG and @CodePsy-2001 have not yet replied to the sms 2 factor removal.

Also removing @karthik-script and @Nico385412 for the same reasons