### PR TITLE
sdptool: add page

### DIFF
--- a/pages/linux/sdptool.md
+++ b/pages/linux/sdptool.md
@@ -1,0 +1,22 @@
+# sdptool
+
+> Query Bluetooth devices for the services they offer via SDP (Service Discovery Protocol).
+> The target device must be connected or reachable.
+> Part of BlueZ. See also: `bluetoothctl devices`.
+> More information: <https://manned.org/sdptool>.
+
+- List all services on a remote Bluetooth device:
+
+`sdptool browse {{00:11:22:33:44:55}}`
+
+- List all services on a remote device, displayed as a tree:
+
+`sdptool browse --tree {{00:11:22:33:44:55}}`
+
+- Search for devices offering a predefined service such as `SP`, `DUN`, `HID`, `A2SNK`, or `FTP`:
+
+`sdptool search {{service_abbreviation}}`
+
+- Retrieve all service records from a remote device as XML:
+
+`sdptool records --xml {{00:11:22:33:44:55}}`


### PR DESCRIPTION
## Summary
- Add a new tldr page for `sdptool`, the BlueZ Bluetooth SDP query tool
- Covers the most practical subcommands: `browse`, `search`, and `records`
- Notes the connection requirement and links to `bluetoothctl devices` for discovering BD_ADDRs

## Checklist
- [x] Page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] Placed in `pages/linux/` (BlueZ/Linux-only tool)
- [x] 4 examples, progressive complexity
- [x] Imperative mood, long-form options, proper placeholder syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)