### PR TITLE
cdrecord: improve functional examples

### DIFF
--- a/pages/linux/cdrecord.md
+++ b/pages/linux/cdrecord.md
@@ -2,20 +2,24 @@
 
 > Record data to CDs or DVDs.
 > Some invocations of cdrecord can cause destructive actions, such as erasing all the data on a disc.
-> More information: <https://manned.org/cdrecord>.
+> More information: <https://manpages.debian.org/bookworm/wodim/cdrecord.1.en.html>.
 
-- Display optical drives available to `cdrecord`:
+- List available optical recorders:
 
 `cdrecord --devices`
 
-- Record ("burn") an audio-only disc:
+- Burn an ISO image to a disc and eject it when done:
 
-`cdrecord dev={{/dev/optical_drive}} -audio {{track*.cdaudio}}`
+`cdrecord -eject dev={{/dev/optical_drive}} -data {{path/to/file.iso}}`
 
-- Burn a file to a disc, ejecting the disc once done (some recorders require this):
+- Burn audio tracks to a disc:
 
-`cdrecord -eject dev={{/dev/optical_drive}} -data {{file.iso}}`
+`cdrecord dev={{/dev/optical_drive}} -audio {{path/to/track1.wav}} {{path/to/track2.wav}}`
 
-- Burn a file to the disc in an optical drive, potentially writing to multiple discs in succession:
+- Test a burn without writing to the disc:
 
-`cdrecord -tao dev={{/dev/optical_drive}} -data {{file.iso}}`
+`cdrecord -dummy dev={{/dev/optical_drive}} -data {{path/to/file.iso}}`
+
+- Quickly blank a rewritable disc:
+
+`cdrecord dev={{/dev/optical_drive}} blank=fast`


### PR DESCRIPTION
### Summary
- replace the current cdrecord examples with directly runnable command forms
- keep destructive actions explicit (lank=fast) and add safer dry-run usage (-dummy)
- use concrete audio/ISO examples with realistic placeholders

### Validation
- 
px tldr-lint pages/linux/cdrecord.md
- 
px markdownlint-cli pages/linux/cdrecord.md

Closes #21343