### PR TITLE
jless: add page

### DIFF
--- a/pages/common/jless.md
+++ b/pages/common/jless.md
@@ -1,0 +1,28 @@
+# jless
+
+> Interactively view, explore, and search JSON and YAML data.
+> More information: <https://jless.io/user-guide>.
+
+- View a JSON file:
+
+`jless {{path/to/file.json}}`
+
+- Read JSON from `stdin`:
+
+`{{command}} | jless`
+
+- View a YAML file:
+
+`jless --yaml {{path/to/file.yaml}}`
+
+- Start in line mode, showing closing delimiters, commas, and quoted object keys:
+
+`jless {{[-m|--mode]}} line {{path/to/file.json}}`
+
+- [Interactive] Expand or collapse the focused object or array:
+
+`<Space>`
+
+- [Interactive] Search forward for a `regex` (press `<n>`/`<N>` to go to the next/previous match):
+
+`</>{{search_pattern}}<Enter>`


### PR DESCRIPTION
Closes #21116

This PR adds a page for `jless`, covering JSON and YAML input, stdin usage, line mode, container navigation, and regex search.

Verification performed:
- Checked the official jless README.
- Checked CLI options in `src/options.rs`.
- Checked interactive commands in `src/jless.help`.
- Ran `npx tldr-lint pages/common/jless.md`.
- Ran `npx markdownlint-cli pages/common/jless.md`.
- Ran `npm run lint-tldr-pages`.

The PR is intentionally limited to the requested `jless` page.