### PR TITLE
pages*: add 37 translations (mostly id and a few zh)

### DIFF
--- a/pages.id/common/flask-unsign.md
+++ b/pages.id/common/flask-unsign.md
@@ -1,0 +1,32 @@
+# flask-unsign
+
+> Alat untuk melakukan brute-force, mendeskripsi (decode), dan membuat cookie sesi Flask.
+> Informasi lebih lanjut: <https://github.com/Paradoxis/Flask-Unsign>.
+
+- Mendekode cookie sesi Flask:
+
+`flask-unsign {{[-d|--decode]}} {{[-c|--cookie]}} {{cookie}}`
+
+- Mendekode cookie sesi yang diambil dari URL yang mengembalikan header `Set-Cookie`:
+
+`flask-unsign {{[-d|--decode]}} --server {{URL}}`
+
+- Melakukan brute-force kunci rahasia (secret key) menggunakan wordlist bawaan flask-unsign (membutuhkan `flask-unsign-wordlist`):
+
+`flask-unsign {{[-u|--unsign]}} {{[-c|--cookie]}} {{cookie}}`
+
+- Melakukan brute-force kunci rahasia dengan wordlist kustom (gunakan `--no-literal-eval` untuk entri tanpa tanda kutip):
+
+`flask-unsign {{[-u|--unsign]}} {{[-c|--cookie]}} {{cookie}} {{[-w|--wordlist]}} {{jalan/ke/wordlist.txt}}`
+
+- Menandatangani (sign) cookie sesi baru dengan kunci rahasia:
+
+`flask-unsign {{[-s|--sign]}} {{[-c|--cookie]}} "{{{'logged_in': False}}}" {{[-S|--secret]}} {{rahasia}}`
+
+- Menandatangani cookie sesi menggunakan timestamp lama/legacy (berguna untuk versi lama):
+
+`flask-unsign {{[-s|--sign]}} {{[-c|--cookie]}} "{{{'logged_in': False}}}" {{[-S|--secret]}} {{rahasia}} {{[-l|--legacy]}}`
+
+- Melakukan brute-force cookie sesi dengan thread kustom dan tanpa evaluasi literal:
+
+`flask-unsign {{[-u|--unsign]}} {{[-c|--cookie]}} {{cookie}} {{[-w|--wordlist]}} {{jalan/ke/wordlist.txt}} {{[-t|--threads]}} {{jumlah_thread}} {{[-nE|--no-literal-eval]}}`

--- a/pages.id/common/flask.md
+++ b/pages.id/common/flask.md
@@ -1,0 +1,16 @@
+# flask
+
+> Skrip utilitas umum untuk aplikasi Flask. Memuat aplikasi yang ditentukan dalam variabel lingkungan $FLASK_APP.
+> Informasi lebih lanjut: <https://flask.palletsprojects.com/en/stable/cli/>.
+
+- Jalankan server pengembangan:
+
+`flask run`
+
+- Tampilkan rute (routes) untuk aplikasi tersebut:
+
+`flask routes`
+
+- Jalankan shell interaktif Python dalam konteks aplikasi:
+
+`flask shell`

--- a/pages.id/common/kaggle-competitions.md
+++ b/pages.id/common/kaggle-competitions.md
@@ -1,0 +1,28 @@
+# kaggle competitions
+
+> Mengelola kompetisi Kaggle.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#competitions>.
+
+- Tampilkan daftar semua kompetisi:
+
+`kaggle {{[c|competitions]}} list`
+
+- Unduh data kompetisi:
+
+`kaggle {{[c|competitions]}} download {{nama_kompetisi}}`
+
+- Unduh berkas tertentu:
+
+`kaggle {{[c|competitions]}} download {{nama_kompetisi}} {{[-f|--file]}} {{berkas}}`
+
+- Kirim berkas ke sebuah kompetisi:
+
+`kaggle {{[c|competitions]}} submit {{nama_kompetisi}} {{[-f|--file]}} {{jalan/ke/berkas}} {{[-m|--message]}} "{{pesan}}"`
+
+- Tampilkan atau unduh papan peringkat (leaderboard):
+
+`kaggle {{[c|competitions]}} leaderboard {{nama_kompetisi}} {{--show|--download}}`
+
+- Lihat kiriman (submission):
+
+`kaggle {{[c|competitions]}} submissions {{nama_kompetisi}}`

--- a/pages.id/common/kaggle-config.md
+++ b/pages.id/common/kaggle-config.md
@@ -1,0 +1,16 @@
+# kaggle config
+
+> Mengelola konfigurasi Kaggle.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#config>.
+
+- Tampilkan nilai konfigurasi saat ini:
+
+`kaggle config view`
+
+- Atur sebuah nilai konfigurasi:
+
+`kaggle config set {{[-n|--name]}} {{parameter_konfigurasi}} {{[-v|--value]}} {{nilai_parameter}}`
+
+- Hapus sebuah nilai konfigurasi:
+
+`kaggle config unset {{[-n|--name]}} {{parameter_konfigurasi}}`

--- a/pages.id/common/kaggle-datasets.md
+++ b/pages.id/common/kaggle-datasets.md
@@ -1,0 +1,32 @@
+# kaggle datasets
+
+> Mengelola dataset Kaggle.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#datasets>.
+
+- Tampilkan semua dataset milik pengguna atau organisasi tertentu:
+
+`kaggle {{[d|datasets]}} list --user {{nama_pengguna}}`
+
+- Cari dataset berdasarkan nama:
+
+`kaggle {{[d|datasets]}} list {{[-s|--search]}} "{{nama_dataset}}"`
+
+- Unduh sebuah dataset:
+
+`kaggle {{[d|datasets]}} download "{{nama_dataset}}"`
+
+- Buat sebuah dataset publik:
+
+`kaggle {{[d|datasets]}} create {{[-p|--path]}} {{jalan/ke/dataset}} {{[-u|--public]}}`
+
+- Unduh metadata dari sebuah dataset:
+
+`kaggle {{[d|datasets]}} metadata {{nama_dataset}}`
+
+- Inisialisasi metadata untuk sebuah dataset:
+
+`kaggle {{[d|datasets]}} init {{[-p|--path]}} {{jalan/ke/dataset}}`
+
+- Hapus sebuah dataset:
+
+`kaggle {{[d|datasets]}} delete {{nama_dataset}}`

