### PR TITLE
container: add page

### DIFF
--- a/pages/osx/container.md
+++ b/pages/osx/container.md
@@ -1,0 +1,37 @@
+# container
+
+> Create and run Linux containers as lightweight virtual machines on macOS.
+> Some subcommands such as `image`, `network`, and `system` have their own usage documentation.
+> More information: <https://github.com/apple/container>.
+
+- Start the container services (required before running containers):
+
+`container system start`
+
+- Run a container from an image interactively and remove it after it exits:
+
+`container run --rm {{[-i|--interactive]}} {{[-t|--tty]}} {{image}} {{sh}}`
+
+- Run a container in the background with a name and a published port:
+
+`container run {{[-d|--detach]}} --name {{container_name}} {{[-p|--publish]}} {{8080:80}} {{image}}`
+
+- Execute a command inside a running container:
+
+`container exec {{[-i|--interactive]}} {{[-t|--tty]}} {{container_name}} {{sh}}`
+
+- List all containers (running and stopped):
+
+`container {{[ls|list]}} {{[-a|--all]}}`
+
+- Follow the logs of a container:
+
+`container logs {{[-f|--follow]}} {{container_name}}`
+
+- Build an image from a Dockerfile in a directory:
+
+`container build {{[-t|--tag]}} {{image_name}} {{path/to/directory}}`
+
+- Stop or delete a container:
+
+`container {{stop|delete}} {{container_name}}`

--- a/pages/osx/container.md
+++ b/pages/osx/container.md
@@ -1,7 +1,6 @@
 # container
 
 > Create and run Linux containers as lightweight virtual machines on macOS.
-> Some subcommands such as `image`, `network`, and `system` have their own usage documentation.
 > More information: <https://github.com/apple/container>.
 
 - Start the container services (required before running containers):

--- a/pages/osx/container.md
+++ b/pages/osx/container.md
@@ -9,7 +9,7 @@
 
 - Run a container from an image interactively and remove it after it exits:
 
-`container run --rm {{[-i|--interactive]}} {{[-t|--tty]}} {{image}} {{sh}}`
+`container run --rm {{[-it|--interactive --tty]}} {{image}} {{sh}}`
 
 - Run a container in the background with a name and a published port:
 
@@ -17,7 +17,7 @@
 
 - Execute a command inside a running container:
 
-`container exec {{[-i|--interactive]}} {{[-t|--tty]}} {{container_name}} {{sh}}`
+`container exec {{[-it|--interactive --tty]}} {{container_name}} {{sh}}`
 
 - List all containers (running and stopped):
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.0.0
- Reference issue: #23039
- Closes: #23039

This adds a page for `container`, Apple's tool for running Linux containers in lightweight virtual machines on Apple silicon Macs. It is placed in `pages/osx/` since the tool is macOS-only.

All flags were checked against the official command reference (`docs/command-reference.md` in apple/container). Short options are kept ungrouped because the CLI (Swift ArgumentParser) does not support combined flags like `-it`. The structure follows the existing `docker.md` page, including the note that subcommands can get their own pages later.