### PR TITLE
add kpsewhich page

### DIFF
--- a/pages/common/kpsewhich.md
+++ b/pages/common/kpsewhich.md
@@ -1,0 +1,24 @@
+# kpsewhich
+
+> Find TeX-related files and expand Kpathsea variables and paths.
+> More information: <https://manned.org/kpsewhich>.
+
+- Find a file in the TeX search path:
+
+`kpsewhich {{article.cls}}`
+
+- Find a file using a specific file format:
+
+`kpsewhich -format {{tex}} {{plain.tex}}`
+
+- Show the search path for a specific file format:
+
+`kpsewhich -show-path {{tex}}`
+
+- Print the value of a Kpathsea variable:
+
+`kpsewhich -var-value {{TEXMFHOME}}`
+
+- Search for a file in a specific path:
+
+`kpsewhich -path {{path/to/directory}} {{filename}}`


### PR DESCRIPTION
## Summary
- add a new common tldr page for `kpsewhich`
- include examples for file lookup, format-specific lookup, path display, variable expansion, and custom path lookup

Closes #23049.

## Validation
- `npx markdownlint pages/common/kpsewhich.md`
- `npx tldr-lint pages/common/kpsewhich.md`
- `npm test`