### PR TITLE
pages.zh: add arc translation

### DIFF
--- a/pages.zh/common/arc.md
+++ b/pages.zh/common/arc.md
@@ -1,0 +1,20 @@
+# arc
+
+> Arcanist：Phabricator 的 CLI。
+> 更多信息：<https://secure.phabricator.com/book/phabricator/article/arcanist/>。
+
+- 将更改发送到 Differential 进行审查：
+
+`arc diff`
+
+- 显示待处理的修订信息：
+
+`arc list`
+
+- 审查后更新 Git 提交消息：
+
+`arc amend`
+
+- 推送 Git 更改：
+
+`arc land`


### PR DESCRIPTION
## Summary

Adds Simplified Chinese translation for **arc** — Arcanist CLI for Phabricator.

Closes #13579

- [x] Passes lint-markdown and lint-tldr-pages