--- a/pages.id/common/kaggle-kernels.md
+++ b/pages.id/common/kaggle-kernels.md
@@ -1,0 +1,32 @@
+# kaggle kernels
+
+> Mengelola kernel Kaggle.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#kernels>.
+
+- Tampilkan daftar semua kernel:
+
+`kaggle {{[k|kernels]}} list`
+
+- Tampilkan daftar berkas keluaran (output) kernel:
+
+`kaggle {{[k|kernels]}} files {{nama_kernel}}`
+
+- Inisialisasi berkas metadata untuk sebuah kernel (secara baku ke direktori saat ini):
+
+`kaggle {{[k|kernels]}} init {{[-p|--path]}} {{jalan/ke/direktori}}`
+
+- Kirim (push) kode baru ke sebuah kernel dan jalankan kernel tersebut:
+
+`kaggle {{[k|kernels]}} push {{[-p|--path]}} {{jalan/ke/direktori}}`
+
+- Ambil (pull) sebuah kernel:
+
+`kaggle {{[k|kernels]}} pull {{nama_kernel}} {{[-p|--path]}} {{jalan/ke/direktori}}`
+
+- Dapatkan data keluaran dari eksekusi kernel terbaru:
+
+`kaggle {{[k|kernels]}} output {{nama_kernel}}`
+
+- Tampilkan status dari eksekusi kernel terbaru:
+
+`kaggle {{[k|kernels]}} status {{nama_kernel}}`

--- a/pages.id/common/kaggle-models.md
+++ b/pages.id/common/kaggle-models.md
@@ -1,0 +1,28 @@
+# kaggle models
+
+> Mengelola model Kaggle.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#models>.
+
+- Dapatkan sebuah model:
+
+`kaggle {{[m|models]}} get "{{nama_model}}"`
+
+- Tampilkan daftar semua model:
+
+`kaggle {{[m|models]}} list`
+
+- Inisialisasi berkas metadata untuk pembuatan model:
+
+`kaggle {{[m|models]}} init`
+
+- Buat sebuah model baru:
+
+`kaggle {{[m|models]}} create`
+
+- Hapus sebuah model:
+
+`kaggle {{[m|models]}} delete "{{nama_model}}"`
+
+- Perbarui sebuah model:
+
+`kaggle {{[m|models]}} update`

--- a/pages.id/common/kaggle.md
+++ b/pages.id/common/kaggle.md
@@ -1,0 +1,36 @@
+# kaggle
+
+> CLI resmi untuk Kaggle yang diimplementasikan dalam Python 3.
+> Informasi lebih lanjut: <https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md>.
+
+- Tampilkan nilai konfigurasi saat ini:
+
+`kaggle config view`
+
+- Unduh berkas tertentu dari dataset kompetisi:
+
+`kaggle {{[c|competitions]}} download {{nama_kompetisi}} {{[-f|--file]}} {{jalan/ke/berkas}}`
+
+- Tampilkan daftar kompetisi yang sesuai dengan kata kunci pencarian:
+
+`kaggle {{[c|competitions]}} list {{[-s|--search]}} {{kata_kunci_pencarian}}`
+
+- Tampilkan daftar berkas yang tersedia untuk kompetisi tertentu:
+
+`kaggle {{[c|competitions]}} files {{nama_kompetisi}}`
+
+- Kirim sebuah berkas ke kompetisi dengan sebuah pesan:
+
+`kaggle {{[c|competitions]}} submit {{nama_kompetisi}} {{[-f|--file]}} {{jalan/ke/berkas_kiriman.csv}} {{[-m|--message]}} "{{pesan}}"`
+
+- Tampilkan daftar dataset yang sesuai dengan kata kunci pencarian:
+
+`kaggle {{[d|datasets]}} list {{[-s|--search]}} {{kata_kunci_pencarian}}`
+
+- Unduh semua berkas dari sebuah dataset:
+
+`kaggle {{[d|datasets]}} download {{pemilik}}/{{nama_dataset}}`
+
+- Tampilkan daftar kernel (notebook) yang sesuai dengan kata kunci pencarian:
+
+`kaggle {{[k|kernels]}} list {{[-s|--search]}} {{kata_kunci_pencarian}}`

--- a/pages.id/common/mysql.md
+++ b/pages.id/common/mysql.md
@@ -1,0 +1,32 @@
+# mysql
+
+> Alat baris perintah MySQL.
+> Informasi lebih lanjut: <https://manned.org/mysql>.
+
+- Menghubungkan ke sebuah basis data:
+
+`mysql {{nama_basis_data}}`
+
+- Menghubungkan ke basis data; pengguna akan diminta memasukkan kata sandi:
+
+`mysql {{[-u|--user]}} {{nama_pengguna}} {{[-p|--password]}} {{nama_basis_data}}`
+
+- Menghubungkan ke basis data pada host lain:
+
+`mysql {{[-h|--host]}} {{host_basis_data}} {{nama_basis_data}}`
+
+- Menghubungkan ke basis data melalui soket Unix:
+
+`mysql {{[-S|--socket]}} {{jalan/ke/soket.sock}}`
+
+- Menjalankan pernyataan SQL dalam sebuah berkas skrip (batch):
+
+`mysql {{[-e|--execute]}} "source {{nama_berkas.sql}}" {{nama_basis_data}}`
+
+- Memulihkan (restore) basis data dari cadangan yang dibuat dengan mysqldump (pengguna akan diminta memasukkan kata sandi):
+
+`mysql < {{jalan/ke/cadangan.sql}} {{[-u|--user]}} {{nama_pengguna}} {{[-p|--password]}} {{nama_basis_data}}`
+
+- Memulihkan semua basis data dari berkas cadangan (pengguna akan diminta memasukkan kata sandi):
+
+`mysql < {{jalan/ke/cadangan.sql}} {{[-u|--user]}} {{nama_pengguna}} {{[-p|--password]}}`

