### PR TITLE
watchexec: make the polling interval used clearer

### DIFF
--- a/pages/common/watchexec.md
+++ b/pages/common/watchexec.md
@@ -22,4 +22,4 @@
 
 - Restart the execution of a command when any Java source file in the current directory changes, sending `SIGKILL` and only checking for updates every `10000` ms:
 
-`watchexec {{[-r|--restart]}} --stop-signal {{SIGKILL}} --poll {{10000}} {{[-e|--exts]}} {{java}} {{command}}`
+`watchexec {{[-r|--restart]}} --stop-signal {{SIGKILL}} --poll 10000 {{[-e|--exts]}} {{java}} {{command}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
