### PR TITLE
agent-tester: add page

### DIFF
--- a/pages/common/agent-tester-repl.md
+++ b/pages/common/agent-tester-repl.md
@@ -1,0 +1,24 @@
+# agent-tester repl
+
+> Start an interactive multi-model REPL to chat with multiple AI coding agents simultaneously.
+> More information: <https://github.com/sroomberg/agenttester>.
+
+- Start the REPL:
+
+`agent-tester repl`
+
+- Start with a named session to save and restore conversation history:
+
+`agent-tester repl --session {{session_name}}`
+
+- Start with a specific working directory for tool use and branch creation:
+
+`agent-tester repl --workdir {{path/to/repo}}`
+
+- Start with a custom configuration file:
+
+`agent-tester repl --config {{path/to/config.yaml}}`
+
+- Skip endpoint connection checks on startup:
+
+`agent-tester repl --skip-checks`

--- a/pages/common/agent-tester-run.md
+++ b/pages/common/agent-tester-run.md
@@ -1,0 +1,33 @@
+# agent-tester run
+
+> Run AI coding agents in parallel on a prompt and compare results.
+> Each agent works in its own git worktree on a separate branch.
+> More information: <https://github.com/sroomberg/agenttester>.
+
+- Run all configured agents on a prompt:
+
+`agent-tester run "{{prompt}}"`
+
+- Run specific agents:
+
+`agent-tester run --agents {{agent_name1,agent_name2}} "{{prompt}}"`
+
+- Read the prompt from a file:
+
+`agent-tester run --prompt-file {{path/to/prompt.txt}}`
+
+- Run with a descriptive name for the branch and report:
+
+`agent-tester run --name {{run_name}} "{{prompt}}"`
+
+- Set a custom timeout for all agents:
+
+`agent-tester run --timeout {{seconds}} "{{prompt}}"`
+
+- Run against a specific git repository:
+
+`agent-tester run --repo {{path/to/repo}} "{{prompt}}"`
+
+- Push agent branches to a remote after the run:
+
+`agent-tester run --push "{{prompt}}"`

--- a/pages/common/agent-tester.md
+++ b/pages/common/agent-tester.md
@@ -1,0 +1,25 @@
+# agent-tester
+
+> Send a prompt to multiple AI coding agents in parallel and compare the results.
+> See also: `agent-tester-run`, `agent-tester-repl`.
+> More information: <https://github.com/sroomberg/agenttester>.
+
+- Run all configured agents on a prompt:
+
+`agent-tester run "{{prompt}}"`
+
+- Start an interactive multi-model REPL:
+
+`agent-tester repl`
+
+- List available agents:
+
+`agent-tester agents`
+
+- List saved REPL sessions:
+
+`agent-tester sessions`
+
+- Resume a previous session:
+
+`agent-tester --resume {{session_id}} repl`


### PR DESCRIPTION
Add tldr pages for `agent-tester`, `agent-tester-run`, and `agent-tester-repl`.

`agent-tester` is a CLI tool that sends a prompt to multiple AI coding agents in parallel (each in its own git worktree) and compares the results. Available on PyPI, cross-platform.

- https://github.com/sroomberg/agenttester

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.4.5
- Reference issue: N/A
- Closes: N/A