### PR TITLE
pages.zh: add 2 new translations (asciitopgm, ast-grep)

### DIFF
--- a/pages.zh/common/asciitopgm.md
+++ b/pages.zh/common/asciitopgm.md
@@ -1,0 +1,12 @@
+# asciitopgm
+
+> 将 ASCII 图形转换为 PGM 文件。
+> 更多信息：<https://netpbm.sourceforge.net/doc/asciitopgm.html>。
+
+- 读取 ASCII 数据作为输入并生成 PGM 图像，像素值近似于 ASCII 字符的"亮度"：
+
+`asciitopgm {{路径/到/input_file}} > {{路径/到/output_file.pgm}}`
+
+- 显示版本：
+
+`asciitopgm {{[-v|-version]}}`

--- a/pages.zh/common/ast-grep.md
+++ b/pages.zh/common/ast-grep.md
@@ -1,0 +1,28 @@
+# ast-grep
+
+> 使用 AST 模式搜索、lint 和重写代码。
+> 更多信息：<https://ast-grep.github.io/reference/cli.html>。
+
+- 在文件中搜索模式：
+
+`ast-grep run {{[-p|--pattern]}} '{{pattern}}' {{路径/到/file}}`
+
+- 在特定语言中搜索模式：
+
+`ast-grep run {{[-p|--pattern]}} '{{pattern}}' {{[-l|--lang]}} {{python}} {{路径/到/目录}}`
+
+- 重写匹配模式的代码：
+
+`ast-grep run {{[-p|--pattern]}} '{{pattern}}' {{[-r|--rewrite]}} '{{replacement}}' {{路径/到/file}}`
+
+- 从配置文件运行规则：
+
+`ast-grep scan {{[-r|--rule]}} {{路径/到/rule.yml}} {{路径/到/目录}}`
+
+- 交互式搜索和重写代码：
+
+`ast-grep run {{[-p|--pattern]}} '{{pattern}}' {{[-i|--interactive]}} {{路径/到/目录}}`
+
+- 显示子命令的帮助：
+
+`ast-grep {{run}} {{[-h|--help]}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **asciitopgm** — ASCII graphics to PGM converter
- **ast-grep** — AST-based code search/lint/rewrite

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages