### PR TITLE
sync.yml: fix CI run for PRs from monthly sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
           commit-message: "pages.*/: synchronize pages"
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: "pages.*/: synchronize pages"
           body: "Automated monthly synchronization of translated pages with existing English tldr pages."
           branch: "monthly-sync"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,6 +37,8 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "pages.*/: synchronize pages"
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: "pages.*/: synchronize pages"
           body: "Automated monthly synchronization of translated pages with existing English tldr pages."
           branch: "monthly-sync"


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Reference issue: https://github.com/tldr-pages/tldr/pull/21303#issuecomment-3979411113

---

When using the default `GITHUB_TOKEN`, GitHub prevents "recursive" workflow runs. This means `ci.yml` does not run on PRs opened by the `create-pull-request` action in `sync.yml`.

According to https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs and https://github.com/peter-evans/create-pull-request#token, we need to configure the workflow to use a PAT secret in place of the default `GITHUB_TOKEN`. This way, GitHub treats the PR as a _manual_ event, allowing `ci.yml` to trigger and validate the PR.

A personal PAT would work, but I think it would be better to use the @tldr-bot account to create the token. (the account that owns the token would be the author of the PR created by the workflow)

Actions needed before merging this: 

1. Create a repository secret named `PAT`.
2. Populate it with a token from the @tldr-bot account.
3. Ensure the token has `contents: write` and `pull-requests: write` permissions.