### PR TITLE
bun-{add, create, remove}: use standard option placeholder format

### DIFF
--- a/pages/common/bun-add.md
+++ b/pages/common/bun-add.md
@@ -1,33 +1,33 @@
 # bun add
 
 > Add and install new dependencies to the current project.
-> Note: `a` can be used as an alias for `add`.
+
 > More information: <https://bun.com/docs>.
 
 - Install a single package:
 
-`bun add {{package}}`
+`bun {{[a|add]}} {{package}}`
 
 - Install multiple packages:
 
-`bun add {{package1 package2 ...}}`
+`bun {{[a|add]}} {{package1 package2 ...}}`
 
 - Install from a Git repository:
 
-`bun add {{git_url}}`
+`bun {{[a|add]}} {{git_url}}`
 
 - Install a specific version:
 
-`bun add {{package}}@{{version}}`
+`bun {{[a|add]}} {{package}}@{{version}}`
 
 - Install from local file or directory:
 
-`bun add file:{{path/to/file_or_directory}}`
+`bun {{[a|add]}} file:{{path/to/file_or_directory}}`
 
 - Add a dev dependency:
 
-`bun add {{[-d|--dev]}} {{package}}`
+`bun {{[a|add]}} {{[-d|--dev]}} {{package}}`
 
 - Add a package globally:
 
-`bun add {{[-g|--global]}} {{package}}`
+`bun {{[a|add]}} {{[-g|--global]}} {{package}}`

--- a/pages/common/bun-add.md
+++ b/pages/common/bun-add.md
@@ -1,7 +1,6 @@
 # bun add
 
 > Add and install new dependencies to the current project.
-
 > More information: <https://bun.com/docs>.
 
 - Install a single package:

--- a/pages/common/bun-create.md
+++ b/pages/common/bun-create.md
@@ -1,33 +1,32 @@
 # bun create
 
 > Create a new project from a template.
-> Note: `c` can be used as an alias for `create`.
 > More information: <https://bun.com/docs/runtime/templating/create>.
 
 - Create a new project from an official template interactively:
 
-`bun create {{template}}`
+`bun {{[c|create]}} {{template}}`
 
 - Create a new project from an official template in a new directory:
 
-`bun create {{template}} {{path/to/destination}}`
+`bun {{[c|create]}} {{template}} {{path/to/destination}}`
 
 - Create a new project from a GitHub repository template:
 
-`bun create {{https://github.com/username/repo}} {{path/to/destination}}`
+`bun {{[c|create]}} {{https://github.com/username/repo}} {{path/to/destination}}`
 
 - Create a new project from a local template:
 
-`bun create {{path/to/template}} {{path/to/destination}}`
+`bun {{[c|create]}} {{path/to/template}} {{path/to/destination}}`
 
 - Create a new project, overwriting the destination directory if it exists:
 
-`bun create {{template}} {{path/to/destination}} --force`
+`bun {{[c|create]}} {{template}} {{path/to/destination}} --force`
 
 - Create a new project without initializing a Git repository automatically:
 
-`bun create {{template}} {{path/to/destination}} --no-git`
+`bun {{[c|create]}} {{template}} {{path/to/destination}} --no-git`
 
 - Create a new project without installing dependencies automatically:
 
-`bun create {{template}} {{path/to/destination}} --no-install`
+`bun {{[c|create]}} {{template}} {{path/to/destination}} --no-install`

--- a/pages/common/bun-remove.md
+++ b/pages/common/bun-remove.md
@@ -1,25 +1,24 @@
 # bun remove
 
 > Remove a dependency from `package.json`.
-> Note: `rm` can be used as an alias for `remove`.
 > More information: <https://bun.com/docs/pm/cli/remove>.
 
 - Remove a dependency:
 
-`bun remove {{package_name}}`
+`bun {{[rm|remove]}} {{package_name}}`
 
 - Remove multiple dependencies:
 
-`bun remove {{package_name1 package_name2 ...}}`
+`bun {{[rm|remove]}} {{package_name1 package_name2 ...}}`
 
 - Remove a globally installed package:
 
-`bun remove {{[-g|--global]}} {{package_name}}`
+`bun {{[rm|remove]}} {{[-g|--global]}} {{package_name}}`
 
 - Remove a dependency without updating the `package.json` file:
 
-`bun remove --no-save {{package_name}}`
+`bun {{[rm|remove]}} --no-save {{package_name}}`
 
 - Run the command without actually removing packages (simulate the removal):
 
-`bun remove --dry-run {{package_name}}`
+`bun {{[rm|remove]}} --dry-run {{package_name}}`


### PR DESCRIPTION
This format was originally discussed in https://github.com/tldr-pages/tldr/pull/19181, but it didn't take off.

`grep -nr "as an alias for"` Still finds a couple more pages that use this format for the binary name like `` windows/clear-history.md:4:> Note: `clhy` can be used as an alias for `Clear-History`. `` where I think it's appropriate.