### PR TITLE
limactl: update template selection syntax for version 2

### DIFF
--- a/pages.es/common/limactl.md
+++ b/pages.es/common/limactl.md
@@ -10,7 +10,7 @@
 
 - Crea una MV usando la configuración predeterminada y opcionalmente proporciona un nombre y/o una plantilla (vea `limactl create --list-templates` para plantillas disponibles):
 
-`limactl create --name {{nombre_de_la_mv}} template://{{debian|fedora|ubuntu|...}}`
+`limactl create --name {{nombre_de_la_mv}} template:{{debian|fedora|ubuntu|...}}`
 
 - Inicia una MV (esto puede instalar algunas dependencias en la misma y tomar unos minutos):
 

--- a/pages.ko/common/limactl.md
+++ b/pages.ko/common/limactl.md
@@ -10,7 +10,7 @@
 
 - 기본 설정을 사용하여 VM 생성(선택적으로 이름 및/또는 템플릿 제공 가능, 사용 가능한 템플릿은 `limactl create --list-templates` 참조):
 
-`limactl create --name {{vm_이름}} template://{{debian|fedora|ubuntu|...}}`
+`limactl create --name {{vm_이름}} template:{{debian|fedora|ubuntu|...}}`
 
 - VM 시작(일부 의존성이 설치될 수 있으며 몇 분이 소요될 수 있음):
 

--- a/pages.nl/common/limactl.md
+++ b/pages.nl/common/limactl.md
@@ -10,7 +10,7 @@
 
 - Maak een VM met standaard instellingen en voorzie optioneel van een naam en/of template (zie `limactl create --list-templates` voor beschikbare templates):
 
-`limactl create --name {{vm_naam}} template://{{debian|fedora|ubuntu|...}}`
+`limactl create --name {{vm_naam}} template:{{debian|fedora|ubuntu|...}}`
 
 - Start een VM (dit kan enkele afhankelijkheden erin installeren en een paar minuten duren):
 

--- a/pages/common/limactl.md
+++ b/pages/common/limactl.md
@@ -10,7 +10,7 @@
 
 - Create a VM using the default settings and optionally provide a name and/or a template (see `limactl create --list-templates` for available templates):
 
-`limactl create --name {{vm_name}} template://{{debian|fedora|ubuntu|...}}`
+`limactl create --name {{vm_name}} template:{{debian|fedora|ubuntu|...}}`
 
 - Start a VM (this might install some dependencies in it and take a few minutes):
 


### PR DESCRIPTION
The old syntax still works but produces this warning:
> WARN[0000] Template locator "template://debian" should be written "template:debian" since Lima v2.0

This PR fixes that, I think the checklist does not apply in this case.