--- a/pages.id/common/mysql_secure_installation.md
+++ b/pages.id/common/mysql_secure_installation.md
@@ -1,0 +1,16 @@
+# mysql_secure_installation
+
+> Mengonfigurasi MySQL untuk keamanan yang lebih baik.
+> Informasi lebih lanjut: <https://dev.mysql.com/doc/refman/en/mysql-secure-installation.html>.
+
+- Memulai konfigurasi interaktif:
+
+`mysql_secure_installation`
+
+- Menggunakan host dan port tertentu:
+
+`mysql_secure_installation --host {{host}} --port {{port}}`
+
+- Menampilkan bantuan:
+
+`mysql_secure_installation --help`

--- a/pages.id/common/mysqlbinlog.md
+++ b/pages.id/common/mysqlbinlog.md
@@ -1,0 +1,24 @@
+# mysqlbinlog
+
+> Utilitas untuk memproses berkas log biner (binary log) MySQL.
+> Informasi lebih lanjut: <https://dev.mysql.com/doc/refman/en/mysqlbinlog.html>.
+
+- Menampilkan peristiwa (event) dari berkas log biner tertentu:
+
+`mysqlbinlog {{jalan/ke/binlog}}`
+
+- Menampilkan entri dari log biner untuk basis data tertentu:
+
+`mysqlbinlog --database {{nama_basis_data}} {{jalan/ke/binlog}}`
+
+- Menampilkan peristiwa dari log biner di antara tanggal-tanggal tertentu:
+
+`mysqlbinlog --start-datetime='{{2022-01-01 01:00:00}}' --stop-datetime='{{2022-02-01 01:00:00}}' {{jalan/ke/binlog}}`
+
+- Menampilkan peristiwa dari log biner di antara posisi-posisi tertentu:
+
+`mysqlbinlog --start-position={{100}} --stop-position={{200}} {{jalan/ke/binlog}}`
+
+- Menampilkan log biner dari peladen (server) MySQL pada host yang diberikan:
+
+`mysqlbinlog --host={{nama_host}} {{jalan/ke/binlog}}`

--- a/pages.id/common/mysqlcheck.md
+++ b/pages.id/common/mysqlcheck.md
@@ -1,0 +1,20 @@
+# mysqlcheck
+
+> Periksa dan perbaiki tabel-tabel MySQL.
+> Informasi lebih lanjut: <https://dev.mysql.com/doc/refman/en/mysqlcheck.html>.
+
+- Periksa sebuah tabel:
+
+`mysqlcheck --check {{nama_tabel}}`
+
+- Periksa sebuah tabel dan berikan kredensial untuk mengaksesnya:
+
+`mysqlcheck --check {{nama_tabel}} --user {{nama_pengguna}} --password {{kata_sandi}}`
+
+- Perbaiki sebuah tabel:
+
+`mysqlcheck --repair {{nama_tabel}}`
+
+- Optimalkan sebuah tabel:
+
+`mysqlcheck --optimize {{nama_tabel}}`

--- a/pages.id/common/mysqld.md
+++ b/pages.id/common/mysqld.md
@@ -1,0 +1,32 @@
+# mysqld
+
+> Memulai peladen (server) basis data MySQL.
+> Informasi lebih lanjut: <https://dev.mysql.com/doc/refman/en/mysqld.html>.
+
+- Memulai peladen basis data MySQL:
+
+`mysqld`
+
+- Memulai peladen, dengan mencetak pesan kesalahan ke konsol:
+
+`mysqld --console`
+
+- Memulai peladen, dengan menyimpan keluaran log ke berkas log tertentu:
+
+`mysqld --log={{jalan/ke/berkas.log}}`
+
+- Tampilkan argumen baku (default) beserta nilainya lalu keluar:
+
+`mysqld --print-defaults`
+
+- Memulai peladen, dengan membaca argumen dan nilai dari sebuah berkas:
+
+`mysqld --defaults-file={{jalan/ke/berkas}}`
+
+- Memulai peladen dan mendengarkan pada port tertentu:
+
+`mysqld --port={{port}}`
+
+- Tampilkan bantuan:
+
+`mysqld --verbose --help`

--- a/pages.id/common/mysqldump.md
+++ b/pages.id/common/mysqldump.md
@@ -1,0 +1,21 @@
+# mysqldump
+
+> Mencadangkan (backup) basis data MySQL.
+> Lihat juga: `mysql`.
+> Informasi lebih lanjut: <https://dev.mysql.com/doc/refman/en/mysqldump.html>.
+
+- Membuat sebuah cadangan (backup); pengguna akan diminta memasukkan kata sandi:
+
+`mysqldump --user {{nama_pengguna}} --password {{nama_basis_data}} --result-file={{jalan/ke/berkas.sql}}`
+
+- Mencadangkan tabel tertentu dengan mengalihkan keluarannya ke sebuah berkas; pengguna akan diminta memasukkan kata sandi:
+
+`mysqldump --user {{nama_pengguna}} --password {{nama_basis_data}} {{nama_tabel}} > {{jalan/ke/berkas.sql}}`
+
+- Mencadangkan semua basis data dengan mengalihkan keluarannya ke sebuah berkas; pengguna akan diminta memasukkan kata sandi:
+
+`mysqldump --user {{nama_pengguna}} --password --all-databases > {{jalan/ke/berkas.sql}}`
+
+- Mencadangkan semua basis data dari host jarak jauh (remote) dengan mengalihkan keluarannya ke sebuah berkas; pengguna akan diminta memasukkan kata sandi:
+
+`mysqldump --host={{ip_atau_nama_host}} --user {{nama_pengguna}} --password --all-databases > {{jalan/ke/berkas.sql}}`

