### PR TITLE
Added bcftools.md page

### DIFF
--- a/pages/common/bcftools.md
+++ b/pages/common/bcftools.md
@@ -1,0 +1,36 @@
+# bcftools
+
+> Tools for manipulating VCF and BCF files.
+> More information: <https://samtools.github.io/bcftools/bcftools.html>.
+
+- View BCF file and convert to [v]CF on `stdout`:
+
+`bcftools view {{path/to/input.bcf}} {{[-O|--output-type]}} v`
+
+- Sort a VCF file variants by chromosome and position, output to a [b]CF file, and index the sorted output:
+
+`bcftools sort {{path/to/input.vcf.gz}} {{[-O|--output-type]}} b {{[-o|--output]}} {{path/to/sorted.bcf}} {{[-W|--write-index]}}`
+
+- Concatenate sorted VCF files that share the same samples to [z]ipped VCF on `stdout`:
+
+`bcftools concat {{path/to/chr1.vcf.gz path/to/chr2.vcf.gz ...}} {{[-O|--output-type]}} z`
+
+- Filter for low quality variants and annotate with "LowQual" tag in the FILTER column:
+
+`bcftools filter {{[-e|--exclude]}} 'QUAL<20' {{[-s|--soft-filter]}} LowQual {{path/to/input.vcf.gz}}`
+
+- Add annotated columns from a tabix-indexed table on `stdout`:
+
+`bcftools annotate {{[-a|--annotations]}} {{path/to/annotations.tsv.gz}} {{[-c|--columns]}} CHROM,POS,REF,ALT,INFO/AF {{path/to/input.vcf.gz}}`
+
+- Output variant [i]nter[sec]tion between VCF files using 4 threads:
+
+`bcftools isec {{path/to/a.vcf.gz path/to/b.vcf.gz ...}} --threads 4 {{[-o|--output]}} {{path/to/intersection.vcf}}`
+
+- Merge non-overlapping samples from vcf files without indices on `stdout`:
+
+`bcftools merge {{path/to/cohort1.vcf.gz}} {{path/to/cohort2.vcf.gz}} --no-index`
+
+- Create index for a bgzipped VCF file on `stdout`:
+
+`bcftools index {{path/to/input.vcf.gz}}`


### PR DESCRIPTION
### Checklist

- [ X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X ] The page description(s) have links to documentation or a homepage.
- [X ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ X] The PR contains at most 5 new pages.
- [ X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  BCFtools 1.23. Though man page still says (1).
- Reference issue: # N/A


bcftools is a very commonly used bioinformatics tool for manipulating bcf/vcf files. It contains too many commands to really contain in one tldr page. I elected to ignore the ones used for doing actual analysis of VCF files as nowadays there are better tools that exist. However, bcftools is still the gold standard for filtering, combining, and similar operations.

I used AI to draft a v0 of the page. But scrapped it and wrote almost all of it myself using examples from my own work and the man page.
