### PR TITLE
style-guide: move windows instructions to their own section

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -485,6 +485,7 @@ To mark keypresses for TUI or GUI programs, use angle brackets `<` and `>`.
 ## Windows-Specific Rules
 
 ### General layout
+
 When documenting PowerShell commands, please take note of the following naming conventions.
 
 - The name of the file name must be written in lowercase, such as `invoke-webrequest.md` instead of `Invoke-WebRequest.md`.


### PR DESCRIPTION
I always felt the windows instructions cluttered the style guide with instructions that don't apply most of the time. An added benefit of this is that all the windows instructions are found in the same place. Only the environment variable instructions are duplicated because I felt that they are short enough snippets that they don't clutter and that they make sense to have in context of the general environment variable instructions.