### PR TITLE
wine-reg-{add,copy,delete,export,import}: link to Microsoft documentation

### DIFF
--- a/pages/linux/wine-reg-add.md
+++ b/pages/linux/wine-reg-add.md
@@ -1,7 +1,7 @@
 # wine reg add
 
 > Add new keys and values to the Wine registry.
-> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-add>.
 
 - Add a new registry key:
 

--- a/pages/linux/wine-reg-copy.md
+++ b/pages/linux/wine-reg-copy.md
@@ -1,7 +1,7 @@
 # wine reg copy
 
 > Copy a registry key to a new location within the Wine registry.
-> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-copy>.
 
 - Copy a registry key to a new location:
 

--- a/pages/linux/wine-reg-delete.md
+++ b/pages/linux/wine-reg-delete.md
@@ -1,7 +1,7 @@
 # wine reg delete
 
 > Delete keys and values from the Wine registry.
-> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-delete>.
 
 - Delete a registry key and all of its values:
 

--- a/pages/linux/wine-reg-export.md
+++ b/pages/linux/wine-reg-export.md
@@ -1,7 +1,7 @@
 # wine reg export
 
 > Export keys, values, and data from the Wine registry to a `.reg` file.
-> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-export>.
 
 - Export a registry key and its subkeys to a file:
 

--- a/pages/linux/wine-reg-import.md
+++ b/pages/linux/wine-reg-import.md
@@ -1,7 +1,7 @@
 # wine reg import
 
 > Import keys, values, and data into the Wine registry from a `.reg` file.
-> More information: <https://gitlab.winehq.org/wine/wine/-/wikis/Commands>.
+> More information: <https://learn.microsoft.com/windows-server/administration/windows-commands/reg-import>.
 
 - Import registry entries from a file:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

- Reference issue: #21837

Applies @Managor 's suggestion from https://github.com/tldr-pages/tldr/pull/22991#issuecomment-4813608398: link the reg subcommands that Wine
fully implements to Microsoft's documentation instead of the generic WineHQ
Commands wiki.

`reg query` and the parent `reg` page stay on the WineHQ wiki, since Wine's
`reg query` lacks /se /f /k /d /c /e /t /z and subcommands like `compare`
aren't implemented.

Reference issue: #21837
