### PR TITLE
grub-{mkrescue,mount,probe,reboot,script-check}: add italian translation

### DIFF
--- a/pages.it/linux/grub-mkrescue.md
+++ b/pages.it/linux/grub-mkrescue.md
@@ -1,0 +1,36 @@
+# grub-mkrescue
+
+> Crea un'immagine avviabile GRUB per CD/USB/floppy.
+> Maggiori informazioni: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dmkrescue>.
+
+- Crea un ISO avviabile dalla directory corrente e lo salva come `grub.iso`:
+
+`grub-mkrescue --output {{grub.iso}} .`
+
+- Crea un ISO usando file GRUB da una directory personalizzata:
+
+`grub-mkrescue --directory {{/usr/lib/grub/i386-pc}} --output {{grub.iso}} {{path/to/source}}`
+
+- Usa la compressione per i file GRUB durante la creazione dell'immagine, impostando `no` disabilita la compressione:
+
+`grub-mkrescue --compress {{no|xz|gz|lzo}} --output {{grub.iso}} {{path/to/source}}`
+
+- Disabilita l'interfaccia a riga di comando GRUB nell'immagine generata:
+
+`grub-mkrescue --disable-cli --output {{grub.iso}} {{path/to/source}}`
+
+- Precarica moduli GRUB specifici nell'immagine:
+
+`grub-mkrescue --modules "{{part_gpt iso9660}}" --output {{grub.iso}} {{path/to/source}}`
+
+- Passa opzioni aggiuntive direttamente a `xorriso`:
+
+`grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{volume_name}} {{path/to/source}}`
+
+- Mostra aiuto:
+
+`grub-mkrescue {{[-?|--help]}}`
+
+- Mostra versione:
+
+`grub-mkrescue --version`

--- a/pages.it/linux/grub-mount.md
+++ b/pages.it/linux/grub-mount.md
@@ -1,0 +1,36 @@
+# grub-mount
+
+> Monta un filesystem o un'immagine di filesystem in sola lettura usando i driver GRUB.
+> Maggiori informazioni: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dmount>.
+
+- Monta un dispositivo a blocchi o un'immagine di filesystem su un punto di mount:
+
+`grub-mount {{/dev/sdXY}} {{/mnt}}`
+
+- Monta la seconda partizione di un'immagine disco completa, `-r` specifica il numero di partizione nell'immagine:
+
+`grub-mount {{[-r|--root]}} {{2}} {{disk.img}} {{/mnt}}`
+
+- Monta un dispositivo crittografato e richiede una passphrase:
+
+`grub-mount {{[-C|--crypto]}} {{/dev/sdXY}} {{/mnt}}`
+
+- Carica una chiave di crittografia ZFS da un file:
+
+`grub-mount {{[-K|--zfs-key]}} /{{path/to/zfs.key}} {{/dev/sdX}} {{/mnt}}`
+
+- Mostra output di debug per una categoria corrispondente:
+
+`grub-mount {{[-d|--debug]}} {{string}} {{image}} {{/mnt}}`
+
+- Abilita output verboso:
+
+`grub-mount {{[-v|--verbose]}} {{image}} {{/mnt}}`
+
+- Mostra aiuto:
+
+`grub-mount {{[-?|--help]}}`
+
+- Mostra versione:
+
+`grub-mount --version`

--- a/pages.it/linux/grub-probe.md
+++ b/pages.it/linux/grub-probe.md
@@ -1,0 +1,32 @@
+# grub-probe
+
+> Analizza le informazioni del dispositivo per un percorso o dispositivo particolare.
+> Maggiori informazioni: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dprobe.html>.
+
+- Ottiene il modulo filesystem GRUB per un percorso:
+
+`sudo grub-probe {{[-t|--target]}} fs {{/boot/grub}}`
+
+- Ottiene il dispositivo di sistema che contiene un percorso:
+
+`sudo grub-probe {{[-t|--target]}} device {{/boot/grub}}`
+
+- Ottiene il nome del disco GRUB per un dispositivo di sistema:
+
+`sudo grub-probe {{[-t|--target]}} drive {{/dev/sdX}} {{[-d|--device]}}`
+
+- Ottiene l'UUID del filesystem:
+
+`sudo grub-probe {{[-t|--target]}} fs_uuid {{/boot/grub}}`
+
+- Ottiene l'etichetta del filesystem:
+
+`sudo grub-probe {{[-t|--target]}} fs_label {{/boot/grub}}`
+
+- Ottiene il codice del tipo di partizione MBR (due cifre esadecimali):
+
+`sudo grub-probe {{[-t|--target]}} msdos_parttype {{/dev/sdX}}`
+
+- Analizza usando una mappa dispositivi personalizzata:
+
+`sudo grub-probe {{[-t|--target]}} drive {{/boot/grub}} {{[-m|--device-map]}} {{path/to/custom_device.map}}`

--- a/pages.it/linux/grub-reboot.md
+++ b/pages.it/linux/grub-reboot.md
@@ -1,0 +1,12 @@
+# grub-reboot
+
+> Imposta la voce di avvio predefinita per GRUB, solo per il prossimo avvio.
+> Maggiori informazioni: <https://manned.org/grub-reboot>.
+
+- Imposta la voce di avvio predefinita su un numero, nome o identificatore per il prossimo avvio:
+
+`sudo grub-reboot {{entry_number}}`
+
+- Imposta la voce di avvio predefinita su un numero, nome o identificatore per una directory di avvio alternativa per il prossimo avvio:
+
+`sudo grub-reboot --boot-directory /{{path/to/boot_directory}} {{entry_number}}`

--- a/pages.it/linux/grub-script-check.md
+++ b/pages.it/linux/grub-script-check.md
@@ -1,0 +1,21 @@
+# grub-script-check
+
+> Il programma `grub-script-check` prende un file script GRUB e lo controlla per errori di sintassi.
+> Può accettare un percorso come argomento non-opzione. Se non viene fornito, legge da `stdin`.
+> Maggiori informazioni: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dscript_002dcheck>.
+
+- Verifica un file script specifico per errori di sintassi:
+
+`grub-script-check {{path/to/grub_config_file}}`
+
+- Mostra ogni riga di input dopo averla letta:
+
+`grub-script-check {{[-v|--verbose]}}`
+
+- Mostra aiuto:
+
+`grub-script-check --help`
+
+- Mostra versione:
+
+`grub-script-check --version`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).