### PR TITLE
kid3: add page

### DIFF
--- a/pages/common/kid3.md
+++ b/pages/common/kid3.md
@@ -1,0 +1,21 @@
+# kid3
+
+> Graphical audio tag editor for MP3, M4A, FLAC, Ogg, and more.
+> See also: `kid3-cli`.
+> More information: <https://kid3.kde.org/>.
+
+- Start Kid3:
+
+`kid3`
+
+- Open a specific directory:
+
+`kid3 {{path/to/directory}}`
+
+- Open one or more specific files:
+
+`kid3 {{path/to/file1.mp3 path/to/file2.flac ...}}`
+
+- Use a portable configuration file (stored next to the executable):
+
+`kid3 --portable`


### PR DESCRIPTION
Adds a page for `kid3`, the graphical audio tag editor from KDE (companion to the `kid3-cli` page in #22949).

The command-line surface of the GUI binary is small — it takes positional directory/file arguments (handled by `openDirectory`) and a `--portable` flag (must be the first argument) to use a configuration file stored next to the executable. Examples are limited to what is supported across builds.

- Modeled on the existing `gimp` GUI page.
- Passes `tldr-lint` and `markdownlint` locally.

Checklist:
- [x] Page is in `pages/common`.
- [x] Page title is lowercase.
- [x] Description has a `More information` link.
- [x] `See also` references the companion `kid3-cli` page.
- [x] Commands use `{{placeholder}}` syntax.
- [x] Passes the linters.