### PR TITLE
docker-container-exec: French translation, 3rd person

### DIFF
--- a/pages.fr/common/docker-container-exec.md
+++ b/pages.fr/common/docker-container-exec.md
@@ -3,26 +3,26 @@
 > Exécute une commande dans un conteneur déjà en cours d'exécution.
 > Plus d'informations : <https://docs.docker.com/reference/cli/docker/container/exec/>.
 
-- Entrer dans un shell interactif dans un conteneur en cours d'exécution :
+- Entre dans un shell interactif dans un conteneur en cours d'exécution :
 
 `docker {{[exec|container exec]}} {{[-it|--interactive --tty]}} {{nom_du_conteneur}} {{/bin/bash}}`
 
-- Exécuter une commande en arrière-plan (détachée) dans un conteneur en cours d'exécution :
+- Exécute une commande en arrière-plan (détachée) dans un conteneur en cours d'exécution :
 
 `docker {{[exec|container exec]}} {{[-d|--detach]}} {{nom_du_conteneur}} {{commande}}`
 
-- Sélectionner le répertoire de travail pour une commande donnée à exécuter :
+- Sélectionne le répertoire de travail pour une commande donnée à exécuter :
 
 `docker {{[exec|container exec]}} {{[-it|--interactive --tty]}} {{[-w|--workdir]}} {{chemin/vers/le/répertoire}} {{nom_du_conteneur}} {{commande}}`
 
-- Exécuter une commande en arrière-plan sur un conteneur existant mais garder `stdin` ouvert :
+- Exécute une commande en arrière-plan sur un conteneur existant mais garde `stdin` ouvert :
 
 `docker {{[exec|container exec]}} {{[-i|--interactive]}} {{[-d|--detach]}} {{nom_du_conteneur}} {{commande}}`
 
-- Définir une variable d'environnement dans une session Bash en cours d'exécution :
+- Définit une variable d'environnement dans une session Bash en cours d'exécution :
 
 `docker {{[exec|container exec]}} {{[-it|--interactive --tty]}} {{[-e|--env]}} {{variable_d_environnement}}={{valeur}} {{nom_du_conteneur}} {{/bin/bash}}`
 
-- Exécuter une commande en tant qu'utilisateur spécifique :
+- Exécute une commande en tant qu'utilisateur spécifique :
 
 `docker {{[exec|container exec]}} {{[-u|--user]}} {{utilisateur}} {{nom_du_conteneur}} {{commande}}`


### PR DESCRIPTION
Convert to third person singular present indicative tense

https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#french-specific-rules

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
