### PR TITLE
npm-{access, audit, config}: update page

### DIFF
--- a/pages.zh/common/npm.md
+++ b/pages.zh/common/npm.md
@@ -1,37 +1,38 @@
 # npm
 
-> JavaScript 和 Node.js 包管理器。
+> JavaScript 和 Node.js 软件包管理器。
 > 管理 Node.js 项目及其模块依赖项。
+> 此命令也有关于其子命令的文件，例如：`install`, `run`.
 > 更多信息：<https://docs.npmjs.com/cli/npm/>。
 
-- 使用默认值创建一个 `package.json` 文件（省略 `--yes` 以交互方式执行）：
+- 使用默认值创建一个 `package.json` 文件（省略 `--yes` 来以交互方式执行）：
 
 `npm init {{[-y|--yes]}}`
 
-- 下载 `package.json` 中列出的所有依赖项包：
+- 下载 `package.json` 中列出的所有依赖项软件包：
 
 `npm {{[i|install]}}`
 
-- 下载包的特定版本并将其添加到 `package.json` 中的依赖项列表中：
+- 下载软件包的特定版本并将其添加到 `package.json` 中的依赖项列表中：
 
-`npm {{[i|install]}} {{包名}}@{{版本号}}`
+`npm {{[i|install]}} {{软件包名}}@{{版本号}}`
 
-- 下载包的最新版本并将其添加到 `package.json` 中的开发依赖项列表中：
+- 下载软件包的最新版本并将其添加到 `package.json` 中的开发依赖项列表中：
 
-`npm {{[i|install]}} {{包名}} {{[-D|--save-dev]}}`
+`npm {{[i|install]}} {{软件包名}} {{[-D|--save-dev]}}`
 
-- 下载包的最新版本并全局安装：
+- 下载软件包的最新版本并全局安装（用 `npm config set prefix` 设置安装位置）：
 
-`npm {{[i|install]}} {{包名}} {{[-g|--global]}}`
+`npm {{[i|install]}} {{软件包名}} {{[-g|--global]}}`
 
-- 卸载包并将其从 `package.json` 中的依赖项列表中删除：
+- 卸载软件包并将其从 `package.json` 中的依赖项列表中删除：
 
-`npm {{[r|uninstall]}} {{包名}}`
+`npm {{[r|uninstall]}} {{软件包名}}`
 
 - 列出所有本地安装的依赖项：
 
 `npm {{[ls|list]}}`
 
-- 列出所有顶级全局安装的包：
+- 列出所有顶层全局安装的软件包：
 
 `npm {{[ls|list]}} {{[-g|--global]}} --depth {{0}}`

--- a/pages/common/npm-access.md
+++ b/pages/common/npm-access.md
@@ -17,7 +17,7 @@
 
 - Set package status (public or private):
 
-`npm access set status {{public|private}} {{package_name}}`
+`npm access set status={{public|private}} {{package_name}}`
 
 - Grant access to a package:
 
@@ -29,4 +29,4 @@
 
 - Configure two-factor authentication requirement:
 
-`npm access set mfa {{none|publish|automation}} {{package_name}}`
+`npm access set mfa={{none|publish|automation}} {{package_name}}`

--- a/pages/common/npm-audit.md
+++ b/pages/common/npm-audit.md
@@ -19,7 +19,7 @@
 
 `npm audit fix --package-lock-only`
 
-- Perform a dry run. Simulate the fix process without making any changes:
+- Simulate the fix process without making any changes:
 
 `npm audit fix --dry-run`
 

--- a/pages/common/npm-config.md
+++ b/pages/common/npm-config.md
@@ -23,9 +23,9 @@
 
 `npm {{[c|config]}} delete {{key}}`
 
-- Edit the global npm configuration file in the default editor:
+- Edit the npm configuration file in the default editor (use the `--global` flag to edit the global config):
 
-`npm {{[c|config]}} edit --global`
+`npm {{[c|config]}} edit`
 
 - Attempt to repair invalid configuration items:
 

--- a/pages/common/npm-config.md
+++ b/pages/common/npm-config.md
@@ -25,7 +25,7 @@
 
 - Edit the global npm configuration file in the default editor:
 
-`npm {{[c|config]}} edit`
+`npm {{[c|config]}} edit --global`
 
 - Attempt to repair invalid configuration items:
 

--- a/pages/common/npm.md
+++ b/pages/common/npm.md
@@ -2,6 +2,7 @@
 
 > JavaScript and Node.js package manager.
 > Manage Node.js projects and their module dependencies.
+> Some subcommands such as `install`, `run`, etc. have their own usage documentation.
 > More information: <https://docs.npmjs.com/cli/npm/>.
 
 - Create a `package.json` file with default values (omit `--yes` to do it interactively):


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**11.12.1
- Reference issue: #

Reason for changes:
- `npm access set` requires an equals sign between status and mfa and their values; otherwise command parsing will fail
- `npm config edit` only opens the global NPM config file when the `--global` option is added
- Add subcommand mentions for the `npm` command