### PR TITLE
fatrace: separate timestamp as its own command

### DIFF
--- a/pages/linux/fatrace.md
+++ b/pages/linux/fatrace.md
@@ -12,6 +12,10 @@
 
 `sudo fatrace {{[-C|--command]}} {{program_name}}`
 
-- Print file access events on the mount of the current directory, with timestamps, to `stdout`:
+- Print file access events on the mount of the current directory to `stdout`:
 
-`sudo fatrace {{[-ct|--current-mount --timestamp]}}`
+`sudo fatrace {{[-c|--current-mount]}}`
+
+- Add timestamps to the printout:
+
+`sudo fatrace {{[-t|--timestamp]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
