### PR TITLE
common/*: add Indonesian translations of alias pages

### DIFF
--- a/pages.id/common/bundler.md
+++ b/pages.id/common/bundler.md
@@ -1,0 +1,9 @@
+# bundler
+
+> Manajer dependensi untuk bahasa pemrograman Ruby.
+> `bundler` adalah nama umum untuk program `bundle`, namun bukan suatu nama perintah.
+> Informasi lebih lanjut: <https://bundler.io/man/bundle.1.html>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr bundle`

--- a/pages.id/common/librewolf.md
+++ b/pages.id/common/librewolf.md
@@ -1,0 +1,8 @@
+# librewolf
+
+> Perintah ini merupakan alias dari `firefox`.
+> Informasi lebih lanjut: <https://librewolf.net/>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr firefox`

--- a/pages.id/common/mcli.md
+++ b/pages.id/common/mcli.md
@@ -1,0 +1,7 @@
+# mcli
+
+> Perintah ini merupakan alias dari `mc` (MinIO client).
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr mc.cli`

--- a/pages.id/common/minio-client.md
+++ b/pages.id/common/minio-client.md
@@ -1,0 +1,7 @@
+# minio-client
+
+> Perintah ini merupakan alias dari `mc` (MinIO client).
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr mc.cli`

--- a/pages.id/common/rnano.md
+++ b/pages.id/common/rnano.md
@@ -1,0 +1,8 @@
+# rnano
+
+> Perintah ini merupakan alias dari `nano --restricted`.
+> Informasi lebih lanjut: <https://manned.org/rnano>.
+
+- Tampilkan dokumentasi untuk perintah asli:
+
+`tldr nano`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
