### PR TITLE
nvm: update page

### DIFF
--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -1,13 +1,13 @@
 # nvm
 
 > Install, uninstall, or switch between Node.js versions.
-> Supports version numbers like "12.8" or "v16.13.1", and labels like "stable", "system", etc.
+> Supports version numbers like "12.8" or "v16.13.1", and labels like "node", "system", etc.
 > See also: `asdf`.
 > More information: <https://github.com/nvm-sh/nvm#usage>.
 
-- Install a specific version of Node.js:
+- Install/uninstall a specific version of Node.js:
 
-`nvm install {{node_version}}`
+`nvm {{install|uninstall}} {{node_version}}`
 
 - Use a specific version of Node.js in the current shell:
 
@@ -17,21 +17,21 @@
 
 `nvm alias default {{node_version}}`
 
-- List all available Node.js versions and highlight the default one:
+- List remote versions available for install, only show LTS (long-term support) versions:
 
-`nvm list`
+`nvm ls-remote --lts`
 
-- Uninstall a given Node.js version:
+- List installed versions:
 
-`nvm uninstall {{node_version}}`
+`nvm {{[ls|list]}}`
 
 - Launch the REPL of a specific version of Node.js:
 
-`nvm run {{node_version}} --version`
+`nvm run {{node_version}}`
 
 - Execute a script in a specific version of Node.js:
 
-`nvm exec {{node_version}} node {{app.js}}`
+`nvm exec {{node_version}} node {{path/to/script.js}}`
 
 - Upgrade to the latest working npm version on the current Node.js version:
 


### PR DESCRIPTION
- version alias `stable` has been deprecated by nvm
- combined install/uninstall to save example for `ls-remote`
- description of `nvm list` is actually for `nvm ls-remote`
- `nvm list` is just an alias of `nvm ls`. It is not even in the CLI reference

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
