### PR TITLE
pages.zh: add 2 new translations (argocd, argos-translate)

### DIFF
--- a/pages.zh/common/argocd.md
+++ b/pages.zh/common/argocd.md
@@ -1,0 +1,13 @@
+# argocd
+
+> 控制 Argo CD 服务器的接口。
+> 某些子命令（如 `app`）有自己的使用文档。
+> 更多信息：<https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd/>。
+
+- 登录 Argo CD 服务器：
+
+`argocd login --insecure --username {{用户}} --password {{密码}} {{argocd_server:port}}`
+
+- 列出应用程序：
+
+`argocd app list`

--- a/pages.zh/common/argos-translate.md
+++ b/pages.zh/common/argos-translate.md
@@ -1,0 +1,32 @@
+# argos-translate
+
+> 用 Python 编写的开源离线翻译库和 CLI 工具。
+> 更多信息：<https://argos-translate.readthedocs.io/en/latest/source/cli.html>。
+
+- 安装西班牙语到英语的翻译对：
+
+`argospm install translate-es_en`
+
+- 将一些文本从西班牙语（`es`）翻译成英语（`en`）（注意：仅支持两个字母的语言代码）：
+
+`argos-translate --from-lang es --to-lang en {{un texto corto}}`
+
+- 将文本文件从英语翻译成印地语：
+
+`cat {{路径/到/file.txt}} | argos-translate --from-lang en --to-lang hi`
+
+- 列出所有已安装的翻译对：
+
+`argospm list`
+
+- 显示可从英语安装的翻译对：
+
+`argospm search --from-lang en`
+
+- 更新已安装的语言包对：
+
+`argospm update`
+
+- 从 `ar` 翻译到 `ru`（注意：这需要安装翻译对 `translate-ar_en` 和 `translate-en_ru`）：
+
+`argos-translate --from-lang ar --to-lang ru {{صورة تساوي أكثر من ألف كلمة}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **argocd** — Argo CD server control interface
- **argos-translate** — offline translation library and CLI

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages