### PR TITLE
cosign: add Chinese translation

### DIFF
--- a/pages.zh/common/cosign.md
+++ b/pages.zh/common/cosign.md
@@ -1,0 +1,36 @@
+# cosign
+
+> 在 OCI 注册表中对容器进行签名、验证和存储。
+> 更多信息：<https://github.com/sigstore/cosign/blob/main/doc/cosign.md>.
+
+- 生成密钥对：
+
+`cosign generate-key-pair`
+
+- 对容器进行签名，并将签名存储在注册表中：
+
+`cosign sign --key {{cosign.key}} {{镜像}}`
+
+- 使用存储在 Kubernetes Secret 中的密钥对容器镜像进行签名：
+
+`cosign sign --key k8s://{{命名空间}}/{{密钥}} {{镜像}}`
+
+- 使用本地密钥对 blob 文件进行签名：
+
+`cosign sign-blob --key {{cosign.key}} {{路径/到/文件}}`
+
+- 使用公钥验证容器：
+
+`cosign verify --key {{cosign.pub}} {{镜像}}`
+
+- 使用 Dockerfile 中的公钥验证镜像：
+
+`cosign dockerfile verify -key {{cosign.pub}} {{路径/到/Dockerfile}}`
+
+- 使用存储在 Kubernetes Secret 中的公钥验证镜像：
+
+`cosign verify --key k8s://{{命名空间}}/{{密钥}} {{镜像}}`
+
+- 复制容器镜像及其签名：
+
+`cosign copy {{example.com/src:latest}} {{example.com/dest:latest}}`

--- a/pages.zh/common/cosign.md
+++ b/pages.zh/common/cosign.md
@@ -1,7 +1,7 @@
 # cosign
 
 > 在 OCI 注册表中对容器进行签名、验证和存储。
-> 更多信息：<https://github.com/sigstore/cosign/blob/main/doc/cosign.md>.
+> 更多信息：<https://github.com/sigstore/cosign/blob/main/doc/cosign.md>。
 
 - 生成密钥对：
 


### PR DESCRIPTION
Add Simplified Chinese translation for the `cosign` page.

`cosign` is a container signing and verification tool in the Sigstore ecosystem. This translation helps Chinese users understand common commands for key generation, signing, verification, and copying signed container images.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

- **Version of the command being documented (if known):** Not applicable, translation of an existing page.
- Reference issue: N/A
- Closes: N/A