### PR TITLE
spa-monitor: add page

### DIFF
--- a/pages/linux/spa-monitor.md
+++ b/pages/linux/spa-monitor.md
@@ -1,0 +1,9 @@
+# spa-monitor
+
+> Load a SPA plugin and instantiate a device from it.
+> Note: This utility is primarily intended for debugging device plugins.
+> More information: <https://docs.pipewire.org/page_man_spa-monitor_1.html>.
+
+- Load a specific SPA plugin:
+
+`spa-monitor {{path/to/plugin.so}}`


### PR DESCRIPTION
This utility does not support any CLI options or flags. 
The `main` function lacks any argument parsing logic and simply checks the number of passed arguments.