### PR TITLE
osx/g*: update Indonesian alias pages to reflect GNU command aliases

### DIFF
--- a/pages.id/osx/gchgrp.md
+++ b/pages.id/osx/gchgrp.md
@@ -1,6 +1,6 @@
 # gchgrp
 
-> Perintah ini merupakan alias dari `chgrp`.
+> Perintah ini merupakan alias dari GNU `chgrp`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gchmod.md
+++ b/pages.id/osx/gchmod.md
@@ -1,6 +1,6 @@
 # gchmod
 
-> Perintah ini merupakan alias dari `chmod`.
+> Perintah ini merupakan alias dari GNU `chmod`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gchown.md
+++ b/pages.id/osx/gchown.md
@@ -1,6 +1,6 @@
 # gchown
 
-> Perintah ini merupakan alias dari `chown`.
+> Perintah ini merupakan alias dari GNU `chown`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gchroot.md
+++ b/pages.id/osx/gchroot.md
@@ -1,6 +1,6 @@
 # gchroot
 
-> Perintah ini merupakan alias dari `chroot`.
+> Perintah ini merupakan alias dari GNU `chroot`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gcksum.md
+++ b/pages.id/osx/gcksum.md
@@ -1,6 +1,6 @@
 # gcksum
 
-> Perintah ini merupakan alias dari `cksum`.
+> Perintah ini merupakan alias dari GNU `cksum`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gcomm.md
+++ b/pages.id/osx/gcomm.md
@@ -1,6 +1,6 @@
 # gcomm
 
-> Perintah ini merupakan alias dari `comm`.
+> Perintah ini merupakan alias dari GNU `comm`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gcp.md
+++ b/pages.id/osx/gcp.md
@@ -1,6 +1,6 @@
 # gcp
 
-> Perintah ini merupakan alias dari `cp`.
+> Perintah ini merupakan alias dari GNU `cp`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gcut.md
+++ b/pages.id/osx/gcut.md
@@ -1,6 +1,6 @@
 # gcut
 
-> Perintah ini merupakan alias dari `cut`.
+> Perintah ini merupakan alias dari GNU `cut`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gdate.md
+++ b/pages.id/osx/gdate.md
@@ -1,6 +1,6 @@
 # gdate
 
-> Perintah ini merupakan alias dari `date`.
+> Perintah ini merupakan alias dari GNU `date`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gdircolors.md
+++ b/pages.id/osx/gdircolors.md
@@ -1,6 +1,6 @@
 # gdircolors
 
-> Perintah ini merupakan alias dari `dircolors`.
+> Perintah ini merupakan alias dari GNU `dircolors`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gdirname.md
+++ b/pages.id/osx/gdirname.md
@@ -1,6 +1,6 @@
 # gdirname
 
-> Perintah ini merupakan alias dari `dirname`.
+> Perintah ini merupakan alias dari GNU `dirname`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gecho.md
+++ b/pages.id/osx/gecho.md
@@ -1,6 +1,6 @@
 # gecho
 
-> Perintah ini merupakan alias dari `echo`.
+> Perintah ini merupakan alias dari GNU `echo`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/ged.md
+++ b/pages.id/osx/ged.md
@@ -1,6 +1,6 @@
 # ged
 
-> Perintah ini merupakan alias dari `ed`.
+> Perintah ini merupakan alias dari GNU `ed`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gegrep.md
+++ b/pages.id/osx/gegrep.md
@@ -1,6 +1,6 @@
 # gegrep
 
-> Perintah ini merupakan alias dari `egrep`.
+> Perintah ini merupakan alias dari GNU `egrep`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/genv.md
+++ b/pages.id/osx/genv.md
@@ -1,6 +1,6 @@
 # genv
 
-> Perintah ini merupakan alias dari `env`.
+> Perintah ini merupakan alias dari GNU `env`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gexpand.md
+++ b/pages.id/osx/gexpand.md
@@ -1,6 +1,6 @@
 # gexpand
 
-> Perintah ini merupakan alias dari `expand`.
+> Perintah ini merupakan alias dari GNU `expand`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gexpr.md
+++ b/pages.id/osx/gexpr.md
@@ -1,6 +1,6 @@
 # gexpr
 
-> Perintah ini merupakan alias dari `expr`.
+> Perintah ini merupakan alias dari GNU `expr`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gfactor.md
+++ b/pages.id/osx/gfactor.md
@@ -1,6 +1,6 @@
 # gfactor
 
-> Perintah ini merupakan alias dari `factor`.
+> Perintah ini merupakan alias dari GNU `factor`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gfalse.md
+++ b/pages.id/osx/gfalse.md
@@ -1,6 +1,6 @@
 # gfalse
 
-> Perintah ini merupakan alias dari `false`.
+> Perintah ini merupakan alias dari GNU `false`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 

--- a/pages.id/osx/gfgrep.md
+++ b/pages.id/osx/gfgrep.md
@@ -1,6 +1,6 @@
 # gfgrep
 
-> Perintah ini merupakan alias dari `fgrep`.
+> Perintah ini merupakan alias dari GNU `fgrep`.
 
 - Tampilkan dokumentasi untuk perintah asli:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

There are many existing alias pages within `osx` that are not explicitly marked as a "GNU alias", so this PR adds them.

Being a minor change, each PR will be limited up to 20 pages (currently up to `gfgrep`).