### PR TITLE
translation-templates/*: add nb (Norwegian Bokmal)

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -27,6 +27,7 @@ The templates can be changed when necessary.
 [ko](#ko) •
 [lo](#lo) •
 [ml](#ml) •
+[nb](#nb) •
 [ne](#ne) •
 [nl](#nl) •
 [no](#no) •
@@ -335,6 +336,20 @@ The templates can be changed when necessary.
 > ഈ കമാൻഡ് `example` എന്നത്തിന്റെ അപരനാമമാണ്.
 
 - യഥാർത്ഥ കമാൻഡിനായി ഡോക്യുമെന്റേഷൻ കാണുക:
+
+`tldr example`
+```
+
+---
+
+### nb
+
+```markdown
+# example
+
+> Denne kommandoen er et alias for `example`.
+
+- Vis dokumentasjonen for den opprinnelige kommandoen:
 
 `tldr example`
 ```

--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -29,6 +29,7 @@ There, the old table can be **imported**, **edited** in a WYSIWYG editor and **e
 | ko    | 경로/대상/파일              | 경로/대상/폴더                 | 경로/대상/파일_또는_폴더                       | 패키지           | 사용자 명              | 비밀번호              | 명령어      | 포트     | 값        |
 | lo    |                       |                          |                                      |               |                    |                   |          |        |          |
 | ml    | ഫയലിലേക്കുള്ള/പാത     | ഡയറക്ടറിയിലേക്കുള്ള/പാത  | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത | പാക്കേജ്      | ഉപയോക്തൃനാമം       |                   |          |        |          |
+| nb    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog            | pakke         | brukernavn         |                   |          |        |          |
 | ne    | फाइल/को/पथ            | निर्देशिका/को/पथ         | फाइल_वा_निर्देशिका/को/पथ             | प्याकेज       | प्रयोगकर्ता_नाम    |                   |          |        |          |
 | nl    | pad/naar/bestand      | pad/naar/map             | pad/naar/bestand_of_map              | pakket        | gebruikersnaam     | wachtwoord        | commando | poort  | waarde   |
 | no    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog            | pakke         | brukernavn         |                   |          |        |          |

--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -29,7 +29,7 @@ There, the old table can be **imported**, **edited** in a WYSIWYG editor and **e
 | ko    | 경로/대상/파일              | 경로/대상/폴더                 | 경로/대상/파일_또는_폴더                       | 패키지           | 사용자 명              | 비밀번호              | 명령어      | 포트     | 값        |
 | lo    |                       |                          |                                      |               |                    |                   |          |        |          |
 | ml    | ഫയലിലേക്കുള്ള/പാത     | ഡയറക്ടറിയിലേക്കുള്ള/പാത  | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത | പാക്കേജ്      | ഉപയോക്തൃനാമം       |                   |          |        |          |
-| nb    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog            | pakke         | brukernavn         |                   |          |        |          |
+| nb    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog            | pakke         | brukernavn         | passord           | kommando | port   | verdi    |
 | ne    | फाइल/को/पथ            | निर्देशिका/को/पथ         | फाइल_वा_निर्देशिका/को/पथ             | प्याकेज       | प्रयोगकर्ता_नाम    |                   |          |        |          |
 | nl    | pad/naar/bestand      | pad/naar/map             | pad/naar/bestand_of_map              | pakket        | gebruikersnaam     | wachtwoord        | commando | poort  | waarde   |
 | no    | sti/til/fil           | sti/til/katalog          | sti/til/fil_eller_katalog            | pakke         | brukernavn         |                   |          |        |          |

--- a/contributing-guides/translation-templates/common-descriptions.md
+++ b/contributing-guides/translation-templates/common-descriptions.md
@@ -27,6 +27,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | ko    | 도움말 표시             | 버전 표시                 | [대화형]            |
 | lo    |                    |                       |                  |
 | ml    |                    |                       |                  |
+| nb    | Vis hjelp          | Vis versjon           | [Interaktivt]    |
 | ne    |                    |                       |                  |
 | nl    | Toon de help       | Toon de versie        | [Interactief]    |
 | no    |                    |                       |                  |

--- a/contributing-guides/translation-templates/more-info-link.md
+++ b/contributing-guides/translation-templates/more-info-link.md
@@ -27,6 +27,7 @@ The templates can be changed when necessary, but if so, it needs to be updated h
 [ko](#ko) •
 [lo](#lo) •
 [ml](#ml) •
+[nb](#nb) •
 [ne](#ne) •
 [nl](#nl) •
 [no](#no) •
@@ -211,6 +212,14 @@ The templates can be changed when necessary, but if so, it needs to be updated h
 
 ```markdown
 > കൂടുതൽ വിവരങ്ങൾ: <https://example.com>.
+```
+
+---
+
+### nb
+
+```markdown
+> Mer informasjon: <https://example.com>.
 ```
 
 ---

--- a/contributing-guides/translation-templates/see-also-mentions.md
+++ b/contributing-guides/translation-templates/see-also-mentions.md
@@ -28,6 +28,7 @@ This file contains the translation templates of this notice.
 [ko](#ko) •
 [lo](#lo) •
 [ml](#ml) •
+[nb](#nb) •
 [ne](#ne) •
 [nl](#nl) •
 [no](#no) •
@@ -212,6 +213,14 @@ This file contains the translation templates of this notice.
 
 ```markdown
 > ഇതും കാണുക: `example`.
+```
+
+---
+
+### nb
+
+```markdown
+> Se også: `example`.
 ```
 
 ---

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -26,6 +26,7 @@ This file contains the translation templates of this notice.
 [ko](#ko) •
 [lo](#lo) •
 [ml](#ml) •
+[nb](#nb) •
 [ne](#ne) •
 [nl](#nl) •
 [no](#no) •
@@ -210,6 +211,14 @@ This file contains the translation templates of this notice.
 
 ```markdown
 > `example` പോലുള്ള ചില ഉപകമാൻഡുകൾക്ക് അവരുടേതായ ഉപയോഗ ഡോക്യുമെന്റേഷൻ ഉണ്ട്.
+```
+
+---
+
+### nb
+
+```markdown
+> Noen underkommandoer som `example` har sin egen bruksdokumentasjon.
 ```
 
 ---


### PR DESCRIPTION
Follow-up to #22905, as suggested by a maintainer there: adds `nb` (Norwegian Bokmål) to the translation templates so the automation tooling has entries matching the `nb` page directory.

## Changes

Adds an `nb` entry (mirroring the existing Bokmål `no` entries) across all six templates, placed alphabetically (after `ml`, before `ne`); the existing `no` entries are left untouched.

- alias-pages.md, more-info-link.md, see-also-mentions.md, subcommand-mention.md — new `nb` nav link + section.
- - common-arguments.md — new `nb` row.
- - common-descriptions.md — new `nb` row, with the Norwegian filled in (the `no` row there was empty): Vis hjelp / Vis versjon / [Interaktivt].
## Disclosure

I'm a native Norwegian (Bokmål) speaker and reviewed every string. AI assistance (Claude) was used to mirror the template structure. The CLA is already signed.