### PR TITLE
vllmd: add page

### DIFF
--- a/pages/common/vllmd-db.md
+++ b/pages/common/vllmd-db.md
@@ -1,0 +1,28 @@
+# vllmd db
+
+> Manage the vllmd local vector database for document and code context retrieval.
+> More information: <https://github.com/sroomberg/vllmd>.
+
+- Ingest a directory of documents into the vector database:
+
+`vllmd db ingest {{path/to/docs}} --type documents --model {{model_name}}`
+
+- Ingest a codebase:
+
+`vllmd db ingest {{path/to/src}} --type code --model {{model_name}}`
+
+- Search for relevant context:
+
+`vllmd db search "{{query}}" --collection {{code|documents}} --model {{model_name}}`
+
+- Sync the vector database to S3:
+
+`vllmd db sync {{s3://bucket/path}} --direction push`
+
+- Pull the vector database from S3:
+
+`vllmd db sync {{s3://bucket/path}} --direction pull`
+
+- Show collection sizes:
+
+`vllmd db stats`

--- a/pages/common/vllmd-session.md
+++ b/pages/common/vllmd-session.md
@@ -1,0 +1,36 @@
+# vllmd session
+
+> Manage persistent named chat sessions against a running vllmd model.
+> More information: <https://github.com/sroomberg/vllmd>.
+
+- Create a session (auto-resolves to the running container):
+
+`vllmd session create {{session_name}}`
+
+- Create a session bound to a specific container:
+
+`vllmd session create {{session_name}} --container {{container_name}}`
+
+- Send a one-shot message in a session:
+
+`vllmd session chat {{session_name}} "{{message}}"`
+
+- Open an interactive REPL for a session:
+
+`vllmd session attach {{session_name}}`
+
+- List all sessions:
+
+`vllmd session list`
+
+- Print recent conversation history:
+
+`vllmd session history {{session_name}} --last {{count}}`
+
+- Clear conversation history (keeps session config):
+
+`vllmd session clear {{session_name}}`
+
+- Delete a session:
+
+`vllmd session delete {{session_name}}`

--- a/pages/common/vllmd-task.md
+++ b/pages/common/vllmd-task.md
@@ -1,0 +1,25 @@
+# vllmd task
+
+> Run an agentic task with tool use against a vllmd-compatible endpoint.
+> The model iterates with bash, file I/O, and git tools until the task is complete.
+> More information: <https://github.com/sroomberg/vllmd>.
+
+- Run a task against a local model:
+
+`vllmd task "{{task_description}}" --endpoint {{http://localhost:port}} --model {{model_name}}`
+
+- Run a task in a specific working directory:
+
+`vllmd task "{{task_description}}" --endpoint {{http://localhost:port}} --model {{model_name}} --workdir {{path/to/repo}}`
+
+- Set a custom maximum number of conversation turns:
+
+`vllmd task "{{task_description}}" --endpoint {{http://localhost:port}} --model {{model_name}} --max-turns {{count}}`
+
+- Use an SSH PEM key for authenticated git operations:
+
+`vllmd task "{{task_description}}" --endpoint {{http://localhost:port}} --model {{model_name}} --pem {{path/to/key.pem}}`
+
+- Override the default system prompt:
+
+`vllmd task "{{task_description}}" --endpoint {{http://localhost:port}} --model {{model_name}} --system "{{system_prompt}}"`

--- a/pages/common/vllmd.md
+++ b/pages/common/vllmd.md
@@ -1,0 +1,33 @@
+# vllmd
+
+> Run and orchestrate vLLM model containers, single-node or across a cluster.
+> See also: `vllmd-session`, `vllmd-db`, `vllmd-task`.
+> More information: <https://github.com/sroomberg/vllmd>.
+
+- Serve a model on a port (foreground):
+
+`vllmd run --model {{path/to/model}} --port {{port}}`
+
+- Serve a model in the background and wait until the API is ready:
+
+`vllmd run --model {{path/to/model}} --port {{port}} --detach`
+
+- List all running vllmd containers:
+
+`vllmd ps`
+
+- Show container and API health:
+
+`vllmd status`
+
+- Stream container logs:
+
+`vllmd logs --follow`
+
+- Stop a container:
+
+`vllmd stop --name {{container_name}}`
+
+- Stop all vllmd containers:
+
+`vllmd stop --all`


### PR DESCRIPTION
Add tldr pages for `vllmd`, `vllmd-session`, `vllmd-db`, and `vllmd-task`.

`vllmd` is a CLI tool for running and orchestrating vLLM model containers — single-node or across a cluster. It exposes an OpenAI-compatible API and includes persistent chat sessions, a vector context database, and agentic task execution. Available on PyPI, cross-platform.

- https://github.com/sroomberg/vllmd

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 2.1.1
- Reference issue: N/A
- Closes: N/A