### PR TITLE
git-status: correct the description

### DIFF
--- a/pages/common/git-status.md
+++ b/pages/common/git-status.md
@@ -20,7 +20,7 @@
 
 `git status {{[-v|--verbose]}}`
 
-- Show the changes in all tracked files (like `git diff`):
+- Show the changes in all tracked files (like `git diff HEAD`):
 
 `git status {{[-vv|--verbose --verbose]}}`
 


### PR DESCRIPTION
mistake from #22127
`git diff` without `HEAD` shows only unstaged changes.