### PR TITLE
Add marzban page

### DIFF
--- a/pages/linux/marzban.md
+++ b/pages/linux/marzban.md
@@ -1,0 +1,24 @@
+# marzban
+
+> Command-line tool for managing Marzban proxy servers.
+> More information: <https://github.com/Gozargah/Marzban>.
+
+- Create a new admin user:
+
+`marzban admin create --username {{username}}`
+
+- List all admin users:
+
+`marzban admin list`
+
+- Import the sudo admin from environment variables:
+
+`marzban admin import-from-env`
+
+- Delete an admin user:
+
+`marzban admin delete --username {{username}}`
+
+- Install shell completion for a specified shell:
+
+`marzban completion install --shell {{bash|zsh|fish}}`


### PR DESCRIPTION
## Description

Add a `marzban` page covering the most common CLI subcommands (admin management and shell completion), based on the official CLI documentation: https://github.com/Gozargah/Marzban/blob/master/cli/README.md

Closes #21925

## Checklist
- [x] Page is in the correct platform directory (`pages/linux`)
- [x] Page follows the formatting guidelines
- [x] `marzban` command does not already exist