### PR TITLE
grafana-cli: expand plugin examples and link admin page

### DIFF
--- a/pages/common/grafana-cli.md
+++ b/pages/common/grafana-cli.md
@@ -1,24 +1,37 @@
 # grafana cli
 
-> Administer Grafana.
+> Administer Grafana plugins and related CLI options.
+> See also: `grafana cli admin`.
 > More information: <https://grafana.com/docs/grafana/latest/administration/cli/>.
 
 - Install plugins:
 
 `grafana cli plugins install {{plugin_id1 plugin_id2 ...}}`
 
-- Specify a homepath when installing a plugin:
+- Install a plugin using a specific Grafana home directory:
 
 `grafana cli --homepath {{/usr/share/grafana}} plugins install {{plugin_id}}`
 
-- Update plugins:
+- List plugins available from the remote repository:
+
+`grafana cli plugins list-remote`
+
+- List all installed plugins:
+
+`grafana cli plugins ls`
+
+- Update one or more plugins:
 
 `grafana cli plugins update {{plugin_id1 plugin_id2 ...}}`
+
+- Update all installed plugins:
+
+`grafana cli plugins update-all`
 
 - Remove plugins:
 
 `grafana cli plugins remove {{plugin_id1 plugin_id2 ...}}`
 
-- List all installed plugins:
+- Display help:
 
-`grafana cli plugins ls`
+`grafana cli {{[-h|--help]}}`


### PR DESCRIPTION
## Summary
Expands the grafana-cli page beyond a short plugin-only list, and points to grafana-cli-admin for administrator commands.

Closes #23030

## Notes
- Adds list-remote, update-all, help, and see-also for grafana cli admin (already documented separately)
- Keeps the page focused on common plugin workflows from the official Grafana CLI docs

## Validation
- tldr-lint pages/common/grafana-cli.md
