### PR TITLE
pages/es: add openssl, docker-compose, ssh-copy-id, docker-image-ls, docker-container-ls Spanish translations

### DIFF
--- a/pages.es/common/docker-compose-down.md
+++ b/pages.es/common/docker-compose-down.md
@@ -1,0 +1,32 @@
+# docker compose down
+
+> Detiene y elimina los contenedores, redes, imágenes y volúmenes creados por `docker compose up`.
+> Más información: <https://docs.docker.com/reference/cli/docker/compose/down/>.
+
+- Detiene y elimina todos los contenedores y redes:
+
+`docker compose down`
+
+- Detiene y elimina contenedores, redes y todas las imágenes usadas por los servicios:
+
+`docker compose down --rmi all`
+
+- Detiene y elimina contenedores, redes y solo las imágenes sin etiqueta personalizada:
+
+`docker compose down --rmi local`
+
+- Detiene y elimina contenedores, redes y todos los volúmenes:
+
+`docker compose down {{[-v|--volumes]}}`
+
+- Detiene y elimina todo incluyendo contenedores huérfanos:
+
+`docker compose down --remove-orphans`
+
+- Detiene y elimina contenedores usando un archivo compose alternativo:
+
+`docker compose {{[-f|--file]}} {{ruta/a/config}} down`
+
+- Detiene y elimina contenedores con un tiempo de espera personalizado en segundos:
+
+`docker compose down {{[-t|--timeout]}} {{tiempo_espera}}`

--- a/pages.es/common/docker-compose-logs.md
+++ b/pages.es/common/docker-compose-logs.md
@@ -1,0 +1,32 @@
+# docker compose logs
+
+> Muestra la salida de los contenedores en una aplicación Docker Compose.
+> Más información: <https://docs.docker.com/reference/cli/docker/compose/logs/>.
+
+- Muestra los logs de todos los servicios:
+
+`docker compose logs`
+
+- Muestra los logs de un servicio específico:
+
+`docker compose logs {{nombre_servicio}}`
+
+- Muestra los logs y sigue la salida nueva (como `tail --follow`):
+
+`docker compose logs {{[-f|--follow]}}`
+
+- Muestra los logs con marcas de tiempo:
+
+`docker compose logs {{[-t|--timestamps]}}`
+
+- Muestra solo las últimas `n` líneas de logs por contenedor:
+
+`docker compose logs {{[-n|--tail]}} {{n}}`
+
+- Muestra los logs desde un momento específico en adelante:
+
+`docker compose logs --since {{marca_de_tiempo}}`
+
+- Muestra los logs hasta un momento específico:
+
+`docker compose logs --until {{marca_de_tiempo}}`

--- a/pages.es/common/docker-compose-up.md
+++ b/pages.es/common/docker-compose-up.md
@@ -1,0 +1,32 @@
+# docker compose up
+
+> Inicia y ejecuta los servicios de Docker definidos en un archivo Compose.
+> Más información: <https://docs.docker.com/reference/cli/docker/compose/up/>.
+
+- Inicia todos los servicios definidos en el archivo docker-compose:
+
+`docker compose up`
+
+- Inicia los servicios en segundo plano (modo desconectado):
+
+`docker compose up {{[-d|--detach]}}`
+
+- Inicia los servicios y reconstruye las imágenes antes de iniciar:
+
+`docker compose up --build`
+
+- Inicia solo servicios específicos:
+
+`docker compose up {{servicio1 servicio2 ...}}`
+
+- Inicia los servicios con un archivo compose personalizado:
+
+`docker compose {{[-f|--file]}} {{ruta/a/config}} up`
+
+- Inicia los servicios y elimina contenedores huérfanos:
+
+`docker compose up --remove-orphans`
+
+- Inicia los servicios con instancias escaladas:
+
+`docker compose up --scale {{servicio}}={{cantidad}}`

--- a/pages.es/common/docker-container-ls.md
+++ b/pages.es/common/docker-container-ls.md
@@ -1,0 +1,32 @@
+# docker container ls
+
+> Lista los contenedores de Docker.
+> Más información: <https://docs.docker.com/reference/cli/docker/container/ls/>.
+
+- Lista los contenedores de Docker en ejecución:
+
+`docker {{[ps|container ls]}}`
+
+- Lista todos los contenedores de Docker (en ejecución y detenidos):
+
+`docker {{[ps|container ls]}} {{[-a|--all]}}`
+
+- Muestra el último contenedor creado (incluye todos los estados):
+
+`docker {{[ps|container ls]}} {{[-l|--latest]}}`
+
+- Filtra contenedores que contienen una subcadena en su nombre:
+
+`docker {{[ps|container ls]}} {{[-f|--filter]}} "name={{nombre}}"`
+
+- Filtra contenedores que comparten una imagen como ancestro:
+
+`docker {{[ps|container ls]}} {{[-f|--filter]}} "ancestor={{imagen}}:{{etiqueta}}"`
+
+- Filtra contenedores por código de estado de salida:
+
+`docker {{[ps|container ls]}} {{[-a|--all]}} {{[-f|--filter]}} "exited={{código}}"`
+
+- Filtra contenedores por estado (created, running, removing, paused, exited, dead):
+
+`docker {{[ps|container ls]}} {{[-f|--filter]}} "status={{estado}}"`

