### PR TITLE
git-commit: update page

### DIFF
--- a/pages/common/git-commit.md
+++ b/pages/common/git-commit.md
@@ -3,7 +3,11 @@
 > Commit files to the repository.
 > More information: <https://git-scm.com/docs/git-commit>.
 
-- Commit staged files to the repository with a message:
+- Open an editor to write a message and commit staged files to the repository:
+
+`git commit`
+
+- Commit staged files to the repository with the specified message:
 
 `git commit {{[-m|--message]}} "{{message}}"`
 
@@ -11,15 +15,15 @@
 
 `git commit {{[-F|--file]}} {{path/to/commit_message_file}}`
 
-- Auto stage all modified and deleted files and commit with a message:
+- Auto stage all modified and deleted files and commit:
 
 `git commit {{[-a|--all]}} {{[-m|--message]}} "{{message}}"`
 
-- Commit staged files and sign them with the specified GPG key (or the one defined in the configuration file if no argument is specified):
+- Commit staged files and sign them with the specified GPG key (or the one defined in the configuration file if no `key_id` is specified):
 
 `git commit {{[-S|--gpg-sign]}} {{key_id}} {{[-m|--message]}} "{{message}}"`
 
-- Update the last commit by adding the currently staged changes, changing the commit's hash:
+- Update the last commit by adding the currently staged changes, changing the commit's hash and open an editor to change the message:
 
 `git commit --amend`
 
@@ -27,10 +31,6 @@
 
 `git commit {{path/to/file1 path/to/file2 ...}}`
 
-- Create a commit, even if there are no staged files:
-
-`git commit {{[-m|--message]}} "{{message}}" --allow-empty`
-
-- Create a commit with a message and a description:
+- Create a commit with the specified message and description:
 
 `git commit {{[-m|--message]}} "{{message}}" {{[-m|--message]}} "{{description}}"`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

The `--allow-empty` option is very unlikely to be used, and the page is missing the most basic example - `git commit` with no other options.

https://git-scm.com/docs/git-commit
> --allow-empty
> This option [...] is primarily for use by foreign SCM interface scripts.