### PR TITLE
ohdear-cli: remove "More information"

### DIFF
--- a/pages.ko/common/ohdear-cli.md
+++ b/pages.ko/common/ohdear-cli.md
@@ -1,7 +1,6 @@
 # ohdear-cli
 
 > 이 명령은 `ohdear`로 이름이 변경됨.
-> 더 많은 정보: <https://ohdear.app/docs/tools-and-sdks/our-cli-tool#available-commands>.
 
 - 현재 이름으로 해당 명령의 문서를 확인:
 

--- a/pages/common/ohdear-cli.md
+++ b/pages/common/ohdear-cli.md
@@ -1,7 +1,6 @@
 # ohdear-cli
 
 > This command has been renamed to `ohdear`.
-> More information: <https://ohdear.app/docs/tools-and-sdks/our-cli-tool#available-commands>.
 
 - View documentation for the command under its current name:
 


### PR DESCRIPTION
This page redirects to `ohdear`, which has the same more info link as this page.
relevant issue: https://github.com/tldr-pages/tldr/issues/14542