### PR TITLE
dmypy: fix check and run command documentation

### DIFF
--- a/pages.fr/common/dmypy.md
+++ b/pages.fr/common/dmypy.md
@@ -6,7 +6,7 @@
 
 - Vérifie les types dans un fichier, et démarre le démon s'il n'est pas lancé :
 
-`dmypy check -- {{chemin/vers/fichier.py}}`
+`dmypy run -- {{chemin/vers/fichier.py}}`
 
 - Démarre le démon :
 
@@ -14,7 +14,7 @@
 
 - Vérifie les types dans un fichier (nécéssite que le démon soit lancé) :
 
-`dmypy run -- {{chemin/vers/fichier.py}}`
+`dmypy check -- {{chemin/vers/fichier.py}}`
 
 - Arrête le démon :
 

--- a/pages/common/dmypy.md
+++ b/pages/common/dmypy.md
@@ -6,7 +6,7 @@
 
 - Type check a file, and start the daemon if it is not running:
 
-`dmypy check -- {{path/to/file.py}}`
+`dmypy run -- {{path/to/file.py}}`
 
 - Start the daemon:
 
@@ -14,7 +14,7 @@
 
 - Type check a file (requires the daemon to be running):
 
-`dmypy run -- {{path/to/file.py}}`
+`dmypy check -- {{path/to/file.py}}`
 
 - Stop the daemon:
 


### PR DESCRIPTION
This PR fixes a mistake I made on the dmypy page creation

Documentation for check and run commands were inverted.

It has been fixed by inverting commands but not documentations, as the more useful command is `run` and it should be first.

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known): 1.19.1**
- Reference issue: #
