### PR TITLE
PULL_REQUEST_TEMPLATE: add "closes #issue"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,5 @@ https://cla-assistant.io/tldr-pages/tldr
 - [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
 - **Version of the command being documented (if known):**
 - Reference issue: #
+- Closes: #
+<!-- Only use "Closes:" if this PR fixes the entire issue. -->


### PR DESCRIPTION
There's tons of people who follow the template to the letter and refuse to link issues to their PRs. I just closed two already fulfilled page requests and linked about 5 existing PRs to issues. We shouldn't need to do this.