### PR TITLE
nix-profile: various updates

### DIFF
--- a/pages/common/nix-profile.md
+++ b/pages/common/nix-profile.md
@@ -9,7 +9,7 @@
 
 - Install a package from a flake on GitHub into a custom profile:
 
-`nix profile install {{github:owner/repo/pkg}} --profile {{path/to/directory}}`
+`nix profile add {{github:owner/repo/pkg}} --profile {{path/to/directory}}`
 
 - List packages currently installed in the default profile:
 
@@ -19,9 +19,9 @@
 
 `nix profile remove {{legacyPackages.x86_64-linux.pkg}}`
 
-- Upgrade packages in the default to the latest available versions:
+- Upgrade packages in the default profile to the latest available versions:
 
-`nix profile upgrade`
+`nix profile upgrade --all`
 
 - Rollback (cancel) the latest action on the default profile:
 


### PR DESCRIPTION
The `nix profile install` command was renamed to `nix profile add` in https://github.com/NixOS/nix/pull/13224 (merged on 20 May 2025). This PR updates the tldr-pages entry accordingly.

Also, the `nix profile upgrade` command cannot be run without arguments; I've added the `--add` option to the example so it works as expected.

Finally, the "more information" link was switched to a more current URL (that of the latest release).

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
