### PR TITLE
firstboot: add page

### DIFF
--- a/pages/linux/firstboot.md
+++ b/pages/linux/firstboot.md
@@ -1,0 +1,17 @@
+# firstboot
+
+> Reset an OpenWrt device to factory defaults by wiping the overlay filesystem.
+> See also: `sysupgrade`.
+> More information: <https://openwrt.org/docs/guide-user/troubleshooting/failsafe_and_factory_reset>.
+
+- Reset configuration to factory defaults (prompts for confirmation):
+
+`firstboot`
+
+- Reset without prompting for confirmation:
+
+`firstboot -y`
+
+- Reset to factory defaults, then restart the device:
+
+`firstboot -y && reboot`


### PR DESCRIPTION
## Summary
Adds a new page for OpenWrt firstboot (soft factory reset of the overlay).

Part of #22787

## Notes
- Covers interactive reset, non-interactive -y, and common reset then restart flow from the OpenWrt factory-reset guide
- Platform set to linux (OpenWrt userland)

## Validation
- tldr-lint pages/linux/firstboot.md
