### PR TITLE
usb-creator: add page

### DIFF
--- a/pages/linux/usb-creator.md
+++ b/pages/linux/usb-creator.md
@@ -1,0 +1,37 @@
+# usb-creator
+
+> Create verified bootable USB installers for Linux and BSD systems.
+> Downloads are checksum and GPG verified, and disks backing the running system are never writable.
+> More information: <https://github.com/Reventlow/usb-creator>.
+
+- Start the interactive wizard (choose desktop/server, a system, and a target device):
+
+`usb-creator`
+
+- List candidate USB devices:
+
+`usb-creator list`
+
+- List all supported systems:
+
+`usb-creator distros`
+
+- Display what "latest" resolves to for a system, including how it will be verified:
+
+`usb-creator info {{arch}}`
+
+- Download and verify an image into the cache without writing it:
+
+`usb-creator download {{fedora}}`
+
+- Write the latest release of a system to a USB device:
+
+`usb-creator write --distro {{debian}} --device {{/dev/sdb}}`
+
+- Write a local image file to a USB device:
+
+`usb-creator write --iso {{path/to/image.iso}} --device {{/dev/sdb}}`
+
+- Update the tool itself (delegates to the package manager where applicable):
+
+`usb-creator update`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- **Version of the command being documented (if known):** 0.12.0
- Reference issue: #

---

Adds a page for [usb-creator](https://github.com/Reventlow/usb-creator), a single-file bash tool that creates bootable USB installers for Linux and BSD systems with checksum and GPG verification of downloads, and hard refusal to write to disks backing the running system. Placed under `linux` since it depends on util-linux (lsblk/findmnt).