### PR TITLE
crackmapexec: add page

### DIFF
--- a/pages/common/crackmapexec.md
+++ b/pages/common/crackmapexec.md
@@ -1,0 +1,37 @@
+# crackmapexec
+
+> Network penetration testing tool for assessing the security of large Active Directory networks.
+> See also: `nmap`, `smbclient`, `enum4linux`.
+> More information: <https://github.com/byt3bl33d3r/CrackMapExec>.
+
+- Enumerate SMB shares on a host or subnet:
+
+`crackmapexec smb {{ip_or_cidr}} --shares`
+
+- Authenticate to SMB with a username and password:
+
+`crackmapexec smb {{ip_or_hostname}} -u {{username}} -p {{password}}`
+
+- Authenticate using an NTLM hash (Pass-the-Hash):
+
+`crackmapexec smb {{ip_or_hostname}} -u {{username}} -H {{nt_hash}}`
+
+- Enumerate logged-on users:
+
+`crackmapexec smb {{ip_or_hostname}} -u {{username}} -p {{password}} --loggedon-users`
+
+- Execute a command on a remote host:
+
+`crackmapexec smb {{ip_or_hostname}} -u {{username}} -p {{password}} -x "{{command}}"`
+
+- Dump SAM hashes from a remote host:
+
+`crackmapexec smb {{ip_or_hostname}} -u {{username}} -p {{password}} --sam`
+
+- Spray a password across multiple hosts:
+
+`crackmapexec smb {{path/to/hosts.txt}} -u {{username}} -p {{password}}`
+
+- Enumerate via WinRM protocol:
+
+`crackmapexec winrm {{ip_or_hostname}} -u {{username}} -p {{password}}`


### PR DESCRIPTION
Adds a tldr page for `crackmapexec`, a widely used Active Directory penetration testing tool supporting SMB, WinRM, LDAP, and more.

#### Self-review checklist

- [x] The page is in the correct directory (`pages/common/`)
- [x] The filename matches the command name
- [x] The page follows the [tldr-pages format](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md)
- [x] There are 8 or fewer examples
- [x] All placeholders use `{{double_curly_braces}}`
- [x] The description ends with a period
- [x] Each example description ends with a colon