### PR TITLE
numbat: add page

### DIFF
--- a/pages.es/common/numbat.md
+++ b/pages.es/common/numbat.md
@@ -1,7 +1,7 @@
 # numbat
 
 > Una calculadora científica de tipado estático con soporte de primera clase para unidades físicas.
-> Véase también: `qalc`, `bc`.
+> Vea también: `qalc`, `bc`.
 > Más información: <https://numbat.dev>.
 
 - Inicia una sesión interactiva:

--- a/pages.es/common/numbat.md
+++ b/pages.es/common/numbat.md
@@ -1,0 +1,29 @@
+# numbat
+
+> Una calculadora científica de tipado estático con soporte de primera clase para unidades físicas.
+> Véase también: `qalc`, `bc`.
+> Más información: <https://numbat.dev>.
+
+- Inicia una sesión interactiva:
+
+`numbat`
+
+- [E]valúa una o más expresiones:
+
+`numbat {{[-e|--expression]}} '{{2 hours + 30 minutes -> seconds}}'`
+
+- Ejecuta un script de Numbat:
+
+`numbat {{ruta/al/script.nbt}}`
+
+- Entra en una sesión [i]nteractiva tras ejecutar un script o expresión:
+
+`numbat {{[-i|--inspect-interactively]}} {{ruta/al/script.nbt}}`
+
+- [N]o cargues el preludio de dimensiones y unidades predefinidas:
+
+`numbat {{[-N|--no-prelude]}}`
+
+- Genera un archivo de configuración predeterminado:
+
+`numbat --generate-config`

--- a/pages.es/common/numbat.md
+++ b/pages.es/common/numbat.md
@@ -2,7 +2,7 @@
 
 > Una calculadora científica de tipado estático con soporte de primera clase para unidades físicas.
 > Vea también: `qalc`, `bc`.
-> Más información: <https://numbat.dev>.
+> Más información: <https://numbat.dev/docs/cli/usage>.
 
 - Inicia una sesión interactiva:
 

--- a/pages/common/numbat.md
+++ b/pages/common/numbat.md
@@ -2,7 +2,7 @@
 
 > A statically-typed scientific calculator with first-class support for physical units.
 > See also: `qalc`, `bc`.
-> More information: <https://numbat.dev>.
+> More information: <https://numbat.dev/docs/cli/usage>.
 
 - Start an interactive session:
 

--- a/pages/common/numbat.md
+++ b/pages/common/numbat.md
@@ -1,0 +1,29 @@
+# numbat
+
+> A statically-typed scientific calculator with first-class support for physical units.
+> See also: `qalc`, `bc`.
+> More information: <https://numbat.dev>.
+
+- Start an interactive session:
+
+`numbat`
+
+- Evaluate one or more expressions:
+
+`numbat {{[-e|--expression]}} '{{2 hours + 30 minutes -> seconds}}'`
+
+- Run a Numbat script:
+
+`numbat {{path/to/script.nbt}}`
+
+- Enter an interactive session after running a script or expression:
+
+`numbat {{[-i|--inspect-interactively]}} {{path/to/script.nbt}}`
+
+- Start without loading the prelude of predefined dimensions and units:
+
+`numbat {{[-N|--no-prelude]}}`
+
+- Generate a default configuration file:
+
+`numbat --generate-config`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.23.0
- Reference issue: #
- Closes: #

Adds English and Spanish pages for `numbat`, a statically-typed scientific calculator with first-class support for physical units (<https://numbat.dev>). Examples were verified against numbat 1.23.0.
