### PR TITLE
pages.nl/*: fix spelling of commando

### DIFF
--- a/pages.nl/common/cut.md
+++ b/pages.nl/common/cut.md
@@ -25,7 +25,7 @@
 
 - Toon geen regels die het scheidingsteken niet bevatten:
 
-`{{command}} | cut {{[-d|--delimiter]}} "{{:}}" {{[-f|--fields]}} {{1}} {{[-s|--only-delimited]}}`
+`{{commando}} | cut {{[-d|--delimiter]}} "{{:}}" {{[-f|--fields]}} {{1}} {{[-s|--only-delimited]}}`
 
 - Toon specifieke velden van regels die `NUL` gebruiken om regels af te sluiten in plaats van newlines:
 

--- a/pages.nl/common/doas.md
+++ b/pages.nl/common/doas.md
@@ -6,7 +6,7 @@
 
 - Voer een commando uit als root:
 
-`doas {{command}}`
+`doas {{commando}}`
 
 - Voer een commando uit als een andere gebruiker:
 
@@ -18,7 +18,7 @@
 
 - Parse een configuratiebestand en controleer of de uitvoering van het commando als een andere gebruiker toegestaan is:
 
-`doas -C {{pad/naar/configuratiebestand}} {{command}}`
+`doas -C {{pad/naar/configuratiebestand}} {{commando}}`
 
 - Zorg ervoor dat `doas` om een wachtwoord vraagt, zelfs als het eerder is opgegeven:
 

--- a/pages.nl/common/history.md
+++ b/pages.nl/common/history.md
@@ -33,4 +33,4 @@
 
 - Voer een commando uit zonder het toe te voegen aan de geschiedenis door te beginnen met een spatie:
 
-`<Spatie>{{command}}`
+`<Spatie>{{commando}}`

--- a/pages.nl/common/npm-exec.md
+++ b/pages.nl/common/npm-exec.md
@@ -17,7 +17,7 @@
 
 - Voer een specifiek commando uit, waarbij uitvoer van `npm` zelf wordt onderdrukt:
 
-`npm {{[x|exec]}} --quiet {{command}} {{argument1 argument2 ...}}`
+`npm {{[x|exec]}} --quiet {{commando}} {{argument1 argument2 ...}}`
 
 - Toon de help:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: # 