### PR TITLE
ssh, chmod, grep, find: add Romanian translation

### DIFF
--- a/pages.ro/common/chmod.md
+++ b/pages.ro/common/chmod.md
@@ -1,0 +1,36 @@
+# chmod
+
+> Schimbă permisiunile de acces ale unui fișier sau folder.
+> Mai multe informații: <https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html>.
+
+- Acordă [u]tilizatorului proprietar al fișierului dreptul de a-l e[x]ecuta:
+
+`chmod u+x {{cale/către/fișier}}`
+
+- Acordă [u]tilizatorului dreptul de a [r]ealiza citire și [w]riere asupra unui fișier/folder:
+
+`chmod u+rw {{cale/către/fișier_sau_folder}}`
+
+- Elimină dreptul de e[x]ecuție al [g]rupului:
+
+`chmod g-x {{cale/către/fișier}}`
+
+- Acordă tuturor utilizatorilor ([a]ll) dreptul de [r]ealizare citire și e[x]ecuție:
+
+`chmod a+rx {{cale/către/fișier}}`
+
+- Acordă [o]ricui (utilizatorilor din afara grupului proprietar) aceleași drepturi ca [g]rupul:
+
+`chmod o=g {{cale/către/fișier}}`
+
+- Elimină toate drepturile pentru [o]ricine:
+
+`chmod o= {{cale/către/fișier}}`
+
+- Schimbă recursiv permisiunile, acordând [g]rupului și c[o]mun dreptul de a scrie ([w]):
+
+`chmod {{[-R|--recursive]}} g+w,o+w {{cale/către/folder}}`
+
+- Acordă recursiv tuturor utilizatorilor ([a]ll) drept de [r]eaplicare. Acordă, de asemenea, drepturi de e[X]ecuție fișierelor care au cel puțin un drept de execuție și tuturor sub-folderelor:
+
+`chmod {{[-R|--recursive]}} a+rX {{cale/către/folder}}`

--- a/pages.ro/common/find.md
+++ b/pages.ro/common/find.md
@@ -1,0 +1,37 @@
+# find
+
+> Găsește fișiere sau foldere într-un arbore de foldere, în mod recursiv.
+> Vezi și: `fd`.
+> Mai multe informații: <https://manned.org/find>.
+
+- Găsește fișiere după extensie:
+
+`find {{cale/către/folder}} -name '{{*.ext}}'`
+
+- Găsește fișiere care se potrivesc mai multor tipare de cale/nume:
+
+`find {{cale/către/folder}} -path '{{*/cale/*/*.ext}}' -or -name '{{*tipar*}}'`
+
+- Găsește foldere care se potrivesc unui nume dat, în mod insensibil la majuscule:
+
+`find {{cale/către/folder}} -type d -iname '{{*lib*}}'`
+
+- Găsește fișiere care se potrivesc unui tipar dat, excluzând căi specifice:
+
+`find {{cale/către/folder}} -name '{{*.py}}' -not -path '{{*/site-packages/*}}'`
+
+- Găsește fișiere într-un interval de dimensiuni dat, limitând adâncimea recursivă la „1”:
+
+`find {{cale/către/folder}} -maxdepth 1 -size {{+500k}} -size {{-10M}}`
+
+- Rulează o comandă pentru fiecare fișier (folosește `{}` în comandă pentru a accesa numele fișierului):
+
+`find {{cale/către/folder}} -name '{{*.ext}}' -exec {{wc -l}} {} \;`
+
+- Găsește toate fișierele modificate astăzi și transmite rezultatele unei singure comenzi ca argumente:
+
+`find {{cale/către/folder}} -daystart -mtime {{-1}} -exec {{tar -cvf archive.tar}} {} \+`
+
+- Caută fișiere sau foldere goale și le șterge cu mesaje detaliate:
+
+`find {{cale/către/folder}} -type {{f|d}} -empty -delete -print`

