### PR TITLE
doctl-databases-replica: fix wrong command

### DIFF
--- a/pages.ko/common/doctl-databases-replica.md
+++ b/pages.ko/common/doctl-databases-replica.md
@@ -5,20 +5,20 @@
 
 - 액세스 토큰을 사용하여 `doctl databases replica` 명령을 실행:
 
-`doctl databases pool {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 읽기 전용 데이터베이스 복제본에 대한 정보를 검색:
 
-`doctl databases replica get {{데이터베이스_아이디}} {{복제본_이름}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{[g|get]}} {{데이터베이스_아이디}} {{복제본_이름}}`
 
 - 읽기 전용 데이터베이스 복제본 목록 검색:
 
-`doctl databases replica list {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{[ls|list]}} {{데이터베이스_아이디}}`
 
 - 읽기 전용 데이터베이스 복제본 생성:
 
-`doctl databases replica create {{데이터베이스_아이디}} {{복제본_이름}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{[c|create]}} {{데이터베이스_아이디}} {{복제본_이름}}`
 
 - 읽기 전용 데이터베이스 복제본 삭제:
 
-`doctl databases replica delete {{데이터베이스_아이디}} {{복제본_이름}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{[rm|delete]}} {{데이터베이스_아이디}} {{복제본_이름}}`

--- a/pages/common/doctl-databases-replica.md
+++ b/pages/common/doctl-databases-replica.md
@@ -5,7 +5,7 @@
 
 - Run a `doctl databases replica` command with an access token:
 
-`doctl {{[d|databases]}} {{[p|pool]}} {{command}} {{[-t|--access-token]}} {{access_token}}`
+`doctl {{[d|databases]}} {{[r|replica]}} {{command}} {{[-t|--access-token]}} {{access_token}}`
 
 - Retrieve information about a read-only database replica:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
