### PR TITLE
mkfs.ext4, toolbox-init-container: expand uid and gid placeholder names

### DIFF
--- a/pages/linux/mkfs.ext4.md
+++ b/pages/linux/mkfs.ext4.md
@@ -13,4 +13,4 @@
 
 - Create an ext4 filesystem owned by a specific user and group:
 
-`sudo mkfs.ext4 -E root_owner={{uid}}:{{gid}} {{/dev/sdXY}}`
+`sudo mkfs.ext4 -E root_owner={{user_id}}:{{group_id}} {{/dev/sdXY}}`

--- a/pages/linux/toolbox-init-container.md
+++ b/pages/linux/toolbox-init-container.md
@@ -6,4 +6,4 @@
 
 - Initialize a running Toolbx container:
 
-`toolbox init-container --gid {{gid}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{uid}} --user {{user}}`
+`toolbox init-container --gid {{group_id}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{user_id}} --user {{user}}`


### PR DESCRIPTION
### Checklist

* [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.

* [x] The page description(s) have links to documentation or a homepage.

* [x] The page(s) follow the content guidelines.

* [x] The page(s) follow the style guide.

* [x] The PR contains at most 5 new pages.

* [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.

* [x] The PR title conforms to the recommended templates.

* **Version of the command being documented (if known):** N/A (placeholder cleanup)

* Reference issue: #22636

### Description

Expands placeholder names in two English pages to improve clarity:

* `{{uid}}` → `{{user_id}}`
* `{{gid}}` → `{{group_id}}`

Files changed:

* `pages/linux/mkfs.ext4.md`
* `pages/linux/toolbox-init-container.md`

This PR intentionally keeps the scope small and focused on the English pages only.
