### PR TITLE
kill: use correct option syntax, fix signal number for SIGSTOP

### DIFF
--- a/pages/common/kill.md
+++ b/pages/common/kill.md
@@ -26,7 +26,7 @@
 
 - Signal the operating system to pause a program until a SIGCONT ("continue") signal is received:
 
-`kill {{[-17|-STOP]}} {{process_id}}`
+`kill {{[-19|-STOP]}} {{process_id}}`
 
 - Send a `SIGUSR1` signal to all processes with the given GID (group id):
 

--- a/pages/linux/kill.md
+++ b/pages/linux/kill.md
@@ -30,7 +30,7 @@
 
 - Signal the operating system to pause a program until a SIGCONT ("continue") signal is received:
 
-`kill {{[-17|-STOP]}} {{process_id}}`
+`kill {{[-19|-STOP]}} {{process_id}}`
 
 - Send a `SIGUSR1` signal to all processes with the given GID (group id):
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** util-linux 2.41.3 (with: sigqueue, pidfd)
- Reference issue: #
