### PR TITLE
pages.zh: add 5 new translations (mesg, mkfifo, nproc, numfmt, pathchk)

### DIFF
--- a/pages.zh/common/mesg.md
+++ b/pages.zh/common/mesg.md
@@ -1,0 +1,17 @@
+# mesg
+
+> 检查或设置终端接收其他用户消息的能力（通常来自 `write` 命令）。
+> 另请参阅：`write`、`talk`。
+> 更多信息：<https://manned.org/mesg.1p>。
+
+- 检查终端是否开放接收消息：
+
+`mesg`
+
+- 禁止接收 write 命令的消息：
+
+`mesg n`
+
+- 允许接收 write 命令的消息：
+
+`mesg y`

--- a/pages.zh/common/mkfifo.md
+++ b/pages.zh/common/mkfifo.md
@@ -1,0 +1,20 @@
+# mkfifo
+
+> 创建命名管道，也称为先进先出（FIFO）。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/mkfifo-invocation.html>。
+
+- 在给定路径创建命名管道：
+
+`mkfifo {{路径/到/管道}}`
+
+- 通过命名管道发送数据并将命令发送到后台：
+
+`echo "{{Hello World}}" > {{路径/到/管道}} &`
+
+- 通过命名管道接收数据：
+
+`cat {{路径/到/管道}}`
+
+- 实时共享终端会话：
+
+`mkfifo {{路径/到/管道}}; script {{[-f|--flush]}} {{路径/到/管道}}`

--- a/pages.zh/common/nproc.md
+++ b/pages.zh/common/nproc.md
@@ -1,0 +1,16 @@
+# nproc
+
+> 打印可用的处理单元（通常是 CPU）数量。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/nproc-invocation.html>。
+
+- 显示可用的处理单元数量：
+
+`nproc`
+
+- 显示已安装的处理单元数量，包括非活动的：
+
+`nproc --all`
+
+- 如果可能，从返回值中减去给定数量的单元：
+
+`nproc --ignore {{数量}}`

--- a/pages.zh/common/numfmt.md
+++ b/pages.zh/common/numfmt.md
@@ -1,0 +1,28 @@
+# numfmt
+
+> 在数字和人类可读的字符串之间转换。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/numfmt-invocation.html>。
+
+- 将 1.5K（SI 单位）转换为 1500：
+
+`numfmt --from si 1.5K`
+
+- 将 1500 转换为 1.5K（SI 单位）：
+
+`numfmt --to si 1500`
+
+- 将 1.5K（IEC 单位）转换为 1536：
+
+`numfmt --from iec 1.5K`
+
+- 根据后缀使用适当的转换：
+
+`numfmt --from auto {{1.5Ki}}`
+
+- 将第 5 个字段（从 1 开始计数）转换为 IEC 单位，不转换表头：
+
+`ls -l | numfmt --header=1 --field 5 --to iec`
+
+- 转换为 IEC 单位，左对齐填充 5 个字符：
+
+`du {{[-s|--summarize]}} * | numfmt --to iec --format "%-5f"`

--- a/pages.zh/common/pathchk.md
+++ b/pages.zh/common/pathchk.md
@@ -1,0 +1,20 @@
+# pathchk
+
+> 检查路径名的有效性和可移植性。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/pathchk-invocation.html>。
+
+- 检查当前系统中文件路径的有效性：
+
+`pathchk {{路径1 路径2 ...}}`
+
+- 检查更广泛的 POSIX 兼容系统中文件路径的有效性：
+
+`pathchk -p {{路径1 路径2 ...}}`
+
+- 检查所有 POSIX 兼容系统中文件路径的有效性：
+
+`pathchk {{[-p -P|--portability]}} {{路径1 路径2 ...}}`
+
+- 仅检查空路径名或前导破折号（-）：
+
+`pathchk -P {{路径1 路径2 ...}}`


### PR DESCRIPTION
## Summary

Adds 5 new Simplified Chinese translations:
- **mesg** — terminal message control
- **mkfifo** — create named pipes
- **nproc** — print CPU count
- **numfmt** — human-readable numbers
- **pathchk** — check path validity

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages