### PR TITLE
awk: fix UID field

### DIFF
--- a/pages/common/awk.md
+++ b/pages/common/awk.md
@@ -35,4 +35,4 @@
 
 - Print table of users with UID >=1000 with header and formatted output, using colon as separator (`%-20s` mean: 20 left-align string characters, `%6s` means: 6 right-align string characters):
 
-`awk 'BEGIN {FS=":";printf "%-20s %6s %25s\n", "Name", "UID", "Shell"} $4 >= 1000 {printf "%-20s %6d %25s\n", $1, $4, $7}' /etc/passwd`
+`awk 'BEGIN {FS=":";printf "%-20s %6s %25s\n", "Name", "UID", "Shell"} $3 >= 1000 {printf "%-20s %6d %25s\n", $1, $3, $7}' /etc/passwd`


### PR DESCRIPTION
Corrects the final awk example to use the UID field (the third field in /etc/passwd) instead of the GID field for filtering and output.

This change follows the tldr style guide and has been checked with tldr-lint and markdownlint.