### PR TITLE
cp: add Arabic translation

### DIFF
--- a/pages.ar/common/cp.md
+++ b/pages.ar/common/cp.md
@@ -1,0 +1,36 @@
+# cp
+
+> نسخ الملفات والمجلدات.
+> لمزيد من التفاصيل: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+
+- نسخ ملف إلى موقع آخر:
+
+`cp {{path/to/source_file}} {{path/to/target_file}}`
+
+- نسخ ملف داخل مجلد مع الاحتفاظ باسمه:
+
+`cp {{path/to/source_file}} {{path/to/target_parent_directory}}`
+
+- نسخ مجلد بالكامل بما يشمل المجلدات الفرعية (إن وُجد المجلد الهدف، يُنسخ المصدر بداخله):
+
+`cp {{[-r|--recursive]}} {{path/to/source_directory}} {{path/to/target_directory}}`
+
+- نسخ مجلد بالكامل مع عرض اسم كل ملف أثناء نسخه:
+
+`cp {{[-vr|--verbose --recursive]}} {{path/to/source_directory}} {{path/to/target_directory}}`
+
+- نسخ عدة ملفات إلى مجلد في آنٍ واحد:
+
+`cp {{[-t|--target-directory]}} {{path/to/destination_directory}} {{path/to/file1 path/to/file2 ...}}`
+
+- نسخ جميع ملفات بامتداد معين مع طلب تأكيد عند الكتابة فوق ملف موجود:
+
+`cp {{[-i|--interactive]}} {{*.ext}} {{path/to/target_directory}}`
+
+- اتباع الروابط الرمزية قبل النسخ:
+
+`cp {{[-L|--dereference]}} {{link}} {{path/to/target_directory}}`
+
+- الحفاظ على هيكل المسار الكامل أثناء النسخ، وإنشاء المجلدات الوسيطة عند الحاجة:
+
+`cp --parents {{source/path/to/file}} {{path/to/target_file}}`


### PR DESCRIPTION
## What
Adds `pages.ar/common/cp.md` — Arabic translation of the `cp` page.

## Why
The Arabic locale (`pages.ar`) is missing the majority of common pages.
`cp` is one of the most essential Unix commands for file management,
yet it has no Arabic translation.

## How
Translated all example descriptions from the English source into natural
Arabic, following the existing style in `pages.ar` (e.g. `git.md`, `docker.md`).
Avoided word-for-word translation in favour of phrasing that reads
naturally to Arabic developers.

## Test
- Formatting verified against the tldr style guide (`{{placeholders}}`,
  backticks, no trailing spaces, at most 8 examples per page)
- Style compared against existing merged Arabic pages for consistency
- Translations written and proofread by a native Arabic speaker

## Checklist
- [x] The page is in the correct platform directory: `common`
- [x] The page description has a link to documentation
- [x] The page follows the content guidelines
- [x] The page follows the style guide
- [x] The PR contains at most 5 new pages
- [x] The PR is authored by me and human-reviewed