### PR TITLE
docker-container-rm, docker-image-pull: remove deprecated -h flag

### DIFF
--- a/pages.bn/common/docker-container-rm.md
+++ b/pages.bn/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - সাহায্য প্রদর্শন:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.es/common/docker-container-rm.md
+++ b/pages.es/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - Muestra la ayuda:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.fr/common/docker-container-rm.md
+++ b/pages.fr/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - Affiche l'aide :
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.fr/common/docker-image-pull.md
+++ b/pages.fr/common/docker-image-pull.md
@@ -21,4 +21,4 @@
 
 - Affiche l'aide :
 
-`docker {{[pull|image pull]}} {{[-h|--help]}}`
+`docker {{[pull|image pull]}} --help`

--- a/pages.ko/common/docker-container-rm.md
+++ b/pages.ko/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - 도움말 표시:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.ko/common/docker-image-pull.md
+++ b/pages.ko/common/docker-image-pull.md
@@ -21,4 +21,4 @@
 
 - 도움말 표시:
 
-`docker {{[pull|image pull]}} {{[-h|--help]}}`
+`docker {{[pull|image pull]}} --help`

--- a/pages.nl/common/docker-container-rm.md
+++ b/pages.nl/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - Toon de help:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.nl/common/docker-image-pull.md
+++ b/pages.nl/common/docker-image-pull.md
@@ -21,4 +21,4 @@
 
 - Toon de help:
 
-`docker {{[pull|image pull]}} {{[-h|--help]}}`
+`docker {{[pull|image pull]}} --help`

--- a/pages.pt_BR/common/docker-image-pull.md
+++ b/pages.pt_BR/common/docker-image-pull.md
@@ -21,4 +21,4 @@
 
 - Exibe ajuda:
 
-`docker {{[pull|image pull]}} {{[-h|--help]}}`
+`docker {{[pull|image pull]}} --help`

--- a/pages.ru/common/docker-container-rm.md
+++ b/pages.ru/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - Показать справку:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages.zh/common/docker-container-rm.md
+++ b/pages.zh/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - 显示帮助：
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages/common/docker-container-rm.md
+++ b/pages/common/docker-container-rm.md
@@ -17,4 +17,4 @@
 
 - Display help:
 
-`docker {{[rm|container rm]}} {{[-h|--help]}}`
+`docker {{[rm|container rm]}} --help`

--- a/pages/common/docker-image-pull.md
+++ b/pages/common/docker-image-pull.md
@@ -21,4 +21,4 @@
 
 - Display help:
 
-`docker {{[pull|image pull]}} {{[-h|--help]}}`
+`docker {{[pull|image pull]}} --help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

The `-h` shorthand for `--help` was deprecated in Docker v1.12.0 due to conflicts with other flags like `-h`/`--hostname`. See [deprecation log](https://docs.docker.com/engine/deprecated#-h-shorthand-for---help) for more info. We shouldn't recommand it.
 