### PR TITLE
linux: add ufw allow, status, and reload subcommand pages

### DIFF
--- a/pages/linux/ufw-allow.md
+++ b/pages/linux/ufw-allow.md
@@ -1,0 +1,33 @@
+# ufw allow
+
+> Allow incoming or outgoing traffic through the Uncomplicated Firewall.
+> See also: `ufw`, `ufw deny`.
+> More information: <https://manned.org/ufw>.
+
+- Allow incoming traffic on a port:
+
+`sudo ufw allow {{port}}`
+
+- Allow traffic for a specific protocol and port:
+
+`sudo ufw allow {{port}}/{{tcp|udp}}`
+
+- Allow traffic from a specific IP address:
+
+`sudo ufw allow from {{ip_address}}`
+
+- Allow TCP traffic from a specific IP to a port on this host:
+
+`sudo ufw allow proto tcp from {{ip_address}} to any port {{port}}`
+
+- Allow traffic on a specific network interface:
+
+`sudo ufw allow in on {{eth0}} to any port {{port}}`
+
+- Allow traffic using an application profile:
+
+`sudo ufw allow '{{Nginx Full}}'`
+
+- Allow traffic and add a comment describing the rule:
+
+`sudo ufw allow {{port}} comment '{{Description}}'`

--- a/pages/linux/ufw-reload.md
+++ b/pages/linux/ufw-reload.md
@@ -1,0 +1,9 @@
+# ufw reload
+
+> Reload the Uncomplicated Firewall without disabling it.
+> See also: `ufw`, `ufw status`.
+> More information: <https://manned.org/ufw>.
+
+- Reload firewall rules after editing `/etc/ufw/` configuration files:
+
+`sudo ufw reload`

--- a/pages/linux/ufw-status.md
+++ b/pages/linux/ufw-status.md
@@ -1,0 +1,17 @@
+# ufw status
+
+> Show the current status and rules of the Uncomplicated Firewall.
+> See also: `ufw`, `ufw reload`.
+> More information: <https://manned.org/ufw>.
+
+- Show whether the firewall is active and list rules:
+
+`sudo ufw status`
+
+- Show rules with line numbers (useful for deleting rules):
+
+`sudo ufw status numbered`
+
+- Show verbose output including logging and default policies:
+
+`sudo ufw status verbose`

--- a/pages/linux/ufw.md
+++ b/pages/linux/ufw.md
@@ -2,6 +2,7 @@
 
 > Uncomplicated Firewall.
 > Frontend for `iptables` aiming to make configuration of a firewall easier.
+> See also: `ufw allow`, `ufw status`, `ufw reload`.
 > More information: <https://manned.org/ufw>.
 
 - Enable/Disable `ufw`:


### PR DESCRIPTION
## Summary
- Add `ufw allow`, `ufw status`, and `ufw reload` subcommand pages under `pages/linux/`
- Cross-link the new pages from the main `ufw` page

Partially addresses #23098 (allow, status, reload).

## Test plan
- [x] `npx tldr-lint` passes on all changed files
- [x] Pre-commit test suite passes locally

Made with [Cursor](https://cursor.com)