### PR TITLE
net: add page

### DIFF
--- a/pages/linux/net.md
+++ b/pages/linux/net.md
@@ -1,0 +1,37 @@
+# net
+
+> Administer Samba and remote CIFS servers.
+> See also: `smbclient`.
+> More information: <https://manned.org/net>.
+
+- Join an Active Directory domain:
+
+`sudo net ads join -U {{administrator}}`
+
+- Leave an Active Directory domain:
+
+`sudo net ads leave -U {{administrator}}`
+
+- Display Active Directory server information:
+
+`net ads info`
+
+- Verify Active Directory domain membership:
+
+`sudo net ads testjoin`
+
+- List shares on a remote server via RPC:
+
+`net rpc share list -S {{server_name}} -U {{username}}`
+
+- Look up domain controllers for a domain:
+
+`net lookup dc {{domain_name}}`
+
+- Display the remote server's time:
+
+`net time -S {{server_name}}`
+
+- Display help for a subcommand:
+
+`net help {{subcommand}}`


### PR DESCRIPTION
Closes #21585.

Add a tldr page for the Samba `net` command (`pages/linux/net.md`).

Placed under `linux` platform, consistent with other Samba-related pages like `smbclient`.

## Examples covered (8)

- `net ads join` - Join an Active Directory domain
- `net ads leave` - Leave an Active Directory domain
- `net ads info` - Display AD server information
- `net ads testjoin` - Verify domain membership
- `net rpc share list` - List shares on a remote server
- `net lookup dc` - Look up domain controllers
- `net time` - Display remote server's time
- `net help` - Display help for a subcommand

## References

- Samba net(8) man page: <https://www.samba.org/samba/docs/current/man-html/net.8.html>
- manned.org: <https://manned.org/net>