### PR TITLE
docs: add testdisk page

### DIFF
--- a/pages/linux/testdisk.md
+++ b/pages/linux/testdisk.md
@@ -1,0 +1,25 @@
+# testdisk
+
+> Scan and recover lost disk partitions.
+> See also: `photorec`, `fdisk`.
+> More information: <https://www.cgsecurity.org/wiki/TestDisk>.
+
+- Start TestDisk on a specific device (interactive TUI):
+
+`sudo testdisk {{/dev/sdX}}`
+
+- Start TestDisk on a disk image:
+
+`sudo testdisk {{path/to/image.dd}}`
+
+- List partitions and write a log file:
+
+`sudo testdisk /list /log`
+
+- Start TestDisk with debug logging enabled:
+
+`sudo testdisk /debug /log {{/dev/sdX}}`
+
+- Show TestDisk version:
+
+`testdisk /version`


### PR DESCRIPTION
## Summary
- Add `pages/linux/testdisk.md` for TestDisk partition recovery.
- Covers device/image start, `/list`, debug logging, and `/version` from `testdisk(8)`.

Closes #23153

## Sources
- https://manned.org/testdisk.8
- https://www.cgsecurity.org/wiki/TestDisk
- Sibling style: `pages/linux/photorec.md`

## Test plan
- [x] `tldr-lint pages/linux/testdisk.md`
- [x] Flags cross-checked against man page (`/log`, `/debug`, `/list`, `/version`)

Signed-off-by: Alex Chen <l46983284@gmail.com>
