### PR TITLE
linux/dd: unify argument order

### DIFF
--- a/pages/linux/dd.md
+++ b/pages/linux/dd.md
@@ -6,7 +6,7 @@
 
 - Make a bootable USB drive from an isohybrid file (such as `archlinux-xxx.iso`) and show the progress:
 
-`sudo dd if={{path/to/file.iso}} of={{/dev/usb_drive}} status=progress`
+`sudo dd status=progress if={{path/to/file.iso}} of={{/dev/usb_drive}}`
 
 - Clone a drive to another drive with 4 MiB block size and flush writes before the command terminates:
 
@@ -22,7 +22,7 @@
 
 - Create a system backup, save it into an IMG file (can be restored later by swapping `if` and `of`), and show the progress:
 
-`sudo dd if={{/dev/drive_device}} of={{path/to/file.img}} status=progress`
+`sudo dd status=progress if={{/dev/drive_device}} of={{path/to/file.img}}`
 
 - Check the progress of an ongoing `dd` operation (run this command from another shell):
 


### PR DESCRIPTION
It is more readable if `if=` and `of=` are at the end of the prompt

<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR contains at most 5 new pages.
- [X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented:** 9.11
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
