### PR TITLE
jffs2reset: add page

### DIFF
--- a/pages/linux/jffs2reset.md
+++ b/pages/linux/jffs2reset.md
@@ -1,0 +1,17 @@
+# jffs2reset
+
+> Reset the OpenWrt overlay filesystem to factory defaults.
+> See also: `firstboot`, `sysupgrade`.
+> More information: <https://openwrt.org/docs/guide-user/troubleshooting/failsafe_and_factory_reset>.
+
+- Reset the overlay filesystem (prompts for confirmation):
+
+`jffs2reset`
+
+- Reset without prompting for confirmation:
+
+`jffs2reset -y`
+
+- Reset the overlay, then restart the device:
+
+`jffs2reset -y && reboot`


### PR DESCRIPTION
## Summary
Adds a new page for OpenWrt jffs2reset (overlay factory reset).

Part of #22787

## Notes
- Covers interactive reset, non-interactive -y, and reset then restart flow from the OpenWrt factory-reset guide
- See also firstboot and sysupgrade
- Platform set to linux (OpenWrt userland)

## Validation
- tldr-lint pages/linux/jffs2reset.md
