### PR TITLE
pages.*: fix untranslated lines in multiple languages

### DIFF
--- a/pages.fr/common/ansible-inventory.md
+++ b/pages.fr/common/ansible-inventory.md
@@ -1,6 +1,6 @@
 # ansible-inventory
 
-> Display or dump an Ansible inventory.
+> Affiche ou exporte un inventaire Ansible.
 > Voir aussi : `ansible`.
 > Plus d'informations : <https://docs.ansible.com/projects/ansible/latest/cli/ansible-inventory.html>.
 

--- a/pages.id/common/chatgpt.md
+++ b/pages.id/common/chatgpt.md
@@ -23,6 +23,6 @@
 
 `echo "{{Bagaimana cara melihat proses yang berjalan di Ubuntu?}}" | chatgpt`
 
-- Generate an image using DALL-E:
+- Buat gambar menggunakan DALL-E:
 
 `chatgpt {{[-p|--prompt]}} "{{image: Seekor kucing putih}}"`

--- a/pages.id/common/clang++.md
+++ b/pages.id/common/clang++.md
@@ -1,7 +1,7 @@
 # clang++
 
 > Susun kode C++.
-> Part of LLVM.
+> Bagian dari LLVM.
 > Informasi lebih lanjut: <https://clang.llvm.org/docs/UsersManual.html#command-line-options>.
 
 - Ubah suatu berkas kode sumber menjadi program:

--- a/pages.id/common/clang.md
+++ b/pages.id/common/clang.md
@@ -1,7 +1,7 @@
 # clang
 
 > Susun kode sumber C, C++, dan Objective-C. Dapat dipakai sebagai pengganti mutlak (drop-in) bagi GCC.
-> Part of LLVM.
+> Bagian dari LLVM.
 > Informasi lebih lanjut: <https://clang.llvm.org/docs/ClangCommandLineReference.html>.
 
 - Ubah suatu berkas kode sumber menjadi program:

--- a/pages.id/common/frpc.md
+++ b/pages.id/common/frpc.md
@@ -12,7 +12,7 @@
 
 `frpc {{[-c|--config]}} ./frps.toml`
 
-- Start the service, using a specific configuration file:
+- Jalankan layanan menggunakan berkas konfigurasi tertentu:
 
 `frpc {{[-c|--config]}} {{jalan/menuju/berkas}}`
 

--- a/pages.id/common/laravel.md
+++ b/pages.id/common/laravel.md
@@ -11,7 +11,7 @@
 
 `laravel new {{nama}} --dev`
 
-- Overwrite if the directory already exists:
+- Timpa jika direktori sudah ada:
 
 `laravel new {{nama}} --force`
 

--- a/pages.id/sunos/svcs.md
+++ b/pages.id/sunos/svcs.md
@@ -19,6 +19,6 @@
 
 `svcs -L apache`
 
-- Display end of a service log file:
+- Tampilkan akhir berkas catatan servis:
 
 `tail $(svcs -L apache)`

--- a/pages.it/common/drill.md
+++ b/pages.it/common/drill.md
@@ -7,7 +7,7 @@
 
 `drill {{esempio.com}}`
 
-- Lookup the mail server(s) associated with a given domain name (MX record):
+- Cerca i server di posta associati a un dato nome di dominio (record MX):
 
 `drill mx {{esempio.com}}`
 

--- a/pages.ko/common/aws-cognito-idp.md
+++ b/pages.ko/common/aws-cognito-idp.md
@@ -1,6 +1,6 @@
 # aws cognito-idp
 
-> Configure an Amazon Cognito user pool and its users and groups and authenticate them.
+> Amazon Cognito 사용자 풀과 사용자 및 그룹을 구성하고 인증.
 > 더 많은 정보: <https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/>.
 
 - 새로운 Cognito 사용자 풀 생성:

--- a/pages.ko/common/cargo-clippy.md
+++ b/pages.ko/common/cargo-clippy.md
@@ -15,7 +15,7 @@
 
 `cargo clippy --workspace`
 
-- Run checks for a package:
+- 패키지에 대한 검사 실행:
 
 `cargo clippy --package {{패키지}}`
 

--- a/pages.ko/common/cargo-tree.md
+++ b/pages.ko/common/cargo-tree.md
@@ -1,6 +1,6 @@
 # cargo tree
 
-> Display a tree visualization of a dependency graph.
+> 종속성 그래프의 트리 시각화를 표시.
 > 참고: 트리에서, `(*)`로 표시된 패키지의 종속성은 이미 그래프의 다른 곳에 표시되었으므로, 반복되지 않음.
 > 더 많은 정보: <https://doc.rust-lang.org/cargo/commands/cargo-tree.html>.
 

--- a/pages.ko/common/cdk.md
+++ b/pages.ko/common/cdk.md
@@ -7,7 +7,7 @@
 
 `cdk ls`
 
-- Synthesize and print the CloudFormation template for the specified stack(s):
+- 지정된 스택에 대한 CloudFormation 템플릿 합성 및 출력:
 
 `cdk synth {{스택_이름}}`
 

--- a/pages.ko/common/certutil.md
+++ b/pages.ko/common/certutil.md
@@ -19,6 +19,6 @@
 
 `certutil -A -n "{{서버_인증서}}" -t ",," -i {{경로/대상/파일.crt}} -d .`
 
