### PR TITLE
osx/*d: Add 'Note:' prefix to 'It should not be invoked manually'

### DIFF
--- a/pages/osx/airportd.md
+++ b/pages/osx/airportd.md
@@ -1,7 +1,7 @@
 # airportd
 
 > Manage wireless interfaces.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/airportd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/applecamerad.md
+++ b/pages/osx/applecamerad.md
@@ -1,7 +1,7 @@
 # applecamerad
 
 > Camera manager.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.theiphonewiki.com/wiki/Services>.
 
 - Start the daemon:

--- a/pages/osx/appsleepd.md
+++ b/pages/osx/appsleepd.md
@@ -1,7 +1,7 @@
 # appsleepd
 
 > Start app sleep services.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/appsleepd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/autofsd.md
+++ b/pages/osx/autofsd.md
@@ -1,7 +1,7 @@
 # autofsd
 
 > Run `automount` on startup and network configuration change events.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/autofsd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/automountd.md
+++ b/pages/osx/automountd.md
@@ -1,7 +1,7 @@
 # automountd
 
 > An automatic mount/unmount daemon for `autofs`. Started on demand by `launchd`.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/automountd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/avbdeviced.md
+++ b/pages/osx/avbdeviced.md
@@ -1,7 +1,7 @@
 # avbdeviced
 
 > A service for managing Audio Video Bridging (AVB) devices.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/avbdeviced.1.html>.
 
 - Start the daemon:

--- a/pages/osx/backupd.md
+++ b/pages/osx/backupd.md
@@ -1,7 +1,7 @@
 # backupd
 
 > Create Time Machine backups and manages its backup history.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/backupd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/biomesyncd.md
+++ b/pages/osx/biomesyncd.md
@@ -1,7 +1,7 @@
 # biomesyncd
 
 > Synchronizes data between devices registered to the same account.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/biomesyncd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/biometrickitd.md
+++ b/pages/osx/biometrickitd.md
@@ -1,7 +1,7 @@
 # biometrickitd
 
 > Get support for biometric operations.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/biometrickitd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/bird.md
+++ b/pages/osx/bird.md
@@ -1,7 +1,7 @@
 # bird
 
 > This supports the syncing of iCloud and iCloud Drive.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/bird.8.html>.
 
 - Start the daemon:

--- a/pages/osx/bnepd.md
+++ b/pages/osx/bnepd.md
@@ -1,7 +1,7 @@
 # bnepd
 
 > A service that handles all Bluetooth network connections.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.manpagez.com/man/8/bnepd/>.
 
 - Start the daemon:

--- a/pages/osx/cfprefsd.md
+++ b/pages/osx/cfprefsd.md
@@ -1,7 +1,7 @@
 # cfprefsd
 
 > Start preferences services (`CFPreferences`, `NSUserDefaults`).
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/cfprefsd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/cloudd.md
+++ b/pages/osx/cloudd.md
@@ -1,7 +1,7 @@
 # cloudd
 
 > Backs the CloudKit feature.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/cloudd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/cloudphotod.md
+++ b/pages/osx/cloudphotod.md
@@ -1,7 +1,7 @@
 # cloudphotod
 
 > This synchronizes iCloud Photos.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.manpagez.com/man/8/cloudphotosd/>.
 
 - Start the daemon:

--- a/pages/osx/contactsd.md
+++ b/pages/osx/contactsd.md
@@ -2,7 +2,7 @@
 
 > Manage the information in your contacts database.
 > It provides functionality to apps using the Contacts API and performs various background maintenance tasks.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/contactsd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/coreaudiod.md
+++ b/pages/osx/coreaudiod.md
@@ -1,7 +1,7 @@
 # coreaudiod
 
 > Service for Core Audio, Apple's audio system.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/WhatisCoreAudio/WhatisCoreAudio.html>.
 
 - Start the daemon:

--- a/pages/osx/coreautha.md
+++ b/pages/osx/coreautha.md
@@ -1,7 +1,7 @@
 # coreautha
 
 > A system agent providing the `LocalAuthentication` framework.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > See also: `coreauthd`.
 > More information: <https://keith.github.io/xcode-man-pages/coreautha.8.html>.
 

--- a/pages/osx/coreauthd.md
+++ b/pages/osx/coreauthd.md
@@ -1,7 +1,7 @@
 # coreauthd
 
 > A system daemon providing the `LocalAuthentication` framework.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > See also: `coreautha`.
 > More information: <https://keith.github.io/xcode-man-pages/coreauthd.8.html>.
 

--- a/pages/osx/corebrightnessd.md
+++ b/pages/osx/corebrightnessd.md
@@ -1,7 +1,7 @@
 # corebrightnessd
 
 > Manage Night Shift.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/corebrightnessd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/coredatad.md
+++ b/pages/osx/coredatad.md
@@ -1,7 +1,7 @@
 # coredatad
 
 > Schedules CloudKit operations for clients of NSPersistentCloudKitContainer.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/coredatad.8.html>.
 
 - Start the daemon:

--- a/pages/osx/ctkd.md
+++ b/pages/osx/ctkd.md
@@ -1,7 +1,7 @@
 # ctkd
 
 > SmartCard daemon.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/ctkd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/deleted.md
+++ b/pages/osx/deleted.md
@@ -1,7 +1,7 @@
 # deleted
 
 > Keeps track of purgeable space and asks clients to purge when space is low.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/deleted.8.html>.
 
 - Start the daemon:

--- a/pages/osx/dhcp6d.md
+++ b/pages/osx/dhcp6d.md
@@ -1,7 +1,7 @@
 # dhcp6d
 
 > Stateless DHCPv6 server.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > See also: `InternetSharing`.
 > More information: <https://keith.github.io/xcode-man-pages/dhcp6d.8.html>.
 

--- a/pages/osx/distnoted.md
+++ b/pages/osx/distnoted.md
@@ -1,7 +1,7 @@
 # distnoted
 
 > Start distributed notification services.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/distnoted.8.html>.
 
 - Start the daemon:

--- a/pages/osx/filecoordinationd.md
+++ b/pages/osx/filecoordinationd.md
@@ -1,7 +1,7 @@
 # filecoordinationd
 
 > Coordinates access to files by multiple processes (`NSFileCoordinator`, `NSFilePresenter`).
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/filecoordinationd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/fontd.md
+++ b/pages/osx/fontd.md
@@ -1,7 +1,7 @@
 # fontd
 
 > Make fonts available to the system.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/fontd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/hidd.md
+++ b/pages/osx/hidd.md
@@ -1,7 +1,7 @@
 # hidd
 
 > HID library userland daemon.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/hidd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/internetsharing.md
+++ b/pages/osx/internetsharing.md
@@ -1,7 +1,7 @@
 # InternetSharing
 
 > Set up Internet Sharing.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.manpagez.com/man/8/InternetSharing/>.
 
 - Start the daemon:

--- a/pages/osx/nfcd.md
+++ b/pages/osx/nfcd.md
@@ -1,7 +1,7 @@
 # nfcd
 
 > This daemon controls the NFC controller.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/nfcd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/notifyd.md
+++ b/pages/osx/notifyd.md
@@ -1,7 +1,7 @@
 # notifyd
 
 > Notification server.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/notifyd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/ocspd.md
+++ b/pages/osx/ocspd.md
@@ -1,7 +1,7 @@
 # ocspd
 
 > This retrieves and caches Certificate Revocation Lists (CRLs) and Online Certificate Status Protocol (OCSP) responses for certificate verification.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/ocspd.1.html>.
 
 - Start the daemon:

--- a/pages/osx/photolibraryd.md
+++ b/pages/osx/photolibraryd.md
@@ -1,7 +1,7 @@
 # photolibraryd
 
 > This handles all photo library requests.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/photolibraryd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/secd.md
+++ b/pages/osx/secd.md
@@ -1,7 +1,7 @@
 # secd
 
 > Control access to and modification of keychain items.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/secd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/securityd.md
+++ b/pages/osx/securityd.md
@@ -2,7 +2,7 @@
 
 > This manages security contexts and cryptographic operations.
 > Works with secd for keychain access.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/securityd.1.html>.
 
 - Start the daemon:

--- a/pages/osx/sntpd.md
+++ b/pages/osx/sntpd.md
@@ -1,7 +1,7 @@
 # sntpd
 
 > An SNTP server.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/sntpd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/symptomsd.md
+++ b/pages/osx/symptomsd.md
@@ -1,7 +1,7 @@
 # symptomsd
 
 > Provides services for `Symptoms.framework`.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/symptomsd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/systemsoundserverd.md
+++ b/pages/osx/systemsoundserverd.md
@@ -1,7 +1,7 @@
 # systemsoundserverd
 
 > Core Audio related daemon.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 
 - Start the daemon:
 

--- a/pages/osx/timed.md
+++ b/pages/osx/timed.md
@@ -1,7 +1,7 @@
 # timed
 
 > Service that synchronizes system time (e.g. using NTP).
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/timed.8.html>.
 
 - Start the daemon:

--- a/pages/osx/translationd.md
+++ b/pages/osx/translationd.md
@@ -1,7 +1,7 @@
 # translationd
 
 > Enable Translation features.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 
 - Start the daemon:
 

--- a/pages/osx/universalaccessd.md
+++ b/pages/osx/universalaccessd.md
@@ -1,7 +1,7 @@
 # universalaccessd
 
 > Get universal access services.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/universalaccessd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/usernoted.md
+++ b/pages/osx/usernoted.md
@@ -1,7 +1,7 @@
 # usernoted
 
 > Provides notification services.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/usernoted.8.html>.
 
 - Start the daemon:

--- a/pages/osx/vpnd.md
+++ b/pages/osx/vpnd.md
@@ -1,7 +1,7 @@
 # vpnd
 
 > Listens for incoming VPN connections.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/vpnd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/warmd.md
+++ b/pages/osx/warmd.md
@@ -1,7 +1,7 @@
 # warmd
 
 > Control caches used during startup and login.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/warmd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/watchdogd.md
+++ b/pages/osx/watchdogd.md
@@ -1,7 +1,7 @@
 # watchdogd
 
 > Works with the Watchdog KEXT to ensure that the system is healthy and running.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/watchdogd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/watchlistd.md
+++ b/pages/osx/watchlistd.md
@@ -1,7 +1,7 @@
 # watchlistd
 
 > Manage the Apple TV app's watch list.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/watchlistd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/webinspectord.md
+++ b/pages/osx/webinspectord.md
@@ -1,7 +1,7 @@
 # webinspectord
 
 > Relays commands between Web Inspector and remote targets like WKWebView.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.manpagez.com/man/8/webinspectord/>.
 
 - Start the daemon:

--- a/pages/osx/wifivelocityd.md
+++ b/pages/osx/wifivelocityd.md
@@ -1,7 +1,7 @@
 # wifivelocityd
 
 > XPC helper for performing system context actions for the WiFiVelocity framework.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/wifivelocityd.8.html>.
 
 - Start the daemon:

--- a/pages/osx/wps.md
+++ b/pages/osx/wps.md
@@ -1,7 +1,7 @@
 # wps
 
 > Assists AirPort in connecting to a network using Wireless Protected Setup.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://www.manpagez.com/man/8/wps/>.
 
 - Start the daemon:

--- a/pages/osx/wwand.md
+++ b/pages/osx/wwand.md
@@ -1,7 +1,7 @@
 # wwand
 
 > USB WWAN device configuration daemon.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://web.archive.org/web/20230331164459/https://keith.github.io/xcode-man-pages/wwand.8.html>.
 
 - Start the daemon:

--- a/pages/osx/xartstorageremoted.md
+++ b/pages/osx/xartstorageremoted.md
@@ -1,7 +1,7 @@
 # xartstorageremoted
 
 > The xART Remote Storage Daemon. Receives save/fetch requests from the CoProcessor.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://keith.github.io/xcode-man-pages/xartstorageremoted.8.html>.
 
 - Start the daemon:

--- a/pages/osx/xsand.md
+++ b/pages/osx/xsand.md
@@ -1,7 +1,7 @@
 # xsand
 
 > Xsan filesystem management daemon. Provides services for the Xsan filesystem.
-> It should not be invoked manually.
+> Note: It should not be invoked manually.
 > More information: <https://developer.apple.com/support/downloads/Xsan-Management-Guide.pdf>.
 
 - Start the daemon:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

Based on @ivanbaluta's comments on #22085, this PR prefixes `It should not be invoked manually` notice with standard `Note:` within the command description.

Due to the large volume of pages this PR only deals with the English documentation.