### PR TITLE
leaks: add page

### DIFF
--- a/pages/osx/leaks.md
+++ b/pages/osx/leaks.md
@@ -1,0 +1,36 @@
+# leaks
+
+> Search a process's memory for unreferenced malloc buffers.
+> More information: <https://keith.github.io/xcode-man-pages/leaks.1.html>.
+
+- Examine a running process for leaks by its name:
+
+`leaks {{process_name}}`
+
+- Examine a running process for leaks by its PID:
+
+`leaks {{pid}}`
+
+- Launch a command and check for leaks when it exits:
+
+`leaks -atExit -- {{command}}`
+
+- Enable backtraces for each leak by setting the `MallocStackLogging` environment variable:
+
+`MallocStackLogging=YES leaks {{process_name}}`
+
+- Display results in the classic list format instead of a tree:
+
+`leaks -list {{process_name}}`
+
+- Group leaked objects by type:
+
+`leaks -groupByType {{process_name}}`
+
+- Save the memory state to a memory graph file for later analysis:
+
+`leaks {{process_name}} -outputGraph {{path/to/file.memgraph}}`
+
+- Examine a previously saved memory graph file:
+
+`leaks {{path/to/file.memgraph}}`


### PR DESCRIPTION
Add a new page for `leaks`, the macOS developer tool that searches a process's memory for unreferenced malloc buffers (memory leaks).

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).