### PR TITLE
pages/es: add docker, ffmpeg, ssh, ssh-keygen, wget, tmux Spanish translations

### DIFF
--- a/pages.es/common/docker-build.md
+++ b/pages.es/common/docker-build.md
@@ -1,0 +1,32 @@
+# docker build
+
+> Construye una imagen a partir de un Dockerfile.
+> Más información: <https://docs.docker.com/reference/cli/docker/buildx/build/>.
+
+- Construye una imagen Docker usando el Dockerfile del directorio actual:
+
+`docker build .`
+
+- Construye una imagen Docker desde un Dockerfile en una URL específica:
+
+`docker build {{github.com/creack/docker-firefox}}`
+
+- Construye una imagen Docker y la etiqueta:
+
+`docker build {{[-t|--tag]}} {{nombre:etiqueta}} .`
+
+- Construye una imagen Docker sin contexto de compilación:
+
+`docker < {{Dockerfile}} build {{[-t|--tag]}} {{nombre:etiqueta}} -`
+
+- No usa la caché al construir la imagen:
+
+`docker build --no-cache {{[-t|--tag]}} {{nombre:etiqueta}} .`
+
+- Construye una imagen Docker usando un Dockerfile específico:
+
+`docker build {{[-f|--file]}} {{Dockerfile}} .`
+
+- Construye con variables personalizadas en tiempo de compilación:
+
+`docker build --build-arg {{HTTP_PROXY=http://10.20.30.2:1234}} --build-arg {{FTP_PROXY=http://40.50.60.5:4567}} .`

--- a/pages.es/common/docker-inspect.md
+++ b/pages.es/common/docker-inspect.md
@@ -1,0 +1,32 @@
+# docker inspect
+
+> Muestra información de bajo nivel sobre objetos de Docker.
+> Más información: <https://docs.docker.com/reference/cli/docker/inspect/>.
+
+- Muestra información sobre un contenedor, imagen o volumen usando un nombre o ID:
+
+`docker inspect {{contenedor|imagen|ID}}`
+
+- Muestra la dirección IP de un contenedor:
+
+`docker inspect {{[-f|--format]}} '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{contenedor}}`
+
+- Muestra la ruta al archivo de log del contenedor:
+
+`docker inspect {{[-f|--format]}} '\{\{.LogPath\}\}' {{contenedor}}`
+
+- Muestra el nombre de la imagen del contenedor:
+
+`docker inspect {{[-f|--format]}} '\{\{.Config.Image\}\}' {{contenedor}}`
+
+- Muestra la información de configuración en formato JSON:
+
+`docker inspect {{[-f|--format]}} '\{\{json .Config\}\}' {{contenedor}}`
+
+- Muestra todos los enlaces de puertos:
+
+`docker inspect {{[-f|--format]}} '\{\{range $p, $conf := .NetworkSettings.Ports\}\} \{\{$p\}\} -> \{\{(index $conf 0).HostPort\}\} \{\{end\}\}' {{contenedor}}`
+
+- Muestra la ayuda:
+
+`docker inspect`

--- a/pages.es/common/docker-login.md
+++ b/pages.es/common/docker-login.md
@@ -1,0 +1,20 @@
+# docker login
+
+> Inicia sesión en un registro de Docker.
+> Más información: <https://docs.docker.com/reference/cli/docker/login/>.
+
+- Inicia sesión en un registro de forma interactiva:
+
+`docker login`
+
+- Inicia sesión en un registro con un nombre de usuario específico (se pedirá la contraseña):
+
+`docker login {{[-u|--username]}} {{usuario}}`
+
+- Inicia sesión en un registro con usuario y contraseña:
+
+`docker login {{[-u|--username]}} {{usuario}} {{[-p|--password]}} {{contraseña}} {{servidor}}`
+
+- Inicia sesión en un registro con la contraseña desde `stdin`:
+
+`echo "{{contraseña}}" | docker login {{[-u|--username]}} {{usuario}} --password-stdin`

