### PR TITLE
echo: add Arabic translation

### DIFF
--- a/pages.ar/common/echo.md
+++ b/pages.ar/common/echo.md
@@ -1,0 +1,33 @@
+# echo
+
+> طباعة نص أو قيمة متغير في الـ terminal.
+> انظر أيضًا: `printf`.
+> لمزيد من التفاصيل: <https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html>.
+
+- طباعة نص على الشاشة. ملاحظة: علامات الاقتباس اختيارية:
+
+`echo "{{Hello World}}"`
+
+- طباعة نص يتضمن قيمة متغير بيئة:
+
+`echo "{{My path is $PATH}}"`
+
+- طباعة نص دون إضافة سطر جديد في النهاية:
+
+`echo -n "{{Hello World}}"`
+
+- إضافة نص إلى نهاية ملف:
+
+`echo "{{Hello World}}" >> {{file.txt}}`
+
+- تفعيل تفسير الرموز الخاصة مثل `\t` للجدولة و`\n` للسطر الجديد:
+
+`echo -e "{{Column 1\tColumn 2}}"`
+
+- عرض رمز الخروج للأمر السابق (في Windows استخدم `echo %errorlevel%`، وفي PowerShell `$lastexitcode`):
+
+`echo $?`
+
+- توجيه نص إلى مدخل برنامج آخر:
+
+`echo "{{Hello World}}" | {{program}}`


### PR DESCRIPTION
## What
Adds `pages.ar/common/echo.md` — Arabic translation of the `echo` page.

## Why
The Arabic locale (`pages.ar`) is missing the majority of common pages.
`echo` is one of the most fundamental Unix commands used daily by
developers, yet it has no Arabic translation.

## How
Translated all example descriptions from the English source into natural
Arabic, following the existing style in `pages.ar` (e.g. `git.md`, `docker.md`).
Avoided word-for-word translation in favour of phrasing that reads
naturally to Arabic developers.

## Test
- Formatting verified against the tldr style guide (`{{placeholders}}`,
  backticks, no trailing spaces, at most 8 examples per page)
- Style compared against existing merged Arabic pages for consistency
- Translations written and proofread by a native Arabic speaker

## Checklist
- [x] The page is in the correct platform directory: `common`
- [x] The page description has a link to documentation
- [x] The page follows the content guidelines
- [x] The page follows the style guide
- [x] The PR contains at most 5 new pages
- [x] The PR is authored by me and human-reviewed