### PR TITLE
scripts/set-alias-page.py: add inexact matching for alias finding

### DIFF
--- a/scripts/set-alias-page.py
+++ b/scripts/set-alias-page.py
@@ -499,6 +499,7 @@ def main():
         language=args.language,
         inexact=args.inexact,
     )
+
     target_paths = []
 
     # Use '--page' option


### PR DESCRIPTION
This should mostly be used with the --dry-run option.

Closes: #19968