### PR TITLE
Add `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,17 +1,29 @@
+Adam Herst <adamherst@adamherst.com>
+Daniil Baturin <daniil@baturin.org> <daniil@vyos.io>
 Emily Grace Seville <EmilySeville7cfg@gmail.com> <emilyseville7cf@gmail.com>
+Fazle Arefin <1625934+FazleArefin@users.noreply.github.com> <fazlearefin@users.noreply.github.com>
+Grzegorz Baranski <root@gbaranski.com>
 Ivan Baluta <ivanbaluta.dev@gmail.com> <50071699+ivanbaluta@users.noreply.github.com>
 Jack Lin <blueskyson1401@gmail.com> <46962923+blueskyson@users.noreply.github.com>
 Jack Lin <blueskyson1401@gmail.com> <jacklin@cybersoft4u.com>
 Jennifer Falco <jenniferfalco@outlook.com>
 Juri Dispan <juri.dispan@posteo.net>
 Juri Dispan <juri.dispan@posteo.net> <juri.dispan@uni-ulm.de>
+Kristopher <kristopherleads@gmail.com> <kristopher@developerfirst.io>
 Lena Pastwa <lena@lnps.me> <126529524+acuteenvy@users.noreply.github.com>
+Lucas Gabriel Schneider <casdpa@gmail.com>
+Lucas Gabriel Schneider <casdpa@gmail.com> <lucas.schneider@sap.com>
 marchersimon <50295997+marchersimon@users.noreply.github.com> <marchersimon@zohomail.eu>
 Marco Bonelli <marco@mebeim.net> <14198070+mebeim@users.noreply.github.com>
 Marco Bonelli <marco@mebeim.net> <mb5.marcob@gmail.com>
 Marco Bonelli <marco@mebeim.net> <mebeim@users.noreply.github.com>
+mister-ben <1676039+mister-ben@users.noreply.github.com> <git@misterben.me>
+Miyuutsu <miyuutsushi@gmail.com> <Miyuu@miyuu.pw>
 Nelson Figueroa <30811275+nelsonfigueroa@users.noreply.github.com>
+Niklas Heer <niklas.heer@gmail.com> <me@nheer.io>
 Owen Voke <development@voke.dev> <owzie123@gmail.com>
+Peter Babič <peter@peterbabic.dev> <peter@peterbabic.com>
+Peter Babič <peter@peterbabic.dev> <peter@babic.dev>
 pixie <pixel+github@chrissx.de>
 pixie <pixel+github@chrissx.de> <35269695+chrissxYT@users.noreply.github.com>
 pixie <pixel+github@chrissx.de> <35269695+pixelcmtd@users.noreply.github.com>
@@ -20,8 +32,11 @@ pixie <pixel+github@chrissx.de> <pixel@chrissx.de>
 Reinhart Previano Koentjoro <reinhart@reinhart1010.id> <reinhart_previano@yahoo.com>
 Romain Prieto <rprieto@users.noreply.github.com> <choicesmade@gmail.com>
 Romain Prieto <rprieto@users.noreply.github.com> <rprieto@Romains-MacBook-Air.local>
+Sebastiaan Speck <12570668+sebastiaanspeck@users.noreply.github.com> <shem.speck@gmail.com>
 Seth Falco <seth@falco.fun>
 Tan Siret A <40173707+yutyo@users.noreply.github.com>
 Tan Siret A <40173707+yutyo@users.noreply.github.com> <40173707+Yutyo@users.noreply.github.com>
 Wiktor Perskawiec <wiktor@perskawiec.cc> <155078792+spageektti@users.noreply.github.com>
 Wiktor Perskawiec <wiktor@perskawiec.cc> <git@spageektti.cc>
+Zlatan Vasović <zlatanvasovic@gmail.com>
+Zlatan Vasović <zlatanvasovic@gmail.com> <legospace9876@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Emily Grace Seville <EmilySeville7cfg@gmail.com> <emilyseville7cf@gmail.com>
+Ivan Baluta <ivanbaluta.dev@gmail.com> <50071699+ivanbaluta@users.noreply.github.com>
+Jack Lin <blueskyson1401@gmail.com> <46962923+blueskyson@users.noreply.github.com>
+Jack Lin <blueskyson1401@gmail.com> <jacklin@cybersoft4u.com>
+Jennifer Falco <jenniferfalco@outlook.com>
+Juri Dispan <juri.dispan@posteo.net>
+Juri Dispan <juri.dispan@posteo.net> <juri.dispan@uni-ulm.de>
+Lena Pastwa <lena@lnps.me> <126529524+acuteenvy@users.noreply.github.com>
+marchersimon <50295997+marchersimon@users.noreply.github.com> <marchersimon@zohomail.eu>
+Marco Bonelli <marco@mebeim.net> <14198070+mebeim@users.noreply.github.com>
+Marco Bonelli <marco@mebeim.net> <mb5.marcob@gmail.com>
+Marco Bonelli <marco@mebeim.net> <mebeim@users.noreply.github.com>
+Nelson Figueroa <30811275+nelsonfigueroa@users.noreply.github.com>
+Owen Voke <development@voke.dev> <owzie123@gmail.com>
+pixie <pixel+github@chrissx.de>
+pixie <pixel+github@chrissx.de> <35269695+chrissxYT@users.noreply.github.com>
+pixie <pixel+github@chrissx.de> <35269695+pixelcmtd@users.noreply.github.com>
+pixie <pixel+github@chrissx.de> <chrissx@chrissx.de>
+pixie <pixel+github@chrissx.de> <pixel@chrissx.de>
+Reinhart Previano Koentjoro <reinhart@reinhart1010.id> <reinhart_previano@yahoo.com>
+Romain Prieto <rprieto@users.noreply.github.com> <choicesmade@gmail.com>
+Romain Prieto <rprieto@users.noreply.github.com> <rprieto@Romains-MacBook-Air.local>
+Seth Falco <seth@falco.fun>
+Tan Siret A <40173707+yutyo@users.noreply.github.com>
+Tan Siret A <40173707+yutyo@users.noreply.github.com> <40173707+Yutyo@users.noreply.github.com>
+Wiktor Perskawiec <wiktor@perskawiec.cc> <155078792+spageektti@users.noreply.github.com>
+Wiktor Perskawiec <wiktor@perskawiec.cc> <git@spageektti.cc>


### PR DESCRIPTION
A lot of people have committed to this repository under different identities. The `.mailmap` file tells `git` to display the correct name and email in the commit history.

I used `git shortlog -sne` to find authors with multiple identities, and the most recent commit for the current name and email. I most likely missed some - to add yourself, use:
```cfg
# to correct the name:
New Name <email>
# to correct the email and/or name:
New Name <new email> <old email>
```
https://git-scm.com/docs/gitmailmap