### PR TITLE
kpsewhich: add page

### DIFF
--- a/pages/common/kpsewhich.md
+++ b/pages/common/kpsewhich.md
@@ -1,0 +1,24 @@
+# kpsewhich
+
+> Find TeX-related files and expand Kpathsea variables and paths.
+> More information: <https://tug.org/texinfohtml/kpathsea.html#Invoking-kpsewhich>.
+
+- Find a file in the TeX search path:
+
+`kpsewhich {{article.cls}}`
+
+- Find a file using a specific file format:
+
+`kpsewhich -format={{tex}} {{plain.tex}}`
+
+- Show the search path for a specific file format:
+
+`kpsewhich -show-path={{tex}}`
+
+- Print the value of a Kpathsea variable:
+
+`kpsewhich -var-value={{TEXMFHOME}}`
+
+- Search for a file only in a specific path:
+
+`kpsewhich -path={{path/to/directory}} {{filename}}`


### PR DESCRIPTION
## Summary
Adds a new page for `kpsewhich`, the standalone Kpathsea path lookup tool used with TeX Live.

Closes #23049

## Notes
- Examples cover the common lookup/show-path/var-value/path cases from the Kpathsea docs
- Earlier attempt #23064 was closed without merge (CLA/stale); rebased on current main with CLA already signed for this account

## Validation
- `tldr-lint pages/common/kpsewhich.md`