### PR TITLE
arch: fix command placeholder syntax in examples

### DIFF
--- a/pages/osx/arch.md
+++ b/pages/osx/arch.md
@@ -10,8 +10,8 @@
 
 - Run a command using x86_64:
 
-`arch -x86_64 "{{command}}"`
+`arch -x86_64 {{command}} {{argument1 argument2 ...}}`
 
 - Run a command using arm:
 
-`arch -arm64 "{{command}}"`
+`arch -arm64 {{command}} {{argument1 argument2 ...}}`

--- a/pages/osx/arch.md
+++ b/pages/osx/arch.md
@@ -12,6 +12,6 @@
 
 `arch -x86_64 {{command}} {{argument1 argument2 ...}}`
 
-- Run a command using arm:
+- Run a command using ARM:
 
 `arch -arm64 {{command}} {{argument1 argument2 ...}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: None


The quotes cause `arch` to treat the entire string as a single executable path. Removing them resolves the confusion.
```bash
# error
arch -x86_64 "/usr/local/bin/brew install tldr"
arch: /usr/local/bin/brew install tldr isn't executable

# ok
arch -x86_64 /usr/local/bin/brew install tldr
```

