### PR TITLE
workflows/codespell.yml: ignore translation templates

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,11 +12,12 @@ on:
       - 'package-lock.json'
 
 jobs:
-  build:
+  codespell:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Get changed files
         id: changed-files
@@ -29,7 +30,10 @@ jobs:
             contributing-guides/translation-templates/*
             package-lock.json
 
-      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
+      - name: Run Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
+        # Only run if there are changed files to check
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           ignore_words_file: .github/codespell-ignore
           # Exit with 0 regardless of typos.


### PR DESCRIPTION
Since translation template mainly consists of multiple languages other than English, it shows lots of unnecessary errors for PRs editing files inside this directory.

### Checklist

- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
