### PR TITLE
COMMUNITY-ROLES: fix welcome message for copy-paste

### DIFF
--- a/COMMUNITY-ROLES.md
+++ b/COMMUNITY-ROLES.md
@@ -157,8 +157,7 @@ using one of the template messages below as a base.
 
    Additionally, consider subscribing to the notifications from the various repositories under the [tldr-pages organization](https://github.com/tldr-pages).
 
-   As one of the public faces of the tldr-pages project, it's also especially important that you follow and encourage the [project
-   governance principles](https://github.com/tldr-pages/tldr/blob/main/GOVERNANCE.md).
+   As one of the public faces of the tldr-pages project, it's also especially important that you follow and encourage the [project governance principles](https://github.com/tldr-pages/tldr/blob/main/GOVERNANCE.md).
 
    How does that sound? Are you up for it?
    ```


### PR DESCRIPTION
The line break transfers itself to the actual message. To improve the copy-pasteability, I removed the line break
What it looks like:

<img width="252" height="152" alt="image" src="https://github.com/user-attachments/assets/7c62e142-abff-4d10-84c6-c1cc6f9cdb3a" />
