### PR TITLE
grafana-cli: update examples

### DIFF
--- a/pages/common/grafana-cli.md
+++ b/pages/common/grafana-cli.md
@@ -3,22 +3,26 @@
 > Administer Grafana.
 > More information: <https://grafana.com/docs/grafana/latest/administration/cli/>.
 
-- Install plugins:
+- Display help:
+
+`grafana cli --help`
+
+- Display the version:
+
+`grafana cli --version`
+
+- Install one or more plugins:
 
 `grafana cli plugins install {{plugin_id1 plugin_id2 ...}}`
 
-- Specify a homepath when installing a plugin:
+- Install a plugin using a custom plugin directory:
 
-`grafana cli --homepath {{/usr/share/grafana}} plugins install {{plugin_id}}`
-
-- Update plugins:
-
-`grafana cli plugins update {{plugin_id1 plugin_id2 ...}}`
-
-- Remove plugins:
-
-`grafana cli plugins remove {{plugin_id1 plugin_id2 ...}}`
+`grafana cli --pluginsDir {{path/to/plugins_directory}} plugins install {{plugin_id}}`
 
 - List all installed plugins:
 
 `grafana cli plugins ls`
+
+- Reset the admin password:
+
+`grafana cli admin reset-admin-password {{new_password}}`


### PR DESCRIPTION
Updates the `grafana-cli` page to better reflect broader Grafana CLI usage instead of only plugin-related commands.

The page now includes examples for displaying help, displaying the version, installing plugins, using a custom plugin directory, listing installed plugins, and resetting the admin password.

Validation:
- Ran `git diff --check`
- Reviewed the modified Markdown file
- Confirmed only `pages/common/grafana-cli.md` was changed

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Not known
- Reference issue: #23030
- Closes: #23030