### PR TITLE
mkfs.ext4: add user ownership example

### DIFF
--- a/pages/linux/mkfs.ext4.md
+++ b/pages/linux/mkfs.ext4.md
@@ -11,6 +11,6 @@
 
 `sudo mkfs.ext4 -L {{volume_label}} {{/dev/sdXY}}`
 
-- Create an ext4 filesystem and give root ownership to the current user:
+- Create an ext4 filesystem owned by a specific user and group:
 
-`sudo mkfs.ext4 -E root_owner {{/dev/sdXY}}`
+`sudo mkfs.ext4 -E root_owner={{uid}}:{{gid}} {{/dev/sdXY}}`


### PR DESCRIPTION
`root_owner` is not a placeholder but one of the extended options. It can be extended as `root_owner=1000:1000`