### PR TITLE
pages.zh: add 2 new translations (audtool, autoload)

### DIFF
--- a/pages.zh/common/audtool.md
+++ b/pages.zh/common/audtool.md
@@ -1,0 +1,37 @@
+# audtool
+
+> 使用命令控制 Audacious。
+> 另请参阅：`audacious`。
+> 更多信息：<https://manned.org/audtool>。
+
+- 播放/暂停音频：
+
+`audtool playback-playpause`
+
+- 打印当前播放歌曲的艺术家、专辑和歌曲名称：
+
+`audtool current-song`
+
+- 设置音频播放音量：
+
+`audtool set-volume {{100}}`
+
+- 跳到下一首歌：
+
+`audtool playlist-advance`
+
+- 以千比特为单位打印当前歌曲的比特率：
+
+`audtool current-song-bitrate-kbps`
+
+- 如果 Audacious 已隐藏，则以全屏打开：
+
+`audtool mainwin-show`
+
+- 显示帮助：
+
+`audtool help`
+
+- 显示设置：
+
+`audtool preferences-show`

--- a/pages.zh/common/autoload.md
+++ b/pages.zh/common/autoload.md
@@ -1,0 +1,19 @@
+# autoload
+
+> 在 Zsh 中标记函数以进行延迟加载。
+> 函数在首次调用之前不会加载到内存中，从而提高 shell 启动速度。
+> 更多信息：<https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html>。
+
+- 按名称自动加载函数：
+
+`autoload {{函数名称}}`
+
+- 自动加载函数并立即解析其定义：
+
+`autoload +X {{函数名称}}`
+
+- 使用 Zsh 风格的自动加载（推荐）：
+
+`autoload -Uz {{函数名称}}`
+
+- 通过将目录添加到 `fpath` 使目录中的函数可用：


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **audtool** — control Audacious
- **autoload** — Zsh lazy function loading

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages