### PR TITLE
cwebp: add lossless compression example

### DIFF
--- a/pages/common/cwebp.md
+++ b/pages/common/cwebp.md
@@ -3,19 +3,23 @@
 > Compress an image file to a WebP file.
 > More information: <https://developers.google.com/speed/webp/docs/cwebp>.
 
-- Compress a WebP file with default settings (q = 75) to the [o]utput file:
+- Compress a WebP file with default settings (lossy compression, q = 75) to the [o]utput file:
 
 `cwebp {{path/to/image_file}} -o {{path/to/output.webp}}`
 
-- Compress a WebP file with the best [q]uality and largest file size:
+- Compress a WebP file with the best lossy compression [q]uality and largest file size:
 
 `cwebp {{path/to/image_file}} -o {{path/to/output.webp}} -q {{100}}`
 
-- Compress a WebP file with the worst [q]uality and smallest file size:
+- Compress a WebP file with the worst lossy compression [q]uality and smallest file size:
 
 `cwebp {{path/to/image_file}} -o {{path/to/output.webp}} -q {{0}}`
 
-- Compress a WebP file and apply resize to image:
+- Compress a WebP file with lossless compression and smallest possible file size:
+
+`cwebp {{path/to/image_file}} -o {{path/to/output.webp}} -z 9`
+
+- Compress a WebP file and apply resize to image (if width or height are 0, scaling preserves aspect ratio):
 
 `cwebp {{path/to/image_file}} -o {{path/to/output.webp}} -resize {{width}} {{height}}`
 


### PR DESCRIPTION
- Mention aspect ratio being preserved with `-resize` if width or height is 0.

By the way, we could replace one of the quality examples with a cropping example instead. Having two examples that are very close to each other feels like they're almost duplicates of each other.
