### PR TITLE
trunk{,.rs,.io}: split page for trunkrs.dev and trunk.io

### DIFF
--- a/pages/common/trunk.io.md
+++ b/pages/common/trunk.io.md
@@ -1,0 +1,32 @@
+# trunk
+
+> Run linters, formatters, and security analyzers on code.
+> More information: <https://docs.trunk.io/code-quality/overview/getting-started/commands-reference>.
+
+- Initialize trunk in a repository:
+
+`trunk init`
+
+- Run all applicable linters and formatters on changed files:
+
+`trunk check`
+
+- Run linters and formatters on specific files:
+
+`trunk check {{path/to/file1 path/to/file2 ...}}`
+
+- Format files in place:
+
+`trunk fmt`
+
+- List all available tools and their status:
+
+`trunk tools list`
+
+- Enable a tool at a specific version:
+
+`trunk tools enable {{tool}}@{{version}}`
+
+- Print an action's execution history:
+
+`trunk actions history {{action}}`

--- a/pages/common/trunk.md
+++ b/pages/common/trunk.md
@@ -1,24 +1,11 @@
 # trunk
 
-> Bundle and serve Rust web apps with CI/CD pipelines.
-> More information: <https://docs.trunk.io/code-quality/overview>.
+> `trunk` can refer to multiple commands with the same name.
 
-- Start local/production server with hot reloading:
+- View documentation for the Rust WASM bundler:
 
-`trunk serve --port {{port}} --release --proxy-backend {{URL}}`
+`tldr trunk.rs`
 
-- Build for production at root or subdirectory:
+- View documentation for the trunk.io code quality platform:
 
-`trunk build --release --dist {{path/to/distribution}} --public-url /{{path/to/app_subdirectory}}`
-
-- List all available tools in the repo and if they are enabled:
-
-`trunk tools list`
-
-- Enable/disable a tool at a specific version:
-
-`trunk tools {{enable|disable}} {{tool}}@{{version}}`
-
-- Print an action's execution history:
-
-`trunk actions history {{action}}`
+`tldr trunk.io`

--- a/pages/common/trunk.rs.md
+++ b/pages/common/trunk.rs.md
@@ -1,0 +1,24 @@
+# trunk
+
+> Bundle and serve Rust WASM web applications.
+> More information: <https://trunkrs.dev/commands/>.
+
+- Build the application in release mode and serve it locally:
+
+`trunk serve --release`
+
+- Build the application and serve it on a specific port:
+
+`trunk serve {{[-p|--port]}} {{port}}`
+
+- Build for production at a specific output directory:
+
+`trunk build --release {{[-d|--dist]}} {{path/to/distribution}}`
+
+- Build with a specific public URL path for hosting in a subdirectory:
+
+`trunk build --release --public-url /{{path/to/app_subdirectory}}`
+
+- Clean the output directory:
+
+`trunk clean`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
