### PR TITLE
jj*: update documentation URL

### DIFF
--- a/pages/common/jj-abandon.md
+++ b/pages/common/jj-abandon.md
@@ -2,7 +2,7 @@
 
 > Abandon a revision, rebasing descendants onto its parent(s).
 > Abandoning a revision removes its associated change ID.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-abandon>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-abandon>.
 
 - Abandon revisions specified by given revsets (e.g. `B::D`, `A..D`, `B|C|D`, etc.):
 

--- a/pages/common/jj-absorb.md
+++ b/pages/common/jj-absorb.md
@@ -2,7 +2,7 @@
 
 > Split changes in the source revision and move each change to the closest mutable ancestor where the corresponding lines were modified last.
 > Changes that have zero or multiple matching regions in ancestral revisions won't be moved.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-absorb>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-absorb>.
 
 - Move all eligible and unambiguous changes from a revision to other revisions automatically:
 

--- a/pages/common/jj-bookmark.md
+++ b/pages/common/jj-bookmark.md
@@ -2,7 +2,7 @@
 
 > Manage bookmarks in a `jj` repository.
 > When using a Git backend, bookmarks correspond to Git branches.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-bookmark>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-bookmark>.
 
 - Create a new bookmark at the given revision:
 

--- a/pages/common/jj-commit.md
+++ b/pages/common/jj-commit.md
@@ -1,7 +1,7 @@
 # jj commit
 
 > Update the description and create a new change on top.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-commit>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-commit>.
 
 - Open editor to write the commit message and then create a new empty commit on top:
 

--- a/pages/common/jj-describe.md
+++ b/pages/common/jj-describe.md
@@ -1,7 +1,7 @@
 # jj describe
 
 > Update the change description or other metadata.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-describe>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-describe>.
 
 - Update the description of the current change:
 

--- a/pages/common/jj-diff.md
+++ b/pages/common/jj-diff.md
@@ -1,7 +1,7 @@
 # jj diff
 
 > Compare file contents between two revisions.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-diff>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-diff>.
 
 - Show changes of current revision:
 

--- a/pages/common/jj-diffedit.md
+++ b/pages/common/jj-diffedit.md
@@ -1,7 +1,7 @@
 # jj diffedit
 
 > Touch up the content changes in a revision with a diff editor.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-diffedit>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-diffedit>.
 
 - Edit changes in the current revision with a diff editor:
 

--- a/pages/common/jj-duplicate.md
+++ b/pages/common/jj-duplicate.md
@@ -1,7 +1,7 @@
 # jj duplicate
 
 > Create new changes with the same content as existing ones.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-duplicate>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-duplicate>.
 
 - Duplicate the current revision onto its existing parent:
 

--- a/pages/common/jj-edit.md
+++ b/pages/common/jj-edit.md
@@ -2,7 +2,7 @@
 
 > Set the specified revision as the working-copy revision.
 > Note: It is generally recommended to instead use `jj new` and `jj squash`.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-edit>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-edit>.
 
 - Set the given revision as the working copy:
 

--- a/pages/common/jj-evolog.md
+++ b/pages/common/jj-evolog.md
@@ -1,7 +1,7 @@
 # jj evolog
 
 > Show how a change has evolved over time, listing the previous commits it has pointed to.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-evolog>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-evolog>.
 
 - Show how a revision has evolved over time:
 

--- a/pages/common/jj-git-clone.md
+++ b/pages/common/jj-git-clone.md
@@ -2,7 +2,7 @@
 
 > Create a new repo backed by a clone of a Git repo.
 > Note: Unless `--colocate` is used, it is not a valid Git repository and `git` commands can't be used on it.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-clone>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git-clone>.
 
 - Create a new repo backed by a clone of a Git repo into a new directory (the default directory is the repository name):
 

--- a/pages/common/jj-git-fetch.md
+++ b/pages/common/jj-git-fetch.md
@@ -1,7 +1,7 @@
 # jj git fetch
 
 > Fetch from a Git remote, downloading objects and refs from the remote repository.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-fetch>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git-fetch>.
 
 - Fetch the latest changes from the default remote repository:
 

--- a/pages/common/jj-git-init.md
+++ b/pages/common/jj-git-init.md
@@ -2,7 +2,7 @@
 
 > Create a new Git backed Jujutsu repo.
 > Note: Unless `--colocate` is used, it is not a valid Git repository and `git` commands can't be used on it.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-init>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git-init>.
 
 - Create a new Git backed repo in the current directory:
 

--- a/pages/common/jj-git-push.md
+++ b/pages/common/jj-git-push.md
@@ -1,7 +1,7 @@
 # jj git push
 
 > Push to a Git remote.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-push>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git-push>.
 
 - Push a bookmark to the given remote (defaults to `git.push` setting):
 

--- a/pages/common/jj-git-remote.md
+++ b/pages/common/jj-git-remote.md
@@ -1,7 +1,7 @@
 # jj git remote
 
 > Manage Git remotes.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-remote>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git-remote>.
 
 - List all Git remotes:
 

--- a/pages/common/jj-git.md
+++ b/pages/common/jj-git.md
@@ -1,7 +1,7 @@
 # jj git
 
 > Run Git-related commands for a `jj` repository.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-git>.
 
 - Create a new Git backed repository:
 

