### PR TITLE
ri: add page and link from ruby

### DIFF
--- a/pages/common/ri.md
+++ b/pages/common/ri.md
@@ -1,0 +1,17 @@
+# ri
+
+> Browse structured API documentation for Ruby.
+> See also: `ruby`.
+> More information: <https://ruby.github.io/rdoc/RI_md.html>.
+
+- Start interactive shell:
+
+`ri`
+
+- View documentation for a particular name:
+
+`ri {{File#read}}`
+
+- List classes and modules for which `ri` has documentation:
+
+`ri {{[-l|--list]}}`

--- a/pages/common/ruby.md
+++ b/pages/common/ruby.md
@@ -1,7 +1,7 @@
 # ruby
 
 > Ruby programming language interpreter.
-> See also: `gem`, `bundler`, `rake`, `irb`.
+> See also: `gem`, `bundler`, `rake`, `irb`, `ri`.
 > More information: <https://manned.org/ruby>.
 
 - Execute a Ruby script:


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `ri 7.2.0`
