### PR TITLE
docker-container-stats: fix command format

### DIFF
--- a/pages.de/common/docker-container-stats.md
+++ b/pages.de/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - Zeige sich stetig aktualisierende Statistiken von allen laufenden Containern:
 
-`docker stats`
+`docker {{[stats|container stats]}}`
 
 - Zeige sich stetig aktualisierende Statistiken der durch Leerzeichen getrennten Container:
 
-`docker stats {{container_name}}`
+`docker {{[stats|container stats]}} {{container_name}}`
 
 - Ändere das Spaltenformat um die CPU Auslastung von Containern in Prozent anzuzeigen:
 
-`docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - Zeige Statistiken für alle Container (laufende und gestoppte):
 
-`docker stats {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - Deaktiviere die laufende Aktualisierung und zeige nur die aktuellen Statistiken:
 
-`docker stats --no-stream`
+`docker {{[stats|container stats]}} --no-stream`

--- a/pages.fr/common/docker-container-stats.md
+++ b/pages.fr/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - Afficher un flux en direct des statistiques d'utilisation des ressources pour tous les conteneurs :
 
-`docker stats`
+`docker {{[stats|container stats]}}`
 
 - Afficher un flux en direct des statistiques d'utilisation des ressources pour un ou plusieurs conteneurs séparés par des espaces :
 
-`docker stats {{nom_du_conteneur}}`
+`docker {{[stats|container stats]}} {{nom_du_conteneur}}`
 
 - Change le format de sortie pour afficher l'utilisation CPU du conteneur en pourcentage :
 
-`docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - Afficher les statistiques d'utilisation des ressources pour tous les conteneurs (y compris ceux qui ne sont pas en cours d'exécution) :
 
-`docker stats {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - Desactiver le flux en direct des statistiques d'utilisation des ressources et afficher les statistiques une seule fois :
 
-`docker stats --no-stream`
+`docker {{[stats|container stats]}} --no-stream`

--- a/pages.ko/common/docker-container-stats.md
+++ b/pages.ko/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - 실행 중인 모든 컨테이너의 통계를 실시간 스트림으로 표시:
 
-`docker stats`
+`docker {{[stats|container stats]}}`
 
 - 하나 이상의 컨테이너에 대한 통계를 실시간 스트림으로 표시:
 
-`docker stats {{컨테이너1 컨테이너2 ...}}`
+`docker {{[stats|container stats]}} {{컨테이너1 컨테이너2 ...}}`
 
 - 컨테이너의 CPU 사용률을 표시하도록 열 형식을 변경:
 
-`docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - 모든 컨테이너(실행 중 및 중지된)의 통계를 표시:
 
-`docker stats {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - 스트리밍 통계를 비활성화하고 현재 통계만 가져오기:
 
-`docker stats --no-stream`
+`docker {{[stats|container stats]}} --no-stream`

--- a/pages.pt_BR/common/docker-container-stats.md
+++ b/pages.pt_BR/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - Exibe estatísticas atualizadas de todos os containers em execução:
 
-`docker stats`
+`docker {{[stats|container stats]}}`
 
 - Exibe estatísticas atualizadas de uma lista separada por espaço dos containers:
 
-`docker stats {{nome_do_container}}`
+`docker {{[stats|container stats]}} {{nome_do_container}}`
 
 - Altera o formato das colunas para exibir o uso da CPU em porcentagem:
 
-`docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - Exibe estatísticas para todos os containers (tanto em execução como parados):
 
-`docker stats {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - Desabilita estatísticas atualizadas e só exibe o status naquele momento:
 
-`docker stats --no-stream`
+`docker {{[stats|container stats]}} --no-stream`

--- a/pages.tr/common/docker-container-stats.md
+++ b/pages.tr/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - Çalışan tüm konteynerlerin aynak kullanım istatistiklerinin canlı yayınını görüntüle:
 
-`docker stats`
+`docker {{[stats|container stats]}}`
 
 - Boşluk ile ayrılmış bir listedeki konteynerlerin canlı yayınını görüntüle:
 
-`docker stats {{container_ismi}}`
+`docker {{[stats|container stats]}} {{container_ismi}}`
 
 - Konteyner'in CPU kullanım yüzdesini göstermek için sütun formatını değiştir:
 
-`docker stats --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - Tüm (çalışan veya durmuş) konteynerler için istatistikleri görüntüle:
 
-`docker stats {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - İstatistikleri canlı yayınlamayı durdur ve yalnızca mevcut durumdaki istatistikleri görüntüle:
 
-`docker stats --no-stream`
+`docker {{[stats|container stats]}} --no-stream`

--- a/pages/common/docker-container-stats.md
+++ b/pages/common/docker-container-stats.md
@@ -5,20 +5,20 @@
 
 - Display a live stream for the statistics of all running containers:
 
-`docker {{[stats|container statss}}`
+`docker {{[stats|container stats]}}`
 
 - Display a live stream of statistics for one or more containers:
 
-`docker {{[stats|container statss}} {{container1 container2 ...}}`
+`docker {{[stats|container stats]}} {{container1 container2 ...}}`
 
 - Change the columns format to display container's CPU usage percentage:
 
-`docker {{[stats|container statss}} --format "{{.Name}}:\t{{.CPUPerc}}"`
+`docker {{[stats|container stats]}} --format "{{.Name}}:\t{{.CPUPerc}}"`
 
 - Display statistics for all containers (both running and stopped):
 
-`docker {{[stats|container statss}} {{[-a|--all]}}`
+`docker {{[stats|container stats]}} {{[-a|--all]}}`
 
 - Disable streaming stats and only pull the current stats:
 
-`docker {{[stats|container statss}} --no-stream`
+`docker {{[stats|container stats]}} --no-stream`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

This PR fixes malformed command syntax `(statss}} → stats]}})` in `docker-container-stats.md` and update all translations to use the `{{[stats|container stats]}}` format.
