### PR TITLE
age: syn French and Spanish translations

### DIFF
--- a/pages.es/common/age.md
+++ b/pages.es/common/age.md
@@ -1,25 +1,25 @@
 # age
 
-> Una herramienta de encriptación de archivos sencilla, moderna y segura.
-> Vea también: `age-keygen`.
+> Una herramienta de cifrado de archivos sencilla, moderna y segura.
+> Vea también: `age-keygen`, `age-inspect`.
 > Más información: <https://github.com/FiloSottile/age#usage>.
 
-- Genera un archivo cifrado que se puede descifrar con una frase de contraseña:
+- Generar un archivo cifrado que se puede descifrar con una frase de contraseña:
 
-`age {{[-p|--passphrase]}} {{[-o|--output]}} {{ruta/al/archivo_encriptado}} {{ruta/al/archivo_no_cifrado}}`
+`age {{[-p|--passphrase]}} {{[-o|--output]}} {{ruta/al/archivo_cifrado.age}} {{ruta/al/archivo_no_cifrado}}`
 
-- Cifra un archivo con una o varias claves públicas introducidas como literales (repite el indicador `--recipient` para especificar varias claves públicas):
+- Cifrar un archivo con una o más claves públicas introducidas como literales (repetir `--recipient` para varias claves):
 
-`age {{[-r|--recipient]}} {{clave_publica}} {{[-o|--output]}} {{ruta/al/archivo_cifrado}} {{ruta/al/archivo_no_cifrado}}`
+`age {{[-r|--recipient]}} {{clave_publica}} {{[-o|--output]}} {{ruta/al/archivo_cifrado.age}} {{ruta/al/archivo_no_cifrado}}`
 
-- Cifra un archivo a uno o más destinatarios con sus claves públicas especificadas en un archivo (una por línea):
+- Cifrar un archivo con las claves públicas especificadas en un archivo de destinatarios (una por línea):
 
-`age {{[-R|--recipients-file]}} {{ruta/al/archivo_recipientes}} {{[-o|--output]}} {{ruta/al/archivo_encriptado}} {{ruta/al/archivo_no_cifrado}}`
+`age {{[-R|--recipients-file]}} {{ruta/al/archivo_destinatarios.txt}} {{[-o|--output]}} {{ruta/al/archivo_cifrado.age}} {{ruta/al/archivo_no_cifrado}}`
 
-- Descifra un archivo con una frase de contraseña:
+- Descifrar un archivo con una frase de contraseña:
 
-`age {{[-d|--decrypt]}} {{[-o|--output]}} {{ruta/al/archivo_descifrado}} {{ruta/para/archivo_cifrado}}`
+`age {{[-d|--decrypt]}} {{[-o|--output]}} {{ruta/al/archivo_descifrado}} {{ruta/al/archivo_cifrado.age}}`
 
-- Descifra un archivo con un archivo de clave privada:
+- Descifrar un archivo con un archivo de clave privada:
 
-`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{ruta/al/archivo_de_clave_privada}} {{[-o|--output]}} {{ruta/para/archivo_descifrado}} {{ruta/al/archivo_cifrado}}`
+`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{ruta/al/archivo_clave_privada}} {{[-o|--output]}} {{ruta/al/archivo_descifrado}} {{ruta/al/archivo_cifrado.age}}`

--- a/pages.es/common/cargo.md
+++ b/pages.es/common/cargo.md
@@ -28,6 +28,10 @@
 
 `cargo {{[b|build]}} {{[-r|--release]}}`
 
+- Ejecuta el binario compilado (lo compila si es necesario):
+
+`cargo {{[r|run]}}`
+
 - Construye el proyecto Rust en el directorio actual utilizando el compilador nightly (requiere `rustup`):
 
 `cargo +nightly {{[b|build]}}`

--- a/pages.fr/common/age.md
+++ b/pages.fr/common/age.md
@@ -1,29 +1,25 @@
 # age
 
-> Un outil de cryptage de fichiers simple, moderne et sécurisé.
-> Voir aussi : `age-keygen`.
+> Un outil de chiffrement de fichiers simple, moderne et sécurisé.
+> Voir aussi : `age-keygen`, `age-inspect`.
 > Plus d'informations : <https://github.com/FiloSottile/age#usage>.
 
