### PR TITLE
pages: add systemd-analyze and nftables

### DIFF
--- a/pages/common/nftables.md
+++ b/pages/common/nftables.md
@@ -1,0 +1,32 @@
+# nftables
+
+> Modern Linux kernel packet filtering framework, replacement for iptables.
+> More information: <https://wiki.nftables.org>.
+
+- List all current ruleset:
+
+`nft list ruleset`
+
+- Add a table for a specific address family:
+
+`nft add table {{family}} {{table_name}}`
+
+- Add a chain to a table:
+
+`nft add chain {{family}} {{table_name}} {{chain_name}} { type {{filter|nat|route}} hook {{hook}} priority {{priority}} \; }`
+
+- Add a rule to allow incoming TCP traffic on port 80:
+
+`nft add rule {{family}} {{table_name}} {{chain_name}} tcp dport {{80}} accept`
+
+- Flush all rules in a table:
+
+`nft flush table {{family}} {{table_name}}`
+
+- Save the current ruleset to a file:
+
+`nft list ruleset > {{path/to/file.nft}}`
+
+- Load a ruleset from a file:
+
+`nft -f {{path/to/file.nft}}`

--- a/pages/common/systemd-analyze.md
+++ b/pages/common/systemd-analyze.md
@@ -1,0 +1,28 @@
+# systemd-analyze
+
+> Analyze and debug systemd boot performance and unit dependencies.
+> More information: <https://www.freedesktop.org/software/systemd/man/systemd-analyze.html>.
+
+- Show the total boot time and a breakdown by kernel, initrd, and userspace:
+
+`systemd-analyze time`
+
+- List all running units sorted by initialization time:
+
+`systemd-analyze blame`
+
+- Print a tree of time-critical chain of units:
+
+`systemd-analyze critical-chain`
+
+- Generate an SVG plot of the boot process and save it to a file:
+
+`systemd-analyze plot > {{path/to/file.svg}}`
+
+- Show security-related information about a running service:
+
+`systemd-analyze security {{service_name}}`
+
+- Verify the syntax and dependencies of all unit files:
+
+`systemd-analyze verify {{/path/to/unit.file}}`


### PR DESCRIPTION
Added two new pages for common Linux commands:

**systemd-analyze** - Analyze and debug systemd boot performance and unit dependencies
**nftables** - Modern Linux kernel packet filtering framework

Both pages follow the standard tldr format with practical examples.