### PR TITLE
*: expand pid placeholder names

### DIFF
--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -17,7 +17,7 @@
 
 - Display logs for a specific PID:
 
-`logcat --pid {{pid}}`
+`logcat --pid {{process_id}}`
 
 - Display logs for the process of a specific package:
 

--- a/pages/common/adb-logcat.md
+++ b/pages/common/adb-logcat.md
@@ -25,7 +25,7 @@
 
 - Display logs for a specific PID:
 
-`adb logcat --pid {{pid}}`
+`adb logcat --pid {{process_id}}`
 
 - Display logs for the process of a specific package:
 

--- a/pages/common/checksec.md
+++ b/pages/common/checksec.md
@@ -14,7 +14,7 @@
 
 - List security properties of a process:
 
-`checksec proc {{pid}}`
+`checksec proc {{process_id}}`
 
 - List security properties of the running kernel:
 

--- a/pages/common/dlv.md
+++ b/pages/common/dlv.md
@@ -21,7 +21,7 @@
 
 - Attach to a running process and begin debugging:
 
-`dlv attach {{pid}}`
+`dlv attach {{process_id}}`
 
 - Compile and begin tracing a program:
 

--- a/pages/common/frida.md
+++ b/pages/common/frida.md
@@ -13,7 +13,7 @@
 
 - Attach to a running process by its PID:
 
-`frida {{[-p|--attach-pid]}} {{pid}}`
+`frida {{[-p|--attach-pid]}} {{process_id}}`
 
 - Load a JavaScript script into a process:
 

--- a/pages/common/gops.md
+++ b/pages/common/gops.md
@@ -9,7 +9,7 @@
 
 - Print more information about a process:
 
-`gops {{pid}}`
+`gops {{process_id}}`
 
 - Display a process tree:
 

--- a/pages/common/haproxy.md
+++ b/pages/common/haproxy.md
@@ -25,7 +25,7 @@
 
 - Reload configuration with graceful shutdown of old process:
 
-`haproxy -f {{path/to/haproxy.cfg}} -sf {{pid}}`
+`haproxy -f {{path/to/haproxy.cfg}} -sf {{process_id}}`
 
 - Set maximum number of simultaneous connections:
 
@@ -33,4 +33,4 @@
 
 - Reload with zero downtime by reusing sockets from old process:
 
-`haproxy -f {{path/to/haproxy.cfg}} -x {{path/to/haproxy.sock}} -sf {{pid}}`
+`haproxy -f {{path/to/haproxy.cfg}} -x {{path/to/haproxy.sock}} -sf {{process_id}}`

--- a/pages/common/iotop.md
+++ b/pages/common/iotop.md
@@ -21,7 +21,7 @@
 
 - Show I/O usage of given PID(s):
 
-`sudo iotop {{[-p|--pid]}} {{pid}}`
+`sudo iotop {{[-p|--pid]}} {{process_id}}`
 
 - Show I/O usage of a given user:
 

--- a/pages/common/jhsdb.md
+++ b/pages/common/jhsdb.md
@@ -5,7 +5,7 @@
 
 - Print stack and locks information of a Java process:
 
-`jhsdb jstack --pid {{pid}}`
+`jhsdb jstack --pid {{process_id}}`
 
 - Open a core dump in interactive debug mode:
 
@@ -13,8 +13,8 @@
 
 - Start a remote debug server:
 
-`jhsdb debugd --pid {{pid}} --serverid {{optional_unique_id}}`
+`jhsdb debugd --pid {{process_id}} --serverid {{optional_unique_id}}`
 
 - Connect to a process in interactive debug mode:
 
-`jhsdb clhsdb --pid {{pid}}`
+`jhsdb clhsdb --pid {{process_id}}`

--- a/pages/common/lldb.md
+++ b/pages/common/lldb.md
@@ -9,7 +9,7 @@
 
 - Attach `lldb` to a running process with a given PID:
 
-`lldb -p {{pid}}`
+`lldb -p {{process_id}}`
 
 - Wait for a new process to launch with a given name, and attach to it:
 

