### PR TITLE
gst-launch-1.0-pipewiresink: add page

### DIFF
--- a/pages/linux/gst-launch-1.0-pipewiresink.md
+++ b/pages/linux/gst-launch-1.0-pipewiresink.md
@@ -1,0 +1,8 @@
+# gst-launch-1.0 pipewiresink
+
+> Create a pipewire node to output data from.
+> More information: <https://github.com/PipeWire/pipewire/tree/master/src/gst>.
+
+- Output test video:
+
+`gst-launch-1.0 videotestsrc ! pipewiresink mode=provide`

--- a/pages/linux/gst-launch-1.0-pipewiresink.md
+++ b/pages/linux/gst-launch-1.0-pipewiresink.md
@@ -1,6 +1,6 @@
 # gst-launch-1.0 pipewiresink
 
-> Create a pipewire node to output data from.
+> Create a PipeWire node to output data from.
 > More information: <https://github.com/PipeWire/pipewire/tree/master/src/gst>.
 
 - Output test video:

--- a/pages/linux/gst-launch-1.0-pipewiresink.md
+++ b/pages/linux/gst-launch-1.0-pipewiresink.md
@@ -6,3 +6,7 @@
 - Output test video:
 
 `gst-launch-1.0 videotestsrc ! pipewiresink mode=provide`
+
+- Give the PipeWire node a name:
+
+`gst-launch-1.0 {{source}} ! pipewiresink client-name={{node_name}}`


### PR DESCRIPTION
I'm a bit puzzled. Even with `gst-launch-1.0 videotestsrc ! pipewiresink mode=provide client-name=lol stream-properties="properties,media.class=Video/Source"` I'm unable to view the video with autovideosink even though the pipeline rolls on both ends. 