### PR TITLE
pages.zh: add 2 new translations (avo, avrdude)

### DIFF
--- a/pages.zh/common/avo.md
+++ b/pages.zh/common/avo.md
@@ -1,0 +1,36 @@
+# avo
+
+> Avo 的官方接口。
+> 更多信息：<https://www.avo.app/docs/implementation/cli>。
+
+- 在当前目录初始化工作区：
+
+`avo init`
+
+- 登录 Avo 平台：
+
+`avo login`
+
+- 切换到现有的 Avo 分支：
+
+`avo checkout {{分支名称}}`
+
+- 拉取当前路径的分析包装器：
+
+`avo pull`
+
+- 显示 Avo 实现的状态：
+
+`avo status`
+
+- 解决 Avo 文件中的 Git 冲突：
+
+`avo conflict`
+
+- 在默认 Web 浏览器中打开当前 Avo 工作区：
+
+`avo edit`
+
+- 显示子命令的帮助：
+
+`avo {{子命令}} --help`

--- a/pages.zh/common/avrdude.md
+++ b/pages.zh/common/avrdude.md
@@ -1,0 +1,20 @@
+# avrdude
+
+> Atmel AVR 微控制器的驱动程序。
+> 更多信息：<https://www.nongnu.org/avrdude/user-manual/avrdude_3.html#Option-Descriptions>。
+
+- 读取具有特定部件 ID 的 AVR 微控制器的闪存 ROM：
+
+`avrdude -p {{部件_id}} -c {{编程器_id}} -U flash:r:{{文件.hex}}:i`
+
+- 写入 AVR 微控制器的闪存 ROM：
+
+`avrdude -p {{部件_id}} -c {{编程器}} -U flash:w:{{文件.hex}}`
+
+- 列出可用的 AVR 设备：
+
+`avrdude -p \?`
+
+- 列出可用的 AVR 编程器：
+
+`avrdude -c \?`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **avo** — Avo analytics CLI
- **avrdude** — AVR microcontroller programmer

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages