### PR TITLE
ibmcloud: rework page to clarify program usage

### DIFF
--- a/pages/common/ibmcloud.md
+++ b/pages/common/ibmcloud.md
@@ -1,24 +1,33 @@
 # ibmcloud
 
-> Manage IBM Cloud apps and services.
+> Manage IBM Cloud resources, apps, and services.
+> Some subcommands such as `login`, `target`, `iam`, `ks`, and `cr` have their own usage documentation.
 > More information: <https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli>.
 
-- Update `ibmcloud` to the latest version:
+- Log in to IBM Cloud:
+
+`ibmcloud login`
+
+- Log in with a federated ID using SSO:
+
+`ibmcloud login --sso`
+
+- Set the target region and resource group:
+
+`ibmcloud target --region {{region}} --resource-group {{resource_group}}`
+
+- List all resource groups:
+
+`ibmcloud resource groups`
+
+- List all service instances in the current target:
+
+`ibmcloud resource service-instances`
+
+- Update the IBM Cloud CLI:
 
 `ibmcloud update`
-
-- List all available IBM Cloud regions:
-
-`ibmcloud regions`
-
-- Display help:
-
-`ibmcloud help`
 
 - Display help for a subcommand:
 
 `ibmcloud help {{subcommand}}`
-
-- Display version:
-
-`ibmcloud version`


### PR DESCRIPTION
Reworks the base page for `ibmcloud` to provide high-value, actionable examples (login, target, list resources) rather than only generic utility commands like update/version.

References to subcommands with dedicated pages are retained in the header.

Closes part of #18255.