### PR TITLE
btrfs-restore: add short/long options and subcommands

### DIFF
--- a/pages.es/linux/btrfs-restore.md
+++ b/pages.es/linux/btrfs-restore.md
@@ -5,20 +5,20 @@
 
 - Restaura todos los archivos de un sistema de archivos btrfs a un directorio dado:
 
-`sudo btrfs restore {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
+`sudo btrfs {{[rest|restore]}} {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
 
 - Lista (sin escribir) los archivos que se van a restaurar de un sistema de archivos btrfs:
 
-`sudo btrfs restore --dry-run {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
+`sudo btrfs {{[rest|restore]}} {{[-D|--dry-run]}} {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
 
 - Restaura archivos que coincidan con una `regex` dada (insensible a mayúsculas) de un sistema de archivos btrfs (todos los directorios padres de los archivos de destino también deben coincidir):
 
-`sudo btrfs restore --path-regex {{regex}} -c {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
+`sudo btrfs {{[rest|restore]}} --path-regex {{regex}} -c {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
 
 - Restaura archivos de un sistema de archivos btrfs usando un `bytenr` específico del árbol raíz (ver `btrfs-find-root`):
 
-`sudo btrfs restore -t {{bytenr}} {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
+`sudo btrfs {{[rest|restore]}} -t {{bytenr}} {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
 
 - Restaura archivos de un sistema de archivos btrfs (junto con metadatos, atributos extendidos y enlaces simbólicos), sobrescribiendo archivos en el destino:
 
-`sudo btrfs restore --metadata --xattr --symlinks --overwrite {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`
+`sudo btrfs {{[rest|restore]}} {{[-m|--metadata]}} {{[-x|--xattr]}} {{[-S|--symlinks]}} {{[-o|--overwrite]}} {{ruta/al_dispositivo_btrfs}} {{ruta/al_directorio_destino}}`

--- a/pages.fr/linux/btrfs-restore.md
+++ b/pages.fr/linux/btrfs-restore.md
@@ -5,20 +5,20 @@
 
 - Restaurer tout les fichiers depuis un système de fichier btrfs vers un répertoire cible indiqué :
 
-`sudo btrfs restore {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
+`sudo btrfs {{[rest|restore]}} {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
 
 - Lister (sans écriture) les fichiers qui peuvent être récupérés depuis un système de fichiers btrfs :
 
-`sudo btrfs restore --dry-run {{chemin/du/device/btrfs}} {{chemin/du/dossier}}`
+`sudo btrfs {{[rest|restore]}} {{[-D|--dry-run]}} {{chemin/du/device/btrfs}} {{chemin/du/dossier}}`
 
 - Restaurer les fichiers correspondants à une expression régulière donnée (non sensible à la casse) à restaurer depuis un système de fichiers btrfs (tous les répertoires parents des fichiers doivent correspondre également à l'expression régulière) :
 
-`sudo btrfs restore --path-regex {{expression_reguliere}} -c {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
+`sudo btrfs {{[rest|restore]}} --path-regex {{expression_reguliere}} -c {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
 
 - Restaurer les fichiers depuis un système de fichiers btrfs en utilisant un arbre racine spécifique `bytenr` (voir `btrfs-find-root`) :
 
-`sudo btrfs restore -t {{bytenr}} {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
+`sudo btrfs {{[rest|restore]}} -t {{bytenr}} {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
 
 - Restaurer les fichiers depuis un système de fichiers btrfs (avec métadonnées, attributs étendus, et liens symboliques) en écrivant par dessus les fichiers déjà existants dans le répertoire cible :
 
-`sudo btrfs restore --metadata --xattr --symlinks --overwrite {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`
+`sudo btrfs {{[rest|restore]}} {{[-m|--metadata]}} {{[-x|--xattr]}} {{[-S|--symlinks]}} {{[-o|--overwrite]}} {{chemin/vers/peripherique_btrfs}} {{chemin/vers/dossier}}`

--- a/pages.ko/linux/btrfs-restore.md
+++ b/pages.ko/linux/btrfs-restore.md
@@ -5,20 +5,20 @@
 
 - btrfs 파일 시스템에서 모든 파일을 지정된 디렉토리로 복원:
 
-`sudo btrfs restore {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
+`sudo btrfs {{[rest|restore]}} {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
 
 - btrfs 파일 시스템에서 복원할 파일 목록 표시 (복원하지 않음):
 
-`sudo btrfs restore --dry-run {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
+`sudo btrfs {{[rest|restore]}} {{[-D|--dry-run]}} {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
 
 - 주어진 정규 표현식과 일치하는 파일을 btrfs 파일 시스템에서 복원 ([대]소문자 구분 없음, 대상 파일의 모든 상위 디렉토리도 일치해야 함):
 
-`sudo btrfs restore --path-regex {{정규식}} -c {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
+`sudo btrfs {{[rest|restore]}} --path-regex {{정규식}} -c {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
 
 - 특정 루트 트리 `bytenr`를 사용하여 btrfs 파일 시스템에서 파일 복원 (`btrfs-find-root` 참조):
 
-`sudo btrfs restore -t {{bytenr}} {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
+`sudo btrfs {{[rest|restore]}} -t {{bytenr}} {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
 
 - btrfs 파일 시스템에서 메타데이터, 확장 속성, 심볼릭 링크와 함께 파일을 복원하여 대상의 파일을 덮어쓰기:
 
-`sudo btrfs restore --metadata --xattr --symlinks --overwrite {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`
+`sudo btrfs {{[rest|restore]}} {{[-m|--metadata]}} {{[-x|--xattr]}} {{[-S|--symlinks]}} {{[-o|--overwrite]}} {{경로/대상/btrfs_장치}} {{경로/대상/대상_폴더}}`

--- a/pages.pt_BR/linux/btrfs-restore.md
+++ b/pages.pt_BR/linux/btrfs-restore.md
@@ -5,20 +5,20 @@
 
 - Restaura todos os arquivos de um sistema de arquivos btrfs para um determinado diretório:
 
-`sudo btrfs restore {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
+`sudo btrfs {{[rest|restore]}} {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
 
 - Lista (sem escrever) os arquivos a serem restaurados de um sistema de arquivos btrfs:
 
-`sudo btrfs restore --dry-run {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
+`sudo btrfs {{[rest|restore]}} {{[-D|--dry-run]}} {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
 
 - Restaura arquivos correspondentes a determinados padrões `regex` ([c]ase-insensitive) de um sistema de arquivos btrfs (todos os diretórios pai do(s) arquivo(s) de destino também devem corresponder):
 
-`sudo btrfs restore --path-regex {{regex}} -c {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
+`sudo btrfs {{[rest|restore]}} --path-regex {{regex}} -c {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
 
 - Restaura arquivos de um sistema de arquivos btrfs usando um `bytenr` específico da árvore raiz (consulte `btrfs-find-root`):
 
-`sudo btrfs restore -t {{bytenr}} {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
+`sudo btrfs {{[rest|restore]}} -t {{bytenr}} {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
 
 - Restaura arquivos de um sistema de arquivos btrfs (juntamente com metadados, atributos estendidos e Symlinks), sobrescrevendo arquivos no destino:
 
-`sudo btrfs restore --metadata --xattr --symlinks --overwrite {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`
+`sudo btrfs {{[rest|restore]}} {{[-m|--metadata]}} {{[-x|--xattr]}} {{[-S|--symlinks]}} {{[-o|--overwrite]}} {{caminho/para/dispositivo_btrfs}} {{caminho/para/diretório_alvo}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
