### PR TITLE
pages.zh: add 2 new translations (bats, bazel)

### DIFF
--- a/pages.zh/common/bats.md
+++ b/pages.zh/common/bats.md
@@ -1,0 +1,28 @@
+# bats
+
+> Bash 自动化测试系统：符合 TAP（<https://testanything.org/>）的 Bash 测试框架。
+> 更多信息：<https://bats-core.readthedocs.io/en/stable/usage.html>。
+
+- 运行 BATS 测试脚本并以 TAP（Test Anything Protocol）格式输出结果：
+
+`bats {{[-t|--tap]}} {{路径/到/test.bats}}`
+
+- 计算测试脚本的测试用例数量而不运行任何测试：
+
+`bats {{[-c|--count]}} {{路径/到/test.bats}}`
+
+- 递归运行 BATS 测试用例（扩展名为 `.bats` 的文件）：
+
+`bats {{[-r|--recursive]}} {{路径/到/目录}}`
+
+- 以特定格式输出结果：
+
+`bats {{[-F|--formatter]}} {{pretty|tap|tap13|junit}} {{路径/到/test.bats}}`
+
+- 为测试添加计时信息：
+
+`bats {{[-T|--timing]}} {{路径/到/test.bats}}`
+
+- 并行运行特定数量的作业（需要安装 GNU `parallel`）：
+
+`bats {{[-j|--jobs]}} {{数量}} {{路径/到/test.bats}}`

--- a/pages.zh/common/bazel.md
+++ b/pages.zh/common/bazel.md
@@ -1,0 +1,28 @@
+# bazel
+
+> 开源构建和测试工具，类似于 Make、Maven 和 Gradle。
+> 更多信息：<https://bazel.build/reference/command-line-reference>。
+
+- 在工作区中构建指定目标：
+
+`bazel build {{目标}}`
+
+- 删除输出文件并停止服务器（如果正在运行）：
+
+`bazel clean`
+
+- 停止 bazel 服务器：
+
+`bazel shutdown`
+
+- 显示 bazel 服务器的运行时信息：
+
+`bazel info`
+
+- 显示帮助：
+
+`bazel help`
+
+- 显示版本：
+
+`bazel version`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **bats** — Bash automated testing system
- **bazel** — build and test tool

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages