### PR TITLE
pages.zh: add 2 new translations (audtool, autoconf)

### DIFF
--- a/pages.zh/common/audtool.md
+++ b/pages.zh/common/audtool.md
@@ -1,0 +1,37 @@
+# audtool
+
+> 使用命令控制 Audacious。
+> 另请参阅：`audacious`。
+> 更多信息：<https://manned.org/audtool>。
+
+- 播放/暂停音频：
+
+`audtool playback-playpause`
+
+- 打印当前播放歌曲的艺术家、专辑和歌曲名称：
+
+`audtool current-song`
+
+- 设置音频播放音量：
+
+`audtool set-volume {{100}}`
+
+- 跳到下一首歌：
+
+`audtool playlist-advance`
+
+- 以千比特为单位打印当前歌曲的比特率：
+
+`audtool current-song-bitrate-kbps`
+
+- 如果 Audacious 已隐藏，则以全屏打开：
+
+`audtool mainwin-show`
+
+- 显示帮助：
+
+`audtool help`
+
+- 显示设置：
+
+`audtool preferences-show`

--- a/pages.zh/common/autoconf.md
+++ b/pages.zh/common/autoconf.md
@@ -1,0 +1,16 @@
+# autoconf
+
+> 自动生成配置脚本，用于自动配置软件源码包。
+> 更多信息：<https://manned.org/autoconf>。
+
+- 从 `configure.ac`（如果存在）或 `configure.in` 生成配置脚本并保存到 `configure`：
+
+`autoconf`
+
+- 从指定模板生成配置脚本，输出到 `stdout`：
+
+`autoconf {{模板文件}}`
+
+- 从指定模板生成配置脚本（即使输入文件未更改）并写入文件：
+
+`autoconf {{[-f|--force]}} {{[-o|--output]}} {{输出文件}} {{模板文件}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **audtool** — control Audacious
- **autoconf** — configuration script generator

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages