### PR TITLE
Clarify Proxmox VM and container IDs

### DIFF
--- a/pages/linux/pct.md
+++ b/pages/linux/pct.md
@@ -9,28 +9,28 @@
 
 - Start/Stop/Reboot a specific container:
 
-`pct {{start|stop|reboot}} {{100}}`
+`pct {{start|stop|reboot}} {{container_id}}`
 
 - Access a specific container's shell:
 
-`pct {{[en|enter]}} {{100}}`
+`pct {{[en|enter]}} {{container_id}}`
 
 - Create a container from template with 4GB size:
 
-`pct {{[cr|create]}} {{100}} {{local:vztmpl/distro-name.tar.zst}} --rootfs {{local-lvm}}:4`
+`pct {{[cr|create]}} {{container_id}} {{local:vztmpl/distro-name.tar.zst}} --rootfs {{local-lvm}}:4`
 
 - Resize the container's disk to 20G:
 
-`pct {{[resi|resize]}} {{100}} {{rootfs|mpX}} {{20G}}`
+`pct {{[resi|resize]}} {{container_id}} {{rootfs|mpX}} {{20G}}`
 
 - Show the configuration of a container, specifying its ID:
 
-`pct {{[conf|config]}} {{100}}`
+`pct {{[conf|config]}} {{container_id}}`
 
 - Snapshot a specific container with description:
 
-`pct {{[sn|snapshot]}} {{100}} {{my-snapshot}} --description {{My snapshot description}}`
+`pct {{[sn|snapshot]}} {{container_id}} {{my-snapshot}} --description {{My snapshot description}}`
 
 - Destroy a container and remove all related resources:
 
-`pct {{[des|destroy]}} {{100}} --purge`
+`pct {{[des|destroy]}} {{container_id}} --purge`

--- a/pages/linux/qm.md
+++ b/pages/linux/qm.md
@@ -8,22 +8,22 @@
 
 `qm list`
 
-- Create a virtual machine with a 4 GB SCSI disk on the `local-lvm` storage and an ID of 100 using an ISO file uploaded on the `local` storage:
+- Create a virtual machine with a 4 GB SCSI disk on the `local-lvm` storage and a VM ID using an ISO file uploaded on the `local` storage:
 
-`qm {{[cr|create]}} 100 --scsi0 local-lvm:4 --net0 {{e1000}} --cdrom local:{{iso/proxmox-mailgateway_2.1.iso}}`
+`qm {{[cr|create]}} {{vm_id}} --scsi0 local-lvm:4 --net0 {{e1000}} --cdrom local:{{iso/proxmox-mailgateway_2.1.iso}}`
 
 - Show the configuration of a virtual machine, specifying its ID:
 
-`qm {{[co|config]}} {{100}}`
+`qm {{[co|config]}} {{vm_id}}`
 
 - Start a specific virtual machine:
 
-`qm start {{100}}`
+`qm start {{vm_id}}`
 
 - Send a shutdown request, then wait until the virtual machine is stopped:
 
-`qm {{[shu|shutdown]}} {{100}} && qm {{[w|wait]}} {{100}}`
+`qm {{[shu|shutdown]}} {{vm_id}} && qm {{[w|wait]}} {{vm_id}}`
 
 - Destroy a virtual machine and remove all related resources:
 
-`qm {{[des|destroy]}} {{100}} --purge`
+`qm {{[des|destroy]}} {{vm_id}} --purge`


### PR DESCRIPTION
This updates the main Proxmox `qm` and `pct` pages to use descriptive placeholders instead of the hard-coded `100` example IDs.

Why:
The current examples read like fixed IDs, which makes the pages less clear for readers adapting them to their own machines.

Validation:
- `git diff --check`
- `npm run lint-tldr-pages`

Fixes #22200
