### PR TITLE
gnome-terminal: add short/long options

### DIFF
--- a/pages.ko/linux/gnome-terminal.md
+++ b/pages.ko/linux/gnome-terminal.md
@@ -17,4 +17,4 @@
 
 - 새 탭의 제목 설정:
 
-`gnome-terminal --tab --title "{{제목}}"`
+`gnome-terminal --tab {{[-t|--title]}} "{{제목}}"`

--- a/pages.ml/linux/gnome-terminal.md
+++ b/pages.ml/linux/gnome-terminal.md
@@ -17,4 +17,4 @@
 
 - പുതിയ ടാബിന്റെ ടൈറ്റിൽ മാറ്റുവാൻ:
 
-`gnome-terminal --tab --title "{{ടൈറ്റിൽ}}"`
+`gnome-terminal --tab {{[-t|--title]}} "{{ടൈറ്റിൽ}}"`

--- a/pages.pt_BR/linux/gnome-terminal.md
+++ b/pages.pt_BR/linux/gnome-terminal.md
@@ -17,4 +17,4 @@
 
 - Define o título da nova aba:
 
-`gnome-terminal --tab --title "{{título}}"`
+`gnome-terminal --tab {{[-t|--title]}} "{{título}}"`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