--- a/pages.id/common/mysqlsh.md
+++ b/pages.id/common/mysqlsh.md
@@ -1,0 +1,33 @@
+# mysqlsh
+
+> Klien MySQL tingkat lanjut (advanced) yang mendukung SQL, JavaScript, dan Python.
+> Alat ini menawarkan fitur untuk mengelola klaster InnoDB dan koleksi penyimpanan dokumen (document store).
+> Informasi lebih lanjut: <https://manned.org/mysqlsh>.
+
+- Mulai MySQL Shell dalam mode interaktif:
+
+`mysqlsh`
+
+- Hubungkan ke sebuah peladen (server) MySQL:
+
+`mysqlsh --user {{nama_pengguna}} --host {{nama_host}} --port {{port}}`
+
+- Jalankan sebuah pernyataan SQL pada peladen lalu keluar:
+
+`mysqlsh --user {{nama_pengguna}} --execute '{{pernyataan_sql}}'`
+
+- Mulai MySQL Shell dalam mode JavaScript:
+
+`mysqlsh --js`
+
+- Mulai MySQL Shell dalam mode Python:
+
+`mysqlsh --py`
+
+- Impor dokumen JSON ke dalam koleksi MySQL:
+
+`mysqlsh --import {{jalan/ke/berkas.json}} --schema {{nama_skema}} --collection {{nama_koleksi}}`
+
+- Aktifkan keluaran yang detail (verbose):
+
+`mysqlsh --verbose`

--- a/pages.id/common/pdf-parser.md
+++ b/pages.id/common/pdf-parser.md
@@ -1,0 +1,16 @@
+# pdf-parser
+
+> Mengidentifikasi elemen-elemen fundamental dari sebuah berkas PDF tanpa merendernya (rendering).
+> Informasi lebih lanjut: <https://blog.didierstevens.com/programs/pdf-tools/>.
+
+- Menampilkan statistik untuk sebuah berkas PDF:
+
+`pdf-parser {{[-a|--stats]}} {{jalan/ke/berkas.pdf}}`
+
+- Menampilkan objek dengan tipe tertentu (/Font, /URI, ...) dalam sebuah berkas PDF:
+
+`pdf-parser {{[-t|--type]}} {{/tipe_objek}} {{jalan/ke/berkas.pdf}}`
+
+- Mencari string (untaian teks) dalam objek-objek tidak langsung (indirect objects):
+
+`pdf-parser {{[-s|--search]}} {{string_pencarian}} {{jalan/ke/berkas.pdf}}`

--- a/pages.id/common/pdffonts.md
+++ b/pages.id/common/pdffonts.md
@@ -1,0 +1,24 @@
+# pdffonts
+
+> Penampil informasi fon (font) berkas Portable Document Format (PDF).
+> Informasi lebih lanjut: <https://www.xpdfreader.com/pdffonts-man.html>.
+
+- Cetak informasi fon berkas PDF:
+
+`pdffonts {{jalan/ke/berkas.pdf}}`
+
+- Tentukan kata sandi pengguna (user password) untuk berkas PDF guna melewati batasan keamanan:
+
+`pdffonts -upw {{kata_sandi}} {{jalan/ke/berkas.pdf}}`
+
+- Tentukan kata sandi pemilik (owner password) untuk berkas PDF guna melewati batasan keamanan:
+
+`pdffonts -opw {{kata_sandi}} {{jalan/ke/berkas.pdf}}`
+
+- Cetak informasi tambahan mengenai lokasi fon yang akan digunakan saat berkas PDF dirasterisasi (rasterized):
+
+`pdffonts -loc {{jalan/ke/berkas.pdf}}`
+
+- Cetak informasi tambahan mengenai lokasi fon yang akan digunakan saat berkas PDF dikonversi ke PostScript:
+
+`pdffonts -locPS {{jalan/ke/berkas.pdf}}`

--- a/pages.id/common/pdfgrep.md
+++ b/pages.id/common/pdfgrep.md
@@ -1,0 +1,24 @@
+# pdfgrep
+
+> Mencari teks di dalam berkas PDF.
+> Informasi lebih lanjut: <https://pdfgrep.org/doc.html>.
+
+- Temukan baris-baris yang cocok dengan pola tertentu dalam berkas PDF:
+
+`pdfgrep {{pola}} {{berkas.pdf}}`
+
+- Sertakan nama berkas dan nomor halaman untuk setiap baris yang cocok:
+
+`pdfgrep {{[-H|--with-filename]}} {{[-n|--page-number]}} {{pola}} {{berkas.pdf}}`
+
+- Lakukan pencarian yang tidak peka huruf besar-kecil (case-insensitive) untuk baris yang diawali dengan nama_berkas dan kembalikan 3 kecocokan pertama:
+
+`pdfgrep {{[-m|--max-count]}} {{3}} {{[-i|--ignore-case]}} '{{^nama_berkas}}' {{berkas.pdf}}`
+
+- Temukan pola dalam berkas-berkas dengan ekstensi .pdf di direktori saat ini secara rekursif:
+
+`pdfgrep {{[-r|--recursive]}} {{pola}}`
+
+- Temukan pola pada berkas yang cocok dengan pola glob tertentu di direktori saat ini secara rekursif:
+
+`pdfgrep {{[-r|--recursive]}} --include '{{*buku.pdf}}' {{pola}}`

--- a/pages.id/common/pdfimages.md
+++ b/pages.id/common/pdfimages.md
@@ -1,0 +1,20 @@
+# pdfimages
+
+> Utilitas untuk mengekstrak gambar dari berkas PDF.
+> Informasi lebih lanjut: <https://manned.org/pdfimages>.
+
+- Ekstrak semua gambar dari sebuah berkas PDF dan simpan sebagai berkas PNG:
+
+`pdfimages -png {{jalan/ke/berkas.pdf}} {{awalan_nama_berkas}}`
+
+- Ekstrak gambar dari halaman 3 sampai 5:
+
+`pdfimages -f {{3}} -l {{5}} {{jalan/ke/berkas.pdf}} {{awalan_nama_berkas}}`
+
+- Ekstrak gambar dari sebuah berkas PDF dan sertakan nomor halaman pada nama berkas keluaran:
+
+`pdfimages -p {{jalan/ke/berkas.pdf}} {{awalan_nama_berkas}}`
+
+- Tampilkan daftar informasi tentang semua gambar dalam sebuah berkas PDF:
+
+`pdfimages -list {{jalan/ke/berkas.pdf}}`

--- a/pages.id/common/pdfinfo.md
+++ b/pages.id/common/pdfinfo.md
@@ -1,0 +1,16 @@
+# pdfinfo
+
+> Penampil informasi berkas Portable Document Format (PDF).
+> Informasi lebih lanjut: <https://www.xpdfreader.com/pdfinfo-man.html>.
+
+- Cetak informasi berkas PDF:
+
+`pdfinfo {{jalan/ke/berkas.pdf}}`
+
+- Tentukan kata sandi pengguna (user password) untuk berkas PDF guna melewati batasan keamanan:
+
+`pdfinfo -upw {{kata_sandi}} {{jalan/ke/berkas.pdf}}`
+
+- Tentukan kata sandi pemilik (owner password) untuk berkas PDF guna melewati batasan keamanan:
+
+`pdfinfo -opw {{kata_sandi}} {{jalan/ke/berkas.pdf}}`

--- a/pages.id/common/pdfjam.md
+++ b/pages.id/common/pdfjam.md
@@ -1,0 +1,28 @@
+# pdfjam
+
+> Antarmuka baris perintah (shell frontend) untuk paket LaTeX pdfpages guna mengolah berkas-berkas PDF.
+> Informasi lebih lanjut: <https://github.com/pdfjam/pdfjam/blob/master/doc/pdfjam-help.txt>.
+
+- Gabungkan dua (atau lebih) berkas PDF:
+
+`pdfjam {{jalan/ke/berkas1.pdf jalan/ke/berkas2.pdf ...}} {{[-o|--outfile]}} {{jalan/ke/berkas_keluaran.pdf}}`
+
+- Gabungkan halaman pertama dari setiap berkas menjadi satu:
+
+`pdfjam {{jalan/ke/berkas1.pdf 1 jalan/ke/berkas2.pdf 1 ...}} {{[-o|--outfile]}} {{jalan/ke/berkas_keluaran.pdf}}`
+
+- Gabungkan sub-rentang (subrange) halaman dari dua berkas PDF:
+
+`pdfjam {{jalan/ke/berkas1.pdf 3-5,1}} {{jalan/ke/berkas2.pdf 4-6}} {{[-o|--outfile]}} {{jalan/ke/berkas_keluaran.pdf}}`
+
+- Tandatangani halaman A4 (sesuaikan nilai delta dengan tinggi untuk format lain) dengan tanda tangan pindaian (scan) dengan cara menumpuknya:
+
+`pdfjam {{jalan/ke/berkas.pdf}} {{jalan/ke/tanda_tangan}} --fitpaper true {{[-o|--outfile]}} {{jalan/ke/berkas_tertanda.pdf}} --nup "{{1x2}}" --delta "{{0 -842pt}}"`
+
+- Atur halaman-halaman dari berkas masukan ke dalam kisi (grid) 2x2:
+
+`pdfjam {{jalan/ke/berkas.pdf}} --nup {{2x2}} --suffix {{4up}} --preamble '{{\usepackage{fancyhdr} \pagestyle{fancy}}}'`
+
+- Balikkan urutan halaman di dalam setiap berkas yang diberikan dan gabungkan mereka:
+
+`pdfjam {{jalan/ke/berkas1.pdf last-1 jalan/ke/berkas2.pdf last-1 ...}} --suffix {{reversed}}`

--- a/pages.id/common/pdfjoin.md
+++ b/pages.id/common/pdfjoin.md
@@ -1,0 +1,20 @@
+# pdfjoin
+
+> Utilitas penggabungan PDF berbasis pdfjam.
+> Informasi lebih lanjut: <https://github.com/pdfjam/pdfjam-extras>.
+
+- Gabungkan dua berkas PDF menjadi satu dengan akhiran (suffix) bawaan "joined":
+
+`pdfjoin {{jalan/ke/berkas1.pdf}} {{jalan/ke/berkas2.pdf}}`
+
+- Gabungkan halaman pertama dari setiap berkas yang diberikan menjadi satu:
+
+`pdfjoin {{jalan/ke/berkas1.pdf jalan/ke/berkas2.pdf ...}} {{1}} --outfile {{berkas_keluaran}}`
+
+- Simpan halaman 3 sampai 5 diikuti dengan halaman 1 ke sebuah berkas PDF baru dengan akhiran kustom:
+
+`pdfjoin {{jalan/ke/berkas.pdf}} {{3-5,1}} --suffix {{diatur_ulang}}`
+
+- Gabungkan sub-rentang (subrange) halaman dari dua berkas PDF:
+
+`pdfjoin /{{jalan/ke/berkas1.pdf}} {{2-}} {{berkas2}} {{last-3}} --outfile {{berkas_keluaran}}`

