### PR TITLE
jless: add page

### DIFF
--- a/pages/common/jless.md
+++ b/pages/common/jless.md
@@ -1,0 +1,37 @@
+# jless
+
+> A command-line JSON viewer with vim-inspired keybindings.
+> Supports JSON and YAML files with syntax highlighting and interactive navigation.
+> More information: <https://jless.io>.
+
+- View a JSON file interactively:
+
+`jless {{path/to/file.json}}`
+
+- Read JSON from `stdin`:
+
+`{{cat path/to/file.json}} | jless`
+
+- View a YAML file:
+
+`jless --yaml {{path/to/file.yaml}}`
+
+- Expand or collapse the currently focused node:
+
+`<Space>`
+
+- Search forward for a pattern:
+
+`/{{pattern}}`
+
+- Copy the path to the currently focused node to the clipboard:
+
+`yp`
+
+- Copy the value of the currently focused node (pretty printed) to the clipboard:
+
+`yy`
+
+- Display help:
+
+`<F1>`


### PR DESCRIPTION
Adds a tldr page for `jless`, a command-line JSON viewer with vim-inspired keybindings.

Closes #21116

## About jless

jless is an interactive JSON/YAML viewer designed for reading, exploring, and searching through JSON data from the command line. It features:
- Vim-inspired navigation and keybindings
- Support for both JSON and YAML files
- Interactive expand/collapse of nested structures
- Full-text search with regex support
- Copy functionality (values, keys, paths)
- Syntax highlighting

## Examples included

- View a JSON file interactively
- Read JSON from stdin
- View a YAML file
- Toggle expand/collapse nodes
- Search forward for a pattern
- Copy path to current node
- Copy value of current node
- Display help

More information: https://jless.io