### PR TITLE
cisco-ios/*: add Korean translation

### DIFF
--- a/pages.ko/cisco-ios/clock.md
+++ b/pages.ko/cisco-ios/clock.md
@@ -1,0 +1,20 @@
+# clock
+
+> 시스템 시계를 설정합니다.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios/fundamentals/command/reference/cf_book/cf_c1.html#clock>.
+
+- 특권 모드에서 실행하여 시스템 시계를 설정:
+
+`clock set {{23}}:{{59}}:{{59}} {{31}} {{april}} {{2000}}`
+
+- 링크 반대편과 자동 협상, (기본값: active-clock):
+
+`clock active prefer`
+
+- 링크 반대편과 자동 협상, (기본값: passive-clock):
+
+`clock passive prefer`
+
+- 펌웨어에서 협상된 현재 clock 모드 확인:
+
+`clock show interfaces`

--- a/pages.ko/cisco-ios/configure.md
+++ b/pages.ko/cisco-ios/configure.md
@@ -1,0 +1,16 @@
+# configure
+
+> 설정 모드로 진입.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios/fundamentals/command/reference/cf_book/cf_c1.html#configure_check_syntax>.
+
+- 터미널에서 설정 모드로 진입:
+
+`{{[conf|configure]}} {{[t|terminal]}}`
+
+- 설정 모드에서 한 단계 상위로 이동:
+
+`exit`
+
+- 설정 모드 완전히 종료:
+
+`end`

--- a/pages.ko/cisco-ios/crypto.md
+++ b/pages.ko/cisco-ios/crypto.md
@@ -1,0 +1,17 @@
+# crypto
+
+> 암호화 관련 기능을 관리.
+> 설정 모드에서 사용함.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/A-H/asa-command-ref-A-H/crypto-is-cz-commands.html>.
+
+- `rsa` 키 생성:
+
+`crypto key generate rsa`
+
+- 키의 modulus 값 지정하여 생성:
+
+`crypto key generate rsa modulus {{1024}}`
+
+- 모든 키 삭제:
+
+`crypto key zeroize`

--- a/pages.ko/cisco-ios/delete.md
+++ b/pages.ko/cisco-ios/delete.md
@@ -1,0 +1,8 @@
+# delete
+
+> 개별 파일을 삭제.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/command/reference/fund/n5k-fund-cr/n5k-fund_cmds_d.html#delete>.
+
+- 플래시 메모리에서 파일 삭제:
+
+`delete {{vlan.dat}}`

--- a/pages.ko/cisco-ios/dir.md
+++ b/pages.ko/cisco-ios/dir.md
@@ -1,0 +1,16 @@
+# dir
+
+> 파일 목록을 출력.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/command/reference/fund/n5k-fund-cr/n5k-fund_cmds_d.html#dir>.
+
+- 현재 작업 디렉토리의 파일 목록 출력:
+
+`dir`
+
+- 특정 파일 시스템의 파일 목록 출력:
+
+`dir {{flash}}:`
+
+- 사용 가능한 파일 시스템 목록 출력:
+
+`dir ?`

--- a/pages.ko/cisco-ios/enable.md
+++ b/pages.ko/cisco-ios/enable.md
@@ -1,0 +1,8 @@
+# enable
+
+> 특권 실행 모드로 진입.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/security/d1/sec-d1-cr-book/sec-cr-e1.html#wp3307186499>.
+
+- 특권 실행 모드로 진입:
+
+`enable`

--- a/pages.ko/cisco-ios/erase.md
+++ b/pages.ko/cisco-ios/erase.md
@@ -1,0 +1,12 @@
+# erase
+
+> 사전에 정의된 설정 또는 데이터를 삭제.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios/ios_xe/fundamentals/configuration/guide/2_xe/cf_xe_book/cf_config-files_xe.html>.
+
+- 시작 설정 삭제:
+
+`erase startup-config`
+
+- 특정 파일 시스템 삭제:
+
+`erase {{플래시}}:`

--- a/pages.ko/cisco-ios/interface.md
+++ b/pages.ko/cisco-ios/interface.md
@@ -1,0 +1,13 @@
+# interface
+
+> 인터페이스를 관리.
+> 설정 모드에서 사용함.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/interface/command/ir-cr-book/ir-i1.html>.
+
+- VLAN 인터페이스 설정:
+
+`interface vlan {{1}}`
+
+- 인터페이스 활성화 또는 비활성화 (interface 명령 내부에서 실행):
+
+`{{no shutdown|shutdown}}`

--- a/pages.ko/cisco-ios/ip.md
+++ b/pages.ko/cisco-ios/ip.md
@@ -1,0 +1,21 @@
+# ip
+
+> IP 설정 관리.
+> 설정 모드에서 사용함.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipaddr/command/ipaddr-cr-book.html>.
+
+- SSH 버전 설정:
+
+`ip ssh version {{2}}`
+
+- 장치의 IP 주소 설정 (`interface 명령` 내부에서 실행):
+
+`ip address {{10.0.0.1}} {{255.255.255.0}}`
+
+- DHCP로 IP 주소 자동 할당 설정 (`interface 명령` 내부에서 실행):
+
+`ip address dhcp`
+
+- 도메인 이름 설정:
+
+`ip domain-name {{example.com}}`

--- a/pages.ko/cisco-ios/line.md
+++ b/pages.ko/cisco-ios/line.md
@@ -1,0 +1,9 @@
+# line
+
+> 라인을 관리합니다.
+> 설정 모드에서 사용함.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/routers/sdwan/command/iosxe/qualified-cli-command-reference-guide/m-line-commands.pdf>.
+
+- 0번부터 15번까지의 VTY 라인 설정:
+
+`line vty 0 15`

--- a/pages.ko/cisco-ios/login.md
+++ b/pages.ko/cisco-ios/login.md
@@ -1,0 +1,9 @@
+# login
+
+> 콘솔 및 가상 라인 인증을 관리.
+> `line` 설정 모드에서 사용함.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/routers/sdwan/command/iosxe/qualified-cli-command-reference-guide/m-line-commands.pdf>.
+
+- 로컬 사용자 이름과 비밀번호를 사용하여 인증:
+
+`login local`

--- a/pages.ko/cisco-ios/question-mark.md
+++ b/pages.ko/cisco-ios/question-mark.md
@@ -1,0 +1,16 @@
+# ?
+
+> 컨텍스트에 따라 사용 가능한 명령어 확인.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/15mt/fundamentals-15-mt-book/cf-cli-basics.html#GUID-223128D2-FB6D-418D-86C6-06D1D0DA51B3>.
+
+- 사용 가능한 명령어 확인:
+
+`?`
+
+- 조회 가능한 저장소(파일 시스템) 확인:
+
+`dir ?`
+
+- 확인 가능한 IP 관련 정보 확인:
+
+`ip show ?`

--- a/pages.ko/cisco-ios/reload.md
+++ b/pages.ko/cisco-ios/reload.md
@@ -1,0 +1,16 @@
+# reload
+
+> 시스템 재부팅 동작을 제어.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/command/reference/fund/n5k-fund-cr/n5k-fund_cmds_r.html#reload>.
+
+- 시스템 재부팅:
+
+`reload`
+
+- `n`초 후 재부팅:
+
+`reload in {{n}}`
+
+- 예약된 재부팅 취소:
+
+`reload cancel`

--- a/pages.ko/cisco-ios/show.md
+++ b/pages.ko/cisco-ios/show.md
@@ -1,0 +1,24 @@
+# show
+
+> 다양한 시스템 정보를 출력.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/command/reference/fund/n5k-fund-cr/n5k-fund_cmds_show.html>.
+
+- 스위치의 IP 주소 정보 출력:
+
+`{{[sh|show]}} ip interface brief`
+
+- 특정 인터페이스 설정 출력 :
+
+`{{[sh|show]}} ip interface {{vlan1}}`
+
+- VLAN 설정 출력:
+
+`{{[sh|show]}} vlan`
+
+- 현재 실행 중인 설정 출력:
+
+`{{[sh|show]}} running-config`
+
+- SSH 설정 출력:
+
+`{{[sh|show]}} ip ssh`

--- a/pages.ko/cisco-ios/transport.md
+++ b/pages.ko/cisco-ios/transport.md
@@ -1,0 +1,13 @@
+# transport
+
+> 라인에서 사용할 전송 프로토콜을 관리.
+> `line` 설정 모드에서 사용.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/routers/sdwan/command/iosxe/qualified-cli-command-reference-guide/m-line-commands.pdf>.
+
+- 라인 프로토콜을 `ssh`로 제한:
+
+`transport input ssh`
+
+- 라인 프로토콜을 `telnet`으로 제한:
+
+`transport input telnet`

--- a/pages.ko/cisco-ios/username.md
+++ b/pages.ko/cisco-ios/username.md
@@ -1,0 +1,9 @@
+# username
+
+> 사용자를 관리.
+> 설정 모드에서 사용.
+> 더 많은 정보: <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/security/s1/sec-s1-xe-3se-3850-cr-book/sec-s1-xe-3se-3850-cr-book_chapter_0110.html>.
+
+- 관리자 계정 생성:
+
+`username {{관리자}} privilege 15 secret {{비밀번호}}`

--- a/pages.ko/cisco-ios/write.md
+++ b/pages.ko/cisco-ios/write.md
@@ -1,0 +1,16 @@
+# write
+
+> 데이터를 메모리에 저장.
+> 더 많은 정보: <https://www.oreilly.com/library/view/cisco-ios-in/0596008694/re869.html#book-content>.
+
+- 현재 설정을 메모리에 저장:
+
+`write memory`
+
+- 메모리에 저장된 설정 삭제:
+
+`write erase`
+
+- 도움말 표시:
+
+`write ?`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
