### PR TITLE
fd: update `--exclude` to specify it matches a glob not a regex

### DIFF
--- a/pages/common/fd.md
+++ b/pages/common/fd.md
@@ -24,9 +24,9 @@
 
 `fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{string|regex}}"`
 
-- Exclude files that match a specific `glob` pattern:
+- Exclude files that match a specific glob pattern:
 
-`fd {{string}} {{[-E|--exclude]}} {{glob*}}`
+`fd {{string}} {{[-E|--exclude]}} {{glob}}`
 
 - Execute a command on each search result returned:
 


### PR DESCRIPTION
small fix, the current page says it takes a regex while it is a glob instead

https://github.com/sharkdp/fd?tab=readme-ov-file#command-line-options 
https://github.com/sharkdp/fd/issues/661

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
