### PR TITLE
pages.nb: add Norwegian (Bokmål) translations for common commands

### DIFF
--- a/pages.nb/common/cat.md
+++ b/pages.nb/common/cat.md
@@ -1,0 +1,24 @@
+# cat
+
+> Skriv ut og slå sammen filer.
+> Mer informasjon: <https://manned.org/cat.1posix>.
+
+- Skriv ut innholdet i en fil til `stdout`:
+
+`cat {{sti/til/fil}}`
+
+- Slå sammen flere filer til en utdatafil:
+
+`cat {{sti/til/fil1 sti/til/fil2 ...}} > {{sti/til/utdatafil}}`
+
+- Legg flere filer til på slutten av en utdatafil:
+
+`cat {{sti/til/fil1 sti/til/fil2 ...}} >> {{sti/til/utdatafil}}`
+
+- Kopier innholdet i en fil til en utdatafil uten bufring:
+
+`cat -u {{/dev/tty12}} > {{/dev/tty13}}`
+
+- Skriv `stdin` til en fil:
+
+`cat - > {{sti/til/fil}}`

--- a/pages.nb/common/cd.md
+++ b/pages.nb/common/cd.md
@@ -1,0 +1,28 @@
+# cd
+
+> Endre gjeldende arbeidsmappe.
+> Mer informasjon: <https://www.gnu.org/software/bash/manual/bash.html#index-cd>.
+
+- Gå til den angitte mappen:
+
+`cd {{sti/til/mappe}}`
+
+- Gå opp til den overordnede mappen til gjeldende mappe:
+
+`cd ..`
+
+- Gå til hjemmemappen til gjeldende bruker:
+
+`cd`
+
+- Gå til hjemmemappen til den angitte brukeren:
+
+`cd ~{{brukernavn}}`
+
+- Gå til den forrige valgte mappen:
+
+`cd -`
+
+- Gå til rotmappen:
+
+`cd /`

--- a/pages.nb/common/cp.md
+++ b/pages.nb/common/cp.md
@@ -1,0 +1,36 @@
+# cp
+
+> Kopier filer og mapper.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html>.
+
+- Kopier en fil til et annet sted:
+
+`cp {{sti/til/kildefil}} {{sti/til/målfil}}`
+
+- Kopier en fil til en annen mappe, og behold filnavnet:
+
+`cp {{sti/til/kildefil}} {{sti/til/overordnet_målmappe}}`
+
+- Kopier innholdet i en mappe rekursivt til et annet sted (hvis målet finnes, kopieres mappen inn i det):
+
+`cp {{[-r|--recursive]}} {{sti/til/kildemappe}} {{sti/til/målmappe}}`
+
+- Kopier en mappe rekursivt, i detaljert modus (viser filer etter hvert som de kopieres):
+
+`cp {{[-vr|--verbose --recursive]}} {{sti/til/kildemappe}} {{sti/til/målmappe}}`
+
+- Kopier flere filer samtidig til en mappe:
+
+`cp {{[-t|--target-directory]}} {{sti/til/målmappe}} {{sti/til/fil1 sti/til/fil2 ...}}`
+
+- Kopier alle filer med en bestemt filendelse til et annet sted, i interaktiv modus (spør brukeren før overskriving):
+
+`cp {{[-i|--interactive]}} {{*.ext}} {{sti/til/målmappe}}`
+
+- Følg symbolske lenker før kopiering:
+
+`cp {{[-L|--dereference]}} {{lenke}} {{sti/til/målmappe}}`
+
+- Bruk hele stien til kildefilene, og opprett eventuelle manglende mellomliggende mapper ved kopiering:
+
+`cp --parents {{kilde/sti/til/fil}} {{sti/til/målfil}}`

--- a/pages.nb/common/ls.md
+++ b/pages.nb/common/ls.md
@@ -1,0 +1,36 @@
+# ls
+
+> List opp innholdet i en mappe.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html>.
+
+- List filer én per linje:
+
+`ls -1`
+
+- List alle filer, inkludert skjulte filer:
+
+`ls {{[-a|--all]}}`
+
+- List filer med et etterstilt symbol som angir filtype (mappe/, symbolsk_lenke@, kjørbar*, ...):
+
+`ls {{[-F|--classify]}}`
+
+- List alle filer i [l]angt format (rettigheter, eierskap, størrelse og endringsdato):
+
+`ls {{[-la|-l --all]}}`
+
+- List filer i [l]angt format med størrelse vist i lesbare enheter (KiB, MiB, GiB):
+
+`ls {{[-lh|-l --human-readable]}}`
+
+- List filer i [l]angt format, sortert etter [S]tørrelse (synkende) rekursivt:
+
+`ls {{[-lSR|-lS --recursive]}}`
+
+- List filer i [l]angt format, sortert etter [t]idspunkt for siste endring og i omvendt rekkefølge (eldste først):
+
+`ls {{[-ltr|-lt --reverse]}}`
+
+- List kun mapper:
+
+`ls {{[-d|--directory]}} */`

