### PR TITLE
lsblk: adjust example

### DIFF
--- a/pages/linux/lsblk.md
+++ b/pages/linux/lsblk.md
@@ -31,6 +31,6 @@
 
 `lsblk {{[-e|--exclude]}} {{1,7,...}}`
 
-- Add extra information to the output using a comma-separated list of columns:
+- Add extra information to the output using a comma-separated list of columns (omit the `+` sign to only display the specified columns):
 
 `lsblk {{[-o|--output]}} +{{NAME,ROTA,SERIAL,MODEL,TRAN,TYPE,SIZE,FSTYPE,MOUNTPOINT,...}}`


### PR DESCRIPTION
Picking and choosing what columns you want to show is very time consuming when the default columns are already good enough. It's better to just tack on what you need