### PR TITLE
style-guide: add summary

### DIFF
--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -483,7 +483,7 @@ To mark keypresses for TUI or GUI programs, use angle brackets `<` and `>`.
 
 ### Summary
 
-Here's a quick table to summarize the syntax used in tldr:
+Here's a quick table to summarize the syntax used in `tldr`:
 
 | Syntax | Meaning |
 |--------|---------|

--- a/contributing-guides/style-guide.md
+++ b/contributing-guides/style-guide.md
@@ -481,6 +481,21 @@ To mark keypresses for TUI or GUI programs, use angle brackets `<` and `>`.
 - For consistency, we prefer generic wording `Display help` and `Display version` for these commands.
 - It is suggested to document the help and version examples if the command follows unconventional flags in platforms like Windows.
 
+### Summary
+
+Here's a quick table to summarize the syntax used in tldr:
+
+| Syntax | Meaning |
+|--------|---------|
+| `{{ }}` | Placeholder |
+| `path/to/thing` | Filepath |
+| `{{[ \| ]}}` | Option placeholder |
+| `{{thing1 thing2 ...}}` | One or more arguments |
+| `{{thing1\|thing2\|...}}` | Mutually exclusive arguments |
+| `{{1..10}}` | Value range |
+| `<Ctrl c>` | Keypress |
+
+
 ## Windows-Specific Rules
 
 ### General layout


### PR DESCRIPTION
I didn't add optional placeholders (`{{path/to/source.tar[.gz|.bz2|.xz]}}`) since they're so rarely used and overlap a bit with option placeholders. Opinions are welcome what we should do with those.