### PR TITLE
test: fix -f placeholder

### DIFF
--- a/pages/common/test.md
+++ b/pages/common/test.md
@@ -15,7 +15,7 @@
 
 - Test if a [f]ile exists:
 
-`test -f "{{path/to/file_or_directory}}"`
+`test -f "{{path/to/file}}"`
 
 - Test if a [d]irectory does not exist:
 


### PR DESCRIPTION
### Checklist

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR contains at most 5 new pages.
- [X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

---

`test -f` checks whether a path exists and is a regular file. This changes the placeholder to `path/to/file` to better match the behavior of `-f`.