--- a/pages.nb/common/mkdir.md
+++ b/pages.nb/common/mkdir.md
@@ -1,0 +1,20 @@
+# mkdir
+
+> Opprett mapper og angi rettighetene deres.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html>.
+
+- Opprett bestemte mapper:
+
+`mkdir {{sti/til/mappe1 sti/til/mappe2 ...}}`
+
+- Opprett bestemte mapper og deres overordnede mapper ved behov:
+
+`mkdir {{[-p|--parents]}} {{sti/til/mappe1 sti/til/mappe2 ...}}`
+
+- Opprett mapper med bestemte rettigheter:
+
+`mkdir {{[-m|--mode]}} {{rwxrw-r--}} {{sti/til/mappe1 sti/til/mappe2 ...}}`
+
+- Opprett flere nøstede mapper rekursivt:
+
+`mkdir {{[-p|--parents]}} {{sti/til/{a,b}/{x,y,z}/{h,i,j}}}`

--- a/pages.nb/common/mv.md
+++ b/pages.nb/common/mv.md
@@ -1,0 +1,36 @@
+# mv
+
+> Flytt eller gi nytt navn til filer og mapper.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html>.
+
+- Gi nytt navn til en fil eller mappe når målet ikke er en eksisterende mappe:
+
+`mv {{sti/til/kilde}} {{sti/til/mål}}`
+
+- Flytt en fil eller mappe inn i en eksisterende mappe:
+
+`mv {{sti/til/kilde}} {{sti/til/eksisterende_mappe}}`
+
+- Flytt flere filer inn i en eksisterende mappe, og behold filnavnene uendret:
+
+`mv {{sti/til/kilde1 sti/til/kilde2 ...}} {{sti/til/eksisterende_mappe}}`
+
+- Ikke spør om bekreftelse før eksisterende filer overskrives:
+
+`mv {{[-f|--force]}} {{sti/til/kilde}} {{sti/til/mål}}`
+
+- Spør om bekreftelse interaktivt før eksisterende filer overskrives, uavhengig av filrettigheter:
+
+`mv {{[-i|--interactive]}} {{sti/til/kilde}} {{sti/til/mål}}`
+
+- Ikke overskriv eksisterende filer på målet:
+
+`mv {{[-n|--no-clobber]}} {{sti/til/kilde}} {{sti/til/mål}}`
+
+- Flytt filer i detaljert modus, og vis filer etter at de er flyttet:
+
+`mv {{[-v|--verbose]}} {{sti/til/kilde}} {{sti/til/mål}}`
+
+- Angi målmappe slik at du kan bruke eksterne verktøy for å samle filer som skal flyttes:
+
+`{{find /var/log -type f -name '*.log' -print0}} | {{xargs -0}} mv {{[-t|--target-directory]}} {{sti/til/målmappe}}`

--- a/pages.nb/common/pwd.md
+++ b/pages.nb/common/pwd.md
@@ -1,0 +1,16 @@
+# pwd
+
+> Skriv ut navnet på gjeldende arbeidsmappe.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/pwd-invocation.html>.
+
+- Skriv ut gjeldende mappe:
+
+`pwd`
+
+- Skriv ut gjeldende mappe, og løs opp alle symbolske lenker (vis den «fysiske» stien):
+
+`pwd {{[-P|--physical]}}`
+
+- Vis hjelp:
+
+`pwd --help`

--- a/pages.nb/common/rm.md
+++ b/pages.nb/common/rm.md
@@ -1,0 +1,29 @@
+# rm
+
+> Fjern filer eller mapper.
+> Se også: `rmdir`, `trash`.
+> Mer informasjon: <https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html>.
+
+- Fjern bestemte filer:
+
+`rm {{sti/til/fil1 sti/til/fil2 ...}}`
+
+- Fjern bestemte filer og ignorer dem som ikke finnes:
+
+`rm {{[-f|--force]}} {{sti/til/fil1 sti/til/fil2 ...}}`
+
+- Fjern bestemte filer interaktivt med spørsmål før hver fjerning:
+
+`rm {{[-i|--interactive]}} {{sti/til/fil1 sti/til/fil2 ...}}`
+
+- Fjern bestemte filer og skriv ut informasjon om hver fjerning:
+
+`rm {{[-v|--verbose]}} {{sti/til/fil1 sti/til/fil2 ...}}`
+
+- Fjern bestemte filer og mapper rekursivt:
+
+`rm {{[-r|--recursive]}} {{sti/til/fil_eller_mappe1 sti/til/fil_eller_mappe2 ...}}`
+
+- Fjern tomme mapper (dette regnes som den trygge metoden):
+
+`rm {{[-d|--dir]}} {{sti/til/mappe}}`


### PR DESCRIPTION
This bootstraps the Norwegian Bokmål (`nb`) language with 8 of the most common command pages: `pwd`, `cd`, `ls`, `cp`, `mv`, `rm`, `mkdir`, `cat`.

I'm a native Norwegian (Bokmål) speaker and have written and reviewed each page myself. Per the contributing guidelines, AI was used only as a reference aid — all wording, terminology, and placeholder localization were checked by me.

Conventions established for `nb`:
- `More information:` → `Mer informasjon:`
- `See also:` → `Se også:`
- Localized placeholders, e.g. `path/to/file` → `sti/til/fil`, `path/to/directory` → `sti/til/mappe`

Happy to follow up with the `nb` entries in `contributing-guides/translation-templates` and more pages. Feedback very welcome!