### PR TITLE
woeusb: add sudo to `-d` flag

### DIFF
--- a/pages/linux/woeusb.md
+++ b/pages/linux/woeusb.md
@@ -5,7 +5,7 @@
 
 - Format a USB then create a bootable Windows installation drive:
 
-`woeusb {{[-d|--device]}} {{path/to/windows.iso}} {{/dev/sdX}}`
+`sudo woeusb {{[-d|--device]}} {{path/to/windows.iso}} {{/dev/sdX}}`
 
 - Copy Windows files to an existing partition of a USB storage device and make it bootable, without erasing the current data:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

I haven't tested the `-p` flag, so that might also require `sudo`.
