### PR TITLE
sg, sg-run, sg-scan, sg-test, sg-new: add subcommand pages

### DIFF
--- a/pages/common/sg-new.md
+++ b/pages/common/sg-new.md
@@ -1,0 +1,28 @@
+# sg new
+
+> Create new ast-grep projects, rules, tests, or utility rules.
+> More information: <https://ast-grep.github.io/reference/cli/new.html>.
+
+- Create a new ast-grep project interactively:
+
+`sg new project`
+
+- Create a new rule:
+
+`sg new rule {{rule_id}}`
+
+- Create a new rule for a specific language:
+
+`sg new rule {{rule_id}} --lang {{javascript}}`
+
+- Create a new test case:
+
+`sg new test {{test_name}}`
+
+- Create a new global utility rule:
+
+`sg new util {{util_name}} --lang {{typescript}}`
+
+- Accept all defaults without interactive input:
+
+`sg new rule {{rule_id}} --lang {{python}} --yes`

--- a/pages/common/sg-run.md
+++ b/pages/common/sg-run.md
@@ -1,0 +1,36 @@
+# sg run
+
+> Run a one-time search or rewrite against a codebase using AST patterns.
+> More information: <https://ast-grep.github.io/reference/cli/run.html>.
+
+- Search for a pattern in the current directory:
+
+`sg run --pattern '{{console.log($ARG)}}' --lang {{javascript}}`
+
+- Replace a pattern with a new string across the codebase:
+
+`sg run --pattern '{{var $NAME = $VALUE}}' --rewrite '{{let $NAME = $VALUE}}' --lang {{javascript}}`
+
+- Search in specific directories or files:
+
+`sg run --pattern '{{$PATTERN}}' --lang {{python}} {{path/to/directory1 path/to/directory2 ...}}`
+
+- Interactively review and apply rewrites:
+
+`sg run --pattern '{{useState<number>($A)}}' --rewrite '{{useState($A)}}' --lang {{typescript}} --interactive`
+
+- Apply all rewrites without confirmation:
+
+`sg run --pattern '{{old_function($ARGS)}}' --rewrite '{{new_function($ARGS)}}' --lang {{python}} --update-all`
+
+- Output matches as JSON:
+
+`sg run --pattern '{{$PATTERN}}' --lang {{rust}} --json`
+
+- Show context lines around each match:
+
+`sg run --pattern '{{$PATTERN}}' --lang {{go}} --context {{3}}`
+
+- Print only file paths containing matches:
+
+`sg run --pattern '{{$PATTERN}}' --lang {{java}} --files-with-matches`

--- a/pages/common/sg-scan.md
+++ b/pages/common/sg-scan.md
@@ -1,0 +1,36 @@
+# sg scan
+
+> Scan and rewrite code using ast-grep rule configurations.
+> More information: <https://ast-grep.github.io/reference/cli/scan.html>.
+
+- Scan the codebase with all configured rules:
+
+`sg scan`
+
+- Scan the codebase with a single rule file:
+
+`sg scan --rule {{path/to/rule.yml}}`
+
+- Scan with an inline rule definition:
+
+`sg scan --inline-rules '{{id: no-console, language: javascript, rule: {pattern: "console.log($ARG)"}}}'`
+
+- Interactively review and apply fixes:
+
+`sg scan --interactive`
+
+- Apply all fixes without confirmation:
+
+`sg scan --update-all`
+
+- Output results in SARIF format:
+
+`sg scan --format {{sarif}}`
+
+- Scan only rules matching a filter regex:
+
+`sg scan --filter '{{rule_id_regex}}'`
+
+- Output results as JSON with rule metadata:
+
+`sg scan --json --include-metadata`

--- a/pages/common/sg-test.md
+++ b/pages/common/sg-test.md
@@ -1,0 +1,28 @@
+# sg test
+
+> Test ast-grep rules against test cases.
+> More information: <https://ast-grep.github.io/reference/cli/test.html>.
+
+- Run all rule tests:
+
+`sg test`
+
+- Run tests from a specific directory:
+
+`sg test --test-dir {{path/to/test_directory}}`
+
+- Update all snapshots that have changed:
+
+`sg test --update-all`
+
+- Interactively review and update snapshots:
+
+`sg test --interactive`
+
+- Only check if test code is valid without checking rule output:
+
+`sg test --skip-snapshot-tests`
+
+- Run only tests matching a regex filter:
+
+`sg test --filter '{{regex_pattern}}'`

--- a/pages/common/sg.md
+++ b/pages/common/sg.md
@@ -1,20 +1,33 @@
 # sg
 
-> Ast-grep is a tool for code structural search, lint, and rewriting.
-> More information: <https://ast-grep.github.io/guide/introduction.html>.
+> A tool for code structural search, lint, and rewriting based on abstract syntax trees.
+> Some subcommands such as `sg run`, `sg scan`, and `sg new` have their own usage documentation.
+> More information: <https://ast-grep.github.io>.
 
-- Scan for possible queries using interactive mode:
+- Search for a pattern in the current directory:
+
+`sg run --pattern '{{console.log($ARG)}}' --lang {{javascript}}`
+
+- Replace a pattern with a new string:
+
+`sg run --pattern '{{var $NAME = $VALUE}}' --rewrite '{{let $NAME = $VALUE}}' --lang {{javascript}}`
+
+- Scan the codebase using configured rules interactively:
 
 `sg scan --interactive`
 
-- Rewrite code in the current directory using patterns:
+- Scan the codebase with a single rule file:
 
-`sg run --pattern '{{foo}}' --rewrite '{{bar}}' --lang {{python}}`
+`sg scan --rule {{path/to/rule.yml}}`
 
-- Visualize possible changes without applying them:
+- Create a new ast-grep project:
 
-`sg run --pattern '{{useState<number>($A)}}' --rewrite '{{useState($A)}}' --lang {{typescript}}`
+`sg new project`
 
-- Output results as JSON, extract information using `jq` and interactively view it using `jless`:
+- Test ast-grep rules:
 
-`sg run --pattern '{{Some($A)}}' --rewrite '{{None}}' --json | jq '{{.[].replacement}}' | jless`
+`sg test`
+
+- Start the language server:
+
+`sg lsp`


### PR DESCRIPTION
## Summary
- Updated `sg.md` to reference subcommands and improve examples with realistic AST patterns
- Added `sg-run.md` — one-time search and rewrite with patterns, JSON output, context lines
- Added `sg-scan.md` — rule-based scanning with SARIF output, inline rules, filtering
- Added `sg-test.md` — testing rules with snapshots, filtering, interactive review
- Added `sg-new.md` — scaffolding projects, rules, tests, and utility rules

Closes #21477

## Test plan
- [ ] Verify all pages pass `tldr-lint`
- [ ] Check examples are accurate against `ast-grep --help` and subcommand help
- [ ] Confirm pages follow the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)