### PR TITLE
qsv: add page

### DIFF
--- a/pages/common/qsv.md
+++ b/pages/common/qsv.md
@@ -1,0 +1,37 @@
+# qsv
+
+> A high-performance CSV data-wrangling toolkit written in Rust.
+> The spiritual successor to `xsv`.
+> More information: <https://github.com/dathere/qsv>.
+
+- Inspect the headers of a CSV file:
+
+`qsv headers {{path/to/file.csv}}`
+
+- Count the number of records:
+
+`qsv count {{path/to/file.csv}}`
+
+- Get per-column statistics, formatted as a table:
+
+`qsv stats {{path/to/file.csv}} | qsv table`
+
+- Select columns by name (in the given order):
+
+`qsv select {{column1,column2}} {{path/to/file.csv}}`
+
+- Show a random sample of records:
+
+`qsv sample {{10}} {{path/to/file.csv}}`
+
+- Filter rows whose column matches a `regex`:
+
+`qsv search --select {{column}} {{pattern}} {{path/to/file.csv}}`
+
+- Show the most frequent values in a column:
+
+`qsv frequency --select {{column}} --limit {{5}} {{path/to/file.csv}}`
+
+- Join two CSV files on a column:
+
+`qsv join {{column1}} {{path/to/file1.csv}} {{column2}} {{path/to/file2.csv}}`


### PR DESCRIPTION
Adds `pages/common/qsv.md` for [qsv](https://github.com/dathere/qsv) — an active, high-performance CSV/TSV toolkit written in Rust, often described as the spiritual successor to `xsv`.

## Examples

1. `qsv headers` — inspect headers
2. `qsv count` — count records
3. `qsv stats | qsv table` — per-column statistics as a formatted table
4. `qsv select` — select columns by name
5. `qsv sample` — random row sample
6. `qsv search --select` — regex-filter rows by column
7. `qsv frequency --select --limit` — top-N most frequent values in a column
8. `qsv join` — join two CSV files on a column

## Verification

Before submitting, every example was tested against multiple authoritative CSV sources to make sure the syntax and flags work as written:

- Our World in Data — CO2 emissions (~50k rows)
- FRED — US unemployment rate \`UNRATE\` (~940 rows)
- World Bank — country list (~250 rows)
- NYC Open Data — popular baby names (~21k rows)
- OWID — life expectancy (~21k rows)
- World Bank / DataHub — GDP per capita (~14k rows)

32/32 example invocations across these datasets passed.

\`qsv sqlp\` was considered but is not present in the prebuilt qsv release binaries (Polars-dependent commands have been split out), so \`qsv frequency\` was used instead — it is universally available in the standard \`qsv\` build and matches a natural CSV exploration workflow.

## Linting

- \`npx tldr-lint pages/common/qsv.md\` — clean
- \`npx markdownlint pages/common/qsv.md\` — clean