### PR TITLE
vagrant-login: add page

### DIFF
--- a/pages/common/vagrant-login.md
+++ b/pages/common/vagrant-login.md
@@ -1,0 +1,22 @@
+# vagrant login
+
+> Authenticate with HashiCorp's Vagrant Cloud server.
+> Logging in is only necessary if you are accessing protected boxes or using Vagrant Share.
+> See also: `vagrant`, `vagrant cloud`.
+> More information: <https://developer.hashicorp.com/vagrant/docs/cli/login>.
+
+- Log in to Vagrant Cloud interactively with a username and password:
+
+`vagrant login`
+
+- Check if you are currently logged in:
+
+`vagrant login --check`
+
+- Log in using a Vagrant Cloud access token:
+
+`vagrant login --token {{your_access_token}}`
+
+- Log out of Vagrant Cloud:
+
+`vagrant login --logout`


### PR DESCRIPTION
## Summary

Add tldr page for `vagrant login` command.

## Description

The `vagrant login` command is used to authenticate with HashiCorp's Vagrant Cloud server for:
- Accessing protected boxes
- Using Vagrant Share

This PR adds documentation for the command with examples covering:
- Interactive login with username/password
- Checking authentication status
- Token-based login
- Logout

## Related Issue

Partially addresses #18895 (vagrant login subcommand from the 'Let's document: vagrant' tracker)

## Checklist

- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] Passes `tldr-lint` validation
- [x] More information link points to official documentation