### PR TITLE
sd: fix some small errors

### DIFF
--- a/pages.ko/common/sd.md
+++ b/pages.ko/common/sd.md
@@ -17,4 +17,4 @@
 
 - 현재 프로젝트의 모든 파일에서 찾기 및 바꾸기 (출력 스트림: `stdout`):
 
-`sd {{'from "react"'}} {{'from "preact"'}} "$(find . -type f)"`
+`find . -type f -exec sd {{'from "react"'}} {{'from "preact"'}} {} \;`

--- a/pages.ko/common/sd.md
+++ b/pages.ko/common/sd.md
@@ -15,6 +15,6 @@
 
 `sd -p {{'window.fetch'}} {{'fetch'}} {{경로/대상/파일.js}}`
 
-- 현재 프로젝트의 모든 파일에서 찾기 및 바꾸기 (출력 스트림: `stdout`):
+- 현재 프로젝트의 모든 파일에서 찾기 및 바꾸기:
 
 `find . -type f -exec sd {{'from "react"'}} {{'from "preact"'}} {} \;`

--- a/pages.ko/common/sd.md
+++ b/pages.ko/common/sd.md
@@ -13,8 +13,8 @@
 
 - 특정 파일에서 찾기 및 바꾸기 (출력 스트림: `stdout`):
 
-`sd -p {{'window.fetch'}} {{'fetch'}} {{경로/대상/파일.js}}`
+`sd {{[-p|--preview]}} '{{window.fetch}}' '{{fetch}}' {{경로/대상/파일.js}}`
 
 - 현재 프로젝트의 모든 파일에서 찾기 및 바꾸기:
 
-`find . -type f -exec sd {{'from "react"'}} {{'from "preact"'}} {} \;`
+`find . -type f -exec sd '{{from "react"}}' '{{from "preact"}}' {} \;`

--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -15,6 +15,6 @@
 
 `sd {{[-p|--preview]}} '{{window.fetch}}' '{{fetch}}' {{path/to/file.js}}`
 
-- Find and replace in all files in the current project (output stream: `stdout`):
+- Find and replace in all files in the current project:
 
 `find . -type f -exec sd '{{from "react"}}' '{{from "preact"}}' {} \;`

--- a/pages/common/sd.md
+++ b/pages/common/sd.md
@@ -17,4 +17,4 @@
 
 - Find and replace in all files in the current project (output stream: `stdout`):
 
-`sd '{{from "react"}}' '{{from "preact"}}' "$(find . -type f)"`
+`find . -type f -exec sd '{{from "react"}}' '{{from "preact"}}' {} \;`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** sd 1.0.0
- Reference issue: (no issue)

---

Just a couple of small fixes to the `sd` page. Namely:

1. The command using `sd` with `find` used the old example from `sd`'s README which was incorrect and now calls `sd` through `fd` (find alternative). I kept `find` to minimize changes
    - The current tldr example passes all of the files as a single argument chmln/sd#137
    - Changed in chmln/sd#61
2. A couple of the examples listed `(output stream: stdout)` while they were modifying the files in-place