### PR TITLE
warp-cli: update page

### DIFF
--- a/pages.id/common/warp-cli.md
+++ b/pages.id/common/warp-cli.md
@@ -23,12 +23,4 @@
 
 - Pindah mode operasi koneksi layanan WARP:
 
-`warp-cli set-mode {{mode_operasi}}`
-
-- Tampilkan bantuan umum:
-
-`warp-cli help`
-
-- Tampilkan bantuan untuk suatu subperintah:
-
-`warp-cli help {{subperintah}}`
+`warp-cli mode {{warp|doh|warp+doh|dot|warp+dot|proxy|tunnel_only}}`

--- a/pages.ko/common/warp-cli.md
+++ b/pages.ko/common/warp-cli.md
@@ -23,12 +23,4 @@
 
 - 특정 모드로 전환:
 
-`warp-cli set-mode {{모드}}`
-
-- 도움말 표시:
-
-`warp-cli help`
-
-- 하위 명령에 대한 도움말 표시:
-
-`warp-cli help {{하위_명령}}`
+`warp-cli mode {{warp|doh|warp+doh|dot|warp+dot|proxy|tunnel_only}}`

--- a/pages/common/warp-cli.md
+++ b/pages/common/warp-cli.md
@@ -9,6 +9,10 @@
 
 `warp-cli registration new`
 
+- Display the current registration information:
+
+`warp-cli registration show`
+
 - Connect to WARP:
 
 `warp-cli connect`
@@ -21,14 +25,10 @@
 
 `warp-cli status`
 
+- Display current application settings:
+
+`warp-cli settings list`
+
 - Switch to a specific mode:
 
-`warp-cli set-mode {{mode}}`
-
-- Display help:
-
-`warp-cli help`
-
-- Display help for a subcommand:
-
-`warp-cli help {{subcommand}}`
+`warp-cli mode {{warp|doh|warp+doh|dot|warp+dot|proxy|tunnel_only}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2026.3.846.0
- Reference issue: #

---

`warp-cli set-mode` is not available as a command now.

```sh
❯ warp-cli set-mode --help
error: unrecognized subcommand 'set-mode'

Usage: warp-cli [OPTIONS] <COMMAND>

For more information, try '--help'.
```