### PR TITLE
rmpc: add page

### DIFF
--- a/pages/common/rmpc.md
+++ b/pages/common/rmpc.md
@@ -1,0 +1,33 @@
+# rmpc
+
+> A terminal music player client for the Music Player Daemon, with album art support.
+> See also: `mpd`, `mpc`, `ncmpcpp`.
+> More information: <https://rmpc.mierak.dev>.
+
+- Start the TUI client:
+
+`rmpc`
+
+- Connect to a specific MPD instance:
+
+`rmpc --address {{host:port}}`
+
+- Toggle between play and pause:
+
+`rmpc togglepause`
+
+- Play the next or previous song:
+
+`rmpc {{next|prev}}`
+
+- Scan the music directory for changes:
+
+`rmpc update`
+
+- Save the currently playing song's album art to a file:
+
+`rmpc albumart --output {{path/to/cover.jpg}}`
+
+- Print the default configuration to use as a starting point:
+
+`rmpc config`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.10.x (current master)
- Reference issue: #22392

Adds a `common` page for [`rmpc`](https://github.com/mierak/rmpc), a TUI Music Player Daemon client with album art support. Commands and flags were verified against `rmpc/src/config/cli.rs` on `master`. Documentation link points to the project's docs site at <https://rmpc.mierak.dev>.

Closes #22392.