### PR TITLE
scripts/check-errors.sh: improve usability

### DIFF
--- a/scripts/check-errors.sh
+++ b/scripts/check-errors.sh
@@ -93,6 +93,7 @@ grep -r $'\u200A'
 grep -r $'\u200B'
 grep -r $'\u200C'
 grep -r $'\u200D'
+grep -r $'\u200F'
 grep -r $'\u202F'
 grep -r $'\uFEFF'
 


### PR DESCRIPTION
Until further improvements are made, you can run this on the top level of the project with `firejail --blacklist=.git --blacklist=scripts --blacklist=images --blacklist=contributing-guides checktldr.sh 2>/dev/null`

Otherwise always run in a language subdirectory

