### PR TITLE
newsboat: link docs to master branch manual

### DIFF
--- a/pages/common/newsboat.md
+++ b/pages/common/newsboat.md
@@ -1,7 +1,7 @@
 # newsboat
 
 > An RSS/Atom feed reader for text terminals.
-> More information: <https://newsboat.org/releases/2.40/docs/newsboat.html#_first_steps>.
+> More information: <https://github.com/newsboat/newsboat/blob/master/doc/newsboat.asciidoc#_first_steps>.
 
 - First import feed URLs from an OPML file:
 


### PR DESCRIPTION
## Summary

Point the newsboat tldr page "More information" link at the manual on the `master` branch instead of a versioned `newsboat.org/releases/...` URL, so it stays current without updating on every release.

Related: https://github.com/newsboat/newsboat/issues/3215

## Test plan

- [x] Single-line URL change in `pages/common/newsboat.md`

Made with [Cursor](https://cursor.com)