### PR TITLE
bcftools: add page

### DIFF
--- a/pages/common/bcftools.md
+++ b/pages/common/bcftools.md
@@ -31,6 +31,6 @@
 
 `bcftools merge {{path/to/cohort1.vcf.gz}} {{path/to/cohort2.vcf.gz}} --no-index`
 
-- Create index for a bgzipped VCF file on `stdout`:
+- Create index for a bgzipped VCF file:
 
 `bcftools index {{path/to/input.vcf.gz}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**  BCFtools 1.23. Though man page still says (1).
- Reference issue: # N/A


bcftools is a very commonly used bioinformatics tool for manipulating bcf/vcf files. It contains too many commands to really contain in one tldr page. I elected to ignore the ones used for doing actual analysis of VCF files as nowadays there are better tools that exist. However, bcftools is still the gold standard for filtering, combining, and similar operations.

I used AI to draft a v0 of the page. But scrapped it and wrote almost all of it myself using examples from my own work and the man page.
