### PR TITLE
Fix Polish translation errors and missing pages (issue #13545)

### DIFF
--- a/pages.pl/common/base32.md
+++ b/pages.pl/common/base32.md
@@ -1,9 +1,9 @@
 # base32
 
-> Enkoduj lub dekoduj plik lub standardowe wejście do/z Base32, na standardowe wyjście.
+> Zakoduj lub zdekoduj plik lub standardowe wejście do/z Base32, na standardowe wyjście.
 > Więcej informacji: <https://manned.org/base32>.
 
-- Enkoduj plik:
+- Zakoduj plik:
 
 `base32 {{ścieżka/do/pliku}}`
 
@@ -15,7 +15,7 @@
 
 `base32 {{[-d|--decode]}} {{ścieżka/do/pliku}}`
 
-- Enkoduj z `stdin`:
+- Zakoduj z `stdin`:
 
 `{{jakiespolecenie}} | base32`
 

--- a/pages.pl/common/base64.md
+++ b/pages.pl/common/base64.md
@@ -1,9 +1,9 @@
 # base64
 
-> Enkoduj lub dekoduj plik lub standardowe wejście do/z Base64, na standardowe wyjście.
+> Zakoduj lub zdekoduj plik lub standardowe wejście do/z Base64, na standardowe wyjście.
 > Więcej informacji: <https://manned.org/base64>.
 
-- Enkoduj plik:
+- Zakoduj plik:
 
 `base64 {{ścieżka/do/pliku}}`
 
@@ -15,7 +15,7 @@
 
 `base64 {{[-d|--decode]}} {{ścieżka/do/pliku}}`
 
-- Enkoduj z `stdin`:
+- Zakoduj z `stdin`:
 
 `{{jakiespolecenie}} | base64`
 

--- a/pages.pl/common/cron.md
+++ b/pages.pl/common/cron.md
@@ -1,0 +1,8 @@
+# cron
+
+> Systemowy harmonogram do uruchamiania zadań bez nadzoru.
+> Polecenie do przesyłania, edytowania lub usuwania wpisów w `cron` nazywa się `crontab`.
+
+- Zobacz dokumentację do zarządzania wpisami `cron`:
+
+`tldr crontab`

--- a/pages.pl/common/vim.md
+++ b/pages.pl/common/vim.md
@@ -33,6 +33,6 @@
 
 `<:>%s/{{wzorzec}}/{{zastąpienie}}/g<Enter>`
 
-- Wyświetlaj numery linii:
+- Wyświetl numery linii:
 
 `<:>set nu<Enter>`

--- a/pages.pl/linux/ac.md
+++ b/pages.pl/linux/ac.md
@@ -19,6 +19,6 @@
 
 `ac {{[-d|--daily-totals]}} {{[-p|--individual-totals]}} {{użytkownik}}`
 
-- Wyświetlaj także dodatkowe szczegóły:
+- Wyświetl także dodatkowe szczegóły:
 
 `ac --compatibility`

--- a/pages.pl/linux/acpi.md
+++ b/pages.pl/linux/acpi.md
@@ -1,6 +1,6 @@
 # acpi
 
-> Wyśwetl status baterii lub informacje dotyczące temperatury.
+> Wyświetl status baterii lub informacje dotyczące temperatury.
 > Więcej informacji: <https://manned.org/acpi>.
 
 - Pokaż informacje o baterii:

--- a/pages.pl/linux/journalctl.md
+++ b/pages.pl/linux/journalctl.md
@@ -12,7 +12,7 @@
 
 `journalctl --vacuum-time 2d`
 
-- Wyświetlaj nowe wiadomości (jak `tail -f` dla tradycyjnego sysloga):
+- Wyświetl nowe wiadomości (jak `tail -f` dla tradycyjnego sysloga):
 
 `journalctl {{[-f|--follow]}}`
 

--- a/pages.pl/linux/pacman-database.md
+++ b/pages.pl/linux/pacman-database.md
@@ -21,7 +21,7 @@
 
 `pacman --database --check --check`
 
-- Wyświetlaj tylko komunikaty o błędach:
+- Wyświetl tylko komunikaty o błędach:
 
 `pacman --database --check --quiet`
 

--- a/pages.pl/linux/unsquashfs.md
+++ b/pages.pl/linux/unsquashfs.md
@@ -11,11 +11,11 @@
 
 `unsquashfs -dest {{ścieżka/do/katalogu}} {{system_plików.squashfs}}`
 
-- Wyświetlaj nazwy plików podczas ich rozpakowywania:
+- Wyświetl nazwy plików podczas ich rozpakowywania:
 
 `unsquashfs -info {{system_plików.squashfs}}`
 
-- Wyświetlaj nazwy plików i ich atrybuty podczas ich rozpakowywania:
+- Wyświetl nazwy plików i ich atrybuty podczas ich rozpakowywania:
 
 `unsquashfs -linfo {{system_plików.squashfs}}`
 


### PR DESCRIPTION
## Summary
This PR fixes Polish (pl) translation errors and adds missing pages to address issues outlined in #13545.

## Changes
- **Fixed typos:**
  - `linux/acpi.md`: "Wyśwetl" → "Wyświetl"
  - `common/base32.md`, `common/base64.md`: "Enkoduj" → "Zakoduj" (proper Polish for "encode")

- **Fixed imperative mood violations (continuous → imperative):**
  - All instances of "Wyświetlaj" → "Wyświetl" in:
    - `common/vim.md`
    - `linux/ac.md`
    - `linux/journalctl.md`
    - `linux/pacman-database.md`
    - `linux/unsquashfs.md` (2 instances)

- **Added missing translation:**
  - `common/cron.md` - Polish translation

## Issue Reference
Addresses items from #13545 (Polish translation request)

## Checklist
- [x] Followed style guide (imperative mood)
- [x] Used proper Polish terminology
- [x] Fixed known typos
- [x] Added missing placeholder page for cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)