### PR TITLE
cage, caligula, cdrdao, cdrecord, cec-client, cec-ctl: add Korean translation

### DIFF
--- a/pages.ko/linux/cage.md
+++ b/pages.ko/linux/cage.md
@@ -1,0 +1,25 @@
+# cage
+
+> 애플리케이션을 키오스크 모드로 실행.
+> 관련 항목: `gamescope`.
+> 더 많은 정보: <https://github.com/cage-kiosk/cage/blob/master/cage.1.scd>.
+
+- 애플리케이션 실행:
+
+`cage {{애플리케이션}}`
+
+- 애플리케이션 인자를 전달:
+
+`cage -- {{애플리케이션}} {{인자}}`
+
+- 창 장식([d]ecorations) 숨김 (터미널 접근이 잠길 수 있음):
+
+`cage -d {{애플리케이션}}`
+
+- `<Ctrl Alt F2>`로 터미널 전환([s]witching) 허용:
+
+`cage -s {{애플리케이션}}`
+
+- 도움말 표시:
+
+`cage -h`

--- a/pages.ko/linux/caligula.md
+++ b/pages.ko/linux/caligula.md
@@ -1,0 +1,13 @@
+# caligula
+
+> 디스크 이미징을 위한 가볍고 사용자 친화적인 TUI 도구.
+> 관련 항목: `dd`.
+> 더 많은 정보: <https://github.com/ifd3f/caligula>.
+
+- ISO 이미지를 드라이브에 플래시(쓰기):
+
+`caligula burn {{경로/대상/이미지.iso}}`
+
+- 해시를 대화형으로 입력하지 않고 ISO 이미지를 드라이브에 플래시(쓰기):
+
+`caligula burn {{경로/대상/이미지.iso}} {{[-s|--hash]}} {{해시}}`

--- a/pages.ko/linux/cdrdao.md
+++ b/pages.ko/linux/cdrdao.md
@@ -1,0 +1,8 @@
+# cdrdao
+
+> Disc-at-once 모드로 CD 읽기 및 쓰기.
+> 더 많은 정보: <https://manned.org/cdrdao>.
+
+- CD를 읽고 내용을 파일로 저장:
+
+`cdrdao read-cd --device {{/dev/cdrom}} --read-raw {{이미지.toc}}`

--- a/pages.ko/linux/cdrecord.md
+++ b/pages.ko/linux/cdrecord.md
@@ -1,0 +1,21 @@
+# cdrecord
+
+> CD 또는 DVD에 데이터를 기록하는 도구.
+> 일부 cdrecord 명령은 디스크 데이터 전체 삭제같은 파괴적인 작업 수행 가능.
+> 더 많은 정보: <https://manned.org/cdrecord>.
+
+- `cdrecord`에서 사용할 수 있는 광학 드라이브 목록 표시:
+
+`cdrecord --devices`
+
+- 오디오 전용 디스크 기록(Record) 또는 굽기(burn):
+
+`cdrecord dev={{/dev/optical_drive}} -audio {{track*.cdaudio}}`
+
+- 파일을 디스크에 굽고, 완료 후 디스크 꺼내기 (일부 레코더는 필요):
+
+`cdrecord -eject dev={{/dev/optical_drive}} -data {{파일.iso}}`
+
+- 광학 드라이브 디스크에 파일 굽기(여러 디스크에 연속으로 기록 가능):
+
+`cdrecord -tao dev={{/dev/optical_drive}} -data {{파일.iso}}`

--- a/pages.ko/linux/cec-client.md
+++ b/pages.ko/linux/cec-client.md
@@ -1,0 +1,29 @@
+# cec-client
+
+> 직렬 버스 CEC 연결 관리.
+> 관련 항목: `cec-ctl`.
+> 더 많은 정보: <https://manned.org/cec-client>.
+
+- 모든 CEC 어댑터 목록 표시:
+
+`cec-client {{[-l|--list-devices]}}`
+
+- 대화형 CEC 세션 시작:
+
+`sudo cec-client`
+
+- On-Screen Display 이름 설정:
+
+`sudo cec-client {{[-o|--osd-name]}} {{이름}}`
+
+- 단일 명령 전송:
+
+`echo {{on 0}} | sudo cec-client {{[-s|--single-command]}}`
+
+- 대화형 모드에서 장치를 대기(standby) 상태로 전환:
+
+`standby {{0}}`
+
+- 대화형 모드에서 장치 전원 켜기:
+
+`on {{0}}`

--- a/pages.ko/linux/cec-ctl.md
+++ b/pages.ko/linux/cec-ctl.md
@@ -1,0 +1,17 @@
+# cec-ctl
+
+> 커널 CEC 장치 제어.
+> 관련 항목: `cec-client`.
+> 더 많은 정보: <https://manned.org/cec-ctl>.
+
+- CEC 장치 목록 표시:
+
+`cec-ctl --list-devices`
+
+- CEC 트래픽 모니터링:
+
+`sudo cec-ctl {{[-m|--monitor]}}`
+
+- CEC 토폴로지 표시:
+
+`cec-ctl {{[-S|--show-topology]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
