### PR TITLE
katana, jupyter lab, jxlinfo, k3s, kdash: add Korean translation

### DIFF
--- a/pages.ko/common/jupyter-lab.md
+++ b/pages.ko/common/jupyter-lab.md
@@ -1,0 +1,20 @@
+# jupyter lab
+
+> Jupyter Notebook용 대화형 개발 환경.
+> 더 많은 정보: <https://jupyterlab.readthedocs.io/en/stable/getting_started/starting.html>.
+
+- JupyterLab 시작:
+
+`jupyter lab`
+
+- 특정 노트북 열기:
+
+`jupyter lab {{경로/대상/노트북}}.ipynb`
+
+- 특정 디렉터리에서 JupyterLab 시작:
+
+`jupyter lab --notebook-dir {{경로/대상/디렉터리}}`
+
+- 디버그 모드로 JupyterLab 시작:
+
+`jupyter lab --debug`

--- a/pages.ko/common/jxlinfo.md
+++ b/pages.ko/common/jxlinfo.md
@@ -1,0 +1,16 @@
+# jxlinfo
+
+> JPEG XL 메타데이터 표시.
+> 더 많은 정보: <https://manned.org/jxlinfo>.
+
+- 이미지의 간단한 정보 표시:
+
+`jxlinfo {{경로/대상/파일}}.jxl`
+
+- 이미지의 자세한 정보 표시:
+
+`jxlinfo {{[-v|--verbose]}} {{경로/대상/파일}}.jxl`
+
+- 도움말 표시:
+
+`jxlinfo {{[-h|--help]}}`

--- a/pages.ko/common/k3s.md
+++ b/pages.ko/common/k3s.md
@@ -1,0 +1,24 @@
+# k3s
+
+> 경량 Kubernetes 클러스터 설치 및 관리.
+> 더 많은 정보: <https://docs.k3s.io/cli>.
+
+- 내장된 `kubectl` 명령 실행:
+
+`k3s kubectl get nodes`
+
+- 클러스터의 etcd 스냅샷 생성:
+
+`k3s etcd-snapshot save`
+
+- CA 인증서 교체 수행:
+
+`k3s certificate rotate-ca`
+
+- 부트스트랩 토큰 관리:
+
+`k3s token list`
+
+- K3s 및 모든 구성 요소 제거:
+
+`k3s-uninstall.sh`

--- a/pages.ko/common/katana.md
+++ b/pages.ko/common/katana.md
@@ -1,29 +1,25 @@
 # katana
 
-> 자동화 파이프라인에서의 실행에 중점을 둔 빠른 크롤러로, 헤드리스 및 비헤드리스 크롤링을 모두 제공합니다.
+> 자동화 파이프라인 실행에 초점을 둔 빠른 웹 크롤러 (헤드리스 및 비헤드리스 크롤링을 지원).
 > 관련 항목: `gau`, `scrapy`, `waymore`.
 > 더 많은 정보: <https://docs.projectdiscovery.io/opensource/katana/usage>.
 
-- URL 목록을 크롤링:
+- URL 목록 크롤링:
 
 `katana -list {{https://example.com,https://google.com,...}}`
 
-- Chromium을 사용하여 헤드리스 모드로 URL 크롤링:
+- Chromium 기반 헤드리스 모드로 URL([u]RL) 크롤링:
 
-`katana -u {{https://example.com}} -headless`
+`katana -u {{https://example.com}} {{[-hl|-headless]}}`
 
-- `subfinder`를 사용하여 서브도메인을 찾고, [p]a[s]sive 소스(Wayback Machine, Common Crawl, AlienVault)로 URL 검색:
+- proxy (http/socks5)를 통해 요청 전달 및 사용자 지정 헤더를 사용:
 
-`subfinder -list {{경로/대상/domains.txt}} | katana -passive`
+`katana -proxy {{http://127.0.0.1:8080}} {{[-H|-headers]}} {{경로/대상/헤더파일.txt}} -u {{https://example.com}}`
 
-- 프록시(http/socks5)를 통해 요청 전달하고 파일에서 사용자 정의 [H]eaders 사용:
+- 크롤링 전략, 하위 디렉터리 탐색 깊이 및 요청 속도를 제한 (초당 요청):
 
-`katana -proxy {{http://127.0.0.1:8080}} -headers {{경로/대상/headers.txt}} -u {{https://example.com}}`
+`katana {{[-s|-strategy]}} {{depth-first|breadth-first}} {{[-d|-depth]}} {{값}} {{[-rl|-rate-limit]}} {{값}} -u {{https://example.com}}`
 
-- 크롤링 [s]trategy, 크롤링할 하위 디렉토리의 [d]epth, 속도 제한(초당 요청 수) 지정:
+- `subfinder`로 서브도메인을 찾고, 각 도메인을 지정시간 동안 크롤링 후, 결과를 파일로 저장:
 
-`katana -strategy {{depth-first|breadth-first}} -depth {{값}} -rate-limit {{값}} -u {{https://example.com}}`
-
-- `subfinder`를 사용하여 서브도메인을 찾고, 각 서브도메인을 최대 시간 동안 크롤링하며 결과를 [o]utput 파일에 저장:
-
-`subfinder -list {{경로/대상/domains.txt}} | katana -crawl-duration {{값}} -output {{경로/대상/output.txt}}`
+`subfinder {{[-dL|-list]}} {{경로/대상/도메인파일}} | katana {{[-ct|-crawl-duration]}} {{값}} {{[-o|-output]}} {{경로/대상/출력파일.txt}}`

--- a/pages.ko/common/kdash.md
+++ b/pages.ko/common/kdash.md
@@ -1,0 +1,20 @@
+# kdash
+
+> Kubernetes용 간단한 대시보드.
+> 더 많은 정보: <https://github.com/kdash-rs/kdash/#usage>.
+
+- 대시보드 표시:
+
+`kdash`
+
+- 디버그 모드로 대시보드 실행 및 현재 디렉터리에 로그 파일 기록:
+
+`kdash {{[-d|--debug]}}`
+
+- tick rate 설정:
+
+`kdash {{[-t|--tick-rate]}} {{100}}`
+
+- polling rate 설정 (tick rate의 배수여야 함):
+
+`kdash {{[-t|--tick-rate]}} {{200}} {{[-p|--poll-rate]}} {{400}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
