### PR TITLE
net: add page

### DIFF
--- a/pages/common/net.md
+++ b/pages/common/net.md
@@ -1,0 +1,37 @@
+# net
+
+> Tool for administering Samba and remote CIFS servers.
+> See also: `smbclient`, `smbpasswd`.
+> More information: <https://www.samba.org/samba/docs/current/man-html/net.8.html>.
+
+- Join an Active Directory domain:
+
+`net ads join -U {{username}}`
+
+- Leave an Active Directory domain:
+
+`net ads leave -U {{username}}`
+
+- Test whether the machine is successfully joined to a domain:
+
+`net ads testjoin`
+
+- List shares on a remote server:
+
+`net rpc share list -S {{server}} -U {{username}}`
+
+- Add a user-defined share:
+
+`net usershare add {{sharename}} {{/path/to/directory}} "{{Comment}}"`
+
+- List user-defined shares:
+
+`net usershare list`
+
+- Display the current time on a remote server:
+
+`net time -S {{server}}`
+
+- Look up the IP address of a NetBIOS name:
+
+`net lookup {{hostname}}`


### PR DESCRIPTION
Closes #21585

Adds a tldr page for the `net` command (Samba tool for administering CIFS servers), with 8 practical examples covering ADS domain operations, share management, time sync, and name lookup.