### PR TITLE
terraform-version: add page

### DIFF
--- a/pages/common/terraform-version.md
+++ b/pages/common/terraform-version.md
@@ -1,0 +1,12 @@
+# terraform version
+
+> Display the Terraform CLI version along with the platform and installed provider versions.
+> More information: <https://developer.hashicorp.com/terraform/cli/commands/version>.
+
+- Show the Terraform version, platform information, and any installed provider versions:
+
+`terraform version`
+
+- Show version information in JSON format (useful for parsing in scripts):
+
+`terraform version -json`


### PR DESCRIPTION
Adds a page for `terraform version`, which is currently unticked in the Terraform tracker issue #21118.

The command has a small surface area (two invocations: default and `-json`), so the page is intentionally short and focused per the style guide's "focus on details specific to the command" rule.

Checklist:
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (`common/`).
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended templates.
- [x] The page follows the content guidelines.
- [x] The page description includes a link to documentation.
- [x] Each example was verified locally against Terraform.
