### PR TITLE
sync: split Linux and macOS platform pages

### DIFF
--- a/pages/common/sync.md
+++ b/pages/common/sync.md
@@ -6,7 +6,3 @@
 - Flush all pending write operations on all disks:
 
 `sync`
-
-- Flush all pending write operations on a single file to disk:
-
-`sync {{path/to/file}}`

--- a/pages/linux/sync.md
+++ b/pages/linux/sync.md
@@ -1,6 +1,7 @@
 # sync
 
 > Flush pending write operations to disk.
+> See also: `sync` for common usage.
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/sync-invocation.html>.
 
 - Flush all pending write operations on all disks:
@@ -10,3 +11,7 @@
 - Flush all pending write operations on a single file to disk:
 
 `sync {{path/to/file}}`
+
+- Flush writes and drop filesystem caches:
+
+`sync; echo 3 | sudo tee /proc/sys/vm/drop_caches`

--- a/pages/linux/sync.md
+++ b/pages/linux/sync.md
@@ -1,17 +1,20 @@
 # sync
 
-> Flush pending write operations to disk.
-> See also: `sync` for common usage.
+> Flush pending write operations to disk (GNU coreutils).
 > More information: <https://www.gnu.org/software/coreutils/manual/html_node/sync-invocation.html>.
 
 - Flush all pending write operations on all disks:
 
 `sync`
 
-- Flush all pending write operations on a single file to disk:
+- Flush pending writes for specific files:
 
-`sync {{path/to/file}}`
+`sync {{path/to/file1 path/to/file2 ...}}`
 
-- Flush writes and drop filesystem caches:
+- Flush pending writes for specific filesystems:
+
+`sync {{[-f|--file-system]}} {{path/to/file1 path/to/file2 ...}}`
+
+- Flush pending writes, then drop pagecache, dentries, and inodes:
 
 `sync; echo 3 | sudo tee /proc/sys/vm/drop_caches`

--- a/pages/osx/sync.md
+++ b/pages/osx/sync.md
@@ -1,10 +1,10 @@
 # sync
 
-> Flush pending write operations to disk.
-> See also: `sync` for common usage, `purge`.
+> Force completion of pending disk writes.
+> See also: `purge`.
 > More information: <https://keith.github.io/xcode-man-pages/sync.8.html>.
 
-- Flush all pending write operations on all disks:
+- Flush all pending disk writes:
 
 `sync`
 

--- a/pages/osx/sync.md
+++ b/pages/osx/sync.md
@@ -1,0 +1,13 @@
+# sync
+
+> Flush pending write operations to disk.
+> See also: `sync` for common usage, `purge`.
+> More information: <https://keith.github.io/xcode-man-pages/sync.8.html>.
+
+- Flush all pending write operations on all disks:
+
+`sync`
+
+- Flush disk writes, then clear inactive memory and filesystem caches:
+
+`sync; sudo purge`


### PR DESCRIPTION
## Summary
Split the mixed `sync` page into platform-specific Linux and macOS pages, keeping a short common page for the shared flush commands.

Closes #19794

## Notes
- Linux keeps the `/proc/sys/vm/drop_caches` example
- macOS uses `sync; sudo purge` and points at the BSD man page
- Common page retains portable `sync` / `sync file` usage

## Validation
- tldr-lint pages/common/sync.md pages/linux/sync.md pages/osx/sync.md