--- a/pages/common/jj-interdiff.md
+++ b/pages/common/jj-interdiff.md
@@ -1,7 +1,7 @@
 # jj interdiff
 
 > Compare changes of two revisions.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-interdiff>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-interdiff>.
 
 - Compare changes from a revision to the working copy:
 

--- a/pages/common/jj-log.md
+++ b/pages/common/jj-log.md
@@ -1,7 +1,7 @@
 # jj log
 
 > Show revision history as a graph.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-log>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-log>.
 
 - Show revision history as a graph:
 

--- a/pages/common/jj-new.md
+++ b/pages/common/jj-new.md
@@ -1,7 +1,7 @@
 # jj new
 
 > Create a new empty change.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-new>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-new>.
 
 - Create a new empty change on top of current revision:
 

--- a/pages/common/jj-next.md
+++ b/pages/common/jj-next.md
@@ -1,7 +1,7 @@
 # jj next
 
 > Move the working-copy commit to a child revision.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-next>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-next>.
 
 - Move the working-copy commit to the next child revision:
 

--- a/pages/common/jj-operation.md
+++ b/pages/common/jj-operation.md
@@ -1,7 +1,7 @@
 # jj operation
 
 > Work with the operation log of a `jj` repository.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-operation>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-operation>.
 
 - Show operation log:
 

--- a/pages/common/jj-parallelize.md
+++ b/pages/common/jj-parallelize.md
@@ -1,7 +1,7 @@
 # jj parallelize
 
 > Parallelize revisions by making them siblings.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-parallelize>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-parallelize>.
 
 - Parallelize given revisions:
 

--- a/pages/common/jj-prev.md
+++ b/pages/common/jj-prev.md
@@ -1,7 +1,7 @@
 # jj prev
 
 > Move the working-copy commit to a parent revision.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-prev>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-prev>.
 
 - Move the working-copy commit to the previous parent revision:
 

--- a/pages/common/jj-rebase.md
+++ b/pages/common/jj-rebase.md
@@ -1,7 +1,7 @@
 # jj rebase
 
 > Move revisions to different parent(s).
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-rebase>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-rebase>.
 
 - Move given revisions to a different parent(s):
 

--- a/pages/common/jj-resolve.md
+++ b/pages/common/jj-resolve.md
@@ -1,7 +1,7 @@
 # jj resolve
 
 > Resolve conflicted files with an external merge tool.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-resolve>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-resolve>.
 
 - Resolve all conflicts:
 

--- a/pages/common/jj-restore.md
+++ b/pages/common/jj-restore.md
@@ -1,7 +1,7 @@
 # jj restore
 
 > Restore files from another revision.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-restore>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-restore>.
 
 - Restore files from a revision into another revision:
 

--- a/pages/common/jj-revert.md
+++ b/pages/common/jj-revert.md
@@ -1,7 +1,7 @@
 # jj revert
 
 > Apply the reverse of the given revision(s).
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-revert>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-revert>.
 
 - Apply the reverse of the revisions specified by the given revsets (e.g. `B::D`, `A..D`, `B|C|D`, etc.):
 

--- a/pages/common/jj-show.md
+++ b/pages/common/jj-show.md
@@ -1,7 +1,7 @@
 # jj show
 
 > Show commit description and changes in a revision.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-show>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-show>.
 
 - Show commit description and changes in a revision:
 

--- a/pages/common/jj-simplify-parents.md
+++ b/pages/common/jj-simplify-parents.md
@@ -2,7 +2,7 @@
 
 > Simplify parent edges for the specified revision(s).
 > For example, "A -> B -> C | A -> C" gets simplified to "A -> B -> C".
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-simplify-parents>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-simplify-parents>.
 
 - Simplify parent edges of given revisions:
 

--- a/pages/common/jj-split.md
+++ b/pages/common/jj-split.md
@@ -1,7 +1,7 @@
 # jj split
 
 > Split a revision in two.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-split>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-split>.
 
 - Split the given revision into two interactively, putting the second revision on top of it:
 

--- a/pages/common/jj-squash.md
+++ b/pages/common/jj-squash.md
@@ -1,7 +1,7 @@
 # jj squash
 
 > Move changes from a revision into another revision.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-squash>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-squash>.
 
 - Move all changes from current revision to its parent:
 

--- a/pages/common/jj-status.md
+++ b/pages/common/jj-status.md
@@ -2,7 +2,7 @@
 
 > Show high-level repository status.
 > This includes the working copy commit and its parents, and a summary of the changes in the working copy and any existing conflicts in the working copy.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-status>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-status>.
 
 - Show high-level status of the repository:
 

--- a/pages/common/jj-undo.md
+++ b/pages/common/jj-undo.md
@@ -1,7 +1,7 @@
 # jj undo
 
 > Undo the most recent recorded operation in a `jj` repository.
-> More information: <https://jj-vcs.github.io/jj/latest/cli-reference/#jj-undo>.
+> More information: <https://docs.jj-vcs.dev/latest/cli-reference/#jj-undo>.
 
 - Undo the last operation:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

The jj project migrated documentation to a custom domain (docs.jj-vcs.dev) for better branding/organization. The old GitHub Pages URLs still work via 301 redirects. See [changelog](https://docs.jj-vcs.dev/latest/changelog/#0360-2025-12-03) for more info.