### PR TITLE
bzgrep, xzgrep, zgrep: standardize examples

### DIFF
--- a/pages/common/bzgrep.md
+++ b/pages/common/bzgrep.md
@@ -7,26 +7,26 @@
 
 `bzgrep "{{search_pattern}}" {{path/to/file}}`
 
-- Recursively search files in a bzip2 compressed `.tar` archive for a pattern:
+- Search for an exact string (disables `regex`es):
 
-`bzgrep {{[-r|--recursive]}} "{{search_pattern}}" {{path/to/tar_file}}`
+`bzgrep -F "{{exact_string}}" {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`bzgrep {{--context|--before-context|--after-context}} 3 "{{search_pattern}}" {{path/to/file}}`
+`bzgrep {{-C|-B|-A}}{{3}} "{{search_pattern}}" {{path/to/file}}`
 
-- Print file name and line number for each match:
+- Print the line number for each match:
 
-`bzgrep {{[-H|--with-filename]}} {{[-n|--line-number]}} "{{search_pattern}}" {{path/to/file}}`
+`bzgrep -n "{{search_pattern}}" {{path/to/file}}`
 
-- Search for lines matching a pattern, printing only the matched text:
+- Print only the matched text:
 
-`bzgrep {{[-o|--only-matching]}} "{{search_pattern}}" {{path/to/file}}`
+`bzgrep -o "{{search_pattern}}" {{path/to/file}}`
 
-- Search `stdin` for lines that do not match a pattern:
+- Do not print lines that match a pattern:
 
-`cat {{path/to/bz_compressed_file}} | bzgrep {{[-v|--invert-match]}} "{{search_pattern}}"`
+`bzgrep -v "{{search_pattern}}" {{path/to/file}}`
 
-- Use extended `regex` (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
+- Use extended `regex`es (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
 
-`bzgrep {{[-E|--extended-regexp]}} {{[-i|--ignore-case]}} "{{search_pattern}}" {{path/to/file}}`
+`bzgrep -Ei "{{search_pattern}}" {{path/to/file}}`

--- a/pages/common/xzgrep.md
+++ b/pages/common/xzgrep.md
@@ -18,7 +18,7 @@
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`xzgrep {{--context|--before-context|--after-context}} 3 "{{search_pattern}}" {{path/to/file}}`
+`xzgrep {{--context=|--before-context=|--after-context=}}{{3}} "{{search_pattern}}" {{path/to/file}}`
 
 - Print file name and line number for each match with color output:
 
@@ -28,6 +28,10 @@
 
 `xzgrep {{[-o|--only-matching]}} "{{search_pattern}}" {{path/to/file}}`
 
-- Use extended `regex` (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
+- Do not print lines that match a pattern:
 
-`xzgrep {{[-E|--extended-regexp]}} {{[-i|--ignore-case]}} "{{search_pattern}}" {{path/to/file}}`
+`xzgrep {{[-v|--invert-match]}} "{{search_pattern}}" {{path/to/file}}`
+
+- Use extended `regex`es (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
+
+`xzgrep {{[-Ei|--extended-regexp --ignore-case]}} "{{search_pattern}}" {{path/to/file}}`

--- a/pages/common/zgrep.md
+++ b/pages/common/zgrep.md
@@ -1,32 +1,32 @@
 # zgrep
 
-> Grep text patterns from files within compressed files.
+> Find patterns in files that may be compressed using `grep`.
 > More information: <https://manned.org/zgrep>.
 
-- Grep a pattern in a compressed file (case-sensitive):
+- Search for a pattern within a compressed file:
 
-`zgrep {{pattern}} {{path/to/compressed_file}}`
+`zgrep "{{search_pattern}}" {{path/to/file}}`
+
+- Search for an exact string (disables `regex`es):
+
+`zgrep {{[-F|--fixed-strings]}} "{{exact_string}}" {{path/to/file}}`
 
 - Print 3 lines of [C]ontext around, [B]efore, or [A]fter each match:
 
-`zgrep {{--context|--before-context|--after-context}} 3 {{pattern}} {{path/to/compressed_file}}`
+`zgrep {{--context=|--before-context=|--after-context=}}{{3}} "{{search_pattern}}" {{path/to/file}}`
 
-- Grep a pattern in a compressed file (case-insensitive):
+- Print only the matched text:
 
-`zgrep {{[-i|--ignore-case]}} {{pattern}} {{path/to/compressed_file}}`
+`zgrep {{[-o|--only-matching]}} "{{search_pattern}}" {{path/to/file}}`
 
-- Output count of lines containing matched pattern in a compressed file:
+- Do not print lines that match a pattern:
 
-`zgrep {{[-c|--count]}} {{pattern}} {{path/to/compressed_file}}`
+`zgrep {{[-v|--invert-match]}} "{{search_pattern}}" {{path/to/file}}`
 
-- Display the lines which don't have the pattern present (Invert the search function):
+- Search for multiple patterns:
 
-`zgrep {{[-v|--invert-match]}} {{pattern}} {{path/to/compressed_file}}`
+`zgrep {{[-e|--regexp]}} "{{pattern1}}" {{[-e|--regexp]}} "{{pattern2}}" {{path/to/file}}`
 
-- Grep a compressed file for multiple patterns:
+- Use extended `regex`es (supports `?`, `+`, `{}`, `()`, and `|`), in case-insensitive mode:
 
-`zgrep {{[-e|--regexp]}} "{{pattern_1}}" {{[-e|--regexp]}} "{{pattern_2}}" {{path/to/compressed_file}}`
-
-- Use extended `regex` (supports `?`, `+`, `{}`, `()`, and `|`):
-
-`zgrep {{[-E|--extended-regexp]}} {{regex}} {{path/to/file}}`
+`zgrep {{[-Ei|--extended-regexp --ignore-case]}} "{{search_pattern}}" {{path/to/file}}`


### PR DESCRIPTION
Part of #19922.

This standardizes common search examples across the compressed-file grep wrappers while preserving implementation-specific behavior:

- replaces the unsupported recursive archive example in `bzgrep` with fixed-string search;
- uses portable short options for `bzgrep`, whose upstream wrapper can misinterpret some long options;
- uses the required attached argument form for context long options;
- adds missing fixed-string, only-matching, and invert-match coverage where appropriate;
- aligns descriptions, placeholders, and example ordering across the three pages.

Verification:

- `npm run lint-tldr-pages`
- `npx markdownlint-cli pages/common/bzgrep.md pages/common/xzgrep.md pages/common/zgrep.md`
- safe execution against upstream `bzgrep`, GNU `zgrep`, and the upstream `xzgrep` script