### PR TITLE
powermetrics: add page

### DIFF
--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -9,7 +9,7 @@
 
 - Sample metrics every 2 seconds, taking 10 samples then exit:
 
-`sudo powermetrics --sample-rate {{2000}} --sample-count {{10}}`
+`sudo powermetrics {{[-i|--sample-rate]}} {{2000}} {{[-n|--sample-count]}} {{10}}`
 
 - Save output to a file instead of `stdout`:
 
@@ -17,7 +17,7 @@
 
 - Order the process list by the specified method (default: `composite`):
 
-`sudo powermetrics --order {{pid|wakeups|cputime|composite}}`
+`sudo powermetrics {{[-r|--order]}} {{pid|wakeups|cputime|composite}}`
 
 - Display output in machine-readable plist format and print a usage summary on exit:
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -21,4 +21,4 @@
 
 - Display output in machine-readable property list format and print a usage summary on exit:
 
-`sudo powermetrics {{[-f|--format]}} {{text|plist}} --show-usage-summary`
+`sudo powermetrics {{[-f|--format]}} plist --show-usage-summary`

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -21,4 +21,4 @@
 
 - Display output in machine-readable plist format and print a usage summary on exit:
 
-`sudo powermetrics --format {{plist}} --show-usage-summary`
+`sudo powermetrics {{[-f|--format]}} {{text|plist}} --show-usage-summary`

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -15,9 +15,9 @@
 
 `sudo powermetrics --output-file {{path/to/output.txt}}`
 
-- Order the process list by a specified method (`pid`, `wakeups`, `cputime`, or `composite`):
+- Order the process list by the specified method (default: `composite`):
 
-`sudo powermetrics --order {{composite}}`
+`sudo powermetrics --order {{pid|wakeups|cputime|composite}}`
 
 - Display output in machine-readable plist format and print a usage summary on exit:
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -1,8 +1,7 @@
 # powermetrics
 
-> Gather and display CPU usage, power, and interrupt wakeup statistics on macOS.
-> Requires root privileges to run.
-> More information: <https://www.unix.com/man_page/osx/1/powermetrics/>.
+> Gather and display CPU usage, power, and interrupt wakeup statistics.
+> More information: <https://keith.github.io/xcode-man-pages/powermetrics.1.html>.
 
 - Display CPU, power, and wakeup metrics using the default 5-second sample interval:
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -8,21 +8,17 @@
 
 `sudo powermetrics`
 
-- Sample metrics every 2 seconds indefinitely:
+- Sample metrics every 2 seconds, taking 10 samples then exit:
 
-`sudo powermetrics --sample-interval {{2000}}`
-
-- Take a specific number of samples then exit:
-
-`sudo powermetrics --sample-count {{10}}`
+`sudo powermetrics --sample-interval {{2000}} --sample-count {{10}}`
 
 - Save output to a file instead of `stdout`:
 
 `sudo powermetrics --output-file {{path/to/output.txt}}`
 
-- Order the process list by CPU time consumed:
+- Order the process list by a specified method (`pid`, `wakeups`, `cputime`, or `composite`):
 
-`sudo powermetrics --order {{cputime}}`
+`sudo powermetrics --order {{composite}}`
 
 - Display output in machine-readable plist format and print a usage summary on exit:
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -1,0 +1,29 @@
+# powermetrics
+
+> Gather and display CPU usage, power, and interrupt wakeup statistics on macOS.
+> Requires root privileges to run.
+> More information: <https://www.unix.com/man_page/osx/1/powermetrics/>.
+
+- Display CPU, power, and wakeup metrics using the default 5-second sample interval:
+
+`sudo powermetrics`
+
+- Sample metrics every 2 seconds indefinitely:
+
+`sudo powermetrics --sample-interval {{2000}}`
+
+- Take a specific number of samples then exit:
+
+`sudo powermetrics --sample-count {{10}}`
+
+- Save output to a file instead of `stdout`:
+
+`sudo powermetrics --output-file {{path/to/output.txt}}`
+
+- Order the process list by CPU time consumed:
+
+`sudo powermetrics --order {{cputime}}`
+
+- Display output in machine-readable plist format and print a usage summary on exit:
+
+`sudo powermetrics --format {{plist}} --show-usage-summary`

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -19,6 +19,6 @@
 
 `sudo powermetrics {{[-r|--order]}} {{pid|wakeups|cputime|composite}}`
 
-- Display output in machine-readable plist format and print a usage summary on exit:
+- Display output in machine-readable property list format and print a usage summary on exit:
 
 `sudo powermetrics {{[-f|--format]}} {{text|plist}} --show-usage-summary`

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -7,9 +7,9 @@
 
 `sudo powermetrics`
 
-- Sample metrics every 2 seconds, taking 10 samples then exit:
+- Sample metrics every 2000 milliseconds taking 10 samples then exit:
 
-`sudo powermetrics {{[-i|--sample-rate]}} {{2000}} {{[-n|--sample-count]}} {{10}}`
+`sudo powermetrics {{[-i|--sample-rate]}} 2000 {{[-n|--sample-count]}} 10`
 
 - Save output to a file instead of `stdout`:
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -13,7 +13,7 @@
 
 - Save output to a file instead of `stdout`:
 
-`sudo powermetrics --output-file {{path/to/output.txt}}`
+`sudo powermetrics {{[-o|--output-file]}} {{path/to/output.txt}}`
 
 - Order the process list by the specified method (default: `composite`):
 

--- a/pages/osx/powermetrics.md
+++ b/pages/osx/powermetrics.md
@@ -9,7 +9,7 @@
 
 - Sample metrics every 2 seconds, taking 10 samples then exit:
 
-`sudo powermetrics --sample-interval {{2000}} --sample-count {{10}}`
+`sudo powermetrics --sample-rate {{2000}} --sample-count {{10}}`
 
 - Save output to a file instead of `stdout`:
 


### PR DESCRIPTION
Closes #21876
   
Adds a new page for the macOS powermetrics command.