### PR TITLE
docs: add xbindkeys page

### DIFF
--- a/pages/linux/xbindkeys.md
+++ b/pages/linux/xbindkeys.md
@@ -1,0 +1,24 @@
+# xbindkeys
+
+> Associate commands with keyboard shortcuts in X.
+> More information: <https://www.nongnu.org/xbindkeys/xbindkeys.html>.
+
+- Create a default configuration file in the home directory:
+
+`xbindkeys --defaults > ~/.xbindkeysrc`
+
+- Start xbindkeys with the default configuration file:
+
+`xbindkeys`
+
+- Reload the configuration file without restarting xbindkeys:
+
+`killall -HUP xbindkeys`
+
+- Show the keycodes of pressed keys:
+
+`xbindkeys --key`
+
+- Display help:
+
+`xbindkeys --help`


### PR DESCRIPTION
## Summary

This PR adds a new tldr page for the `xbindkeys` command.

The page includes examples for:
- Creating a default configuration file.
- Starting xbindkeys.
- Reloading the configuration.
- Showing pressed keycodes.
- Displaying help information.

Closes #21343