### PR TITLE
invoke-webrequest: Add `-UseBasicParsing` parameter

### DIFF
--- a/pages/windows/invoke-webrequest.md
+++ b/pages/windows/invoke-webrequest.md
@@ -8,6 +8,10 @@
 
 `Invoke-WebRequest {{http://example.com}} -OutFile {{path\to\file}}`
 
+- Only return raw HTML data instead of parsing it under Internet Explorer (PowerShell 3.0-5.1 only):
+
+`Invoke-WebRequest {{http://example.com}} -UseBasicParsing`
+
 - Send form-encoded data (POST request of type `application/x-www-form-urlencoded`):
 
 `Invoke-WebRequest -Method Post -Body @{ name='bob' } {{http://example.com/form}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: 

`-UseBasicParsing` is necessary to avoid PowerShell to parse untrusted HTML output from `Invoke-WebRequest` in Windows PowerShell versions 3.0-5.1.

`-UseBasicParsing` is already the default behavior in PowerShell 6.0 and above, so the flag does essentially nothing.