### PR TITLE
fw_printenv: add page

### DIFF
--- a/pages/linux/fw_printenv.md
+++ b/pages/linux/fw_printenv.md
@@ -1,0 +1,17 @@
+# fw_printenv
+
+> Print U-Boot environment variables from Linux userspace.
+> See also: `fw_setenv`.
+> More information: <https://manned.org/fw_printenv>.
+
+- Print the entire U-Boot environment:
+
+`fw_printenv`
+
+- Print specific environment variables:
+
+`fw_printenv {{bootcmd bootargs ...}}`
+
+- Use a specific configuration file:
+
+`fw_printenv {{[-c|--config]}} {{path/to/fw_env.config}}`


### PR DESCRIPTION
## Summary
Adds a page for `fw_printenv` (print U-Boot environment from Linux).

Part of #22787

## Validation
- tldr-lint pages/linux/fw_printenv.md
