### PR TITLE
gws: add page

### DIFF
--- a/pages/common/gws.md
+++ b/pages/common/gws.md
@@ -1,0 +1,33 @@
+# gws
+
+> Google Workspace CLI for Drive, Gmail, Calendar, Sheets, Docs, Chat, and more.
+> Commands are generated dynamically from Google's Discovery Service.
+> More information: <https://github.com/googleworkspace/cli>.
+
+- Walk through Google Cloud project and OAuth setup:
+
+`gws auth setup`
+
+- Log in with OAuth:
+
+`gws auth login`
+
+- List Drive files:
+
+`gws drive files list --params '{"pageSize": 10}'`
+
+- Create a Google Sheet:
+
+`gws sheets spreadsheets create --json '{"properties": {"title": "Q1 Budget"}}'`
+
+- Preview a Chat API request without sending it:
+
+`gws chat spaces messages create --params '{"parent": "spaces/xyz"}' --json '{"text": "Deploy complete."}' --dry-run`
+
+- Show help for a dynamically discovered method:
+
+`gws drive files list --help`
+
+- Print the installed CLI version:
+
+`gws --version`


### PR DESCRIPTION
## Summary
Adds a new page for `gws` (Google Workspace CLI).

Closes #21936

## Notes
- Project is actively maintained and well over the one-year guidance (public CLI with 29k+ stars)
- Examples follow the upstream quick start and common Drive/Sheets/Chat flows

## Validation
- `tldr-lint pages/common/gws.md`
