### PR TITLE
crane-*: fix mismatched documentation URLs

### DIFF
--- a/pages.ko/common/crane-export.md
+++ b/pages.ko/common/crane-export.md
@@ -1,7 +1,7 @@
 # crane export
 
 > 컨테이너 이미지의 파일 시스템을 tarball로 내보냄.
-> 더 많은 정보: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> 더 많은 정보: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md>.
 
 - `stdout`에 tarball을 작성:
 

--- a/pages.ko/common/crane-flatten.md
+++ b/pages.ko/common/crane-flatten.md
@@ -2,7 +2,7 @@
 
 > 이미지의 레이어를 단일 레이어로 병합.
 > 태그가 지정되지 않은 경우, 다이제스트를 원본 이미지 저장소에 푸시.
-> 더 많은 정보: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> 더 많은 정보: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_flatten.md>.
 
 - 이미지 병합:
 

--- a/pages.nl/common/crane-export.md
+++ b/pages.nl/common/crane-export.md
@@ -1,7 +1,7 @@
 # crane export
 
 > Exporteer het bestandssysteem van een containerimage als een tarball.
-> Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md>.
 
 - Schrijf de tarball naar `stdout`:
 

--- a/pages.nl/common/crane-flatten.md
+++ b/pages.nl/common/crane-flatten.md
@@ -2,7 +2,7 @@
 
 > Flatten de lagen van een image tot een enkele laag.
 > Push de digest naar de oorspronkelijke image-repository als er geen tags zijn opgegeven.
-> Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> Meer informatie: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_flatten.md>.
 
 - Flatten een image:
 

--- a/pages/common/crane-export.md
+++ b/pages/common/crane-export.md
@@ -1,7 +1,7 @@
 # crane export
 
 > Export filesystem of a container image as a tarball.
-> More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md>.
 
 - Write tarball to `stdout`:
 

--- a/pages/common/crane-flatten.md
+++ b/pages/common/crane-flatten.md
@@ -2,7 +2,7 @@
 
 > Flatten an image's layers into a single layer.
 > Pushes digest to original image repository if no tags are specified.
-> More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md>.
+> More information: <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_flatten.md>.
 
 - Flatten an image:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
