### PR TITLE
pyats: rework page to clarify program usage

### DIFF
--- a/pages/common/pyats.md
+++ b/pages/common/pyats.md
@@ -1,20 +1,33 @@
 # pyats
 
-> A vendor agnostic test automation framework by Cisco Systems, used for network and systems testing.
-> More information: <https://developer.cisco.com/pyats/>.
+> A Python-based network test and automation framework.
+> Some subcommands such as `run`, `shell`, and `parse` have their own usage documentation.
+> More information: <https://developer.cisco.com/docs/pyats/>.
 
-- Run a `pyATS` subcommand:
+- Run a pyATS testscript or a job file:
 
-`pyats {{subcommand}}`
+`pyats run job {{path/to/script_or_job.py}}`
 
-- Display help:
+- Open a Python shell with the pyATS environment loaded:
 
-`pyats --help`
+`pyats shell --testbed-file {{path/to/testbed.yaml}}`
 
-- Display help about a specific subcommand:
+- Parse the output of a router `show` command using Genie parsers:
 
-`pyats {{subcommand}} --help`
+`pyats parse "{{show_command}}" --testbed-file {{path/to/testbed.yaml}} --device {{device_name}}`
 
-- Display version:
+- Learn and profile device features (e.g., OSPF, BGP) using Genie:
 
-`pyats version check`
+`pyats learn {{feature}} --testbed-file {{path/to/testbed.yaml}} --device {{device_name}}`
+
+- Save the parsed output to a specific directory:
+
+`pyats parse "{{show_command}}" --testbed-file {{path/to/testbed.yaml}} --device {{device_name}} --output {{path/to/directory}}`
+
+- Create a template testbed YAML file or Python script:
+
+`pyats create {{testbed|script}}`
+
+- Display help for a subcommand:
+
+`pyats {{run|shell|parse|learn|create}} --help`


### PR DESCRIPTION
Reworks the base page for `pyats` to document its actual core workflows (running testscripts, loading a pyats shell, parsing `show` commands via Genie, tracking feature states, and creating testbed templates) rather than just leaving the user with basic sub-command wrappers.

Closes part of #18255.