### PR TITLE
fix: correct conda create example - separate numpy and scipy arguments

### DIFF
--- a/pages/common/conda-create.md
+++ b/pages/common/conda-create.md
@@ -5,7 +5,7 @@
 
 - Create a new environment named `py39`, install Python 3.9, NumPy v1.11 or above in it, and the latest stable version of SciPy. Say yes to all confirmations:
 
-`conda create {{[-ny|--name --yes]}} py39 python=3.9 "numpy>=1.11 scipy"`
+`conda create {{[-ny|--name --yes]}} py39 python=3.9 "numpy>=1.11" scipy`
 
 - Create a new environment named `myenv` and install packages listed in files:
 


### PR DESCRIPTION
The original example had "numpy>=1.11 scipy" which treats scipy as part of the numpy version constraint. Fixed to "numpy>=1.11" scipy (separate arguments).

Fixes #22903