--- a/pages.id/common/pdflatex.md
+++ b/pages.id/common/pdflatex.md
@@ -1,0 +1,16 @@
+# pdflatex
+
+> Mengompilasi dokumen PDF dari berkas sumber LaTeX.
+> Informasi lebih lanjut: <https://manned.org/pdflatex>.
+
+- Mengompilasi sebuah dokumen PDF:
+
+`pdflatex {{sumber.tex}}`
+
+- Mengompilasi dokumen PDF dengan menentukan direktori keluaran:
+
+`pdflatex -output-directory={{jalan/ke/direktori}} {{sumber.tex}}`
+
+- Mengompilasi dokumen PDF, dan segera berhenti jika terjadi kesalahan (error):
+
+`pdflatex -halt-on-error {{sumber.tex}}`

--- a/pages.id/common/pdfposter.md
+++ b/pages.id/common/pdfposter.md
@@ -1,0 +1,12 @@
+# pdfposter
+
+> Mengonversi berkas PDF berukuran besar menjadi beberapa halaman A4 untuk keperluan pencetakan.
+> Informasi lebih lanjut: <https://pdfposter.readthedocs.io/en/stable/Usage.html>.
+
+- Mengonversi poster A2 menjadi 4 halaman A4:
+
+`pdfposter {{[-p|--poster-size]}} a2 {{berkas_masukan.pdf}} {{berkas_keluaran.pdf}}`
+
+- Skalakan poster A4 ke A3 lalu hasilkan 2 halaman A4:
+
+`pdfposter {{[-s|--scale]}} 2 {{berkas_masukan.pdf}} {{berkas_keluaran.pdf}}`

--- a/pages.id/common/pdfseparate.md
+++ b/pages.id/common/pdfseparate.md
@@ -1,0 +1,16 @@
+# pdfseparate
+
+> Utilitas pengekstrak halaman berkas Portable Document Format (PDF).
+> Informasi lebih lanjut: <https://manned.org/pdfseparate>.
+
+- Ekstrak halaman-halaman dari berkas PDF dan buat berkas PDF terpisah untuk setiap halaman:
+
+`pdfseparate {{jalan/ke/berkas_sumber.pdf}} {{jalan/ke/berkas_tujuan-%d.pdf}}`
+
+- Tentukan halaman pertama/awal untuk ekstraksi:
+
+`pdfseparate -f {{3}} {{jalan/ke/berkas_sumber.pdf}} {{jalan/ke/berkas_tujuan-%d.pdf}}`
+
+- Tentukan halaman terakhir untuk ekstraksi:
+
+`pdfseparate -l {{10}} {{jalan/ke/berkas_sumber.pdf}} {{jalan/ke/berkas_tujuan-%d.pdf}}`

--- a/pages.id/common/pdftex.md
+++ b/pages.id/common/pdftex.md
@@ -1,0 +1,16 @@
+# pdftex
+
+> Mengompilasi dokumen PDF dari berkas sumber TeX.
+> Informasi lebih lanjut: <https://www.tug.org/applications/pdftex/>.
+
+- Mengompilasi sebuah dokumen PDF:
+
+`pdftex {{sumber.tex}}`
+
+- Mengompilasi dokumen PDF dengan menentukan direktori keluaran:
+
+`pdftex -output-directory={{jalan/ke/direktori}} {{sumber.tex}}`
+
+- Mengompilasi dokumen PDF, dan segera berhenti jika terjadi kesalahan (error):
+
+`pdftex -halt-on-error {{sumber.tex}}`

--- a/pages.id/common/pdftk.md
+++ b/pages.id/common/pdftk.md
@@ -1,0 +1,28 @@
+# pdftk
+
+> Perangkat perkakas (toolkit) PDF.
+> Informasi lebih lanjut: <https://www.pdflabs.com/docs/pdftk-man-page/>.
+
+- Ekstrak halaman 1-3, 5, dan 6-10 dari sebuah berkas PDF dan simpan sebagai berkas baru:
+
+`pdftk {{jalan/ke/berkas_masukan}}.pdf cat 1-3 5 6-10 output {{jalan/ke/berkas_keluaran}}.pdf`
+
+- Gabungkan (gabung berturutan) daftar berkas PDF dan simpan hasilnya sebagai berkas baru:
+
+`pdftk {{jalan/ke/berkas1}}.pdf {{jalan/ke/berkas2}}.pdf cat output {{jalan/ke/berkas_keluaran}}.pdf`
+
+- Pecah setiap halaman berkas PDF menjadi berkas-berkas terpisah, dengan pola nama berkas keluaran tertentu:
+
+`pdftk {{jalan/ke/berkas_masukan}}.pdf burst output {{jalan/ke/keluaran_%d}}.pdf`
+
+- Putar semua halaman sebesar 180 derajat searah jarum jam:
+
+`pdftk {{jalan/ke/berkas_masukan}}.pdf cat 1-endsouth output {{jalan/ke/berkas_keluaran}}.pdf`
+
+- Putar halaman ketiga sebesar 90 derajat searah jarum jam dan biarkan halaman lainnya tidak berubah:
+
+`pdftk {{jalan/ke/berkas_masukan}}.pdf cat 1-2 3east 4-end output {{jalan/ke/berkas_keluaran}}.pdf`
+
+- Selipkan (interleave) halaman-halaman dari dua PDF yang berisi hasil pemindaian satu sisi dari dokumen dua sisi, di mana bagian belakang dipindai dari belakang ke depan:
+
+`pdftk A={{jalan/ke/halaman_depan}}.pdf B={{jalan/ke/halaman_belakang}}.pdf shuffle A1-end Bend-1 output {{jalan/ke/berkas_keluaran}}.pdf`

