### PR TITLE
metaflac, micromamba, minecraft, minidlna: add Korean translation

### DIFF
--- a/pages.ko/common/metaflac.md
+++ b/pages.ko/common/metaflac.md
@@ -1,0 +1,37 @@
+# metaflac
+
+> FLAC 오디오 파일의 메타데이터 조회 및 수정.
+> 관련 항목: `flac`.
+> 더 많은 정보: <https://xiph.org/flac/documentation_tools_metaflac.html>.
+
+- FLAC 파일의 모든 태그 표시:
+
+`metaflac --show-all-tags {{경로/대상/파일.flac}}`
+
+- FLAC 파일로부터 특정 태그만 표시:
+
+`metaflac --show-tag {{태그_이름1}} --show-tag {{태그_이름2}} {{경로/대상/파일.flac}}`
+
+- FLAC 파일 내 태그 설정:
+
+`metaflac --set-tag "{{태그_이름}}={{태그_값}}" {{경로/대상/파일.flac}}`
+
+- FLAC 파일 내 특정 이름의 태그를 제거:
+
+`metaflac --remove-tag {{태그_이름}} {{경로/대상/파일.flac}}`
+
+- FLAC 파일로부터 모든 태그 제거:
+
+`metaflac --remove-all-tags {{경로/대상/파일.flac}}`
+
+- 파일에서 태그 가져오기 (`NAME=VALUE` 형식):
+
+`metaflac --import-tags-from {{경로/대상/태그.txt}} {{경로/대상/파일.flac}}`
+
+- FLAC 파일의 모든 메타데이터 블록 표시:
+
+`metaflac --list {{경로/대상/파일.flac}}`
+
+- FLAC 파일의 샘플 레이트와 채널 수 표시:
+
+`metaflac --show-sample-rate --show-channels {{경로/대상/파일.flac}}`

--- a/pages.ko/common/micromamba.md
+++ b/pages.ko/common/micromamba.md
@@ -1,0 +1,37 @@
+# micromamba
+
+> `conda` 패키지용 빠르고, 가벼우며, 독립형 패키지 및 환경 관리자.
+> `conda`의 대체품으로 사용할 수 있으며, CI, Docker 및 경량 환경에 적합.
+> 더 많은 정보: <https://manned.org/micromamba>.
+
+- 특정 경로에 새로운 환경 생성 후 패키지 설치:
+
+`micromamba create {{[-p|--prefix]}} /{{경로/대상/환경변수}} {{python=3.11 numpy}}`
+
+- 이름 또는 경로로 환경 활성화:
+
+`micromamba activate {{[-p|--prefix]}} /{{경로/대상/환경변수}}`
+
+- 쉘에서 활성화하지 않고 환경 내부에서 명령어 실행:
+
+`micromamba run {{[-p|--prefix]}} /{{경로/대상/환경변수}} {{pytest tests/}}`
+
+- 현재 활성화된 환경에 패키지 설치:
+
+`micromamba install {{scipy pandas}}`
+
+- 현재 환경의 설치된 패키지 목록 조회:
+
+`micromamba list`
+
+- 채널 또는 현재 환경에서 패키지를 검색:
+
+`micromamba search {{패키지_이름}}`
+
+- 패키지 의존성 트리 조회:
+
+`micromamba repoquery depends {{[-t|--tree]}} {{패키지_이름}}`
+
+- 현재 `micromamba` 설정 정보 확인:
+
+`micromamba info`

--- a/pages.ko/common/minecraft.md
+++ b/pages.ko/common/minecraft.md
@@ -1,0 +1,20 @@
+# Minecraft
+
+> 헤드리스 Minecraft 서버 실행.
+> 더 많은 정보: <https://minecraft.wiki/w/Tutorial:Setting_up_a_Java_Edition_server>.
+
+- Minecraft 서버를 실행하며, 월드가 없으면 자동으로 생성:
+
+`java -jar {{경로/대상/서버.jar}} --nogui`
+
+- 서버의 최소/최대 메모리 설정 후 실행 (참고: 최소값과 최대값을 동일하게 설정하면 JVM 힙 크기 조정으로 인한 지연을 줄일 수 있습니다):
+
+`java -Xms{{1024M}} -Xmx{{2048M}} -jar {{경로/대상/서버.jar}} --nogui`
+
+- GUI와 함께 서버 실행:
+
+`java -jar {{경로/대상/서버.jar}}`
+
+- [대화형] 서버 종료:
+
+`stop`

--- a/pages.ko/common/minidlna.md
+++ b/pages.ko/common/minidlna.md
@@ -1,0 +1,38 @@
+# minidlna
+
+> ReadyMedia(이전 MiniDLNA)는 DLNA/UPnP-AV 클라이언트와 호환되는 경량 미디어 서버.
+> 스마트 TV, 게임 콘솔 및 기타 DLNA 지원 장치로 미디어 스트리밍 가능.
+> 일반적으로 `minidlna.conf` 파일을 설정 파일로 사용해 구성.
+> 더 많은 정보: <https://manned.org/minidlna>.
+
+- 기본 설정 파일 `/etc/minidlna.conf`을 사용하여 MiniDLNA 데몬 시작:
+
+`minidlna`
+
+- 특정 설정 파일을 사용해 MiniDLNA 시작:
+
+`minidlna -f {{경로/대상/minidlna.conf}}`
+
+- 시작할 때 미디어 데이터베이스 강제 재스캔:
+
+`minidlna -R`
+
+- 포그라운드 모드로 MiniDLNA 실행 (디버깅에 유용):
+
+`minidlna -d`
+
+- 상세 디버그 로그 출력:
+
+`minidlna -d -v`
+
+- 사용자 지정 미디어 디렉터리 지정 (설정 파일의 값을 덮어 씀):
+
+`minidlna -m {{경로/대상/media}}`
+
+- 사용자 지정 PID 파일 위치 지정:
+
+`minidlna -P {{경로/대상/pidfile}}`
+
+- 사용자 지정 로그 파일 위치 지정:
+
+`minidlna -l {{경로/대상/logfil.log}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
