### PR TITLE
supabase-{db-pull, db-push, gen-types, migration-new}: add page

### DIFF
--- a/pages/common/supabase-db-pull.md
+++ b/pages/common/supabase-db-pull.md
@@ -1,0 +1,21 @@
+# supabase db pull
+
+> Pull schema changes from a remote database and create a local migration file.
+> Requires `supabase link` to be run first, or use `--db-url` for a custom database.
+> More information: <https://supabase.com/docs/reference/cli/supabase-db-pull>.
+
+- Pull schema from the linked remote project:
+
+`supabase db pull`
+
+- Pull schema from a custom database using a connection string:
+
+`supabase db pull --db-url {{postgresql://user:password@host/database}}`
+
+- Pull only specific schemas:
+
+`supabase db pull --schema {{public,auth}}`
+
+- Pull schema from the local development database:
+
+`supabase db pull --local`

--- a/pages/common/supabase-db-push.md
+++ b/pages/common/supabase-db-push.md
@@ -1,0 +1,25 @@
+# supabase db push
+
+> Push local database migrations to a remote Supabase project.
+> Requires `supabase link` to be run first, or use `--db-url` for a custom database.
+> More information: <https://supabase.com/docs/reference/cli/supabase-db-push>.
+
+- Push migrations to the linked remote project:
+
+`supabase db push`
+
+- Preview migrations without applying them:
+
+`supabase db push --dry-run`
+
+- Push to a custom database using a connection string:
+
+`supabase db push --db-url {{postgresql://user:password@host/database}}`
+
+- Push migrations including custom roles and seed data:
+
+`supabase db push --include-roles --include-seed`
+
+- Push to the local development database:
+
+`supabase db push --local`

--- a/pages/common/supabase-gen-types.md
+++ b/pages/common/supabase-gen-types.md
@@ -1,0 +1,25 @@
+# supabase gen types
+
+> Generate type definitions from a Supabase database schema.
+> Supports TypeScript, Go, Swift, and Python.
+> More information: <https://supabase.com/docs/reference/cli/supabase-gen-types>.
+
+- Generate TypeScript types from the local development database:
+
+`supabase gen types --lang typescript --local`
+
+- Generate TypeScript types from the linked remote project:
+
+`supabase gen types --lang typescript --linked`
+
+- Generate types and save to a file:
+
+`supabase gen types --lang {{typescript|go|swift|python}} --local > {{path/to/output_file}}`
+
+- Generate types for specific schemas only:
+
+`supabase gen types --lang typescript --local --schema {{public,auth}}`
+
+- Generate types from a specific project by ID:
+
+`supabase gen types --lang typescript --project-id {{project_id}}`

--- a/pages/common/supabase-migration-new.md
+++ b/pages/common/supabase-migration-new.md
@@ -1,0 +1,12 @@
+# supabase migration new
+
+> Create a new timestamped migration file in `supabase/migrations`.
+> More information: <https://supabase.com/docs/reference/cli/supabase-migration-new>.
+
+- Create a new migration with a descriptive name:
+
+`supabase migration new {{migration_name}}`
+
+- Create a migration by piping the output of `supabase db diff`:
+
+`supabase db diff | supabase migration new {{migration_name}}`


### PR DESCRIPTION
Adds tldr pages for 4 Supabase CLI subcommands (database/code-generation):
- `supabase-db-pull`: Pull schema changes from a remote Supabase database
- `supabase-db-push`: Push local migrations to a remote Supabase database
- `supabase-migration-new`: Create a new migration file
- `supabase-gen-types`: Generate TypeScript types from a Supabase database schema