### PR TITLE
retch: add page

### DIFF
--- a/pages/common/retch.md
+++ b/pages/common/retch.md
@@ -1,0 +1,28 @@
+# retch
+
+> A fast, feature-rich system information fetcher.
+> More information: <https://github.com/l1a/retch>.
+
+- Display system information with default settings:
+  `retch`
+
+- Display system information in short format:
+  `retch --short`
+
+- Display system information in long format:
+  `retch --long`
+
+- Display system information with a specific distribution logo:
+  `retch --logo {{distribution_name}}`
+
+- Force the use of an ASCII representation for the logo:
+  `retch --ascii-logo`
+
+- Display system information using a specific theme:
+  `retch --theme {{theme_name}}`
+
+- Print the default configuration to stdout:
+  `retch --generate-config`
+
+- Write the default configuration to a file:
+  `retch --write-config {{path/to/config.toml}}`


### PR DESCRIPTION
This PR adds the tldr-page entry for the `retch` system information fetcher.

Command repository: https://github.com/l1a/retch

Assisted-by: Gemini 3.5 Flash