### PR TITLE
fd: refresh page

### DIFF
--- a/pages.ko/common/fd.md
+++ b/pages.ko/common/fd.md
@@ -4,9 +4,9 @@
 > 관련 항목: `find`.
 > 더 많은 정보: <https://github.com/sharkdp/fd#how-to-use>.
 
-- 현재 디렉터리에서 특정 패턴과 일치하는 파일을 반복적으로 찾음:
+- 특정 패턴과 일치하는 파일을 재귀적으로 찾기 (기본값은 현재 디렉터리):
 
-`fd "{{string|regex}}"`
+`fd "{{string|regex}}" {{경로/대상/디렉터리}}`
 
 - `foo`로 시작하는 파일 찾기:
 
@@ -16,9 +16,9 @@
 
 `fd --extension txt`
 
-- 특정 디렉터리에서 파일 찾기:
+- 특정 패턴과 일치하는 디렉터리만 찾기:
 
-`fd "{{string|regex}}" {{경로/대상/디렉터리}}`
+`fd {{[-t|--type]}} {{d|directory}} "{{string|regex}}"`
 
 - 검색에 무시되거나 숨겨진 파일을 포함:
 

--- a/pages.ko/common/fd.md
+++ b/pages.ko/common/fd.md
@@ -14,7 +14,7 @@
 
 - 특정 확장자를 가진 파일 찾기:
 
-`fd --extension txt`
+`fd {{[-e|--extension]}} {{txt}}`
 
 - 특정 패턴과 일치하는 디렉터리만 찾기:
 
@@ -22,8 +22,16 @@
 
 - 검색에 무시되거나 숨겨진 파일을 포함:
 
-`fd --hidden --no-ignore "{{string|regex}}"`
+`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{string|regex}}"`
+
+- 특정 glob 패턴과 일치하는 파일을 제외:
+
+`fd {{string}} {{[-E|--exclude]}} {{glob}}`
 
 - 반환된 각 검색 결과에 대해 명령을 실행:
 
-`fd "{{string|regex}}" --exec {{명령어}}`
+`fd "{{string|regex}}" {{[-x|--exec]}} {{명령어}}`
+
+- 현재 디렉터리에서만 파일 찾기:
+
+`fd {{[-d|--max-depth]}} 1 "{{string|regex}}"`

--- a/pages.ko/common/fd.md
+++ b/pages.ko/common/fd.md
@@ -2,7 +2,7 @@
 
 > `find`의 대안.
 > 관련 항목: `find`, `regex`.
-> 더 많은 정보: <https://github.com/sharkdp/fd#how-to-use>.
+> 더 많은 정보: <https://github.com/sharkdp/fd#command-line-options>.
 
 - 현재 디렉터리에서 특정 패턴과 일치하는 파일을 재귀적으로 찾기:
 
@@ -18,15 +18,15 @@
 
 - 특정 패턴과 일치하는 디렉터리만 찾기:
 
-`fd {{[-t|--type]}} {{d|directory}} "{{regex}}"`
+`fd "{{regex}}" {{[-t|--type]}} {{[d|directory]}}`
 
 - 검색에 무시되거나 숨겨진 파일을 포함:
 
-`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{regex}}"`
+`fd "{{regex}}" {{[-H|--hidden]}} {{[-I|--no-ignore]}}`
 
 - 특정 glob 패턴과 일치하는 파일을 제외:
 
-`fd {{regex}} {{[-E|--exclude]}} {{glob}}`
+`fd "{{regex}}" {{[-E|--exclude]}} {{glob}}`
 
 - 반환된 각 검색 결과에 대해 명령을 실행:
 
@@ -34,4 +34,4 @@
 
 - 현재 디렉터리에서만 파일 찾기:
 
-`fd {{[-d|--max-depth]}} 1 "{{regex}}"`
+`fd "{{regex}}" {{[-d|--max-depth]}} 1`

--- a/pages.ko/common/fd.md
+++ b/pages.ko/common/fd.md
@@ -4,13 +4,13 @@
 > 관련 항목: `find`.
 > 더 많은 정보: <https://github.com/sharkdp/fd#how-to-use>.
 
-- 특정 패턴과 일치하는 파일을 재귀적으로 찾기 (기본값은 현재 디렉터리):
+- 현재 디렉터리에서 특정 패턴과 일치하는 파일을 재귀적으로 찾기:
 
-`fd "{{string|regex}}" {{경로/대상/디렉터리}}`
+`fd "{{regex}}"`
 
-- `foo`로 시작하는 파일 찾기:
+- 특정 디렉터리에서 파일 찾기:
 
-`fd "^foo"`
+`fd "{{regex}}" {{경로/대상/디렉터리}}`
 
 - 특정 확장자를 가진 파일 찾기:
 
@@ -18,20 +18,20 @@
 
 - 특정 패턴과 일치하는 디렉터리만 찾기:
 
-`fd {{[-t|--type]}} {{d|directory}} "{{string|regex}}"`
+`fd {{[-t|--type]}} {{d|directory}} "{{regex}}"`
 
 - 검색에 무시되거나 숨겨진 파일을 포함:
 
-`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{string|regex}}"`
+`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{regex}}"`
 
 - 특정 glob 패턴과 일치하는 파일을 제외:
 
-`fd {{string}} {{[-E|--exclude]}} {{glob}}`
+`fd {{regex}} {{[-E|--exclude]}} {{glob}}`
 
 - 반환된 각 검색 결과에 대해 명령을 실행:
 
