### PR TITLE
translation-templates/common-arguments: add column for command, value, and port

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -30,7 +30,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | lo    |                       |                          |                                    |             |                    |          |
 | ml    | ഫയലിലേക്കുള്ള/പാത        | ഡയറക്ടറിയിലേക്കുള്ള/പാത      | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത   | പാക്കേജ്      | ഉപയോക്തൃനാമം         |          |
 | ne    | फाइल/को/पथ            | निर्देशिका/को/पथ           | फाइल_वा_निर्देशिका/को/पथ             | प्याकेज       | प्रयोगकर्ता_नाम      |          |
-| nl    | pad/naar/bestand      | pad/naar/map             | pad/naar/bestand_of_map            | pakket      | gebruikersnaam     | wachtwoord | commando |
+| nl    | pad/naar/bestand      | pad/naar/map             | pad/naar/bestand_of_map            | pakket      | gebruikersnaam     | wachtwoord | commando | poort | waarde |
 | no    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog          | pakke       | brukernavn         |          |
 | pl    | ścieżka/do/pliku      | ścieżka/do/katalogu      | ścieżka/do/pliku_lub_katalogu      | pakiet      | nazwa_użytkownika  |          |
 | pt_BR | caminho/para/arquivo  | caminho/para/diretorio   | caminho/para/arquivo_ou_diretorio  | pacote      | nome_do_usuario    |          |


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
