### PR TITLE
pages/es: add curl, nmap, jq, brew-install, git-stash Spanish translations

### DIFF
--- a/pages.es/common/brew-install.md
+++ b/pages.es/common/brew-install.md
@@ -1,0 +1,16 @@
+# brew install
+
+> Instala una fórmula o cask de Homebrew.
+> Más información: <https://docs.brew.sh/Manpage#install-options-formulacask->.
+
+- Instala una fórmula o cask:
+
+`brew install {{formula|cask}}`
+
+- Compila e instala una fórmula desde el código fuente (las dependencias se seguirán instalando desde bottles):
+
+`brew install {{[-s|--build-from-source]}} {{formula}}`
+
+- Descarga el manifiesto, muestra lo que se instalaría pero sin instalar nada:
+
+`brew install {{[-n|--dry-run]}} {{formula|cask}}`

--- a/pages.es/common/curl.md
+++ b/pages.es/common/curl.md
@@ -1,0 +1,38 @@
+# curl
+
+> Transfiere datos desde o hacia un servidor.
+> Admite la mayoría de los protocolos, incluyendo HTTP, HTTPS, FTP, SCP, etc.
+> Ver también: `wcurl`, `wget`.
+> Más información: <https://curl.se/docs/manpage.html>.
+
+- Realiza una petición HTTP GET y vuelca el contenido en `stdout`:
+
+`curl {{https://example.com}}`
+
+- Realiza una petición HTTP GET, sigue cualquier redirección `3xx` y vuelca las cabeceras y el contenido en `stdout`:
+
+`curl {{[-L|--location]}} {{[-D|--dump-header]}} - {{https://example.com}}`
+
+- Descarga un archivo guardando la salida con el nombre indicado en la URL:
+
+`curl {{[-O|--remote-name]}} {{https://example.com/archivo.zip}}`
+
+- Envía datos codificados como formulario (petición POST de tipo `application/x-www-form-urlencoded`). Usa `--data @nombre_archivo` o `--data @'-'` para leer desde `stdin`:
+
+`curl {{[-X|--request]}} POST {{[-d|--data]}} '{{nombre=bob}}' {{http://example.com/formulario}}`
+
+- Envía una petición con una cabecera extra, usando un método HTTP personalizado y a través de un proxy (como BurpSuite), ignorando certificados autofirmados no seguros:
+
+`curl {{[-k|--insecure]}} {{[-x|--proxy]}} {{http://127.0.0.1:8080}} {{[-H|--header]}} '{{Authorization: Bearer token}}' {{[-X|--request]}} {{GET|PUT|POST|DELETE|PATCH|...}} {{https://example.com}}`
+
+- Envía datos en formato JSON especificando la cabecera Content-Type apropiada:
+
+`curl {{[-d|--data]}} '{{{"nombre":"bob"}}}' {{[-H|--header]}} '{{Content-Type: application/json}}' {{http://example.com/usuarios/1234}}`
+
+- Pasa un certificado de cliente y clave privada para la petición, omitiendo la validación del certificado:
+
+`curl {{[-E|--cert]}} {{cliente.pem}} --key {{clave.pem}} {{[-k|--insecure]}} {{https://example.com}}`
+
+- Resuelve un nombre de host a una dirección IP personalizada con salida detallada (similar a editar `/etc/hosts` para resolución DNS personalizada):
+
+`curl {{[-v|--verbose]}} --resolve {{example.com}}:{{80}}:{{127.0.0.1}} {{http://example.com}}`

--- a/pages.es/common/git-stash.md
+++ b/pages.es/common/git-stash.md
@@ -1,35 +1,35 @@
 # git stash
 
-> Almacena los cambios locales de Git en un área temporal.
+> Guarda los cambios locales de Git en un área temporal.
 > Más información: <https://git-scm.com/docs/git-stash>.
 
-- Almacena los cambios actuales, excepto los archivos nuevos (sin seguimiento):
+- Guarda los cambios actuales con un mensaje, excepto archivos nuevos (sin seguimiento):
 
-`git stash push {{[-m|--message]}} {{mensaje_opcional_stash}}`
+`git stash push {{[-m|--message]}} {{mensaje_stash}}`
 
