### PR TITLE
oras: add page

### DIFF
--- a/pages/common/oras.md
+++ b/pages/common/oras.md
@@ -1,0 +1,28 @@
+# oras
+
+> Manage artifacts in OCI registries and image layouts.
+> More information: <https://oras.land/docs/commands/use_oras_cli>.
+
+- List available subcommands:
+
+`oras help`
+
+- Show the installed ORAS version:
+
+`oras version`
+
+- Log in to a remote registry interactively:
+
+`oras login {{registry}}`
+
+- Push a file to a registry reference:
+
+`oras push {{registry}}/{{repository}}:{{tag}} {{path/to/file}}`
+
+- Pull artifact files from a registry reference:
+
+`oras pull {{registry}}/{{repository}}:{{tag}}`
+
+- Copy an artifact between registries:
+
+`oras cp {{source_registry}}/{{repository}}:{{tag}} {{destination_registry}}/{{repository}}:{{tag}}`


### PR DESCRIPTION
## Summary
- add a new common `oras` page for the base CLI
- include representative examples for `help`, `version`, `login`, `push`, `pull`, and `cp`
- match the page structure to the tldr style guide and upstream ORAS docs

## Validation
- `npx --yes tldr-lint pages/common/oras.md`
- `git diff --check`
- read the final page back locally against the repo style guide and upstream ORAS command docs