### PR TITLE
wifi: add OpenWrt page

### DIFF
--- a/pages/linux/wifi.md
+++ b/pages/linux/wifi.md
@@ -1,0 +1,36 @@
+# wifi
+
+> Enable, disable, and reconfigure wireless radios on OpenWrt.
+> More information: <https://openwrt.org/docs/guide-user/network/wifi/basic>.
+
+- Bring up all wireless devices (default action):
+
+`wifi`
+
+- Bring up a specific radio device:
+
+`wifi up {{radio0}}`
+
+- Shut down all wireless devices:
+
+`wifi down`
+
+- Shut down a specific radio device:
+
+`wifi down {{radio0}}`
+
+- Reload wireless configuration without a full network restart:
+
+`wifi reload`
+
+- Reconfigure wireless after editing `/etc/config/wireless`:
+
+`wifi reconf`
+
+- Show wireless status:
+
+`wifi status`
+
+- Detect hardware and write a default wireless config:
+
+`wifi config`


### PR DESCRIPTION
## Summary
Adds an OpenWrt `wifi` page covering up/down/reload/reconf/status/config.

Part of #22787

## Validation
- tldr-lint pages/linux/wifi.md
