### PR TITLE
openssl-*: remove "OpenSSL command" from descriptions

### DIFF
--- a/pages/common/openssl-dgst.md
+++ b/pages/common/openssl-dgst.md
@@ -1,6 +1,6 @@
 # openssl dgst
 
-> OpenSSL command to generate digest values and perform signature operations.
+> Generate digest values and perform signature operations.
 > More information: <https://docs.openssl.org/master/man1/openssl-dgst/>.
 
 - Calculate the SHA256 digest for a file, saving the result to a specific file:

--- a/pages/common/openssl-genpkey.md
+++ b/pages/common/openssl-genpkey.md
@@ -1,6 +1,6 @@
 # openssl genpkey
 
-> OpenSSL command to generate asymmetric key pairs.
+> Generate asymmetric key pairs.
 > More information: <https://docs.openssl.org/master/man1/openssl-genpkey/>.
 
 - Generate an RSA private key of 2048 bits, saving it to a specific file:

--- a/pages/common/openssl-genrsa.md
+++ b/pages/common/openssl-genrsa.md
@@ -1,6 +1,6 @@
 # openssl genrsa
 
-> OpenSSL command to generate RSA private keys.
+> Generate RSA private keys.
 > More information: <https://docs.openssl.org/master/man1/openssl-genrsa/>.
 
 - Generate an RSA private key of 2048 bits to `stdout`:

--- a/pages/common/openssl-prime.md
+++ b/pages/common/openssl-prime.md
@@ -1,6 +1,6 @@
 # openssl prime
 
-> OpenSSL command to compute prime numbers.
+> Compute prime numbers.
 > More information: <https://docs.openssl.org/master/man1/openssl-prime/>.
 
 - Generate a 2048bit prime number and display it in hexadecimal:

--- a/pages/common/openssl-req.md
+++ b/pages/common/openssl-req.md
@@ -1,6 +1,6 @@
 # openssl req
 
-> OpenSSL command to manage PKCS#10 Certificate Signing Requests.
+> Manage PKCS#10 Certificate Signing Requests.
 > More information: <https://docs.openssl.org/master/man1/openssl-req/>.
 
 - Generate a certificate signing request to be sent to a certificate authority:

--- a/pages/common/openssl-s_client.md
+++ b/pages/common/openssl-s_client.md
@@ -1,6 +1,6 @@
 # openssl s_client
 
-> OpenSSL command to create TLS client connections.
+> Create TLS client connections.
 > More information: <https://docs.openssl.org/master/man1/openssl-s_client/>.
 
 - Display the start and expiry dates for a domain's certificate:

--- a/pages/common/openssl-ts.md
+++ b/pages/common/openssl-ts.md
@@ -1,6 +1,6 @@
 # openssl ts
 
-> OpenSSL command to generate and verify timestamps.
+> Generate and verify timestamps.
 > More information: <https://docs.openssl.org/master/man1/openssl-ts/>.
 
 - Generate a SHA-512 timestamp request of a specific file and output to `file.tsq`:

--- a/pages/common/openssl-x509.md
+++ b/pages/common/openssl-x509.md
@@ -1,6 +1,6 @@
 # openssl x509
 
-> OpenSSL command to manage X.509 certificates.
+> Manage X.509 certificates.
 > More information: <https://docs.openssl.org/master/man1/openssl-x509/>.
 
 - Display certificate information:


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).