### PR TITLE
paramspider: add page

### DIFF
--- a/pages/common/paramspider.md
+++ b/pages/common/paramspider.md
@@ -1,0 +1,24 @@
+# paramspider
+
+> Mine URLs with parameters from web archives.
+> More information: <https://github.com/devanshbatham/ParamSpider>.
+
+- Mine URLs with parameters for a specific [d]omain:
+
+`paramspider {{[-d|--domain]}} {{example.com}}`
+
+- Mine URLs for multiple domains from a [l]ist file:
+
+`paramspider {{[-l|--list]}} {{path/to/domains.txt}}`
+
+- Mine URLs and [s]tream the output to the terminal:
+
+`paramspider {{[-d|--domain]}} {{example.com}} {{[-s|--stream]}}`
+
+- Mine URLs using a custom [p]laceholder for parameter values:
+
+`paramspider {{[-d|--domain]}} {{example.com}} {{[-p|--placeholder]}} "{{FUZZ}}"`
+
+- Mine URLs through a proxy:
+
+`paramspider {{[-d|--domain]}} {{example.com}} --proxy {{http://127.0.0.1:8080}}`


### PR DESCRIPTION
Added a page for `paramspider` — mines URLs with parameters from web archives, useful for parameter discovery during security testing.

Checked the existing pages and confirmed this tool doesn't have one yet. Examples are based on the tool's actual help output and common usage patterns.