### PR TITLE
linux/free: clarify which units are used

### DIFF
--- a/pages/linux/free.md
+++ b/pages/linux/free.md
@@ -3,17 +3,21 @@
 > Display amount of free and used memory in the system.
 > More information: <https://manned.org/free>.
 
-- Display system memory:
+- Display system memory in KiB:
 
 `free`
 
-- Display memory in Bytes/KB/MB/GB:
+- Display memory in Bytes/KiB/MiB/GiB:
 
 `free -{{b|k|m|g}}`
 
-- Display memory in human-readable units:
+- Display memory alongside the most appropriate human-readable unit (KiB/MiB/GiB etc):
 
 `free {{[-h|--human]}}`
+
+- Display memory alongside the most appropriate human-readable unit that is a power of 1000 (kB/MB/GB etc):
+
+`free {{-h|--human}} --si`
 
 - Refresh the output every 2 seconds:
 

--- a/pages/linux/free.md
+++ b/pages/linux/free.md
@@ -7,15 +7,15 @@
 
 `free`
 
-- Display memory in Bytes/KiB/MiB/GiB:
+- Display memory in bytes/KiB/MiB/GiB:
 
 `free -{{b|k|m|g}}`
 
-- Display memory alongside the most appropriate human-readable unit (KiB/MiB/GiB etc):
+- Display memory in the most appropriate human-readable units (KiB/MiB/GiB etc):
 
 `free {{[-h|--human]}}`
 
-- Display memory alongside the most appropriate human-readable unit that is a power of 1000 (kB/MB/GB etc):
+- Display memory in the most appropriate human-readable unit that is a power of 1000 (kB/MB/GB etc):
 
 `free {{-h|--human}} --si`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

This pull request modifies the documentation for the `free` command to make it clear which units are being used (KiB/MiB/GiB or kB/MB/GB).