### PR TITLE
renice: expand pid and uid to process_id and user_id

### DIFF
--- a/pages/common/renice.md
+++ b/pages/common/renice.md
@@ -1,18 +1,17 @@
 # renice
 
-> Alter the scheduling priority/niceness of running processes.
-> Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
+> Alter the scheduling priority/niceness of running processes. Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process).
 > See also: `nice`.
 > More information: <https://manned.org/renice.1p>.
 
-- Increase/decrease the priority of a running [p]rocess:
+- Increase/decrease the priority of a running process:
 
-`renice -n {{3}} -p {{pid}}`
+`renice -n {{3}} -p {{process_id}}`
 
-- Increase/decrease the priority of all processes owned by a [u]ser:
+- Increase/decrease the priority of all processes owned by a user:
 
-`renice -n {{-4}} -u {{uid|user}}`
+`renice -n {{-4}} -u {{user_id}}`
 
-- Increase/decrease the priority of all processes that belong to a process [g]roup:
+- Increase/decrease the priority of all processes that belong to a process group:
 
 `renice -n {{5}} -g {{process_group}}`


### PR DESCRIPTION
## Description

Expands the short placeholders `pid` and `uid` to `process_id` and `user_id` 
in the `renice` page.

This improves clarity and supports the overall effort in #22636.

## Related Issue

Part of #22636

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #22636
- Closes: