### PR TITLE
zed: fix CLI documentation URL

### DIFF
--- a/pages.es/common/zed.md
+++ b/pages.es/common/zed.md
@@ -1,7 +1,7 @@
 # zed
 
 > Editor de texto diseñado para ser rápido, eficiente y cómodo.
-> Más información: <https://zed.dev/docs/#cli>.
+> Más información: <https://zed.dev/docs/reference/cli>.
 
 - Abre rutas específicas en Zed:
 

--- a/pages.nl/common/zed.md
+++ b/pages.nl/common/zed.md
@@ -1,7 +1,7 @@
 # zed
 
 > Tekstverwerker ontworpen om snel, efficiënt en handig te zijn.
-> Meer informatie: <https://zed.dev/docs/#cli>.
+> Meer informatie: <https://zed.dev/docs/reference/cli>.
 
 - Open specifieke paden in Zed:
 

--- a/pages.zh/common/zed.md
+++ b/pages.zh/common/zed.md
@@ -1,7 +1,7 @@
 # zed
 
 > 一款旨在快速、高效且便捷的文本编辑器。
-> 更多信息：<https://zed.dev/docs/#cli>。
+> 更多信息：<https://zed.dev/docs/reference/cli>。
 
 - 在 Zed 中打开指定路径：
 

--- a/pages/common/zed.md
+++ b/pages/common/zed.md
@@ -1,7 +1,7 @@
 # zed
 
 > Text editor designed to be fast, efficient, and convenient.
-> More information: <https://zed.dev/docs/#cli>.
+> More information: <https://zed.dev/docs/reference/cli>.
 
 - Open specific paths in Zed:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
