### PR TITLE
cargo-*: add short/long options to Korean pages

### DIFF
--- a/pages.ko/common/cargo-clean.md
+++ b/pages.ko/common/cargo-clean.md
@@ -13,7 +13,7 @@
 
 - 릴리스 아티팩트 제거 (`target/release` 디렉터리):
 
-`cargo clean --release`
+`cargo clean {{[-r|--release]}}`
 
 - 지정된 프로필의 디렉터리에서 아티팩트를 제거 (이 경우, `target/debug`):
 

--- a/pages.ko/common/cargo-clippy.md
+++ b/pages.ko/common/cargo-clippy.md
@@ -21,15 +21,15 @@
 
 - 린트 그룹에 대한 검사 실행 (<https://rust-lang.github.io/rust-clippy/stable/index.html#?groups=cargo,complexity,correctness,deprecated,nursery,pedantic,perf,restriction,style,suspicious> 참조):
 
-`cargo clippy -- --warn clippy::{{린트_그룹}}`
+`cargo clippy -- {{[-W|--warn]}} clippy::{{린트_그룹}}`
 
 - 경고를 오류로 처리:
 
-`cargo clippy -- --deny warnings`
+`cargo clippy -- {{[-D|--deny]}} warnings`
 
 - 검사를 실행하고 경고를 무시:
 
-`cargo clippy -- --allow warnings`
+`cargo clippy -- {{[-A|--allow]}} warnings`
 
 - Clippy 제안을 자동으로 적용:
 

--- a/pages.ko/common/cargo-owner.md
+++ b/pages.ko/common/cargo-owner.md
@@ -5,15 +5,15 @@
 
 - 특정 사용자나 팀을 소유자로 초대:
 
-`cargo owner --add {{사용자명|github:조직_이름:팀_이름}} {{크레이트}}`
+`cargo owner {{[-a|--add]}} {{사용자명|github:조직_이름:팀_이름}} {{크레이트}}`
 
 - 지정된 사용자 또는 팀을 소유자로 제거:
 
-`cargo owner --remove {{사용자명|github:조직_이름:팀_이름}} {{크레이트}}`
+`cargo owner {{[-r|--remove]}} {{사용자명|github:조직_이름:팀_이름}} {{크레이트}}`
 
 - 크레이트 소유자 목록:
 
-`cargo owner --list {{크레이트}}`
+`cargo owner {{[-l|--list]}} {{크레이트}}`
 
 - 지정된 레지스트리를 사용 (레지스트리 이름은 구성에서 정의할 수 있음 - 기본값은 <https://crates.io>):
 

--- a/pages.ko/common/cargo-package.md
+++ b/pages.ko/common/cargo-package.md
@@ -10,4 +10,4 @@
 
 - 실제로 tarball을 생성하지 않고 tarball에 포함될 파일을 표시:
 
-`cargo package --list`
+`cargo package {{[-l|--list]}}`

--- a/pages.ko/common/cargo-publish.md
+++ b/pages.ko/common/cargo-publish.md
@@ -10,7 +10,7 @@
 
 - 검사를 수행하고, `.crate` 파일을 생성하여 레지스트리에 업로드하지 않음 (`cargo package`와 동일):
 
-`cargo publish --dry-run`
+`cargo publish {{[-n|--dry-run]}}`
 
 - 지정된 레지스트리를 사용함 (레지스트리 이름은 구성에서 정의할 수 있음 - 기본값은 <https://crates.io>):
 

--- a/pages.ko/common/cargo-tree.md
+++ b/pages.ko/common/cargo-tree.md
@@ -22,4 +22,4 @@
 
 - 일반/빌드/개발 종속성만 표시:
 
-`cargo tree --edges {{normal|build|dev}}`
+`cargo tree {{[-e|--edges]}} {{normal|build|dev}}`

--- a/pages.ko/common/cargo-update.md
+++ b/pages.ko/common/cargo-update.md
@@ -9,7 +9,7 @@
 
 - 업데이트될 내용을 표시하지만, 실제로 잠금 파일을 작성하지는 않음:
 
-`cargo update --dry-run`
+`cargo update {{[-n|--dry-run]}}`
 
 - 지정된 종속성만 업데이트함:
 

--- a/pages.ko/common/cargo-version.md
+++ b/pages.ko/common/cargo-version.md
@@ -9,4 +9,4 @@
 
 - 추가 빌드 정보 표시:
 
-`cargo version --verbose`
+`cargo version {{[-v|--verbose]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

