### PR TITLE
coredumpctl: unify PID notation

### DIFF
--- a/pages/linux/coredumpctl.md
+++ b/pages/linux/coredumpctl.md
@@ -11,7 +11,7 @@
 
 `coredumpctl list {{program}}`
 
-- Show information about the core dumps matching a program with `PID`:
+- Show information about the core dumps matching a program with PID:
 
 `coredumpctl info {{PID}}`
 


### PR DESCRIPTION
Even though PID is sort of technical wording, everywhere else PID is being used without backticks. Probably a job for a later date to change these into `` `PID` `` unless we reach a conclusion that without backticks is better.