### PR TITLE
pages.zh: add 2 new translations (bind, bison)

### DIFF
--- a/pages.zh/common/bind.md
+++ b/pages.zh/common/bind.md
@@ -1,0 +1,24 @@
+# bind
+
+> Bash 内建命令，用于管理 bash 热键和变量。
+> 更多信息：<https://www.gnu.org/software/bash/manual/bash.html#index-bind>。
+
+- 列出所有绑定的命令及其热键：
+
+`bind {{-p|-P}}`
+
+- 查询命令的热键：
+
+`bind -q {{命令}}`
+
+- 绑定按键：
+
+`bind -x '"{{按键序列}}":{{命令}}'`
+
+- 列出用户定义的绑定：
+
+`bind -X`
+
+- 显示帮助：
+
+`help bind`

--- a/pages.zh/common/bison.md
+++ b/pages.zh/common/bison.md
@@ -1,0 +1,20 @@
+# bison
+
+> GNU 解析器生成器。
+> 更多信息：<https://manned.org/bison>。
+
+- 编译 bison 定义文件：
+
+`bison {{路径/到/file.y}}`
+
+- 以调试模式编译，导致生成的解析器将附加信息写入 `stdout`：
+
+`bison {{[-t|--debug]}} {{路径/到/file.y}}`
+
+- 指定输出文件名：
+
+`bison {{[-o|--output]}} {{路径/到/output.c}} {{路径/到/file.y}}`
+
+- 编译时显示详细信息：
+
+`bison {{[-v|--verbose]}}`


### PR DESCRIPTION
## Summary

Adds 2 new Simplified Chinese translations:
- **bind** — manage bash hotkeys
- **bison** — GNU parser generator

Closes #13579

- [x] All pages pass lint-markdown and lint-tldr-pages