### PR TITLE
llm-{aliases, chat, keys, logs, models, plugins, templates}: add page

### DIFF
--- a/pages/common/llm-aliases.md
+++ b/pages/common/llm-aliases.md
@@ -1,0 +1,25 @@
+# llm aliases
+
+> Create and manage shortcut names for Large Language Models.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- List all defined aliases:
+
+`llm aliases list`
+
+- Create an alias for a model:
+
+`llm aliases set {{alias_name}} {{model_id}}`
+
+- Remove an alias:
+
+`llm aliases remove {{alias_name}}`
+
+- Display the path to the `aliases.json` file:
+
+`llm aliases path`
+
+- Display help:
+
+`llm aliases --help`

--- a/pages/common/llm-chat.md
+++ b/pages/common/llm-chat.md
@@ -1,0 +1,33 @@
+# llm chat
+
+> Hold an interactive chat conversation with a Large Language Model.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- Start an interactive chat session with the default model:
+
+`llm chat`
+
+- Start a chat session with a specific model:
+
+`llm chat {{[-m|--model]}} {{gpt-4o}}`
+
+- Start a chat session with a system prompt:
+
+`llm chat {{[-s|--system]}} "{{You are a helpful coding assistant}}"`
+
+- Continue the most recent chat session:
+
+`llm chat {{[-c|--continue]}}`
+
+- Start a chat session using a saved template:
+
+`llm chat {{[-t|--template]}} {{template_name}}`
+
+- Start a chat session with a tool available to the model:
+
+`llm chat {{[-T|--tool]}} {{tool_name}}`
+
+- Display help:
+
+`llm chat --help`

--- a/pages/common/llm-keys.md
+++ b/pages/common/llm-keys.md
@@ -1,0 +1,25 @@
+# llm keys
+
+> Manage API keys for Large Language Model providers.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- Set an API key for a provider (prompts for key input):
+
+`llm keys set {{provider_name}}`
+
+- List all stored API key names:
+
+`llm keys list`
+
+- Retrieve the value of a specific key:
+
+`llm keys get {{provider_name}}`
+
+- Display the path to the `keys.json` file:
+
+`llm keys path`
+
+- Display help:
+
+`llm keys --help`

--- a/pages/common/llm-logs.md
+++ b/pages/common/llm-logs.md
@@ -1,0 +1,37 @@
+# llm logs
+
+> View and manage logged prompt/response history.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- Display the 3 most recent logged conversations:
+
+`llm logs list`
+
+- Display a specific number of recent logged conversations:
+
+`llm logs list {{[-n|--count]}} {{10}}`
+
+- Search logs for a specific term:
+
+`llm logs list {{[-q|--query]}} "{{search_term}}"`
+
+- Filter logs by a specific model:
+
+`llm logs list {{[-m|--model]}} {{gpt-4o}}`
+
+- Output logs in JSON format:
+
+`llm logs list --json`
+
+- Display the path to the logs database:
+
+`llm logs path`
+
+- Turn logging on or off globally:
+
+`llm logs {{on|off}}`
+
+- Display help:
+
+`llm logs --help`

--- a/pages/common/llm-models.md
+++ b/pages/common/llm-models.md
@@ -1,0 +1,33 @@
+# llm models
+
+> Manage and list available Large Language Models.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- List all available models:
+
+`llm models list`
+
+- Search for models matching a keyword:
+
+`llm models list {{[-q|--query]}} "{{search_term}}"`
+
+- List models that support tool use:
+
+`llm models list --tools`
+
+- List models and show their available options:
+
+`llm models list --options`
+
+- Display the current default model:
+
+`llm models default`
+
+- Set a default model:
+
+`llm models default {{gpt-4o}}`
+
+- Display help:
+
+`llm models --help`

--- a/pages/common/llm-plugins.md
+++ b/pages/common/llm-plugins.md
@@ -1,0 +1,21 @@
+# llm plugins
+
+> List installed plugins that extend LLM functionality.
+> See also: `llm`, `llm install`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- List all installed plugins:
+
+`llm plugins`
+
+- List all plugins including built-in default plugins:
+
+`llm plugins --all`
+
+- List plugins that implement a specific hook:
+
+`llm plugins --hook {{hook_name}}`
+
+- Display help:
+
+`llm plugins --help`

--- a/pages/common/llm-templates.md
+++ b/pages/common/llm-templates.md
@@ -1,0 +1,25 @@
+# llm templates
+
+> Manage stored prompt templates for reuse with the LLM tool.
+> See also: `llm`.
+> More information: <https://llm.datasette.io/en/stable/help.html>.
+
+- List all available prompt templates:
+
+`llm templates list`
+
+- Display the contents of a specific template:
+
+`llm templates show {{template_name}}`
+
+- Edit a template using the default editor:
+
+`llm templates edit {{template_name}}`
+
+- Display the path to the templates directory:
+
+`llm templates path`
+
+- Display help:
+
+`llm templates --help`

--- a/pages/common/llm.md
+++ b/pages/common/llm.md
@@ -1,6 +1,7 @@
 # llm
 
 > Interact with Large Language Models (LLMs) via remote APIs and models that can be installed and run on your machine.
+> Some subcommands such as `chat`, `models`, `keys`, `logs`, etc. have their own usage documentation.
 > More information: <https://llm.datasette.io/en/stable/help.html>.
 
 - Set up an OpenAI API Key:


### PR DESCRIPTION
## Summary

- Add tldr pages for seven `llm` subcommands: `aliases`, `chat`, `keys`, `logs`, `models`, `plugins`, and `templates`
- Update the base `llm` page to reference these subcommands with the standard subcommand mention line

Partial fix for #11448 — this covers 7 of the unchecked subcommands listed in the "Let's document: llm" tracking issue.

## Details

Each page follows the standard tldr format with practical examples:

| Page | Examples |
|------|----------|
| `llm-models` | list, search, tool-capable models, default model |
| `llm-chat` | start session, specific model, system prompt, continue, templates, tools |
| `llm-keys` | set, list, get, path |
| `llm-logs` | list, count, search, filter by model, JSON output, on/off |
| `llm-aliases` | list, set, remove, path |
| `llm-plugins` | list, list all, filter by hook |
| `llm-templates` | list, show, edit, path |

All pages pass `tldr-lint` locally.

## Checklist

- [x] Pages follow the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] Pages pass `tldr-lint`
- [x] Pre-commit hooks pass
- [x] Based on `main` branch