### PR TITLE
translation-templates/alias-pages: adjust Finnish translation

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -220,7 +220,7 @@ The templates can be changed when necessary.
 ```markdown
 # example
 
-> Tämä on alias komennolle `example`.
+> Tämä on alias `example` komennolle.
 
 - Näytä alkuperäisen komennon dokumentaatio:
 


### PR DESCRIPTION
This will allow for a more natural GNU alias page: ``Tämä on alias GNU:n `example` komennolle.``

Currently there is no place to put it where it feels natural.