### PR TITLE
cargo-{rustc,rustdoc,search,test,tree}: add italian translation

### DIFF
--- a/pages.it/common/cargo-rustc.md
+++ b/pages.it/common/cargo-rustc.md
@@ -1,0 +1,38 @@
+# cargo rustc
+
+> Compila un pacchetto Rust. Simile a `cargo build`, ma permette di passare opzioni aggiuntive al compilatore.
+> Vedi `rustc --help` per tutte le opzioni disponibili.
+> Vedi anche: `rustc`.
+> Maggiori informazioni: <https://doc.rust-lang.org/cargo/commands/cargo-rustc.html>.
+
+- Compila il pacchetto e passa opzioni a `rustc`:
+
+`cargo rustc -- {{rustc_options}}`
+
+- Compila gli artefatti in modalità release:
+
+`cargo rustc {{[-r|--release]}}`
+
+- Compila con ottimizzazioni specifiche per l'architettura della CPU corrente:
+
+`cargo rustc {{[-r|--release]}} -- {{[-C|--codegen]}} target-cpu=native`
+
+- Compila con ottimizzazioni per la velocità:
+
+`cargo rustc -- {{[-C|--codegen]}} opt-level={{1|2|3}}`
+
+- Compila con ottimizzazioni per la dimensione (`s` disattiva anche la vettorizzazione dei loop):
+
+`cargo rustc -- {{[-C|--codegen]}} opt-level={{s|z}}`
+
+- Controlla se il pacchetto utilizza codice `unsafe`:
+
+`cargo rustc --lib -- -D unsafe-code`
+
+- Compila un pacchetto specifico:
+
+`cargo rustc {{[-p|--package]}} {{package}}`
+
+- Compila solo il binario specificato:
+
+`cargo rustc --bin {{name}}`

--- a/pages.it/common/cargo-rustc.md
+++ b/pages.it/common/cargo-rustc.md
@@ -31,8 +31,8 @@
 
 - Compila un pacchetto specifico:
 
-`cargo rustc {{[-p|--package]}} {{package}}`
+`cargo rustc {{[-p|--package]}} {{pacchetto}}`
 
 - Compila solo il binario specificato:
 
-`cargo rustc --bin {{name}}`
+`cargo rustc --bin {{nome}}`

--- a/pages.it/common/cargo-rustdoc.md
+++ b/pages.it/common/cargo-rustdoc.md
@@ -23,12 +23,12 @@
 
 - Documenta il binario specificato:
 
-`cargo rustdoc --bin {{name}}`
+`cargo rustdoc --bin {{nome}}`
 
 - Documenta l'example specificato:
 
-`cargo rustdoc --example {{name}}`
+`cargo rustdoc --example {{nome}}`
 
 - Documenta il test di integrazione specificato:
 
-`cargo rustdoc --test {{name}}`
+`cargo rustdoc --test {{nome}}`

--- a/pages.it/common/cargo-rustdoc.md
+++ b/pages.it/common/cargo-rustdoc.md
@@ -1,0 +1,34 @@
+# cargo rustdoc
+
+> Costruisci la documentazione dei pacchetti Rust.
+> Simile a `cargo doc`, ma permette di passare opzioni a `rustdoc`. Vedi `rustdoc --help` per tutte le opzioni disponibili.
+> Vedi anche: `rustdoc`.
+> Maggiori informazioni: <https://doc.rust-lang.org/cargo/commands/cargo-rustdoc.html>.
+
+- Passa opzioni a `rustdoc`:
+
+`cargo rustdoc -- {{rustdoc_options}}`
+
+- Segnala un lint della documentazione:
+
+`cargo rustdoc -- {{[-W|--warn]}} rustdoc::{{lint_name}}`
+
+- Ignora un lint della documentazione:
+
+`cargo rustdoc -- {{[-A|--allow]}} rustdoc::{{lint_name}}`
+
+- Documenta la libreria del pacchetto:
+
+`cargo rustdoc --lib`
+
+- Documenta il binario specificato:
+
+`cargo rustdoc --bin {{name}}`
+
+- Documenta l'example specificato:
+
+`cargo rustdoc --example {{name}}`
+
+- Documenta il test di integrazione specificato:
+
+`cargo rustdoc --test {{name}}`