-- Almacena los cambios actuales, incluyendo los archivos nuevos (sin seguimiento):
+- Guarda los cambios actuales, incluyendo archivos nuevos sin seguimiento:
 
 `git stash {{[-u|--include-untracked]}}`
 
-- Selecciona interactivamente partes de los archivos modificados para almacenarlos:
+- Selecciona interactivamente partes de los archivos modificados para guardar:
 
 `git stash {{[-p|--patch]}}`
 
-- Lista todos los stashes (muestra el nombre del stash, la rama relacionada y el mensaje):
+- Lista todos los stashes (muestra el nombre, la rama relacionada y el mensaje):
 
 `git stash list`
 
-- Muestra los cambios como un parche entre el stash (por defecto es `stash@{0}`) y la confirmación de cuando se creó la entrada stash por primera vez:
+- Muestra los cambios como un parche entre el stash (por defecto `stash@{0}`) y el commit en el que se creó la entrada del stash:
 
 `git stash show {{[-p|--patch]}} {{stash@{0}}}`
 
-- Aplica un stash (por defecto es el último, llamado `stash@{0}`):
+- Aplica un stash (por defecto el más reciente, llamado `stash@{0}`):
 
-`git stash apply {{nombre_opcional_del_stash_o_confirmación}}`
+`git stash apply {{nombre_stash_o_commit_opcional}}`
 
-- Suelta o aplica un stash (por defecto es `stash@{0}`) y lo elimina de la lista de stash si su aplicación no causa conflictos:
+- Aplica un stash (por defecto `stash@{0}`) y lo elimina de la lista si no hay conflictos:
 
-`git stash pop {{nombre_opcional_stash}}`
+`git stash pop {{nombre_stash_opcional}}`
 
 - Elimina todos los stashes:
 

--- a/pages.es/common/jq.md
+++ b/pages.es/common/jq.md
@@ -1,0 +1,36 @@
+# jq
+
+> Procesador de JSON que utiliza un lenguaje de dominio específico (DSL).
+> Más información: <https://jqlang.org/manual/>.
+
+- Ejecuta una expresión específica usando solo el binario `jq` (imprime la salida JSON con colores y formato):
+
+`jq '.' {{ruta/al/archivo.json}}`
+
+- Ejecuta un script específico:
+
+`{{cat ruta/al/archivo.json}} | jq {{[-f|--from-file]}} {{ruta/al/script.jq}}`
+
+- Pasa argumentos específicos:
+
+`{{cat ruta/al/archivo.json}} | jq {{--arg "nombre1" "valor1" --arg "nombre2" "valor2" ...}} '{{. + $ARGS.named}}'`
+
+- Crea un nuevo objeto JSON a partir de objetos JSON de múltiples archivos:
+
+`{{cat ruta/a/multiples_archivos_json_*.json}} | jq '{{{nuevaClave1: .clave1, nuevaClave2: .clave2.claveAnidada, ...}}}'`
+
+- Imprime elementos específicos de un array:
+
+`{{cat ruta/al/archivo.json}} | jq '{{.[indice1], .[indice2], ...}}'`
+
+- Imprime todos los valores de un array u objeto:
+
+`{{cat ruta/al/archivo.json}} | jq '.[]'`
+
+- Imprime objetos con filtro de 2 condiciones en un array:
+
+`{{cat ruta/al/archivo.json}} | jq '.[] | select((.clave1=="valor1") and .clave2=="valor2")'`
+
+- Añade o elimina claves específicas:
+
+`{{cat ruta/al/archivo.json}} | jq '. {{+|-}} {{{"clave1": "valor1", "clave2": "valor2", ...}}}'`

--- a/pages.es/common/nmap.md
+++ b/pages.es/common/nmap.md
@@ -1,38 +1,38 @@
 # nmap
 
-> Herramienta de exploración de redes y escáner de seguridad/puertos.
-> Algunas funciones (por ejemplo, el escaneo SYN) solo se activan cuando se ejecuta `nmap` con privilegios de root.
-> Vea también: `hping3`, `masscan`, `naabu`, `rustscan`, `zmap`.
+> Herramienta de exploración de redes y escáner de puertos/seguridad.
+> Algunas funciones (p. ej., escaneo SYN) solo se activan cuando `nmap` se ejecuta con privilegios de root.
+> Ver también: `hping3`, `masscan`, `naabu`, `rustscan`, `zmap`.
 > Más información: <https://nmap.org/book/man.html>.
 
-- Escanea los 1000 puertos principales de un host remoto con varios niveles de [v]erbosidad:
+- Escanea los 1000 puertos principales de un host remoto con distintos niveles de [v]erbosidad:
 
-`nmap -v{{1|2|3}} {{ip_o_nombre_del_host}}`
+`nmap -v{{1|2|3}} {{ip_o_nombre_host}}`
 
-- Ejecuta un barrido de ping sobre toda una [s]ub[n]et o hosts individuales de forma muy agresiva:
+- Realiza un barrido de ping en toda una [s]ub[r]ed o hosts individuales de forma muy agresiva:
 
-`nmap -T5 -sn {{192.168.0.0/24|ip_o_nombre_del_host1,ip_o_nombre_del_host2,...}}`
+`nmap -T5 -sn {{192.168.0.0/24|ip_o_host1,ip_o_host2,...}}`
 
-- Habilita la detección del sistema operativo, la detección de la versión, el escaneo de scripts y el traceroute de los hosts desde un archivo:
+- Activa detección de SO, de versión, análisis de scripts y traceroute de hosts desde un archivo:
 
 `sudo nmap -A -iL {{ruta/al/archivo.txt}}`
 
-- Escanea una lista específica de puertos (usa `-p-` para todos los puertos del 1 al 65535):
+- Escanea una lista específica de [p]uertos (usa `-p-` para todos los puertos del 1 al 65535):
 
 `nmap -p {{puerto1,puerto2,...}} {{ip_o_host1,ip_o_host2,...}}`
 
-- Realiza la detección de servicios y versiones de los 1000 puertos principales utilizando scripts NSE predeterminados, escribiendo los resultados (`-oA`) en archivos de salida:
+- Realiza detección de servicios y versiones en los 1000 puertos principales usando scripts NSE por defecto y escribe los resultados (`-oA`) en archivos de salida:
 
-`nmap -sC -sV -oA {{top-1000-ports}} {{ip_o_host1,ip_o_host2,...}}`
+`nmap -sC -sV -oA {{top-1000-puertos}} {{ip_o_host1,ip_o_host2,...}}`
 
-- Escanea los objetivos cuidadosamente utilizando scripts NSE "predeterminados y seguros":
+- Escanea el/los objetivo(s) cuidadosamente usando scripts NSE `default and safe`:
 
 `nmap --script "default and safe" {{ip_o_host1,ip_o_host2,...}}`
 
-- Escanea los servidores web que se ejecutan en los puertos estándar 80 y 443 utilizando todos los scripts NSE "http-*" disponibles:
+- Escanea servidores web en los [p]uertos estándar 80 y 443 usando todos los scripts NSE `http-*` disponibles:
 
 `nmap --script "http-*" {{ip_o_host1,ip_o_host2,...}} -p 80,443`
 
-- Intenta evadir la detección de IDS/IPS utilizando un escaneo extremadamente lento (`-T0`), direcciones de origen [D]e señuelo, paquetes [f]ragmentados, datos aleatorios y otros métodos:
+- Intenta evadir la detección de IDS/IPS usando un escaneo extremadamente lento (`-T0`), direcciones de origen [D]ecoy, paquetes [f]ragmentados, datos aleatorios y otros métodos:
 
-`sudo nmap -T0 -D {{señuelo_ip1,señuelo_ip2,...}} --source-port {{53}} -f --data-length {{16}} -Pn {{ip_o_host}}`
+`sudo nmap -T0 -D {{ip_decoy1,ip_decoy2,...}} --source-port {{53}} -f --data-length {{16}} -Pn {{ip_o_host}}`


### PR DESCRIPTION
## Description

Add Spanish translations for 5 missing/outdated pages:

- `curl` — HTTP client
- `nmap` — network scanner  
- `jq` — JSON processor
- `brew-install` — Homebrew package manager
- `git-stash` — Git stash management

All pages follow the [translation guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-guide.md).

## Checklist

- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The page(s) are based on the latest English version
- [x] Commands have been tested where possible