### PR TITLE
pages.zh: add aconnect translation

### DIFF
--- a/pages.zh/common/aconnect.md
+++ b/pages.zh/common/aconnect.md
@@ -1,0 +1,20 @@
+# aconnect
+
+> 管理 ALSA 音序器连接。
+> 更多信息：<https://manned.org/aconnect>。
+
+- 列出所有端口：
+
+`aconnect {{[-a|--all]}}`
+
+- 列出可读输入端口：
+
+`aconnect {{[-i|--input]}}`
+
+- 列出可写输出端口：
+
+`aconnect {{[-o|--output]}}`
+
+- 显示帮助：
+
+`aconnect`


### PR DESCRIPTION
## Summary

Adds Simplified Chinese translation for **aconnect** — manage ALSA sequencer connections.

Closes #13579

- [x] Passes lint-markdown and lint-tldr-pages