### PR TITLE
cargo-{publish, remove, report}:add Traditional Chinese translation & update Simplified Chinese translation

### DIFF
--- a/pages.zh/common/cargo-add.md
+++ b/pages.zh/common/cargo-add.md
@@ -1,6 +1,6 @@
 # cargo add
 
-> 向 Rust 项目的 `Cargo.toml` 文件添加依赖项。
+> 向 Rust 项目的 `Cargo.toml` 清单添加依赖项。
 > 更多信息：<https://doc.rust-lang.org/cargo/commands/cargo-add.html>。
 
 - 将最新版本的依赖项添加到当前项目：

--- a/pages.zh/common/cargo-locate-project.md
+++ b/pages.zh/common/cargo-locate-project.md
@@ -1,10 +1,10 @@
 # cargo locate-project
 
-> 打印项目的 `Cargo.toml` 清单文件的完整路径。
-> 如果项目是工作区的一部分，则显示项目的清单文件，而不是工作区的清单文件。
+> 打印项目的 `Cargo.toml` 清单的完整路径。
+> 如果项目是工作区的一部分，则显示项目的清单，而不是工作区的。
 > 更多信息：<https://doc.rust-lang.org/cargo/commands/cargo-locate-project.html>。
 
-- 显示包含完整路径到 `Cargo.toml` 清单文件的 JSON 对象：
+- 显示包含完整路径到 `Cargo.toml` 清单的 JSON 对象：
 
 `cargo locate-project`
 
@@ -12,10 +12,10 @@
 
 `cargo locate-project --message-format {{plain|json}}`
 
-- 显示位于工作区根目录而不是当前工作区成员的 `Cargo.toml` 清单文件：
+- 显示位于工作区根目录而不是当前工作区成员的 `Cargo.toml` 清单：
 
 `cargo locate-project --workspace`
 
-- 显示特定目录中的 `Cargo.toml` 清单文件：
+- 显示特定目录中的 `Cargo.toml` 清单：
 
 `cargo locate-project --manifest-path {{path/to/Cargo.toml}}`

--- a/pages.zh/common/cargo-publish.md
+++ b/pages.zh/common/cargo-publish.md
@@ -1,17 +1,17 @@
 # cargo publish
 
-> 将包上传到注册表。
-> 注意：在发布包之前，您必须使用 `cargo login` 添加身份验证令牌。
+> 将软件包上传到注册表。
+> 注意：在发布软件包之前，您必须使用 `cargo login` 添加身份验证令牌。
 > 更多信息：<https://doc.rust-lang.org/cargo/commands/cargo-publish.html>。
 
 - 执行检查，创建一个 `.crate` 文件并将其上传到注册表：
 
 `cargo publish`
 
-- 执行检查，创建一个 `.crate` 文件，但不上传它 (相当于 `cargo package`)：
+- 执行检查，创建一个 `.crate` 文件，但不上传它（相当于 `cargo package`）：
 
 `cargo publish {{[-n|--dry-run]}}`
 
