### PR TITLE
docs(ewfmount): add ewfmount command page

### DIFF
--- a/pages/common/ewfmount.md
+++ b/pages/common/ewfmount.md
@@ -1,0 +1,20 @@
+# ewfmount
+
+> Mount data stored in Expert Witness Compression Format (EWF) files.
+> More information: <https://manpages.debian.org/unstable/ewf-tools/ewfmount.1.en.html>.
+
+- Mount an EWF image file:
+
+`ewfmount {{path/to/image.E01}} {{path/to/mount_point}}`
+
+- Mount an EWF image using the raw input format:
+
+`ewfmount -f raw {{path/to/image.E01}} {{path/to/mount_point}}`
+
+- Mount logical volume files only:
+
+`ewfmount -f files {{path/to/image.E01}} {{path/to/mount_point}}`
+
+- Mount an EWF image with verbose output:
+
+`ewfmount -v {{path/to/image.E01}} {{path/to/mount_point}}`


### PR DESCRIPTION
## What

Add a new TLDR page for the `ewfmount` command.

## Why

`ewfmount` is a utility used to mount Expert Witness Compression Format (EWF) image files and currently does not have a TLDR page.

## How

* Added a new `pages/common/ewfmount.md` page.
* Included examples for mounting EWF images using common input formats.
* Followed the TLDR formatting and style guidelines.

## Test

* Ran `tldr-lint pages/common/ewfmount.md`.
* Verified the examples against `ewfmount -h` and the man page.