### PR TITLE
common-arguments.md: update Italian translation

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -24,7 +24,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | fr    | chemin/vers/fichier   | chemin/vers/dossier      | chemin/vers/fichier_ou_dossier     | paquet      | nom_d_utilisateur  | mot_de_passe | commande | port | valeur |
 | hi    | फ़ाइल/का/पथ            | निर्देशिका/का/पथ           | फ़ाइल_या_निर्देशिका/का/पथ             | पैकेज         | उपयोगकर्ता_नाम      |          |
 | id    | jalan/menuju/berkas   | jalan/menuju/direktori   | jalan/menuju/berkas_atau_direktori | paket       | nama_pengguna      |          |
-| it    | percorso/del/file     | percorso/della/directory | percorso/del/file_o_directory      | pacchetto   | nome_utente        |          |
+| it    | percorso/del/file     | percorso/della/directory | percorso/del/file_o_directory      | pacchetto   | nome_utente        | password | comando | porta | valore |
 | ja    | ファイルパス          | ディレクトリパス         | ファイルパスまたはディレクトリパス | パッケージ  | ユーザー名         |          |
 | ko    | 경로/대상/파일        | 경로/대상/폴더           | 경로/대상/파일_또는_폴더           | 패키지      | 사용자 명          |          |
 | lo    |                       |                          |                                    |             |                    |          |


### PR DESCRIPTION
Added missing fields for Italian translation.


### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

