### PR TITLE
uv-pip: replace 'freeze' command with 'compile' for locking dependencies

### DIFF
--- a/pages/common/uv-pip.md
+++ b/pages/common/uv-pip.md
@@ -19,7 +19,7 @@
 
 `uv pip uninstall {{package}}`
 
-- Lock dependencies from a `pyproject.toml` to a `requirements.txt`:
+- Lock dependencies from `pyproject.toml` to `requirements.txt`:
 
 `uv pip compile pyproject.toml {{[-o|--output-file]}} requirements.txt`
 


### PR DESCRIPTION
https://docs.astral.sh/uv/pip/compile/#locking-requirements