### PR TITLE
topgrade, github-backup: add pages

### DIFF
--- a/pages/common/github-backup.md
+++ b/pages/common/github-backup.md
@@ -1,0 +1,23 @@
+# github-backup
+
+> Backup a GitHub user or organization's repositories and metadata.
+> More information: <https://github.com/josegonzalez/python-github-backup>.
+
+- Backup a user's repositories:
+  `github-backup {{username}} --output-directory {{path/to/directory}} --repositories`
+
+  - Backup a user's repositories including private ones:
+    `github-backup {{username}} --token {{github_token}} --output-directory {{path/to/directory}} --repositories --private`
+
+    - Backup an organization's repositories:
+      `github-backup {{organization}} --output-directory {{path/to/directory}} --repositories --organization`
+
+      - Backup repositories and also include issues and pull requests:
+        `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --issues --pulls`
+
+        - Backup a single repository of a user:
+          `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --repository {{repository_name}}`
+
+          - Backup a user's repositories including wikis:
+            `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --wikis`
+            

--- a/pages/common/github-backup.md
+++ b/pages/common/github-backup.md
@@ -4,20 +4,25 @@
 > More information: <https://github.com/josegonzalez/python-github-backup>.
 
 - Backup a user's repositories:
-  `github-backup {{username}} --output-directory {{path/to/directory}} --repositories`
 
-  - Backup a user's repositories including private ones:
-    `github-backup {{username}} --token {{github_token}} --output-directory {{path/to/directory}} --repositories --private`
+`github-backup {{username}} --output-directory {{path/to/directory}} --repositories`
 
-    - Backup an organization's repositories:
-      `github-backup {{organization}} --output-directory {{path/to/directory}} --repositories --organization`
+- Backup repositories including private ones (requires a GitHub token):
 
-      - Backup repositories and also include issues and pull requests:
-        `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --issues --pulls`
+`github-backup {{username}} --token {{github_token}} --output-directory {{path/to/directory}} --repositories --private`
 
-        - Backup a single repository of a user:
-          `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --repository {{repository_name}}`
+- Backup an organization's repositories:
 
-          - Backup a user's repositories including wikis:
-            `github-backup {{username}} --output-directory {{path/to/directory}} --repositories --wikis`
-            
+`github-backup {{organization}} --output-directory {{path/to/directory}} --repositories --organization`
+
+- Backup repositories and also include issues and pull requests:
+
+`github-backup {{username}} --output-directory {{path/to/directory}} --repositories --issues --pulls`
+
+- Backup a single specific repository of a user:
+
+`github-backup {{username}} --output-directory {{path/to/directory}} --repositories --repository {{repository_name}}`
+
+- Backup repositories including wikis:
+
+`github-backup {{username}} --output-directory {{path/to/directory}} --repositories --wikis`

--- a/pages/common/topgrade.md
+++ b/pages/common/topgrade.md
@@ -1,28 +1,33 @@
 # topgrade
 
-> Update all applications on the system.
-> More information: <https://github.com/r-darwish/topgrade>.
-
-- Run updates:
-
-`topgrade`
-
-- Say yes to all updates:
-
-`topgrade {{[-y|--yes]}}`
-
-- Cleanup temporary/old files:
-
-`topgrade {{[-c|--cleanup]}}`
-
-- Disable a certain update operation:
-
-`topgrade --disable {{operation}}`
-
-- Only perform a certain update operation:
-
-`topgrade --only {{operation}}`
-
-- Edit the configuration file with default editor:
-
-`topgrade --edit-config`
+> Upgrade all the things.
+> > More information: <https://github.com/topgrade-rs/topgrade>.
+> >
+> > - Update everything:
+> >
+> > - `topgrade`
+> >
+> > - - Run only specific update steps:
+> >  
+> >   - `topgrade --only {{step_name1}} --only {{step_name2}}`
+> >  
+> >   - - Skip specific update steps:
+> >    
+> >     - `topgrade --disable {{step_name1}} --disable {{step_name2}}`
+> >    
+> >     - - Dry run (show what would run without making changes):
+> >      
+> >       - `topgrade --dry-run`
+> >      
+> >       - - Only check for available updates without installing them:
+> >        
+> >         - `topgrade --check`
+> >        
+> >         - - Open the configuration file:
+> >          
+> >           - `topgrade --edit-config`
+> >          
+> >           - - Clean up old package versions and caches after upgrading:
+> >            
+> >             - `topgrade --cleanup`
+> >             - 

--- a/pages/common/topgrade.md
+++ b/pages/common/topgrade.md
@@ -2,30 +2,31 @@
 
 > Upgrade all the things.
 > More information: <https://github.com/topgrade-rs/topgrade>.
+
 - Update everything:
 
-  `topgrade`
+`topgrade`
 
-  - Run only specific update steps (use `topgrade --help` to see all step names):
+- Run only specific update steps (use `topgrade --help` to see all step names):
 
-    `topgrade --only {{step_name1,step_name2}}`
+`topgrade --only {{step_name1,step_name2}}`
 
-    - Skip specific update steps:
+- Skip specific update steps:
 
-      `topgrade --disable {{step_name1,step_name2}}`
+`topgrade --disable {{step_name1,step_name2}}`
 
-      - Perform a dry run (show what would be done, but don't make changes):
+- Perform a dry run (show what would be done, but don't make changes):
 
-        `topgrade --dry-run`
+`topgrade --dry-run`
 
-        - Only check for available updates without installing them:
+- Only check for available updates without installing them:
 
-          `topgrade --check`
+`topgrade --check`
 
-          - Open the configuration file in the default editor:
+- Open the configuration file in the default editor:
 
-            `topgrade --edit-config`
+`topgrade --edit-config`
 
-            - Cleanup old package versions after upgrading:
+- Cleanup old package versions after upgrading:
 
-              `topgrade --cleanup`
+`topgrade --cleanup`

--- a/pages/common/topgrade.md
+++ b/pages/common/topgrade.md
@@ -1,33 +1,31 @@
 # topgrade
 
 > Upgrade all the things.
-> > More information: <https://github.com/topgrade-rs/topgrade>.
-> >
-> > - Update everything:
-> >
-> > - `topgrade`
-> >
-> > - - Run only specific update steps:
-> >  
-> >   - `topgrade --only {{step_name1}} --only {{step_name2}}`
-> >  
-> >   - - Skip specific update steps:
-> >    
-> >     - `topgrade --disable {{step_name1}} --disable {{step_name2}}`
-> >    
-> >     - - Dry run (show what would run without making changes):
-> >      
-> >       - `topgrade --dry-run`
-> >      
-> >       - - Only check for available updates without installing them:
-> >        
-> >         - `topgrade --check`
-> >        
-> >         - - Open the configuration file:
-> >          
-> >           - `topgrade --edit-config`
-> >          
-> >           - - Clean up old package versions and caches after upgrading:
-> >            
-> >             - `topgrade --cleanup`
-> >             - 
+> More information: <https://github.com/topgrade-rs/topgrade>.
+- Update everything:
+
+  `topgrade`
+
+  - Run only specific update steps (use `topgrade --help` to see all step names):
+
+    `topgrade --only {{step_name1,step_name2}}`
+
+    - Skip specific update steps:
+
+      `topgrade --disable {{step_name1,step_name2}}`
+
+      - Perform a dry run (show what would be done, but don't make changes):
+
+        `topgrade --dry-run`
+
+        - Only check for available updates without installing them:
+
+          `topgrade --check`
+
+          - Open the configuration file in the default editor:
+
+            `topgrade --edit-config`
+
+            - Cleanup old package versions after upgrading:
+
+              `topgrade --cleanup`


### PR DESCRIPTION
### What does this pull request do?

Add two new tldr pages:

- `topgrade`: A tool that upgrades all the things (system packages, package managers, etc.)
- `github-backup`: A tool for backing up a GitHub user or organization's repositories and metadata
