### PR TITLE
argospm, argos-translate: setup alias and add Indonesian translation

### DIFF
--- a/pages.es/common/argospm.md
+++ b/pages.es/common/argospm.md
@@ -1,0 +1,7 @@
+# argospm
+
+> Este comando es un alias de `argos-translate`.
+
+- Vea la documentación del comando original:
+
+`tldr argos-translate`

--- a/pages.id/common/argos-translate.md
+++ b/pages.id/common/argos-translate.md
@@ -1,0 +1,32 @@
+# argos-translate
+
+> Sebuah pustaka Python bersumber terbuka dengan alat baris perintah untuk melakukan alih bahasa secara luring.
+> Informasi lebih lanjut: <https://argos-translate.readthedocs.io/en/latest/source/cli.html>.
+
+- Pasang berkas penerjemah untuk alih bahasa dari bahasa Spanyol menuju Inggris:
+
+`argospm install translate-es_en`
+
+- Terjemahkan sebagian teks dari bahasa Spanyol (`es`) menuju Inggris (`en`) (Catatan: Program ini hanya mendukung kode bahasa dengan dua huruf):
+
+`argos-translate --from-lang es --to-lang en {{un texto corto}}`
+
+- Terjemahkan suatu berkas teks dari bahasa Inggris menuju Hindi:
+
+`cat {{jalan/menuju/berkas.txt}} | argos-translate --from-lang en --to-lang hi`
+
+- Tampilkan daftar seluruh pasangan penerjemah bahasa yang tersedia:
+
+`argospm list`
+
+- Tampilkan pasangan penerjemah yang tersedia untuk menerjemahkan teks bahasa Inggris menuju bahasa lain:
+
+`argospm search --from-lang en`
+
+- Perbarui berkas penerjemah bahasa yang terpasang:
+
+`argospm update`
+
+- Terjemahkan teks dari `ar` menuju `ru` (Catatan: Proses ini membutuhkan berkas penerjemah `translate-ar_en` dan `translate-en_ru` untuk terpasang terlebih dahulu):
+
+`argos-translate --from-lang ar --to-lang ru {{صورة تساوي أكثر من ألف كلمة}}`

--- a/pages.id/common/argospm.md
+++ b/pages.id/common/argospm.md
@@ -1,0 +1,7 @@
+# argospm
+
+> Perintah ini merupakan alias dari `argos-translate`.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr argos-translate`

--- a/pages.ko/common/argospm.md
+++ b/pages.ko/common/argospm.md
@@ -1,0 +1,7 @@
+# argospm
+
+> 이 명령은 `argos-translate`의 별칭입니다.
+
+- 자세한 내용은 원본 명령을 참고하세요:
+
+`tldr argos-translate`

--- a/pages/common/argospm.md
+++ b/pages/common/argospm.md
@@ -1,0 +1,7 @@
+# argospm
+
+> This command is an alias of `argos-translate`.
+
+- View documentation for the original command:
+
+`tldr argos-translate`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

The `argos-translate` page contains examples that use `argospm` command, so I added `argospm` as an alias.