### PR TITLE
astro: add page

### DIFF
--- a/pages/common/astro.md
+++ b/pages/common/astro.md
@@ -1,0 +1,34 @@
+# astro
+
+> Build fast, content-focused websites with any UI framework.
+> Supports React, Vue, Svelte, Preact, Solid, and Lit.
+> See also: `npm`, `pnpm`, `bun`.
+> More information: <https://docs.astro.build/en/reference/cli-reference/>.
+
+- Start the local development server:
+
+`astro dev`
+
+- Build the project for production (outputs to `dist/` by default):
+
+`astro build`
+
+- Preview the production build locally before deploying:
+
+`astro preview`
+
+- Check the project for TypeScript and syntax errors:
+
+`astro check`
+
+- Add an official integration (e.g. react, vue, tailwind):
+
+`astro add {{integration_name}}`
+
+- Sync content collection types and generate TypeScript definitions:
+
+`astro sync`
+
+- Display information about the current project and environment:
+
+`astro info`


### PR DESCRIPTION
Adds documentation for the `astro` CLI tool, the official command-line interface for the Astro framework (<https://docs.astro.build/en/reference/cli-reference/>).

This addresses a missing page for a highly popular and rapidly growing web framework. I have included the most common commands: `dev`, `build`, `preview`, `check`, `add`, `sync`, and `info`.