### PR TITLE
pages.zh: add 7 new translations (sha1sum, sha512sum, od, mktemp, readlink, realpath, shuf)

### DIFF
--- a/pages.zh/common/mktemp.md
+++ b/pages.zh/common/mktemp.md
@@ -1,0 +1,24 @@
+# mktemp
+
+> 创建临时文件或目录。
+> 更多信息：<https://man.openbsd.org/mktemp.1>。
+
+- 创建空临时文件并打印其绝对路径：
+
+`mktemp`
+
+- 如果未设置 `$TMPDIR`，则使用自定义目录（默认值因平台而异，通常为 `/tmp`）：
+
+`mktemp -p /{{路径/到/临时目录}}`
+
+- 使用自定义路径模板（`X` 被替换为随机字母数字字符）：
+
+`mktemp {{/tmp/example.XXXXXXXX}}`
+
+- 使用自定义文件名模板：
+
+`mktemp -t {{example.XXXXXXXX}}`
+
+- 创建空临时目录并打印其绝对路径：
+
+`mktemp -d`

--- a/pages.zh/common/od.md
+++ b/pages.zh/common/od.md
@@ -1,0 +1,30 @@
+# od
+
+> 以八进制、十进制或十六进制格式显示文件内容。
+> 可选显示每行的字节偏移量和/或可打印字符表示。
+> 另请参阅：`hexyl`、`xxd`、`hexdump`。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/od-invocation.html>。
+
+- 以默认设置显示文件：八进制格式，每行 8 字节，八进制字节偏移量，重复行替换为 `*`：
+
+`od {{路径/到/文件}}`
+
+- 以详细模式显示文件，即不替换重复行：
+
+`od {{[-v|--output-duplicates]}} {{路径/到/文件}}`
+
+- 以十六进制格式（2 字节单位）和十进制字节偏移量显示文件：
+
+`od {{[-t|--format]}} {{x}} {{[-A|--address-radix]}} {{d}} {{[-v|--output-duplicates]}} {{路径/到/文件}}`
+
+- 以十六进制格式（1 字节单位）和每行 4 字节显示文件：
+
+`od {{[-t|--format]}} {{x1}} {{[-w|--width=]}}4 {{[-v|--output-duplicates]}} {{路径/到/文件}}`
+
+- 以十六进制格式及其字符表示显示文件，不打印字节偏移量：
+
+`od {{[-t|--format]}} {{xz}} {{[-A|--address-radix]}} {{n}} {{[-v|--output-duplicates]}} {{路径/到/文件}}`
+
+- 从第 500 个字节开始读取文件的 100 个字节：
+
+`od {{[-N|--read-bytes]}} 100 {{[-j|--skip-bytes]}} 500 {{[-v|--output-duplicates]}} {{路径/到/文件}}`

--- a/pages.zh/common/readlink.md
+++ b/pages.zh/common/readlink.md
@@ -1,0 +1,12 @@
+# readlink
+
+> 跟踪符号链接并获取符号链接信息。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/readlink-invocation.html>。
+
+- 获取符号链接指向的实际文件：
+
+`readlink {{路径/到/文件}}`
+
+- 获取文件的绝对路径：
+
+`readlink {{[-f|--canonicalize]}} {{路径/到/文件}}`

--- a/pages.zh/common/realpath.md
+++ b/pages.zh/common/realpath.md
@@ -1,0 +1,24 @@
+# realpath
+
+> 显示文件或目录的解析后绝对路径。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/realpath-invocation.html>。
+
+- 显示文件或目录的绝对路径：
+
+`realpath {{路径/到/文件或目录}}`
+
+- 要求所有路径组件都必须存在：
+
+`realpath {{[-e|--canonicalize-existing]}} {{路径/到/文件或目录}}`
+
+- 在符号链接之前解析 `..` 组件：
+
+`realpath {{[-L|--logical]}} {{路径/到/文件或目录}}`
+
+- 禁用符号链接展开：
+
+`realpath {{[-s|--no-symlinks]}} {{路径/到/文件或目录}}`
+
+- 抑制错误消息：
+
+`realpath {{[-q|--quiet]}} {{路径/到/文件或目录}}`

--- a/pages.zh/common/sha1sum.md
+++ b/pages.zh/common/sha1sum.md
@@ -1,0 +1,32 @@
+# sha1sum
+
+> 计算 SHA1 加密校验和。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/sha1sum-invocation.html>。
+
+- 计算一个或多个文件的 SHA1 校验和：
+
+`sha1sum {{路径/到/文件1 路径/到/文件2 ...}}`
+
+- 计算并保存 SHA1 校验和列表到文件：
+
+`sha1sum {{路径/到/文件1 路径/到/文件2 ...}} > {{路径/到/文件.sha1}}`
+
+- 从 `stdin` 计算 SHA1 校验和：
+
+`{{命令}} | sha1sum`
+
+- 读取 SHA1 校验和文件并验证所有文件是否匹配：
+
+`sha1sum {{[-c|--check]}} {{路径/到/文件.sha1}}`
+
+- 仅对缺失文件或验证失败显示消息：
+
+`sha1sum {{[-c|--check]}} --quiet {{路径/到/文件.sha1}}`
+
+- 验证失败时显示消息，忽略缺失文件：
+
+`sha1sum --ignore-missing {{[-c|--check]}} --quiet {{路径/到/文件.sha1}}`
+
+- 检查文件的已知 SHA1 校验和：
+
+`echo {{文件的已知_sha1_校验和}} {{路径/到/文件}} | sha1sum {{[-c|--check]}}`

--- a/pages.zh/common/sha512sum.md
+++ b/pages.zh/common/sha512sum.md
@@ -1,0 +1,32 @@
+# sha512sum
+
+> 计算 SHA512 加密校验和。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/sha2-utilities.html>。
+
+- 计算一个或多个文件的 SHA512 校验和：
+
+`sha512sum {{路径/到/文件1 路径/到/文件2 ...}}`
+
+- 计算并保存 SHA512 校验和列表到文件：
+
+`sha512sum {{路径/到/文件1 路径/到/文件2 ...}} > {{路径/到/文件.sha512}}`
+
+- 从 `stdin` 计算 SHA512 校验和：
+
+`{{命令}} | sha512sum`
+
+- 读取 SHA512 校验和文件并验证所有文件是否匹配：
+
+`sha512sum {{[-c|--check]}} {{路径/到/文件.sha512}}`
+
+- 仅对缺失文件或验证失败显示消息：
+
+`sha512sum {{[-c|--check]}} --quiet {{路径/到/文件.sha512}}`
+
+- 验证失败时显示消息，忽略缺失文件：
+
+`sha512sum --ignore-missing {{[-c|--check]}} --quiet {{路径/到/文件.sha512}}`
+
+- 检查文件的已知 SHA512 校验和：
+
+`echo {{文件的已知_sha512_校验和}} {{路径/到/文件}} | sha512sum {{[-c|--check]}}`

--- a/pages.zh/common/shuf.md
+++ b/pages.zh/common/shuf.md
@@ -1,0 +1,20 @@
+# shuf
+
+> 生成随机排列。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/shuf-invocation.html>。
+
+- 随机排列文件中的行并输出结果：
+
+`shuf {{路径/到/文件}}`
+
+- 仅输出结果的前 5 行：
+
+`shuf {{[-n|--head-count]}} 5 {{路径/到/文件}}`
+
+- 将输出写入另一个文件：
+
+`shuf {{路径/到/输入文件}} {{[-o|--output]}} {{路径/到/输出文件}}`
+
+- 生成 3 个 1-10 范围内的随机数（含，数字可重复）：
+
+`shuf {{[-n|--head-count]}} 3 {{[-i|--input-range]}} 1-10 {{[-r|--repeat]}}`


### PR DESCRIPTION
## Summary

Adds 7 new Simplified Chinese translations:

- **sha1sum** — SHA1 checksum
- **sha512sum** — SHA512 checksum
- **od** — octal/hex viewer
- **mktemp** — create temporary files
- **readlink** — follow symlinks
- **realpath** — resolve absolute paths
- **shuf** — random permutations

Closes #13579

## Checklist

- [x] All pages pass lint-markdown and lint-tldr-pages
- [x] Follows the style guide