### PR TITLE
pages*: put nginx in backticks and fix case

### DIFF
--- a/pages.bn/common/acme.sh.md
+++ b/pages.bn/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn {{[-d|--domain]}} {{example.com}}`
 
-- কার্যকর (working) Nginx কনফিগারেশন ব্যবহার করে একটি সার্টিফিকেট ইস্যু করুন:
+- কার্যকর (working) `nginx` কনফিগারেশন ব্যবহার করে একটি সার্টিফিকেট ইস্যু করুন:
 
 `acme.sh --issue --nginx {{[-d|--domain]}} {{example.com}}`
 

--- a/pages.de/common/kubectl-run.md
+++ b/pages.de/common/kubectl-run.md
@@ -3,15 +3,15 @@
 > Pods in Kubernetes ausführen. Gibt den Pod-Generator an, um einen deprecation Fehler in einigen Kubernetes Versionen zu vermeiden.
 > Weitere Informationen: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run/>.
 
-- Starte einen nginx-Pod und gib Port 80 frei:
+- Starte einen `nginx`-Pod und gib Port 80 frei:
 
 `kubectl run {{nginx-dev}} --image nginx --port 80`
 
-- Starte einen nginx-Pod und setze die Umgebungsvariable TEST_VAR:
+- Starte einen `nginx`-Pod und setze die Umgebungsvariable TEST_VAR:
 
 `kubectl run {{nginx-dev}} --image nginx --env "{{TEST_VAR}}={{testing}}"`
 
-- Zeige API-Aufrufe an, die zur Erstellung eines Nginx-Containers erfolgen würden:
+- Zeige API-Aufrufe an, die zur Erstellung eines `nginx`-Containers erfolgen würden:
 
 `kubectl run {{nginx-dev}} --image nginx --dry-run={{none|server|client}}`
 

--- a/pages.de/common/nginx.md
+++ b/pages.de/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx Webserver.
+> `nginx` Webserver.
 > Weitere Informationen: <https://nginx.org/docs/switches.html>.
 
 - Starte den Server mit der standardmäßigen Konfigurationsdatei:

--- a/pages.de/linux/certbot.md
+++ b/pages.de/linux/certbot.md
@@ -8,7 +8,7 @@
 
 `sudo certbot certonly --webroot {{[-w|--webroot-path]}} {{pfad/zu/webroot}} {{[-d|--domain]}} {{subdomain.example.com}}`
 
-- Beziehe ein neues Zertifikat über die nginx-Autorisierung und automatische Installation des neuen Zertifikats:
+- Beziehe ein neues Zertifikat über die `nginx`-Autorisierung und automatische Installation des neuen Zertifikats:
 
 `sudo certbot --nginx {{[-d|--domain]}} {{subdomain.example.com}}`
 

--- a/pages.es/common/acme.sh.md
+++ b/pages.es/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn {{[-d|--domain]}} {{example.com}}`
 
-- Emite un certificado utilizando una configuración Nginx que está operativa:
+- Emite un certificado utilizando una configuración `nginx` que está operativa:
 
 `acme.sh --issue --nginx {{[-d|--domain]}} {{example.com}}`
 

--- a/pages.es/common/nginx.md
+++ b/pages.es/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Servidor web Nginx.
+> Servidor web `nginx`.
 > Más información: <https://nginx.org/docs/switches.html>.
 
 - Inicia el servidor con el archivo de configuración por defecto:

--- a/pages.es/osx/aiac.md
+++ b/pages.es/osx/aiac.md
@@ -7,7 +7,7 @@
 
 `aiac get terraform {{for an azure storage account}}`
 
-- Genera un Dockerfile para nginx:
+- Genera un Dockerfile para `nginx`:
 
 `aiac get dockerfile {{for a secured nginx}}`
 

--- a/pages.fr/common/acme.sh.md
+++ b/pages.fr/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn --domain {{exemple.com}}`
 
-- Publie un certificat en utilisant une configuration Nginx :
+- Publie un certificat en utilisant une configuration `nginx` :
 
 `acme.sh --issue --nginx --domain {{exemple.com}}`
 

--- a/pages.id/common/acme.sh.md
+++ b/pages.id/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn --domain {{example.com}}`
 
-- Terbitkan sertifikat dengan konfigurasi server Nginx untuk memasangnya:
+- Terbitkan sertifikat dengan konfigurasi server `nginx` untuk memasangnya:
 
 `acme.sh --issue --nginx --domain {{example.com}}`
 

--- a/pages.ja/common/nginx.md
+++ b/pages.ja/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx ウェブサーバ。
+> `nginx` ウェブサーバ。
 > もっと詳しく: <https://nginx.org/docs/switches.html>。
 
 - デフォルトの設定ファイルでサーバーを起動する:

--- a/pages.ko/common/acme.sh.md
+++ b/pages.ko/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn --domain {{example.com}}`
 
-- 작동하는 Nginx 구성파일을 사용해 인증서 발급:
+- 작동하는 `nginx` 구성파일을 사용해 인증서 발급:
 
 `acme.sh --issue --nginx --domain {{example.com}}`
 

--- a/pages.ko/common/gixy.md
+++ b/pages.ko/common/gixy.md
@@ -1,20 +1,20 @@
 # gixy
 
-> nginx 구성 파일 분석.
+> `nginx` 구성 파일 분석.
 > 더 많은 정보: <https://github.com/yandex/gixy>.
 
-- nginx 구성 파일 분석 (기본 경로: `/etc/nginx/nginx.conf`):
+- nginx 구성 파일 분석 (기본 경로: `/etc/nginx/`nginx`.conf`):
 
 `gixy`
 
-- nginx 구성 분석하지만 특정 테스트 넘어감:
+- `nginx` 구성 분석하지만 특정 테스트 넘어감:
 
 `gixy --skips {{http_splitting}}`
 
-- 특정 세부 수준으로 nginx 구성을 분석:
+- 특정 세부 수준으로 `nginx` 구성을 분석:
 
 `gixy {{-l|-ll|-lll}}`
 
-- 특정 경로에서 nginx 구성 파일을 분석:
+- 특정 경로에서 `nginx` 구성 파일을 분석:
 
 `gixy {{경로/대상/구성_파일_1}} {{경로/대상/구성_파일_2}}`

--- a/pages.ko/common/kubectl-run.md
+++ b/pages.ko/common/kubectl-run.md
@@ -3,15 +3,15 @@
 > Kubernetes에서 파드를 실행. 일부 K8S 버전에서 경고 메시지를 피하기 위해 파드 생성기를 지정.
 > 더 많은 정보: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run/>.
 
-- nginx 파드를 실행하고 포트 80을 노출:
+- `nginx` 파드를 실행하고 포트 80을 노출:
 
 `kubectl run {{nginx-dev}} --image nginx --port 80`
 
-- TEST_VAR 환경 변수를 설정하여 nginx 파드 실행:
+- TEST_VAR 환경 변수를 설정하여 `nginx` 파드 실행:
 
 `kubectl run {{nginx-dev}} --image nginx --env "{{TEST_VAR}}={{testing}}"`
 
-- nginx 컨테이너를 생성하기 위해 수행될 API 호출을 표시:
+- `nginx` 컨테이너를 생성하기 위해 수행될 API 호출을 표시:
 
 `kubectl run {{nginx-dev}} --image nginx --dry-run={{none|server|client}}`
 

--- a/pages.ko/common/nginx.md
+++ b/pages.ko/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx 웹 서버.
+> `nginx` 웹 서버.
 > 더 많은 정보: <https://nginx.org/docs/switches.html>.
 
 - 기본 설정 파일로 서버 시작:

--- a/pages.ko/linux/certbot.md
+++ b/pages.ko/linux/certbot.md
@@ -8,7 +8,7 @@
 
 `sudo certbot certonly --webroot {{[-w|--webroot-path]}} {{경로/대상/웹루트}} {{[-d|--domain]}} {{서브도메인.example.com}}`
 
-- nginx 인증을 통해 새 인증서를 획득하고 자동으로 설치하기:
+- `nginx` 인증을 통해 새 인증서를 획득하고 자동으로 설치하기:
 
 `sudo certbot --nginx {{[-d|--domain]}} {{서브도메인.example.com}}`
 

--- a/pages.ko/osx/aiac.md
+++ b/pages.ko/osx/aiac.md
@@ -7,7 +7,7 @@
 
 `aiac get terraform {{Azure 스토리지 계정을 위한}}`
 
-- nginx를 위한 Dockerfile 생성:
+- `nginx`를 위한 Dockerfile 생성:
 
 `aiac get dockerfile {{보안을 강화한 nginx를 위한}}`
 

--- a/pages.nl/common/acme.sh.md
+++ b/pages.nl/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn {{[-d|--domain]}} {{example.com}}`
 
