### PR TITLE
doctl-*: add short/long options and subcommand aliases to Korean pages

### DIFF
--- a/pages.ko/common/doctl-account.md
+++ b/pages.ko/common/doctl-account.md
@@ -5,12 +5,12 @@
 
 - 계정 정보 표시:
 
-`doctl account get`
+`doctl account {{[g|get]}}`
 
 - 시간별 API 한도, 진행 상황, 비율 한도 재설정 시점을 표시:
 
-`doctl account ratelimit`
+`doctl account {{[rl|ratelimit]}}`
 
 - 도움말 표시:
 
-`doctl account --help`
+`doctl account {{[-h|--help]}}`

--- a/pages.ko/common/doctl-apps.md
+++ b/pages.ko/common/doctl-apps.md
@@ -5,32 +5,32 @@
 
 - 애플리케이션 생성:
 
-`doctl apps create`
+`doctl {{[a|apps]}} {{[c|create]}}`
 
 - 특정 애플리케이션에 대한 배포 생성:
 
-`doctl apps create-deployment {{앱_아이디}}`
+`doctl {{[a|apps]}} {{[cd|create-deployment]}} {{앱_아이디}}`
 
 - 대화형으로 앱 삭제:
 
-`doctl apps delete {{앱_아이디}}`
+`doctl {{[a|apps]}} {{[d|delete]}} {{앱_아이디}}`
 
 - 앱 다운로드:
 
-`doctl apps get`
+`doctl {{[a|apps]}} {{[g|get]}}`
 
 - 모든 앱 나열:
 
-`doctl apps list`
+`doctl {{[a|apps]}} {{[ls|list]}}`
 
 - 특정 앱의 모든 배포를 나열:
 
-`doctl apps list-deployments {{앱_아이디}}`
+`doctl {{[a|apps]}} {{[lsd|list-deployments]}} {{앱_아이디}}`
 
 - 특정 앱에서 로그를 가져오기:
 
-`doctl apps logs {{앱_아이디}}`
+`doctl {{[a|apps]}} {{[l|logs]}} {{앱_아이디}}`
 
 - 특정 앱 사양으로 특정 앱을 업데이트:
 
-`doctl apps update {{앱_아이디}} --spec {{path/to/spec.yml}}`
+`doctl {{[a|apps]}} {{[u|update]}} {{앱_아이디}} --spec {{path/to/spec.yml}}`

--- a/pages.ko/common/doctl-auth.md
+++ b/pages.ko/common/doctl-auth.md
@@ -9,7 +9,7 @@
 
 - 인증 컨텍스트 나열 (API 토큰):
 
-`doctl auth list`
+`doctl auth {{[ls|list]}}`
 
 - 컨텍스트 전환 (API 토큰):
 
@@ -21,4 +21,4 @@
 
 - 사용 가능한 명령 표시:
 
-`doctl auth --help`
+`doctl auth {{[-h|--help]}}`

--- a/pages.ko/common/doctl-balance.md
+++ b/pages.ko/common/doctl-balance.md
@@ -5,12 +5,12 @@
 
 - 현재 컨텍스트와 관련된 계정의 잔액을 가져옴:
 
-`doctl balance get`
+`doctl balance {{[g|get]}}`
 
 - 액세스 토큰과 연결된 계정 잔액을 가져옴:
 
