### PR TITLE
trivy: change deprecated fs flags

### DIFF
--- a/pages/common/trivy.md
+++ b/pages/common/trivy.md
@@ -17,7 +17,7 @@
 
 - Scan the filesystem for vulnerabilities and misconfigurations:
 
-`trivy fs --security-checks {{vuln,config}} {{path/to/project_directory}}`
+`trivy fs --scanners {{vuln,misconfig}} {{path/to/project_directory}}`
 
 - Scan a IaC (Terraform, CloudFormation, ARM, Helm, and Dockerfile) directory for misconfigurations:
 


### PR DESCRIPTION
Changed `--security-check vuln,config` to `--scanners vuln,misconfig` as `--security-check` and `config` are deprecated.

`--security-check` deprecation:
- [commit](https://github.com/aquasecurity/trivy/commit/e1076085d937c7ad5962332268039fc8b5317ee3)
- [discussion](https://github.com/aquasecurity/trivy/discussions/3519)

`config` deprecation:
- [commit](https://github.com/aquasecurity/trivy/commit/a3895298dec37b291ae5968bd6c3aa7c155b3d44)
- [discussion](https://github.com/aquasecurity/trivy/discussions/5586)

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
