### PR TITLE
dpkg-buildpackage, drm_info, dump.exfat, dutree: add Korean translation

### DIFF
--- a/pages.ko/linux/dpkg-buildpackage.md
+++ b/pages.ko/linux/dpkg-buildpackage.md
@@ -1,0 +1,34 @@
+# dpkg-buildpackage
+
+> 소스 코드로부터 Debian 바이너리 및/또는 소스 패키지를 빌드.
+> 일반적으로 `debian/` 디렉터리를 포함한 소스 트리에서 실행됨.
+> 빌드 의존성 처리, `.buildinfo` 및 `.changes` 파일 생성, 필요한 경우 결과물 서명도 수행.
+> 더 많은 정보: <https://manned.org/dpkg-buildpackage>.
+
+- 소스 및 바이너리 패키지 생성:
+
+`dpkg-buildpackage`
+
+- 바이너리 패키지만 생성 (소스 패키지는 생성하지 않음):
+
+`dpkg-buildpackage {{[-b|--build=binary]}}`
+
+- 소스 패키지만 생성 (바이너리 컴파일 없이):
+
+`dpkg-buildpackage {{[-S|--build=source]}}`
+
+- `.dsc` 및 `.changes` 파일에 서명하지 않음:
+
+`dpkg-buildpackage {{[-us|--unsigned-source]}} {{[-uc|--unsigned-changes]}}`
+
+- 컴파일 전에 `clean` 대상 실행 생략:
+
+`dpkg-buildpackage {{[-nc|--no-pre-clean]}}`
+
+- 빌드 중 루트 권한 획득을 위해 `fakeroot` 사용:
+
+`dpkg-buildpackage {{[-r|--root-command=]}}fakeroot`
+
+- 지정한 `debian/rules` 대상 실행:
+
+`dpkg-buildpackage {{[-T|--rules-target=]}}{{clean}}`

--- a/pages.ko/linux/drm_info.md
+++ b/pages.ko/linux/drm_info.md
@@ -1,0 +1,12 @@
+# drm_info
+
+> Direct Rendering Manager 장치 정보를 출력.
+> 더 많은 정보: <https://manned.org/drm_info>.
+
+- DRM 정보 출력:
+
+`drm_info`
+
+- DRM 정보를 JSON([j]SON) 형식으로 출력:
+
+`drm_info -j`

--- a/pages.ko/linux/dump.exfat.md
+++ b/pages.ko/linux/dump.exfat.md
@@ -1,0 +1,8 @@
+# dump.exfat
+
+> exFAT 파일시스템의 디스크 상(On-disk) 정보를 표시.
+> 더 많은 정보: <https://manned.org/dump.exfat>.
+
+- 지정한 파일 시스템의 디스크 상(On-disk) 정보 출력:
+
+`dump.exfat {{/dev/sdXY}}`

--- a/pages.ko/linux/dutree.md
+++ b/pages.ko/linux/dutree.md
@@ -1,0 +1,28 @@
+# dutree
+
+> 컬러 텍스트 기반 트리 형태로 파일 시스템 사용량을 분석.
+> 더 많은 정보: <https://github.com/nachoparker/dutree#usage>.
+
+- 현재 디렉터리의 트리 형태 사용량 표시:
+
+`dutree`
+
+- 지정한 디렉터리의 사용량 표시:
+
+`dutree {{경로/대상/디렉터리}}`
+
+- 지정한 크기(KB - K, MB - M, GB - G)보다 작은 항목을 하나로 묶어 표시:
+
+`dutree --aggr {{숫자}}K`
+
+- 지정한 깊이까지 하위 디렉터리 표시 (기본값: 1):
+
+`dutree --depth {{깊이}}`
+
+- 파일만 표시하여 빠르게 개요 확인:
+
+`dutree --files-only`
+
+- 숨김 파일 제외:
+
+`dutree --no-hidden`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
