### PR TITLE
pages.zh: add 2 new translations (audacious, auditd)

### DIFF
--- a/pages.zh/common/audacious.md
+++ b/pages.zh/common/audacious.md
@@ -1,0 +1,37 @@
+# audacious
+
+> 开源音频播放器。间接基于 XMMS。
+> 另请参阅：`audtool`、`clementine`、`mpc`、`ncmpcpp`。
+> 更多信息：<https://manned.org/audacious>。
+
+- 启动 GUI：
+
+`audacious`
+
+- 启动新实例并播放音频：
+
+`audacious {{[-N|--new-instance]}} {{路径/到/音频}}`
+
+- 将特定目录的音频文件加入队列：
+
+`audacious {{[-e|--enqueue]}} {{路径/到/目录}}`
+
+- 开始或停止播放：
+
+`audacious {{[-t|--play-pause]}}`
+
+- 在播放列表中向前或向后跳转：
+
+`audacious --{{fwd|rew}}`
+
+- 停止播放：
+
+`audacious {{[-s|--stop]}}`
+
+- 以 CLI 模式（无头）启动：
+
+`audacious {{[-H|--headless]}}`
+
+- 播放停止或没有可播放内容时退出：
+
+`audacious {{[-q|--quit-after-play]}}`

--- a/pages.zh/common/auditd.md
+++ b/pages.zh/common/auditd.md
@@ -1,0 +1,17 @@
+# auditd
+
+> 响应审计工具的请求和内核的通知。
+> 不应手动调用。
+> 更多信息：<https://manned.org/auditd>。
+
+- 启动守护进程：
+
+`auditd`
+
+- 以调试模式启动守护进程：
+
+`auditd -d`
+
+- 按需从 launchd 启动守护进程：
+
+`auditd -l`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **audacious** — open-source audio player
- **auditd** — audit daemon

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages