### PR TITLE
hol-registry, hashnet-mcp: add page

### DIFF
--- a/pages/common/hashnet-mcp.md
+++ b/pages/common/hashnet-mcp.md
@@ -1,0 +1,24 @@
+# hashnet-mcp
+
+> Start the Hashgraph Online Hashnet MCP server.
+> More information: <https://github.com/hashgraph-online/hashnet-mcp-js>.
+
+- Start the MCP server over stdio (default transport):
+
+`hashnet-mcp up`
+
+- Start the MCP server over SSE transport:
+
+`hashnet-mcp up --transport sse`
+
+- Show available command options:
+
+`hashnet-mcp up --help`
+
+- Run it without a global install:
+
+`npx @hol-org/hashnet-mcp up`
+
+- Run it over SSE without a global install:
+
+`npx @hol-org/hashnet-mcp up --transport sse`

--- a/pages/common/hol-registry.md
+++ b/pages/common/hol-registry.md
@@ -1,0 +1,28 @@
+# hol-registry
+
+> Search, resolve, and chat with AI agents through the Hashgraph Online Registry Broker.
+> More information: <https://github.com/hashgraph-online/registry-broker-skills>.
+
+- Search for agents matching a query:
+
+`hol-registry search "{{query}}" {{10}}`
+
+- Resolve an agent by UAID:
+
+`hol-registry resolve "{{uaid}}"`
+
+- Start a chat session with an agent and an initial message:
+
+`hol-registry chat "{{uaid}}" "{{message}}"`
+
+- Show platform statistics:
+
+`hol-registry stats`
+
+- Check your registry credit balance:
+
+`hol-registry balance`
+
+- Initialize a local skill package:
+
+`hol-registry skills init --dir {{./my-skill}} --name "{{skill-name}}" --version {{0.1.0}}`


### PR DESCRIPTION
## Summary
- add a `hol-registry` page with practical search, resolve, chat, stats, balance, and skills-init examples
- add a `hashnet-mcp` page covering stdio and SSE startup flows
- link both pages to canonical upstream repositories

## Validation
- `npx markdownlint pages/common/hol-registry.md pages/common/hashnet-mcp.md`
- `npx tldr-lint pages/common`
