### PR TITLE
pages.zh: add 2 new translations (agg, aha)

### DIFF
--- a/pages.zh/common/agg.md
+++ b/pages.zh/common/agg.md
@@ -1,0 +1,20 @@
+# agg
+
+> 从 `asciinema` 终端会话录制创建 GIF。
+> 更多信息：<https://docs.asciinema.org/manual/agg/usage/>。
+
+- 创建 GIF：
+
+`agg {{路径/到/demo.cast}} {{路径/到/demo.gif}}`
+
+- 创建宽度为 80 列、高度为 25 行的 GIF：
+
+`agg --cols 80 --rows 25 {{路径/到/demo.cast}} {{路径/到/demo.gif}}`
+
+- 创建字体大小为 24 像素的 GIF：
+
+`agg --font-size 24 {{路径/到/demo.cast}} {{路径/到/demo.gif}}`
+
+- 显示帮助：
+
+`agg {{[-h|--help]}}`

--- a/pages.zh/common/aha.md
+++ b/pages.zh/common/aha.md
@@ -1,0 +1,32 @@
+# aha
+
+> 将 ANSI 转义序列转换为 HTML。
+> 更多信息：<https://manned.org/aha>。
+
+- 将终端输出转换为 HTML：
+
+`{{颜色命令}} | aha > {{路径/到/output}}.html`
+
+- 从文件读取而不是 `stdin`：
+
+`aha -f {{路径/到/input.txt}} > {{路径/到/output}}.html`
+
+- 转换为黑色背景的 HTML：
+
+`{{颜色命令}} | aha {{[-b|--black]}} > {{路径/到/output}}.html`
+
+- 转换为粉色背景的 HTML 并设置文档标题：
+
+`{{颜色命令}} | aha {{[-p|--pink]}} {{[-t|--title]}} "{{标题}}" > {{路径/到/output}}.html`
+
+- 向 HTML 输出添加 CSS 文件：
+
+`{{颜色命令}} | aha {{[-c|--css]}} {{路径/到/style}}.css > {{路径/到/output}}.html`
+
+- 启用自动换行以防止水平滚动：
+
+`{{颜色命令}} | aha {{[-w|--word-wrap]}} > {{路径/到/output}}.html`
+
+- 显示帮助：
+
+`aha {{[-h|--help]}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **agg** — create GIF from asciinema recording
- **aha** — convert ANSI escape sequences to HTML

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages