### PR TITLE
pages/es: add openssl subcommands, nc, ssh-agent, ssh-keyscan Spanish translations

### DIFF
--- a/pages.es/common/nc.md
+++ b/pages.es/common/nc.md
@@ -1,32 +1,24 @@
 # nc
 
-> Redirige datos de entrada o salida a un flujo de red a través de esta versátil herramienta.
+> Redirige E/S hacia un flujo de red mediante esta versátil herramienta.
 > Más información: <https://manned.org/nc>.
 
-- Inicia un escuchador en un puerto TCP y le envía un archivo:
+- Inicia un [l]istener en el [p]uerto TCP especificado y envía un archivo hacia él:
 
-`nc -l -p {{puerto}} < {{nombre_de_archivo}}`
+`nc < {{nombre_archivo}} -l -p {{puerto}}`
 
-- Conecta a un escuchador en un puerto y recibe un archivo de él:
+- Se conecta a un listener destino en el puerto especificado y recibe un archivo de él:
 
-`nc {{host}} {{puerto}} > {{nombre_de_archivo_por_recibir}}`
+`nc {{host}} {{puerto}} > {{nombre_archivo_recibido}}`
 
-- Escanea los puertos TCP abiertos en un host:
+- Escanea los puertos TCP abiertos de un host específico:
 
-`nc -v -z -w {{tiempo_de_espera_en_segundos}} {{host}} {{puerto_inicial}}-{{puerto_final}}`
+`nc -v -z -w {{tiempo_espera_segundos}} {{host}} {{puerto_inicio}}-{{puerto_fin}}`
 
-- Inicia un escuchador en un puerto TCP y provee de acceso a tu intérprete de comandos local a la parte conectada (esto es peligroso y podría ser explotado):
+- Inicia un [l]istener en el [p]uerto TCP especificado y da acceso al shell local a la parte conectada (esto es peligroso y puede ser abusado):
 
-`nc -l -p {{puerto}} -e {{ejecutable_del_intérprete}}`
+`nc -l -p {{puerto}} -e {{ejecutable_shell}}`
 
-- Conecta a un escuchador y provee de acceso a tu intérprete de comandos local a una parte remota (esto es peligroso y podría ser explotado):
+- Se conecta a un listener destino y da acceso al shell local a la parte remota (esto es peligroso y puede ser abusado):
 
-`nc {{host}} {{puerto}} -e {{ejecutable_del_intérprete}}`
-
-- Actúa como un proxy y envía información de un puerto TCP local a un host remoto:
-
-`nc -l -p {{puerto_local}} | nc {{host}} {{puerto_remoto}}`
-
-- Envía una petición HTTP GET:
-
-`echo -e "GET / HTTP/1.1\nHost: {{host}}\n\n" | nc {{host}} 80`
+`nc {{host}} {{puerto}} -e {{ejecutable_shell}}`

--- a/pages.es/common/openssl-dgst.md
+++ b/pages.es/common/openssl-dgst.md
@@ -1,0 +1,24 @@
+# openssl dgst
+
+> Genera valores de resumen (digest) y realiza operaciones de firma.
+> Más información: <https://docs.openssl.org/master/man1/openssl-dgst/>.
+
+- Calcula el digest SHA256 de un archivo y guarda el resultado en un archivo específico:
+
+`openssl dgst -sha256 -binary -out {{archivo_salida}} {{archivo_entrada}}`
+
+- Firma un archivo usando una clave RSA y guarda el resultado en un archivo específico:
+
+`openssl dgst -sign {{archivo_clave_privada}} -sha256 -sigopt rsa_padding_mode:pss -out {{archivo_salida}} {{archivo_entrada}}`
+
+- Verifica una firma RSA:
+
+`openssl dgst -verify {{archivo_clave_publica}} -signature {{archivo_firma}} -sigopt rsa_padding_mode:pss {{archivo_mensaje_firmado}}`
+
+- Firma un archivo usando una clave ECDSA:
+
+`openssl dgst -sign {{archivo_clave_privada}} -sha256 -out {{archivo_salida}} {{archivo_entrada}}`
+
+- Verifica una firma ECDSA:
+
+`openssl dgst -verify {{archivo_clave_publica}} -signature {{archivo_firma}} {{archivo_mensaje_firmado}}`

--- a/pages.es/common/openssl-genrsa.md
+++ b/pages.es/common/openssl-genrsa.md
@@ -1,0 +1,16 @@
+# openssl genrsa
+
+> Genera claves privadas RSA.
+> Más información: <https://docs.openssl.org/master/man1/openssl-genrsa/>.
+
+- Genera una clave privada RSA de 2048 bits en `stdout`:
+
+`openssl genrsa`
+
+- Guarda una clave privada RSA de un número arbitrario de bits en el archivo de salida:
+
+`openssl genrsa -out {{archivo_salida.key}} {{1234}}`
+
+- Genera una clave privada RSA y la cifra con AES256 (se pedirá una frase de contraseña):
+
+`openssl genrsa {{-aes256}}`

--- a/pages.es/common/openssl-rand.md
+++ b/pages.es/common/openssl-rand.md
@@ -1,0 +1,20 @@
+# openssl rand
+
+> Genera bytes aleatorios usando un PRNG criptográficamente seguro.
+> Más información: <https://docs.openssl.org/master/man1/openssl-rand/>.
+
+- Genera una cadena hexadecimal de 8 bytes (16 caracteres) y la escribe en `stdout`:
+
+`openssl rand -hex 8`
+
+- Genera 20 bytes aleatorios codificados en base64:
+
+`openssl rand -base64 20`
+
+- Genera bytes aleatorios y los escribe en un archivo (sin codificación):
+
+`openssl rand -out {{ruta/al/archivo}} {{longitud}}`
+
+- Genera 1 KiB/MiB/GiB/TiB de bytes aleatorios codificados en hex/base64:
+
+`openssl rand -{{hex|base64}} 1{{K|M|G|T}}`

--- a/pages.es/common/openssl-req.md
+++ b/pages.es/common/openssl-req.md
@@ -1,0 +1,12 @@
+# openssl req
+
+> Gestiona Solicitudes de Firma de Certificado (CSR) PKCS#10.
+> Más información: <https://docs.openssl.org/master/man1/openssl-req/>.
+
+- Genera una solicitud de firma de certificado para enviar a una autoridad certificadora:
+
+`openssl req -new -sha256 -key {{nombre_archivo.key}} -out {{nombre_archivo.csr}}`
+
+- Genera un certificado autofirmado y su par de claves correspondiente, almacenando ambos en un archivo:
+
+`openssl req -new -x509 -newkey {{rsa}}:{{4096}} -keyout {{nombre_archivo.key}} -out {{nombre_archivo.cert}} -subj "{{/C=XX/CN=foobar}}" -days {{365}}`

--- a/pages.es/common/openssl-s_client.md
+++ b/pages.es/common/openssl-s_client.md
@@ -1,0 +1,20 @@
+# openssl s_client
+
+> Crea conexiones de cliente TLS.
+> Más información: <https://docs.openssl.org/master/man1/openssl-s_client/>.
+
+- Muestra las fechas de inicio y vencimiento del certificado de un dominio:
+
+`openssl s_client -connect {{host}}:{{puerto}} 2>/dev/null | openssl x509 -noout -dates`
+
+- Muestra el certificado presentado por un servidor SSL/TLS:
+
+`openssl < /dev/null s_client -connect {{host}}:{{puerto}}`
+
+- Establece el Indicador de Nombre de Servidor (SNI) al conectar al servidor SSL/TLS:
+
+`openssl s_client -connect {{host}}:{{puerto}} -servername {{nombre_host}}`
+
+- Muestra la cadena de certificados completa de un servidor HTTPS:
+
+`openssl < /dev/null s_client -connect {{host}}:443 -showcerts`

--- a/pages.es/common/openssl-x509.md
+++ b/pages.es/common/openssl-x509.md
@@ -1,0 +1,20 @@
+# openssl x509
+
+> Gestiona certificados X.509.
+> Más información: <https://docs.openssl.org/master/man1/openssl-x509/>.
+
+- Muestra información de un certificado:
+
+`openssl x509 -in {{nombre_archivo.crt}} -noout -text`
+
+- Muestra la fecha de vencimiento de un certificado:
+
+`openssl x509 -enddate -noout -in {{nombre_archivo.pem}}`
+
+- Convierte un certificado entre codificación binaria DER y codificación textual PEM:
+
+`openssl x509 -inform {{der}} -outform {{pem}} -in {{archivo_certificado_original}} -out {{archivo_certificado_convertido}}`
+
+- Almacena la clave pública de un certificado en un archivo:
+
+`openssl x509 -in {{archivo_certificado}} -noout -pubkey -out {{archivo_salida}}`

--- a/pages.es/common/ssh-agent.md
+++ b/pages.es/common/ssh-agent.md
@@ -1,0 +1,14 @@
+# ssh-agent
+
+> Inicia un proceso SSH Agent.
+> Nota: Un SSH Agent mantiene las claves SSH descifradas en memoria hasta que se eliminan o se mata el proceso.
+> Ver también: `ssh-add`.
+> Más información: <https://man.openbsd.org/ssh-agent>.
+
+- Inicia un SSH Agent para el shell actual:
+
+`eval $(ssh-agent)`
+
+- Termina el agente en ejecución actual:
+
+`ssh-agent -k`

--- a/pages.es/common/ssh-keyscan.md
+++ b/pages.es/common/ssh-keyscan.md
@@ -1,0 +1,20 @@
+# ssh-keyscan
+
+> Obtiene las claves SSH públicas de hosts remotos.
+> Más información: <https://man.openbsd.org/ssh-keyscan>.
+
+- Obtiene todas las claves SSH públicas de un host remoto:
+
+`ssh-keyscan {{nombre_host}}`
+
+- Obtiene todas las claves SSH públicas de un host remoto escuchando en un puerto específico:
+
+`ssh-keyscan -p {{puerto}} {{nombre_host}}`
+
+- Obtiene ciertos tipos de claves SSH públicas de un host remoto:
+
+`ssh-keyscan -t {{rsa,dsa,ecdsa,ed25519}} {{nombre_host}}`
+
+- Actualiza manualmente el archivo SSH known_hosts con la huella digital de un host dado:
+
+`ssh-keyscan -H {{nombre_host}} >> ~/.ssh/known_hosts`


### PR DESCRIPTION
## Description

Add Spanish translations for 9 security-focused missing pages:

- `openssl-req` — manage CSR PKCS#10
- `openssl-x509` — manage X.509 certificates
- `openssl-genrsa` — generate RSA private keys
- `openssl-s_client` — create TLS client connections
- `openssl-rand` — generate cryptographically secure random bytes
- `openssl-dgst` — generate digest values and signatures
- `nc` — netcat network tool
- `ssh-agent` — SSH agent process
- `ssh-keyscan` — get public SSH keys from remote hosts

All pages follow the [translation guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-guide.md).

## Checklist

- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The page(s) are based on the latest English version
- [x] Commands have been tested where possible