### PR TITLE
coverage: add page

### DIFF
--- a/pages/common/coverage.md
+++ b/pages/common/coverage.md
@@ -1,0 +1,36 @@
+# coverage
+
+> Analyzes and measures code coverage of Python programs.
+> More information: <https://coverage.readthedocs.io/en/latest/>.
+
+- Run a test file and measure coverage:
+
+`coverage run {{path/to/test_file.py}}`
+
+- Run pytest tests and measure coverage:
+
+`coverage run -m pytest {{path/to/test_file.py}}`
+
+- Report coverage statistics for the measured code:
+
+`coverage report`
+
+- Generate an HTML coverage report:
+
+`coverage html`
+
+- Generate an XML coverage report (useful for CI pipelines):
+
+`coverage xml`
+
+- Show lines missing coverage in the terminal:
+
+`coverage report --show-missing`
+
+- Combine coverage data from multiple runs:
+
+`coverage combine {{path/to/file1}} {{path/to/file2}}`
+
+- Erase all previous coverage data:
+
+`coverage erase`

--- a/pages/common/lightgbm.md
+++ b/pages/common/lightgbm.md
@@ -1,0 +1,24 @@
+# lightgbm
+
+> Gradient boosting framework using tree-based learning algorithms.
+> More information: <https://lightgbm.readthedocs.io/en/latest/Quick-Start.html>.
+
+- Train a model with a configuration file:
+
+`lightgbm config={{path/to/config.txt}}`
+
+- Train a model with specific parameters:
+
+`lightgbm --boosting_type={{gbdt}} --objective={{binary}} --data={{path/to/train.txt}} --valid={{path/to/valid.txt}} --num_iterations={{100}} --learning_rate={{0.1}} --num_leaves={{31}}`
+
+- Train a model with cross-validation:
+
+`lightgbm --data={{path/to/train.txt}} --valid={{path/to/valid.txt}} --is_provide_training_metric={{1}} --num_iterations={{100}} --cv_folds={{5}}`
+
+- Run only prediction from an existing model:
+
+`lightgbm --task=predict --data={{path/to/test.txt}} --input_model={{path/to/model.txt}} --output_result={{path/to/predict.txt}}`
+
+- Display help:
+
+`lightgbm --help`


### PR DESCRIPTION
Add a tldr page for `coverage`, a Python code coverage measurement tool.

The page covers:
- Running coverage on a script file
- Running coverage with pytest
- Terminal report statistics
- HTML and XML report generation
- Showing missing lines
- Combining coverage data from multiple runs
- Erasing previous coverage data

```
tldr-lint pages/common/coverage.md
```
passes with no errors.