### PR TITLE
pages.nl/*: fix subcommand mention in Dutch pages; cargo-index: fix subcommand mention

### DIFF
--- a/pages.nl/common/cargo.md
+++ b/pages.nl/common/cargo.md
@@ -1,7 +1,7 @@
 # cargo
 
 > Beheer Rust projecten en hun afhankelijkheden (crates).
-> Sommige subcommando's zoals `build` hebben een eigen documentatie pagina.
+> Sommige subcommando's zoals `build` hebben hun eigen documentatie.
 > Meer informatie: <https://doc.rust-lang.org/stable/cargo/>.
 
 - Zoek naar crates:

--- a/pages.nl/common/conda.md
+++ b/pages.nl/common/conda.md
@@ -1,7 +1,7 @@
 # conda
 
 > Pakket-, afhankelijkheids- en omgevingsbeheer voor alle programmeertalen.
-> Sommige subcommando's zoals `create` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `create` hebben hun eigen documentatie.
 > Meer informatie: <https://docs.conda.io/projects/conda/en/latest/commands/index.html>.
 
 - Maak een nieuwe omgeving aan en installeer hierin benoemde pakketten:

--- a/pages.nl/common/crane-index.md
+++ b/pages.nl/common/crane-index.md
@@ -1,7 +1,7 @@
 # crane index
 
 > Wijzig een image-index.
-> De subcommando's `append` en `filter` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `append` en `filter` hebben hun eigen documentatie.
 > Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_index.md>.
 
 - Wijzig een image-index:

--- a/pages.nl/common/crane.md
+++ b/pages.nl/common/crane.md
@@ -1,7 +1,7 @@
 # crane
 
 > Hulpmiddel voor het beheren van containerimages.
-> Sommige subcommando's zoals `pull`, `push`, `copy`, enz. hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `pull`, `push`, `copy`, etc. hebben hun eigen documentatie.
 > Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md/>.
 
 - Log in op een register:

--- a/pages.nl/common/gcrane.md
+++ b/pages.nl/common/gcrane.md
@@ -2,8 +2,8 @@
 
 > Beheer tool voor containerafbeeldingen.
 > Deze tool implementeert een superset van de `crane`-commando's, met aanvullende commando's die specifiek zijn voor Google Container Registry (`gcr.io`).
-> Sommige subcommando's zoals `append`, `auth`, `copy`, enz. hebben hun eigen gebruiksdocumentatie die te vinden is onder `crane`.
-> Sommige subcommando's zoals `completion`, `gc`, `help` zijn specifiek voor gcrane en hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `append`, `auth`, `copy`, etc. hebben hun eigen documentatie die te vinden is onder `crane`.
+> Sommige subcommando's zoals `completion`, `gc`, `help` zijn specifiek voor gcrane en hebben hun eigen documentatie.
 > Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md>.
 
 - Log in op een register:

--- a/pages.nl/common/gh-pr.md
+++ b/pages.nl/common/gh-pr.md
@@ -1,7 +1,7 @@
 # gh pr
 
 > Beheer GitHub pull requests.
-> Sommige subcommando's zoals `create` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `create` hebben hun eigen documentatie.
 > Meer informatie: <https://cli.github.com/manual/gh_pr>.
 
 - Maak een pull request aan:

--- a/pages.nl/common/gh.md
+++ b/pages.nl/common/gh.md
@@ -1,7 +1,7 @@
 # gh
 
 > Werk gemakkelijk met GitHub.
-> Sommige subcommando's zoals `config` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `config` hebben hun eigen documentatie.
 > Meer informatie: <https://cli.github.com/manual/gh>.
 
 - Kloon een GitHub-repository lokaal:

--- a/pages.nl/common/linode-cli.md
+++ b/pages.nl/common/linode-cli.md
@@ -1,7 +1,7 @@
 # linode-cli
 
 > Beheer Linode cloud-diensten.
-> Sommige subcommando's zoals `events` hebben een eigen documentatie pagina.
+> Sommige subcommando's zoals `events` hebben hun eigen documentatie.
 > Meer informatie: <https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-cli>.
 
 - Toon alle Linodes:

--- a/pages.nl/common/nxc.md
+++ b/pages.nl/common/nxc.md
@@ -1,7 +1,7 @@
 # nxc
 
 > Netwerk service opsomming en exploitatie gereedschap.
-> Sommige subcommando's zoals `smb` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `smb` hebben hun eigen documentatie.
 > Meer informatie: <https://www.netexec.wiki/getting-started/selecting-and-using-a-protocol>.
 
 - Toon een lijst van beschikbare modules voor het opgegeven protocol:

--- a/pages.nl/linux/dpkg.md
+++ b/pages.nl/linux/dpkg.md
@@ -1,7 +1,7 @@
 # dpkg
 
 > Debian pakketbeheerder.
-> Sommige subcommando's zoals `deb` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `deb` hebben hun eigen documentatie.
 > Voor gelijkwaardige commando's in andere pakket managers, zie <https://wiki.archlinux.org/title/Pacman/Rosetta>.
 > Meer informatie: <https://manned.org/dpkg>.
 

--- a/pages.nl/linux/ip.md
+++ b/pages.nl/linux/ip.md
@@ -1,7 +1,7 @@
 # ip
 
 > Toon/manipuleer routing, apparaten, beleidsrouting en tunnels.
-> Sommige subcommando's zoals `address` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `address` hebben hun eigen documentatie.
 > Meer informatie: <https://manned.org/ip.8>.
 
 - Toon interfaces met gedetailleerde informatie:

--- a/pages.nl/linux/qm.md
+++ b/pages.nl/linux/qm.md
@@ -1,7 +1,7 @@
 # qm
 
 > QEMU/KVM Virtual Machine Manager.
-> Sommige subcommando's zoals `list`, `start`, `stop`, `clone`, etc. hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `list`, `start`, `stop`, `clone`, etc. hebben hun eigen documentatie.
 > Meer informatie: <https://pve.proxmox.com/pve-docs/qm.1.html>.
 
 - Toon alle virtual machines:

--- a/pages.nl/linux/semanage.md
+++ b/pages.nl/linux/semanage.md
@@ -1,7 +1,7 @@
 # semanage
 
 > SELinux persistent beleid beheertool.
-> Sommige subcommando's zoals `boolean`, `fcontext`, `port`, etc. hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `boolean`, `fcontext`, `port`, etc. hebben hun eigen documentatie.
 > Meer informatie: <https://manned.org/semanage>.
 
 - Stel een SELinux-boolean in of uit. Booleans stellen de beheerder in staat om aan te passen hoe beleidsregels invloed hebben op ingesloten procestypes (ook wel domeinen genoemd):

--- a/pages.nl/windows/choco.md
+++ b/pages.nl/windows/choco.md
@@ -1,7 +1,7 @@
 # choco
 
 > De Chocolatey pakket manager.
-> Sommige subcommando's zoals `install`, `upgrade`, `pin` hebben hun eigen gebruiksdocumentatie.
+> Sommige subcommando's zoals `install`, `upgrade`, `pin` hebben hun eigen documentatie.
 > Meer informatie: <https://docs.chocolatey.org/en-us/choco/commands/>.
 
 - Installeer een pakket:

--- a/pages/common/crane-index.md
+++ b/pages/common/crane-index.md
@@ -1,7 +1,7 @@
 # crane index
 
 > Modify an image index.
-> The subcommands `append` and `filter` have their own usage documentation.
+> Some subcommands such as `append` and `filter` have their own usage documentation.
 > More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_index.md>.
 
 - Modify an image index:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
