### PR TITLE
style-guide: add instructions for when a command is run in interactive mode

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -327,7 +327,8 @@ Whereas for Powershell, prepend the environment variable with a dollar sign, Env
 
 When describing file formats, primarily use the brand name in plain text (e.g. JSON, SQLite), or use the file extension preceded by a dot, wrapped in backticks (e.g. `.txt`).
 
-If the command that is being described is part of an interactive mode, mention the word "interactive" in a previous example that enters said mode and mark the beginning of the description for the interactive commands with `[Interactive]`. Interactive mode can be defined as running commands within the command the page describes, and the prompt not having access to programs in $PATH.
+If the command that is being described is part of an interactive mode, mention the word "interactive" in a previous example that enters said mode and mark the beginning of the description for the interactive commands with `[Interactive]`.
+Interactive mode can be defined as running commands within the command the page describes, and the prompt not having access to programs in $PATH.
 
 ### Standardized Terms
 


### PR DESCRIPTION
As was conceptualized in #19991, this gives a general guideline for how to mark interactive modes in commands like `parted`, `ftp`, and `sftp`. The definition is there just so that custom shells don't fall into this category.

The wording feels a bit off though. I would appreciate someone making the wording sound less janky.
Closes: #17317