### PR TITLE
cpuctl, espeak-ng: add Korean translation

### DIFF
--- a/pages.ko/common/cpuctl.md
+++ b/pages.ko/common/cpuctl.md
@@ -1,0 +1,17 @@
+# cpuctl
+
+> 커멘드라인에서 시스템 CPU를 제어하고 상태를 확인하는 도구.
+> 참고: 시스템에는 최소 하나의 CPU가 항상 온라인 상태로 유지되어야 함.
+> 더 많은 정보: <https://man.netbsd.org/cpuctl.8>.
+
+- 시스템 내 각 CPU의 현재 상태와 마지막 상태 변경 시간 출력:
+
+`sudo cpuctl list`
+
+- 지정된 CPU들을 오프라인으로 설정:
+
+`sudo cpuctl offline {{cpu_번호1 cpu_번호2 ...}}`
+
+- 지정된 CPU들을 온라인으로 설정:
+
+`sudo cpuctl online {{cpu_번호1 cpu_번호2 ...}}`

--- a/pages.ko/common/espeak-ng.md
+++ b/pages.ko/common/espeak-ng.md
@@ -1,0 +1,33 @@
+# espeak-ng
+
+> 다국어를 지원하는 소프트웨어 음성 합성기.
+> 관련 항목: `speak-ng`, `espeak`.
+> 더 많은 정보: <https://github.com/espeak-ng/espeak-ng/blob/master/src/espeak-ng.1.ronn>.
+
+- 텍스트를 음성으로 출력:
+
+`espeak-ng "{{text}}"`
+
+- `stdin`의 텍스트를 음성으로 출력:
+
+`echo "{{text}}" | espeak-ng`
+
+- 파일([f]ile) 내용을 음성으로 출력:
+
+`espeak-ng -f {{경로/대상/파일}}`
+
+- 특정 음성([v]oice)으로 출력:
+
+`espeak-ng -v {{음성}} "{{텍스트}}"`
+
+- 속도([s]peed) (기본값: 175)와 음높이([p]itch) (기본값: 50) 설정:
+
+`espeak-ng -s {{속도}} -p {{음높이}} "{{텍스트}}"`
+
+- 음성을 직접 재생하지 않고 [w]AV 파일로 저장:
+
+`espeak-ng -w {{경로/대상/출력파일.wav}} "{{텍스트}}"`
+
+- 사용 가능한 모든 음성 목록 출력:
+
+`espeak-ng --voices`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