--- a/pages.es/common/docker-search.md
+++ b/pages.es/common/docker-search.md
@@ -1,0 +1,28 @@
+# docker search
+
+> Busca imágenes de Docker en Docker Hub.
+> Más información: <https://docs.docker.com/reference/cli/docker/search/>.
+
+- Busca imágenes de Docker por nombre o palabra clave:
+
+`docker search {{palabra_clave}}`
+
+- Busca imágenes y muestra solo las oficiales:
+
+`docker search {{[-f|--filter]}} is-official=true {{palabra_clave}}`
+
+- Busca imágenes y muestra solo las compilaciones automatizadas:
+
+`docker search {{[-f|--filter]}} is-automated=true {{palabra_clave}}`
+
+- Busca imágenes con un número mínimo de estrellas:
+
+`docker search {{[-f|--filter]}} stars={{número}} {{palabra_clave}}`
+
+- Limita el número de resultados:
+
+`docker search --limit {{número}} {{palabra_clave}}`
+
+- Personaliza el formato de salida:
+
+`docker search {{[-f|--format]}} "{{.Name}}: {{.Description}}" {{palabra_clave}}`

--- a/pages.es/common/ffmpeg.md
+++ b/pages.es/common/ffmpeg.md
@@ -1,0 +1,37 @@
+# ffmpeg
+
+> Herramienta de conversión de video.
+> Ver también: `gst-launch-1.0`.
+> Más información: <https://ffmpeg.org/ffmpeg.html#Options>.
+
+- Extrae el sonido de un video y lo guarda como MP3:
+
+`ffmpeg -i {{ruta/al/video.mp4}} -vn {{ruta/al/sonido.mp3}}`
+
+- Transcodifica un archivo FLAC al formato Red Book CD (44100kHz, 16 bits):
+
+`ffmpeg -i {{ruta/al/audio_entrada.flac}} -ar 44100 -sample_fmt s16 {{ruta/al/audio_salida.wav}}`
+
+- Guarda un video como GIF escalando la altura a 1000px y ajustando la tasa de fotogramas a 15:
+
+`ffmpeg -i {{ruta/al/video.mp4}} {{[-vf|-filter:v]}} 'scale=-1:1000' -r 15 {{ruta/al/salida.gif}}`
+
+- Combina imágenes numeradas (`frame_1.jpg`, `frame_2.jpg`, etc.) en un video o GIF:
+
+`ffmpeg -i {{ruta/al/frame_%d.jpg}} -f image2 {{video.mpg|video.gif}}`
+
+- Recorta un video desde un tiempo de inicio mm:ss hasta un tiempo de fin mm2:ss2 (omite -to para recortar hasta el final):
+
+`ffmpeg -i {{ruta/al/video_entrada.mp4}} -ss {{mm:ss}} -to {{mm2:ss2}} {{[-c|-codec]}} copy {{ruta/al/video_salida.mp4}}`
+
+- Convierte video AVI a MP4. Audio AAC @ 128kbits, video h264 @ CRF 23:
+
+`ffmpeg -i {{ruta/al/video_entrada}}.avi {{[-c|-codec]}}:a aac -b:a 128k {{[-c|-codec]}}:v libx264 -crf 23 {{ruta/al/video_salida}}.mp4`
+
+- Remultiplexa video MKV a MP4 sin recodificar los flujos de audio o video:
+
+`ffmpeg -i {{ruta/al/video_entrada}}.mkv {{[-c|-codec]}} copy {{ruta/al/video_salida}}.mp4`
+
+- Convierte video MP4 al codec VP9. Para la mejor calidad usa un valor CRF (rango recomendado 15-35) y -b:v DEBE ser 0:
+
+`ffmpeg -i {{ruta/al/video_entrada}}.mp4 {{[-c|-codec]}}:v libvpx-vp9 -crf {{30}} -b:v 0 {{[-c|-codec]}}:a libopus -vbr on -threads {{número_de_hilos}} {{ruta/al/video_salida}}.webm`

--- a/pages.es/common/ssh-keygen.md
+++ b/pages.es/common/ssh-keygen.md
@@ -1,0 +1,37 @@
+# ssh-keygen
+
+> Genera claves SSH usadas para autenticación, inicios de sesión sin contraseña y otras tareas.
+> Vea también: `ssh-copy-id`.
+> Más información: <https://man.openbsd.org/ssh-keygen>.
+
+- Genera una clave de forma interactiva:
+
+`ssh-keygen`
+
+- Genera una clave ed25519 con 32 rondas de la función de derivación de claves y guarda la clave en un archivo específico:
+
+`ssh-keygen -t ed25519 -a 32 -f {{~/.ssh/nombre_de_archivo}}`
+
+- Genera una clave RSA de 4096 bits con un correo electrónico como comentario:
+
+`ssh-keygen -t rsa -b 4096 -C "{{comentario|correo_electronico}}"`
+
+- Elimina las claves de un host del archivo `known_hosts` (útil cuando un host conocido tiene una nueva clave):
+
+`ssh-keygen -R {{host_remoto}}`
+
+- Obtiene la huella digital de una clave en MD5 Hex:
+
+`ssh-keygen -l -E md5 -f {{~/.ssh/nombre_de_archivo}}`
+
+- Cambia la contraseña de una clave:
+
+`ssh-keygen -p -f {{~/.ssh/nombre_de_archivo}}`
+
+- Cambia el tipo de formato de la clave (por ejemplo, de formato OPENSSH a PEM), el archivo se reescribirá en el lugar:
+
+`ssh-keygen -p -m PEM -f {{~/.ssh/clave_privada_OpenSSH}}`
+
+- Obtiene la clave pública a partir de la clave privada:
+
+`ssh-keygen -y -f {{~/.ssh/clave_privada_OpenSSH}}`

--- a/pages.es/common/ssh.md
+++ b/pages.es/common/ssh.md
@@ -1,0 +1,37 @@
+# ssh
+
+> Secure Shell es un protocolo para conectarse de forma segura a sistemas remotos.
+> Puede usarse para iniciar sesión o ejecutar comandos en un servidor remoto.
+> Más información: <https://man.openbsd.org/ssh>.
+
+- Conecta a un servidor remoto:
+
+`ssh {{usuario}}@{{host_remoto}}`
+
+- Conecta a un servidor remoto con una [i]dentidad específica (clave privada):
+
+`ssh -i {{ruta/al/archivo_clave}} {{usuario}}@{{host_remoto}}`
+
+- Conecta a un servidor con IP `10.0.0.1` y usando un [p]uerto específico:
+
+`ssh {{usuario}}@10.0.0.1 -p {{2222}}`
+
+- Ejecuta un comando en un servidor remoto con asignación de [t]ty para interacción:
+
+`ssh {{usuario}}@{{host_remoto}} -t {{comando}} {{argumentos_del_comando}}`
+
+- Túnel SSH: reenvío de puerto [D]inámico (proxy SOCKS en `localhost:1080`):
+
+`ssh -D {{1080}} {{usuario}}@{{host_remoto}}`
+
+- Túnel SSH: reenvía un puerto específico (`localhost:9999` a `example.org:80`) desactivando la asignación de pseudo-[T]ty y la ejecució[N] de comandos remotos:
+
+`ssh -L {{9999}}:{{example.org}}:{{80}} -N -T {{usuario}}@{{host_remoto}}`
+
+- SSH [J]umping: conecta a través de un jumphost a un servidor remoto (se pueden especificar múltiples saltos separados por comas):
+
+`ssh -J {{usuario}}@{{jump_host}} {{usuario}}@{{host_remoto}}`
+
+- Cierra una sesión colgada:
+
+`<Intro><~><.>`

--- a/pages.es/common/tmux.md
+++ b/pages.es/common/tmux.md
@@ -2,14 +2,14 @@
 
 > Multiplexor de terminal.
 > Permite múltiples sesiones con ventanas, paneles y más.
-> Vea también: `zellij`, `screen`.
+> Ver también: `zellij`, `screen`.
 > Más información: <https://github.com/tmux/tmux>.
 
 - Inicia una nueva sesión:
 
 `tmux`
 
-- Inicia una nueva sesión con nombre:
+- Inicia una nueva sesión con [n]ombre:
 
 `tmux {{[new|new-session]}} -s {{nombre}}`
 
@@ -17,11 +17,11 @@
 
 `tmux {{[ls|list-sessions]}}`
 
-- Adjunta a la última sesión utilizada:
+- Se adjunta a la sesión usada más recientemente:
 
 `tmux {{[a|attach]}}`
 
-- Separa la sesión actual (dentro de una sesión tmux):
+- Se desconecta de la sesión actual (dentro de una sesión tmux):
 
 `<Ctrl b><d>`
 
@@ -33,6 +33,6 @@
 
 `<Ctrl b><w>`
 
-- Da de baja una sesión por su nombre:
+- Termina una sesión por nombre de [o]bjetivo:
 
 `tmux kill-session -t {{nombre}}`

--- a/pages.es/common/wget.md
+++ b/pages.es/common/wget.md
@@ -1,0 +1,38 @@
+# wget
+
+> Descarga archivos de la web.
+> Admite HTTP, HTTPS y FTP.
+> Ver también: `wcurl`, `curl`.
+> Más información: <https://www.gnu.org/software/wget/manual/wget.html>.
+
+- Descarga el contenido de una URL en un archivo (llamado "foo" en este caso):
+
+`wget {{https://example.com/foo}}`
+
+- Descarga el contenido de una URL en un archivo con un nombre específico (llamado "bar"):
+
+`wget {{[-O|--output-document]}} {{bar}} {{https://example.com/foo}}`
+
+- Descarga una página web completa con todos sus recursos con intervalos de 3 segundos entre peticiones (scripts, hojas de estilo, imágenes, etc.):
+
+`wget {{[-pkw|--page-requisites --convert-links --wait]}} 3 {{https://example.com/some_page.html}}`
+
+- Descarga todos los archivos listados en un directorio y sus subdirectorios (no descarga elementos embebidos):
+
+`wget {{[-mnp|--mirror --no-parent]}} {{https://example.com/ruta/}}`
+
+- Limita la velocidad de descarga y el número de reintentos de conexión:
+
+`wget --limit-rate {{300k}} {{[-t|--tries]}} {{100}} {{https://example.com/ruta/}}`
+
+- Descarga un archivo de un servidor HTTP usando autenticación básica (también funciona con FTP):
+
+`wget --user {{usuario}} --password {{contraseña}} {{https://example.com}}`
+
+- Continúa una descarga incompleta:
+
+`wget {{[-c|--continue]}} {{https://example.com}}`
+
+- Descarga todas las URLs almacenadas en un archivo de texto a un directorio específico:
+
+`wget {{[-P|--directory-prefix]}} {{ruta/al/directorio}} {{[-i|--input-file]}} {{ruta/a/URLs.txt}}`


### PR DESCRIPTION
## Description

Add Spanish translations for 9 missing pages:

- `docker-build` — build Docker images
- `docker-login` — log into a Docker registry
- `docker-search` — search Docker Hub
- `docker-inspect` — inspect Docker objects
- `ffmpeg` — video conversion tool
- `ssh` — Secure Shell client
- `ssh-keygen` — SSH key generation
- `wget` — web file downloader
- `tmux` — terminal multiplexer

All pages follow the [translation guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-guide.md).

## Checklist

- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The page(s) are based on the latest English version
- [x] Commands have been tested where possible