### PR TITLE
kscreenctl: add page

### DIFF
--- a/pages/linux/kscreenctl.md
+++ b/pages/linux/kscreenctl.md
@@ -1,0 +1,21 @@
+# kscreenctl
+
+> Manage display outputs on KDE Plasma (intended replacement for `kscreen-doctor`).
+> See also: `kscreen-doctor`, `kscreen-console`.
+> More information: <https://invent.kde.org/plasma/kscreen/-/merge_requests/487>.
+
+- Show an on-screen popup on each connected monitor to identify them:
+
+`kscreenctl identify`
+
+- Run a command against the currently active output:
+
+`kscreenctl active-output calibrate-hdr`
+
+- Run a command against a specific output:
+
+`kscreenctl {{HDMI-A-1}} {{command}}`
+
+- Display help:
+
+`kscreenctl {{help|--help}}`


### PR DESCRIPTION
### Checklist

- [x] The page follows the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)
- [x] The command works on Linux
- [x] I have checked that there aren't other open pull requests for the same change

### Summary

Add a `kscreenctl` page for the new KDE Plasma display CLI (replacement direction for `kscreen-doctor`).

Examples follow the upstream MR description: global commands (`identify`) and `OUTPUT command` / `active-output` forms.

Closes #23313
