### PR TITLE
supabase: add subcommand pages

### DIFF
--- a/pages/common/supabase-db-pull.md
+++ b/pages/common/supabase-db-pull.md
@@ -1,0 +1,21 @@
+# supabase db pull
+
+> Pull schema changes from a remote database and create a local migration file.
+> Requires `supabase link` to be run first, or use `--db-url` for a custom database.
+> More information: <https://supabase.com/docs/reference/cli/supabase-db-pull>.
+
+- Pull schema from the linked remote project:
+
+`supabase db pull`
+
+- Pull schema from a custom database using a connection string:
+
+`supabase db pull --db-url {{postgresql://user:password@host/database}}`
+
+- Pull only specific schemas:
+
+`supabase db pull --schema {{public,auth}}`
+
+- Pull schema from the local development database:
+
+`supabase db pull --local`

--- a/pages/common/supabase-db-push.md
+++ b/pages/common/supabase-db-push.md
@@ -1,0 +1,25 @@
+# supabase db push
+
+> Push local database migrations to a remote Supabase project.
+> Requires `supabase link` to be run first, or use `--db-url` for a custom database.
+> More information: <https://supabase.com/docs/reference/cli/supabase-db-push>.
+
+- Push migrations to the linked remote project:
+
+`supabase db push`
+
+- Preview migrations without applying them:
+
+`supabase db push --dry-run`
+
+- Push to a custom database using a connection string:
+
+`supabase db push --db-url {{postgresql://user:password@host/database}}`
+
+- Push migrations including custom roles and seed data:
+
+`supabase db push --include-roles --include-seed`
+
+- Push to the local development database:
+
+`supabase db push --local`

--- a/pages/common/supabase-gen-types.md
+++ b/pages/common/supabase-gen-types.md
@@ -1,0 +1,25 @@
+# supabase gen types
+
+> Generate type definitions from a Supabase database schema.
+> Supports TypeScript, Go, Swift, and Python.
+> More information: <https://supabase.com/docs/reference/cli/supabase-gen-types>.
+
+- Generate TypeScript types from the local development database:
+
+`supabase gen types --lang typescript --local`
+
+- Generate TypeScript types from the linked remote project:
+
+`supabase gen types --lang typescript --linked`
+
+- Generate types and save to a file:
+
+`supabase gen types --lang {{typescript|go|swift|python}} --local > {{path/to/output_file}}`
+
+- Generate types for specific schemas only:
+
+`supabase gen types --lang typescript --local --schema {{public,auth}}`
+
+- Generate types from a specific project by ID:
+
+`supabase gen types --lang typescript --project-id {{project_id}}`

--- a/pages/common/supabase-init.md
+++ b/pages/common/supabase-init.md
@@ -1,0 +1,21 @@
+# supabase init
+
+> Initialize a Supabase project in the current directory.
+> Creates a `supabase/config.toml` configuration file.
+> More information: <https://supabase.com/docs/reference/cli/supabase-init>.
+
+- Initialize a new Supabase project:
+
+`supabase init`
+
+- Overwrite an existing configuration:
+
+`supabase init --force`
+
+- Initialize with interactive IDE settings configuration:
+
+`supabase init --interactive`
+
+- Initialize using the OrioleDB storage engine:
+
+`supabase init --use-orioledb`

--- a/pages/common/supabase-link.md
+++ b/pages/common/supabase-link.md
@@ -1,0 +1,17 @@
+# supabase link
+
+> Link the local project to a remote Supabase project.
+> Required before using remote database operations like `db push` or `db pull`.
+> More information: <https://supabase.com/docs/reference/cli/supabase-link>.
+
+- Link to a remote project by its reference ID:
+
+`supabase link --project-ref {{project_ref}}`
+
+- Link and provide the database password:
+
+`supabase link --project-ref {{project_ref}} --password {{db_password}}`
+
+- Link using a direct database connection instead of the connection pooler:
+
+`supabase link --project-ref {{project_ref}} --skip-pooler`

--- a/pages/common/supabase-login.md
+++ b/pages/common/supabase-login.md
@@ -1,0 +1,20 @@
+# supabase login
+
+> Authenticate the Supabase CLI with a personal access token.
+> More information: <https://supabase.com/docs/reference/cli/supabase-login>.
+
+- Authenticate interactively (opens browser to generate a token):
+
+`supabase login`
+
+- Authenticate with a pre-generated access token:
+
+`supabase login --token {{access_token}}`
+
+- Authenticate without opening a browser:
+
+`supabase login --no-browser`
+
+- Store the token with a custom name:
+
+`supabase login --name {{token_name}}`

--- a/pages/common/supabase-migration-new.md
+++ b/pages/common/supabase-migration-new.md
@@ -1,0 +1,12 @@
+# supabase migration new
+
+> Create a new timestamped migration file in `supabase/migrations`.
+> More information: <https://supabase.com/docs/reference/cli/supabase-migration-new>.
+
+- Create a new migration with a descriptive name:
+
+`supabase migration new {{migration_name}}`
+
+- Create a migration by piping the output of `supabase db diff`:
+
+`supabase db diff | supabase migration new {{migration_name}}`

--- a/pages/common/supabase-start.md
+++ b/pages/common/supabase-start.md
@@ -1,0 +1,17 @@
+# supabase start
+
+> Start the local Supabase development stack.
+> Requires Docker to be running.
+> More information: <https://supabase.com/docs/reference/cli/supabase-start>.
+
+- Start all local Supabase services:
+
+`supabase start`
+
+- Start services while excluding specific ones:
+
+`supabase start --exclude {{realtime,storage-api}}`
+
+- Start services and ignore health check failures:
+
+`supabase start --ignore-health-check`

--- a/pages/common/supabase-stop.md
+++ b/pages/common/supabase-stop.md
@@ -1,0 +1,20 @@
+# supabase stop
+
+> Stop the local Supabase development stack.
+> More information: <https://supabase.com/docs/reference/cli/supabase-stop>.
+
+- Stop the local stack while preserving data in Docker volumes:
+
+`supabase stop`
+
+- Stop all local Supabase instances across all projects:
+
+`supabase stop --all`
+
+- Stop and permanently delete all local data:
+
+`supabase stop --no-backup`
+
+- Stop a specific project instance:
+
+`supabase stop --project-id {{project_id}}`


### PR DESCRIPTION
## Description

Adds tldr pages for the most commonly used Supabase CLI subcommands, which are currently undocumented. This addresses #19693.

## New pages

- `supabase-init` — Initialize a new project
- `supabase-login` — Authenticate with a personal access token
- `supabase-link` — Link local project to a remote Supabase project
- `supabase-start` — Start the local development stack
- `supabase-stop` — Stop the local development stack
- `supabase-db-push` — Push local migrations to a remote database
- `supabase-db-pull` — Pull schema changes from a remote database
- `supabase-migration-new` — Create a new timestamped migration file
- `supabase-gen-types` — Generate type definitions from the database schema

All examples are sourced from the [official Supabase CLI reference](https://supabase.com/docs/reference/cli/introduction) and verified against the current CLI documentation.