### PR TITLE
uv: add build command

### DIFF
--- a/pages/common/uv.md
+++ b/pages/common/uv.md
@@ -28,6 +28,10 @@
 
 `uv sync`
 
+- Create a lock file for the project's dependencies:
+
+`uv lock`
+
 - Build the project into source and binary distributions:
 
 `uv build`


### PR DESCRIPTION
Added missing `uv build` command which builds the project into source and binary distributions. Documented in the official uv docs: https://docs.astral.sh/uv/guides/package/