--- a/pages.ro/common/grep.md
+++ b/pages.ro/common/grep.md
@@ -1,0 +1,37 @@
+# grep
+
+> Caută tipare în fișiere folosind expresii regulate (`regex`).
+> Vezi și: `regex`.
+> Mai multe informații: <https://www.gnu.org/software/grep/manual/grep.html>.
+
+- Caută un tipar într-un set de fișiere:
+
+`grep "{{tipar_de_căutare}}" {{cale/către/fișier1 cale/către/fișier2 ...}}`
+
+- Caută un șir de caractere exact (dezactivează `regex`-ul):
+
+`grep {{[-F|--fixed-strings]}} "{{șir_exact}}" {{cale/către/fișier}}`
+
+- Caută un tipar recursiv în toate fișierele dintr-un folder, ignorând fișierele binare:
+
+`grep {{[-rI|--recursive --binary-files=without-match]}} "{{tipar_de_căutare}}" {{cale/către/folder}}`
+
+- Afișează 3 linii de [C]ontext (în jur, î[B]ainte sau [A]fter de fiecare potrivire):
+
+`grep {{--context|--before-context|--after-context}} 3 "{{tipar_de_căutare}}" {{cale/către/fișier}}`
+
+- Afișează numele fișierului și numărul liniei pentru fiecare potrivire, cu ieșire colorată:
+
+`grep {{[-Hn|--with-filename --line-number]}} --color=always "{{tipar_de_căutare}}" {{cale/către/fișier}}`
+
+- Afișează doar textul potrivit:
+
+`grep {{[-o|--only-matching]}} "{{tipar_de_căutare}}" {{cale/către/fișier}}`
+
+- Citește datele din `stdin` și nu afișează liniile care se potrivesc cu tiparul:
+
+`cat {{cale/către/fișier}} | grep {{[-v|--invert-match]}} "{{tipar_de_căutare}}"`
+
+- Folosește `regex` extins (suportă `?`, `+`, `{}`, `()` și `|`), în mod insensibil la majuscule:
+
+`grep {{[-Ei|--extended-regexp --ignore-case]}} "{{tipar_de_căutare}}" {{cale/către/fișier}}`

--- a/pages.ro/common/ssh.md
+++ b/pages.ro/common/ssh.md
@@ -1,0 +1,37 @@
+# ssh
+
+> Secure Shell este un protocol folosit pentru a te conecta în siguranță la sisteme la distanță.
+> Poate fi folosit pentru autentificare sau pentru a rula comenzi pe un server la distanță.
+> Mai multe informații: <https://man.openbsd.org/ssh>.
+
+- Conectare la un server la distanță:
+
+`ssh {{nume_utilizator}}@{{server_distant}}`
+
+- Conectare la un server la distanță cu o [i]dentitate specifică (cheie privată):
+
+`ssh -i {{cale/către/fișier_cheie}} {{nume_utilizator}}@{{server_distant}}`
+
+- Conectare la un server la distanță cu IP-ul `10.0.0.1` folosind un [p]ort specific (Notă: `10.0.0.1` poate fi scurtat la `10.1`):
+
+`ssh {{nume_utilizator}}@10.0.0.1 -p {{2222}}`
+
+- Rulează o comandă pe un server la distanță cu alocare [t]ty pentru a permite interacțiunea cu comanda:
+
+`ssh {{nume_utilizator}}@{{server_distant}} -t {{comandă}} {{argumente_comandă}}`
+
+- Tunelare SSH: redirecționare [D]inamică de port (proxy SOCKS pe `localhost:1080`):
+
+`ssh -D {{1080}} {{nume_utilizator}}@{{server_distant}}`
+
+- Tunelare SSH: redirecționează un port specific (`localhost:9999` către `example.org:80`) dezactivând alocarea de pseudo-[T]ty și execuți[N]a comenzilor la distanță:
+
+`ssh -L {{9999}}:{{example.org}}:{{80}} -N -T {{nume_utilizator}}@{{server_distant}}`
+
+- Salt SSH ([J]umping): conectare printr-un jumphost către un server la distanță (mai multe salturi pot fi specificate separate prin virgulă):
+
+`ssh -J {{nume_utilizator}}@{{jump_host}} {{nume_utilizator}}@{{server_distant}}`
+
+- Închide o sesiune blocată:
+
+`<Enter><~><.>`


### PR DESCRIPTION
Adds Romanian translations for four commonly-used commands that didn't have a `pages.ro/common` entry yet:

- `ssh.md`
- `chmod.md`
- `grep.md`
- `find.md`

Followed the existing style in `pages.ro/common` (see `git-add.md` etc.):
- Romanian sentence case.
- Placeholders translated to Romanian (`{{path/to/file}}` → `{{cale/către/fișier}}`).
- Technical terms / acronyms preserved (`SSH`, `IP`, `regex`, `stdin`, port numbers, flags).
- Romanian diacritics used throughout (`ț`, `ă`, `î`, `ș`).

Native Romanian speaker check welcome.