### PR TITLE
clangd: update more info link

### DIFF
--- a/pages/common/clangd.md
+++ b/pages/common/clangd.md
@@ -2,7 +2,7 @@
 
 > Language server that provides IDE-like features to editors.
 > It should be used via an editor plugin rather than invoked directly.
-> More information: <https://manpages.ubuntu.com/manpages/man1/clangd.1>.
+> More information: <https://manned.org/clangd-22>.
 
 - Display available options:
 


### PR DESCRIPTION
I do not know of a stable manual page that always points towards the latest version. This will have to do