-`doctl balance get --access-token {{액세스_토큰}}`
+`doctl balance {{[g|get]}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 지정된 컨텍스트와 연결된 계정의 잔액을 가져옴:
 
-`doctl balance get --context`
+`doctl balance {{[g|get]}} --context`

--- a/pages.ko/common/doctl-compute-droplet.md
+++ b/pages.ko/common/doctl-compute-droplet.md
@@ -5,12 +5,12 @@
 
 - 드롭릿 생성:
 
-`doctl compute droplet create --region {{지역}} --image {{os_이미지}} --size {{vps_타입}} {{드롭릿_이름}}`
+`doctl compute {{[d|droplet]}} {{[c|create]}} --region {{지역}} --image {{os_이미지}} --size {{vps_타입}} {{드롭릿_이름}}`
 
 - 드롭릿 삭제:
 
-`doctl compute droplet delete {{드롭릿_아이디|드롭릿_이름}}`
+`doctl compute {{[d|droplet]}} {{[d|delete]}} {{드롭릿_아이디|드롭릿_이름}}`
 
 - 드롭릿 나열:
 
-`doctl compute droplet list`
+`doctl compute {{[d|droplet]}} {{[ls|list]}}`

--- a/pages.ko/common/doctl-databases-db.md
+++ b/pages.ko/common/doctl-databases-db.md
@@ -5,20 +5,20 @@
 
 - 액세스 토큰을 사용하여 `doctl databases db` 명령을 실행:
 
-`doctl databases db {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} db {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 특정 데이터베이스 클러스터에서 호스팅되는 특정 데이터베이스의 이름을 검색:
 
-`doctl databases db get {{데이터베이스_아이디}} {{데이터베이스_이름}}`
+`doctl {{[d|databases]}} db {{[g|get]}} {{데이터베이스_아이디}} {{데이터베이스_이름}}`
 
 - 특정 데이터베이스 클러스터 내에서 호스팅되는 기존 데이터베이스를 나열:
 
-`doctl databases db list {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} db {{[ls|list]}} {{데이터베이스_아이디}}`
 
 - 주어진 데이터베이스 클러스터에 주어진 이름을 가진 데이터베이스를 생성:
 
-`doctl databases db create {{데이터베이스_아이디}} {{데이터베이스_이름}}`
+`doctl {{[d|databases]}} db {{[c|create]}} {{데이터베이스_아이디}} {{데이터베이스_이름}}`
 
 - 주어진 데이터베이스 클러스터에 주어진 이름을 가진 데이터베이스를 삭제:
 
-`doctl databases db delete {{데이터베이스_아이디}} {{데이터베이스_이름}}`
+`doctl {{[d|databases]}} db {{[rm|delete]}} {{데이터베이스_아이디}} {{데이터베이스_이름}}`

--- a/pages.ko/common/doctl-databases-firewalls.md
+++ b/pages.ko/common/doctl-databases-firewalls.md
@@ -5,16 +5,16 @@
 
 - 액세스 토큰을 사용하여 `doctl databases firewalls` 명령을 실행:
 
-`doctl databases firewalls {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[fw|firewalls]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 특정 데이터베이스에 대한 방화벽 규칙 목록을 검색:
 
-`doctl databases firewalls list`
+`doctl {{[d|databases]}} {{[fw|firewalls]}} {{[ls|list]}}`
 
 - 특정 데이터베이스에 데이터베이스 방화벽 규칙을 추가:
 
-`doctl databases firewalls append {{데이터베이스_아이디}} --rule {{droplet|k8s|ip_addr|tag|app}}:{{value}}`
+`doctl {{[d|databases]}} {{[fw|firewalls]}} {{[a|append]}} {{데이터베이스_아이디}} --rule {{droplet|k8s|ip_addr|tag|app}}:{{value}}`
 
 - 특정 데이터베이스에 대한 방화벽 규칙을 추가:
 
-`doctl databases firewalls remove {{데이터베이스_아이디}} {{룰_uuid}}`
+`doctl {{[d|databases]}} {{[fw|firewalls]}} {{[rm|remove]}} {{데이터베이스_아이디}} {{룰_uuid}}`

--- a/pages.ko/common/doctl-databases-maintenance-window.md
+++ b/pages.ko/common/doctl-databases-maintenance-window.md
@@ -5,12 +5,12 @@
 
 - 액세스 토큰을 사용하여 `doctl databases maintenance-window` 명령을 실행:
 
-`doctl databases maintenance-window {{command}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[mw|maintenance-window]}} {{command}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 데이터베이스 클러스터의 유지 관리 기간에 대한 세부 정보를 검색:
 
-`doctl databases maintenance-window get {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[mw|maintenance-window]}} {{[g|get]}} {{데이터베이스_아이디}}`
 
 - 데이터베이스 클러스터의 유지 관리 기간을 업데이트:
 
-`doctl databases maintenance-window update {{데이터베이스_아이디}} --day {{요일}} --hour {{24시간_형식의_시간}}`
+`doctl {{[d|databases]}} {{[mw|maintenance-window]}} {{[u|update]}} {{데이터베이스_아이디}} --day {{요일}} --hour {{24시간_형식의_시간}}`

--- a/pages.ko/common/doctl-databases-options.md
+++ b/pages.ko/common/doctl-databases-options.md
@@ -5,20 +5,20 @@
 
 - 액세스 토큰을 사용하여 `doctl databases options` 명령을 실행:
 
-`doctl databases options {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[o|options]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 사용 가능한 데이터베이스 엔진 목록을 검색:
 
-`doctl databases options engines`
+`doctl {{[d|databases]}} {{[o|options]}} {{[eng|engines]}}`
 
 - 특정 데이터베이스 엔진에 사용 가능한 지역 목록을 검색:
 
-`doctl databases options regions --engine {{pg|mysql|redis|mongodb}}`
+`doctl {{[d|databases]}} {{[o|options]}} {{[r|regions]}} --engine {{pg|mysql|redis|mongodb}}`
 
 - 특정 데이터베이스 엔진에 사용 가능한 슬러그 목록을 검색:
 
-`doctl databases options slugs --engine {{pg|mysql|redis|mongodb}}`
+`doctl {{[d|databases]}} {{[o|options]}} {{[s|slugs]}} --engine {{pg|mysql|redis|mongodb}}`
 
 - 특정 데이터베이스 엔진에 사용 가능한 버전 목록을 검색:
 
-`doctl databases options versions --engine {{pg|mysql|redis|mongodb}}`
+`doctl {{[d|databases]}} {{[o|options]}} {{[v|versions]}} --engine {{pg|mysql|redis|mongodb}}`

--- a/pages.ko/common/doctl-databases-sql-mode.md
+++ b/pages.ko/common/doctl-databases-sql-mode.md
@@ -5,12 +5,12 @@
 
 - 액세스 토큰을 사용하여 `doctl databases sql-mode` 명령을 실행:
 
-`doctl databases sql-mode {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{[sm|sql-mode]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - MySQL 데이터베이스 클러스터의 SQL 모드를 가져옴:
 
-`doctl databases sql-mode get {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[sm|sql-mode]}} {{[g|get]}} {{데이터베이스_아이디}}`
 
 - MySQL 데이터베이스 클러스터의 SQL 모드를 지정된 모드로 덮어씀:
 
-`doctl databases sql-mode set {{데이터베이스_아이디}} {{sql_모드_1 sql_모드_2 ...}}`
+`doctl {{[d|databases]}} {{[sm|sql-mode]}} {{[s|set]}} {{데이터베이스_아이디}} {{sql_모드_1 sql_모드_2 ...}}`

--- a/pages.ko/common/doctl-databases-user.md
+++ b/pages.ko/common/doctl-databases-user.md
@@ -5,28 +5,28 @@
 
 - 액세스 토큰을 사용하여 `doctl databases user` 명령을 실행:
 
-`doctl databases user {{명령어}} --access-token {{access_token}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{명령어}} {{[-t|--access-token]}} {{access_token}}`
 
 - 데이터베이스 사용자에 대한 세부 정보를 검색:
 
-`doctl databases user get {{데이터베이스_아이디}} {{사용자_이름}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[g|get]}} {{데이터베이스_아이디}} {{사용자_이름}}`
 
 - 특정 데이터베이스에 대한 데이터베이스 사용자 목록을 검색:
 
-`doctl databases user list {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[ls|list]}} {{데이터베이스_아이디}}`
 
 - 특정 사용자의 인증 비밀번호를 재설정:
 
-`doctl databases user reset {{데이터베이스_아이디}} {{사용자_이름}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[rs|reset]}} {{데이터베이스_아이디}} {{사용자_이름}}`
 
 - 특정 사용자에 대한 MySQL 인증 플러그인 재설정:
 
-`doctl databases user reset {{데이터베이스_아이디}} {{사용자_이름}} {{caching_sha2_password|mysql_native_password}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[rs|reset]}} {{데이터베이스_아이디}} {{사용자_이름}} {{caching_sha2_password|mysql_native_password}}`
 
 - 주어진 사용자 이름으로 주어진 데이터베이스에 사용자를 생성:
 
-`doctl databases user create {{데이터베이스_아이디}} {{사용자_이름}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[c|create]}} {{데이터베이스_아이디}} {{사용자_이름}}`
 
 - 주어진 사용자 이름을 가진 주어진 데이터베이스에서 사용자를 삭제:
 
-`doctl databases user delete {{데이터베이스_아이디}} {{사용자_이름}}`
+`doctl {{[d|databases]}} {{[u|user]}} {{[rm|delete]}} {{데이터베이스_아이디}} {{사용자_이름}}`

--- a/pages.ko/common/doctl-databases.md
+++ b/pages.ko/common/doctl-databases.md
@@ -5,20 +5,20 @@
 
 - 액세스 토큰을 사용하여 `doctl databases` 명령을 실행:
 
-`doctl databases {{명령어}} --access-token {{액세스_토큰}}`
+`doctl {{[d|databases]}} {{명령어}} {{[-t|--access-token]}} {{액세스_토큰}}`
 
 - 데이터베이스 클러스터에 대한 세부 정보를 가져옴:
 
-`doctl databases get`
+`doctl {{[d|databases]}} {{[g|get]}}`
 
 - 데이터베이스 클러스터를 나열:
 
-`doctl databases list`
+`doctl {{[d|databases]}} {{[ls|list]}}`
 
 - 데이터베이스 클러스터 생성:
 
-`doctl databases create {{데이터베이스_이름}}`
+`doctl {{[d|databases]}} {{[c|create]}} {{데이터베이스_이름}}`
 
 - 클러스터 삭제:
 
-`doctl databases delete {{데이터베이스_아이디}}`
+`doctl {{[d|databases]}} {{[rm|delete]}} {{데이터베이스_아이디}}`

--- a/pages.ko/common/doctl-kubernetes-cluster.md
+++ b/pages.ko/common/doctl-kubernetes-cluster.md
@@ -5,24 +5,24 @@
 
 - Kubernetes 클러스터 생성:
 
-`doctl kubernetes cluster create --count {{3}} --region {{nyc1}} --size {{s-1vcpu-2gb}} --version {{latest}} {{클러스터_이름}}`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} {{[c|create]}} --count {{3}} --region {{nyc1}} --size {{s-1vcpu-2gb}} --version {{latest}} {{클러스터_이름}}`
 
 - 모든 Kubernetes 클러스터 나열:
 
-`doctl kubernetes cluster list`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} {{[ls|list]}}`
 
 - kubeconfig를 가져와 저장:
 
-`doctl kubernetes cluster kubeconfig save {{클러스터_이름}}`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} {{[cfg|kubeconfig]}} {{[s|save]}} {{클러스터_이름}}`
 
 - 사용 가능한 업그레이드 확인:
 
-`doctl kubernetes cluster get-upgrades {{클러스터_이름}}`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} {{[gu|get-upgrades]}} {{클러스터_이름}}`
 
 - 클러스터를 새로운 Kubernetes 버전으로 업그레이드:
 
-`doctl kubernetes cluster upgrade {{클러스터_이름}}`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} upgrade {{클러스터_이름}}`
 
 - 클러스터 삭제:
 
-`doctl kubernetes cluster delete {{클러스터_이름}}`
+`doctl {{[k|kubernetes]}} {{[c|cluster]}} {{[d|delete]}} {{클러스터_이름}}`

--- a/pages.ko/common/doctl-kubernetes-options.md
+++ b/pages.ko/common/doctl-kubernetes-options.md
@@ -5,12 +5,12 @@
 
 - Kubernetes 클러스터를 지원하는 지역 목록 나열:
 
-`doctl kubernetes options regions`
+`doctl {{[k|kubernetes]}} {{[o|options]}} {{[r|regions]}}`
 
 - Kubernetes 클러스터에서 사용할 수 있는 머신 크기를 나열:
 
-`doctl kubernetes options sizes`
+`doctl {{[k|kubernetes]}} {{[o|options]}} {{[s|sizes]}}`
 
 - DigitalOcean 클러스터와 함께 사용할 수 있는 Kubernetes 버전을 나열:
 
-`doctl kubernetes options versions`
+`doctl {{[k|kubernetes]}} {{[o|options]}} {{[v|versions]}}`

--- a/pages.ko/common/doctl-serverless.md
+++ b/pages.ko/common/doctl-serverless.md
@@ -5,16 +5,16 @@
 
 - 로컬 서버리스 지원을 함수 네임스페이스에 연결:
 
-`doctl serverless connect`
+`doctl {{[sls|serverless]}} connect`
 
 - 함수 네임스페이스에 함수 프로젝트를 배포:
 
-`doctl serverless deploy`
+`doctl {{[sls|serverless]}} deploy`
 
 - 함수 프로젝트의 메타데이터 얻기:
 
-`doctl serverless get-metadata`
+`doctl {{[sls|serverless]}} get-metadata`
 
 - 서버리스 지원에 대한 정보를 제공:
 
-`doctl serverless status`
+`doctl {{[sls|serverless]}} status`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
