### PR TITLE
translation-templates/*: add Sinhala translations

### DIFF
--- a/contributing-guides/translation-templates/alias-pages.md
+++ b/contributing-guides/translation-templates/alias-pages.md
@@ -36,6 +36,7 @@ The templates can be changed when necessary.
 [pt_PT](#pt_pt) •
 [ro](#ro) •
 [ru](#ru) •
+[si](#si) •
 [sr](#sr) •
 [sv](#sv) •
 [ta](#ta) •
@@ -462,6 +463,20 @@ The templates can be changed when necessary.
 > Эта команда — псевдоним для `example`.
 
 - Смотри документацию для оригинальной команды:
+
+`tldr example`
+```
+
+---
+
+### si
+
+```markdown
+# example
+
+> මෙම විධානය `example` සඳහා අන්වර්ථ නාමයක් වේ.
+
+- මුල් විධානය සඳහා ලේඛනය බලන්න:
 
 `tldr example`
 ```

--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -38,6 +38,7 @@ There, the old table can be **imported**, **edited** in a WYSIWYG editor and **e
 | pt_PT | caminho/para/ficheiro | caminho/para/diretório   | caminho/para/ficheiro_ou_diretório   | pacote        | nome_de_utilizador |                   |          |        |          |
 | ro    | cale/către/fișier     | cale/către/director      | cale/către/fișier_sau_director       | pachet        | nume_utilizator    | parolă            | comandă  | port   |          |
 | ru    | путь/к/файлу          | путь/к/каталогу          | путь/к/файлу_или_каталогу            | пакет         | имя_пользователя   | пароль            | команда  | порт   | значение |
+| si    | ගොනුව/වෙත/මාර්ගය         |  බහාලුම/වෙත/මාර්ගය         | ගොනුව_හෝ_බහාලුම/වෙත/මාර්ගය           | පැකේජය         | පරිශීලක_නාමය  | මුරපදය            | විධානය  | පොර්ට්   | අගය |
 | sr    | put/do/datoteke       | put/do/direktorijuma     | put/do/datoteke_ili_direktorijuma    | paket         | korisničko_ime     |                   |          |        |          |
 | sv    | sökväg/till/fil       | sökväg/till/katalog      | sökväg/till/fil_eller_katalog        | paket         | användarnamn       | lösenord          | kommando | port   | värde    |
 | ta    | கோப்பு/பாதை           | அடைவிற்குப்/பாதை         | கோப்பு_அல்லது_அடைவு/பாதை             | நிரல்தொகுப்பு | பயனர்ப்பெயர்       | கடவுச்சொல்        | கட்டளை   | குதை   | மதிப்பு  |

--- a/contributing-guides/translation-templates/common-descriptions.md
+++ b/contributing-guides/translation-templates/common-descriptions.md
@@ -36,6 +36,7 @@ Only the left-alignment of the header gets lost and has to be re-added again (`|
 | pt_PT |                    |                       |                  |
 | ro    | Afișare ajutor     | Afișare versiune      | [Interactiv]     |
 | ru    | Показать справку   | Показать версию       | [Интерактивно]   |
+| si    | උදව් දැක්වීම   | අනුවාදය දැක්වීම       | [අන්තර් ක්‍රියාකාරී]   |
 | sr    |                    |                       |                  |
 | sv    | Visa hjälpen       | Visa versionen        | [Interaktiv]     |
 | ta    | உதவியைக் காட்டு    | பதிப்பைக் காட்டு      | [ஊடாடும் கட்டளை] |

--- a/contributing-guides/translation-templates/more-info-link.md
+++ b/contributing-guides/translation-templates/more-info-link.md
@@ -288,6 +288,14 @@ The templates can be changed when necessary, but if so, it needs to be updated h
 
 ---
 
+### si
+
+```markdown
+> වැඩිදුර තොරතුරු සඳහා: <https://example.com>.
+```
+
+---
+
 ### sr
 
 ```markdown

--- a/contributing-guides/translation-templates/more-info-link.md
+++ b/contributing-guides/translation-templates/more-info-link.md
@@ -36,6 +36,7 @@ The templates can be changed when necessary, but if so, it needs to be updated h
 [pt_PT](#pt_pt) •
 [ro](#ro) •
 [ru](#ru) •
+[si](#si) •
 [sr](#sr) •
 [sv](#sv) •
 [ta](#ta) •

--- a/contributing-guides/translation-templates/see-also-mentions.md
+++ b/contributing-guides/translation-templates/see-also-mentions.md
@@ -37,6 +37,7 @@ This file contains the translation templates of this notice.
 [pt_PT](#pt_pt) •
 [ro](#ro) •
 [ru](#ru) •
+[si](#si) •
 [sr](#sr) •
 [sv](#sv) •
 [ta](#ta) •

--- a/contributing-guides/translation-templates/see-also-mentions.md
+++ b/contributing-guides/translation-templates/see-also-mentions.md
@@ -289,6 +289,14 @@ This file contains the translation templates of this notice.
 
 ---
 
+### si
+
+```markdown
+> මෙයද බලන්න: `example`.
+```
+
+---
+
 ### sr
 
 ```markdown

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -287,6 +287,14 @@ This file contains the translation templates of this notice.
 
 ---
 
+### si
+
+```markdown
+> `example` වැනි ඇතැම් අනු විධාන සඳහා, එයටම සඳහාම වූ ලේඛන පවතී.
+```
+
+---
+
 ### sr
 
 ```markdown

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -35,6 +35,7 @@ This file contains the translation templates of this notice.
 [pt_PT](#pt_pt) •
 [ro](#ro) •
 [ru](#ru) •
+[si](#si) •
 [sr](#sr) •
 [sv](#sv) •
 [ta](#ta) •

--- a/contributing-guides/translation-templates/subcommand-mention.md
+++ b/contributing-guides/translation-templates/subcommand-mention.md
@@ -290,7 +290,7 @@ This file contains the translation templates of this notice.
 ### si
 
 ```markdown
-> `example` වැනි ඇතැම් අනු විධාන සඳහා, එයටම සඳහාම වූ ලේඛන පවතී.
+> `example` වැනි ඇතැම් අනු විධාන සඳහා, එය සඳහාම වූ ලේඛන පවතී.
 ```
 
 ---


### PR DESCRIPTION
### Description 
This PR introduces initial Sinhala Translations in translation-templates.

##### Changed files
- alias-pages.md        
- common-arguments.md   
- common-descriptions.md
- more-info-link.md     
- see-also-mentions.md  
- subcommand-mention.md 

#### Changes
- Translated the foundational markdown files in the 'translations-templates' directory.
- Changes are according to the Contribution Guidelines.
- No original paths or directories changed.