--- a/pages.id/common/pdftocairo.md
+++ b/pages.id/common/pdftocairo.md
@@ -1,0 +1,28 @@
+# pdftocairo
+
+> Konversi berkas PDF ke PNG/JPEG/TIFF/PDF/PS/EPS/SVG menggunakan cairo.
+> Informasi lebih lanjut: <https://manned.org/pdftocairo>.
+
+- Konversi sebuah berkas PDF ke JPEG:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} -jpeg`
+
+- Konversi ke PDF dengan memperluas keluaran hingga memenuhi kertas:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} {{keluaran.pdf}} -pdf -expand`
+
+- Konversi ke SVG dengan menentukan halaman pertama/terakhir yang akan dikonversi:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} {{keluaran.svg}} -svg -f {{halaman_pertama}} -l {{halaman_terakhir}}`
+
+- Konversi ke PNG dengan resolusi 200ppi:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} {{keluaran.png}} -png -r 200`
+
+- Konversi ke TIFF skala abu-abu (grayscale) dengan mengatur ukuran kertas ke A3:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} -tiff -gray -paper A3`
+
+- Konversi ke PNG dengan memotong (crop) piksel x dan y dari pojok kiri atas:
+
+`pdftocairo {{jalan/ke/berkas.pdf}} -png -x {{piksel_x}} -y {{piksel_y}}`

--- a/pages.id/common/pdftotext.md
+++ b/pages.id/common/pdftotext.md
@@ -1,0 +1,24 @@
+# pdftotext
+
+> Konversi berkas PDF ke format teks murni (plain text).
+> Informasi lebih lanjut: <https://www.xpdfreader.com/pdftotext-man.html>.
+
+- Konversi `nama_berkas.pdf` ke teks murni dan cetak ke `stdout`:
+
+`pdftotext {{nama_berkas.pdf}} -`
+
+- Konversi `nama_berkas.pdf` ke teks murni dan simpan sebagai `nama_berkas.txt`:
+
+`pdftotext {{nama_berkas.pdf}}`
+
+- Konversi `nama_berkas.pdf` ke teks murni dengan tetap mempertahankan tata letak (layout):
+
+`pdftotext -layout {{nama_berkas.pdf}}`
+
+- Konversi `berkas_masukan.pdf` ke teks murni dan simpan sebagai `berkas_keluaran.txt`:
+
+`pdftotext {{berkas_masukan.pdf}} {{berkas_keluaran.txt}}`
+
+- Konversi halaman 2, 3, dan 4 dari `berkas_masukan.pdf` ke teks murni dan simpan sebagai `berkas_keluaran.txt`:
+
+`pdftotext -f {{2}} -l {{4}} {{berkas_masukan.pdf}} {{berkas_keluaran.txt}}`

--- a/pages.id/common/pdfunite.md
+++ b/pages.id/common/pdfunite.md
@@ -1,0 +1,12 @@
+# pdfunite
+
+> Utilitas penggabungan PDF.
+> Informasi lebih lanjut: <https://github.com/mtgrosser/pdfunite>.
+
+- Gabungkan 2 berkas PDF menjadi sebuah berkas PDF tunggal:
+
+`pdfunite {{jalan/ke/berkasA.pdf}} {{jalan/ke/berkasB.pdf}} {{jalan/ke/berkas_keluaran_gabungan.pdf}}`
+
+- Gabungkan seluruh berkas PDF dalam sebuah direktori menjadi sebuah berkas PDF tunggal:
+
+`pdfunite {{jalan/ke/direktori/*.pdf}} {{jalan/ke/berkas_keluaran_gabungan.pdf}}`

--- a/pages.id/common/streamlit.md
+++ b/pages.id/common/streamlit.md
@@ -1,0 +1,20 @@
+# streamlit
+
+> Kerangka kerja (framework) untuk membuat aplikasi web interaktif berbasis data dalam bahasa Python.
+> Informasi lebih lanjut: <https://docs.streamlit.io/develop/api-reference/cli>.
+
+- Periksa instalasi Streamlit:
+
+`streamlit hello`
+
+- Jalankan aplikasi Streamlit:
+
+`streamlit run {{nama_proyek}}`
+
+- Tampilkan bantuan:
+
+`streamlit --help`
+
+- Tampilkan versi:
+
+`streamlit --version`

--- a/pages.zh/common/kaggle-competitions.md
+++ b/pages.zh/common/kaggle-competitions.md
@@ -1,0 +1,28 @@
+# kaggle competitions
+
+> 管理 Kaggle 竞赛。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#competitions>。
+
+- 列出所有竞赛：
+
+`kaggle {{[c|competitions]}} list`
+
+- 下载竞赛相关的全部数据：
+
+`kaggle {{[c|competitions]}} download {{竞赛名称}}`
+
+- 下载竞赛中的特定文件：
+
+`kaggle {{[c|competitions]}} download {{竞赛名称}} {{[-f|--file]}} {{文件名}}`
+
+- 向竞赛提交文件（通常是预测结果）：
+
+`kaggle {{[c|competitions]}} submit {{竞赛名称}} {{[-f|--file]}} {{文件路径}} {{[-m|--message]}} "{{提交信息}}"`
+
+- 显示或下载竞赛排行榜：
+
+`kaggle {{[c|competitions]}} leaderboard {{竞赛名称}} {{--show|--download}}`
+
+- 查看之前的提交记录：
+
+`kaggle {{[c|competitions]}} submissions {{竞赛名称}}`

--- a/pages.zh/common/kaggle-config.md
+++ b/pages.zh/common/kaggle-config.md
@@ -1,0 +1,16 @@
+# kaggle config
+
+> 管理 Kaggle 配置信息。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#config>。
+
+- 查看当前所有配置项的值：
+
+`kaggle config view`
+
+- 设置特定配置项的值：
+
+`kaggle config set {{[-n|--name]}} {{配置项名称}} {{[-v|--value]}} {{参数值}}`
+
+- 清除（取消设置）某个配置项：
+
+`kaggle config unset {{[-n|--name]}} {{配置项名称}}`

--- a/pages.zh/common/kaggle-datasets.md
+++ b/pages.zh/common/kaggle-datasets.md
@@ -1,0 +1,32 @@
+# kaggle datasets
+
+> 管理 Kaggle 数据集。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#datasets>。
+
+- 列出特定用户或组织下的所有数据集：
+
+`kaggle {{[d|datasets]}} list --user {{用户名}}`
+
+- 按名称搜索数据集：
+
+`kaggle {{[d|datasets]}} list {{[-s|--search]}} "{{数据集名称}}"`
+
+- 下载指定的数据集：
+
+`kaggle {{[d|datasets]}} download "{{数据集名称}}"`
+
+- 创建一个公开的数据集：
+
+`kaggle {{[d|datasets]}} create {{[-p|--path]}} {{数据集路径}} {{[-u|--public]}}`
+
+- 下载数据集的元数据文件：
+
+`kaggle {{[d|datasets]}} metadata {{数据集名称}}`
+
+- 初始化数据集的元数据文件（通常用于创建新数据集前）：
+
+`kaggle {{[d|datasets]}} init {{[-p|--path]}} {{数据集路径}}`
+
+- 删除指定的数据集：
+
+`kaggle {{[d|datasets]}} delete {{数据集名称}}`

--- a/pages.zh/common/kaggle-kernels.md
+++ b/pages.zh/common/kaggle-kernels.md
@@ -1,0 +1,32 @@
+# kaggle kernels
+
+> 管理 Kaggle 内核（即代码/笔记本）。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#kernels>。
+
+- 列出所有内核：
+
+`kaggle {{[k|kernels]}} list`
+
+- 列出指定内核的输出文件：
+
+`kaggle {{[k|kernels]}} files {{内核名称}}`
+
+- 为内核初始化元数据文件（默认为当前目录）：
+
+`kaggle {{[k|kernels]}} init {{[-p|--path]}} {{目录路径}}`
+
+- 将新代码推送（push）到内核并运行：
+
+`kaggle {{[k|kernels]}} push {{[-p|--path]}} {{目录路径}}`
+
+- 拉取（pull）指定的内核到本地：
+
+`kaggle {{[k|kernels]}} pull {{内核名称}} {{[-p|--path]}} {{目录路径}}`
+
+- 获取最近一次内核运行的输出数据：
+
+`kaggle {{[k|kernels]}} output {{内核名称}}`
+
+- 显示最近一次内核运行的状态：
+
+`kaggle {{[k|kernels]}} status {{内核名称}}`

--- a/pages.zh/common/kaggle-models.md
+++ b/pages.zh/common/kaggle-models.md
@@ -1,0 +1,28 @@
+# kaggle models
+
+> 管理 Kaggle 模型。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#models>。
+
+- 获取一个模型：
+
+`kaggle {{[m|models]}} get "{{模型名称}}"`
+
+- 列出所有模型：
+
+`kaggle {{[m|models]}} list`
+
+- 初始化模型创建所需的元数据文件：
+
+`kaggle {{[m|models]}} init`
+
+- 创建一个新模型：
+
+`kaggle {{[m|models]}} create`
+
+- 删除一个模型：
+
+`kaggle {{[m|models]}} delete "{{模型名称}}"`
+
+- 更新一个模型：
+
+`kaggle {{[m|models]}} update`

--- a/pages.zh/common/kaggle.md
+++ b/pages.zh/common/kaggle.md
@@ -1,0 +1,36 @@
+# kaggle
+
+> 基于 Python 3 开发的 Kaggle 官方命令行工具 (CLI)。
+> 更多信息：<https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md>。
+
+- 查看当前配置项的值：
+
+`kaggle config view`
+
+- 从指定的竞赛数据集中下载特定文件：
+
+`kaggle {{[c|competitions]}} download {{竞赛名称}} {{[-f|--file]}} {{文件路径}}`
+
+- 列出与搜索关键词匹配的竞赛：
+
+`kaggle {{[c|competitions]}} list {{[-s|--search]}} {{搜索关键词}}`
+
+- 列出指定竞赛中所有可用的文件：
+
+`kaggle {{[c|competitions]}} files {{竞赛名称}}`
+
+- 向竞赛提交文件并附带说明信息：
+
+`kaggle {{[c|competitions]}} submit {{竞赛名称}} {{[-f|--file]}} {{提交文件路径.csv}} {{[-m|--message]}} "{{提交信息}}"`
+
+- 列出与搜索关键词匹配的数据集：
+
+`kaggle {{[d|datasets]}} list {{[-s|--search]}} {{搜索关键词}}`
+
+- 下载指定数据集中的所有文件：
+
+`kaggle {{[d|datasets]}} download {{用户名}}/{{数据集名称}}`
+
+- 列出与搜索关键词匹配的内核（Notebook）：
+
+`kaggle {{[k|kernels]}} list {{[-s|--search]}} {{搜索关键词}}`


### PR DESCRIPTION
i have added 35+ translation files to the Indonesian (id) and Simplified Chinese (zh) documentation ! :)

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
