### PR TITLE
translation-templates: add trailing period to Thai more-info template

### DIFF
--- a/contributing-guides/translation-templates/more-info-link.md
+++ b/contributing-guides/translation-templates/more-info-link.md
@@ -297,7 +297,7 @@ The templates can be changed when necessary, but if so, it needs to be updated h
 ### th
 
 ```markdown
-> ข้อมูลเพิ่มเติม: <https://example.com>
+> ข้อมูลเพิ่มเติม: <https://example.com>.
 ```
 
 ---


### PR DESCRIPTION
This PR adds a trailing period to the Thai (th) "More information" template in
`contributing-guides/translation-templates/more-info-link.md`.

The English template in the style guide shows the "More information" line ending
with punctuation after the URL. Most other language templates in this file also
include terminal punctuation.

This update aligns the Thai template with the general formatting convention used
throughout the file.

No other changes were made.

### Checklist

- [x] The PR follows the style guide.
- [x] The PR title conforms to the recommended templates.
- [x] The PR is authored by me.

Version of the command being documented (if known): N/A  
Reference issue: N/A