### PR TITLE
oras: add page

### DIFF
--- a/pages/common/oras.md
+++ b/pages/common/oras.md
@@ -1,0 +1,37 @@
+# oras
+
+> Manage artifacts in OCI registries and image layouts.
+> Some subcommands such as `pull`, `push`, and `manifest` have their own usage documentation.
+> More information: <https://oras.land/docs/commands/use_oras_cli/>.
+
+- Log in to a remote registry:
+
+`oras login {{registry}}`
+
+- Push a local file to a registry reference:
+
+`oras push {{registry}}/{{repository}}:{{tag}} {{path/to/file}}`
+
+- Pull artifact files from a registry reference:
+
+`oras pull {{registry}}/{{repository}}:{{tag}}`
+
+- Copy an artifact between registries:
+
+`oras cp {{source_registry}}/{{repository}}:{{tag}} {{destination_registry}}/{{repository}}:{{tag}}`
+
+- List repositories in a registry:
+
+`oras repo ls {{registry}}`
+
+- List tags for a repository:
+
+`oras repo tags {{registry}}/{{repository}}`
+
+- Tag an existing artifact with a new tag:
+
+`oras tag {{registry}}/{{repository}}:{{tag}} {{new_tag}}`
+
+- Show the installed ORAS version:
+
+`oras version`


### PR DESCRIPTION
## Summary
Adds a new overview page for `oras` (OCI Registry As Storage), covering the common registry workflows.

Closes #22180

## Notes
- Examples follow the official CLI docs: login, push, pull, cp, repo ls/tags, tag, version
- Structure mirrors sibling registry tools such as `crane`
- Previous attempts (#22182, #22538) closed without merge; this is a fresh page on current main with CLA already signed

## Validation
- `tldr-lint pages/common/oras.md`
