### PR TITLE
 scripts/set-alias-page.py: match the title and the original command

### DIFF
--- a/scripts/set-alias-page.py
+++ b/scripts/set-alias-page.py
@@ -173,12 +173,11 @@ def set_alias_page(
     )
 
     if (
-        existing_locale_page_content.title
-            == page_content.title
+        existing_locale_page_content.title == page_content.title
         and existing_locale_page_content.original_command
-            == page_content.original_command
+        == page_content.original_command
         and existing_locale_page_content.documentation_command
-            == page_content.documentation_command
+        == page_content.documentation_command
     ):
         return ""
 


### PR DESCRIPTION
Currently the script doesn't detect if an alias is malformed or outdated like in #19927. This change makes it so that the title, original command and documentation suggestion are checked.