### PR TITLE
picotool: reorganize commands

### DIFF
--- a/pages.ar/common/picotool.md
+++ b/pages.ar/common/picotool.md
@@ -23,10 +23,10 @@
 
 `picotool otp list`
 
-- عرض إصدار الأداة:
-
-`picotool version`
-
 - عرض المساعدة:
 
 `picotool help`
+
+- عرض إصدار الأداة:
+
+`picotool version`

--- a/pages.cs/common/picotool.md
+++ b/pages.cs/common/picotool.md
@@ -23,10 +23,10 @@
 
 `picotool otp list`
 
-- Zobrazit verzi:
-
-`picotool version`
-
 - Zobrazit nápovědu:
 
 `picotool help`
+
+- Zobrazit verzi:
+
+`picotool version`

--- a/pages.es/common/picotool.md
+++ b/pages.es/common/picotool.md
@@ -23,10 +23,10 @@
 
 `picotool otp list`
 
-- Muestra la versión:
-
-`picotool version`
-
 - Muestra la ayuda:
 
 `picotool help`
+
+- Muestra la versión:
+
+`picotool version`


### PR DESCRIPTION
Reorganizing `picotool version` and `picotool help` to match english page.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