-- Add subject alternative names to a given [c]ertificate with a specific key size ([g]):
+- 주어진 인증서([c])에 특정 키 크기([g])로 주체 대체 이름 추가:
 
 `certutil -S -f {{경로/대상/패스워드_파일.txt}} -d . -t ",," -c "{{서버_인증서}}" -n "{{서버_이름}}" -g {{2048}} -s "CN={{공통_이름}},O={{조직}}"`

--- a/pages.ko/common/exenv.md
+++ b/pages.ko/common/exenv.md
@@ -15,7 +15,7 @@
 
 `exenv local {{버전}}`
 
-- Show the currently selected Elixir version:
+- 현재 선택된 Elixir 버전 표시:
 
 `exenv {{버전}}`
 

--- a/pages.ko/common/fossil-commit.md
+++ b/pages.ko/common/fossil-commit.md
@@ -15,6 +15,6 @@
 
 `fossil commit --message-file {{경로/대상/커밋_메시지}}`
 
-- Create a new version containing changes from the specified files; user will be prompted for a comment:
+- 지정된 파일의 변경 사항을 포함하는 새 버전 생성; 사용자에게 설명을 요청하는 메시지가 표시됨:
 
 `fossil commit {{경로/대상/파일1 경로/대상/파일2 ...}}`

--- a/pages.ko/common/helm-install.md
+++ b/pages.ko/common/helm-install.md
@@ -23,7 +23,7 @@
 
 `helm install {{이름}} {{레포지토리_이름}}/{{차트_이름}} --dry-run`
 
-- Install a helm chart with custom values:
+- 사용자 정의 값으로 helm 차트 설치:
 
 `helm install {{이름}} {{레포지토리_이름}}/{{차트_이름}} --set {{매개변수1}}={{값1}},{{매개변수2}}={{값2}}`
 

--- a/pages.ko/common/ignite.md
+++ b/pages.ko/common/ignite.md
@@ -15,6 +15,6 @@
 
 `ignite add {{플러그인_이름}}`
 
-- Remove an Ignite plugin from the project:
+- 프로젝트에서 Ignite 플러그인 제거:
 
 `ignite remove {{플러그인_이름}}`

--- a/pages.nl/android/cmd.md
+++ b/pages.nl/android/cmd.md
@@ -1,6 +1,6 @@
 # cmd
 
-> Android service manager.
+> Android servicebeheerder.
 > Meer informatie: <https://cs.android.com/android/platform/superproject/+/main:frameworks/native/cmds/cmd/>.
 
 - Toon een [l]ijst met alle draaiende services:

--- a/pages.nl/common/mpicc.md
+++ b/pages.nl/common/mpicc.md
@@ -1,6 +1,6 @@
 # mpicc
 
-> Open MPI C wrapper compiler.
+> Open MPI C wrapper-compiler.
 > Meer informatie: <https://www.mpich.org/static/docs/latest/www1/mpicc.html>.
 
 - Compileer een bronbestand naar een objectbestand:

--- a/pages.nl/common/php.md
+++ b/pages.nl/common/php.md
@@ -1,6 +1,6 @@
 # php
 
-> PHP command-line interface.
+> PHP commandoregelinterface.
 > Meer informatie: <https://www.php.net/manual/en/features.commandline.options.php>.
 
 - Parse en voer een PHP-script uit:

--- a/pages.pt_BR/common/zip.md
+++ b/pages.pt_BR/common/zip.md
@@ -28,6 +28,6 @@
 
 `zip {{[-rs|--recurse-paths --split-size]}} {{3g}} {{caminho/para/comprimido.zip}} {{caminho/para/arquivo_ou_diretorio1 caminho/para/arquivo_ou_diretorio2 ...}}`
 
-- Print a specific archive contents:
+- Exibe o conteúdo de um arquivo compactado específico:
 
 `zip {{[-sf|--split-size --freshen]}} {{caminho/para/comprimido.zip}}`

--- a/pages.tr/linux/pw-link.md
+++ b/pages.tr/linux/pw-link.md
@@ -11,7 +11,7 @@
 
 `pw-link {{çıktı_port_ismi}} {{girdi_port_ismi}}`
 
-- Disconnect two ports:
+- İki portu ayır:
 
 `pw-link {{[-d|--disconnect]}} {{çıktı_port_ismi}} {{girdi_port_ismi}}`
 


### PR DESCRIPTION
Fix untranslated lines (TLDR113) across multiple language pages.

**Changes:**
- French: `ansible-inventory.md`
- Indonesian: `chatgpt.md`, `clang++.md`, `clang.md`, `frpc.md`, `laravel.md`, `svcs.md`
- Italian: `drill.md`
- Korean: `aws-cognito-idp.md`, `cargo-clippy.md`, `cargo-tree.md`, `cdk.md`, `certutil.md`, `exenv.md`, `fossil-commit.md`, `helm-install.md`, `ignite.md`
- Dutch: `cmd.md`, `mpicc.md`, `php.md`
- Portuguese (BR): `zip.md`
- Turkish: `pw-link.md`

Closes #20542