### PR TITLE
pages.sv/*: fix "original" typo in Swedish alias translations

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -474,7 +474,7 @@ The templates can be changed when necessary.
 
 > Det här kommandot är ett alias för `example`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr example`
 ```

--- a/pages.sv/common/((.md
+++ b/pages.sv/common/((.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `let`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr let`

--- a/pages.sv/common/arch.md
+++ b/pages.sv/common/arch.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `uname --machine`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr uname`

--- a/pages.sv/common/argospm.md
+++ b/pages.sv/common/argospm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `argos-translate`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr argos-translate`

--- a/pages.sv/common/azure-cli.md
+++ b/pages.sv/common/azure-cli.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `az`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr az`

--- a/pages.sv/common/brew-abv.md
+++ b/pages.sv/common/brew-abv.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `brew info`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr brew info`

--- a/pages.sv/common/brew-remove.md
+++ b/pages.sv/common/brew-remove.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `brew uninstall`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr brew uninstall`

--- a/pages.sv/common/brew-rm.md
+++ b/pages.sv/common/brew-rm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `brew uninstall`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr brew uninstall`

--- a/pages.sv/common/bun-c.md
+++ b/pages.sv/common/bun-c.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bun create`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bun create`

--- a/pages.sv/common/bun-i.md
+++ b/pages.sv/common/bun-i.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bun install`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bun install`

--- a/pages.sv/common/bun-list.md
+++ b/pages.sv/common/bun-list.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bun pm ls`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bun pm ls`

--- a/pages.sv/common/bun-rm.md
+++ b/pages.sv/common/bun-rm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bun remove`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bun remove`

--- a/pages.sv/common/bun-x.md
+++ b/pages.sv/common/bun-x.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bunx`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bunx`

--- a/pages.sv/common/bundler.md
+++ b/pages.sv/common/bundler.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bundle`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bundle`

--- a/pages.sv/common/bunzip2.md
+++ b/pages.sv/common/bunzip2.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bzip2 --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bzip2`

--- a/pages.sv/common/bye.md
+++ b/pages.sv/common/bye.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `exit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr exit`

--- a/pages.sv/common/bzcat.md
+++ b/pages.sv/common/bzcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bzip2 --decompress --stdout`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bzip2`

--- a/pages.sv/common/bzegrep.md
+++ b/pages.sv/common/bzegrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bzgrep --extended-regexp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bzgrep`

--- a/pages.sv/common/bzfgrep.md
+++ b/pages.sv/common/bzfgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bzgrep --fixed-strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bzgrep`

--- a/pages.sv/common/c++.md
+++ b/pages.sv/common/c++.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `g++`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr g++`

--- a/pages.sv/common/chdir.md
+++ b/pages.sv/common/chdir.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `cd`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr cd`

--- a/pages.sv/common/clang-cpp.md
+++ b/pages.sv/common/clang-cpp.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `clang++`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr clang++`

--- a/pages.sv/common/clojure.md
+++ b/pages.sv/common/clojure.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `clj`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr clj`

--- a/pages.sv/common/codium.md
+++ b/pages.sv/common/codium.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `code`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr code`

--- a/pages.sv/common/cola.md
+++ b/pages.sv/common/cola.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `git-cola`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr git-cola`

--- a/pages.sv/common/comma.md
+++ b/pages.sv/common/comma.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `,`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ,`

--- a/pages.sv/common/compare.md
+++ b/pages.sv/common/compare.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `magick compare`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr magick compare`

--- a/pages.sv/common/copr.md
+++ b/pages.sv/common/copr.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `copr-cli`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr copr-cli`

--- a/pages.sv/common/crane-cp.md
+++ b/pages.sv/common/crane-cp.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `crane copy`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr crane copy`

--- a/pages.sv/common/docker-commit.md
+++ b/pages.sv/common/docker-commit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container commit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container commit`

--- a/pages.sv/common/docker-container-diff.md
+++ b/pages.sv/common/docker-container-diff.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `docker diff`.
 > Mer information: <https://docs.docker.com/reference/cli/docker/container/diff/>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker diff`

--- a/pages.sv/common/docker-container-remove.md
+++ b/pages.sv/common/docker-container-remove.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container rm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container rm`

--- a/pages.sv/common/docker-container-rename.md
+++ b/pages.sv/common/docker-container-rename.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `docker rename`.
 > Mer information: <https://docs.docker.com/reference/cli/docker/container/rename/>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker rename`

--- a/pages.sv/common/docker-container-rm.md
+++ b/pages.sv/common/docker-container-rm.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `docker rm`.
 > Mer information: <https://docs.docker.com/reference/cli/docker/container/rm/>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker rm`

--- a/pages.sv/common/docker-container-top.md
+++ b/pages.sv/common/docker-container-top.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `docker top`.
 > Mer information: <https://docs.docker.com/reference/cli/docker/container/top/>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker top`

--- a/pages.sv/common/docker-cp.md
+++ b/pages.sv/common/docker-cp.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container cp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container cp`

--- a/pages.sv/common/docker-diff.md
+++ b/pages.sv/common/docker-diff.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container diff`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container diff`

--- a/pages.sv/common/docker-exec.md
+++ b/pages.sv/common/docker-exec.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container exec`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container exec`

--- a/pages.sv/common/docker-images.md
+++ b/pages.sv/common/docker-images.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image ls`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image ls`

--- a/pages.sv/common/docker-load.md
+++ b/pages.sv/common/docker-load.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image load`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image load`

--- a/pages.sv/common/docker-logs.md
+++ b/pages.sv/common/docker-logs.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container logs`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container logs`

--- a/pages.sv/common/docker-ps.md
+++ b/pages.sv/common/docker-ps.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container ls`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container ls`

--- a/pages.sv/common/docker-pull.md
+++ b/pages.sv/common/docker-pull.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image pull`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image pull`

--- a/pages.sv/common/docker-rename.md
+++ b/pages.sv/common/docker-rename.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container rename`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container rename`

--- a/pages.sv/common/docker-rm.md
+++ b/pages.sv/common/docker-rm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container rm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container rm`

--- a/pages.sv/common/docker-rmi.md
+++ b/pages.sv/common/docker-rmi.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image rm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image rm`

--- a/pages.sv/common/docker-run.md
+++ b/pages.sv/common/docker-run.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container run`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container run`

--- a/pages.sv/common/docker-save.md
+++ b/pages.sv/common/docker-save.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image save`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image save`

--- a/pages.sv/common/docker-slim.md
+++ b/pages.sv/common/docker-slim.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `slim`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr slim`

--- a/pages.sv/common/docker-start.md
+++ b/pages.sv/common/docker-start.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container start`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container start`

--- a/pages.sv/common/docker-stats.md
+++ b/pages.sv/common/docker-stats.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container stats`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container stats`

--- a/pages.sv/common/docker-tag.md
+++ b/pages.sv/common/docker-tag.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker image tag`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker image tag`

--- a/pages.sv/common/docker-top.md
+++ b/pages.sv/common/docker-top.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container top`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container top`

--- a/pages.sv/common/docker-update.md
+++ b/pages.sv/common/docker-update.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `docker container update`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr docker container update`

--- a/pages.sv/common/egrep.md
+++ b/pages.sv/common/egrep.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `grep --extended-regexp`.
 > Mer information: <https://manned.org/egrep>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr grep`

--- a/pages.sv/common/fdfind.md
+++ b/pages.sv/common/fdfind.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `fd`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fd`

--- a/pages.sv/common/fgrep.md
+++ b/pages.sv/common/fgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `grep --fixed-strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr grep`

--- a/pages.sv/common/file-rename.md
+++ b/pages.sv/common/file-rename.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rename`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr {{[-p|--platform]}} common rename`

--- a/pages.sv/common/fossil-ci.md
+++ b/pages.sv/common/fossil-ci.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `fossil commit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fossil commit`

--- a/pages.sv/common/fossil-forget.md
+++ b/pages.sv/common/fossil-forget.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `fossil rm`.
 > Mer information: <https://fossil-scm.org/home/help/forget>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fossil rm`

--- a/pages.sv/common/fossil-new.md
+++ b/pages.sv/common/fossil-new.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `fossil init`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fossil init`

--- a/pages.sv/common/fossil-rm.md
+++ b/pages.sv/common/fossil-rm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `fossil delete`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fossil delete`

--- a/pages.sv/common/gdm-binary.md
+++ b/pages.sv/common/gdm-binary.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gdm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gdm`

--- a/pages.sv/common/getln.md
+++ b/pages.sv/common/getln.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `read -zr`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr read`

--- a/pages.sv/common/gh-a11y.md
+++ b/pages.sv/common/gh-a11y.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gh accessibility`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gh accessibility`

--- a/pages.sv/common/gh-agent.md
+++ b/pages.sv/common/gh-agent.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gh agent-task`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gh agent-task`

--- a/pages.sv/common/gh-at.md
+++ b/pages.sv/common/gh-at.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gh attestation`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gh attestation`

--- a/pages.sv/common/gh-cs.md
+++ b/pages.sv/common/gh-cs.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gh codespace`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gh codespace`

--- a/pages.sv/common/gh-rs.md
+++ b/pages.sv/common/gh-rs.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gh ruleset`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gh ruleset`

--- a/pages.sv/common/git-continue.md
+++ b/pages.sv/common/git-continue.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `git abort`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr git abort`

--- a/pages.sv/common/git-stage.md
+++ b/pages.sv/common/git-stage.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `git add`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr git add`

--- a/pages.sv/common/gnmic-sub.md
+++ b/pages.sv/common/gnmic-sub.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gnmic subscribe`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gnmic subscribe`

--- a/pages.sv/common/gpg2.md
+++ b/pages.sv/common/gpg2.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gpg`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gpg`

--- a/pages.sv/common/gunzip.md
+++ b/pages.sv/common/gunzip.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gzip --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gzip`

--- a/pages.sv/common/hd.md
+++ b/pages.sv/common/hd.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hexdump`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hexdump`

--- a/pages.sv/common/helix.md
+++ b/pages.sv/common/helix.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hx`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hx`

--- a/pages.sv/common/hping.md
+++ b/pages.sv/common/hping.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hping3`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hping3`

--- a/pages.sv/common/https.md
+++ b/pages.sv/common/https.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `http`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr http`

--- a/pages.sv/common/huggingface-cli.md
+++ b/pages.sv/common/huggingface-cli.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hf`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hf`

--- a/pages.sv/common/hugo-serve.md
+++ b/pages.sv/common/hugo-serve.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hugo server`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hugo server`

--- a/pages.sv/common/ic.md
+++ b/pages.sv/common/ic.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ibmcloud`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ibmcloud`

--- a/pages.sv/common/identify.md
+++ b/pages.sv/common/identify.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `magick identify`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr magick identify`

--- a/pages.sv/common/impacket-addcomputer.md
+++ b/pages.sv/common/impacket-addcomputer.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `addcomputer.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr addcomputer.py`

--- a/pages.sv/common/impacket-dumpntlminfo.md
+++ b/pages.sv/common/impacket-dumpntlminfo.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `DumpNTLMInfo.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr DumpNTLMInfo.py`

--- a/pages.sv/common/impacket-getadusers.md
+++ b/pages.sv/common/impacket-getadusers.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `GetADUsers.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr GetADUsers.py`

--- a/pages.sv/common/impacket-getarch.md
+++ b/pages.sv/common/impacket-getarch.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `getArch.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr getArch.py`

--- a/pages.sv/common/impacket-getnpusers.md
+++ b/pages.sv/common/impacket-getnpusers.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `GetNPUsers.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr GetNPUsers.py`

--- a/pages.sv/common/impacket-getst.md
+++ b/pages.sv/common/impacket-getst.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `getST.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr getST.py`

--- a/pages.sv/common/impacket-gettgt.md
+++ b/pages.sv/common/impacket-gettgt.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `getTGT.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr getTGT.py`

--- a/pages.sv/common/impacket-getuserspns.md
+++ b/pages.sv/common/impacket-getuserspns.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `GetUserSPNs.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr GetUserSPNs.py`

--- a/pages.sv/common/impacket-mqtt_check.md
+++ b/pages.sv/common/impacket-mqtt_check.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mqtt_check.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mqtt_check.py`

--- a/pages.sv/common/impacket-mssqlclient.md
+++ b/pages.sv/common/impacket-mssqlclient.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mssqlclient.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mssqlclient.py`

--- a/pages.sv/common/impacket-ntfs-read.md
+++ b/pages.sv/common/impacket-ntfs-read.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ntfs-read.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ntfs-read.py`

--- a/pages.sv/common/impacket-ping.md
+++ b/pages.sv/common/impacket-ping.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ping.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ping.py`

--- a/pages.sv/common/impacket-ping6.md
+++ b/pages.sv/common/impacket-ping6.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ping6.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ping6.py`

--- a/pages.sv/common/impacket-psexec.md
+++ b/pages.sv/common/impacket-psexec.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `psexec.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr psexec.py`

--- a/pages.sv/common/impacket-rdp_check.md
+++ b/pages.sv/common/impacket-rdp_check.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rdp_check.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rdp_check.py`

--- a/pages.sv/common/impacket-reg.md
+++ b/pages.sv/common/impacket-reg.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `reg.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr reg.py`

--- a/pages.sv/common/impacket-rpcdump.md
+++ b/pages.sv/common/impacket-rpcdump.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rpcdump.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rpcdump.py`

--- a/pages.sv/common/impacket-rpcmap.md
+++ b/pages.sv/common/impacket-rpcmap.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rpcmap.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rpcmap.py`

--- a/pages.sv/common/impacket-sambapipe.md
+++ b/pages.sv/common/impacket-sambapipe.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `sambaPipe.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr sambaPipe.py`

--- a/pages.sv/common/impacket-secretsdump.md
+++ b/pages.sv/common/impacket-secretsdump.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `secretsdump.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr secretsdump.py`

--- a/pages.sv/common/impacket-smbclient.md
+++ b/pages.sv/common/impacket-smbclient.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `smbclient.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr smbclient.py`

--- a/pages.sv/common/impacket-smbserver.md
+++ b/pages.sv/common/impacket-smbserver.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `smbserver.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr smbserver.py`

--- a/pages.sv/common/impacket-sniff.md
+++ b/pages.sv/common/impacket-sniff.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `sniff.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr sniff.py`

--- a/pages.sv/common/impacket-sniffer.md
+++ b/pages.sv/common/impacket-sniffer.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `sniffer.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr sniffer.py`

--- a/pages.sv/common/impacket-ticketconverter.md
+++ b/pages.sv/common/impacket-ticketconverter.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ticketConverter.py`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ticketConverter.py`

--- a/pages.sv/common/import.md
+++ b/pages.sv/common/import.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `magick import`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr magick import`

--- a/pages.sv/common/j.md
+++ b/pages.sv/common/j.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `autojump`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr autojump`

--- a/pages.sv/common/jco.md
+++ b/pages.sv/common/jco.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `autojump`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr autojump`

--- a/pages.sv/common/jfrog.md
+++ b/pages.sv/common/jfrog.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jf`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jf`

--- a/pages.sv/common/jira-browse.md
+++ b/pages.sv/common/jira-browse.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jira open`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jira open`

--- a/pages.sv/common/jira-issues.md
+++ b/pages.sv/common/jira-issues.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jira issue`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jira issue`

--- a/pages.sv/common/jira-navigate.md
+++ b/pages.sv/common/jira-navigate.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jira open`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jira open`

--- a/pages.sv/common/jira-projects.md
+++ b/pages.sv/common/jira-projects.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jira project`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jira project`

--- a/pages.sv/common/jira-sprints.md
+++ b/pages.sv/common/jira-sprints.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jira sprint`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jira sprint`

--- a/pages.sv/common/jo.md
+++ b/pages.sv/common/jo.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `autojump`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr autojump`

--- a/pages.sv/common/jupyterlab.md
+++ b/pages.sv/common/jupyterlab.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `jupyter lab`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr jupyter lab`

--- a/pages.sv/common/kafkacat.md
+++ b/pages.sv/common/kafkacat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `kcat`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr kcat`

--- a/pages.sv/common/kite.md
+++ b/pages.sv/common/kite.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `kiterunner`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr kiterunner`

--- a/pages.sv/common/kr.md
+++ b/pages.sv/common/kr.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `kiterunner`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr kiterunner`

--- a/pages.sv/common/libreoffice.md
+++ b/pages.sv/common/libreoffice.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `soffice`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr soffice`

--- a/pages.sv/common/llvm-ar.md
+++ b/pages.sv/common/llvm-ar.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ar`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ar`

--- a/pages.sv/common/llvm-g++.md
+++ b/pages.sv/common/llvm-g++.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `clang++`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr clang++`

--- a/pages.sv/common/llvm-gcc.md
+++ b/pages.sv/common/llvm-gcc.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `clang`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr clang`

--- a/pages.sv/common/llvm-nm.md
+++ b/pages.sv/common/llvm-nm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nm`

--- a/pages.sv/common/llvm-objdump.md
+++ b/pages.sv/common/llvm-objdump.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `objdump`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr objdump`

--- a/pages.sv/common/llvm-strings.md
+++ b/pages.sv/common/llvm-strings.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr strings`

--- a/pages.sv/common/luantiserver.md
+++ b/pages.sv/common/luantiserver.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `luanti --server`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr luanti`

--- a/pages.sv/common/lzcat.md
+++ b/pages.sv/common/lzcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xz --format lzma --decompress --stdout`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xz`

--- a/pages.sv/common/lzcmp.md
+++ b/pages.sv/common/lzcmp.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzcmp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzcmp`

--- a/pages.sv/common/lzdiff.md
+++ b/pages.sv/common/lzdiff.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzdiff`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzdiff`

--- a/pages.sv/common/lzegrep.md
+++ b/pages.sv/common/lzegrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzgrep --extended-regexp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzgrep`

--- a/pages.sv/common/lzfgrep.md
+++ b/pages.sv/common/lzfgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzgrep --fixed-strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzgrep`

--- a/pages.sv/common/lzgrep.md
+++ b/pages.sv/common/lzgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzgrep`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzgrep`

--- a/pages.sv/common/lzless.md
+++ b/pages.sv/common/lzless.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzless`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzless`

--- a/pages.sv/common/lzma.md
+++ b/pages.sv/common/lzma.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xz --format lzma`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xz`

--- a/pages.sv/common/lzmore.md
+++ b/pages.sv/common/lzmore.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzmore`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzmore`

--- a/pages.sv/common/mapfile.md
+++ b/pages.sv/common/mapfile.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `readarray`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr readarray`

--- a/pages.sv/common/minetest.md
+++ b/pages.sv/common/minetest.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `luanti`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr luanti`

--- a/pages.sv/common/minetestserver.md
+++ b/pages.sv/common/minetestserver.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `luanti --server`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr luanti`

--- a/pages.sv/common/mogrify.md
+++ b/pages.sv/common/mogrify.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `magick mogrify`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr magick mogrify`

--- a/pages.sv/common/montage.md
+++ b/pages.sv/common/montage.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `magick montage`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr magick montage`

--- a/pages.sv/common/mpicxx.md
+++ b/pages.sv/common/mpicxx.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mpic++`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mpic++`

--- a/pages.sv/common/mpiexec.md
+++ b/pages.sv/common/mpiexec.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mpirun`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mpirun`

--- a/pages.sv/common/mscore.md
+++ b/pages.sv/common/mscore.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `musescore`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr musescore`

--- a/pages.sv/common/msedit.md
+++ b/pages.sv/common/msedit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `edit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr edit`

--- a/pages.sv/common/netcat.md
+++ b/pages.sv/common/netcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nc`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nc`

--- a/pages.sv/common/netexec.md
+++ b/pages.sv/common/netexec.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nxc`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nxc`

--- a/pages.sv/common/nm-classic.md
+++ b/pages.sv/common/nm-classic.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nm`

--- a/pages.sv/common/npm-author.md
+++ b/pages.sv/common/npm-author.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm owner`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm owner`

--- a/pages.sv/common/npm-it.md
+++ b/pages.sv/common/npm-it.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm install-test`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm install-test`

--- a/pages.sv/common/npm-list.md
+++ b/pages.sv/common/npm-list.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm ls`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm ls`

--- a/pages.sv/common/npm-rb.md
+++ b/pages.sv/common/npm-rb.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm-rebuild`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm-rebuild`

--- a/pages.sv/common/npm-restart.md
+++ b/pages.sv/common/npm-restart.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm run restart`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm run`

--- a/pages.sv/common/npm-run-script.md
+++ b/pages.sv/common/npm-run-script.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm run`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm run`

--- a/pages.sv/common/npm-start.md
+++ b/pages.sv/common/npm-start.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm run start`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm run`

--- a/pages.sv/common/npm-stop.md
+++ b/pages.sv/common/npm-stop.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm run stop`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm run`

--- a/pages.sv/common/npm-test.md
+++ b/pages.sv/common/npm-test.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm run test`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm run`

--- a/pages.sv/common/npx.md
+++ b/pages.sv/common/npx.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `npm exec`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr npm exec`

--- a/pages.sv/common/ntl.md
+++ b/pages.sv/common/ntl.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `netlify`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr netlify`

--- a/pages.sv/common/pamnoraw.md
+++ b/pages.sv/common/pamnoraw.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pamtopnm -plain`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pamtopnm`

--- a/pages.sv/common/perl-rename.md
+++ b/pages.sv/common/perl-rename.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rename`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr {{[-p|--platform]}} common rename`

--- a/pages.sv/common/pio-init.md
+++ b/pages.sv/common/pio-init.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pio project init`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pio project`

--- a/pages.sv/common/piodebuggdb.md
+++ b/pages.sv/common/piodebuggdb.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pio debug --interface gdb`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pio debug`

--- a/pages.sv/common/pip3.md
+++ b/pages.sv/common/pip3.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pip`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pip`

--- a/pages.sv/common/piper-tts.md
+++ b/pages.sv/common/piper-tts.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `piper`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr piper`

--- a/pages.sv/common/platformio.md
+++ b/pages.sv/common/platformio.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pio`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pio`

--- a/pages.sv/common/pnmdepth.md
+++ b/pages.sv/common/pnmdepth.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pamdepth`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pamdepth`

--- a/pages.sv/common/pnmtoplainpnm.md
+++ b/pages.sv/common/pnmtoplainpnm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pamtopnm -plain`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pamtopnm`

--- a/pages.sv/common/pnmtopnm.md
+++ b/pages.sv/common/pnmtopnm.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pamtopnm`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pamtopnm`

--- a/pages.sv/common/podman-image-load.md
+++ b/pages.sv/common/podman-image-load.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `podman load`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr podman load`

--- a/pages.sv/common/podman-image-pull.md
+++ b/pages.sv/common/podman-image-pull.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `podman pull`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr podman pull`

--- a/pages.sv/common/prename.md
+++ b/pages.sv/common/prename.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rename`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr {{[-p|--platform]}} common rename`

--- a/pages.sv/common/ptpython3.md
+++ b/pages.sv/common/ptpython3.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ptpython`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ptpython`

--- a/pages.sv/common/pulumi-down.md
+++ b/pages.sv/common/pulumi-down.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pulumi destroy`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pulumi destroy`

--- a/pages.sv/common/pulumi-stack-hist.md
+++ b/pages.sv/common/pulumi-stack-hist.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pulumi stack history`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pulumi stack history`

--- a/pages.sv/common/pulumi-update.md
+++ b/pages.sv/common/pulumi-update.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pulumi up`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pulumi up`

--- a/pages.sv/common/pushln.md
+++ b/pages.sv/common/pushln.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `print -nz`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr print`

--- a/pages.sv/common/python3.md
+++ b/pages.sv/common/python3.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `python`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr python`

--- a/pages.sv/common/r.zsh.md
+++ b/pages.sv/common/r.zsh.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `fc -e -`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr fc`

--- a/pages.sv/common/r2.md
+++ b/pages.sv/common/r2.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `radare2`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr radare2`

--- a/pages.sv/common/rbash.md
+++ b/pages.sv/common/rbash.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bash --restricted`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bash`

--- a/pages.sv/common/rcat.md
+++ b/pages.sv/common/rcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rc`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rc`

--- a/pages.sv/common/rehash.md
+++ b/pages.sv/common/rehash.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hash -r`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hash`

--- a/pages.sv/common/rgrep.md
+++ b/pages.sv/common/rgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `grep --recursive`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr grep`

--- a/pages.sv/common/rustup-install.md
+++ b/pages.sv/common/rustup-install.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rustup toolchain install`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rustup toolchain`

--- a/pages.sv/common/rustup-uninstall.md
+++ b/pages.sv/common/rustup-uninstall.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rustup toolchain uninstall`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rustup toolchain`

--- a/pages.sv/common/sr.md
+++ b/pages.sv/common/sr.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `surfraw`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr surfraw`

--- a/pages.sv/common/sudoedit.md
+++ b/pages.sv/common/sudoedit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `sudo --edit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr sudo`

--- a/pages.sv/common/tldrl.md
+++ b/pages.sv/common/tldrl.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `tldr-lint`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr tldr-lint`

--- a/pages.sv/common/tlmgr-arch.md
+++ b/pages.sv/common/tlmgr-arch.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `tlmgr platform`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr tlmgr platform`

--- a/pages.sv/common/todoman.md
+++ b/pages.sv/common/todoman.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `todo`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr todo`

--- a/pages.sv/common/trash-cli.md
+++ b/pages.sv/common/trash-cli.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `trash`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr trash`

--- a/pages.sv/common/typeset.md
+++ b/pages.sv/common/typeset.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `declare`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr declare`

--- a/pages.sv/common/ug.md
+++ b/pages.sv/common/ug.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ugrep --config --pretty --sort`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ugrep`

--- a/pages.sv/common/unfunction.md
+++ b/pages.sv/common/unfunction.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `unhash -f`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr unhash`

--- a/pages.sv/common/unlzma.md
+++ b/pages.sv/common/unlzma.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xz --format lzma --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xz`

--- a/pages.sv/common/unxz.md
+++ b/pages.sv/common/unxz.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xz --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xz`

--- a/pages.sv/common/unzstd.md
+++ b/pages.sv/common/unzstd.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zstd --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zstd`

--- a/pages.sv/common/uvx.md
+++ b/pages.sv/common/uvx.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `uv tool run`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr uv tool`

--- a/pages.sv/common/vc.md
+++ b/pages.sv/common/vc.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `vercel`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr vercel`

--- a/pages.sv/common/vdir.md
+++ b/pages.sv/common/vdir.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ls -l --escape`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ls`

--- a/pages.sv/common/vi.md
+++ b/pages.sv/common/vi.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `vim`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr vim`

--- a/pages.sv/common/whoami.md
+++ b/pages.sv/common/whoami.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `id --user --name`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr id`

--- a/pages.sv/common/xml-c14n.md
+++ b/pages.sv/common/xml-c14n.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xml canonic`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xml canonic`

--- a/pages.sv/common/xml-p2x.md
+++ b/pages.sv/common/xml-p2x.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xml depyx`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xml depyx`

--- a/pages.sv/common/xml-xmln.md
+++ b/pages.sv/common/xml-xmln.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xml pyx`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xml pyx`

--- a/pages.sv/common/xzcat.md
+++ b/pages.sv/common/xzcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xz --decompress --stdout`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xz`

--- a/pages.sv/common/xzegrep.md
+++ b/pages.sv/common/xzegrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzgrep --extended-regexp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzgrep`

--- a/pages.sv/common/xzfgrep.md
+++ b/pages.sv/common/xzfgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `xzgrep --fixed-strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr xzgrep`

--- a/pages.sv/common/zcat.md
+++ b/pages.sv/common/zcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gzip --stdout --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gzip`

--- a/pages.sv/common/zeditor.md
+++ b/pages.sv/common/zeditor.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zed`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zed`

--- a/pages.sv/common/zegrep.md
+++ b/pages.sv/common/zegrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zgrep --extended-regexp`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zgrep`

--- a/pages.sv/common/zfgrep.md
+++ b/pages.sv/common/zfgrep.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zgrep --fixed-strings`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zgrep`

--- a/pages.sv/common/zstdcat.md
+++ b/pages.sv/common/zstdcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zstd --decompress --stdout --force`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zstd`

--- a/pages.sv/common/zstdmt.md
+++ b/pages.sv/common/zstdmt.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `zstd --threads 0`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr zstd`

--- a/pages.sv/dos/chdir.md
+++ b/pages.sv/dos/chdir.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `CD`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr {{[-p|--platform]}} dos cd`

--- a/pages.sv/freebsd/chfn.md
+++ b/pages.sv/freebsd/chfn.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/freebsd/chsh.md
+++ b/pages.sv/freebsd/chsh.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/freebsd/ypchfn.md
+++ b/pages.sv/freebsd/ypchfn.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/freebsd/ypchpass.md
+++ b/pages.sv/freebsd/ypchpass.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/freebsd/ypchsh.md
+++ b/pages.sv/freebsd/ypchsh.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/linux/abrt.md
+++ b/pages.sv/linux/abrt.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `abrt-cli`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr abrt-cli`

--- a/pages.sv/linux/alternatives.md
+++ b/pages.sv/linux/alternatives.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `update-alternatives`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr update-alternatives`

--- a/pages.sv/linux/apparmor_status.md
+++ b/pages.sv/linux/apparmor_status.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `aa-status`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr aa-status`

--- a/pages.sv/linux/apt-add-repository.md
+++ b/pages.sv/linux/apt-add-repository.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `add-apt-repository`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr add-apt-repository`

--- a/pages.sv/linux/avahi-resolve-address.md
+++ b/pages.sv/linux/avahi-resolve-address.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `avahi-resolve --address`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr avahi-resolve`

--- a/pages.sv/linux/avahi-resolve-host-name.md
+++ b/pages.sv/linux/avahi-resolve-host-name.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `avahi-resolve --name`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr avahi-resolve`

--- a/pages.sv/linux/batcat.md
+++ b/pages.sv/linux/batcat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bat`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bat`

--- a/pages.sv/linux/br.md
+++ b/pages.sv/linux/br.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `broot`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr broot`

--- a/pages.sv/linux/cc.md
+++ b/pages.sv/linux/cc.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `gcc`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr gcc`

--- a/pages.sv/linux/compose.md
+++ b/pages.sv/linux/compose.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `run-mailcap --action=compose`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr run-mailcap`

--- a/pages.sv/linux/cs2.md
+++ b/pages.sv/linux/cs2.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `counter strike 2`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr counter strike 2`

--- a/pages.sv/linux/dir.md
+++ b/pages.sv/linux/dir.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ls -C --escape`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ls`

--- a/pages.sv/linux/dnf-deplist.md
+++ b/pages.sv/linux/dnf-deplist.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `dnf repoquery --deplist`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr dnf repoquery`

--- a/pages.sv/linux/dnf5.md
+++ b/pages.sv/linux/dnf5.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `dnf`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr dnf`

--- a/pages.sv/linux/edit.md
+++ b/pages.sv/linux/edit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `run-mailcap --action=edit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr run-mailcap`

--- a/pages.sv/linux/genisoimage.md
+++ b/pages.sv/linux/genisoimage.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mkisofs`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mkisofs`

--- a/pages.sv/linux/hwloc-ls.md
+++ b/pages.sv/linux/hwloc-ls.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `lstopo-no-graphics`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr lstopo-no-graphics`

--- a/pages.sv/linux/i386.md
+++ b/pages.sv/linux/i386.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `setarch i386`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr setarch`

--- a/pages.sv/linux/ip-route-list.md
+++ b/pages.sv/linux/ip-route-list.md
@@ -3,6 +3,6 @@
 > Det här kommandot är ett alias för `ip route show`.
 > Mer information: <https://manned.org/ip-route>.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ip route show`

--- a/pages.sv/linux/ip-route-show.md
+++ b/pages.sv/linux/ip-route-show.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `ip route list`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ip route list`

--- a/pages.sv/linux/lex.md
+++ b/pages.sv/linux/lex.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `flex`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr flex`

--- a/pages.sv/linux/libuser-lid.md
+++ b/pages.sv/linux/libuser-lid.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `lid`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr lid.libuser`

--- a/pages.sv/linux/limine-scan.md
+++ b/pages.sv/linux/limine-scan.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `limine-entry-tool --scan`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr limine-entry-tool`

--- a/pages.sv/linux/linux32.md
+++ b/pages.sv/linux/linux32.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `setarch linux32`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr setarch`

--- a/pages.sv/linux/linux64.md
+++ b/pages.sv/linux/linux64.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `setarch linux64`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr setarch`

--- a/pages.sv/linux/lookandfeeltool.md
+++ b/pages.sv/linux/lookandfeeltool.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `plasma-apply-lookandfeel`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr plasma-apply-lookandfeel`

--- a/pages.sv/linux/lrunzip.md
+++ b/pages.sv/linux/lrunzip.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `lrzip --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr lrzip`

--- a/pages.sv/linux/lrzuntar.md
+++ b/pages.sv/linux/lrzuntar.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `lrztar --decompress`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr lrztar`

--- a/pages.sv/linux/megadl.md
+++ b/pages.sv/linux/megadl.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `megatools-dl`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr megatools-dl`

--- a/pages.sv/linux/mkfs.vfat.md
+++ b/pages.sv/linux/mkfs.vfat.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mkfs.fat`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mkfs.fat`

--- a/pages.sv/linux/ncal.md
+++ b/pages.sv/linux/ncal.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `cal`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr cal`

--- a/pages.sv/linux/nmtui-connect.md
+++ b/pages.sv/linux/nmtui-connect.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nmtui connect`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nmtui`

--- a/pages.sv/linux/nmtui-edit.md
+++ b/pages.sv/linux/nmtui-edit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nmtui edit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nmtui`

--- a/pages.sv/linux/nmtui-hostname.md
+++ b/pages.sv/linux/nmtui-hostname.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `nmtui hostname`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr nmtui`

--- a/pages.sv/linux/pacinstall.md
+++ b/pages.sv/linux/pacinstall.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pactrans --install`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pactrans`

--- a/pages.sv/linux/pacman-d.md
+++ b/pages.sv/linux/pacman-d.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --database`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman database`

--- a/pages.sv/linux/pacman-f.md
+++ b/pages.sv/linux/pacman-f.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --files`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman files`

--- a/pages.sv/linux/pacman-q.md
+++ b/pages.sv/linux/pacman-q.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --query`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman query`

--- a/pages.sv/linux/pacman-r.md
+++ b/pages.sv/linux/pacman-r.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --remove`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman remove`

--- a/pages.sv/linux/pacman-s.md
+++ b/pages.sv/linux/pacman-s.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --sync`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman sync`

--- a/pages.sv/linux/pacman-t.md
+++ b/pages.sv/linux/pacman-t.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --deptest`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman deptest`

--- a/pages.sv/linux/pacman-u.md
+++ b/pages.sv/linux/pacman-u.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pacman --upgrade`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pacman upgrade`

--- a/pages.sv/linux/pacremove.md
+++ b/pages.sv/linux/pacremove.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pactrans --remove`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pactrans`

--- a/pages.sv/linux/pct-move_volume.md
+++ b/pages.sv/linux/pct-move_volume.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pct move-volume`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pct move-volume`

--- a/pages.sv/linux/pw-dsdplay.md
+++ b/pages.sv/linux/pw-dsdplay.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --playback --dsd`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/pw-encplay.md
+++ b/pages.sv/linux/pw-encplay.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --playback --encoded`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/pw-midiplay.md
+++ b/pages.sv/linux/pw-midiplay.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --playback --midi`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/pw-midirecord.md
+++ b/pages.sv/linux/pw-midirecord.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --record --midi`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/pw-play.md
+++ b/pages.sv/linux/pw-play.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --playback`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/pw-record.md
+++ b/pages.sv/linux/pw-record.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `pw-cat --record`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr pw-cat`

--- a/pages.sv/linux/qm-agent.md
+++ b/pages.sv/linux/qm-agent.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm guest cmd`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm guest`

--- a/pages.sv/linux/qm-importdisk.md
+++ b/pages.sv/linux/qm-importdisk.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk import`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/qm-move-disk.md
+++ b/pages.sv/linux/qm-move-disk.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk move`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/qm-move_disk.md
+++ b/pages.sv/linux/qm-move_disk.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk move`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/qm-rescan.md
+++ b/pages.sv/linux/qm-rescan.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk rescan`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/qm-resize.md
+++ b/pages.sv/linux/qm-resize.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk resize`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/qm-unlink.md
+++ b/pages.sv/linux/qm-unlink.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `qm disk unlink`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr qm disk`

--- a/pages.sv/linux/rename.ul.md
+++ b/pages.sv/linux/rename.ul.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `rename.util`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr rename.util`

--- a/pages.sv/linux/see.md
+++ b/pages.sv/linux/see.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `run-mailcap --action=view`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr run-mailcap`

--- a/pages.sv/linux/shntool-split.md
+++ b/pages.sv/linux/shntool-split.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `shnsplit`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr shnsplit`

--- a/pages.sv/linux/steamos-boot-install.md
+++ b/pages.sv/linux/steamos-boot-install.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `steamos-finalize-install`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr steamos-finalize-install`

--- a/pages.sv/linux/systemctl-condreload.md
+++ b/pages.sv/linux/systemctl-condreload.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemctl try-reload-or-restart`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemctl try-reload-or-restart`

--- a/pages.sv/linux/systemctl-condrestart.md
+++ b/pages.sv/linux/systemctl-condrestart.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemctl try-restart`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemctl try-restart`

--- a/pages.sv/linux/systemctl-condstop.md
+++ b/pages.sv/linux/systemctl-condstop.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemctl stop`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemctl stop`

--- a/pages.sv/linux/systemctl-force-reload.md
+++ b/pages.sv/linux/systemctl-force-reload.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemctl try-reload-or-restart`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemctl try-reload-or-restart`

--- a/pages.sv/linux/systemctl-reload-or-try-restart.md
+++ b/pages.sv/linux/systemctl-reload-or-try-restart.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemctl try-reload-or-restart`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemctl try-reload-or-restart`

--- a/pages.sv/linux/systemd-umount.md
+++ b/pages.sv/linux/systemd-umount.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `systemd-mount --umount`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr systemd-mount`

--- a/pages.sv/linux/trash-put.md
+++ b/pages.sv/linux/trash-put.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `trash`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr trash`

--- a/pages.sv/linux/ubuntu-bug.md
+++ b/pages.sv/linux/ubuntu-bug.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `apport-bug`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr apport-bug`

--- a/pages.sv/linux/uname26.md
+++ b/pages.sv/linux/uname26.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `setarch uname26`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr setarch`

--- a/pages.sv/linux/update-grub.md
+++ b/pages.sv/linux/update-grub.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `grub-mkconfig --output /boot/grub/grub.cfg`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr grub-mkconfig`

--- a/pages.sv/linux/wodim.md
+++ b/pages.sv/linux/wodim.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `cdrecord`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr cdrecord`

--- a/pages.sv/linux/x86_64.md
+++ b/pages.sv/linux/x86_64.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `setarch x86_64`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr setarch`

--- a/pages.sv/linux/yum-config-manager.md
+++ b/pages.sv/linux/yum-config-manager.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `dnf config-manager`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr dnf config-manager`

--- a/pages.sv/netbsd/chfn.md
+++ b/pages.sv/netbsd/chfn.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/netbsd/chsh.md
+++ b/pages.sv/netbsd/chsh.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/openbsd/chfn.md
+++ b/pages.sv/openbsd/chfn.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/openbsd/chsh.md
+++ b/pages.sv/openbsd/chsh.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `chpass`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr chpass`

--- a/pages.sv/osx/aa.md
+++ b/pages.sv/osx/aa.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `yaa`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr yaa`

--- a/pages.sv/osx/hdid.md
+++ b/pages.sv/osx/hdid.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `hdiutil attach`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr hdiutil`

--- a/pages.sv/osx/llvm-lipo.md
+++ b/pages.sv/osx/llvm-lipo.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `lipo`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr lipo`

--- a/pages.sv/osx/mo.md
+++ b/pages.sv/osx/mo.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `mole`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr mole`

--- a/pages.sv/windows/bleachbit.md
+++ b/pages.sv/windows/bleachbit.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `bleachbit_console`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr bleachbit_console`

--- a/pages.sv/windows/cinst.md
+++ b/pages.sv/windows/cinst.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `choco install`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr choco install`

--- a/pages.sv/windows/clhy.md
+++ b/pages.sv/windows/clhy.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Clear-History`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Clear-History`

--- a/pages.sv/windows/clist.md
+++ b/pages.sv/windows/clist.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `choco list`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr choco list`

--- a/pages.sv/windows/color.md
+++ b/pages.sv/windows/color.md
@@ -3,7 +3,7 @@
 > Används för att ändra bakgrunds och textfärgen i kommandotolken.
 > Mer information: <https://learn.microsoft.com/windows-server/administration/windows-commands/color>.
 
-- Återställer färgerna till orginal (svart bakgrund, vit text):
+- Återställer färgerna till original (svart bakgrund, vit text):
 
 `color`
 

--- a/pages.sv/windows/cpush.md
+++ b/pages.sv/windows/cpush.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `choco push`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr choco push`

--- a/pages.sv/windows/cuninst.md
+++ b/pages.sv/windows/cuninst.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `choco uninstall`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr choco uninstall`

--- a/pages.sv/windows/gcb.md
+++ b/pages.sv/windows/gcb.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Get-Clipboard`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr get-clipboard`

--- a/pages.sv/windows/ghy.md
+++ b/pages.sv/windows/ghy.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Get-History`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Get-History`

--- a/pages.sv/windows/h.md
+++ b/pages.sv/windows/h.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Get-History`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Get-History`

--- a/pages.sv/windows/history.md
+++ b/pages.sv/windows/history.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Get-History`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Get-History`

--- a/pages.sv/windows/ii.md
+++ b/pages.sv/windows/ii.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Invoke-Item`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr invoke-item`

--- a/pages.sv/windows/iwr.md
+++ b/pages.sv/windows/iwr.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `invoke-webrequest`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr invoke-webrequest`

--- a/pages.sv/windows/pwsh-where.md
+++ b/pages.sv/windows/pwsh-where.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Where-Object`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Where-Object`

--- a/pages.sv/windows/ren.md
+++ b/pages.sv/windows/ren.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Rename-Item`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Rename-Item`

--- a/pages.sv/windows/rni.md
+++ b/pages.sv/windows/rni.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Rename-Item`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Rename-Item`

--- a/pages.sv/windows/sal.md
+++ b/pages.sv/windows/sal.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Set-Alias`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr set-alias`

--- a/pages.sv/windows/scb.md
+++ b/pages.sv/windows/scb.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Set-Clipboard`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr Set-Clipboard`

--- a/pages.sv/windows/slmgr.md
+++ b/pages.sv/windows/slmgr.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `slmgr.vbs`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr slmgr.vbs`

--- a/pages.sv/windows/sls.md
+++ b/pages.sv/windows/sls.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Select-String`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr select-string`

--- a/pages.sv/windows/ventoy.md
+++ b/pages.sv/windows/ventoy.md
@@ -2,6 +2,6 @@
 
 > Det här kommandot är ett alias för `Ventoy2Disk`.
 
-- Se dokumentationen för orginalkommandot:
+- Se dokumentationen för originalkommandot:
 
 `tldr ventoy2disk`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

Fixed Swedish spelling of the word "original" in the alias page template and the alias pages. Also fixed the spelling for it in pages.sv/windows/color.md. Done by batch replace command.
