### PR TITLE
mat: add page

### DIFF
--- a/pages/common/mat-finetune.md
+++ b/pages/common/mat-finetune.md
@@ -1,0 +1,29 @@
+# mat finetune
+
+> Fine-tune a model on the corpus ingested by MultiAgentTrainer.
+> Supports open-source models via HuggingFace/LoRA and managed models via AWS Bedrock.
+> More information: <https://github.com/sroomberg/MultiAgentTrainer>.
+
+- Start fine-tuning on the default ingested corpus:
+
+`mat finetune start`
+
+- Fine-tune using a specific corpus file:
+
+`mat finetune start --corpus {{path/to/corpus.txt}}`
+
+- Start a named fine-tuning job:
+
+`mat finetune start --name {{job_name}}`
+
+- List all fine-tuning jobs and their identifiers:
+
+`mat finetune list`
+
+- Check the status of a fine-tuning job:
+
+`mat finetune status {{job_id}}`
+
+- Cancel a running Bedrock fine-tuning job:
+
+`mat finetune cancel {{job_arn}}`

--- a/pages/common/mat-train.md
+++ b/pages/common/mat-train.md
@@ -1,0 +1,28 @@
+# mat train
+
+> Run the full MultiAgentTrainer pipeline: ingest data sources, build a corpus, and run training experiments.
+> More information: <https://github.com/sroomberg/MultiAgentTrainer>.
+
+- Run the full pipeline with default settings:
+
+`mat train`
+
+- Limit the number of training experiments:
+
+`mat train --max-experiments {{count}}`
+
+- Write output to a custom directory:
+
+`mat train --output-dir {{path/to/output}}`
+
+- Label the run for identification in `mat watch` and `mat status`:
+
+`mat train --name {{label}}`
+
+- Ingest an extra repository without editing the config (repeatable):
+
+`mat train --repo {{owner/repo}}`
+
+- Use a custom configuration file:
+
+`mat train --config {{path/to/config.yaml}}`

--- a/pages/common/mat.md
+++ b/pages/common/mat.md
@@ -1,0 +1,29 @@
+# mat
+
+> Collect data from multiple sources, run autonomous LLM training experiments, and fine-tune models.
+> Companion to `agent-tester`. See also: `mat-train`, `mat-finetune`.
+> More information: <https://github.com/sroomberg/MultiAgentTrainer>.
+
+- List configured data sources:
+
+`mat sources`
+
+- Ingest data sources and build a corpus without training:
+
+`mat ingest`
+
+- Run the full pipeline (ingest → corpus → train):
+
+`mat train`
+
+- Watch multiple training runs in real-time:
+
+`mat watch`
+
+- Show historical training run results:
+
+`mat status`
+
+- Fine-tune a model on the ingested corpus:
+
+`mat finetune start`


### PR DESCRIPTION
Add tldr pages for `mat`, `mat-train`, and `mat-finetune`.

`mat` (MultiAgentTrainer) is a CLI tool for collecting data from multiple sources, running autonomous LLM training experiments, and fine-tuning models. Designed as a companion to `agent-tester`. Available on PyPI, cross-platform.

- https://github.com/sroomberg/MultiAgentTrainer

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2.0.2
- Reference issue: N/A
- Closes: N/A