### PR TITLE
qm-*: add subcommand aliases for Spanish pages

### DIFF
--- a/pages.es/linux/qm-config.md
+++ b/pages.es/linux/qm-config.md
@@ -5,12 +5,12 @@
 
 - Muestra la configuración de la máquina virtual:
 
-`qm config {{id_mv}}`
+`qm {{[co|config]}} {{id_mv}}`
 
 - Muestra los valores de configuración actuales en lugar de los valores pendientes en la máquina virtual:
 
-`qm config --current {{true}} {{id_mv}}`
+`qm {{[co|config]}} --current {{true}} {{id_mv}}`
 
 - Obtiene los valores de configuración de la instantánea (snapshot) dada:
 
-`qm config --snapshot {{nombre_de_la_instantánea}} {{id_mv}}`
+`qm {{[co|config]}} --snapshot {{nombre_de_la_instantánea}} {{id_mv}}`

--- a/pages.es/linux/qm-delsnapshot.md
+++ b/pages.es/linux/qm-delsnapshot.md
@@ -5,8 +5,8 @@
 
 - Elimina una instantánea:
 
-`qm delsnapshot {{id_mv}} {{nombre_de_la_instantánea}}`
+`qm {{[del|delsnapshot]}} {{id_mv}} {{nombre_de_la_instantánea}}`
 
 - Elimina una instantánea de un archivo de configuración (incluso si la eliminación del disco de la instantánea falla):
 
-`qm delsnapshot {{id_mv}} {{nombre_de_la_instantánea}} --force 1`
+`qm {{[del|delsnapshot]}} {{id_mv}} {{nombre_de_la_instantánea}} --force 1`

--- a/pages.es/linux/qm-destroy.md
+++ b/pages.es/linux/qm-destroy.md
@@ -5,16 +5,16 @@
 
 - Destruye una máquina virtual específica:
 
-`qm destroy {{id_mv}}`
+`qm {{[des|destroy]}} {{id_mv}}`
 
 - Destruye todos los discos que no se mencionan explícitamente en la configuración de una máquina virtual específica:
 
-`qm destroy {{id_mv}} --destroy-unreferenced-disks`
+`qm {{[des|destroy]}} {{id_mv}} --destroy-unreferenced-disks`
 
 - Destruye una máquina virtual y la elimina de todos los lugares (inventarios, trabajos de copia de seguridad, manejadores de alta disponibilidad, etc.):
 
-`qm destroy {{id_mv}} --purge`
+`qm {{[des|destroy]}} {{id_mv}} --purge`
 
 - Destruye una máquina virtual específica ignorando las cerraduras (locks) y forzando su destrucción:
 
-`sudo qm destroy {{id_mv}} --skiplock`
+`sudo qm {{[des|destroy]}} {{id_mv}} --skiplock`

--- a/pages.es/linux/qm-help.md
+++ b/pages.es/linux/qm-help.md
@@ -5,8 +5,8 @@
 
 - Muestra ayuda para una orden específica:
 
-`qm help {{orden}}`
+`qm {{[h|help]}} {{orden}}`
 
 - Muestra ayuda para una orden específica con información detallada:
 
-`qm help {{orden}} --verbose {{true|false}}`
+`qm {{[h|help]}} {{orden}} --verbose {{true|false}}`

--- a/pages.es/linux/qm-listsnapshot.md
+++ b/pages.es/linux/qm-listsnapshot.md
@@ -5,4 +5,4 @@
 
 - Lista todas las instantáneas de una máquina virtual específica:
 
-`qm listsnapshot {{id_mv}}`
+`qm {{[lists|listsnapshot]}} {{id_mv}}`

--- a/pages.es/linux/qm-migrate.md
+++ b/pages.es/linux/qm-migrate.md
@@ -6,20 +6,20 @@
 
 - Migra una máquina virtual específica:
 
-`qm migrate {{id_mv}} {{destino}}`
+`qm {{[mi|migrate]}} {{id_mv}} {{destino}}`
 
 - Supera el límite de ancho de banda E/S actual con 10 KiB/s:
 
-`qm migrate {{id_mv}} {{destino}} --bwlimit 10`
+`qm {{[mi|migrate]}} {{id_mv}} {{destino}} --bwlimit 10`
 
 - Permite la migración de máquinas virtuales usando dispositivos locales (solo root):
 
-`qm migrate {{id_mv}} {{destino}} --force true`
+`qm {{[mi|migrate]}} {{id_mv}} {{destino}} --force true`
 
 - Utiliza la migración en vivo (online) si una máquina virtual está ejecutándose:
 
-`qm migrate {{id_mv}} {{destino}} --online true`
+`qm {{[mi|migrate]}} {{id_mv}} {{destino}} --online true`
 
 - Permite la migración de almacenamiento en vivo para discos locales:
 
-`qm migrate {{id_mv}} {{destino}} --with-local-disks true`
+`qm {{[mi|migrate]}} {{id_mv}} {{destino}} --with-local-disks true`

--- a/pages.es/linux/qm-monitor.md
+++ b/pages.es/linux/qm-monitor.md
@@ -5,4 +5,4 @@
 
 - Introduce la interfaz QEMU Monitor de una máquina virtual específica:
 
-`qm monitor {{id_mv}}`
+`qm {{[mo|monitor]}} {{id_mv}}`

--- a/pages.es/linux/qm-mtunnel.md
+++ b/pages.es/linux/qm-mtunnel.md
@@ -6,4 +6,4 @@
 
 - Comando utilizado por `qmigrate` durante la migración de datos de una MV a otro host:
 
-`qm mtunnel`
+`qm {{[mt|mtunnel]}}`

--- a/pages.es/linux/qm-nbdstop.md
+++ b/pages.es/linux/qm-nbdstop.md
@@ -5,4 +5,4 @@
 
 - Detiene el servidor nbd integrado:
 
-`qm nbdstop {{VM_ID}}`
+`qm {{[n|nbdstop]}} {{VM_ID}}`

--- a/pages.es/linux/qm-pending.md
+++ b/pages.es/linux/qm-pending.md
@@ -5,4 +5,4 @@
 
 - Obtiene la configuración de la máquina virtual de una máquina virtual (mv) específica:
 
-`qm pending {{id_mv}}`
+`qm {{[p|pending]}} {{id_mv}}`

--- a/pages.es/linux/qm-reboot.md
+++ b/pages.es/linux/qm-reboot.md
@@ -5,8 +5,8 @@
 
 - Reinicia una máquina virtual:
 
-`qm reboot {{id_mv}}`
+`qm {{[reb|reboot]}} {{id_mv}}`
 
 - Reinicia una máquina virtual después de esperar por lo menos 10 segundos:
 
-`qm reboot --timeout {{10}} {{id_mv}}`
+`qm {{[reb|reboot]}} --timeout {{10}} {{id_mv}}`

--- a/pages.es/linux/qm-resume.md
+++ b/pages.es/linux/qm-resume.md
@@ -5,8 +5,8 @@
 
 - Reanuda una máquina virtual dada:
 
-`qm resume {{id_mv}}`
+`qm {{[resu|resume]}} {{id_mv}}`
 
 - Recupera una máquina virtual específica omitiendo cualquier bloqueo (requiere root):
 
-`sudo qm resume {{id_mv}} --skiplock true`
+`sudo qm {{[resu|resume]}} {{id_mv}} --skiplock true`

--- a/pages.es/linux/qm-rollback.md
+++ b/pages.es/linux/qm-rollback.md
@@ -5,4 +5,4 @@
 
 - Revierte el estado de una MV a una instantánea dada:
 
-`qm rollback {{id_mv}} {{nombre_de_la_instantánea}}`
+`qm {{[ro|rollback]}} {{id_mv}} {{nombre_de_la_instantánea}}`

--- a/pages.es/linux/qm-sendkey.md
+++ b/pages.es/linux/qm-sendkey.md
@@ -5,8 +5,8 @@
 
 - Envía el evento de teclado (key) especificado a una máquina virtual específica:
 
-`qm sendkey {{id_mv}} {{tecla}}`
+`qm {{[sen|sendkey]}} {{id_mv}} {{tecla}}`
 
 - Permite al usuario root enviar el evento clave e ignorar cualquier bloqueo:
 
-`qm sendkey --skiplock {{true}} {{id_mv}} {{tecla}}`
+`qm {{[sen|sendkey]}} --skiplock {{true}} {{id_mv}} {{tecla}}`

--- a/pages.es/linux/qm-showcmd.md
+++ b/pages.es/linux/qm-showcmd.md
@@ -5,12 +5,12 @@
 
 - Muestra la línea de comando inicial de una máquina virtual específica:
 
-`qm showcmd {{id_mv}}`
+`qm {{[sho|showcmd]}} {{id_mv}}`
 
 - Pone cada opción en una nueva línea para mejorar la legibilidad:
 
-`qm showcmd --pretty {{true}} {{id_mv}}`
+`qm {{[sho|showcmd]}} --pretty {{true}} {{id_mv}}`
 
 - Obtiene valores de configuración de una instantánea específica:
 
-`qm showcmd --snapshot {{cadena}} {{id_mv}}`
+`qm {{[sho|showcmd]}} --snapshot {{cadena}} {{id_mv}}`

