### PR TITLE
fw_setenv: add page

### DIFF
--- a/pages/linux/fw_setenv.md
+++ b/pages/linux/fw_setenv.md
@@ -1,0 +1,21 @@
+# fw_setenv
+
+> Modify U-Boot environment variables from Linux userspace.
+> See also: `fw_printenv`.
+> More information: <https://manned.org/fw_setenv>.
+
+- Set or update an environment variable:
+
+`fw_setenv {{name}} {{value}}`
+
+- Delete an environment variable:
+
+`fw_setenv {{name}}`
+
+- Use a specific configuration file:
+
+`fw_setenv {{[-c|--config]}} {{path/to/fw_env.config}} {{name}} {{value}}`
+
+- Apply multiple variable changes from a script file:
+
+`fw_setenv {{[-s|--script]}} {{path/to/script}}`


### PR DESCRIPTION
## Summary
Adds a page for `fw_setenv` (modify U-Boot environment from Linux).

Part of #22787

## Validation
- tldr-lint pages/linux/fw_setenv.md
