### PR TITLE
jless: add page

### DIFF
--- a/pages/common/jless.md
+++ b/pages/common/jless.md
@@ -11,10 +11,10 @@
 
 `{{cat path/to/file.json}} | jless`
 
-- View a YAML file:
+- View a YAML file (`--yaml` is optional, the format is automatically detected from the file extension):
 
 `jless --yaml {{path/to/file.yaml}}`
 
-- View JSON in line mode (newline-delimited data):
+- View JSON in line mode (quote object keys and include curly and square brackets):
 
 `jless {{path/to/file.jsonl}} {{[-m|--mode]}} line`


### PR DESCRIPTION
Adds a tldr page for `jless`, a command-line JSON viewer with vim-style navigation.

Covers: viewing JSON files, piping from stdin, YAML mode, line mode for JSONL, and initial search query.

Documentation: https://jless.io/user-guide

Fixes #21116

This contribution was developed with AI assistance (Claude Code).