--- a/pages.es/linux/qm-shutdown.md
+++ b/pages.es/linux/qm-shutdown.md
@@ -5,20 +5,20 @@
 
 - Apaga una máquina virtual:
 
-`qm shutdown {{VM_ID}}`
+`qm {{[shu|shutdown]}} {{VM_ID}}`
 
 - Apaga una máquina virtual después de esperar por lo menos 10 segundos:
 
-`qm shutdown --timeout {{10}} {{VM_ID}}`
+`qm {{[shu|shutdown]}} --timeout {{10}} {{VM_ID}}`
 
 - Apaga una máquina virtual y no desactiva los volúmenes de almacenamiento:
 
-`qm shutdown --keepActive {{true}} {{VM_ID}}`
+`qm {{[shu|shutdown]}} --keepActive {{true}} {{VM_ID}}`
 
 - Apaga una máquina virtual y omite cualquier bloqueo (solo el root puede usar esta opción):
 
-`qm shutdown --skiplock {{true}} {{VM_ID}}`
+`qm {{[shu|shutdown]}} --skiplock {{true}} {{VM_ID}}`
 
 - Detiene y apaga una máquina virtual:
 
-`qm shutdown --forceStop {{true}} {{VM_ID}}`
+`qm {{[shu|shutdown]}} --forceStop {{true}} {{VM_ID}}`

--- a/pages.es/linux/qm-status.md
+++ b/pages.es/linux/qm-status.md
@@ -5,8 +5,8 @@
 
 - Muestra el estado de una máquina virtual dada:
 
-`qm status {{id_mv}}`
+`qm {{[stat|status]}} {{id_mv}}`
 
 - Muestra el estado detallado de una máquina virtual dada:
 
-`qm status --verbose {{true}} {{id_mv}}`
+`qm {{[stat|status]}} --verbose {{true}} {{id_mv}}`

--- a/pages.es/linux/qm-suspend.md
+++ b/pages.es/linux/qm-suspend.md
@@ -6,12 +6,12 @@
 
 - Suspende una máquina virtual por ID:
 
-`qm suspend {{id_mv}} {{entero}}`
+`qm {{[su|suspend]}} {{id_mv}} {{entero}}`
 
 - Omite el chequeo de bloqueo al suspender una MV:
 
-`qm suspend {{id_mv}} {{entero}} --skiplock`
+`qm {{[su|suspend]}} {{id_mv}} {{entero}} --skiplock`
 
 - Omite el chequeo de bloqueo por almacenamiento al suspender una MV:
 
-`qm suspend {{id_mv}} {{entero}} --skiplockstorage`
+`qm {{[su|suspend]}} {{id_mv}} {{entero}} --skiplockstorage`

--- a/pages.es/linux/qm-template.md
+++ b/pages.es/linux/qm-template.md
@@ -5,4 +5,4 @@
 
 - Crea una plantilla a partir de una máquina virtual dada:
 
-`qm template {{id_mv}}`
+`qm {{[tem|template]}} {{id_mv}}`

--- a/pages.es/linux/qm-unlock.md
+++ b/pages.es/linux/qm-unlock.md
@@ -5,4 +5,4 @@
 
 - Desbloquea una máquina virtual específica:
 
-`qm unlock {{id_mv}}`
+`qm {{[u|unlock]}} {{id_mv}}`

--- a/pages.es/linux/qm-vncproxy.md
+++ b/pages.es/linux/qm-vncproxy.md
@@ -5,4 +5,4 @@
 
 - Hace proxy de una máquina virtual específica:
 
-`qm vncproxy {{id_mv}}`
+`qm {{[v|vncproxy]}} {{id_mv}}`

--- a/pages.es/linux/qm-wait.md
+++ b/pages.es/linux/qm-wait.md
@@ -5,12 +5,12 @@
 
 - Espera hasta que se detenga la máquina virtual:
 
-`qm wait {{id_mv}}`
+`qm {{[w|wait]}} {{id_mv}}`
 
 - Espera hasta que la máquina virtual se detenga con un tiempo de espera máximo de 10 segundos:
 
-`qm wait --timeout {{10}} {{id_mv}}`
+`qm {{[w|wait]}} --timeout {{10}} {{id_mv}}`
 
 - Envía una solicitud de apagado, luego espera hasta que la máquina virtual se detenga con un tiempo máximo de espera de 10 segundos:
 
-`qm shutdown {{id_mv}} && qm wait --timeout {{10}} {{id_mv}}`
+`qm {{[shu|shutdown]}} {{id_mv}} && qm {{[w|wait]}} --timeout {{10}} {{id_mv}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
