### PR TITLE
gh-{pr-create, ssh-key}: add Portuguese translation

### DIFF
--- a/pages.pt_BR/common/gh-pr-create.md
+++ b/pages.pt_BR/common/gh-pr-create.md
@@ -1,0 +1,24 @@
+# gh pr create
+
+> Gerencia pull requests do GitHub.
+> Mais informações: <https://cli.github.com/manual/gh_pr_create>.
+
+- Cria um pull request interativamente:
+
+`gh pr {{[new|create]}}`
+
+- Cria um pull request, determinando o título e a descrição a partir das mensagens de commit da branch atual:
+
+`gh pr {{[new|create]}} {{[-f|--fill]}}`
+
+- Cria um pull request de rascunho:
+
+`gh pr {{[new|create]}} {{[-d|--draft]}}`
+
+- Cria um pull request especificando a branch base, o título e a descrição:
+
+`gh pr {{[new|create]}} {{[-B|--base]}} {{branch_base}} {{[-t|--title]}} "{{título}}" {{[-b|--body]}} "{{descrição}}"`
+
+- Começa a abrir um pull request no navegador padrão:
+
+`gh pr {{[new|create]}} {{[-w|--web]}}`

--- a/pages.pt_BR/common/gh-ssh-key.md
+++ b/pages.pt_BR/common/gh-ssh-key.md
@@ -1,0 +1,20 @@
+# gh ssh-key
+
+> Gerencia chaves SSH do GitHub.
+> Mais informações: <https://cli.github.com/manual/gh_ssh-key>.
+
+- Lista as chaves SSH do usuário autenticado no momento:
+
+`gh ssh-key {{[ls|list]}}`
+
+- Adiciona uma chave SSH à conta do usuário autenticado no momento:
+
+`gh ssh-key add {{caminho/para/chave.pub}}`
+
+- Adiciona uma chave SSH à conta do usuário autenticado no momento com um título específico:
+
+`gh ssh-key add {{[-t|--title]}} {{título}} {{caminho/para/chave.pub}}`
+
+- Mostra ajuda:
+
+`gh ssh-key`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A, translation of existing pages.
- Reference issue: #13575