### PR TITLE
system_profiler: add wattage report

### DIFF
--- a/pages/osx/system_profiler.md
+++ b/pages/osx/system_profiler.md
@@ -21,4 +21,4 @@
 
 - Display the negotiated max wattage of the connected charger and cable:
 
-`system_profiler SPPowerDataType | grep Wattage | sed 's/^ *//'`
+`system_profiler SPPowerDataType | awk '/Wattage/ {print $3}'`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

Adds getting power information, as it's a useful one-liner.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Tahoe 26.3.1 (and earlier)
