### PR TITLE
ping: add page

### DIFF
--- a/pages/windows/ping.md
+++ b/pages/windows/ping.md
@@ -4,7 +4,7 @@
 > Unlike Unix-like systems, Windows `ping` sends only 4 packets by default.
 > More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/ping>.
 
-- Ping a host:
+- Ping a host 4 times:
 
 `ping {{host}}`
 


### PR DESCRIPTION
Add a Windows-specific page for the ping command.

Windows ping behaves differently from the Unix version, for example it sends only 4 packets by default and uses different flags (-n instead of -c, -t for continuous, etc.).

7 examples covering the most common use cases.

Closes #21363