### PR TITLE
pages.zh: add 2 new translations (mesg, mkfifo)

### DIFF
--- a/pages.zh/common/mesg.md
+++ b/pages.zh/common/mesg.md
@@ -1,0 +1,17 @@
+# mesg
+
+> 检查或设置终端接收其他用户消息的能力（通常来自 `write` 命令）。
+> 另请参阅：`write`、`talk`。
+> 更多信息：<https://manned.org/mesg.1p>。
+
+- 检查终端是否开放接收消息：
+
+`mesg`
+
+- 禁止接收 write 命令的消息：
+
+`mesg n`
+
+- 允许接收 write 命令的消息：
+
+`mesg y`

--- a/pages.zh/common/mkfifo.md
+++ b/pages.zh/common/mkfifo.md
@@ -1,0 +1,20 @@
+# mkfifo
+
+> 创建命名管道，也称为先进先出（FIFO）。
+> 更多信息：<https://www.gnu.org/software/coreutils/manual/html_node/mkfifo-invocation.html>。
+
+- 在给定路径创建命名管道：
+
+`mkfifo {{路径/到/管道}}`
+
+- 通过命名管道发送数据并将命令发送到后台：
+
+`echo "{{Hello World}}" > {{路径/到/管道}} &`
+
+- 通过命名管道接收数据：
+
+`cat {{路径/到/管道}}`
+
+- 实时共享终端会话：
+
+`mkfifo {{路径/到/管道}}; script {{[-f|--flush]}} {{路径/到/管道}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **mesg** — terminal message control
- **mkfifo** — create named pipes

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages