### PR TITLE
translation-templates: improve Chinese translation of "Display help"

### DIFF
--- a/contributing-guides/translation-templates/common-descriptions.md
+++ b/contributing-guides/translation-templates/common-descriptions.md
@@ -41,6 +41,6 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | tr    | Yardımı görüntüle  | Sürümü görüntüle      | [Etkileşimli]    |
 | uk    |                    |                       |                  |
 | uz    |                    |                       |                  |
-| zh    | 显示说明               | 显示版本                  | [交互式]            |
+| zh    | 显示帮助               | 显示版本                  | [交互式]            |
 | zh_TW | 顯示說明               | 顯示版本                  | [互動式]            |
 


### PR DESCRIPTION
### Optimize the Simplified Chinese translation of “Display help.” 

I noticed that “Display help” has been translated as “显示说明” (Display Instructions). Generally, a more natural and fluent rendering would be “显示帮助” (Display help).