### PR TITLE
parallel: fix example

### DIFF
--- a/pages/common/parallel.md
+++ b/pages/common/parallel.md
@@ -29,7 +29,7 @@
 
 - Download 4 files simultaneously from a text file containing links showing progress:
 
-`parallel {{[-j|--jobs]}} 4 --bar --eta curl {{[-s|--silent]}} {{[-O|--remote-name]}} {} :::: {{path/to/links.txt}}`
+`parallel {{[-j|--jobs]}} 4 --bar --eta curl {{[-sO|--silent --remote-name]}} {} :::: {{path/to/links.txt}}`
 
 - Print the jobs which `parallel` is running in `stderr`:
 


### PR DESCRIPTION
wget is used wrong way

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #19833
