### PR TITLE
Add ifreload page

### DIFF
--- a/pages/linux/ifreload.md
+++ b/pages/linux/ifreload.md
@@ -1,0 +1,24 @@
+# ifreload
+
+> Reload network interface configuration.
+> More information: <https://manned.org/ifreload>.
+
+- Reload all interfaces marked as "auto" in the interfaces file:
+
+`ifreload -a`
+
+- Reload only the interfaces that are currently up:
+
+`ifreload -c`
+
+- Reload all "auto" interfaces with verbose output:
+
+`ifreload -v -a`
+
+- Check the syntax of the interfaces file without applying any changes:
+
+`ifreload -s`
+
+- Reload all "auto" interfaces while excluding specific ones:
+
+`ifreload -a -X "eth0"`


### PR DESCRIPTION
## Description

Add an `ifreload` page (reload network interface configuration) for Linux, based on the official man page: https://manned.org/ifreload

Closes #23331

## Checklist
- [x] Page is in the correct platform directory (`pages/linux`)
- [x] Page follows the formatting guidelines
- [x] `ifreload` command does not already exist