-- Geef een certificaat uit met een werkende Nginx-configuratie:
+- Geef een certificaat uit met een werkende `nginx`-configuratie:
 
 `acme.sh --issue --nginx {{[-d|--domain]}} {{example.com}}`
 

--- a/pages.nl/common/nginx.md
+++ b/pages.nl/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx webserver.
+> `nginx` webserver.
 > Meer informatie: <https://nginx.org/docs/switches.html>.
 
 - Start de server met het standaard configuratiebestand:

--- a/pages.nl/linux/certbot.md
+++ b/pages.nl/linux/certbot.md
@@ -8,7 +8,7 @@
 
 `sudo certbot certonly --webroot {{[-w|--webroot-path]}} {{pad/naar/webroot}} {{[-d|--domain]}} {{subdomein.example.com}}`
 
-- Verkrijg een nieuw certificaat via nginx authorisatie, installeer het nieuwe certificaat automatisch:
+- Verkrijg een nieuw certificaat via `nginx` authorisatie, installeer het nieuwe certificaat automatisch:
 
 `sudo certbot --nginx {{[-d|--domain]}} {{subdomein.example.com}}`
 

--- a/pages.pt_BR/common/acme.sh.md
+++ b/pages.pt_BR/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn --domain {{example.com}}`
 
-- Emite um certificado usando uma configuração válida Nginx:
+- Emite um certificado usando uma configuração válida `nginx`:
 
 `acme.sh --issue --nginx --domain {{example.com}}`
 

--- a/pages.pt_BR/linux/certbot.md
+++ b/pages.pt_BR/linux/certbot.md
@@ -8,7 +8,7 @@
 
 `sudo certbot certonly --webroot {{[-w|--webroot-path]}} {{caminho_para_webroot}} {{[-d|--domain]}} {{subdominio.dominio.com}}`
 
-- Obtém um novo certificado via autorização nginx e instala-o automaticamente:
+- Obtém um novo certificado via autorização `nginx` e instala-o automaticamente:
 
 `sudo certbot --nginx {{[-d|--domain]}} {{subdominio.dominio.com}}`
 

--- a/pages.th/osx/aiac.md
+++ b/pages.th/osx/aiac.md
@@ -7,7 +7,7 @@
 
 `aiac get terraform {{for an azure storage account}}`
 
-- สร้าง Dockerfile สำหรับ nginx:
+- สร้าง Dockerfile สำหรับ `nginx`:
 
 `aiac get dockerfile {{for a secured nginx}}`
 

--- a/pages.tr/common/nginx.md
+++ b/pages.tr/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx web sunucusu.
+> `nginx` web sunucusu.
 > Daha fazla bilgi için: <https://nginx.org/docs/switches.html>.
 
 - Varsayılan konfigürasyon dosyasıyla sunucuyu başlat:

--- a/pages.zh/common/acme.sh.md
+++ b/pages.zh/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn --domain {{example.com}}`
 
-- 使用运行中的 Nginx 的配置来签发证书：
+- 使用运行中的 `nginx` 的配置来签发证书：
 
 `acme.sh --issue --nginx --domain {{example.com}}`
 

