### PR TITLE
supabase-{init, link, login, start, stop}: add page

### DIFF
--- a/pages/common/supabase-init.md
+++ b/pages/common/supabase-init.md
@@ -1,0 +1,21 @@
+# supabase init
+
+> Initialize a Supabase project in the current directory.
+> Creates a `supabase/config.toml` configuration file.
+> More information: <https://supabase.com/docs/reference/cli/supabase-init>.
+
+- Initialize a new Supabase project:
+
+`supabase init`
+
+- Overwrite an existing configuration:
+
+`supabase init --force`
+
+- Initialize with interactive IDE settings configuration:
+
+`supabase init --interactive`
+
+- Initialize using the OrioleDB storage engine:
+
+`supabase init --use-orioledb`

--- a/pages/common/supabase-link.md
+++ b/pages/common/supabase-link.md
@@ -1,0 +1,17 @@
+# supabase link
+
+> Link the local project to a remote Supabase project.
+> Required before using remote database operations like `db push` or `db pull`.
+> More information: <https://supabase.com/docs/reference/cli/supabase-link>.
+
+- Link to a remote project by its reference ID:
+
+`supabase link --project-ref {{project_ref}}`
+
+- Link and provide the database password:
+
+`supabase link --project-ref {{project_ref}} --password {{db_password}}`
+
+- Link using a direct database connection instead of the connection pooler:
+
+`supabase link --project-ref {{project_ref}} --skip-pooler`

--- a/pages/common/supabase-login.md
+++ b/pages/common/supabase-login.md
@@ -1,0 +1,20 @@
+# supabase login
+
+> Authenticate the Supabase CLI with a personal access token.
+> More information: <https://supabase.com/docs/reference/cli/supabase-login>.
+
+- Authenticate interactively (opens browser to generate a token):
+
+`supabase login`
+
+- Authenticate with a pre-generated access token:
+
+`supabase login --token {{access_token}}`
+
+- Authenticate without opening a browser:
+
+`supabase login --no-browser`
+
+- Store the token with a custom name:
+
+`supabase login --name {{token_name}}`

--- a/pages/common/supabase-start.md
+++ b/pages/common/supabase-start.md
@@ -1,0 +1,17 @@
+# supabase start
+
+> Start the local Supabase development stack.
+> Requires Docker to be running.
+> More information: <https://supabase.com/docs/reference/cli/supabase-start>.
+
+- Start all local Supabase services:
+
+`supabase start`
+
+- Start services while excluding specific ones:
+
+`supabase start --exclude {{realtime,storage-api}}`
+
+- Start services and ignore health check failures:
+
+`supabase start --ignore-health-check`

--- a/pages/common/supabase-stop.md
+++ b/pages/common/supabase-stop.md
@@ -1,0 +1,20 @@
+# supabase stop
+
+> Stop the local Supabase development stack.
+> More information: <https://supabase.com/docs/reference/cli/supabase-stop>.
+
+- Stop the local stack while preserving data in Docker volumes:
+
+`supabase stop`
+
+- Stop all local Supabase instances across all projects:
+
+`supabase stop --all`
+
+- Stop and permanently delete all local data:
+
+`supabase stop --no-backup`
+
+- Stop a specific project instance:
+
+`supabase stop --project-id {{project_id}}`


### PR DESCRIPTION
Adds tldr pages for 5 Supabase CLI subcommands:
- `supabase-login`: Authenticate with the Supabase platform
- `supabase-link`: Link a local project to a Supabase project
- `supabase-init`: Initialize a Supabase project locally
- `supabase-start`: Start local Supabase services via Docker
- `supabase-stop`: Stop local Supabase services