### PR TITLE
dotnet: rework page to clarify program usage

### DIFF
--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,21 +1,37 @@
 # dotnet
 
-> Cross platform .NET tools for .NET Core.
-> Some subcommands such as `build` have their own usage documentation.
+> Cross-platform .NET tools for .NET Core.
+> Some subcommands such as `build` and `run` have their own usage documentation.
 > More information: <https://learn.microsoft.com/dotnet/core/tools>.
 
 - Initialize a new .NET project:
 
 `dotnet new {{template_short_name}}`
 
+- Add a NuGet package to the project:
+
+`dotnet add package {{package_name}}`
+
 - Restore NuGet packages:
 
 `dotnet restore`
 
-- Build and execute the .NET project in the current directory:
+- Build the project and its dependencies:
+
+`dotnet build`
+
+- Build and execute the .NET project:
 
 `dotnet run`
 
-- Run a packaged dotnet application (only needs the runtime, the rest of the commands require the .NET Core SDK installed):
+- Execute unit tests in the current directory:
+
+`dotnet test`
+
+- Publish the .NET application for deployment:
+
+`dotnet publish`
+
+- Run a packaged .NET application:
 
 `dotnet {{path/to/application.dll}}`

--- a/pages/common/dotnet.md
+++ b/pages/common/dotnet.md
@@ -1,7 +1,7 @@
 # dotnet
 
 > Cross-platform .NET tools for .NET Core.
-> Some subcommands such as `build` and `run` have their own usage documentation.
+> Some subcommands such as `build`, `run`, `test`, `publish`, `restore`, and `add` have their own usage documentation.
 > More information: <https://learn.microsoft.com/dotnet/core/tools>.
 
 - Initialize a new .NET project:


### PR DESCRIPTION
Reworks the `dotnet` base page to explicitly show what the program does and how to use it, instead of relying solely on subcommand pages. 

Changes:
- Added `dotnet add package` to add NuGet packages
- Added `dotnet build` to build the project
- Added `dotnet test` to run unit tests
- Added `dotnet publish` to publish the application
- Updated the "Some subcommands" header line to enumerate all subcommands that have dedicated pages: `build`, `run`, `test`, `publish`, `restore`, and `add`
- Fixed description from "Cross platform" to "Cross-platform" (hyphen)
- Simplified the description of running a packaged DLL

Closes part of #18255.