### PR TITLE
vtool: add page

### DIFF
--- a/pages/osx/vtool.md
+++ b/pages/osx/vtool.md
@@ -1,0 +1,24 @@
+# vtool
+
+> Display and edit Mach-O build and source version load commands.
+> More information: <https://keith.github.io/xcode-man-pages/vtool.1.html>.
+
+- Display build and source version information:
+
+`vtool --show {{path/to/file}}`
+
+- Display only build version information:
+
+`vtool --show-build {{path/to/file}}`
+
+- Display load command space information:
+
+`vtool --show-space {{path/to/file}}`
+
+- Display version information for a specific architecture in a universal file:
+
+`vtool --arch {{architecture}} --show {{path/to/file}}`
+
+- Set the source version and write the result to a new file:
+
+`vtool --set-source-version {{A.B.C.D.E}} --output {{path/to/output_file}} {{path/to/file}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** macOS man page, vtool first appeared in macOS 10.15
- Reference issue: #6431
- Closes:

Adds a new macOS page for `vtool`, covering common display commands and a source-version edit example that writes to a separate output file.

Validation performed:

- `npx tldr-lint pages/osx/vtool.md`
- `npx markdownlint pages/osx/vtool.md`
- `bash scripts/test.sh` via the commit hook

Note: this page was prepared with Codex assistance and checked against the local macOS `vtool(1)` man page.