### PR TITLE
doctl-databases-pool: fix wrong command

### DIFF
--- a/pages.ko/common/doctl-databases-pool.md
+++ b/pages.ko/common/doctl-databases-pool.md
@@ -5,20 +5,20 @@
 
 - 액세스 토큰을 사용하여 `doctl databases pool` 명령을 실행:
 
-`doctl databases pool {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 데이터베이스 연결 풀에 대한 정보 검색:
 
-`doctl databases pool get {{데이터베이스_아이디}} {{풀_이름}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{[g|get]}} {{데이터베이스_아이디}} {{풀_이름}}`
 
 - 데이터베이스 클러스터에 대한 연결 풀을 나열:
 
-`doctl databases pool list {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{[ls|list]}} {{데이터베이스_아이디}}`
 
 - 데이터베이스에 대한 연결 풀을 생성:
 
-`doctl databases pool create {{데이터베이스_아이디}} {{풀_이름}} --db {{새로운_풀_이름}} --size {{풀_크기}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{[c|create]}} {{데이터베이스_아이디}} {{풀_이름}} --db {{새로운_풀_이름}} --size {{풀_크기}}`
 
 - 데이터베이스에 대한 연결 풀을 삭제:
 
-`doctl databases pool create {{데이터베이스_아이디}} {{풀_이름}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{[rm|delete]}} {{데이터베이스_아이디}} {{풀_이름}}`

--- a/pages/common/doctl-databases-pool.md
+++ b/pages/common/doctl-databases-pool.md
@@ -21,4 +21,4 @@
 
 - Delete a connection pool for a database:
 
-`doctl {{[d|databases]}} {{[p|pool]}} {{[c|create]}} {{database_id}} {{pool_name}}`
+`doctl {{[d|databases]}} {{[p|pool]}} {{[rm|delete]}} {{database_id}} {{pool_name}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
