### PR TITLE
linux: add ufw deny, default, and logging pages

### DIFF
--- a/pages/linux/ufw-allow.md
+++ b/pages/linux/ufw-allow.md
@@ -1,0 +1,33 @@
+# ufw allow
+
+> Allow traffic through the Uncomplicated Firewall.
+> See also: `ufw`, `ufw status`.
+> More information: <https://manned.org/ufw>.
+
+- Allow incoming traffic on a port:
+
+`sudo ufw allow {{port}}`
+
+- Allow traffic for a specific protocol and port:
+
+`sudo ufw allow {{port}}/{{tcp|udp}}`
+
+- Allow traffic from a specific IP address:
+
+`sudo ufw allow from {{ip_address}}`
+
+- Allow TCP traffic from a specific IP to a port on this host:
+
+`sudo ufw allow proto tcp from {{ip_address}} to any port {{port}}`
+
+- Allow traffic on a specific network interface:
+
+`sudo ufw allow in on {{interface}} to any port {{port}}`
+
+- Allow traffic using an application profile:
+
+`sudo ufw allow "{{Nginx Full}}"`
+
+- Allow traffic and add a comment describing the rule:
+
+`sudo ufw allow {{port}} comment "{{Service}}"`

--- a/pages/linux/ufw-default.md
+++ b/pages/linux/ufw-default.md
@@ -1,0 +1,17 @@
+# ufw default
+
+> Set the default policy for the Uncomplicated Firewall.
+> See also: `ufw`, `ufw status`, `ufw allow`.
+> More information: <https://manned.org/ufw>.
+
+- Set the default policy for incoming traffic:
+
+`sudo ufw default {{allow|deny|reject}} incoming`
+
+- Set the default policy for outgoing traffic:
+
+`sudo ufw default {{allow|deny|reject}} outgoing`
+
+- Set the default policy for routed traffic:
+
+`sudo ufw default {{allow|deny|reject}} routed`

--- a/pages/linux/ufw-deny.md
+++ b/pages/linux/ufw-deny.md
@@ -1,0 +1,25 @@
+# ufw deny
+
+> Deny traffic through the Uncomplicated Firewall.
+> See also: `ufw`, `ufw allow`, `ufw status`.
+> More information: <https://manned.org/ufw>.
+
+- Deny incoming traffic on a port:
+
+`sudo ufw deny {{port}}`
+
+- Deny traffic for a specific protocol and port:
+
+`sudo ufw deny {{port}}/{{tcp|udp}}`
+
+- Deny traffic from a specific IP address:
+
+`sudo ufw deny from {{ip_address}}`
+
+- Deny UDP traffic to a range of ports:
+
+`sudo ufw deny proto udp from any to any port {{start_port}}:{{end_port}}`
+
+- Deny traffic and add a comment describing the rule:
+
+`sudo ufw deny {{port}} comment "{{Service}}"`

--- a/pages/linux/ufw-logging.md
+++ b/pages/linux/ufw-logging.md
@@ -1,0 +1,17 @@
+# ufw logging
+
+> Configure logging for the Uncomplicated Firewall.
+> See also: `ufw`, `ufw status`.
+> More information: <https://manned.org/ufw>.
+
+- Enable logging with the default level:
+
+`sudo ufw logging on`
+
+- Disable logging:
+
+`sudo ufw logging off`
+
+- Set a specific logging level:
+
+`sudo ufw logging {{low|medium|high|full}}`

--- a/pages/linux/ufw-reload.md
+++ b/pages/linux/ufw-reload.md
@@ -1,0 +1,9 @@
+# ufw reload
+
+> Reload the Uncomplicated Firewall without disabling it.
+> See also: `ufw`, `ufw status`.
+> More information: <https://manned.org/ufw>.
+
+- Reload firewall rules after editing `/etc/ufw/` configuration files:
+
+`sudo ufw reload`

--- a/pages/linux/ufw-status.md
+++ b/pages/linux/ufw-status.md
@@ -1,0 +1,17 @@
+# ufw status
+
+> Show the current status and rules of the Uncomplicated Firewall.
+> See also: `ufw`, `ufw allow`, `ufw reload`.
+> More information: <https://manned.org/ufw>.
+
+- Show whether the firewall is active and list rules:
+
+`sudo ufw status`
+
+- Show rules with line numbers (useful for deleting rules):
+
+`sudo ufw status numbered`
+
+- Show verbose output including logging and default policies:
+
+`sudo ufw status verbose`

--- a/pages/linux/ufw.md
+++ b/pages/linux/ufw.md
@@ -2,7 +2,7 @@
 
 > Uncomplicated Firewall.
 > Frontend for `iptables` aiming to make configuration of a firewall easier.
-> See also: `ufw allow`, `ufw status`, `ufw reload`.
+> See also: `ufw allow`, `ufw deny`, `ufw status`, `ufw default`, `ufw logging`, `ufw reload`.
 > More information: <https://manned.org/ufw>.
 
 - Enable/Disable `ufw`:

--- a/pages/linux/ufw.md
+++ b/pages/linux/ufw.md
@@ -2,6 +2,7 @@
 
 > Uncomplicated Firewall.
 > Frontend for `iptables` aiming to make configuration of a firewall easier.
+> See also: `ufw allow`, `ufw status`, `ufw reload`.
 > More information: <https://manned.org/ufw>.
 
 - Enable/Disable `ufw`:


### PR DESCRIPTION
## Summary
- Add `ufw deny`, `ufw default`, and `ufw logging` pages
- Extend see-also links on the main `ufw` page

Partial fix for #23098 (alongside allow/status/reload and the open enable/disable PR).

## Test plan
- [x] Page structure matches sibling subcommand pages
- [x] Examples aligned with common `ufw` manpage usage
