### PR TITLE
repo: add page

### DIFF
--- a/pages/common/repo.md
+++ b/pages/common/repo.md
@@ -1,0 +1,24 @@
+# repo
+
+> Manage multiple Git repositories with a single workflow.
+> More information: <https://source.android.com/docs/setup/reference/repo>.
+
+- Initialize a client checkout from a manifest repository:
+
+`repo init -u {{manifest_repository_url}}`
+
+- Synchronize all projects in the current checkout:
+
+`repo sync`
+
+- Synchronize only a specific project path:
+
+`repo sync {{path/to/project}}`
+
+- Create and switch to a topic branch in all projects:
+
+`repo start {{branch_name}} --all`
+
+- Run a Git command in every project managed by `repo`:
+
+`repo forall -c '{{git status --short}}'`


### PR DESCRIPTION
### Summary
- add a new epo command page in pages/common/repo.md
- cover core workflow commands (init, sync, start, orall)
- keep examples scoped to manifest-driven multi-repo usage

### Validation
- 
px tldr-lint pages/common/repo.md
- 
px markdownlint-cli pages/common/repo.md

Closes #21435