### PR TITLE
k3d: document cluster list examples

### DIFF
--- a/pages/common/k3d.md
+++ b/pages/common/k3d.md
@@ -11,6 +11,14 @@
 
 `k3d cluster delete {{cluster_name}}`
 
+- List existing clusters:
+
+`k3d cluster list`
+
+- List clusters as JSON:
+
+`k3d cluster list {{[-o|--output]}} json`
+
 - Create a new containerized k3s node:
 
 `k3d node create {{node_name}}`


### PR DESCRIPTION
## Summary
Adds `k3d cluster list` examples to the existing `k3d` page, including JSON output.

Closes #22958

## Notes
- Examples match current k3d CLI (`--no-headers` / `-o json|yaml` exist; kept the common list + JSON cases)
- Page stays within the 8-example limit

## Validation
- `tldr-lint pages/common/k3d.md`