### PR TITLE
scripts/test: parallelize to fix performance issue

### DIFF
--- a/scripts/test-tldr-lint.sh
+++ b/scripts/test-tldr-lint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+
+# This helper script was split out of function run_tests in test.sh
+# so that it can be parallelized
+
+checks="TLDR104"
+# Don't ignore anything for the `pages.en` symlink.
+[[ -h $1 ]] && checks=""
+case $1 in
+  *ar*|*bn*|*fa*|*hi*|*ja*|*ko*|*lo*|*ml*|*ne*|*ta*|*th*|*tr*)
+    checks+=",TLDR003,TLDR004,TLDR015"
+  ;;
+  *zh*)
+    checks+=",TLDR003,TLDR004,TLDR005,TLDR015"
+  ;;
+esac
+exec tldr-lint --ignore "$checks" "$1"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -83,22 +83,10 @@ function run_shellcheck {
 
 # Default test function, run by `npm test`.
 function run_tests {
-  find pages* -name '*.md' -exec markdownlint {} +
-  tldr-lint ./pages
-  for f in ./pages.*; do
-    checks="TLDR104"
-    # Skip the `pages.en` symlink.
-    [[ -h $f ]] && continue
-    case $f in
-      *ar*|*bn*|*fa*|*hi*|*ja*|*ko*|*lo*|*ml*|*ne*|*ta*|*th*|*tr*)
-        checks+=",TLDR003,TLDR004,TLDR015"
-      ;;
-      *zh*)
-        checks+=",TLDR003,TLDR004,TLDR005,TLDR015"
-      ;;
-    esac
-    tldr-lint --ignore "$checks" "$f"
-  done
+  page_count="$(find pages* -name '*.md' -printf . | wc -c)"
+  nproc="$(nproc)"
+  find pages* -name '*.md' -print0 | xargs -0 -n $((page_count / nproc / 2)) -P "$nproc" markdownlint
+  echo ./pages.* | xargs -n1 -P "$nproc" scripts/test-tldr-lint.sh
   run_black
   run_flake8
   run_pytest


### PR DESCRIPTION
This makes `npm test` 6x faster on a 24-core CPU, and 1.85x faster on GitHub Actions' 4-core CPU. Previously, the bottleneck was `markdownlint` and `tldr-lint` being single-threaded while trying to process 36089 files.

### Checklist

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR is authored by me
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

### Before

```console
$ time npm test

> test
> bash scripts/test.sh

Test ran successfully!

real    0m38.974s
user    0m44.493s
sys     0m3.057s
```

[GitHub Actions: Test: 1m 3s](https://github.com/danielzgtg/tldr/actions/runs/26580255716/job/78310889471?pr=1)

### After

```console
$ time npm test

> test
> bash scripts/test.sh

Test ran successfully!

real    0m6.415s
user    1m36.236s
sys     0m11.355s
```

[GitHub Actions: Test: 34s](https://github.com/danielzgtg/tldr/actions/runs/26580463170/job/78311660685?pr=2)