### PR TITLE
curl, wget, ssh: add Turkish translation

### DIFF
--- a/pages.tr/common/curl.md
+++ b/pages.tr/common/curl.md
@@ -1,0 +1,38 @@
+# curl
+
+> Bir sunucuya veya sunucudan veri aktarır.
+> HTTP, HTTPS, FTP, SCP gibi birçok protokolü destekler.
+> Ayrıca bakınız: `wcurl`, `wget`.
+> Daha fazla bilgi için: <https://curl.se/docs/manpage.html>.
+
+- Bir HTTP GET isteği yap ve içeriği `stdout`'a yaz:
+
+`curl {{https://example.com}}`
+
+- HTTP GET isteği yap, `3xx` yönlendirmelerini takip et ve yanıt başlıklarıyla içeriği `stdout`'a yaz:
+
+`curl {{[-L|--location]}} {{[-D|--dump-header]}} - {{https://example.com}}`
+
+- Bir dosyayı indir ve URL'deki dosya adıyla kaydet:
+
+`curl {{[-O|--remote-name]}} {{https://example.com/dosya.zip}}`
+
+- Form ile kodlanmış veri gönder (`application/x-www-form-urlencoded` türünde POST isteği). `stdin`'den okumak için `--data @dosya_adı` veya `--data @'-'` kullan:
+
+`curl {{[-X|--request]}} POST {{[-d|--data]}} '{{isim=ali}}' {{http://example.com/form}}`
+
+- Ekstra başlık, özel HTTP yöntemi ve proxy (BurpSuite gibi) ile istek gönder, güvensiz sertifikaları yoksay:
+
+`curl {{[-k|--insecure]}} {{[-x|--proxy]}} {{http://127.0.0.1:8080}} {{[-H|--header]}} '{{Authorization: Bearer token}}' {{[-X|--request]}} {{GET|PUT|POST|DELETE|PATCH|...}} {{https://example.com}}`
+
+- JSON formatında veri gönder ve uygun Content-Type başlığını belirt:
+
+`curl {{[-d|--data]}} '{{{"isim":"ali"}}}' {{[-H|--header]}} '{{Content-Type: application/json}}' {{http://example.com/users/1234}}`
+
+- İstemci sertifikası ve özel anahtar ile istek gönder, sertifika doğrulamasını atla:
+
+`curl {{[-E|--cert]}} {{istemci.pem}} --key {{anahtar.pem}} {{[-k|--insecure]}} {{https://example.com}}`
+
+- Bir alan adını özel bir IP adresine çözümle, ayrıntılı çıktı ile (DNS çözümlemesi için `/etc/hosts` dosyasını düzenlemeye benzer):
+
+`curl {{[-v|--verbose]}} --resolve {{example.com}}:{{80}}:{{127.0.0.1}} {{http://example.com}}`

--- a/pages.tr/common/ssh.md
+++ b/pages.tr/common/ssh.md
@@ -1,0 +1,37 @@
+# ssh
+
+> Secure Shell, uzak sistemlere güvenli bağlantı kurmak için kullanılan bir protokoldür.
+> Uzak sunucuda oturum açmak veya komut çalıştırmak için kullanılabilir.
+> Daha fazla bilgi için: <https://man.openbsd.org/ssh>.
+
+- Uzak bir sunucuya bağlan:
+
+`ssh {{kullanici}}@{{uzak_sunucu}}`
+
+- Belirli bir kimlik dosyası (özel anahtar) ile uzak sunucuya bağlan:
+
+`ssh -i {{anahtar/dosyasi/yolu}} {{kullanici}}@{{uzak_sunucu}}`
+
+- `10.0.0.1` IP adresli uzak sunucuya belirli bir port ile bağlan (Not: `10.0.0.1` kısaltılarak `10.1` yazılabilir):
+
+`ssh {{kullanici}}@10.0.0.1 -p {{2222}}`
+
+- Uzak sunucuda etkileşimli komut çalıştırmak için tty tahsisi ile bağlan:
+
+`ssh {{kullanici}}@{{uzak_sunucu}} -t {{komut}} {{komut_argumanlari}}`
+
+- SSH tünelleme: Dinamik port yönlendirme (`localhost:1080` üzerinde SOCKS proxy):
+
+`ssh -D {{1080}} {{kullanici}}@{{uzak_sunucu}}`
+
+- SSH tünelleme: Belirli bir portu yönlendir (`localhost:9999`'dan `example.org:80`'e), sahte tty tahsisini ve uzak komut çalıştırmayı devre dışı bırak:
+
+`ssh -L {{9999}}:{{example.org}}:{{80}} -N -T {{kullanici}}@{{uzak_sunucu}}`
+
+- SSH atlama: Bir atlama sunucusu üzerinden uzak sunucuya bağlan (birden fazla atlama virgülle ayrılabilir):
+
+`ssh -J {{kullanici}}@{{atlama_sunucusu}} {{kullanici}}@{{uzak_sunucu}}`
+
+- Takılmış bir oturumu kapat:
+
+`<Enter><~><.>`

--- a/pages.tr/common/wget.md
+++ b/pages.tr/common/wget.md
@@ -1,0 +1,38 @@
+# wget
+
+> Web'den dosya indirir.
+> HTTP, HTTPS ve FTP protokollerini destekler.
+> Ayrıca bakınız: `wcurl`, `curl`.
+> Daha fazla bilgi için: <https://www.gnu.org/software/wget/manual/wget.html>.
+
+- Bir URL'nin içeriğini bir dosyaya indir (bu örnekte dosya adı "foo"):
+
+`wget {{https://example.com/foo}}`
+
+- Bir URL'nin içeriğini belirtilen dosya adıyla indir (bu örnekte "bar"):
+
+`wget {{[-O|--output-document]}} {{bar}} {{https://example.com/foo}}`
+
+- Tek bir web sayfasını ve tüm kaynaklarını (betikler, stil dosyaları, görseller vb.) istekler arasında 3 saniyelik aralıklarla indir:
+
+`wget {{[-pkw|--page-requisites --convert-links --wait]}} 3 {{https://example.com/bir_sayfa.html}}`
+
+- Bir dizindeki ve alt dizinlerindeki tüm dosyaları indir (gömülü sayfa öğelerini indirmez):
+
+`wget {{[-mnp|--mirror --no-parent]}} {{https://example.com/bir_dizin/}}`
+
+- İndirme hızını ve bağlantı yeniden deneme sayısını sınırla:
+
+`wget --limit-rate {{300k}} {{[-t|--tries]}} {{100}} {{https://example.com/bir_dizin/}}`
+
+- HTTP sunucusundan Temel Kimlik Doğrulama ile dosya indir (FTP için de geçerlidir):
+
+`wget --user {{kullanici_adi}} --password {{sifre}} {{https://example.com}}`
+
+- Tamamlanmamış bir indirmeye devam et:
+
+`wget {{[-c|--continue]}} {{https://example.com}}`
+
+- Bir metin dosyasında saklanan tüm URL'leri belirtilen dizine indir:
+
+`wget {{[-P|--directory-prefix]}} {{dizin/yolu}} {{[-i|--input-file]}} {{URL_listesi.txt}}`


### PR DESCRIPTION
## Summary
- Added Turkish translations for three commonly used commands: `curl`, `wget`, and `ssh`
- Translations follow the existing Turkish page style and conventions (checked `tar.md` as reference)
- All examples and command structures match the English source pages

## Related issue
Contributes to #13578 (Page translation request: outdated or missing Turkish pages)