### PR TITLE
translation-templates/common-descriptions: remove improper translations

### DIFF
--- a/contributing-guides/translation-templates/common-descriptions.md
+++ b/contributing-guides/translation-templates/common-descriptions.md
@@ -23,7 +23,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | id    | Tampilkan bantuan            |  |                  |
 | it    | Mostra l'aiuto | Controlla la versione     | [Interattivo]  |
 | ja    | ヘルプを表示する                | バージョンを表示            |                  |
-| ko    | 도움말 표시                    |                |                  |
+| ko    | 도움말 표시                    | 버전 표시                   |                  |
 | lo    |                              |                           |                  |
 | ml    |                              |                           |                  |
 | ne    |                              |                           |                  |


### PR DESCRIPTION
Indonesian and korean was adding an extra word "information" to the description and Serbian was actually written in Bosnian (according to chatgpt and google translate)