### PR TITLE
style-guide: adjust grouping wording

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -155,7 +155,7 @@ For example `adb disconnect` has a single way using it, but `adb` is expansive e
 ```md
 # adb disconnect
 
-> This command has been moved together with `adb connect`.
+> The examples for this command have been moved together with `adb connect`.
 
 - View documentation for `adb disconnect`:
 


### PR DESCRIPTION
The original wording feels like it implies that upstream has moved the command. 
This change should make it clearer that it means that we moved it to another page. If you have better wording ideas, let me know.