### PR TITLE
kubectl-completion: add page

### DIFF
--- a/pages/common/kubectl-completion.md
+++ b/pages/common/kubectl-completion.md
@@ -1,0 +1,36 @@
+# kubectl completion
+
+> Generate shell completion code for `kubectl` commands.
+> More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/>.
+
+- Print the completion script for Bash, Zsh, fish, or PowerShell:
+
+`kubectl completion {{bash|zsh|fish|powershell}}`
+
+- Load Bash or Zsh completions into the current shell session:
+
+`source <(kubectl completion {{bash|zsh}})`
+
+- Append Bash completion script to `~/.bashrc`:
+
+`kubectl completion bash >> ~/.bashrc`
+
+- Write Zsh completion script to a file in the `fpath`:
+
+`kubectl completion zsh > "${fpath[1]}/_kubectl"`
+
+- Load fish completions into the current shell session:
+
+`kubectl completion fish | source`
+
+- Persist fish completions:
+
+`kubectl completion fish > ~/.config/fish/completions/kubectl.fish`
+
+- Load PowerShell completions into the current shell session:
+
+`kubectl completion powershell | Out-String | Invoke-Expression`
+
+- Persist PowerShell completions:
+
+`kubectl completion powershell >> $PROFILE`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.34.1v 
- Reference issue: #17606

Simple explanation: 

| #   | Shell      | Action  | Command                                                           |
|-----|------------|---------|-------------------------------------------------------------------|
| 1   | All        | Print   | `kubectl completion {{bash\|zsh\|fish\|powershell}}`                   |
| 2   | Bash/Zsh   | Load    | `source <(kubectl completion {{bash\|zsh}})`                         |
| 3   | Bash       | Persist | `kubectl completion bash >> ~/.bashrc`                              |
| 4   | Zsh        | Persist | `kubectl completion zsh > "${fpath[1]}/_kubectl"`                   |
| 5   | fish       | Load    | `kubectl completion fish \| source`                                  |
| 6   | fish       | Persist | `kubectl completion fish > ~/.config/fish/completions/kubectl.fish` |
| 7   | PowerShell | Load    | `kubectl completion powershell \| Out-String \| Invoke-Expression`    |
| 8   | PowerShell | Persist | `kubectl completion powershell >> $PROFILE`                        |