### PR TITLE
vue: rework page to clarify program usage

### DIFF
--- a/pages/common/vue.md
+++ b/pages/common/vue.md
@@ -1,13 +1,29 @@
 # vue
 
-> Multi-purpose CLI for Vue.js.
-> Some subcommands such as `build` have their own usage documentation.
+> Manage Vue.js projects.
+> Some subcommands such as `build`, `serve`, and `init` have their own usage documentation.
 > More information: <https://cli.vuejs.org/guide/>.
 
-- Create a new Vue project interactively:
+- Create a new Vue.js project interactively:
 
 `vue create {{project_name}}`
 
-- Create a new project with web UI:
+- Create a new project using the web-based GUI:
 
 `vue ui`
+
+- Add a plugin to an existing project:
+
+`vue add {{plugin_name}}`
+
+- Inspect the resolved webpack configuration of a Vue CLI project:
+
+`vue inspect`
+
+- Upgrade all Vue CLI plugins:
+
+`vue upgrade`
+
+- Display help for a subcommand:
+
+`vue {{build|serve|create}} --help`


### PR DESCRIPTION
Reworks the base page for `vue` to provide direct, actionable examples (`add`, `inspect`, `upgrade`) rather than a minimal two-example page that misses core workflow functions. 

References to subcommands that have their own pages (`build`, `serve`, `init`) are kept in the header.

Closes part of #18255.