### PR TITLE
cargo-{rustc,rustdoc}: mention `rustc/rustdoc --help`

### DIFF
--- a/pages/common/cargo-rustc.md
+++ b/pages/common/cargo-rustc.md
@@ -1,6 +1,7 @@
 # cargo rustc
 
 > Compile a Rust package. Similar to `cargo build`, but you can pass extra options to the compiler.
+> See `rustc --help` for all available options.
 > See also: `rustc`.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-rustc.html>.
 

--- a/pages/common/cargo-rustdoc.md
+++ b/pages/common/cargo-rustdoc.md
@@ -1,7 +1,7 @@
 # cargo rustdoc
 
 > Build the documentation of Rust packages.
-> Similar to `cargo doc`, but you can pass options to `rustdoc`.
+> Similar to `cargo doc`, but you can pass options to `rustdoc`. See `rustdoc --help` for all available options.
 > See also: `rustdoc`.
 > More information: <https://doc.rust-lang.org/cargo/commands/cargo-rustdoc.html>.
 


### PR DESCRIPTION
Removed in #22281. [I suggested to add this back](https://github.com/tldr-pages/tldr/pull/22281#discussion_r3176710421), but the PR got merged without the suggestion.

I still think this is useful, because the only reason for using `cargo rustc` instead of `cargo build` or `cargo rustdoc` instead of `cargo doc` is if you want to use some options that are only available on `rustc`/`rustdoc` and not on `cargo`. These are only documented in the help messages. I know there's a `--help` example in the rustdoc and rustc tldr pages, but it doesn't hurt to have this in here too.