--- a/pages.es/common/docker-image-ls.md
+++ b/pages.es/common/docker-image-ls.md
@@ -1,0 +1,28 @@
+# docker image ls
+
+> Lista las imágenes de Docker.
+> Más información: <https://docs.docker.com/reference/cli/docker/image/ls/>.
+
+- Lista todas las imágenes de Docker:
+
+`docker {{[images|image ls]}}`
+
+- Lista todas las imágenes de Docker incluyendo las intermedias:
+
+`docker {{[images|image ls]}} {{[-a|--all]}}`
+
+- Muestra la salida en modo silencioso (solo IDs numéricos):
+
+`docker {{[images|image ls]}} {{[-q|--quiet]}}`
+
+- Lista todas las imágenes de Docker no usadas por ningún contenedor:
+
+`docker {{[images|image ls]}} {{[-f|--filter]}} dangling=true`
+
+- Lista las imágenes que contienen una subcadena en su nombre:
+
+`docker {{[images|image ls]}} "{{*nombre*}}"`
+
+- Ordena las imágenes por tamaño:
+
+`docker {{[images|image ls]}} --format "\{\{.ID\}\}\t\{\{.Size\}\}\t\{\{.Repository\}\}:\{\{.Tag\}\}" | sort {{[-k|--key]}} 2 {{[-h|--human-numeric-sort]}}`

--- a/pages.es/common/openssl.md
+++ b/pages.es/common/openssl.md
@@ -1,0 +1,37 @@
+# openssl
+
+> Kit de herramientas criptográficas OpenSSL.
+> Algunos subcomandos como `req` tienen su propia documentación de uso.
+> Más información: <https://docs.openssl.org/master/man1/openssl/>.
+
+- Genera una clave privada y cifra el archivo de salida usando AES-256:
+
+`openssl genpkey -algorithm {{rsa|ec}} -out {{ruta/a/privada.key}} -aes256`
+
+- Genera la clave pública correspondiente a partir de la clave privada usando `rsa`:
+
+`openssl rsa -in {{ruta/a/privada.key}} -pubout -out {{ruta/a/publica.key}}`
+
+- Genera un certificado autofirmado válido por un número específico de días (365):
+
+`openssl req -new -x509 -key {{ruta/a/privada.key}} -out {{ruta/a/certificado.crt}} -days 365`
+
+- Convierte un certificado al formato `.pem` o `.der`:
+
+`openssl x509 -in {{ruta/a/certificado.crt}} -out {{ruta/a/certificado.pem|ruta/a/certificado.der}} -outform {{pem|der}}`
+
+- Verifica los detalles de un certificado:
+
+`openssl x509 -in {{ruta/a/certificado.crt}} -text -noout`
+
+- Genera una solicitud de firma de certificado (CSR):
+
+`openssl req -new -key {{ruta/a/privada.key}} -out {{ruta/a/solicitud.csr}}`
+
+- Muestra la ayuda:
+
+`openssl help`
+
+- Muestra la versión:
+
+`openssl version`

--- a/pages.es/common/ssh-copy-id.md
+++ b/pages.es/common/ssh-copy-id.md
@@ -1,0 +1,16 @@
+# ssh-copy-id
+
+> Instala tu clave pública en el archivo authorized_keys de una máquina remota.
+> Más información: <https://manned.org/ssh-copy-id>.
+
+- Copia tus claves a la máquina remota:
+
+`ssh-copy-id {{usuario}}@{{host_remoto}}`
+
+- Copia la clave pública indicada al equipo remoto:
+
+`ssh-copy-id -i {{ruta/al/certificado}} {{usuario}}@{{host_remoto}}`
+
+- Copia la clave pública indicada al equipo remoto con un puerto específico:
+
+`ssh-copy-id -i {{ruta/al/certificado}} -p {{puerto}} {{usuario}}@{{host_remoto}}`


### PR DESCRIPTION
## Description

Add Spanish translations for 7 missing pages:

- `openssl` — cryptographic toolkit
- `docker-compose-up` — start Docker Compose services
- `docker-compose-down` — stop Docker Compose services
- `docker-compose-logs` — view Compose container logs
- `ssh-copy-id` — install SSH public key on remote
- `docker-image-ls` — list Docker images
- `docker-container-ls` — list Docker containers

All pages follow the [translation guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-guide.md).

## Checklist

- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The page(s) are based on the latest English version
- [x] Commands have been tested where possible