### PR TITLE
pages.zh: add 2 new translations (arping, basenc)

### DIFF
--- a/pages.zh/common/arping.md
+++ b/pages.zh/common/arping.md
@@ -1,0 +1,29 @@
+# arping
+
+> 使用 ARP 协议在网络中探测主机。
+> 适用于 MAC 地址发现。
+> 更多信息：<https://manned.org/arping>。
+
+- 通过 ARP 请求包 Ping 主机：
+
+`sudo arping {{主机_ip}}`
+
+- 在特定接口上 Ping 主机：
+
+`sudo arping -I {{接口}} {{主机_ip}}`
+
+- Ping 主机并在第一次回复后结束：
+
+`sudo arping -f {{主机_ip}}`
+
+- Ping 主机特定次数：
+
+`sudo arping -c {{次数}} {{主机_ip}}`
+
+- 广播 ARP 请求包以更新邻居的 ARP 缓存（非请求 ARP 模式）：
+
+`sudo arping -U {{要广播的_ip}}`
+
+- 通过发送带有 3 秒超时的 ARP 请求来检测网络中的重复 IP 地址：
+
+`sudo arping -D -w {{3}} {{要检查的_ip}}`

--- a/pages.zh/common/basenc.md
+++ b/pages.zh/common/basenc.md
@@ -1,0 +1,8 @@
+# basenc
+
+> 使用指定的编码对文件或 `stdin` 进行编码或解码，输出到 `stdout`。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/basenc-invocation.html>。
+
+- 使用 Base64 编码对文件进行编码：
+
+`basenc --base64 {{路径/到/文件}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **arping** — ARP protocol host discovery
- **basenc** — base encoding/decoding utility

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages