### PR TITLE
wine-reg-{export,import}: add page

### DIFF
--- a/pages/linux/wine-reg-export.md
+++ b/pages/linux/wine-reg-export.md
@@ -1,0 +1,20 @@
+# wine reg export
+
+> Export keys, values, and data from the Wine registry to a `.reg` file.
+> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+
+- Export a registry key and its subkeys to a file:
+
+`wine reg export '{{HKEY_CURRENT_USER\path\to\key}}' {{path/to/file.reg}}`
+
+- Export an entire registry hive to a file:
+
+`wine reg export {{HKEY_CURRENT_USER}} {{path/to/file.reg}}`
+
+- Overwrite the output file if it already exists, without prompting:
+
+`wine reg export '{{HKEY_CURRENT_USER\path\to\key}}' {{path/to/file.reg}} /y`
+
+- Display help:
+
+`wine reg export /?`

--- a/pages/linux/wine-reg-import.md
+++ b/pages/linux/wine-reg-import.md
@@ -1,0 +1,12 @@
+# wine reg import
+
+> Import keys, values, and data into the Wine registry from a `.reg` file.
+> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+
+- Import registry entries from a file:
+
+`wine reg import {{path/to/file.reg}}`
+
+- Display help:
+
+`wine reg import /?`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `linux`
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the content guidelines.
- [x] The page(s) follow the style guide.
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended templates.
- **Version of the command being documented (if known):** Wine (`wine reg`)
- Reference issue: #21837

Adds the `wine reg export` and `wine reg import` subcommands. Companion to the `wine reg` core PR.
Examples verified against a real Wine `reg` build.