### PR TITLE
docs(foremost): add foremost command page

### DIFF
--- a/pages/linux/foremost.md
+++ b/pages/linux/foremost.md
@@ -1,0 +1,24 @@
+# foremost
+
+> Recover files using their headers, footers, and data structures.
+> More information: <https://foremost.sourceforge.net/>.
+
+- Recover all supported file types from a disk image:
+
+`foremost -i {{path/to/image.dd}}`
+
+- Recover only JPEG files, skipping the first 100 blocks:
+
+`foremost -s 100 -t {{jpg}} -i {{path/to/image.dd}}`
+
+- Recover GIF and PDF files from a disk image:
+
+`foremost -t {{gif,pdf}} -i {{path/to/image.dd}}`
+
+- Save recovered files to a specific output directory:
+
+`foremost -o {{path/to/output_directory}} -i {{path/to/image.dd}}`
+
+- Recover Office documents and JPEG files in verbose mode with indirect block detection enabled:
+
+`foremost -v -d -t {{ole,jpg}} -i {{path/to/image.dd}}`


### PR DESCRIPTION
## What

Add a new TLDR page for the `foremost` command.

## Why

`foremost` is a commonly used file recovery and digital forensics tool that currently does not have a TLDR page.

## How

* Added a new `pages/linux/foremost.md` page.
* Included examples for common file recovery workflows.
* Followed the TLDR formatting and style guidelines.

## Test

* Verified examples against the `foremost` manual page.
* Ran `tldr-lint` successfully.