### PR TITLE
lastcomm, makepasswd, pdfseparate, autopkgtest, snake4scores: move from debian man pages to manned

### DIFF
--- a/pages/common/lastcomm.md
+++ b/pages/common/lastcomm.md
@@ -1,7 +1,7 @@
 # lastcomm
 
 > Show last commands executed.
-> More information: <https://manpages.debian.org/latest/acct/lastcomm.1.en.html>.
+> More information: <https://manned.org/lastcomm>.
 
 - Print information about all the commands in the acct (record file):
 

--- a/pages/common/makepasswd.md
+++ b/pages/common/makepasswd.md
@@ -1,7 +1,7 @@
 # makepasswd
 
 > Generate and encrypt passwords.
-> More information: <https://manpages.debian.org/latest/makepasswd/makepasswd.1.en.html>.
+> More information: <https://manned.org/makepasswd>.
 
 - Generate a random password (8 to 10 characters long, containing letters and numbers):
 

--- a/pages/common/pdfseparate.md
+++ b/pages/common/pdfseparate.md
@@ -1,7 +1,7 @@
 # pdfseparate
 
 > Portable Document Format (PDF) file page extractor.
-> More information: <https://manpages.debian.org/latest/poppler-utils/pdfseparate.1.en.html>.
+> More information: <https://manned.org/pdfseparate>.
 
 - Extract pages from PDF file and make a separate PDF file for each page:
 

--- a/pages/linux/autopkgtest.md
+++ b/pages/linux/autopkgtest.md
@@ -1,7 +1,7 @@
 # autopkgtest
 
 > Run tests on Debian packages.
-> More information: <https://manpages.debian.org/bookworm/autopkgtest/autopkgtest.1.en.html>.
+> More information: <https://manned.org/autopkgtest>.
 
 - Build the package in the current directory and run all tests directly on the system:
 

--- a/pages/linux/snake4scores.md
+++ b/pages/linux/snake4scores.md
@@ -1,7 +1,7 @@
 # snake4scores
 
 > Show the high scores from the snake4 game.
-> More information: <https://manpages.debian.org/snake4/snake4.6.en.html>.
+> More information: <https://manned.org/snake4>.
 
 - Show the highscores:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
