### PR TITLE
ddcutil: refresh page

### DIFF
--- a/pages/linux/ddcutil.md
+++ b/pages/linux/ddcutil.md
@@ -21,7 +21,7 @@
 
 `ddcutil {{[-d|--display]}} 1 {{[set|setvcp]}} 12 + 5`
 
-- Change the display source of a display:
+- Change the display source (option `60`) of a display:
 
 `ddcutil {{[-d|--display]}} {{1}} {{[set|setvcp]}} 60 0x{{0f}}`
 


### PR DESCRIPTION
I would like to refresh the page completely to unify the placeholders and all that, but the tool segfaults when doing `ddcutil cap` on one of my monitors. I'll put that off until later date