### PR TITLE
git-status: update page

### DIFF
--- a/pages.es/common/git-status.md
+++ b/pages.es/common/git-status.md
@@ -16,10 +16,6 @@
 
 `git status {{[-vv|--verbose --verbose]}}`
 
-- Muestra la rama (branch) e información de seguimiento:
-
-`git status {{[-b|--branch]}}`
-
 - Muestra la salida en formato breve junto a la información de la rama (branch):
 
 `git status {{[-sb|--short --branch]}}`

--- a/pages.id/common/git-status.md
+++ b/pages.id/common/git-status.md
@@ -16,10 +16,6 @@
 
 `git status {{[-vv|--verbose --verbose]}}`
 
-- Tampilkan informasi mengenai cabang ([b]ranch) dan status pelacakan dari remote:
-
-`git status {{[-b|--branch]}}`
-
 - Tampilkan daftar berkas beserta informasi cabang dalam format:
 
 `git status {{[-sb|--short --branch]}}`

--- a/pages.ko/common/git-status.md
+++ b/pages.ko/common/git-status.md
@@ -16,10 +16,6 @@
 
 `git status {{[-vv|--verbose --verbose]}}`
 
-- [b]ranch 및 추적 정보 표시:
-
-`git status {{[-b|--branch]}}`
-
 - [s]hort 형식으로 출력하면서 [b]ranch 정보 표시:
 
 `git status {{[-sb|--short --branch]}}`

--- a/pages.pt_BR/common/git-status.md
+++ b/pages.pt_BR/common/git-status.md
@@ -16,10 +16,6 @@
 
 `git status {{[-vv|--verbose --verbose]}}`
 
-- Mostra informações da branch e de rastreamento:
-
-`git status {{[-b|--branch]}}`
-
 - Mostra a saída em formato curto junto com as informações da branch:
 
 `git status {{[-sb|--short --branch]}}`

--- a/pages.zh/common/git-status.md
+++ b/pages.zh/common/git-status.md
@@ -16,10 +16,6 @@
 
 `git status {{[-vv|--verbose --verbose]}}`
 
-- 显示当前分支及其跟踪（上游）分支信息：
-
-`git status {{[-b|--branch]}}`
-
 - 以简短形式输出，同时包含分支信息：
 
 `git status {{[-sb|--short --branch]}}`

--- a/pages/common/git-status.md
+++ b/pages/common/git-status.md
@@ -4,7 +4,7 @@
 > List changed, added, and deleted files compared to the currently checked-out commit.
 > More information: <https://git-scm.com/docs/git-status>.
 
-- Show changed files which are not yet added for commit:
+- Show untracked and changed files which are not yet added for commit:
 
 `git status`
 
@@ -12,17 +12,17 @@
 
 `git status {{[-s|--short]}}`
 
-- Show verbose information on changes in both the staging area and working directory:
-
-`git status {{[-vv|--verbose --verbose]}}`
-
-- Show the branch and tracking info:
-
-`git status {{[-b|--branch]}}`
-
 - Show output in short format along with branch info:
 
 `git status {{[-sb|--short --branch]}}`
+
+- Show the changes in staged files (like `git diff --cached`):
+
+`git status {{[-v|--verbose]}}`
+
+- Show the changes in all tracked files (like `git diff`):
+
+`git status {{[-vv|--verbose --verbose]}}`
 
 - Show the number of entries currently stashed away:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

The `--branch` option has no effect without `--short`, because the branch info is always shown in the long format:

https://git-scm.com/docs/git-status
> -b, --branch
> Show the branch and tracking info _**even in short-format**_.
