### PR TITLE
passage: add page

### DIFF
--- a/pages/common/passage.md
+++ b/pages/common/passage.md
@@ -2,6 +2,7 @@
 
 > Store and read passwords or other sensitive data.
 > Note: All data is age-encrypted (as opposed to GPG used by `pass`).
+> See also: `pass`.
 > More information: <https://github.com/FiloSottile/passage>.
 
 - Insert a new password (press `<Ctrl d>` on a new line to complete):

--- a/pages/common/passage.md
+++ b/pages/common/passage.md
@@ -1,16 +1,16 @@
 # passage
 
 > Store and read passwords or other sensitive data.
-> All data is age-encrypted (as opposed to GPG used by `pass`).
+> Note: All data is age-encrypted (as opposed to GPG used by `pass`).
 > More information: <https://github.com/FiloSottile/passage>.
 
-- Insert a new password (press `Ctrl + D` on a new line to complete):
+- Insert a new password (press `<Ctrl d>` on a new line to complete):
 
-`passage insert {{path/to/data}}`
+`passage insert {{[-m|--multiline]}} {{path/to/data}}`
 
 - Insert a new password from `stdin`:
 
-`echo "{{password}}" | passage insert --echo {{path/to/data}}`
+`echo "{{password}}" | passage insert {{[-e|--echo]}} {{path/to/data}}`
 
 - Show a password:
 
@@ -18,7 +18,7 @@
 
 - Copy a password to the clipboard:
 
-`passage --clip {{path/to/data}}`
+`passage {{[-c|--clip]}} {{path/to/data}}`
 
 - List the whole store tree:
 

--- a/pages/common/passage.md
+++ b/pages/common/passage.md
@@ -1,0 +1,37 @@
+# passage
+
+> Store and read passwords or other sensitive data.
+> All data is age-encrypted (as opposed to GPG used by `pass`).
+> More information: <https://github.com/FiloSottile/passage>.
+
+- Insert a new password (press `Ctrl + D` on a new line to complete):
+
+`passage insert {{path/to/data}}`
+
+- Insert a new password from `stdin`:
+
+`echo "{{password}}" | passage insert --echo {{path/to/data}}`
+
+- Show a password:
+
+`passage {{path/to/data}}`
+
+- Copy a password to the clipboard:
+
+`passage --clip {{path/to/data}}`
+
+- List the whole store tree:
+
+`passage ls`
+
+- Generate a new random password of a given length:
+
+`passage generate {{path/to/data}} {{length}}`
+
+- Edit an entry:
+
+`passage edit {{path/to/data}}`
+
+- Remove an entry:
+
+`passage rm {{path/to/data}}`


### PR DESCRIPTION
Adds a tldr page for [passage](https://github.com/FiloSottile/passage), an age-encrypted password manager and drop-in replacement for `pass`.

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.7.4
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
