### PR TITLE
docs(scalpel): add scalpel command page

### DIFF
--- a/pages/common/scalpel.md
+++ b/pages/common/scalpel.md
@@ -1,0 +1,24 @@
+# scalpel
+
+> Recover files from a disk image or raw block device based on file headers and footers.
+> More information: <https://manpages.ubuntu.com/manpages/jammy/man1/scalpel.1.html>.
+
+- Recover files from a disk image:
+
+`scalpel {{path/to/disk_image}}`
+
+- Use a specific configuration file:
+
+`scalpel -c {{path/to/scalpel.conf}} {{path/to/disk_image}}`
+
+- Save recovered files to a specific output directory:
+
+`scalpel -o {{path/to/output_directory}} {{path/to/disk_image}}`
+
+- Preview which files would be recovered without actually carving them:
+
+`scalpel -p {{path/to/disk_image}}`
+
+- Read a list of input files from a file:
+
+`scalpel -i {{path/to/input_file_list}}`


### PR DESCRIPTION
## What

Add a new TLDR page for the `scalpel` command.

## Why

`scalpel` is a commonly used file carving tool in digital forensics and currently does not have a TLDR page.

## How

* Added a new `pages/common/scalpel.md` page.
* Included examples for common file carving and recovery workflows.
* Followed the TLDR formatting and style guidelines.

## Test

* Ran `tldr-lint pages/common/scalpel.md`.
* Verified the examples against `scalpel -h` and the man page.