### PR TITLE
done, doom, dosbox, dotenvx: add Korean translation

### DIFF
--- a/pages.ko/common/done.md
+++ b/pages.ko/common/done.md
@@ -1,0 +1,19 @@
+# done
+
+> `for`, `while`, `select`, `until` 루프의 끝을 표시하는 쉘 키워드.
+
+- `for` 키워드 문서 확인:
+
+`tldr for`
+
+- `while` 키워드 문서 확인:
+
+`tldr while`
+
+- `select` 키워드 문서 확인:
+
+`tldr select`
+
+- `until` 키워드 문서 확인:
+
+`tldr until`

--- a/pages.ko/common/doom.md
+++ b/pages.ko/common/doom.md
@@ -1,0 +1,13 @@
+# DOOM
+
+> 모딩과 멀티플레이를 지원하는 클래식 오픈소스 FPS 게임.
+> `zandronum-server`은 대부분의 소스 포트로 대체 가능.
+> 더 많은 정보: <https://doomwiki.org/wiki/Source_port_parameters>.
+
+- 협동(co-op) 멀티플레이 호스트 실행:
+
+`{{zandronum-server}} -iwad {{wad}} +map {{map}} -host {{플레이어}}`
+
+- 데스매치 멀티플레이 호스트 실행:
+
+`{{zandronum-server}} -iwad {{wad}} +map {{map}} -host {{플레이어}} -deathmatch`

--- a/pages.ko/common/dosbox.md
+++ b/pages.ko/common/dosbox.md
@@ -1,0 +1,24 @@
+# dosbox
+
+> 레거시 DOS 애플리케이션과 게임을 실행하기 위한 MS-DOS 에뮬레이터.
+> 더 많은 정보: <https://www.dosbox.com/wiki/Usage>.
+
+- 기본 설정으로 DOSBox 실행:
+
+`dosbox`
+
+- 특정 경로의 DOS 실행 파일 실행:
+
+`dosbox {{경로/대상/실행파일.exe}}`
+
+- 폴더를 C: 드라이브로 마운트하고 실행파일 실행:
+
+`dosbox {{경로/대상/실행파일.exe}} -c "MOUNT C {{경로/대상/폴더}}"`
+
+- 전체 화면 모드로 DOSBox 실행:
+
+`dosbox -fullscreen`
+
+- DOSBox 실행 후 자동 종료:
+
+`dosbox {{경로/대상/실행파일.exe}} -exit`

--- a/pages.ko/common/dotenvx.md
+++ b/pages.ko/common/dotenvx.md
@@ -1,0 +1,32 @@
+# dotenvx
+
+> `dotenv`의 제작자가 만든 더 개선된 `dotenv` 도구.
+> 더 많은 정보: <https://dotenvx.com/docs/>.
+
+- `.env` 파일의 환경 변수를 사용하여 명령 실행:
+
+`dotenvx run -- {{명령어}}`
+
+- 특정 `.env` 파일의 환경 변수를 사용하여 명령 실행:
+
+`dotenvx run -f {{경로/대상/파일.env}} -- {{명령어}}`
+
+- 환경 변수를 암호화하여 설정:
+
+`dotenvx set {{키}} {{값}}`
+
+- 환경 변수를 암호화 없이 설정:
+
+`dotenvx set {{키}} {{값}} --plain`
+
+- `.env` 파일에 정의된 환경 변수 조회:
+
+`dotenvx get`
+
+- `.env` 파일에 정의된 특정 환경 변수 값 조회:
+
+`dotenvx get {{키}}`
+
+- `.env` 파일과 OS의 모든 환경 변수 조회:
+
+`dotenvx get --all`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