--- a/pages.it/common/cargo-search.md
+++ b/pages.it/common/cargo-search.md
@@ -1,0 +1,13 @@
+# cargo search
+
+> Cerca pacchetti su <https://crates.io>.
+> I crate vengono mostrati insieme alle descrizioni in formato TOML, adatto per essere copiato in `Cargo.toml`.
+> Maggiori informazioni: <https://doc.rust-lang.org/cargo/commands/cargo-search.html>.
+
+- Cerca pacchetti:
+
+`cargo search {{query}}`
+
+- Mostra `n` risultati (predefinito: 10, massimo: 100):
+
+`cargo search --limit {{n}} {{query}}`

--- a/pages.it/common/cargo-test.md
+++ b/pages.it/common/cargo-test.md
@@ -5,11 +5,11 @@
 
 - Esegui solo i test che contengono una stringa specifica nel loro nome:
 
-`cargo {{[t|test]}} {{test_name}}`
+`cargo {{[t|test]}} {{nome_test}}`
 
 - Imposta il numero di casi di test eseguiti contemporaneamente:
 
-`cargo {{[t|test]}} -- --test-threads {{count}}`
+`cargo {{[t|test]}} -- --test-threads {{conto}}`
 
 - Esegui i test in modalità release, con ottimizzazioni:
 
@@ -21,7 +21,7 @@
 
 - Esegui i test per un pacchetto specifico:
 
-`cargo {{[t|test]}} {{[-p|--package]}} {{package}}`
+`cargo {{[t|test]}} {{[-p|--package]}} {{pacchetto}}`
 
 - Esegui i test senza nascondere l'output delle esecuzioni dei test:
 

--- a/pages.it/common/cargo-test.md
+++ b/pages.it/common/cargo-test.md
@@ -1,0 +1,28 @@
+# cargo test
+
+> Esegui i test unitari e di integrazione di un pacchetto Rust.
+> Maggiori informazioni: <https://doc.rust-lang.org/cargo/commands/cargo-test.html>.
+
+- Esegui solo i test che contengono una stringa specifica nel loro nome:
+
+`cargo {{[t|test]}} {{test_name}}`
+
+- Imposta il numero di casi di test eseguiti contemporaneamente:
+
+`cargo {{[t|test]}} -- --test-threads {{count}}`
+
+- Esegui i test in modalità release, con ottimizzazioni:
+
+`cargo {{[t|test]}} {{[-r|--release]}}`
+
+- Esegui i test per tutti i pacchetti nello workspace:
+
+`cargo {{[t|test]}} --workspace`
+
+- Esegui i test per un pacchetto specifico:
+
+`cargo {{[t|test]}} {{[-p|--package]}} {{package}}`
+
+- Esegui i test senza nascondere l'output delle esecuzioni dei test:
+
+`cargo {{[t|test]}} -- --nocapture`

--- a/pages.it/common/cargo-tree.md
+++ b/pages.it/common/cargo-tree.md
@@ -1,0 +1,25 @@
+# cargo tree
+
+> Mostra una visualizzazione ad albero della dipendenza di un progetto.
+> Nota: nell'albero, le dipendenze dei pacchetti contrassegnati con `(*)` sono già state mostrate altrove nel grafo, e quindi non sono ripetute.
+> Maggiori informazioni: <https://doc.rust-lang.org/cargo/commands/cargo-tree.html>.
+
+- Mostra un albero delle dipendenze del progetto corrente:
+
+`cargo tree`
+
+- Mostra solo le dipendenze fino alla profondità specificata (es. quando `n` è 1 mostra solo le dipendenze dirette):
+
+`cargo tree --depth {{n}}`
+
+- Non visualizzare il pacchetto dato (e le sue dipendenze) nell'albero:
+
+`cargo tree --prune {{package_spec}}`
+
+- Mostra tutte le occorrenze delle dipendenze ripetute:
+
+`cargo tree --no-dedupe`
+
+- Mostra solo dipendenze normali/build/dev:
+
+`cargo tree {{[-e|--edges]}} {{normal|build|dev}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).