--- a/pages/common/acme.sh.md
+++ b/pages/common/acme.sh.md
@@ -16,7 +16,7 @@
 
 `acme.sh --issue --alpn {{[-d|--domain]}} {{example.com}}`
 
-- Issue a certificate using a working Nginx configuration:
+- Issue a certificate using a working `nginx` configuration:
 
 `acme.sh --issue --nginx {{[-d|--domain]}} {{example.com}}`
 

--- a/pages/common/gixy.md
+++ b/pages/common/gixy.md
@@ -1,20 +1,20 @@
 # gixy
 
-> Analyze nginx configuration files.
+> Analyze `nginx` configuration files.
 > More information: <https://github.com/yandex/gixy>.
 
-- Analyze nginx configuration (default path: `/etc/nginx/nginx.conf`):
+- Analyze nginx configuration (default path: `/etc/nginx/`nginx`.conf`):
 
 `gixy`
 
-- Analyze nginx configuration but skip specific tests:
+- Analyze `nginx` configuration but skip specific tests:
 
 `gixy --skips {{http_splitting}}`
 
-- Analyze nginx configuration with the specific severity level:
+- Analyze `nginx` configuration with the specific severity level:
 
 `gixy {{-l|-ll|-lll}}`
 
-- Analyze nginx configuration files on the specific path:
+- Analyze `nginx` configuration files on the specific path:
 
 `gixy {{path/to/configuration_file_1}} {{path/to/configuration_file_2}}`

--- a/pages/common/kubectl-run.md
+++ b/pages/common/kubectl-run.md
@@ -4,15 +4,15 @@
 > Specifies pod generator to avoid deprecation error in some K8S versions.
 > More information: <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_run/>.
 
-- Run an nginx pod and expose port 80:
+- Run an `nginx` pod and expose port 80:
 
 `kubectl run {{nginx-dev}} --image nginx --port 80`
 
-- Run an nginx pod, setting the `$TEST_VAR` environment variable:
+- Run an `nginx` pod, setting the `$TEST_VAR` environment variable:
 
 `kubectl run {{nginx-dev}} --image nginx --env "{{TEST_VAR}}={{testing}}"`
 
-- Show API calls that would be made to create an nginx container:
+- Show API calls that would be made to create an `nginx` container:
 
 `kubectl run {{nginx-dev}} --image nginx --dry-run={{none|server|client}}`
 

--- a/pages/common/nginx.md
+++ b/pages/common/nginx.md
@@ -1,6 +1,6 @@
 # nginx
 
-> Nginx web server.
+> `nginx` web server.
 > More information: <https://nginx.org/docs/switches.html>.
 
 - Start the server with the default configuration file:

--- a/pages/linux/certbot.md
+++ b/pages/linux/certbot.md
@@ -8,7 +8,7 @@
 
 `sudo certbot certonly --webroot {{[-w|--webroot-path]}} {{path/to/webroot}} {{[-d|--domain]}} {{subdomain.example.com}}`
 
-- Obtain a new certificate via nginx authorization, installing the new certificate automatically:
+- Obtain a new certificate via `nginx` authorization, installing the new certificate automatically:
 
 `sudo certbot --nginx {{[-d|--domain]}} {{subdomain.example.com}}`
 

--- a/pages/linux/systemctl-reload.md
+++ b/pages/linux/systemctl-reload.md
@@ -1,7 +1,7 @@
 # systemctl reload
 
 > Reload a service's configuration without restarting it.
-> This reloads the service itself (like Apache or Nginx configs), not the systemd unit file.
+> This reloads the service itself (like Apache or `nginx` configs), not the systemd unit file.
 > To reload unit files, use `systemctl daemon-reload`.
 
 - Reload a service:

--- a/pages/osx/aiac.md
+++ b/pages/osx/aiac.md
@@ -7,7 +7,7 @@
 
 `aiac get terraform {{for an azure storage account}}`
 
-- Generate a Dockerfile for nginx:
+- Generate a Dockerfile for `nginx`:
 
 `aiac get dockerfile {{for a secured nginx}}`
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: # 