### PR TITLE
systemsettings, termshark, tload, tmt-*: add Korean translation

### DIFF
--- a/pages.ko/linux/systemsettings.md
+++ b/pages.ko/linux/systemsettings.md
@@ -1,0 +1,16 @@
+# systemsettings
+
+> KDE의 중앙 설정 프로그램.
+> 더 많은 정보: <https://manned.org/systemsettings>.
+
+- 설정 GUI 실행:
+
+`systemsettings`
+
+- `systemsettings`를 위한 사용 가능한 모든 KCM 모듈 목록 출력:
+
+`systemsettings --list`
+
+- 도움말 표시:
+
+`systemsettings {{[-h|--help]}}`

--- a/pages.ko/linux/termshark.md
+++ b/pages.ko/linux/termshark.md
@@ -1,0 +1,12 @@
+# termshark
+
+> `tshark`를 위한 터미널 UI 도구이며, `wireshark`와 유사한 인터페이스를 제공.
+> 더 많은 정보: <https://github.com/gcla/termshark/blob/master/docs/UserGuide.md>.
+
+- 기본 네트워크 인터페이스 모니터링:
+
+`sudo termshark`
+
+- 특정 인터페이스 지정하여 모니터링:
+
+`sudo termshark {{인터페이스}}`

--- a/pages.ko/linux/tload.md
+++ b/pages.ko/linux/tload.md
@@ -1,0 +1,21 @@
+# tload
+
+> 시스템 load average를 ASCII 그래프로 표시하는 도구.
+> 관련 항목: `uptime`, `w`, `top`, `ps`.
+> 더 많은 정보: <https://manned.org/tload>.
+
+- Run tload 실행:
+
+`tload`
+
+- 특정 세로 스케일로 그래프 표시 (e.g. 10 -> 1:1 스케일):
+
+`tload {{[-s|--scale]}} {{값}}`
+
+- 그래프 갱신 주기 설정:
+
+`tload {{[-d|--delay]}} {{초}}`
+
+- 특정 터미널에 그래프 표시:
+
+`tload {{/dev/tty1}}`

--- a/pages.ko/linux/tmt-run.md
+++ b/pages.ko/linux/tmt-run.md
@@ -1,0 +1,36 @@
+# tmt run
+
+> `tmt` 테스트 단계를 실행. 기본값으로, 모든 테스트 단계를 실행.
+> 더 많은 정보: <https://tmt.readthedocs.io/en/stable/stories/cli.html#run>.
+
+- 각 계획에 대해 모든 테스트 단계 실행:
+
+`tmt run`
+
+- discover 단계만 실행하여 어떤 테스트가 실행될 지 확인:
+
+`tmt run discover {{[-v|--verbose]}}`
+
+- 모든 단계를 실행하면서 provision 단계 옵션 지정:
+
+`tmt run {{[-a|--all]}} provision {{[-h|--how]}} {{컨테이너}} {{[-i|--image]}} {{fedora:rawhide}}`
+
+- 특정 플랜과 테스트만 선택하여 실행:
+
+`tmt run plan {{[-n|--name]}} {{/플랜/이름}} test {{[-n|--name]}} {{/테스트/이름}}`
+
+- 마지막 실행 결과를 웹 브라우저로 표시:
+
+`tmt run {{[-l|--last]}} report {{[-h|--how]}} {{html}} {{[-o|--open]}}`
+
+- 지정한 컨텍스트로 테스트 실행:
+
+`tmt run {{[-c|--context]}} {{key=value}} {{[-c|--context]}} {{distro=fedora}}`
+
+- 대화형으로 테스트 실행 (테스트 중간에 디버깅 가능):
+
+`tmt run {{[-a|--all]}} execute {{[-h|--how]}} {{tmt}} --interactive`
+
+- dry 모드로 실행될 작업 확인 및 최대 상세정보 출력:
+
+`tmt run {{[-n|--dry]}} {{[-vvv|--verbose --verbose --verbose]}}`

--- a/pages.ko/linux/tmt-try.md
+++ b/pages.ko/linux/tmt-try.md
@@ -1,0 +1,36 @@
+# tmt try
+
+> 테스트와 환경을 빠르게 실험할 수 있는 명령어.
+> 더 많은 정보: <https://tmt.readthedocs.io/en/stable/stories/cli.html#try>.
+
+- 기본 provision 방식으로 빠르게 실험 (현재 디렉터리에 테스트 없음):
+
+`tmt try`
+
+- 현재 디렉터리에서 테스트 실행:
+
+`cd {{경로/대상/테스트_디렉터리}} && tmt try`
+
+- 특정 운영체제를 사용:
+
+`tmt try {{rhel-9}}`
+
+- 사용자 지정 이미지와 provision 방식 선택:
+
+`tmt try {{fedora@container}}`
+
+- 사용자 정의 필터로 테스트 선택:
+
+`tmt try {{[-t|--test]}} {{feature}}`
+
+- 게스트를 준비하고 사용자 입력 대기:
+
+`tmt try {{[-a|--ask]}}`
+
+- 묻지 않고 바로 게스트에 로그인:
+
+`tmt try {{[-l|--login]}}`
+
+- 도움말 표시:
+
+`tmt try --help`

--- a/pages.ko/linux/tmt.md
+++ b/pages.ko/linux/tmt.md
@@ -1,0 +1,37 @@
+# tmt
+
+> 테스트를 생성, 실행, 디버깅하기 위한 테스트 관리 도구.
+> `run`, `try`와 같은 하위 명령어는 사용법 문서를 자체적으로 가짐.
+> 더 많은 정보: <https://tmt.readthedocs.io/en/stable/examples.html>.
+
+- 사용 가능한 테스트, 플랜, 스토리 목록 출력:
+
+`tmt`
+
+- tmt 파일/프로젝트 구조 초기화:
+
+`tmt init`
+
+- 템플릿과 링크를 사용해 새로운 테스트 생성:
+
+`tmt test create {{[-t|--template]}} {{beakerlib}} --link {{verifies:issue#1234}}`
+
+- 테스트, 플랜, 스토리 목록 출력:
+
+`tmt {{test|plan|story}} ls {{패턴}}`
+
+- 특정 컨텍스트에서 테스트 메타데이터 상세 출력:
+
+`tmt {{[-c|--context]}} {{arch=aarch64}} test show`
+
+- tmt 파일을 스펙에 맞게 검증:
+
+`tmt lint`
+
+- filter 사용:
+
+`tmt tests ls {{[-f|--filter]}} {{tag:foo}} {{[-f|--filter]}} {{tier:0}}`
+
+- 도움말 표시:
+
+`tmt --help`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
