### PR TITLE
multipass: update more info link

### DIFF
--- a/pages/common/multipass.md
+++ b/pages/common/multipass.md
@@ -1,7 +1,7 @@
 # multipass
 
 > Manage Ubuntu virtual machines using native hypervisors.
-> More information: <https://documentation.ubuntu.com/multipass/latest/reference/command-line-interface/>.
+> More information: <https://canonical.com/multipass/docs/latest/reference/command-line-interface/>.
 
 - List the aliases that can be used to launch an instance:
 


### PR DESCRIPTION
previous url: documentation.ubuntu.com is a 301 the canonical.com url (updated in commit)

Proof of url change/direct:
```
$ curl -v 'https://documentation.ubuntu.com/multipass/latest/reference/command-line-interface/' 2>&1| grep location:
< location: https://canonical.com/multipass/docs//latest/reference/command-line-interface/

```

Also, the CLA is signed 


<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
