### PR TITLE
npm-cache: fix incorrect commands and sync translations

### DIFF
--- a/pages.ko/common/npm-cache.md
+++ b/pages.ko/common/npm-cache.md
@@ -7,30 +7,26 @@
 
 `npm cache add {{패키지_이름}}`
 
-- 특정 패키지를 캐시에서 제거:
-
-`npm cache remove {{패키지_이름}}`
-
 - 키를 사용하여 특정 캐시 항목 삭제:
 
 `npm cache clean {{키}}`
 
 - 전체 npm 캐시 삭제:
 
-`npm cache clean --force`
+`npm cache clean {{[-f|--force]}}`
 
-- npm 캐시의 내용 나열:
+- 캐시된 패키지 나열:
 
 `npm cache ls`
+
+- 특정 이름과 버전과 일치하는 캐시된 패키지 나열:
+
+`npm cache ls {{이름}}@{{버전}}`
 
 - npm 캐시의 무결성 확인:
 
 `npm cache verify`
 
-- npm 캐시 위치 및 구성 정보 표시:
+- npx 캐시의 모든 항목 나열:
 
-`npm cache dir`
-
-- 캐시 경로 변경:
-
-`npm config set cache {{경로/대상/폴더}}`
+`npm cache npx ls`

--- a/pages/common/npm-cache.md
+++ b/pages/common/npm-cache.md
@@ -7,30 +7,26 @@
 
 `npm cache add {{package_name}}`
 
-- Remove a specific package from the cache:
-
-`npm cache remove {{package_name}}`
-
 - Clear a specific cached item by key:
 
 `npm cache clean {{key}}`
 
 - Clear the entire npm cache:
 
-`npm cache clean --force`
+`npm cache clean {{[-f|--force]}}`
 
-- List the contents of the npm cache:
+- List cached packages:
 
 `npm cache ls`
+
+- List cached packages matching a specific name and version:
+
+`npm cache ls {{name}}@{{version}}`
 
 - Verify the integrity of the npm cache:
 
 `npm cache verify`
 
-- Show the cache path:
+- List all entries in the npx cache:
 
-`npm {{[c|config]}} get cache`
-
-- Change the cache path:
-
-`npm {{[c|config]}} set cache {{path/to/directory}}`
+`npm cache npx ls`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

The `npm-cache` page contained several incorrect commands and was out of sync with its Korean translation; this PR fixes it by:
- Removing non-existent `npm cache remove` command
- Removing non-existent `npm cache dir` command (Korean only)
- Removing out-of-scope `npm config` examples (belong in `npm-config` page which already has them)
- Adding `{{[-f|--force]}}` short/long format for `--force` flag
- Adding useful commands of `npm cache ls {{name}}@{{version}}` and `npm cache npx ls`
- Syncing Korean translation with corrected English version - please review this change deeply as I don't speak the language
