### PR TITLE
gcloud: fix subcommand mention

### DIFF
--- a/pages/common/gcloud.md
+++ b/pages/common/gcloud.md
@@ -1,7 +1,7 @@
 # gcloud
 
 > The official CLI tool for Google Cloud Platform.
-> Note: `gcloud` subcommands have their own usage documentation.
+> Some subcommands such as `app` and `init` have their own usage documentation.
 > More information: <https://docs.cloud.google.com/sdk/gcloud>.
 
 - List all properties in one's active configuration:


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #