### PR TITLE
pages.es: fix typo in common arguments

### DIFF
--- a/pages.es/common/2to3.md
+++ b/pages.es/common/2to3.md
@@ -11,15 +11,15 @@
 
 - Convierte un archivo Python 2 a Python 3:
 
-`2to3 {{[-w|--write]}} {{ruta/a/archivo.py}}`
+`2to3 {{[-w|--write]}} {{ruta/al/archivo.py}}`
 
 - Convierte funciones específicas del lenguaje Python 2 a Python 3:
 
-`2to3 {{[-w|--write]}} {{ruta/a/archivo.py}} {{[-f|--fix]}} {{raw_input}} {{[-f|--fix]}} {{print}}`
+`2to3 {{[-w|--write]}} {{ruta/al/archivo.py}} {{[-f|--fix]}} {{raw_input}} {{[-f|--fix]}} {{print}}`
 
 - Convierte todas las funciones del lenguaje Python 2 excepto las especificadas a Python 3:
 
-`2to3 {{[-w|--write]}} {{ruta/a/archivo.py}} {{[-x|--nofix]}} {{has_key}} {{[-x|--nofix]}} {{isinstance}}`
+`2to3 {{[-w|--write]}} {{ruta/al/archivo.py}} {{[-x|--nofix]}} {{has_key}} {{[-x|--nofix]}} {{isinstance}}`
 
 - Muestra una lista de todas las características disponibles del lenguaje que se pueden convertir de Python 2 a Python 3:
 
@@ -27,8 +27,8 @@
 
 - Convierte todos los archivos Python 2 en un directorio a Python 3:
 
-`2to3 {{[-o|--output-dir]}} {{ruta/a/directorio_python3}} {{[-W|--write-unchanged-files]}} {{[-n|--nobackups]}} {{ruta/a/directorio_python2}}`
+`2to3 {{[-o|--output-dir]}} {{ruta/al/directorio_python3}} {{[-W|--write-unchanged-files]}} {{[-n|--nobackups]}} {{ruta/al/directorio_python2}}`
 
 - Ejecuta 2to3 con varios hilos (threads):
 
-`2to3 {{[-j|--processes]}} {{1..infinity}} {{[-o|--output-dir]}} {{ruta/a/directorio_python3}} {{[-w|--write]}} {{[-n|--nobackups]}} --no-diffs {{ruta/a/directorio_python2}}`
+`2to3 {{[-j|--processes]}} {{1..infinity}} {{[-o|--output-dir]}} {{ruta/al/directorio_python3}} {{[-w|--write]}} {{[-n|--nobackups]}} --no-diffs {{ruta/al/directorio_python2}}`

--- a/pages.es/common/adscript.md
+++ b/pages.es/common/adscript.md
@@ -9,12 +9,12 @@
 
 - Compila y vincula un archivo a un ejecutable independiente:
 
-`adscript --executable --output {{ruta/a/archivo}} {{ruta/a/archivo_entrada.adscript}}`
+`adscript --executable --output {{ruta/al/archivo}} {{ruta/al/archivo_entrada.adscript}}`
 
 - Compila un archivo a LLVM IR en lugar de código de máquina nativo:
 
-`adscript --llvm-ir --output {{ruta/a/archivo.ll}} {{ruta/a/archivo_entrada.adscript}}`
+`adscript --llvm-ir --output {{ruta/al/archivo.ll}} {{ruta/al/archivo_entrada.adscript}}`
 
 - Crea un archivo con código objeto para otra arquitectura u otro sistema operativo:
 
-`adscript --target-triple {{i386-linux-elf}} --output {{ruta/a/archivo.o}} {{ruta/a/archivo_entrada.adscript}}`
+`adscript --target-triple {{i386-linux-elf}} --output {{ruta/al/archivo.o}} {{ruta/al/archivo_entrada.adscript}}`

--- a/pages.es/common/age.md
+++ b/pages.es/common/age.md
@@ -14,7 +14,7 @@
 
 - Cifra un archivo a uno o más destinatarios con sus claves públicas especificadas en un archivo (una por línea):
 
-`age {{[-R|--recipients-file]}} {{ruta/a/archivo_recipientes}} {{[-o|--output]}} {{ruta/al/archivo_encriptado}} {{ruta/al/archivo_no_cifrado}}`
+`age {{[-R|--recipients-file]}} {{ruta/al/archivo_recipientes}} {{[-o|--output]}} {{ruta/al/archivo_encriptado}} {{ruta/al/archivo_no_cifrado}}`
 
 - Descifra un archivo con una frase de contraseña:
 
@@ -22,4 +22,4 @@
 
 - Descifra un archivo con un archivo de clave privada:
 
-`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{ruta/al/archivo_de_clave_privada}} {{[-o|--output]}} {{ruta/para/archivo_descifrado}} {{ruta/a/archivo_cifrado}}`
+`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{ruta/al/archivo_de_clave_privada}} {{[-o|--output]}} {{ruta/para/archivo_descifrado}} {{ruta/al/archivo_cifrado}}`

--- a/pages.es/common/alacritty.md
+++ b/pages.es/common/alacritty.md
@@ -17,7 +17,7 @@
 
 - Inicia el intérprete de comandos en un directorio específico (también funciona con `alacritty msg create-window`):
 
-`alacritty --working-directory {{ruta/a/directorio}}`
+`alacritty --working-directory {{ruta/al/directorio}}`
 
 - [e]jecuta un comando en una nueva ventana de Alacritty (también funciona con `alacritty msg create-window`):
 

--- a/pages.es/common/amass-enum.md
+++ b/pages.es/common/amass-enum.md
@@ -21,7 +21,7 @@
 
 - Guarda la salida del terminal en un archivo y otros resultados detallados en un directorio:
 
-`amass enum -o {{fichero_de_salida}} -dir {{ruta/a/directorio}} -d {{nombre_dominio}}`
+`amass enum -o {{fichero_de_salida}} -dir {{ruta/al/directorio}} -d {{nombre_dominio}}`
 
 - Lista todas las fuentes de datos disponibles:
 

--- a/pages.es/common/b2.md
+++ b/pages.es/common/b2.md
@@ -17,7 +17,7 @@
 
 - Sube un archivo. Elige un archivo, un bucket y una carpeta:
 
-`b2 upload_file {{nombre_cubo}} {{ruta/a/archivo}} {{nombre_carpeta}}`
+`b2 upload_file {{nombre_cubo}} {{ruta/al/archivo}} {{nombre_carpeta}}`
 
 - Sube un directorio de origen a un destino de Backblaze B2 bucket:
 
@@ -25,7 +25,7 @@
 
 - Copia un archivo de un bucket a otro bucket:
 
-`b2 copy-file-by-id {{ruta/al/archivo_de_origen}} {{nombre_cubo_destino}} {{ruta/a/archivo/b2}}`
+`b2 copy-file-by-id {{ruta/al/archivo_de_origen}} {{nombre_cubo_destino}} {{ruta/al/archivo/b2}}`
 
 - Muestra los archivos de tu bucket:
 

--- a/pages.es/common/bacon.md
+++ b/pages.es/common/bacon.md
@@ -9,7 +9,7 @@
 
 - Ejecuta `cargo test` siempre que se detecte un cambio en el directorio dado:
 
-`bacon test {{ruta/a/directorio}}`
+`bacon test {{ruta/al/directorio}}`
 
 - Ejecuta `cargo check` contra todos los objetivos siempre que se detecte un cambio en el directorio actual:
 

--- a/pages.es/common/basenc.md
+++ b/pages.es/common/basenc.md
@@ -5,11 +5,11 @@
 
 - Codifica un archivo con codificación base64:
 
-`basenc --base64 {{ruta/a/archivo}}`
+`basenc --base64 {{ruta/al/archivo}}`
 
 - Descifra un archivo con codificación base64:
 
-`basenc {{[-d|--decode]}} --base64 {{ruta/a/archivo}}`
+`basenc {{[-d|--decode]}} --base64 {{ruta/al/archivo}}`
 
 - Codifica desde `stdin` con codificación base32 con 42 columnas:
 

--- a/pages.es/common/bats.md
+++ b/pages.es/common/bats.md
@@ -13,7 +13,7 @@
 
 - Ejecuta casos de prueba BATS [r]ecursivamente (archivos con extensión `.bats`):
 
-`bats --recursive {{ruta/a/directorio}}`
+`bats --recursive {{ruta/al/directorio}}`
 
 - Muestra los resultados en un [f]ormato específico:
 

--- a/pages.es/common/bison.md
+++ b/pages.es/common/bison.md
@@ -5,15 +5,15 @@
 
 - Compila un archivo de definición en tono con  bison:
 
-`bison {{ruta/a/archivo.y}}`
+`bison {{ruta/al/archivo.y}}`
 
 - Compila en modo debug, lo que hace que el analizador sintáctico resultante escriba información adicional en `stdout`:
 
-`bison {{[-t|--debug]}} {{ruta/a/archivo.y}}`
+`bison {{[-t|--debug]}} {{ruta/al/archivo.y}}`
 
 - Especifique el nombre del archivo de salida:
 
-`bison {{[-o|--output]}} {{ruta/a/salida.c}} {{ruta/a/archivo.y}}`
+`bison {{[-o|--output]}} {{ruta/a/salida.c}} {{ruta/al/archivo.y}}`
 
 - Sea detallista al compilar:
 

--- a/pages.es/common/bitcoind.md
+++ b/pages.es/common/bitcoind.md
@@ -18,4 +18,4 @@
 
 - Inicia el daemon Bitcoin Core usando un archivo de configuración y directorio de datos específicos:
 
-`bitcoind -conf={{ruta/a/bitcoin.conf}} -datadir={{ruta/a/directorio}}`
+`bitcoind -conf={{ruta/a/bitcoin.conf}} -datadir={{ruta/al/directorio}}`

--- a/pages.es/common/bru.md
+++ b/pages.es/common/bru.md
@@ -21,7 +21,7 @@
 
 - Ejecuta la solicitud y guarda los resultados en un archivo de salida:
 
-`bru run --output {{ruta/a/archivo_de_salida.json}}`
+`bru run --output {{ruta/al/archivo_de_salida.json}}`
 
 - Muestra ayuda:
 

--- a/pages.es/common/bzgrep.md
+++ b/pages.es/common/bzgrep.md
@@ -9,7 +9,7 @@
 
 - Busca un patrón de forma recursiva en un archivo comprimido bzip2 `.tar`:
 
-`bzgrep {{[-r|--recursive]}} "{{patrón_de_búsqueda}}" {{ruta/a/archivo_tar}}`
+`bzgrep {{[-r|--recursive]}} "{{patrón_de_búsqueda}}" {{ruta/al/archivo_tar}}`
 
 - Imprime 3 líneas de [C]ontexto alrededor, [A]ntes o [D]espués de cada coincidencia:
 

--- a/pages.es/common/chown.md
+++ b/pages.es/common/chown.md
@@ -18,7 +18,7 @@
 
 - Cambia recursivamente el propietario de un directorio y su contenido:
 
-`chown {{[-R|--recursive]}} {{usuario}} {{ruta/a/directorio}}`
+`chown {{[-R|--recursive]}} {{usuario}} {{ruta/al/directorio}}`
 
 - Cambia el propietario de un enlace simbólico:
 

--- a/pages.es/common/clamdscan.md
+++ b/pages.es/common/clamdscan.md
@@ -21,7 +21,7 @@
 
 - Mueve los archivos infectados a un directorio específico:
 
-`clamdscan --move {{ruta/a/directorio_de_cuarentena}}`
+`clamdscan --move {{ruta/al/directorio_de_cuarentena}}`
 
 - Elimina los archivos infectados:
 

--- a/pages.es/common/cp.md
+++ b/pages.es/common/cp.md
@@ -33,4 +33,4 @@
 
 - Utiliza el primer argumento como directorio de destino (útil para `xargs ... | cp -t <DEST_DIR>`):
 
-`cp {{[-t|--target-directory]}} {{ruta/a/directorio_de_destino}} {{ruta/a/archivo_o_directorio1 ruta/al/archivo_o_directorio2 ...}}`
+`cp {{[-t|--target-directory]}} {{ruta/al/directorio_de_destino}} {{ruta/al/archivo_o_directorio1 ruta/al/archivo_o_directorio2 ...}}`

--- a/pages.es/common/dbx.md
+++ b/pages.es/common/dbx.md
@@ -10,7 +10,7 @@
 
 - Sincroniza archivos locales de la ruta especificada a DBFS y vigila los cambios:
 
-`dbx sync dbfs --source {{ruta/a/directorio}} --dest {{ruta/a/directorio_remoto}}`
+`dbx sync dbfs --source {{ruta/al/directorio}} --dest {{ruta/al/directorio_remoto}}`
 
 - Despliega el flujo de trabajo especificado en el almacenamiento de artefactos:
 

--- a/pages.es/common/dirname.md
+++ b/pages.es/common/dirname.md
@@ -5,7 +5,7 @@
 
 - Calcula el directorio padre de una ruta dada:
 
-`dirname {{ruta/a/archivo_o_directorio}}`
+`dirname {{ruta/al/archivo_o_directorio}}`
 
 - Calcula el directorio padre de múltiples rutas:
 

--- a/pages.es/common/dockdiver.md
+++ b/pages.es/common/dockdiver.md
@@ -17,7 +17,7 @@
 
 - Vuelca un repositorio con un puerto personalizado y un límite de velocidad:
 
-`dockdiver -url {{http://example.com}} -dump {{nombre_repositorio}} -port {{puerto}} -rate {{solicitudes_por_segundo}} -dir {{ruta/a/directorio_salida}}`
+`dockdiver -url {{http://example.com}} -dump {{nombre_repositorio}} -port {{puerto}} -rate {{solicitudes_por_segundo}} -dir {{ruta/al/directorio_salida}}`
 
 - Vuelca todos los repositorios con token de portador para autorización:
 

--- a/pages.es/common/fabric.md
+++ b/pages.es/common/fabric.md
@@ -14,7 +14,7 @@
 
 - Ejecuta un patrón con la entrada de un archivo:
 
-`fabric {{[-p|--pattern]}} {{nombre_del_patrón}} < {{ruta/a/archivo_de_entrada}}`
+`fabric {{[-p|--pattern]}} {{nombre_del_patrón}} < {{ruta/al/archivo_de_entrada}}`
 
 - Ejecuta un patrón en una dirección URL de YouTube:
 

--- a/pages.es/common/faker.md
+++ b/pages.es/common/faker.md
@@ -17,7 +17,7 @@
 
 - Genera un número de ciudades en un país específico y las muestra en un archivo (usa `localectl list-locales | cut -d. -f1` para obtener la lista de locales):
 
-`faker --repeat {{número}} --lang {{en_AU|en_US|...}} city -o {{ruta/a/archivo.txt}}`
+`faker --repeat {{número}} --lang {{en_AU|en_US|...}} city -o {{ruta/al/archivo.txt}}`
 
 - Genera una serie de agentes de usuario HTTP aleatorios mostrando una salida detallada:
 

--- a/pages.es/common/fclones.md
+++ b/pages.es/common/fclones.md
@@ -9,15 +9,15 @@
 
 - Busca archivos duplicados en varios directorios y almacena los resultados en la caché:
 
-`fclones group --cache {{ruta/a/directorio1 ruta/a/directorio2}}`
+`fclones group --cache {{ruta/al/directorio1 ruta/al/directorio2}}`
 
 - Busca archivos duplicados solo en el directorio especificado, omitiendo los subdirectorios y guarda los resultados en un archivo:
 
-`fclones group {{ruta/a/directorio}} --depth 1 > {{ruta/al/archivo.txt}}`
+`fclones group {{ruta/al/directorio}} --depth 1 > {{ruta/al/archivo.txt}}`
 
 - Mueve los archivos duplicados en un archivo de texto a un directorio diferente:
 
-`fclones move {{ruta/a/directorio_objetivo}} < {{ruta/al/archivo.txt}}`
+`fclones move {{ruta/al/directorio_objetivo}} < {{ruta/al/archivo.txt}}`
 
 - Simula un enlace simbólico a un archivo de texto sin realmente enlazarlo:
 

--- a/pages.es/common/fpsync.md
+++ b/pages.es/common/fpsync.md
@@ -17,7 +17,7 @@
 
 - Sincroniza recursivamente un directorio a un destino utilizando 8 trabajos de sincronización concurrentes repartidos entre dos trabajadores remotos (máquina1 y máquina2):
 
-`fpsync -v -n 8 -E -w login@machine1 -w login@machine2 -d {{/ruta/a/directorio/compartido}} {{/ruta/a/origen/}} {{/ruta/a/destino/}}`
+`fpsync -v -n 8 -E -w login@machine1 -w login@machine2 -d {{/ruta/al/directorio/compartido}} {{/ruta/a/origen/}} {{/ruta/a/destino/}}`
 
 - Sincroniza recursivamente un directorio a un destino utilizando cuatro trabajadores locales, cada uno transfiriendo como máximo 1000 archivos y 100 MB por trabajo de sincronización:
 

--- a/pages.es/common/gdown.md
+++ b/pages.es/common/gdown.md
@@ -17,7 +17,7 @@
 
 - Descarga una carpeta utilizando su ID o la URL completa:
 
-`gdown {{id_de_carpeta|url}} -O {{ruta/a/directorio_de_salida}} --folder`
+`gdown {{id_de_carpeta|url}} -O {{ruta/al/directorio_de_salida}} --folder`
 
 - Descarga un archivo `.tar`, escríbelo en `stdout` y extráelo:
 

--- a/pages.es/common/git-blame.md
+++ b/pages.es/common/git-blame.md
@@ -29,4 +29,4 @@
 
 - Ignora los espacios en blanco y los movimientos de línea:
 
-`git blame -w -C -C -C {{ruta/a/archivo}}`
+`git blame -w -C -C -C {{ruta/al/archivo}}`

--- a/pages.es/common/gitleaks.md
+++ b/pages.es/common/gitleaks.md
@@ -17,7 +17,7 @@
 
 - Utiliza un archivo de reglas personalizado:
 
-`gitleaks detect --source {{ruta/al/repositorio}} --config-path {{ruta/a/archivo_de_configuración.toml}}`
+`gitleaks detect --source {{ruta/al/repositorio}} --config-path {{ruta/al/archivo_de_configuración.toml}}`
 
 - Inicia la búsqueda a partir de una confirmación específica:
 

--- a/pages.es/common/htmlq.md
+++ b/pages.es/common/htmlq.md
@@ -21,4 +21,4 @@
 
 - Impresión bonita y escritura de la salida en un archivo:
 
-`htmlq --pretty --filename {{ruta/a/archivo.html}} --output {{ruta/a/salida.html}}`
+`htmlq --pretty --filename {{ruta/al/archivo.html}} --output {{ruta/a/salida.html}}`

--- a/pages.es/common/immich-go.md
+++ b/pages.es/common/immich-go.md
@@ -6,15 +6,15 @@
 
 - Sube un archivo takeout de Google al servidor Immich:
 
-`immich-go -server={{url_del_servidor}} -key={{clave_de_servidor}} upload {{ruta/a/archivo_takeout.zip}}`
+`immich-go -server={{url_del_servidor}} -key={{clave_de_servidor}} upload {{ruta/al/archivo_takeout.zip}}`
 
 - Importa fotos capturadas en junio del 2019, mientras se generan los álbumes automáticamente:
 
-`immich-go -server={{url_del_servidor}} -key={{clave_del_servidor}} upload -create-albums -google-photos -date={{2019-06}} {{ruta/a/archivo_takeout.zip}}`
+`immich-go -server={{url_del_servidor}} -key={{clave_del_servidor}} upload -create-albums -google-photos -date={{2019-06}} {{ruta/al/archivo_takeout.zip}}`
 
 - Sube un archivo usando servidor y clave de un archivo de configuración:
 
-`immich-go -use-configuration={{~/.immich-go/immich-go.json}} upload {{ruta/a/archivo_takeout.zip}}`
+`immich-go -use-configuration={{~/.immich-go/immich-go.json}} upload {{ruta/al/archivo_takeout.zip}}`
 
 - Examina el contenido del servidor Immich, elimina las imágenes de menor calidad y preserva álbumes:
 

--- a/pages.es/common/kerl.md
+++ b/pages.es/common/kerl.md
@@ -5,7 +5,7 @@
 
 - Compila e instala una versión de Erlang/OTP en un directorio:
 
-`kerl build-install {{28.0}} {{28.0}} {{ruta/a/directorio_de_instalación}}/{{28.0}}`
+`kerl build-install {{28.0}} {{28.0}} {{ruta/al/directorio_de_instalación}}/{{28.0}}`
 
 - Activa una instalación Erlang/OTP:
 

--- a/pages.es/common/m4b-tool.md
+++ b/pages.es/common/m4b-tool.md
@@ -5,8 +5,8 @@
 
 - Crea un audiolibro con los archivos de audio del directorio de entrada:
 
-`m4b-tool merge {{ruta/a/directorio_de_entrada}} --output-file={{ruta/a/fusionado.m4b}}`
+`m4b-tool merge {{ruta/al/directorio_de_entrada}} --output-file={{ruta/a/fusionado.m4b}}`
 
 - Hace capítulos utilizando los nombres de los archivos de entrada:
 
-`m4b-tool merge {{ruta/a/directorio_de_entrada}} --output-file={{ruta/a/fusionado.m4b}} --use-filenames-as-chapters`
+`m4b-tool merge {{ruta/al/directorio_de_entrada}} --output-file={{ruta/a/fusionado.m4b}} --use-filenames-as-chapters`

--- a/pages.es/common/magick.md
+++ b/pages.es/common/magick.md
@@ -23,4 +23,4 @@
 
 - Crea un archivo PDF a partir de todas las imágenes JPEG en el directorio actual:
 
-`magick {{*.jpg}} -adjoin {{ruta/a/archivo.pdf}}`
+`magick {{*.jpg}} -adjoin {{ruta/al/archivo.pdf}}`

--- a/pages.es/common/mcs.md
+++ b/pages.es/common/mcs.md
@@ -5,12 +5,12 @@
 
 - Compila los archivos indicados:
 
-`mcs {{ruta/a/archivo_entrada1.cs ruta/a/archivo_entrada2.cs ...}}`
+`mcs {{ruta/al/archivo_entrada1.cs ruta/al/archivo_entrada2.cs ...}}`
 
 - Indica el nombre del programa de salida:
 
-`mcs -out:{{ruta/a/archivo.exe}} {{ruta/a/archivo_entrada1.cs ruta/a/archivo_entrada2.cs ...}}`
+`mcs -out:{{ruta/al/archivo.exe}} {{ruta/al/archivo_entrada1.cs ruta/al/archivo_entrada2.cs ...}}`
 
 - Indica el tipo de programa de salida:
 
-`mcs -target:{{exe|winexe|library|module}} {{ruta/a/archivo_entrada1.cs ruta/a/archivo_entrada2.cs ...}}`
+`mcs -target:{{exe|winexe|library|module}} {{ruta/al/archivo_entrada1.cs ruta/al/archivo_entrada2.cs ...}}`

--- a/pages.es/common/mosh.md
+++ b/pages.es/common/mosh.md
@@ -10,7 +10,7 @@
 
 - Conecta a un servidor remoto con una identidad específica (clave privada):
 
-`mosh --ssh="ssh -i {{ruta/a/archivo_de_clave}}" {{usuario}}@{{equipo_remoto}}`
+`mosh --ssh="ssh -i {{ruta/al/archivo_de_clave}}" {{usuario}}@{{equipo_remoto}}`
 
 - Conecta a un servidor remoto usando un puerto específico:
 

--- a/pages.es/common/mv.md
+++ b/pages.es/common/mv.md
@@ -9,11 +9,11 @@
 
 - Mueve un archivo o directorio a un directorio existente:
 
-`mv {{ruta/a/origen}} {{ruta/a/directorio_existente}}`
+`mv {{ruta/a/origen}} {{ruta/al/directorio_existente}}`
 
 - Mueve varios archivos a un directorio existente, manteniendo los nombres de archivo sin cambios:
 
-`mv {{ruta/a/origen1 ruta/a/origen2 ...}} {{ruta/a/directorio_existente}}`
+`mv {{ruta/a/origen1 ruta/a/origen2 ...}} {{ruta/al/directorio_existente}}`
 
 - No pedir confirmación antes de sobrescribir los archivos existentes:
 
@@ -33,4 +33,4 @@
 
 - Especifica el directorio de destino para poder utilizar herramientas externas para recopilar archivos movibles:
 
-`{{find /var/log -type f -name '*.log' -print0}} | {{xargs -0}} mv {{[-t|--target-directory]}} {{ruta/a/directorio_destino}}`
+`{{find /var/log -type f -name '*.log' -print0}} | {{xargs -0}} mv {{[-t|--target-directory]}} {{ruta/al/directorio_destino}}`

--- a/pages.es/common/o.md
+++ b/pages.es/common/o.md
@@ -5,11 +5,11 @@
 
 - Abre un archivo en el editor:
 
-`o {{ruta/a/archivo}}`
+`o {{ruta/al/archivo}}`
 
 - Abre un archivo como de solo lectura:
 
-`o {{[-m|-monitor]}} {{ruta/a/archivo}}`
+`o {{[-m|-monitor]}} {{ruta/al/archivo}}`
 
 - Guarda el archivo:
 

--- a/pages.es/common/octez-client.md
+++ b/pages.es/common/octez-client.md
@@ -21,7 +21,7 @@
 
 - Crea (despliega) un contrato inteligente, le asignar un alias local y establece su almacenamiento inicial como un valor codificado por Michelson:
 
-`octez-client originate contract {{alias}} transferring {{0}} from {{alias|address}} running {{ruta/a/archivo_de_origen.tz}} --init "{{almacenamiento_inicial}}" --burn_cap {{1}}`
+`octez-client originate contract {{alias}} transferring {{0}} from {{alias|address}} running {{ruta/al/archivo_de_origen.tz}} --init "{{almacenamiento_inicial}}" --burn_cap {{1}}`
 
 - Llama a un contrato inteligente por su alias o dirección y pasa un parámetro codificado por Michelson:
 

--- a/pages.es/common/pambrighten.md
+++ b/pages.es/common/pambrighten.md
@@ -5,8 +5,8 @@
 
 - Aumenta la saturación de cada píxel con un porcentaje específico:
 
-`pambrighten {{[-s|-saturation]}} {{valor_porcentual}} {{ruta/a/imagen.pam}} > {{ruta/a/archivo_de_salida.pam}}`
+`pambrighten {{[-s|-saturation]}} {{valor_porcentual}} {{ruta/a/imagen.pam}} > {{ruta/al/archivo_de_salida.pam}}`
 
 - Aumenta el valor (del espacio de color HSV) de cada píxel con un porcentaje específico:
 
-`pambrighten {{[-va|-value]}} {{valor_porcentual}} {{ruta/a/imagen.pam}} > {{ruta/a/archivo_de_salida.pam}}`
+`pambrighten {{[-va|-value]}} {{valor_porcentual}} {{ruta/a/imagen.pam}} > {{ruta/al/archivo_de_salida.pam}}`

--- a/pages.es/common/phpstan.md
+++ b/pages.es/common/phpstan.md
@@ -5,23 +5,23 @@
 
 - Analiza uno o más directorios:
 
-`phpstan analyse {{ruta/a/directorio1 ruta/a/directorio2 ...}}`
+`phpstan analyse {{ruta/al/directorio1 ruta/al/directorio2 ...}}`
 
 - Analiza un directorio utilizando un archivo de configuración:
 
-`phpstan analyse {{ruta/a/directorio}} {{[-c|--configuration]}} {{ruta/a/configuración}}`
+`phpstan analyse {{ruta/al/directorio}} {{[-c|--configuration]}} {{ruta/a/configuración}}`
 
 - Analiza usando un nivel de regla específico (0-10, más alto es más estricto):
 
-`phpstan analyse {{ruta/a/directorio}} {{[-l|--level]}} {{nivel}}`
+`phpstan analyse {{ruta/al/directorio}} {{[-l|--level]}} {{nivel}}`
 
 - Especifica un archivo de carga automática para cargar antes de analizar:
 
-`phpstan analyse {{ruta/a/directorio}} {{[-a|--autoload-file]}} {{ruta/archivo/archivo_autocarga}}`
+`phpstan analyse {{ruta/al/directorio}} {{[-a|--autoload-file]}} {{ruta/archivo/archivo_autocarga}}`
 
 - Especifica un límite de memoria durante el análisis:
 
-`phpstan analyse {{ruta/a/directorio}} --memory-limit {{límite_memoria}}`
+`phpstan analyse {{ruta/al/directorio}} --memory-limit {{límite_memoria}}`
 
 - Muestra las opciones disponibles para el análisis:
 

--- a/pages.es/common/protoc.md
+++ b/pages.es/common/protoc.md
@@ -5,11 +5,11 @@
 
 - Genera código Python a partir de un archivo `.proto`:
 
-`protoc --python_out={{ruta/a/directorio_salida}} {{archivo_entrada.proto}}`
+`protoc --python_out={{ruta/al/directorio_salida}} {{archivo_entrada.proto}}`
 
 - Genera código Java a partir de un archivo `.proto` que importa otros archivos `.proto`:
 
-`protoc --java_out={{ruta/a/directorio_salida}} --proto_path={{ruta/a/importación_ruta_de_busqueda}} {{archivo_entrada.proto}}`
+`protoc --java_out={{ruta/al/directorio_salida}} --proto_path={{ruta/a/importación_ruta_de_busqueda}} {{archivo_entrada.proto}}`
 
 - Genera código para múltiples lenguajes:
 

--- a/pages.es/common/pydocstyle.md
+++ b/pages.es/common/pydocstyle.md
@@ -17,11 +17,11 @@
 
 - Muestra el número total de errores:
 
-`pydocstyle --count {{archivo.py|ruta/a/directorio}}`
+`pydocstyle --count {{archivo.py|ruta/al/directorio}}`
 
 - Utiliza un archivo de configuración específico:
 
-`pydocstyle --config {{ruta/a/archivo_config}} {{archivo.py|ruta/al/directorio}}`
+`pydocstyle --config {{ruta/al/archivo_config}} {{archivo.py|ruta/al/directorio}}`
 
 - Ignora uno o más errores:
 
@@ -29,4 +29,4 @@
 
 - Busca errores de una convención específica:
 
-`pydocstyle --convention {{pep257|numpy|google}} {{archivo.py|ruta/a/directorio}}`
+`pydocstyle --convention {{pep257|numpy|google}} {{archivo.py|ruta/al/directorio}}`

--- a/pages.es/common/qalc.md
+++ b/pages.es/common/qalc.md
@@ -26,4 +26,4 @@
 
 - Ejecuta comandos desde un archivo:
 
-`qalc --file {{ruta/a/archivo}}`
+`qalc --file {{ruta/al/archivo}}`

--- a/pages.es/common/rmlint.md
+++ b/pages.es/common/rmlint.md
@@ -5,15 +5,15 @@
 
 - Comprueba los directorios en busca de archivos duplicados, vacíos y rotos:
 
-`rmlint {{ruta/a/directorio1 ruta/a/directorio2 ...}}`
+`rmlint {{ruta/al/directorio1 ruta/al/directorio2 ...}}`
 
 - Comprueba si hay duplicados mayores a un tamaño determinado, preferiblemente manteniendo los archivos en directorios etiquetados (después de la doble barra):
 
-`rmlint -s {{1MB}} {{ruta/a/directorio}} // {{ruta/a/directorio_original}}`
+`rmlint -s {{1MB}} {{ruta/al/directorio}} // {{ruta/al/directorio_original}}`
 
 - Comprueba que no se desperdicia espacio, manteniendo todo en los directorios no etiquetados:
 
-`rmlint --keep-all-untagged {{ruta/a/directorio}} // {{ruta/a/directorio_original}}`
+`rmlint --keep-all-untagged {{ruta/al/directorio}} // {{ruta/al/directorio_original}}`
 
 - Elimina archivos duplicados encontrados tras una ejecución de `rmlint`:
 
@@ -21,15 +21,15 @@
 
 - Encuentra árboles de directorios duplicados basándose en los datos, ignorando los nombres:
 
-`rmlint --merge-directories {{ruta/a/directorio}}`
+`rmlint --merge-directories {{ruta/al/directorio}}`
 
 - Marca archivos en la profundida[d] de la ruta inferior como originales, en caso de igualdad elegir uno más corto [l]:
 
-`rmlint --rank-by={{dl}} {{ruta/a/directorio}}`
+`rmlint --rank-by={{dl}} {{ruta/al/directorio}}`
 
 - Encuentra archivos con idéntico nombre de archivo y contenido, y vincula en lugar de eliminar los duplicados:
 
-`rmlint -c sh:link --match-basename {{ruta/a/directorio}}`
+`rmlint -c sh:link --match-basename {{ruta/al/directorio}}`
 
 - Utiliza `data` como directorio maestro. Busca solo los duplicados de la copia de seguridad que también estén en `datos`. No elimina ningún archivo de "datos":
 

--- a/pages.es/common/rsactftool.py.md
+++ b/pages.es/common/rsactftool.py.md
@@ -9,7 +9,7 @@
 
 - Descifra un fichero utilizando una clave pública:
 
-`RsaCtfTool.py --publickey {{ruta/a/clave.pub}} --decryptfile {{ruta/a/archivo_cifrado}}`
+`RsaCtfTool.py --publickey {{ruta/a/clave.pub}} --decryptfile {{ruta/al/archivo_cifrado}}`
 
 - Descifra una cadena de texto cifrado específica:
 

--- a/pages.es/common/sha1sum.md
+++ b/pages.es/common/sha1sum.md
@@ -25,7 +25,7 @@
 
 - Solo muestra un mensaje cuando falla la verificación, ignorando los archivos que faltan:
 
-`sha1sum --ignore-missing {{[-c|--check]}} --quiet {{ruta/a/archivo.sha1}}`
+`sha1sum --ignore-missing {{[-c|--check]}} --quiet {{ruta/al/archivo.sha1}}`
 
 - Comprueba una suma de comprobación SHA1 conocida de un archivo:
 

--- a/pages.es/common/trdsql.md
+++ b/pages.es/common/trdsql.md
@@ -25,7 +25,7 @@
 
 - Crea una tabla de datos en una base de datos MySQL a partir de un archivo CSV:
 
-`trdsql -driver mysql -dsn "{{usuario}}:{{contraseña}}@{{nombre_del_host}}/{{base_de_datos}}" -ih "CREATE TABLE {{tabla}} ({{columna1}} int, {{columna2}} varchar(20)) AS SELECT {{columna3}} AS {{columna1}},{{columna2}} FROM {{ruta/a/archivo_cabecera.csv}}"`
+`trdsql -driver mysql -dsn "{{usuario}}:{{contraseña}}@{{nombre_del_host}}/{{base_de_datos}}" -ih "CREATE TABLE {{tabla}} ({{columna1}} int, {{columna2}} varchar(20)) AS SELECT {{columna3}} AS {{columna1}},{{columna2}} FROM {{ruta/al/archivo_cabecera.csv}}"`
 
 - Muestra datos de archivos de registro comprimidos:
 

--- a/pages.es/common/usql.md
+++ b/pages.es/common/usql.md
@@ -25,7 +25,7 @@
 
 - Exporta los resultados de la consulta a un archivo específico:
 
-`{{prompt}}=> \g {{ruta/a/archivo_con_resultados}}`
+`{{prompt}}=> \g {{ruta/al/archivo_con_resultados}}`
 
 - Importa datos de un archivo CSV a una tabla específica:
 

--- a/pages.es/common/uv.md
+++ b/pages.es/common/uv.md
@@ -10,7 +10,7 @@
 
 - Crear un nuevo proyecto Python en la ruta especificada:
 
-`uv init {{ruta/a/directorio}}`
+`uv init {{ruta/al/directorio}}`
 
 - Añade una nueva dependencia al proyecto:
 

--- a/pages.es/common/virsh.md
+++ b/pages.es/common/virsh.md
@@ -18,7 +18,7 @@
 
 - Crea un invitado a partir de un archivo de configuración:
 
-`virsh create {{ruta/a/archivo_de_configuración.xml}}`
+`virsh create {{ruta/al/archivo_de_configuración.xml}}`
 
 - Edita el archivo de configuración de un invitado (el editor puede cambiarse con `$EDITOR`):
 

--- a/pages.es/common/waybar.md
+++ b/pages.es/common/waybar.md
@@ -9,7 +9,7 @@
 
 - Usa un archivo de configuración diferente:
 
-`waybar {{[-c|--config]}} {{ruta/a/archivo_de_configuración.jsonc}}`
+`waybar {{[-c|--config]}} {{ruta/al/archivo_de_configuración.jsonc}}`
 
 - Utiliza un archivo de hoja de estilo diferente:
 

--- a/pages.es/common/whatwaf.md
+++ b/pages.es/common/whatwaf.md
@@ -9,11 +9,11 @@
 
 - Detecta protección en un [l]ista de URLs en paralelo desde un archivo (una URL por línea):
 
-`whatwaf --threads {{número}} --list {{ruta/a/archivo}}`
+`whatwaf --threads {{número}} --list {{ruta/al/archivo}}`
 
 - Envía peticiones a través de un proxy y utiliza una lista de carga útil personalizada desde un archivo (una carga útil por línea):
 
-`whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{ruta/a/archivo}} -u {{https://example.com}}`
+`whatwaf --proxy {{http://127.0.0.1:8080}} --pl {{ruta/al/archivo}} -u {{https://example.com}}`
 
 - Envía peticiones a través de Tor (Tor debe estar instalado) utilizando cargas personalizadas (separadas por comas):
 

--- a/pages.es/common/yazi.md
+++ b/pages.es/common/yazi.md
@@ -14,7 +14,7 @@
 
 - Escribe el directorio de trabajo actual al salir del archivo:
 
-`yazi --cwd-file {{ruta/a/archivo_cwd}}`
+`yazi --cwd-file {{ruta/al/archivo_cwd}}`
 
 - Borra el directorio de caché:
 

--- a/pages.es/common/zed.md
+++ b/pages.es/common/zed.md
@@ -21,4 +21,4 @@
 
 - Abre una pestaña diff en Zed para dos versiones de un archivo:
 
-`zed --diff {{ruta/a/archivo_antiguo}} {{ruta/al/archivo_nuevo}}`
+`zed --diff {{ruta/al/archivo_antiguo}} {{ruta/al/archivo_nuevo}}`

--- a/pages.es/linux/arptables.md
+++ b/pages.es/linux/arptables.md
@@ -26,4 +26,4 @@
 
 - Guarda las reglas ARP actuales en un archivo:
 
-`sudo arptables-save > {{ruta/a/archivo}}`
+`sudo arptables-save > {{ruta/al/archivo}}`

--- a/pages.es/linux/audit2allow.md
+++ b/pages.es/linux/audit2allow.md
@@ -27,7 +27,7 @@
 
 - Especifica un archivo de política para su posterior análisis:
 
-`audit2allow {{[-p|--policy]}} {{ruta/a/archivo_de_directiva}}`
+`audit2allow {{[-p|--policy]}} {{ruta/al/archivo_de_directiva}}`
 
 - Limita el análisis a los mensajes con un tipo especificado en `regex`:
 

--- a/pages.es/linux/bluebuild.md
+++ b/pages.es/linux/bluebuild.md
@@ -17,7 +17,7 @@
 
 - Genera una ISO a partir de una receta:
 
-`bluebuild generate-iso --output-dir {{ruta/a/directorio_salida}} --iso-name {{nombre_iso.iso}} recipe {{ruta/a/receta.yml}}`
+`bluebuild generate-iso --output-dir {{ruta/al/directorio_salida}} --iso-name {{nombre_iso.iso}} recipe {{ruta/a/receta.yml}}`
 
 - Muestra la ayuda:
 

--- a/pages.es/linux/bspwm.md
+++ b/pages.es/linux/bspwm.md
@@ -6,4 +6,4 @@
 
 - Inicia `bspwm` (cabe recalcar que no debe haber otro gestor de ventanas al ejecutar este comando):
 
-`bspwm -c {{ruta/a/archivo_de_configuración}}`
+`bspwm -c {{ruta/al/archivo_de_configuración}}`

--- a/pages.es/linux/cmus.md
+++ b/pages.es/linux/cmus.md
@@ -7,11 +7,11 @@
 
 - Abre `cmus` en el directorio especificado (se convertirá en tu nuevo directorio de trabajo):
 
-`cmus {{ruta/a/directorio}}`
+`cmus {{ruta/al/directorio}}`
 
 - Añade archivo/directorio a la biblioteca:
 
-`<:>add {{ruta/a/archivo_o_directorio}}`
+`<:>add {{ruta/al/archivo_o_directorio}}`
 
 - Actualiza los metadatos de las canciones de la biblioteca:
 

--- a/pages.es/linux/kpackagetool6.md
+++ b/pages.es/linux/kpackagetool6.md
@@ -9,11 +9,11 @@
 
 - Instala el paquete desde un directorio:
 
-`kpackagetool6 --type {{tipo_paquete}} --install {{ruta/a/directorio}}`
+`kpackagetool6 --type {{tipo_paquete}} --install {{ruta/al/directorio}}`
 
 - Actualiza el paquete instalado desde un directorio:
 
-`kpackagetool6 --type {{tipo_paquete}} --upgrade {{ruta/a/directorio}}`
+`kpackagetool6 --type {{tipo_paquete}} --upgrade {{ruta/al/directorio}}`
 
 - Lista los plasmoides instalados (`--global` para todos los usuarios):
 

--- a/pages.es/linux/sslstrip.md
+++ b/pages.es/linux/sslstrip.md
@@ -22,7 +22,7 @@
 
 - Especifica la ruta del archivo para almacenar los registros:
 
-`sslstrip --listen={{8080}} --write={{ruta/a/archivo}}`
+`sslstrip --listen={{8080}} --write={{ruta/al/archivo}}`
 
 - Muestra la ayuda:
 

--- a/pages.es/linux/torify.md
+++ b/pages.es/linux/torify.md
@@ -30,4 +30,4 @@
 
 - Redirige la salida a un archivo:
 
-`torify {{comando}} > {{ruta/a/archivo_de_salida}}`
+`torify {{comando}} > {{ruta/al/archivo_de_salida}}`

--- a/pages.es/linux/unix2dos.md
+++ b/pages.es/linux/unix2dos.md
@@ -11,7 +11,7 @@
 
 - Crea una copia con finales de línea de estilo DOS:
 
-`unix2dos {{[-n|--newfile]}} {{ruta/al/archivo}} {{ruta/a/archivo_nuevo}}`
+`unix2dos {{[-n|--newfile]}} {{ruta/al/archivo}} {{ruta/al/archivo_nuevo}}`
 
 - Muestra información del archivo:
 

--- a/pages.es/linux/unix2mac.md
+++ b/pages.es/linux/unix2mac.md
@@ -11,7 +11,7 @@
 
 - Crea una copia con finales de línea de estilo macOS:
 
-`unix2mac {{[-n|--newfile]}} {{ruta/al/archivo}} {{ruta/a/archivo_nuevo}}`
+`unix2mac {{[-n|--newfile]}} {{ruta/al/archivo}} {{ruta/al/archivo_nuevo}}`
 
 - Muestra información del archivo:
 

--- a/pages.es/linux/useradd.md
+++ b/pages.es/linux/useradd.md
@@ -26,7 +26,7 @@
 
 - Crea un usuario con el directorio home con una copia de los archivos provenientes de un directorio plantilla:
 
-`sudo useradd {{[-k|--skel]}} {{ruta/a/directorio_plantilla}} {{[-m|--create-home]}} {{usuario}}`
+`sudo useradd {{[-k|--skel]}} {{ruta/al/directorio_plantilla}} {{[-m|--create-home]}} {{usuario}}`
 
 - Crea un usuario del sistema sin directorio home:
 

--- a/pages.es/linux/virt-qemu-run.md
+++ b/pages.es/linux/virt-qemu-run.md
@@ -9,7 +9,7 @@
 
 - Ejecuta una máquina virtual QEMU y almacena el estado en un directorio específico:
 
-`virt-qemu-run --root={{ruta/a/directorio}} {{ruta/a/guest.xml}}`
+`virt-qemu-run --root={{ruta/al/directorio}} {{ruta/a/guest.xml}}`
 
 - Ejecuta una máquina virtual QEMU y muestra información detallada sobre el inicio:
 

--- a/pages.es/osx/mist.md
+++ b/pages.es/osx/mist.md
@@ -26,7 +26,7 @@
 
 - Lista y exporta instaladores de macOS a un archivo CSV:
 
-`mist list installer --export "/{{ruta/a/archivo_con_datos_exportados.csv}}"`
+`mist list installer --export "/{{ruta/al/archivo_con_datos_exportados.csv}}"`
 
 - Descarga el último firmware de macOS Sonoma para los Mac Silicon de Apple, con un nombre personalizado:
 

--- a/pages.es/osx/xcodes-runtimes.md
+++ b/pages.es/osx/xcodes-runtimes.md
@@ -21,7 +21,7 @@
 
 - Establece una ubicación específica en la que se descargará primero el archivo de tiempo de ejecución (por defecto es `~/Downloads`):
 
-`xcodes runtimes {{download|install}} {{nombre_del_tiempo_de_ejecución}} --directory {{ruta/a/directorio}}`
+`xcodes runtimes {{download|install}} {{nombre_del_tiempo_de_ejecución}} --directory {{ruta/al/directorio}}`
 
 - No elimina el archivo descargado cuando el Simulator se instala correctamente:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: # 