### PR TITLE
diffstitch: add page

### DIFF
--- a/pages/common/diffstitch.md
+++ b/pages/common/diffstitch.md
@@ -1,0 +1,24 @@
+# diffstitch
+
+> Compare multiple git branches against a base in a side-by-side HTML diff view.
+> More information: <https://github.com/sroomberg/diffstitch>.
+
+- Compare one or more branches against a base branch:
+
+`diffstitch {{base_branch}} {{branch1}} {{branch2}}`
+
+- Open the generated report in the browser immediately:
+
+`diffstitch {{base_branch}} {{branch1}} --open`
+
+- Write output to a custom directory:
+
+`diffstitch {{base_branch}} {{branch1}} --output {{path/to/output}}`
+
+- Set a custom title for the report page:
+
+`diffstitch {{base_branch}} {{branch1}} --title "{{Report Title}}"`
+
+- Print the version:
+
+`diffstitch --version`


### PR DESCRIPTION
Add tldr page for `diffstitch`.

`diffstitch` is a CLI tool that compares multiple git branches against a base in a side-by-side HTML diff view, generating a self-contained report with a branch switcher dropdown. Available on RubyGems, cross-platform.

- https://github.com/sroomberg/diffstitch

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.0.4
- Reference issue: N/A
- Closes: N/A