### PR TITLE
pages.zh: add 2 new translations (autoload, automake)

### DIFF
--- a/pages.zh/common/autoload.md
+++ b/pages.zh/common/autoload.md
@@ -1,0 +1,29 @@
+# autoload
+
+> 在 Zsh 中标记函数以进行延迟加载。
+> 函数在首次调用之前不会加载到内存中，从而提高 shell 启动速度。
+> 更多信息：<https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html>。
+
+- 按名称自动加载函数：
+
+`autoload {{函数名称}}`
+
+- 自动加载函数并立即解析其定义：
+
+`autoload +X {{函数名称}}`
+
+- 使用 Zsh 风格的自动加载（推荐）：
+
+`autoload -Uz {{函数名称}}`
+
+- 通过将目录添加到 `fpath` 使目录中的函数可用：
+
+`fpath=({{路径/到/functions_dir}} $fpath) && autoload -Uz {{函数名称}}`
+
+- 自动加载 Zsh 补全系统：
+
+`autoload -Uz compinit && compinit`
+
+- 自动加载并使用 `add-zsh-hook` 实用程序：
+
+`autoload -Uz add-zsh-hook`

--- a/pages.zh/common/automake.md
+++ b/pages.zh/common/automake.md
@@ -1,0 +1,24 @@
+# automake
+
+> 为使用 GNU 标准的软件项目自动生成 Makefile。
+> 更多信息：<https://www.gnu.org/software/automake/manual/automake.html#automake-Invocation>。
+
+- 运行 automake 在编辑 `Makefile.am` 后重新生成 Makefile：
+
+`automake`
+
+- 为非 GNU 项目生成 `Makefile.in`（foreign 模式）：
+
+`automake --foreign`
+
+- 添加详细输出以进行调试：
+
+`automake {{[-v|--verbose]}}`
+
+- 添加缺失的标准文件（INSTALL、COPYING、depcomp 等）：
+
+`automake {{[-a|--add-missing]}}`
+
+- 显示帮助：
+
+`automake --help`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **autoload** — Zsh lazy function loading
- **automake** — Makefile generator

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages