### PR TITLE
pages.zh: add 2 new translations (alr, animdl)

### DIFF
--- a/pages.zh/common/alr.md
+++ b/pages.zh/common/alr.md
@@ -1,0 +1,21 @@
+# alr
+
+> Ada 包管理器。
+> 管理 Ada 工具链、依赖项、工具和库。
+> 更多信息：<https://alire.ada.dev/docs/#first-steps>。
+
+- 创建二进制或库项目：
+
+`alr init {{--bin|--lib}} {{项目名称}}`
+
+- 向项目添加依赖项：
+
+`alr add {{crate}}`
+
+- 运行编译后的二进制文件（无需先执行 `build`）：
+
+`alr run`
+
+- 编译项目：
+
+`alr build {{--release|--development|--validation}}`

--- a/pages.zh/common/animdl.md
+++ b/pages.zh/common/animdl.md
@@ -1,0 +1,37 @@
+# animdl
+
+> 搜索、流媒体播放和下载动漫。
+> 另请参阅：`ani-cli`。
+> 更多信息：<https://github.com/justfoolingaround/animdl#usage>。
+
+- 下载特定动漫：
+
+`animdl download "{{动漫标题}}"`
+
+- 通过指定剧集范围下载特定动漫：
+
+`animdl download "{{动漫标题}}" {{[-r|--range]}} {{起始剧集}}-{{结束剧集}}`
+
+- 通过指定下载目录下载特定动漫：
+
+`animdl download "{{动漫标题}}" {{[-d|--download-dir]}} {{路径/到/目录}}`
+
+- 获取特定动漫的流媒体 URL：
+
+`animdl grab "{{动漫标题}}"`
+
+- 显示下周即将播出的动漫时间表：
+
+`animdl schedule`
+
+- 搜索特定动漫：
+
+`animdl search "{{动漫标题}}"`
+
+- 流媒体播放特定动漫：
+
+`animdl stream "{{动漫标题}}"`
+
+- 流媒体播放特定动漫的最新一集：
+
+`animdl stream "{{动漫标题}}" {{[-s|--special]}} latest`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **alr** — Ada package manager
- **animdl** — search, stream, and download anime

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages