### PR TITLE
pages.zh: add 2 new translations (archwiki-rs, arduino-builder)

### DIFF
--- a/pages.zh/common/archwiki-rs.md
+++ b/pages.zh/common/archwiki-rs.md
@@ -1,0 +1,20 @@
+# archwiki-rs
+
+> 阅读、搜索和下载 ArchWiki 页面。
+> 更多信息：<https://gitlab.com/lucifayr/archwiki-rs>。
+
+- 从 ArchWiki 阅读页面：
+
+`archwiki-rs read-page {{页面标题}}`
+
+- 以指定格式从 ArchWiki 阅读页面：
+
+`archwiki-rs read-page {{页面标题}} --format {{plain-text|markdown|html}}`
+
+- 在 ArchWiki 中搜索包含所提供文本的页面：
+
+`archwiki-rs search "{{搜索文本}}" --text-search`
+
+- 将所有 ArchWiki 页面的本地副本下载到特定目录：
+
+`archwiki-rs local-wiki /{{路径/到/local_wiki}} --format {{plain-text|markdown|html}}`

--- a/pages.zh/common/arduino-builder.md
+++ b/pages.zh/common/arduino-builder.md
@@ -1,0 +1,25 @@
+# arduino-builder
+
+> 编译 arduino 草图。
+> 弃警告：此工具正在被 `arduino` 取代。
+> 更多信息：<https://github.com/arduino/arduino-builder>。
+
+- 编译草图：
+
+`arduino-builder -compile {{路径/到/sketch.ino}}`
+
+- 指定调试级别（默认：5）：
+
+`arduino-builder -debug-level {{1..10}}`
+
+- 指定自定义构建目录：
+
+`arduino-builder -build-path {{路径/到/build_directory}}`
+
+- 使用构建选项文件，而不是每次手动指定 `-hardware`、`-tools` 等：
+
+`arduino-builder -build-options-file {{路径/到/build.options.json}}`
+
+- 启用详细模式：
+
+`arduino-builder -verbose true`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **archwiki-rs** — ArchWiki reader/search/downloader
- **arduino-builder** — Arduino sketch compiler

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages