### PR TITLE
pages.nl/*: fix Dutch placeholder translation

### DIFF
--- a/pages.nl/common/objdump.md
+++ b/pages.nl/common/objdump.md
@@ -21,7 +21,7 @@
 
 - Toon de gedemonteerde uitvoer van uitvoerbare secties met jump visualisaties en syntax highlighting:
 
-`objdump {{[-d|--disassemble]}} {{path/to/binary}} --visualize-jumps={{color|extended-color}} --disassembler-color={{color|extended-color}}`
+`objdump {{[-d|--disassemble]}} {{pad/naar/binary}} --visualize-jumps={{color|extended-color}} --disassembler-color={{color|extended-color}}`
 
 - Toon de symbooltabel:
 

--- a/pages.nl/common/readarray.md
+++ b/pages.nl/common/readarray.md
@@ -25,7 +25,7 @@
 
 - Zet een aangepast schei[d]ingsteken:
 
-`readarray < {{path/to/file.txt}} -d {{scheidingsteken}} {{array_naam}}`
+`readarray < {{pad/naar/bestand.txt}} -d {{scheidingsteken}} {{array_naam}}`
 
 - Toon de help:
 

--- a/pages.nl/common/tail.md
+++ b/pages.nl/common/tail.md
@@ -10,7 +10,7 @@
 
 - Toon de laatste 10 regels van meerdere bestanden:
 
-`tail {{path/to/file1 path/to/file2 ...}}`
+`tail {{pad/naar/bestand1 pad/naar/bestand2 ...}}`
 
 - Toon laatste 5 regels in een bestand:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: # 