### PR TITLE
pdftk: add example for interleaving PDFs with one-sided scans

### DIFF
--- a/pages/common/pdftk.md
+++ b/pages/common/pdftk.md
@@ -5,24 +5,24 @@
 
 - Extract pages 1-3, 5, and 6-10 from a PDF file and save them as another one:
 
-`pdftk {{input.pdf}} cat {{1-3 5 6-10}} output {{output.pdf}}`
+`pdftk {{path/to/input}}.pdf cat 1-3 5 6-10 output {{path/to/output}}.pdf`
 
 - Merge (concatenate) a list of PDF files and save the result as another one:
 
-`pdftk {{file1.pdf file2.pdf ...}} cat output {{output.pdf}}`
+`pdftk {{path/to/file1}}.pdf {{path/to/file2}}.pdf cat output {{path/to/output}}.pdf`
 
 - Split each page of a PDF file into a separate file, with a given filename output pattern:
 
-`pdftk {{input.pdf}} burst output {{out_%d.pdf}}`
+`pdftk {{path/to/input}}.pdf burst output {{path/to/out_%d}}.pdf`
 
 - Rotate all pages by 180 degrees clockwise:
 
-`pdftk {{input.pdf}} cat {{1-endsouth}} output {{output.pdf}}`
+`pdftk {{path/to/input}}.pdf cat 1-endsouth output {{path/to/output}}.pdf`
 
 - Rotate third page by 90 degrees clockwise and leave others unchanged:
 
-`pdftk {{input.pdf}} cat {{1-2 3east 4-end}} output {{output.pdf}}`
+`pdftk {{path/to/input}}.pdf cat 1-2 3east 4-end output {{path/to/output}}.pdf`
 
 - Interleave two PDFs with one-sided scans of a two-sided document, where the backs were scanned back to front:
 
-`pdftk A={{fronts.pdf}} B={{backs.pdf}} shuffle A1-end Bend-1 output {{output.pdf}}`
+`pdftk A={{path/to/fronts}}.pdf B={{path/to/backs}}.pdf shuffle A1-end Bend-1 output {{path/to/output}}.pdf`


### PR DESCRIPTION
### Checklist

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR contains at most 5 new pages.
- [X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** at least "pdftk port to java 3.3.3"