### PR TITLE
git-{cliff, fast-export, filter-branch, for-each-ref, get-tar-commit-id, lfs-transfer}: add Korean translation page

### DIFF
--- a/pages.ko/common/git-cliff.md
+++ b/pages.ko/common/git-cliff.md
@@ -1,0 +1,24 @@
+# git cliff
+
+> 매우 높은 수준으로 사용자 지정 가능한 changelog 생성기.
+> 더 많은 정보: <https://git-cliff.org/docs/usage/args/>.
+
+- Git 저장소의 모든 커밋으로부터 changelog 생성 후 `CHANGELOG.md`에 저장:
+
+`git cliff > {{CHANGELOG.md}}`
+
+- 최신 태그 이후의 커밋으로 changelog 생성 후 `stdout`에 출력:
+
+`git cliff {{[-l|--latest]}}`
+
+- 현재 태그에 속한 커밋으로 changelog 생성 (`git checkout`으로 태그 상태여야 함):
+
+`git cliff --current`
+
+- 태그에 속하지 않은 커밋으로 changelog 생성:
+
+`git cliff {{[-u|--unreleased]}}`
+
+- 현재 디렉터리에 기본 설정 파일 `cliff.toml` 생성:
+
+`git cliff {{[-i|--init]}}`

--- a/pages.ko/common/git-fast-export.md
+++ b/pages.ko/common/git-fast-export.md
@@ -1,0 +1,24 @@
+# git fast-export
+
+> Git 저장소의 내용과 히스토리를 스트리밍 가능한 일반 텍스트 형식으로 내보내기.
+> 더 많은 정보: <https://manned.org/git-fast-export>.
+
+- 전체 Git 저장소 히스토리를 `stdout`으로 출력:
+
+`git fast-export --all`
+
+- 전체 저장소를 파일로 내보내기:
+
+`git fast-export --all > {{경로/대상/파일}}`
+
+- 특정 브랜치만 내보내기:
+
+`git fast-export {{main}}`
+
+- `n`개 객체마다 진행 상태(`progress`) 출력하며 내보내기 (`git fast-import` 진행 표시용):
+
+`git fast-export --progress {{n}} --all > {{경로/대상/파일}}`
+
+- 특정 하위 디렉터리의 히스토리만 내보내기:
+
+`git fast-export --all -- {{경로/대상/디렉토리}} > {{경로/대상/파일}}`

--- a/pages.ko/common/git-filter-branch.md
+++ b/pages.ko/common/git-filter-branch.md
@@ -1,0 +1,16 @@
+# git filter-branch
+
+> 파일 제거 등 Git 브랜치 히스토리 변경.
+> 더 많은 정보: <https://git-scm.com/docs/git-filter-branch>.
+
+- 모든 커밋에서 특정 파일 제거:
+
+`git filter-branch --tree-filter 'rm {{[-f|--force]}} {{파일}}' HEAD`
+
+- 작성자 이메일 업데이트:
+
+`git filter-branch --env-filter 'GIT_AUTHOR_EMAIL={{새로운_이메일}}' HEAD`
+
+- 히스토리에서 특정 폴더 삭제:
+
+`git filter-branch --tree-filter 'rm {{[-rf|--recursive --force]}} {{폴더}}' HEAD`

--- a/pages.ko/common/git-for-each-ref.md
+++ b/pages.ko/common/git-for-each-ref.md
@@ -1,0 +1,36 @@
+# git for-each-ref
+
+> Git 저장소의 참조(ref: 브랜치, 태그 등) 목록 표시 및 형식 지정.
+> 더 많은 정보: <https://git-scm.com/docs/git-for-each-ref>.
+
+- 모든 ref(브랜치와 태그) 목록 표시:
+
+`git for-each-ref`
+
+- 브랜치만 목록 표시:
+
+`git for-each-ref refs/heads/`
+
+- 태그만 목록 표시:
+
+`git for-each-ref refs/tags/`
+
+- `HEAD`에 병합된 브랜치 목록 표시:
+
+`git for-each-ref --merged HEAD refs/heads/`
+
+- 모든 ref의 짧은 이름 표시:
+
+`git for-each-ref --format "%(refname:short)"`
+
+- 커미터 날짜 기준으로 최신순 정렬:
+
+`git for-each-ref --sort -committerdate`
+
+- 커미터 날짜 기준으로 오래된순 정렬:
+
+`git for-each-ref --sort committerdate`
+
+- 지정한 개수만큼만 ref 출력:
+
+`git for-each-ref --count {{숫자}}`

--- a/pages.ko/common/git-get-tar-commit-id.md
+++ b/pages.ko/common/git-get-tar-commit-id.md
@@ -1,0 +1,8 @@
+# git get-tar-commit-id
+
+> `git archive`로 생성된 아카이브에서 커밋 ID 추출.
+> 더 많은 정보: <https://git-scm.com/docs/git-get-tar-commit-id>.
+
+- 커밋 해시 ID를 추출하거나, 정보가 없으면 조용히 종료하며 반환 코드 1 반환:
+
+`git < {{경로/대상/아카이브.tar}} get-tar-commit-id`

--- a/pages.ko/common/git-lfs-transfer.md
+++ b/pages.ko/common/git-lfs-transfer.md
@@ -1,0 +1,13 @@
+# git-lfs-transfer
+
+> Git LFS 순수 SSH 전송 프로토콜의 서버 측 구현.
+> Git LFS가 HTTPS 대신 SSH를 통해 대용량 파일을 업로드 및 다운로드할 수 있도록 지원.
+> 더 많은 정보: <https://github.com/charmbracelet/git-lfs-transfer#usage>.
+
+- Git LFS로 추적되는 대용량 파일을 저장소에 업로드:
+
+`git-lfs-transfer {{경로/대상/저장소.git}} upload`
+
+- Git LFS로 추적되는 대용량 파일을 저장소에서 다운로드:
+
+`git-lfs-transfer {{경로/대상/저장소.git}} download`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
