### PR TITLE
README: Add semantic search for tldr-pages to similar projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ You are also welcome to join us on the [matrix chatroom](https://matrix.to/#/#tl
   The examples are submitted by the user base, and can be voted up or down;
   the best entries are what people see first when they look up a command.
 
+- [Semantic Search for TLDR pages](https://jslambda.github.io/tldr-vsearch)
+  provides semantic search for TLDR pages, working fully client-side in the browser. For example try searching for 'convert json to yaml'.
+  The project uses the TLDR pages and can be helpful to users who prefer searching by description and intent rather than by command name.
+  
 ## What does "tldr" mean?
 
 TL;DR stands for "Too Long; Didn't Read".


### PR DESCRIPTION
This PR adds semantic search for TLDR pages to the Similar projects section.
The project works fully client-side in the browser. At the moment it searches in pages in `linux` and `common` folders, but I plan improve the performance, and cover more pages.

### Checklist

- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
