### PR TITLE
gitty: add page

### DIFF
--- a/pages/common/gitty.md
+++ b/pages/common/gitty.md
@@ -1,0 +1,28 @@
+# gitty
+
+> Minimal Git and GitHub CLI wrapper with human-readable commands.
+> More information: <https://github.com/Omibranch/gitty>.
+
+- Stage all changes, commit with an auto-generated message, and push:
+
+`gitty up`
+
+- Stage all changes and commit with a custom message:
+
+`gitty up "{{commit message}}"`
+
+- Show a compact, decorated git log:
+
+`gitty log`
+
+- Restore a specific file to its state before uncommitted changes:
+
+`gitty fix {{file}}`
+
+- Remove a file or path from all past commits permanently:
+
+`gitty erase {{path_or_file}}`
+
+- Undo the latest N commits (keeps changes staged):
+
+`gitty back {{n}}`


### PR DESCRIPTION
Adds a tldr page for [gitty](https://github.com/Omibranch/gitty) — a minimal Git + GitHub CLI wrapper that provides human-readable shortcuts for common git workflows.

**Checklist:**
- [x] New page for an existing command
- [x] Follows the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#content-guidelines)
- [x] Page file in \`pages/common/\`
- [x] Descriptions are concise
- [x] Examples use \`{{placeholders}}\`