### PR TITLE
swift: remove 'generate-xcodeproj' example

### DIFF
--- a/pages.ko/common/swift.md
+++ b/pages.ko/common/swift.md
@@ -15,10 +15,6 @@
 
 `swift package init`
 
-- Xcode 프로젝트 파일 생성:
-
-`swift package generate-xcodeproj`
-
 - 의존성 업데이트:
 
 `swift package update`

--- a/pages/common/swift.md
+++ b/pages/common/swift.md
@@ -15,10 +15,6 @@
 
 `swift package init`
 
-- Generate an Xcode project file:
-
-`swift package generate-xcodeproj`
-
 - Update dependencies:
 
 `swift package update`


### PR DESCRIPTION
Hi folks!

`generate-xcodeproj` was deprecated a while ago, and was finally removed in swiftlang/swift-package-manager#5748. Since that PR was merged ~3.5 years ago, I think it should be safe to remove that example from the `tldr` page as well?

Thanks!

---

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
    ```bash
    $ swift --version
    Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
    ```
