### PR TITLE
grafana: add page

### DIFF
--- a/pages/common/grafana.md
+++ b/pages/common/grafana.md
@@ -1,0 +1,33 @@
+# grafana
+
+> Grafana server and command-line interface for managing the Grafana instance and its plugins.
+> Some subcommands such as `cli` have their own usage documentation.
+> More information: <https://grafana.com/docs/grafana/latest/cli/>.
+
+- Start the Grafana server in the foreground:
+
+`grafana server`
+
+- Start the Grafana server with a specific configuration file:
+
+`grafana server --config {{path/to/grafana.ini}}`
+
+- Start the Grafana server with a specific home path (containing the `conf`, `public`, and `data` directories):
+
+`grafana server --homepath {{path/to/grafana_home}}`
+
+- Run a `grafana cli` subcommand (e.g. install a plugin):
+
+`grafana cli plugins install {{plugin_id}}`
+
+- Reset the admin user's password:
+
+`grafana cli admin reset-admin-password {{new_password}}`
+
+- Display the Grafana server version:
+
+`grafana --version`
+
+- Display help:
+
+`grafana --help`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 9.2+
- Reference issue: #22349

Documents the top-level `grafana` binary, which dispatches to the `cli` and `server` subcommands (see `pkg/cmd/grafana/main.go`). The existing `grafana-cli` page covers the legacy bundled wrapper; this page covers the canonical entry point and demonstrates the `grafana cli plugins` and `grafana cli admin` flows that are still unchecked under #22349.

Local lint clean: `npx tldr-lint pages/common/grafana.md` and `npx markdownlint pages/common/grafana.md`.