### PR TITLE
zoxide: update German translation

### DIFF
--- a/pages.de/common/zoxide.md
+++ b/pages.de/common/zoxide.md
@@ -4,13 +4,13 @@
 > Verwendet einen Ranking-Algorithmus, um zum besten Treffer zu navigieren.
 > Weitere Informationen: <https://manned.org/zoxide>.
 
-- Wechsel zu dem Verzeichnis mit dem höchsten Rang, das "foo" im Namen enthält:
+- Wechsel zu dem Verzeichnis mit dem höchsten Rang, das `string` im Namen enthält:
 
-`zoxide query {{foo}}`
+`zoxide query string`
 
-- Wechsel in das höchstrangige Verzeichnis, das "foo" und danach "bar" enthält:
+- Wechsel in das höchstrangige Verzeichnis, das `string1` und dann `string2` enthält:
 
-`zoxide query {{foo}} {{bar}}`
+`zoxide query string1 string2`
 
 - Starte eine interaktive Verzeichnissuche (erfordert `fzf`):
 


### PR DESCRIPTION
## Summary

Fix incorrect information in the German translation of the `zoxide` page.

## Changes

1. **Fixed aliases**: Changed `z`, `za`, `zi`, `zq`, `zr` → `z`, `zi`
   - `zoxide init` only generates `z` and `zi` commands
   - The aliases `za`, `zq`, `zr` do not exist

2. **Updated shell list**: `bash|fish|zsh` → `bash|elvish|fish|nushell|posix|powershell|tcsh|xonsh|zsh`
   - Now matches the English version and actual `zoxide init --help` output

3. **Consistent option format**: `--interactive` → `{{[-i|--interactive]}}`
   - Matches the English version style

## Verification

```
$ zoxide --version
zoxide 0.9.8

$ zoxide init --help
...
Options:
      --no-cmd       Prevents zoxide from defining the `z` and `zi` commands
      --cmd <CMD>    Changes the prefix of the `z` and `zi` commands [default: z]
```

Fixes #20603