-- 使用指定的注册表 (注册表名称可以在配置中定义，默认为 <https://crates.io>)：
+- 使用指定的注册表（注册表名称可以在配置中定义，默认为 <https://crates.io>）：
 
 `cargo publish --registry {{名称}}`

--- a/pages.zh/common/cargo-remove.md
+++ b/pages.zh/common/cargo-remove.md
@@ -1,6 +1,6 @@
 # cargo remove
 
-> 从 Rust 项目的 `Cargo.toml` 清单中移除依赖关系。
+> 从 Rust 项目的 `Cargo.toml` 清单中移除依赖项。
 > 更多信息：<https://doc.rust-lang.org/cargo/commands/cargo-remove.html>。
 
 - 从当前项目中移除一个依赖项：
@@ -13,4 +13,4 @@
 
 - 移除给定目标平台的依赖项：
 
-`cargo remove --target {{目标平台}} {{依赖项}}`
+`cargo remove --target {{目标}} {{依赖项}}`

--- a/pages.zh/common/cargo-report.md
+++ b/pages.zh/common/cargo-report.md
@@ -3,14 +3,14 @@
 > 显示各种类型的报告。
 > 更多信息：<https://doc.rust-lang.org/cargo/commands/cargo-report.html>。
 
-- 显示一个报告：
+- 显示一份属于未来将无法编译的包（crate）的报告：
 
-`cargo report {{future-incompatibilities|...}}`
+`cargo report future-incompatibilities`
 
-- 显示具有指定由 Cargo 生成的 id 的报告：
+- 显示具有指定 Cargo 生成标识符的报告：
 
-`cargo report {{future-incompatibilities|...}} --id {{id}}`
+`cargo report future-incompatibilities --id {{标识符}}`
 
-- 为指定的包显示报告：
+- 为指定的软件包显示报告：
 
-`cargo report {{future-incompatibilities|...}} --package {{package}}`
+`cargo report future-incompatibilities {{[-p|--package]}} {{软件包}}`

--- a/pages.zh_TW/common/cargo-add.md
+++ b/pages.zh_TW/common/cargo-add.md
@@ -1,6 +1,6 @@
 # cargo add
 
-> 向 Rust 專案的 `Cargo.toml` 檔案新增相依項。
+> 向 Rust 專案的 `Cargo.toml` 清單新增相依項。
 > 更多資訊：<https://doc.rust-lang.org/cargo/commands/cargo-add.html>。
 
 - 將最新版本的相依項新增到目前專案：

--- a/pages.zh_TW/common/cargo-locate-project.md
+++ b/pages.zh_TW/common/cargo-locate-project.md
@@ -1,10 +1,10 @@
 # cargo locate-project
 
-> 列印專案的 `Cargo.toml` 清單檔案的完整路徑。
-> 如果專案是工作區的一部分，則顯示專案的清單檔案，而不是工作區的清單檔案。
+> 列印專案的 `Cargo.toml` 清單的完整路徑。
+> 如果專案是工作區的一部分，則顯示專案的清單，而不是工作區的。
 > 更多資訊：<https://doc.rust-lang.org/cargo/commands/cargo-locate-project.html>。
 
-- 顯示包含完整路徑到 `Cargo.toml` 清單檔案的 JSON 物件：
+- 顯示包含完整路徑到 `Cargo.toml` 清單的 JSON 物件：
 
 `cargo locate-project`
 
@@ -12,10 +12,10 @@
 
 `cargo locate-project --message-format {{plain|json}}`
 
-- 顯示位於工作區根目錄而不是目前工作區成員的 `Cargo.toml` 清單檔案：
+- 顯示位於工作區根目錄而不是目前工作區成員的 `Cargo.toml` 清單：
 
 `cargo locate-project --workspace`
 
-- 顯示特定目錄中的 `Cargo.toml` 清單檔案：
+- 顯示特定目錄中的 `Cargo.toml` 清單：
 
 `cargo locate-project --manifest-path {{path/to/Cargo.toml}}`

--- a/pages.zh_TW/common/cargo-publish.md
+++ b/pages.zh_TW/common/cargo-publish.md
@@ -1,0 +1,17 @@
+# cargo publish
+
+> 將套件上傳到註冊表。
+> 注意：在發布套件之前，您必須使用 `cargo login` 新增身份驗證權杖。
+> 更多資訊：<https://doc.rust-lang.org/cargo/commands/cargo-publish.html>。
+
+- 執行檢查，建立一個 `.crate` 檔案並將其上傳到註冊表：
+
+`cargo publish`
+
+- 執行檢查，建立一個 `.crate` 檔案，但不上傳它（相當於 `cargo package`）：
+
+`cargo publish {{[-n|--dry-run]}}`
+
+- 使用指定的註冊表（註冊表名稱可以在設定中定義，預設為 <https://crates.io>）：
+
+`cargo publish --registry {{名稱}}`

--- a/pages.zh_TW/common/cargo-remove.md
+++ b/pages.zh_TW/common/cargo-remove.md
@@ -1,0 +1,16 @@
+# cargo remove
+
+> 從 Rust 專案的 `Cargo.toml` 清單中移除相依項。
+> 更多資訊：<https://doc.rust-lang.org/cargo/commands/cargo-remove.html>。
+
+- 從目前專案中移除一個相依項：
+
+`cargo remove {{相依項}}`
+
+- 移除開發或組建相依項：
+
+`cargo remove --{{dev|build}} {{相依項}}`
+
+- 移除給定目標平台的相依項：
+
+`cargo remove --target {{目标}} {{相依項}}`

--- a/pages.zh_TW/common/cargo-report.md
+++ b/pages.zh_TW/common/cargo-report.md
@@ -1,0 +1,16 @@
+# cargo report
+
+> 顯示各種類型的報告。
+> 更多資訊：<https://doc.rust-lang.org/cargo/commands/cargo-report.html>。
+
+- 顯示一份屬於未來將無法編譯的包（crate）的報告：
+
+`cargo report future-incompatibilities`
+
+- 顯示具有指定 Cargo 生成識別碼的報告：
+
+`cargo report future-incompatibilities --id {{識別碼}}`
+
+- 為指定的套件顯示報告：
+
+`cargo report future-incompatibilities {{[-p|--package]}} {{套件}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

This PR also unifies the Chinese translation of "manifest" to "清单" instead of "清单文件" or "文件"
