### PR TITLE
dns-sd: add page

### DIFF
--- a/pages/osx/dns-sd.md
+++ b/pages/osx/dns-sd.md
@@ -1,0 +1,28 @@
+# dns-sd
+
+> Discover, resolve, and advertise network services using Multicast DNS (mDNS) and DNS Service Discovery (DNS-SD).
+> More information: <https://keith.github.io/xcode-man-pages/dns-sd.1.html>.
+
+- Browse for all HTTP services in the local domain:
+
+`dns-sd -B {{_http._tcp}} local`
+
+- Resolve a service and display its hostname, port, and TXT records:
+
+`dns-sd -L "{{service_name}}" {{_http._tcp}} local`
+
+- Look up IPv4 and IPv6 addresses for a hostname:
+
+`dns-sd -G v4v6 {{hostname}}`
+
+- Query a DNS resource record:
+
+`dns-sd -q {{hostname}} {{A}} {{IN}}`
+
+- Advertise an HTTP service on a specific port:
+
+`dns-sd -R "{{service_name}}" {{_http._tcp}} local {{port}}`
+
+- Display the version of the running mDNSResponder daemon:
+
+`dns-sd -V`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** macOS Xcode man page
- Reference issue: #20354
- Closes: #20354

### Summary

- Add a macOS page for discovering, resolving, querying, and advertising DNS-SD services.
- Link to the current Apple/Xcode man-page export.

### Validation

- `npx tldr-lint pages/osx/dns-sd.md`
- `npx markdownlint pages/osx/dns-sd.md`
- Repository pre-commit test suite

### AI assistance disclosure

This page was drafted with AI assistance. Every command and option was checked against the Apple/Xcode `dns-sd(1)` man page, and the repository linters pass. The human-review checklist remains unchecked pending the contributor's review.