### PR TITLE
buns, bun-feedback, ts-node: fix spelling of Bun/Node and update Korean translation

### DIFF
--- a/pages.ko/common/ts-node.md
+++ b/pages.ko/common/ts-node.md
@@ -3,7 +3,7 @@
 > TypeScript 코드를 컴파일 없이 직접 실행.
 > 더 많은 정보: <https://typestrong.org/ts-node/docs/options/>.
 
-- TypeScript 파일을 컴파일 없이 실행 (`Node` + `tsc`):
+- TypeScript 파일을 컴파일 없이 실행 (Node + `tsc`):
 
 `ts-node {{경로/대상/파일.ts}}`
 

--- a/pages.nl/common/bunx.md
+++ b/pages.nl/common/bunx.md
@@ -12,7 +12,7 @@
 
 `bunx {{pakket_naam}} --version`
 
-- Forceer een uitvoerbaar bestand om te draaien met de `Bun` runtime (in plaats van `Node`):
+- Forceer een uitvoerbaar bestand om te draaien met de Bun runtime (in plaats van Node):
 
 `bunx --bun {{pakket_naam}}`
 

--- a/pages/common/bun-feedback.md
+++ b/pages/common/bun-feedback.md
@@ -1,6 +1,6 @@
 # bun feedback
 
-> Send feedback to `Bun`.
+> Send feedback to Bun.
 > More information: <https://bun.com/docs/feedback#use-bun-feedback>.
 
 - Send text as feedback:

--- a/pages/common/bunx.md
+++ b/pages/common/bunx.md
@@ -12,7 +12,7 @@
 
 `bunx {{package_name}} --version`
 
-- Force an executable to run with the `Bun` runtime (instead of `Node`):
+- Force an executable to run with the Bun runtime (instead of Node):
 
 `bunx --bun {{package_name}}`
 

--- a/pages/common/ts-node.md
+++ b/pages/common/ts-node.md
@@ -3,7 +3,7 @@
 > Run TypeScript code directly, without any compiling.
 > More information: <https://typestrong.org/ts-node/docs/options/>.
 
-- Execute a TypeScript file without compiling (`Node` + `tsc`):
+- Execute a TypeScript file without compiling (Node + `tsc`):
 
 `ts-node {{path/to/file.ts}}`
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: # 