### PR TITLE
rmpc: add page

### DIFF
--- a/pages/linux/rmpc.md
+++ b/pages/linux/rmpc.md
@@ -1,0 +1,37 @@
+# rmpc
+
+> A modern terminal Music Player Daemon (MPD) client with album art support.
+> See also: `ncmpcpp`, `mpc`, `mpd`.
+> More information: <https://rmpc.mierak.dev>.
+
+- Start the interactive client:
+
+`rmpc`
+
+- Connect to a specific MPD address:
+
+`rmpc {{[-a|--address]}} {{ip_address:port}}`
+
+- Toggle play/pause:
+
+`rmpc togglepause`
+
+- Play the next or previous song:
+
+`rmpc {{next|prev}}`
+
+- Set or print the current volume:
+
+`rmpc volume {{volume}}`
+
+- Add a path from the music library to the queue:
+
+`rmpc add {{path/to/song_or_directory}}`
+
+- Save the current song's album art to a file:
+
+`rmpc albumart {{[-o|--output]}} {{path/to/cover.png}}`
+
+- Print the default config to bootstrap a config file:
+
+`rmpc config`


### PR DESCRIPTION
## Summary
Adds a new page for `rmpc` (Rusty Music Player Client), a modern terminal MPD client.

Closes #22392

## Notes
- Examples cover both the interactive TUI entrypoint and common CLI subcommands from the upstream clap interface
- Platform set to `linux` per the issue request
- Project is actively maintained (3k+ stars, created 2024-03, still receiving updates)

## Validation
- `tldr-lint pages/linux/rmpc.md`