### PR TITLE
scripts: Explicitly exclude pages.en, add PowerShell test script version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
   "scripts": {
     "lint-markdown": "markdownlint pages*/**/*.md",
     "lint-tldr-pages": "tldr-lint ./pages",
-    "test": "bash scripts/test.sh",
+    "test": "node scripts/test.cjs",
+    "test-bash": "bash scripts/test.sh",
+    "test-powershell": "powershell scripts/test.ps1",
+    "test-pwsh": "pwsh scripts/test.ps1",
     "build-index": "node ./scripts/build-index.js > index.json",
     "prepare": "husky"
   },

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: MIT
+ */
+const { execSync } = require("child_process");
+
+const isWindows = process.platform === "win32";
+
+/**
+ * Simple method to check whether the new Cross-Platform
+ * PowerShell (`pwsh`) is installed.
+ * 
+ * More information: <https://learn.microsoft.com/powershell/scripting/whats-new/differences-from-windows-powershell>
+ * 
+ * @returns `"pwsh"` for the new PowerShell, `"powershell"` for legacy Windows PowerShell, and `null` for none.
+ */
+function detectPowerShell() {
+    const checkCommand = isWindows ? "where pwsh" : "command -v pwsh";
+
+    try {
+        execSync(checkCommand, {stdio: "ignore"});
+        return "pwsh"
+    } catch (e) {
+        return isWindows ? "powershell" : null
+    }
+}
+
+if (isWindows) {
+    const pwsh = detectPowerShell();
+    console.info(`> ${pwsh} scripts/test.ps1`);
+    execSync(`${pwsh} scripts/test.ps1`, {stdio: "inherit"});
+} else {
+    console.info(`> bash scripts/test.sh`);
+    execSync("bash scripts/test.sh", {stdio: "inherit"});
+}

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+
+# This script is executed by GitHub Actions for every successful push (on any branch, PR or not).
+# It runs some basic tests on pages. If the build is also a PR, additional
+# checks are run through the check-pr script, and any message or error is sent
+# to tldr-bot to be commented on the PR.
+#
+# NOTE: must be run from the repository root directory to correctly work!
+
+# check if a command is available to run in the system
+function Exists {
+    param (
+        [string]$Command
+    )
+    
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        return $true
+    }
+
+    return $false
+}
+
+function Assert-Black {
+    <#
+    .DESCRIPTION
+        Wrapper around black as it outputs everything to stderr,
+        but we want to only print if there are actual errors, and not
+        the "All done!" success message.
+    #>
+    $targetBlackVersion = (Get-Content requirements.txt | Where-Object { $_ -match "black==([\d.]+)" } | Select-String -Pattern "black==([\d.]+)").Matches.Groups[1].Value
+    
+    if ((python3 -m pip --disable-pip-version-check list) -match "black") {
+        $errs = python3 -m black scripts --check --required-version "$targetBlackVersion" 2>&1
+    }
+
+    if (!$errs) {
+        # skip the black check if the command is not available in the system.
+        if ((!$CI) -and (-not (Exists("black")))) {
+            Write-Host "Skipping black check, command not available."
+            return $false
+        }
+
+        $errs = black scripts --check --required-version "$targetBlackVersion" 2>&1
+    }
+
+    if ($errs -match "does not match the running version") {
+        Write-Host "Skipping black check, required version not available, try running: pip3 install -r requirements.txt"
+        return $true
+    }
+
+    <#
+    We want to ignore the exit code from black on failure so that we can
+    do the conditional printing below
+    #>
+    if (!"$errs".StartsWith("All done!")) {
+        Write-Error $errs
+        return $false
+    }
+}
+
+function Assert-Flake8 {
+    # skip flake8 check if the command is not available in the system.
+    if ((!$CI) -and (-not (Exists("flake8")))) {
+        Write-Host "Skipping flake8 check, command not available."
+        return $false
+    }
+    
+    flake8 scripts
+}
+
+function Assert-Pytest {
+    # skip pytest check if the command is not available in the system.
+    if ((!$CI) -and (-not (Exists("pytest")))) {
+        Write-Host "Skipping pytest check, command not available."
+        return $false
+    }
+
+    $errs = pytest scripts/*.py 2>&1
+    if ($errs -match "failed") {
+        Write-Error $errs
+        return $false
+    }
+}
+
+function Assert-Shellcheck {
+    # skip flake8 check if the command is not available in the system.
+    if ((!$CI) -and (-not (Exists("shellcheck")))) {
+        Write-Host "Skipping shellcheck check, command not available."
+        return $false
+    }
+    
+    shellcheck --enable require-double-brackets,avoid-nullary-conditions,quote-safe-variables scripts/*.sh
+}
+
+# Default test function, run by `npm test`.
+function Assert-Tests {
+    Get-ChildItem -Path "pages*" -Recurse | Select-String -SimpleMatch "*.md" | ForEach-Object {
+        markdownlint $_.ToString()
+    }
+    tldr-lint ./pages
+    Get-ChildItem -Path "pages.*" | ForEach-Object {
+        $checks = "TLDR104"
+        # Skip the `pages.en` symlink
+        if (($_.LinkType) -or ($_.Name -eq "pages.en")) {
+            return
+        }
+
+        $lang = @("ar", "bn", "fa", "hi", "ja", "ko", "lo", "ml", "ne", "ta", "th", "tr")
+        $exp = ($lang -join "|")
+        if ($_.Name -match $exp) {
+            $checks += ",TLDR003,TLDR004,TLDR015"
+        } elseif ($_.Name -match "zh") {
+            $checks += ",TLDR003,TLDR004,TLDR005,TLDR015"
+        }
+
+        tldr-lint --ignore "$checks" $_.Name
+    }
+    Assert-Black | Out-Null
+    Assert-Flake8 | Out-Null
+    Assert-Pytest | Out-Null
+    Assert-Shellcheck | Out-Null
+}
+
+function Assert-Tests-PR {
+    <#
+    .DESCRIPTION
+        Special test function for GitHub Actions pull request builds.
+        Runs run_tests collecting errors for tldr-bot.
+    #>
+    $errs = Assert-Tests 2>&1
+
+    if ($errs) {
+        Write-Error "Test failed!`n$errs`n"
+        Write-Error 'Sending errors to tldr-bot.'
+        Write-Host $errs | python3 scripts/send-to-bot.py report-errors
+        Exit 1
+    }
+}
+
+function Assert-Checks-PR {
+    <#
+    .DESCRIPTION
+        Additional checks for GitHub Actions pull request builds.
+        Only taken as suggestions, does not make the build fail.
+    #>
+
+    # Check which PowerShell version available, prefers `pwsh` over `powershell`.
+    if (Exists("pwsh")) {
+        $msgs = pwsh "scripts\check-pr.ps1"
+    } else {
+        $msgs = powershell "scripts\check-pr.ps1"
+    }
+
+    if ($msgs) {
+        Write-Host $msgs | python3 scripts/send-to-bot.py report-check-results
+    }
+}
+
+<#
+###################################
+# MAIN
+###################################
+#>
+
+if (($CI -eq $true) -and ($GITHUB_REPOSITORY -eq "tldr-pages/tldr") -and ($PULL_REQUEST_ID)) {
+    Assert-Checks-PR | Out-Null
+    Assert-Tests-PR | Out-Null
+} else {
+    Assert-Tests | Out-Null
+}
+
+Write-Host 'Test ran successfully!'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -88,7 +88,7 @@ function run_tests {
   for f in ./pages.*; do
     checks="TLDR104"
     # Skip the `pages.en` symlink.
-    [[ -h $f ]] && continue
+    ([[ -h $f ]] || $f == "pages.en") && continue
     case $f in
       *ar*|*bn*|*fa*|*hi*|*ja*|*ko*|*lo*|*ml*|*ne*|*ta*|*th*|*tr*)
         checks+=",TLDR003,TLDR004,TLDR015"


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** PowerShell 5.1.26100.7462

I'm making significant changes to the test scripts to support Windows development environments by rewriting `scripts/test.sh` into PowerShell, then modify the `npm test` command (as used in Git pre-commit hooks) to check the host operating system before loading the correct Bash/PowerShell file.

This is because `bash` in Windows 10 and Windows 11 users would trigger the WSL environment instead of `bash` in Cygwin, Git Bash, or Msys2, and will break if necessary Node.js and Python tools are not present in both Windows and WSL.

In addition to that, `pages.en` is explicitly excluded in the Bash script (similar to #18653) because Git would most likely not to resolve symbolic links in Windows (and hence WSL while accessing Windows directories) for technical reasons (https://gitforwindows.org/symbolic-links.html). `pages.en` is treated as a normal file in the existing Bash script, and will trigger TLDR107 errors for the specific file.

Note:
+ The PowerShell functions are renamed to use the approved list of verbs in the PowerShell convention: https://learn.microsoft.com/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-7.5
+ The PowerShell has been tested in the legacy Windows PowerShell (5.x) for backward-compatibility.