### PR TITLE
deno: add run subcommand page

### DIFF
--- a/pages/common/deno-run.md
+++ b/pages/common/deno-run.md
@@ -1,0 +1,32 @@
+# deno run
+
+> Run a JavaScript or TypeScript program with the Deno runtime.
+> More information: <https://docs.deno.com/runtime/reference/cli/run/>.
+
+- Run a local JavaScript or TypeScript file:
+
+`deno run {{path/to/file.ts}}`
+
+- Run a remote script:
+
+`deno run {{https://deno.land/std/examples/welcome.ts}}`
+
+- Run a file with all permissions:
+
+`deno run {{[-A|--allow-all]}} {{path/to/file.ts}}`
+
+- Run a file with specific network and read permissions:
+
+`deno run --allow-net={{example.com}} --allow-read={{/etc}} {{path/to/file.ts}}`
+
+- Run a file and watch for changes:
+
+`deno run --watch {{path/to/file.ts}}`
+
+- Run a script with a specific `deno.json` configuration file:
+
+`deno run {{[-c|--config]}} {{path/to/deno.json}} {{path/to/file.ts}}`
+
+- Run a file and automatically download dependencies if they are missing:
+
+`deno run --reload {{path/to/file.ts}}`

--- a/pages/common/deno.md
+++ b/pages/common/deno.md
@@ -2,6 +2,7 @@
 
 > A secure runtime for JavaScript, TypeScript, and WebAssembly.
 > Includes dependency management using `npm` or `jsr`, and tooling like bench, bundle, doc, and coverage.
+> Some subcommands such as `run`, `compile`, `test`, `lint`, `fmt` have their own usage documentation.
 > More information: <https://docs.deno.com/runtime/reference/cli/>.
 
 - Start a REPL (interactive shell, also known as Read-Eval-Print Loop):


### PR DESCRIPTION
This PR adds a dedicated page for the `deno run` subcommand and updates the main `deno` page to refer to subcommand documentation.

### Checklist
- [x] The page(s) are in the correct platform directories: `common`
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the content guidelines.
- [x] The page(s) follow the style guide.
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended templates.