-`fd "{{string|regex}}" {{[-x|--exec]}} {{명령어}}`
+`fd "{{regex}}" {{[-x|--exec]}} {{명령어}}`
 
 - 현재 디렉터리에서만 파일 찾기:
 
-`fd {{[-d|--max-depth]}} 1 "{{string|regex}}"`
+`fd {{[-d|--max-depth]}} 1 "{{regex}}"`

--- a/pages.ko/common/fd.md
+++ b/pages.ko/common/fd.md
@@ -1,7 +1,7 @@
 # fd
 
 > `find`의 대안.
-> 관련 항목: `find`.
+> 관련 항목: `find`, `regex`.
 > 더 많은 정보: <https://github.com/sharkdp/fd#how-to-use>.
 
 - 현재 디렉터리에서 특정 패턴과 일치하는 파일을 재귀적으로 찾기:

--- a/pages/common/fd.md
+++ b/pages/common/fd.md
@@ -2,7 +2,7 @@
 
 > Find entries in the filesystem.
 > See also: `find`, `regex`.
-> More information: <https://github.com/sharkdp/fd#how-to-use>.
+> More information: <https://github.com/sharkdp/fd#command-line-options>.
 
 - Recursively find files matching a specific pattern in the current directory:
 
@@ -18,15 +18,15 @@
 
 - Find only directories matching a specific pattern:
 
-`fd {{[-t|--type]}} {{d|directory}} "{{regex}}"`
+`fd "{{regex}}" {{[-t|--type]}} {{[d|directory]}}`
 
 - Include ignored and hidden files in the search:
 
-`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{regex}}"`
+`fd "{{regex}}" {{[-H|--hidden]}} {{[-I|--no-ignore]}}`
 
 - Exclude files that match a specific glob pattern:
 
-`fd {{regex}} {{[-E|--exclude]}} {{glob}}`
+`fd "{{regex}}" {{[-E|--exclude]}} {{glob}}`
 
 - Execute a command on each search result returned:
 
@@ -34,4 +34,4 @@
 
 - Find files only in the current directory:
 
-`fd {{[-d|--max-depth]}} 1 "{{regex}}"`
+`fd "{{regex}}" {{[-d|--max-depth]}} 1`

--- a/pages/common/fd.md
+++ b/pages/common/fd.md
@@ -4,13 +4,13 @@
 > See also: `find`.
 > More information: <https://github.com/sharkdp/fd#how-to-use>.
 
-- Recursively find files matching a specific pattern (defaults to the current directory):
+- Recursively find files matching a specific pattern in the current directory:
 
-`fd "{{string|regex}}" {{path/to/directory}}`
+`fd "{{regex}}"`
 
-- Find files that begin with a specific string:
+- Find files in a specific directory:
 
-`fd "{{^string}}"`
+`fd "{{regex}}" {{path/to/directory}}`
 
 - Find files with a specific extension:
 
@@ -18,20 +18,20 @@
 
 - Find only directories matching a specific pattern:
 
-`fd {{[-t|--type]}} {{d|directory}} "{{string|regex}}"`
+`fd {{[-t|--type]}} {{d|directory}} "{{regex}}"`
 
 - Include ignored and hidden files in the search:
 
-`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{string|regex}}"`
+`fd {{[-H|--hidden]}} {{[-I|--no-ignore]}} "{{regex}}"`
 
 - Exclude files that match a specific glob pattern:
 
-`fd {{string}} {{[-E|--exclude]}} {{glob}}`
+`fd {{regex}} {{[-E|--exclude]}} {{glob}}`
 
 - Execute a command on each search result returned:
 
-`fd "{{string|regex}}" {{[-x|--exec]}} {{command}}`
+`fd "{{regex}}" {{[-x|--exec]}} {{command}}`
 
 - Find files only in the current directory:
 
-`fd {{[-d|--max-depth]}} 1 "{{string|regex}}"`
+`fd {{[-d|--max-depth]}} 1 "{{regex}}"`

--- a/pages/common/fd.md
+++ b/pages/common/fd.md
@@ -4,9 +4,9 @@
 > See also: `find`.
 > More information: <https://github.com/sharkdp/fd#how-to-use>.
 
-- Recursively find files matching a specific pattern in the current directory:
+- Recursively find files matching a specific pattern (defaults to the current directory):
 
-`fd "{{string|regex}}"`
+`fd "{{string|regex}}" {{path/to/directory}}`
 
 - Find files that begin with a specific string:
 
@@ -16,9 +16,9 @@
 
 `fd {{[-e|--extension]}} {{txt}}`
 
-- Find files in a specific directory:
+- Find only directories matching a specific pattern:
 
-`fd "{{string|regex}}" {{path/to/directory}}`
+`fd {{[-t|--type]}} {{d|directory}} "{{string|regex}}"`
 
 - Include ignored and hidden files in the search:
 

--- a/pages/common/fd.md
+++ b/pages/common/fd.md
@@ -1,7 +1,7 @@
 # fd
 
 > Find entries in the filesystem.
-> See also: `find`.
+> See also: `find`, `regex`.
 > More information: <https://github.com/sharkdp/fd#how-to-use>.
 
 - Recursively find files matching a specific pattern in the current directory:


### PR DESCRIPTION
## Summary

- Merge the two basic search examples into one (current dir + specific dir) to free a slot under the 8-example limit.
- Add a `--type` example for finding directories matching a pattern, covering the common `fd -t d` use case.
- Apply the same restructure to the Korean translation.