### PR TITLE
pages/es: add pip, pipenv, nslookup, gzip, rsync, sudo, xargs Spanish translations

### DIFF
--- a/pages.es/common/gzip.md
+++ b/pages.es/common/gzip.md
@@ -1,0 +1,36 @@
+# gzip
+
+> Comprime/descomprime archivos con compresión `gzip` (LZ77).
+> Más información: <https://www.gnu.org/software/gzip/manual/gzip.html>.
+
+- Comprime un archivo, reemplazándolo con un archivo `gzip`:
+
+`gzip {{ruta/al/archivo}}`
+
+- Descomprime un archivo, reemplazándolo con la versión original sin comprimir:
+
+`gzip {{[-d|--decompress]}} {{ruta/al/archivo.gz}}`
+
+- Muestra el nombre y el porcentaje de reducción de cada archivo comprimido:
+
+`gzip {{[-v|--verbose]}} {{ruta/al/archivo.gz}}`
+
+- Comprime un archivo, conservando el archivo original:
+
+`gzip {{[-k|--keep]}} {{ruta/al/archivo}}`
+
+- Comprime un archivo, especificando el nombre del archivo de salida:
+
+`gzip {{[-c|--stdout]}} {{ruta/al/archivo}} > {{ruta/al/archivo_comprimido.gz}}`
+
+- Descomprime un archivo `gzip` especificando el nombre del archivo de salida:
+
+`gzip {{[-cd|--stdout --decompress]}} {{ruta/al/archivo.gz}} > {{ruta/al/archivo_descomprimido}}`
+
+- Especifica el nivel de compresión. 1 es el más rápido (baja compresión), 9 es el más lento (alta compresión), 6 es el predeterminado:
+
+`gzip -{{1..9}} {{[-c|--stdout]}} {{ruta/al/archivo}} > {{ruta/al/archivo_comprimido.gz}}`
+
+- Lista el contenido de un archivo comprimido:
+
+`gzip {{[-l|--list]}} {{ruta/al/archivo.txt.gz}}`

--- a/pages.es/common/nslookup.md
+++ b/pages.es/common/nslookup.md
@@ -1,0 +1,33 @@
+# nslookup
+
+> Consulta servidores de nombres para varios registros de dominio.
+> Vea también: `dig`, `resolvectl`, `host`.
+> Más información: <https://manned.org/nslookup>.
+
+- Consulta el servidor de nombres predeterminado del sistema para obtener una dirección IP (registro A) del dominio:
+
+`nslookup {{example.com}}`
+
+- Consulta un servidor de nombres específico para obtener un registro NS del dominio:
+
+`nslookup -type=NS {{example.com}} {{8.8.8.8}}`
+
+- Consulta una búsqueda inversa (registro PTR) de una dirección IP:
+
+`nslookup -type=PTR {{54.240.162.118}}`
+
+- Consulta cualquier registro disponible usando el protocolo TCP:
+
+`nslookup -vc -type=ANY {{example.com}}`
+
+- Consulta un servidor de nombres específico para obtener el archivo de zona completo (transferencia de zona) del dominio usando el protocolo TCP:
+
+`nslookup -vc -type=AXFR {{example.com}} {{servidor_de_nombres}}`
+
+- Consulta un servidor de correo (registro MX) del dominio mostrando los detalles de la transacción:
+
+`nslookup -type=MX -debug {{example.com}}`
+
+- Consulta un servidor de nombres específico en un número de puerto determinado para obtener un registro TXT del dominio:
+
+`nslookup -port={{número_de_puerto}} -type=TXT {{example.com}} {{servidor_de_nombres}}`

--- a/pages.es/common/pip-freeze.md
+++ b/pages.es/common/pip-freeze.md
@@ -1,0 +1,24 @@
+# pip freeze
+
+> Lista los paquetes instalados en formato de requisitos.
+> Más información: <https://pip.pypa.io/en/stable/cli/pip_freeze/>.
+
+- Lista los paquetes instalados:
+
+`pip freeze`
+
+- Escribe los paquetes instalados en el archivo `requirements.txt`:
+
+`pip freeze > requirements.txt`
+
+- Lista los paquetes instalados en un entorno virtual, excluyendo los instalados globalmente:
+
+`pip freeze {{[-l|--local]}}`
+
+- Lista los paquetes instalados en el directorio del usuario:
+
+`pip freeze --user`
+
+- Lista todos los paquetes, incluyendo `pip`, `distribute`, `setuptools` y `wheel` (se omiten por defecto):
+
+`pip freeze --all`

--- a/pages.es/common/pip-install.md
+++ b/pages.es/common/pip-install.md
@@ -1,0 +1,36 @@
+# pip install
+
+> Instala paquetes de Python.
+> Más información: <https://pip.pypa.io/en/stable/cli/pip_install/>.
+
+- Instala uno o más paquetes:
+
+`pip install {{paquete1 paquete2 ...}}`
+
+- Actualiza todos los paquetes especificados a la última versión, instalando los que no estén presentes:
+
+`pip install {{paquete1 paquete2 ...}} {{[-U|--upgrade]}}`
+
+- Instala una versión específica de un paquete:
+
+`pip install {{paquete}}=={{versión}}`
+
+- Instala paquetes listados en un archivo:
+
+`pip install {{[-r|--requirement]}} {{ruta/al/requirements.txt}}`
+
+- Instala un paquete desde un archivo o directorio local:
+
+`pip install {{ruta/al/archivo.whl|ruta/al/archivo.tar.gz|ruta/al/directorio}}`
+
+- Instala un paquete desde un repositorio Git:
+
+`pip install git+https://{{example.com}}/{{usuario}}/{{repositorio}}.git`
+
+- Instala un paquete desde una fuente alternativa (URL o directorio) en lugar de PyPI:
+
+`pip install {{[-f|--find-links]}} {{url|ruta/al/directorio}} {{paquete}}`
+
+- Instala el paquete local del directorio actual en modo de desarrollo (editable):
+
+`pip install {{[-e|--editable]}} .`

--- a/pages.es/common/pip-list.md
+++ b/pages.es/common/pip-list.md
@@ -1,0 +1,36 @@
+# pip list
+
+> Lista los paquetes de Python instalados.
+> Más información: <https://pip.pypa.io/en/stable/cli/pip_list/>.
+
+- Lista los paquetes instalados:
+
+`pip list`
+
+- Lista los paquetes desactualizados que se pueden actualizar:
+
+`pip list {{[-o|--outdated]}}`
+
+- Lista los paquetes actualizados:
+
+`pip list {{[-u|--uptodate]}}`
+
+- Lista los paquetes en formato JSON:
+
+`pip list --format json`
+
+- Lista los paquetes que no son requeridos por otros paquetes:
+
+`pip list --not-required`
+
+- Lista los paquetes instalados solo en el directorio del usuario:
+
+`pip list --user`
+
+- Lista los paquetes y excluye los paquetes editables de la salida:
+
+`pip list --exclude-editable`
+
+- Lista los paquetes en formato freeze (a diferencia de `pip freeze`, no muestra información de instalaciones editables):
+
+`pip list --format freeze`

--- a/pages.es/common/pip.md
+++ b/pages.es/common/pip.md
@@ -1,0 +1,37 @@
+# pip
+
+> Gestor de paquetes de Python.
+> Algunos subcomandos como `install` tienen su propia documentación de uso.
+> Más información: <https://pip.pypa.io/en/stable/cli/pip/>.
+
+- Instala un paquete (consulta `pip install` para más ejemplos de instalación):
+
+`pip install {{paquete}}`
+
+- Instala un paquete en el directorio del usuario en lugar de la ubicación predeterminada del sistema:
+
+`pip install --user {{paquete}}`
+
+- Actualiza un paquete:
+
+`pip install {{[-U|--upgrade]}} {{paquete}}`
+
+- Desinstala un paquete:
+
+`pip uninstall {{paquete}}`
+
+- Guarda los paquetes instalados en un archivo:
+
+`pip freeze > {{requirements.txt}}`
+
+- Lista los paquetes instalados:
+
+`pip list`
+
+- Muestra información de un paquete instalado:
+
+`pip show {{paquete}}`
+
+- Instala paquetes desde un archivo:
+
+`pip install {{[-r|--requirement]}} {{requirements.txt}}`

--- a/pages.es/common/pipenv.md
+++ b/pages.es/common/pipenv.md
@@ -1,0 +1,37 @@
+# pipenv
+
+> Flujo de trabajo de desarrollo Python simple y unificado.
+> Gestiona paquetes y el entorno virtual para un proyecto.
+> Más información: <https://pypi.org/project/pipenv>.
+
+- Crea un nuevo proyecto:
+
+`pipenv`
+
+- Crea un nuevo proyecto usando Python 3:
+
+`pipenv --three`
+
+- Instala un paquete:
+
+`pipenv install {{paquete}}`
+
+- Instala todas las dependencias de un proyecto:
+
+`pipenv install`
+
+- Instala todas las dependencias de un proyecto (incluyendo los paquetes de desarrollo):
+
+`pipenv install --dev`
+
+- Desinstala un paquete:
+
+`pipenv uninstall {{paquete}}`
+
+- Inicia un shell dentro del entorno virtual creado:
+
+`pipenv shell`
+
+- Genera un `requirements.txt` (lista de dependencias) para un proyecto:
+
+`pipenv lock --requirements`

--- a/pages.es/common/rsync.md
+++ b/pages.es/common/rsync.md
@@ -1,0 +1,37 @@
+# rsync
+
+> Transfiere archivos hacia o desde un host remoto (pero no entre dos hosts remotos), usando SSH por defecto.
+> Para especificar una ruta remota, usa `usuario@host:ruta/al/archivo_o_directorio`.
+> Más información: <https://download.samba.org/pub/rsync/rsync.1>.
+
+- Transfiere un archivo (usa `--dry-run` para simular la transferencia):
+
+`rsync {{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Usa el modo archivo (copia directorios recursivamente, copia enlaces simbólicos sin resolverlos y preserva permisos, propiedad y marcas de tiempo):
+
+`rsync {{[-a|--archive]}} {{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Comprime los datos al enviarlos al destino, muestra el progreso detallado y legible, y conserva los archivos parcialmente transferidos si se interrumpe:
+
+`rsync {{[-zvhP|--compress --verbose --human-readable --partial --progress]}} {{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Copia directorios recursivamente y garantiza que cada archivo esté completamente guardado en disco en lugar de permanecer en RAM:
+
+`rsync {{[-r|--recursive]}} --fsync {{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Transfiere el contenido de un directorio, pero no el directorio en sí:
+
+`rsync {{[-r|--recursive]}} {{ruta/al/origen}}/ {{ruta/al/destino}}`
+
+- Usa el modo archivo, resuelve enlaces simbólicos y omite archivos que sean más recientes en el destino:
+
+`rsync {{[-auL|--archive --update --copy-links]}} {{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Transfiere un directorio desde un host remoto que ejecuta `rsyncd` y elimina archivos en el destino que no existen en el origen:
+
+`rsync {{[-r|--recursive]}} --delete rsync://{{host}}:{{ruta/al/origen}} {{ruta/al/destino}}`
+
+- Transfiere un archivo a través de SSH usando un puerto diferente al predeterminado (22) y muestra el progreso global:
+
+`rsync {{[-e|--rsh]}} 'ssh -p {{puerto}}' --info=progress2 {{host}}:{{ruta/al/origen}} {{ruta/al/destino}}`

--- a/pages.es/common/sudo.md
+++ b/pages.es/common/sudo.md
@@ -1,0 +1,37 @@
+# sudo
+
+> Ejecuta un único comando como superusuario u otro usuario.
+> Vea también: `pkexec`, `run0`, `doas`.
+> Más información: <https://www.sudo.ws/sudo.html>.
+
+- Ejecuta un comando como superusuario:
+
+`sudo {{less /var/log/syslog}}`
+
+- Edita un archivo como superusuario con tu editor predeterminado:
+
+`sudo {{[-e|--edit]}} {{/etc/fstab}}`
+
+- Ejecuta un comando como otro usuario y/o grupo:
+
+`sudo {{[-u|--user]}} {{usuario}} {{[-g|--group]}} {{grupo}} {{id -a}}`
+
+- Repite el último comando prefijado con `sudo` (solo en Bash, Zsh, etc.):
+
+`sudo !!`
+
+- Inicia el shell predeterminado con privilegios de superusuario y ejecuta los archivos específicos de inicio de sesión (`.profile`, `.bash_profile`, etc.):
+
+`sudo {{[-i|--login]}}`
+
+- Inicia el shell predeterminado con privilegios de superusuario sin cambiar el entorno:
+
+`sudo {{[-s|--shell]}}`
+
+- Inicia el shell predeterminado como el usuario especificado, cargando su entorno y leyendo los archivos de inicio de sesión (`.profile`, `.bash_profile`, etc.):
+
+`sudo {{[-i|--login]}} {{[-u|--user]}} {{usuario}}`
+
+- Lista los comandos permitidos (y prohibidos) para el usuario que lo invoca en formato detallado:
+
+`sudo {{[-ll|--list --list]}}`

--- a/pages.es/common/xargs.md
+++ b/pages.es/common/xargs.md
@@ -1,0 +1,38 @@
+# xargs
+
+> Ejecuta un comando con argumentos canalizados provenientes de otro comando, un archivo, etc.
+> La entrada se trata como un único bloque de texto y se divide en partes separadas por espacios, tabulaciones, saltos de línea y fin de archivo.
+> Vea también: `parallel`.
+> Más información: <https://www.gnu.org/software/findutils/manual/html_mono/find.html#Invoking-xargs>.
+
+- Ejecuta un comando usando los datos de entrada como argumentos:
+
+`{{fuente_de_argumentos}} | xargs {{comando}}`
+
+- Ejecuta múltiples comandos encadenados sobre los datos de entrada:
+
+`{{fuente_de_argumentos}} | xargs sh -c "{{comando1}} && {{comando2}} | {{comando3}}"`
+
+- Ejecuta un nuevo comando con cada argumento:
+
+`{{fuente_de_argumentos}} | xargs {{[-n|--max-args]}} 1 {{comando}}`
+
+- Aumenta el límite de procesos paralelos a 10 (el predeterminado es 1; 0 significa tantos procesos como sea posible):
+
+`{{fuente_de_argumentos}} | xargs {{[-P|--max-procs]}} 10 {{[-n|--max-args]}} {{1}} {{comando}}`
+
+- Ejecuta el comando una vez por cada línea de entrada, reemplazando las ocurrencias del marcador (aquí indicado como `_`) con la línea de entrada:
+
+`{{fuente_de_argumentos}} | xargs -I _ {{comando}} _ {{argumentos_opcionales_extra}}`
+
+- Solicita confirmación al usuario antes de ejecutar el comando (confirma con `y` o `Y`):
+
+`{{fuente_de_argumentos}} | xargs {{[-p|--interactive]}} {{comando}}`
+
+- Lee un archivo para obtener los argumentos que se pasarán a un comando:
+
+`xargs {{[-a|--arg-file]}} {{ruta/al/archivo}} {{comando}}`
+
+- Permite que el comando acceda al terminal para entrada interactiva:
+
+`{{fuente_de_argumentos}} | xargs {{[-o|--open-tty]}} {{comando}}`


### PR DESCRIPTION
## Description
Add Spanish translations for 10 missing pages: `pip`, `pip-install`, `pip-list`, `pip-freeze`, `pipenv`, `nslookup`, `gzip`, `rsync`, `sudo`, `xargs`.

All pages follow the [translation guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/translation-guide.md).

## Checklist
- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The page(s) are based on the latest English version
- [x] Commands have been tested where possible