### PR TITLE
duff: add page

### DIFF
--- a/pages/linux/duff.md
+++ b/pages/linux/duff.md
@@ -1,0 +1,33 @@
+# duff
+
+> Find duplicate files.
+> See also: `fdupes`, `jdupes`.
+> More information: <https://github.com/elmindreda/duff>.
+
+- Find duplicate files in a directory recursively:
+
+`duff -r {{path/to/directory}}`
+
+- Find duplicate files and list all but one file from each cluster:
+
+`duff -er {{path/to/directory}}`
+
+- Find unique files instead of duplicates:
+
+`duff -ur {{path/to/directory}}`
+
+- Search recursively and include hidden files:
+
+`duff -ra {{path/to/directory}}`
+
+- Use a specific message digest function:
+
+`duff -d {{sha256}} -r {{path/to/directory}}`
+
+- Do not report empty files as duplicates:
+
+`duff -zr {{path/to/directory}}`
+
+- Read NUL-terminated paths from `stdin` and print NUL-terminated results:
+
+`find {{path/to/directory}} -type f -print0 | duff -0`


### PR DESCRIPTION
## Summary
Adds a new page for `duff`, a duplicate file finder.

Closes #23220

## Notes
- `duff` only exposes short options in its man page, so examples use short flags
- Platform set to `linux` per the issue request
- Project has been maintained for well over a year (public since 2011, last push 2024)

## Validation
- `tldr-lint pages/linux/duff.md`