### PR TITLE
docs: fix dead More information links flagged by the link checker

### DIFF
--- a/pages/common/clangd.md
+++ b/pages/common/clangd.md
@@ -2,7 +2,7 @@
 
 > Language server that provides IDE-like features to editors.
 > It should be used via an editor plugin rather than invoked directly.
-> More information: <https://manpages.ubuntu.com/manpages/man1/clangd.1>.
+> More information: <https://clangd.llvm.org/>.
 
 - Display available options:
 

--- a/pages/common/flox.md
+++ b/pages/common/flox.md
@@ -1,7 +1,7 @@
 # flox
 
 > Easy to use Nix package and environment manager.
-> More information: <https://flox.dev/docs/reference/command-reference/flox/>.
+> More information: <https://flox.dev/docs/man/flox>.
 
 - Create a new environment in the current directory:
 

--- a/pages/common/fls.md
+++ b/pages/common/fls.md
@@ -1,7 +1,7 @@
 # fls
 
 > List files and directories in an image file or device.
-> More information: <https://wiki.sleuthkit.org/index.php?title=Fls>.
+> More information: <https://github.com/sleuthkit/sleuthkit/wiki/fls>.
 
 - Build a recursive fls list over a device, output paths will start with C:
 

--- a/pages/common/github-label-sync.md
+++ b/pages/common/github-label-sync.md
@@ -1,7 +1,7 @@
 # github-label-sync
 
 > Synchronize GitHub labels.
-> More information: <https://github.com/Financial-Times/github-label-sync>.
+> More information: <https://www.npmjs.com/package/github-label-sync>.
 
 - Synchronize labels using a local `labels.json` file:
 

--- a/pages/common/gunicorn.md
+++ b/pages/common/gunicorn.md
@@ -1,7 +1,7 @@
 # gunicorn
 
 > Python WSGI HTTP Server.
-> More information: <https://docs.gunicorn.org/en/latest/run.html>.
+> More information: <https://gunicorn.org/run/>.
 
 - Run Python web app:
 

--- a/pages/common/mmls.md
+++ b/pages/common/mmls.md
@@ -1,7 +1,7 @@
 # mmls
 
 > Display the partition layout of a volume system.
-> More information: <https://wiki.sleuthkit.org/index.php?title=Mmls>.
+> More information: <https://github.com/sleuthkit/sleuthkit/wiki/mmls>.
 
 - Display the partition table stored in an image file:
 

--- a/pages/common/piactl.md
+++ b/pages/common/piactl.md
@@ -1,7 +1,7 @@
 # piactl
 
 > The tool for Private Internet Access, a commercial VPN provider.
-> More information: <https://helpdesk.privateinternetaccess.com/kb/articles/pia-desktop-command-line-interface-2>.
+> More information: <https://helpdesk.privateinternetaccess.com/hc/en-us/articles/46815372532123-PIA-Desktop-Command-Line-Interface>.
 
 - Log in to Private Internet Access:
 

--- a/pages/common/picard.md
+++ b/pages/common/picard.md
@@ -1,7 +1,7 @@
 # picard
 
 > Next generation MusicBrainz tagging application.
-> More information: <https://picard-docs.musicbrainz.org/en/getting_started/starting.html>.
+> More information: <https://picard-docs.musicbrainz.org/en/latest/getting_started/starting.html>.
 
 - Start Picard:
 

--- a/pages/common/pydocstyle.md
+++ b/pages/common/pydocstyle.md
@@ -1,7 +1,7 @@
 # pydocstyle
 
 > Statically check Python scripts for compliance with Python docstring conventions.
-> More information: <https://www.pydocstyle.org/en/latest/>.
+> More information: <https://pydocstyle.readthedocs.io/en/latest/>.
 
 - Analyze a Python script or all the Python scripts in a specific directory:
 

--- a/pages/common/siege.md
+++ b/pages/common/siege.md
@@ -1,7 +1,7 @@
 # siege
 
 > HTTP loadtesting and benchmarking tool.
-> More information: <https://www.joedog.org/siege-manual/>.
+> More information: <https://www.joedog.org/siege/manual/>.
 
 - Test a URL with default settings:
 

--- a/pages/common/virtualenv.md
+++ b/pages/common/virtualenv.md
@@ -1,7 +1,7 @@
 # virtualenv
 
 > Create virtual isolated Python environments.
-> More information: <https://virtualenv.pypa.io/en/latest/cli_interface.html>.
+> More information: <https://virtualenv.pypa.io/en/latest/reference/cli.html>.
 
 - Create a new environment:
 

--- a/pages/linux/hyprctl.md
+++ b/pages/linux/hyprctl.md
@@ -1,7 +1,7 @@
 # hyprctl
 
 > Control parts of the Hyprland Wayland compositor.
-> More information: <https://wiki.hypr.land/Configuring/Using-hyprctl/>.
+> More information: <https://wiki.hypr.land/Configuring/Advanced-and-Cool/Using-hyprctl/>.
 
 - Reload Hyprland configuration:
 

--- a/pages/linux/pamac.md
+++ b/pages/linux/pamac.md
@@ -2,7 +2,7 @@
 
 > Utility for the GUI package manager pamac.
 > If you can't see the AUR packages, enable it in `/etc/pamac.conf` or in the GUI.
-> More information: <https://wiki.manjaro.org/index.php/Pamac>.
+> More information: <https://wiki.manjaro.org/index.php?title=Pamac>.
 
 - Install a new package:
 


### PR DESCRIPTION
## Summary

Fixes 13 of the dead/broken "More information" links currently listed in the link-checker tracker (tldr-pages/tldr-maintenance#129), which #14098 references. I verified each old URL is actually dead and each new URL actually loads before swapping it in (not just trusting search-engine snippets, several of which were stale).

| Page | Old | New | Why |
|---|---|---|---|
| `pamac.md` | `wiki.manjaro.org/index.php/Pamac` | `wiki.manjaro.org/index.php?title=Pamac` | Path-style URL 404s; query-string form of the same page is live (HTTP 200) |
| `hyprctl.md` | `wiki.hypr.land/Configuring/Using-hyprctl/` | `wiki.hypr.land/Configuring/Advanced-and-Cool/Using-hyprctl/` | Page moved on the Hyprland wiki |
| `virtualenv.md` | `virtualenv.pypa.io/en/latest/cli_interface.html` | `virtualenv.pypa.io/en/latest/reference/cli.html` | Docs site restructured |
| `siege.md` | `www.joedog.org/siege-manual/` | `www.joedog.org/siege/manual/` | Path moved |
| `pydocstyle.md` | `www.pydocstyle.org/en/latest/` | `pydocstyle.readthedocs.io/en/latest/` | **The old domain has expired and is now squatted by an unrelated gambling site** — worth fixing promptly |
| `picard.md` | `picard-docs.musicbrainz.org/en/getting_started/starting.html` | `picard-docs.musicbrainz.org/en/latest/getting_started/starting.html` | Docs now require a version segment in the path |
| `piactl.md` | `helpdesk.privateinternetaccess.com/kb/articles/pia-desktop-command-line-interface-2` | `helpdesk.privateinternetaccess.com/hc/en-us/articles/46815372532123-PIA-Desktop-Command-Line-Interface` | Helpdesk migrated to a new Zendesk-style URL scheme |
| `mmls.md` | `wiki.sleuthkit.org/index.php?title=Mmls` | `github.com/sleuthkit/sleuthkit/wiki/mmls` | `wiki.sleuthkit.org` is gone; docs moved to the GitHub wiki |
| `fls.md` | `wiki.sleuthkit.org/index.php?title=Fls` | `github.com/sleuthkit/sleuthkit/wiki/fls` | Same as above |
| `gunicorn.md` | `docs.gunicorn.org/en/latest/run.html` | `gunicorn.org/run/` | `docs.gunicorn.org` subdomain is gone; project consolidated docs onto the main domain with a simplified path structure |
| `github-label-sync.md` | `github.com/Financial-Times/github-label-sync` | `npmjs.com/package/github-label-sync` | The repo itself no longer exists (confirmed via `gh api repos/Financial-Times/github-label-sync` → 404, even though the `Financial-Times` org and the npm package are both still very much alive) |
| `flox.md` | `flox.dev/docs/reference/command-reference/flox/` | `flox.dev/docs/man/flox` | Docs restructured under `/docs/man/` |
| `clangd.md` | `manpages.ubuntu.com/manpages/man1/clangd.1` | `clangd.llvm.org/` | Version-pinned Ubuntu manpage URLs rot every release cycle; linked the stable, official project site instead |

Not touched: `rubocop.md` and `vulkaninfo.md` were also flagged in the same report, but on inspection their current content either already points to a live URL (rubocop — already fixed in a prior commit) or the flagged URL actually still loads fine for me (vulkaninfo — likely a checker flake/bot-block, not a real 404), so I left them alone rather than churn working links.

## Test plan
- [x] Fetched every **old** URL above directly and confirmed it 404s (or, for pydocstyle, resolves to an unrelated squatter site) — not relying solely on the bot report.
- [x] Fetched every **new** URL above directly and confirmed it loads and documents the right thing.
- [x] `npx tldr-lint <file>` — clean, zero errors, on all 13 changed files.
- [x] `npx markdownlint <file>` — clean, zero errors, on all 13 changed files.
- [ ] Full `npm test` (`scripts/test.sh`) — couldn't get a clean run in my local checkout: `pages.en` is meant to be a symlink to `pages/`, and Windows without symlink permissions checks it out as a placeholder text file instead, which breaks the script's `pages*/**/*.md` page-file scan for any commit in this clone (unrelated to this diff — confirmed the same failure occurs against an unmodified checkout). I relied on `tldr-lint`/`markdownlint` directly instead, which are the actual content-validation tools `npm test` invokes for page files.
