### PR TITLE
pages.zh: add 2 new translations (avrdude, badblocks)

### DIFF
--- a/pages.zh/common/avrdude.md
+++ b/pages.zh/common/avrdude.md
@@ -1,0 +1,20 @@
+# avrdude
+
+> Atmel AVR 微控制器的驱动程序。
+> 更多信息：<https://www.nongnu.org/avrdude/user-manual/avrdude_3.html#Option-Descriptions>。
+
+- 读取具有特定部件 ID 的 AVR 微控制器的闪存 ROM：
+
+`avrdude -p {{部件_id}} -c {{编程器_id}} -U flash:r:{{文件.hex}}:i`
+
+- 写入 AVR 微控制器的闪存 ROM：
+
+`avrdude -p {{部件_id}} -c {{编程器}} -U flash:w:{{文件.hex}}`
+
+- 列出可用的 AVR 设备：
+
+`avrdude -p \?`
+
+- 列出可用的 AVR 编程器：
+
+`avrdude -c \?`

--- a/pages.zh/common/badblocks.md
+++ b/pages.zh/common/badblocks.md
@@ -1,0 +1,20 @@
+# badblocks
+
+> 搜索设备上的坏块。
+> 更多信息：<https://manned.org/badblocks>。
+
+- 搜索设备上的坏块：
+
+`sudo badblocks {{/dev/sda}}`
+
+- 搜索设备上的坏块并显示进度：
+
+`sudo badblocks -s {{/dev/sda}}`
+
+- 搜索设备上的坏块并将结果保存到文件：
+
+`sudo badblocks -o {{badblocks.txt}} {{/dev/sda}}`
+
+- 非破坏性读写测试：
+
+`sudo badblocks -nsv {{/dev/sda}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **avrdude** — AVR microcontroller programmer
- **badblocks** — search for bad blocks

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages