### PR TITLE
tshark: fix to claim it only captures default interface

### DIFF
--- a/pages/linux/tshark.md
+++ b/pages/linux/tshark.md
@@ -3,7 +3,7 @@
 > Packet analysis tool, CLI version of Wireshark.
 > More information: <https://tshark.dev/#sitemap-in-tshark---help>.
 
-- Monitor everything on localhost:
+- Monitor packets from the default interface:
 
 `tshark`
 


### PR DESCRIPTION
The previous claim of "localhost" is usually wrong because `man tshark` says it avoids loopback interfaces, and it only captures one interface instead of "everything".

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 4.6.4.
- Reference issue: N/A
- Closes: N/A
