### PR TITLE
adb-kill-server: add Chinese translation

### DIFF
--- a/pages.zh/common/adb-kill-server.md
+++ b/pages.zh/common/adb-kill-server.md
@@ -1,0 +1,8 @@
+# adb kill-server
+
+> 停止安卓调试桥（adb）server，并断开设备和模拟器连接。
+> 更多信息：<https://manned.org/adb#head14>。
+
+- 如果 adb server 正在运行，终止它：
+
+`adb kill-server`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** adb from Android Debug Bridge
- Reference issue: #13579

### Validation

- `curl -sL -o /dev/null -w "%{http_code}" https://manned.org/adb#head14` returned `200`.
- `npx tldr-lint --ignore TLDR104,TLDR003,TLDR004,TLDR005,TLDR015 pages.zh/common/adb-kill-server.md`
- `npx markdownlint pages.zh/common/adb-kill-server.md`
- `npm test`