-- Générez un fichier crypté qui peut être décrypté avec une mot de passe :
+- Générer un fichier chiffré déchiffrable avec une phrase de passe :
 
-`age --passphrase --output {{chemin/vers/fichier_crypté}} {{chemin/vers/fichier_non_crypté}}`
+`age {{[-p|--passphrase]}} {{[-o|--output]}} {{chemin/vers/fichier_chiffré.age}} {{chemin/vers/fichier_non_chiffré}}`
 
-- Générer une paire de clés, en enregistrant la clé privée dans un fichier non crypté et en imprimant la clé publique sur `stdout` :
+- Chiffrer un fichier avec une ou plusieurs clés publiques entrées comme des littéraux (répéter `--recipient` pour plusieurs clés) :
 
-`age-keygen --output {{chemin/vers/fichier}}`
+`age {{[-r|--recipient]}} {{clé_publique}} {{[-o|--output]}} {{chemin/vers/fichier_chiffré.age}} {{chemin/vers/fichier_non_chiffré}}`
 
-- Cryptage d'un fichier avec une ou plusieurs clés publiques qui sont entrées comme des littéraux :
+- Chiffrer un fichier avec les clés publiques spécifiées dans un fichier de destinataires (une par ligne) :
 
-`age --recipient {{clé_publique_1}} --recipient {{clé_publique_2}} {{chemin/vers/fichier_non_crypté}} --output {{chemin/vers/fichier_crypté}}`
+`age {{[-R|--recipients-file]}} {{chemin/vers/fichier_destinataires.txt}} {{[-o|--output]}} {{chemin/vers/fichier_chiffré.age}} {{chemin/vers/fichier_non_chiffré}}`
 
-- Cryptez un fichier avec une ou plusieurs clés publiques spécifiées dans un fichier de destinataires :
+- Déchiffrer un fichier avec une phrase de passe :
 
-`age --recipients-file {{chemin/vers/fichier_destinataire}} {{chemin/vers/fichier_non_crypté}} --output {{chemin/vers/fichier_crypté}}`
+`age {{[-d|--decrypt]}} {{[-o|--output]}} {{chemin/vers/fichier_déchiffré}} {{chemin/vers/fichier_chiffré.age}}`
 
-- Déchiffrer un fichier avec un mot de passe :
+- Déchiffrer un fichier avec un fichier de clé privée :
 
-`age --decrypt --output {{chemin/vers/fichier_décrypté}} {{chemin/vers/fichier_crypté}}`
-
-- Decrypt a file with a private key file :
-
-`age --decrypt --identity {{chemin/vers/fichier_clé_privée}} --output {{chemin/vers/fichier_décrypté}} {{chemin/vers/fichier_crypté}}`
+`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{chemin/vers/fichier_clé_privée}} {{[-o|--output]}} {{chemin/vers/fichier_déchiffré}} {{chemin/vers/fichier_chiffré.age}}`

--- a/pages.fr/common/cargo.md
+++ b/pages.fr/common/cargo.md
@@ -20,9 +20,17 @@
 
 `cargo init --{{bin|lib}} {{chemin/vers/dossier}}`
 
+- Ajouter une dépendance dans `Cargo.toml` du dossier courant :
+
+`cargo add {{dépendance}}`
+
 - Compile le projet Rust dans le dossier courant en utilisant le profil release :
 
 `cargo {{[b|build]}} {{[-r|--release]}}`
+
+- Exécuter le binaire compilé (le compile si nécessaire) :
+
+`cargo {{[r|run]}}`
 
 - Compiler le projet Rust dans le dossier courant en utilisant le compilateur nightly :
 


### PR DESCRIPTION

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR is authored by me.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

- Fix untranslated line in FR page
- Replace incorrect `crypté` with `chiffré` (correct French term)
- Add short flag syntax `{{[-p|--passphrase]}}` etc. to FR page
- Add `age-inspect` to "See also" in both pages
- Add `.age` extension to encrypted file examples
- Align commands order and structure with EN page

- **Version:** 1.1.1
