### PR TITLE
razify: add page

### DIFF
--- a/pages/common/razify.md
+++ b/pages/common/razify.md
@@ -1,0 +1,29 @@
+# razify
+
+> CLI tool to scan, validate, audit and document `.env` files.
+> Detects leaked secrets, validates missing variables, and gives a health score.
+> More information: <https://github.com/Hossiy21/razify>.
+
+- Scan a `.env` file for leaked secrets:
+
+`razify scan {{path/to/.env}}`
+
+- Validate missing variables against a template:
+
+`razify validate {{path/to/.env}} {{path/to/.env.example}}`
+
+- Install a pre-commit hook to block secret commits:
+
+`razify guard install`
+
+- Audit a `.env` file and get a health score out of 100:
+
+`razify audit {{path/to/.env}} {{path/to/.env.example}}`
+
+- Auto-generate documentation from `.env.example`:
+
+`razify docs {{path/to/.env.example}}`
+
+- Compare two environment files:
+
+`razify diff {{path/to/.env}} {{path/to/.env.staging}}`


### PR DESCRIPTION
Added documentation for the razify CLI tool, including commands for scanning, validating, auditing, and generating documentation from .env files.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the content guidelines.
- [x] The page(s) follow the style guide.
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended templates.
- Version of the command being documented: v0.1.1
- Reference issue: #