### PR TITLE
ld: refresh page

### DIFF
--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -1,7 +1,7 @@
 # ld
 
 > Link object files together.
-> More information: <https://sourceware.org/binutils/docs/ld.html>.
+> More information: <https://sourceware.org/binutils/docs/ld.html#Options>.
 
 - Link a specific object file with no dependencies into an executable:
 

--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -17,4 +17,4 @@
 
 - Dynamically link an x86_64 program to glibc (file paths change depending on the system):
 
-`ld {{[-o|--output]}} {{path/to/output_executable}} {{[-I|--dynamic-linker]}} /lib/ld-linux-x86-64.so.2 /lib/crt1.o /lib/crti.o -lc {{path/to/file.o}} /lib/crtn.o`
+`ld {{[-o|--output]}} {{path/to/output_executable}} {{[-I|--dynamic-linker]}} {{/lib/ld-linux-x86-64.so.2}} {{/lib/crt1.o}} {{/lib/crti.o}} -lc {{path/to/file.o}} {{/lib/crtn.o}}`

--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -7,10 +7,6 @@
 
 `ld {{path/to/file.o}} {{[-o|--output]}} {{path/to/output_executable}}`
 
-- Link two object files together:
-
-`ld {{path/to/file.o}} {{[-o|--output]}} {{path/to/output_executable}}`
-
 - Link multiple object files together:
 
 `ld {{path/to/file1.o path/to/file2.o ...}} {{[-o|--output]}} {{path/to/output_executable}}`

--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -11,7 +11,7 @@
 
 `ld {{path/to/file1.o}} {{path/to/file2.o}} {{[-o|--output]}} {{path/to/output_executable}}`
 
-- Link a object file to a specific target emulation 
+- Link a object file to a specific target emulation:
 
 `ld {{path/to/file.o}} -m {{targer_emulation}} {{[-o|--output]}} {{path/to/output_executable}}`
 

--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -11,6 +11,10 @@
 
 `ld {{path/to/file1.o}} {{path/to/file2.o}} {{[-o|--output]}} {{path/to/output_executable}}`
 
+- Link a object file to a specific target emulation 
+
+`ld {{path/to/file.o}} -m {{targer_emulation}} {{[-o|--output]}} {{path/to/output_executable}}`
+
 - Dynamically link an x86_64 program to glibc (file paths change depending on the system):
 
 `ld {{[-o|--output]}} {{path/to/output_executable}} {{[-I|--dynamic-linker]}} /lib/ld-linux-x86-64.so.2 /lib/crt1.o /lib/crti.o -lc {{path/to/file.o}} /lib/crtn.o`

--- a/pages/common/ld.md
+++ b/pages/common/ld.md
@@ -9,7 +9,11 @@
 
 - Link two object files together:
 
-`ld {{path/to/file1.o}} {{path/to/file2.o}} {{[-o|--output]}} {{path/to/output_executable}}`
+`ld {{path/to/file.o}} {{[-o|--output]}} {{path/to/output_executable}}`
+
+- Link multiple object files together:
+
+`ld {{path/to/file1.o path/to/file2.o ...}} {{[-o|--output]}} {{path/to/output_executable}}`
 
 - Link a object file to a specific target emulation:
 


### PR DESCRIPTION
I added an extra entry to the `ld` doc. I use the -m flag quite regularly and I think its quite useful to add.
the -m flags lets you specify a specific taget emulation format.

### Checklist

- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
GNU ld (GNU Binutils) 2.46.0
