### PR TITLE
gst-inspect-1.0: add vaapi example back

### DIFF
--- a/pages/common/gst-inspect-1.0.md
+++ b/pages/common/gst-inspect-1.0.md
@@ -9,7 +9,7 @@
 
 - List hardware transcoding capabilities of your device:
 
-`gst-inspect-1.0 {{va|nvcodec|...}}`
+`gst-inspect-1.0 {{va|vaapi|nvcodec|...}}`
 
 - List available container plugins:
 


### PR DESCRIPTION
va is a rewrite of vaapi, not a rename. Thus they should exist as separate entries.