--- a/pages/common/lsof.md
+++ b/pages/common/lsof.md
@@ -26,7 +26,7 @@
 
 - List files opened by a specific process, given its PID:
 
-`lsof -p {{pid}}`
+`lsof -p {{process_id}}`
 
 - List open files in a directory:
 

--- a/pages/common/polybar-msg.md
+++ b/pages/common/polybar-msg.md
@@ -30,4 +30,4 @@
 
 - Only send messages to a specific Polybar instance (all instances by default):
 
-`polybar-msg -p {{pid}} {{cmd|action}} {{payload}}`
+`polybar-msg -p {{process_id}} {{cmd|action}} {{payload}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -25,7 +25,7 @@
 
 - Get the parent PID of a process:
 
-`ps {{[-o|--format]}} ppid= {{[-p|--pid]}} {{pid}}`
+`ps {{[-o|--format]}} ppid= {{[-p|--pid]}} {{process_id}}`
 
 - Sort processes by memory consumption:
 

--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -17,7 +17,7 @@
 
 - Attach to an already running process and see its file reading progress:
 
-`pv {{[-d|--watchfd]}} {{pid}}`
+`pv {{[-d|--watchfd]}} {{process_id}}`
 
 - Read an erroneous file, skip errors as `dd conv=sync,noerror` would:
 

--- a/pages/common/py-spy.md
+++ b/pages/common/py-spy.md
@@ -5,7 +5,7 @@
 
 - Show a live view of the functions that take the most execution time of a running process:
 
-`py-spy top {{[-p|--pid]}} {{pid}}`
+`py-spy top {{[-p|--pid]}} {{process_id}}`
 
 - Start a program and show a live view of the functions that take the most execution time:
 
@@ -13,8 +13,8 @@
 
 - Produce an SVG flame graph of the function call execution time:
 
-`py-spy record {{[-o|--output]}} {{path/to/profile.svg}} {{[-p|--pid]}} {{pid}}`
+`py-spy record {{[-o|--output]}} {{path/to/profile.svg}} {{[-p|--pid]}} {{process_id}}`
 
 - Dump the call stack of a running process:
 
-`py-spy dump {{[-p|--pid]}} {{pid}}`
+`py-spy dump {{[-p|--pid]}} {{process_id}}`

--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -7,7 +7,7 @@
 
 - Increase/decrease the priority of a running [p]rocess:
 
-`renice -n {{3}} -p {{pid}}`
+`renice -n {{3}} -p {{process_id}}`
 
 - Increase/decrease the priority of all processes owned by a [u]ser:
 

--- a/pages/common/wait.md
+++ b/pages/common/wait.md
@@ -6,7 +6,7 @@
 
 - Wait for a process to finish given its process ID (PID) and return its exit status:
 
-`wait {{pid}}`
+`wait {{process_id}}`
 
 - Wait for all processes known to the invoking shell to finish:
 

--- a/pages/common/yara.md
+++ b/pages/common/yara.md
@@ -14,7 +14,7 @@
 
 - Scan a running process by its PID using multiple rules:
 
-`yara {{path/to/rule1.yar path/to/rule2.yar ...}} {{pid}}`
+`yara {{path/to/rule1.yar path/to/rule2.yar ...}} {{process_id}}`
 
 - Print metadata associated with the matching rules:
 

--- a/pages/freebsd/procstat.md
+++ b/pages/freebsd/procstat.md
@@ -5,16 +5,16 @@
 
 - Display file descriptors of a specific process:
 
-`procstat fds {{pid}}`
+`procstat fds {{process_id}}`
 
 - Show virtual memory mappings of a process:
 
-`procstat vm {{pid}}`
+`procstat vm {{process_id}}`
 
 - Display process arguments:
 
-`procstat arguments {{pid}}`
+`procstat arguments {{process_id}}`
 
 - Show resource limits of a process:
 
-`procstat rlimit {{pid}}`
+`procstat rlimit {{process_id}}`

--- a/pages/linux/apport-bug.md
+++ b/pages/linux/apport-bug.md
@@ -17,4 +17,4 @@
 
 - Report a bug about a specific process:
 
-`apport-bug {{pid}}`
+`apport-bug {{process_id}}`

--- a/pages/linux/choom.md
+++ b/pages/linux/choom.md
@@ -5,11 +5,11 @@
 
 - Display the OOM-killer score of the process with a specific ID:
 
-`choom {{[-p|--pid]}} {{pid}}`
+`choom {{[-p|--pid]}} {{process_id}}`
 
 - Change the adjust OOM-killer score of a specific process:
 
-`choom {{[-p|--pid]}} {{pid}} {{[-n|--adjust]}} {{-1000..+1000}}`
+`choom {{[-p|--pid]}} {{process_id}} {{[-n|--adjust]}} {{-1000..+1000}}`
 
 - Run a command with a specific adjust OOM-killer score:
 

--- a/pages/linux/chrt.md
+++ b/pages/linux/chrt.md
@@ -5,11 +5,11 @@
 
 - Display attributes of a process:
 
-`chrt {{[-p|--pid]}} {{pid}}`
+`chrt {{[-p|--pid]}} {{process_id}}`
 
 - Display attributes of all threads of a process:
 
-`chrt {{[-a|--all-tasks]}} {{[-p|--pid]}} {{pid}}`
+`chrt {{[-a|--all-tasks]}} {{[-p|--pid]}} {{process_id}}`
 
 - Display the min/max priority values that can be used with `chrt`:
 
@@ -17,8 +17,8 @@
 
 - Set the scheduling priority of a process:
 
-`chrt {{[-p|--pid]}} {{priority}} {{pid}}`
+`chrt {{[-p|--pid]}} {{priority}} {{process_id}}`
 
 - Set the scheduling policy of a process:
 
-`chrt --{{deadline|idle|batch|rr|fifo|other}} {{[-p|--pid]}} {{priority}} {{pid}}`
+`chrt --{{deadline|idle|batch|rr|fifo|other}} {{[-p|--pid]}} {{priority}} {{process_id}}`

--- a/pages/linux/coredumpctl.md
+++ b/pages/linux/coredumpctl.md
@@ -13,7 +13,7 @@
 
 - Show information about the core dumps matching a program with PID:
 
-`coredumpctl info {{pid}}`
+`coredumpctl info {{process_id}}`
 
 - Invoke debugger using the last core dump:
 

--- a/pages/linux/ionice.md
+++ b/pages/linux/ionice.md
@@ -19,12 +19,12 @@
 
 - Ignore failure to set the requested priority:
 
-`ionice {{[-t|--ignore]}} {{[-n|--classdata]}} {{priority}} {{[-p|--pid]}} {{pid}}`
+`ionice {{[-t|--ignore]}} {{[-n|--classdata]}} {{priority}} {{[-p|--pid]}} {{process_id}}`
 
 - Run the command even in case it was not possible to set the desired priority (this can happen due to insufficient privileges or an old kernel version):
 
-`ionice {{[-t|--ignore]}} {{[-n|--classdata]}} {{priority}} {{[-p|--pid]}} {{pid}}`
+`ionice {{[-t|--ignore]}} {{[-n|--classdata]}} {{priority}} {{[-p|--pid]}} {{process_id}}`
 
 - Print the I/O scheduling class and priority of a running process:
 
-`ionice {{[-p|--pid]}} {{pid}}`
+`ionice {{[-p|--pid]}} {{process_id}}`

--- a/pages/linux/journalctl.md
+++ b/pages/linux/journalctl.md
@@ -26,7 +26,7 @@
 
 - Show all messages by a specific process:
 
-`journalctl _PID={{pid}}`
+`journalctl _PID={{process_id}}`
 
 - Show all messages by a specific executable:
 

--- a/pages/linux/lsns.md
+++ b/pages/linux/lsns.md
@@ -13,7 +13,7 @@
 
 - List namespaces associated with the specified process:
 
-`lsns {{[-p|--task]}} {{pid}}`
+`lsns {{[-p|--task]}} {{process_id}}`
 
 - List the specified type of namespaces only:
 

--- a/pages/linux/nsenter.md
+++ b/pages/linux/nsenter.md
@@ -6,16 +6,16 @@
 
 - Run a specific command using the same namespaces as an existing process:
 
-`nsenter {{[-t|--target]}} {{pid}} {{[-a|--all]}} {{command}} {{command_arguments}}`
+`nsenter {{[-t|--target]}} {{process_id}} {{[-a|--all]}} {{command}} {{command_arguments}}`
 
 - Run a specific command in an existing process's mount|UTS|IPC|network|PID|user|cgroup|time namespace:
 
-`nsenter {{[-t|--target]}} {{pid}} --{{mount|uts|ipc|net|pid|user|cgroup}} {{command}} {{command_arguments}}`
+`nsenter {{[-t|--target]}} {{process_id}} --{{mount|uts|ipc|net|pid|user|cgroup}} {{command}} {{command_arguments}}`
 
 - Run a specific command in an existing process's UTS, time, and IPC namespaces:
 
-`nsenter {{[-t|--target]}} {{pid}} {{[-u|--uts]}} {{[-T|--time]}} {{[-i|--ipc]}} -- {{command}} {{command_arguments}}`
+`nsenter {{[-t|--target]}} {{process_id}} {{[-u|--uts]}} {{[-T|--time]}} {{[-i|--ipc]}} -- {{command}} {{command_arguments}}`
 
 - Run a specific command in an existing process's namespace by referencing procfs:
 
-`nsenter {{[-p|--pid=]}}/proc/{{pid}}/pid/net -- {{command}} {{command_arguments}}`
+`nsenter {{[-p|--pid=]}}/proc/{{process_id}}/pid/net -- {{command}} {{command_arguments}}`

--- a/pages/linux/perf.md
+++ b/pages/linux/perf.md
@@ -17,7 +17,7 @@
 
 - Record the profile of an existing process into `perf.data`:
 
-`sudo perf record {{[-p|--pid]}} {{pid}}`
+`sudo perf record {{[-p|--pid]}} {{process_id}}`
 
 - Read `perf.data` (created by `perf record`) and display the profile:
 

--- a/pages/linux/pidstat.md
+++ b/pages/linux/pidstat.md
@@ -17,7 +17,7 @@
 
 - Show information on a specific PID:
 
-`pidstat -p {{pid}}`
+`pidstat -p {{process_id}}`
 
 - Show memory statistics for all processes whose command name include "fox" or "bird":
 

--- a/pages/linux/pmap.md
+++ b/pages/linux/pmap.md
@@ -5,15 +5,15 @@
 
 - Print memory map for a specific process ID (PID):
 
-`pmap {{pid}}`
+`pmap {{process_id}}`
 
 - Show the extended format:
 
-`pmap --extended {{pid}}`
+`pmap --extended {{process_id}}`
 
 - Show the device format:
 
-`pmap --device {{pid}}`
+`pmap --device {{process_id}}`
 
 - Limit results to a memory address range specified by `low` and `high`:
 

--- a/pages/linux/pstree.md
+++ b/pages/linux/pstree.md
@@ -21,8 +21,8 @@
 
 - Display children of a specified process:
 
-`pstree {{pid}}`
+`pstree {{process_id}}`
 
 - Display parents of a specified process:
 
-`pstree {{[-s|--show-parents]}} {{pid}}`
+`pstree {{[-s|--show-parents]}} {{process_id}}`

--- a/pages/linux/qm-guest.md
+++ b/pages/linux/qm-guest.md
@@ -5,7 +5,7 @@
 
 - Print the status of a specific PID:
 
-`qm {{[g|guest]}} {{[exec-s|exec-status]}} {{100}} {{pid}}`
+`qm {{[g|guest]}} {{[exec-s|exec-status]}} {{100}} {{process_id}}`
 
 - Set a password for a specific user in a virtual machine interactively:
 

--- a/pages/linux/renice.md
+++ b/pages/linux/renice.md
@@ -7,11 +7,11 @@
 
 - Set the absolute priority of a running process:
 
-`renice --priority {{3}} {{[-p|--pid]}} {{pid}}`
+`renice --priority {{3}} {{[-p|--pid]}} {{process_id}}`
 
 - Increase the priority of a running process:
 
-`sudo renice --relative {{-4}} {{[-p|--pid]}} {{pid}}`
+`sudo renice --relative {{-4}} {{[-p|--pid]}} {{process_id}}`
 
 - Decrease the priority of all processes owned by a user:
 

--- a/pages/linux/reptyr.md
+++ b/pages/linux/reptyr.md
@@ -6,7 +6,7 @@
 
 - Move a running process to your current terminal:
 
-`reptyr {{pid}}`
+`reptyr {{process_id}}`
 
 - Attach to a process using its name:
 

--- a/pages/linux/strace.md
+++ b/pages/linux/strace.md
@@ -6,19 +6,19 @@
 
 - Start tracing a specific process by its PID:
 
-`sudo strace {{[-p|--attach]}} {{pid}}`
+`sudo strace {{[-p|--attach]}} {{process_id}}`
 
 - Trace a process and filter output by system call [e]xpression:
 
-`sudo strace {{[-p|--attach]}} {{pid}} -e {{system_call,system_call2,...}}`
+`sudo strace {{[-p|--attach]}} {{process_id}} -e {{system_call,system_call2,...}}`
 
 - Count time, calls, and errors for each system call and report a summary on program exit:
 
-`sudo strace {{[-p|--attach]}} {{pid}} {{[-c|--summary-only]}}`
+`sudo strace {{[-p|--attach]}} {{process_id}} {{[-c|--summary-only]}}`
 
 - Show the time spent in every system call and specify the maximum string size to print:
 
-`sudo strace {{[-p|--attach]}} {{pid}} {{[-T|--syscall-times]}} {{[-s|--string-limit]}} {{32}}`
+`sudo strace {{[-p|--attach]}} {{process_id}} {{[-T|--syscall-times]}} {{[-s|--string-limit]}} {{32}}`
 
 - Start tracing a program by executing it:
 

--- a/pages/linux/systemctl-help.md
+++ b/pages/linux/systemctl-help.md
@@ -21,4 +21,4 @@
 
 - Show the manual page for the unit of a process by PID:
 
-`systemctl help {{pid}}`
+`systemctl help {{process_id}}`

--- a/pages/linux/systemctl-whoami.md
+++ b/pages/linux/systemctl-whoami.md
@@ -14,7 +14,7 @@
 
 - Show the unit a specific process belongs to:
 
-`systemctl whoami {{pid}}`
+`systemctl whoami {{process_id}}`
 
 - Show the units for multiple processes:
 

--- a/pages/linux/taskset.md
+++ b/pages/linux/taskset.md
@@ -5,11 +5,11 @@
 
 - Get a running process' CPU affinity by PID:
 
-`taskset {{[-p|--pid]}} {{[-c|--cpu-list]}} {{pid}}`
+`taskset {{[-p|--pid]}} {{[-c|--cpu-list]}} {{process_id}}`
 
 - Set a running process' CPU affinity by PID:
 
-`taskset {{[-p|--pid]}} {{[-c|--cpu-list]}} {{cpu_id}} {{pid}}`
+`taskset {{[-p|--pid]}} {{[-c|--cpu-list]}} {{cpu_id}} {{process_id}}`
 
 - Start a new process with affinity for a single CPU:
 

--- a/pages/linux/trace-cmd-record.md
+++ b/pages/linux/trace-cmd-record.md
@@ -26,4 +26,4 @@
 
 - Record a trace from a specific process ID:
 
-`sudo trace-cmd record -P {{pid}}`
+`sudo trace-cmd record -P {{process_id}}`

--- a/pages/osx/caffeinate.md
+++ b/pages/osx/caffeinate.md
@@ -17,7 +17,7 @@
 
 - Prevent from sleeping until a process with the specified PID completes:
 
-`caffeinate -w {{pid}}`
+`caffeinate -w {{process_id}}`
 
 - Prevent disk from sleeping (use `<Ctrl c>` to exit):
 

--- a/pages/osx/dtrace.md
+++ b/pages/osx/dtrace.md
@@ -30,8 +30,8 @@
 
 - Grad the specified [p]rocess ID, cache its symbol table, and exit upon completion:
 
-`dtrace -p {{pid}}`
+`dtrace -p {{process_id}}`
 
 - Combine different options for tracing function in a process:
 
-`dtrace -a -b {{buffer_size}} -f {{function}} -p {{pid}}`
+`dtrace -a -b {{buffer_size}} -f {{function}} -p {{process_id}}`

--- a/pages/osx/lldb.md
+++ b/pages/osx/lldb.md
@@ -9,7 +9,7 @@
 
 - Attach `lldb` to a running process with a given PID:
 
-`lldb -p {{pid}}`
+`lldb -p {{process_id}}`
 
 - Wait for a new process to launch with a given name, and attach to it:
 

--- a/pages/osx/opensnoop.md
+++ b/pages/osx/opensnoop.md
@@ -13,7 +13,7 @@
 
 - Track all file opens by a process by PID:
 
-`sudo opensnoop -p {{pid}}`
+`sudo opensnoop -p {{process_id}}`
 
 - Track which processes open a specified file:
 

--- a/pages/osx/ps.md
+++ b/pages/osx/ps.md
@@ -17,7 +17,7 @@
 
 - Get the parent PID of a process:
 
-`ps -o ppid= -p {{pid}}`
+`ps -o ppid= -p {{process_id}}`
 
 - Sort processes by memory usage:
 

--- a/pages/sunos/prctl.md
+++ b/pages/sunos/prctl.md
@@ -5,12 +5,12 @@
 
 - Examine process limits and permissions:
 
-`prctl {{pid}}`
+`prctl {{process_id}}`
 
 - Examine process limits and permissions in machine parsable format:
 
-`prctl -P {{pid}}`
+`prctl -P {{process_id}}`
 
 - Get specific limit for a running process:
 
-`prctl -n process.max-file-descriptor {{pid}}`
+`prctl -n process.max-file-descriptor {{process_id}}`

--- a/pages/sunos/truss.md
+++ b/pages/sunos/truss.md
@@ -10,7 +10,7 @@
 
 - Start tracing a specific process by its PID:
 
-`truss -p {{pid}}`
+`truss -p {{process_id}}`
 
 - Start tracing a program by executing it, showing arguments and environment variables:
 
@@ -18,8 +18,8 @@
 
 - Count time, calls, and errors for each system call and report a summary on program exit:
 
-`truss -c -p {{pid}}`
+`truss -c -p {{process_id}}`
 
 - Trace a process filtering output by system call:
 
-`truss -p {{pid}} -t {{system_call_name}}`
+`truss -p {{process_id}} -t {{system_call_name}}`

--- a/pages/windows/wmic.md
+++ b/pages/windows/wmic.md
@@ -25,8 +25,8 @@
 
 - Display specific fields for a specific process:
 
-`wmic process where processid={{pid}} get {{name,commandline}}`
+`wmic process where processid={{process_id}} get {{name,commandline}}`
 
 - Kill a process:
 
-`wmic process {{pid}} delete`
+`wmic process {{process_id}} delete`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A, placeholder-only cleanup.
- Refs #22636

### Description

Expands `{{pid}}` placeholders to `{{process_id}}` across English pages.

This keeps the change focused on the `pid` part of #22636. The previous draft PR #22652 bundled additional placeholder families, so this PR is split smaller for review.

### Testing

- `npx markdownlint $(git diff --name-only -- 'pages/**/*.md')`
- `npx tldr-lint ./pages`
- `npm test`
