### PR TITLE
pio: rework page to clarify program usage

### DIFF
--- a/pages/common/pio.md
+++ b/pages/common/pio.md
@@ -1,17 +1,33 @@
 # pio
 
-> Development environment for embedded boards.
-> Some subcommands such as `run` have their own usage documentation.
+> Manage embedded development projects using PlatformIO.
+> Some subcommands such as `run`, `init`, `device`, and `pkg` have their own usage documentation.
 > More information: <https://docs.platformio.org/en/latest/core/userguide/>.
 
-- Display help and list subcommands:
+- Initialize a new project for a specific board:
 
-`pio {{[-h|--help]}}`
+`pio project init --board {{board_id}}`
 
-- Display help for a specific subcommand:
+- Build the project in the current directory:
 
-`pio {{subcommand}} {{[-h|--help]}}`
+`pio run`
 
-- Display version:
+- Upload firmware to the connected device:
 
-`pio --version`
+`pio run --target upload`
+
+- Open a serial monitor:
+
+`pio device monitor`
+
+- Install a library dependency:
+
+`pio pkg install --library "{{library_name}}"`
+
+- List all available boards:
+
+`pio boards`
+
+- Display help for a subcommand:
+
+`pio {{run|init|device|pkg}} --help`


### PR DESCRIPTION
Reworks the base page for `pio` to explicit examples of core PlatformIO workflows: initializing a project (`project init`), building (`run`), uploading firmware (`run --target upload`), and opening the serial monitor (`device monitor`).

Also retained references to `run`, `init`, `device`, and `pkg` subcommand pages in the header.

Closes part of #18255.