### PR TITLE
touch: fix option display format

### DIFF
--- a/pages/common/touch.md
+++ b/pages/common/touch.md
@@ -9,7 +9,7 @@
 
 - Set the file [a]ccess or [m]odification times to the current one and don't create file if it doesn't exist:
 
-`touch {{[-c|--no-create]}} -{{a|m}} {{path/to/file1 path/to/file2 ...}}`
+`touch {{[-c|--no-create]}} {{-a|-m}} {{path/to/file1 path/to/file2 ...}}`
 
 - Set the file [t]ime to a specific value and don't create file if it doesn't exist:
 


### PR DESCRIPTION
In my option this looks very confusing
<img width="65" height="53" alt="image" src="https://github.com/user-attachments/assets/28e7dc2d-0e38-45ea-897d-426f951b6398" />

Whereas this is much clearer that they both need a dash
<img width="63" height="49" alt="image" src="https://github.com/user-attachments/assets/42d95612-71fe-4511-8099-0109c2cdfad2" />
