### PR TITLE
minio-client, minio-server, minipro, modutil, monolith: add Korean translation

### DIFF
--- a/pages.ko/common/minio-client.md
+++ b/pages.ko/common/minio-client.md
@@ -1,0 +1,7 @@
+# minio-client
+
+> 이 명령어는 `mc` (MinIO 클라이언트)의 별칭.
+
+- 원본 명령어 문서 보기:
+
+`tldr mc.cli`

--- a/pages.ko/common/minio-server.md
+++ b/pages.ko/common/minio-server.md
@@ -1,0 +1,16 @@
+# minio server
+
+> MinIO S3 호환 오브젝트 스토리지 엔진을 실행하는 서버 명령어.
+> 더 많은 정보: <https://docs.min.io/enterprise/aistor-object-store/reference/aistor-server/>.
+
+- 기본 설정으로 MinIO 서버 시작:
+
+`minio server {{경로/대상/데이터_디렉터리}}`
+
+- API 포트와 웹 콘솔 포트를 지정하여 서버 시작:
+
+`minio server --address ":{{포트}}" --console-address ":{{포트}}" {{경로/대상/데이터_디렉터리}}`
+
+- 2개 노드 클러스터의 일부로 서버 시작:
+
+`minio server {{노드1_호스트명}} {{경로/대상/데이터_디렉터리}} {{노드2_호스트명}} {{경로/대상/데이터_디렉터리}}`

--- a/pages.ko/common/minipro.md
+++ b/pages.ko/common/minipro.md
@@ -1,0 +1,37 @@
+# minipro
+
+> Xgecu 칩 프로그래머 (TL866A/CS, TL866II+, T48, T56) 제어 도구.
+> AVR, PIC, 마이크로컨트롤러 및 메모리 등 다양한 칩 지원.
+> 더 많은 정보: <https://manned.org/minipro>.
+
+- 지원되는 모든 장치 목록 표시:
+
+`minipro {{[-l|--list]}}`
+
+- 특정 장치 검색:
+
+`minipro {{[-L|--search]}} {{장치_이름}}`
+
+- 칩 ID 읽기:
+
+`minipro {{[-p|--device]}} {{칩_이름}} {{[-D|--read_id]}}`
+
+- 칩 내용을 파일로 읽기:
+
+`minipro {{[-p|--device]}} {{칩_이름}} {{[-r|--read]}} {{경로/대상/출력_파일.bin}}`
+
+- 파일 내용을 칩에 기록:
+
+`minipro {{[-p|--device]}} {{칩_이름}} {{[-w|--write]}} {{경로/대상/입력_파일.bin}}`
+
+- 칩 내용과 파일 비교:
+
+`minipro {{[-p|--device]}} {{칩_이름}} {{[-m|--verify]}} {{경로/대상/파일.bin}}`
+
+- 칩 지우기:
+
+`minipro {{[-p|--device]}} {{칩_이름}} {{[-E|--erase]}}`
+
+- 도움말 표시:
+
+`minipro {{[-h|--help]}}`

--- a/pages.ko/common/modutil.md
+++ b/pages.ko/common/modutil.md
@@ -1,0 +1,12 @@
+# modutil
+
+> NSS 보안 모듈 데이터베이스에서 PKCS #11 모듈 정보 관리.
+> 더 많은 정보: <https://manned.org/modutil>.
+
+- NSS 데이터베이스에 PKCS #11 모듈 추가 (예: Firefox 프로필 디렉터리: `$HOME/.mozilla/firefox/default-release`):
+
+`modutil -dbdir sql:{{경로/대상/nss_데이터베이스_디렉터리}} -add "{{모듈_라벨}}" -libfile {{경로/대상/pkcs11_mod.so}}`
+
+- NSS 데이터베이스에 등록된 PKCS #11 모듈 목록 조회:
+
+`modutil -dbdir sql:{{경로/대상/nss_데이터베이스_디렉터리}} -list`

--- a/pages.ko/common/monolith.md
+++ b/pages.ko/common/monolith.md
@@ -1,0 +1,36 @@
+# monolith
+
+> 단일 HTML 파일로 웹 페이지 저장.
+> 더 많은 정보: <https://github.com/Y2Z/monolith>.
+
+- 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}}`
+
+- 오디오를 제외하고, 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-a|--no-audio]}}`
+
+- CSS를 제외하고 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-c|--no-css]}}`
+
+- 이미지를 제외하고 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-i|--no-images]}}`
+
+- 비디오를 제외하고 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-v|--no-video]}}`
+
+- JavaScript 제외하고 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-j|--no-js]}}`
+
+- 유효하지 않은 TLS 인증서를 허용하고 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-k|--insecure]}}`
+
+- 출력 파일명을 지정하여 단일 HTML 파일로 웹 페이지 저장:
+
+`monolith {{주소}} {{[-o|--output]}} {{경로/대상/파일.html}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
