### PR TITLE
ps: add example for displaying threads

### DIFF
--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -33,4 +33,4 @@
 
 - Display threads for a specific process:
 
-`ps -L -p {{pid}}`
+`ps -L -p {{process_id}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -30,3 +30,7 @@
 - Sort processes by memory consumption:
 
 `ps --sort size`
+
+- Display threads belonging to a process:
+
+`ps -L -p {{pid}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -31,6 +31,6 @@
 
 `ps --sort size`
 
-- Display threads belonging to a process:
+- Display threads for a specific process:
 
 `ps -L -p {{pid}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -33,4 +33,4 @@
 
 - Display threads for a specific process:
 
-`ps -L -p {{process_id}}`
+`ps -L {{[-p|--pid]}} {{process_id}}`

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -29,7 +29,7 @@
 
 - Sort processes by memory consumption:
 
-`ps --sort size`
+`ps {{[k|--sort]}} size`
 
 - Display threads for a specific process:
 


### PR DESCRIPTION
Add an example showing how to display threads belonging to a process using `ps -L`.