### PR TITLE
tldr: add --short-option example

### DIFF
--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -28,10 +28,10 @@
 
 `tldr {{[-l|--list]}}`
 
+- Print the tldr page for a command with short options:
+
+`tldr {{[--short-options]}} {{command}}`
+
 - Browse tldr pages in a terminal window (`fzf` must be available):
 
 `tldr {{[-l|--list]}} | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr`
-
-- Print the tldr page for a random command:
-
-`tldr {{[-l|--list]}} | shuf {{[-n|--head-count]}} 1 | xargs tldr`

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -28,7 +28,7 @@
 
 `tldr {{[-l|--list]}}`
 
-- Print the tldr page for a command with short options:
+- Print the tldr page for a command and display short options:
 
 `tldr --short-options {{command}}`
 

--- a/pages/common/tldr.md
+++ b/pages/common/tldr.md
@@ -30,7 +30,7 @@
 
 - Print the tldr page for a command with short options:
 
-`tldr {{[--short-options]}} {{command}}`
+`tldr --short-options {{command}}`
 
 - Browse tldr pages in a terminal window (`fzf` must be available):
 


### PR DESCRIPTION
Also remove shuffle example to keep within 8 options.
I think this example is more useful. Also I question the value of the `fzf` example, which seems extremely specific, but I have left it in.

I would like to also document `export TLDR_OPTIONS=short` because I think a lot of people would want it (I did), but that appears to be python client-specific.

<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

