### PR TITLE
pages.zh: add 2 new translations (asciidoctor, asciiquarium)

### DIFF
--- a/pages.zh/common/asciidoctor.md
+++ b/pages.zh/common/asciidoctor.md
@@ -1,0 +1,20 @@
+# asciidoctor
+
+> 将 AsciiDoc 文件转换为可发布的格式。
+> 更多信息：<https://docs.asciidoctor.org/asciidoctor/latest/cli/man1/asciidoctor/>。
+
+- 将特定 `.adoc` 文件转换为 HTML（默认输出格式）：
+
+`asciidoctor {{路径/到/file.adoc}}`
+
+- 将特定 `.adoc` 文件转换为 HTML 并链接 CSS 样式表：
+
+`asciidoctor {{[-a|--attribute]}} stylesheet={{路径/到/stylesheet.css}} {{路径/到/file.adoc}}`
+
+- 将特定 `.adoc` 文件转换为嵌入式 HTML，移除正文以外的所有内容：
+
+`asciidoctor {{[-e|--embedded]}} {{路径/到/file.adoc}}`
+
+- 使用 `asciidoctor-pdf` 库将特定 `.adoc` 文件转换为 PDF：
+
+`asciidoctor {{[-b|--backend]}} pdf {{[-r|--require]}} asciidoctor-pdf {{路径/到/file.adoc}}`

--- a/pages.zh/common/asciiquarium.md
+++ b/pages.zh/common/asciiquarium.md
@@ -1,0 +1,25 @@
+# asciiquarium
+
+> 在终端内显示 ASCII 艺术的动画水族馆。
+> 另请参阅：`cmatrix`、`cbonsai`、`pipes.sh`。
+> 更多信息：<https://robobunny.com/projects/asciiquarium/html/?page=2>。
+
+- 启动 `asciiquarium`：
+
+`asciiquarium`
+
+- 通过 `lolcat` 管道输出以获得彩虹颜色：
+
+`asciiquarium | lolcat`
+
+- 切换暂停：
+
+`<p>`
+
+- 重绘水族馆和所有实体：
+
+`<r>`
+
+- 退出 `asciiquarium`：
+
+`<q>`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **asciidoctor** — AsciiDoc to publishable format converter
- **asciiquarium** — animated ASCII aquarium

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages