### PR TITLE
growpart, grub-mkrescue, grub-mount, grub-probe, grub2-mkpasswd-pbkdf2: add korean translation

### DIFF
--- a/pages.ko/linux/growpart.md
+++ b/pages.ko/linux/growpart.md
@@ -1,0 +1,12 @@
+# growpart
+
+> 디스크 또는 디스크 이미지의 파티션을 확장해 사용 가능한 공간을 모두 활용.
+> 더 많은 정보: <https://github.com/canonical/cloud-utils>.
+
+- `sdX`의 `n`번 파티션을 디스크의 끝 또는 다음 파티션 시작 지점까지 확장:
+
+`growpart {{/dev/sdX}} {{n}}`
+
+- 디스크 이미지의 `n`번 파티션을 확장할 때 적용될 변경 사항을 dry-run으로 표시:
+
+`growpart {{[-N|--dry-run]}} /{{경로/대상/디스크.img}} {{n}}`

--- a/pages.ko/linux/grub-mkrescue.md
+++ b/pages.ko/linux/grub-mkrescue.md
@@ -1,0 +1,36 @@
+# grub-mkrescue
+
+> GRUB 용 부팅 가능한 CD/USB/floppy 이미지를 생성.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dmkrescue>.
+
+- 현재 디렉터리에서 부팅 가능한 ISO를 생성해 `grub.iso`로 저장:
+
+`grub-mkrescue --output {{grub.iso}} .`
+
+- 사용자 지정 디렉터리의 GRUB 파일을 사용하여 ISO 생성:
+
+`grub-mkrescue --directory {{/usr/lib/grub/i386-pc}} --output {{grub.iso}} {{경로/대상/소스파일}}`
+
+- 이미지 생성 시 GRUB 파일 압축 방식 지정, (`no`: 압축 비활성화):
+
+`grub-mkrescue --compress {{no|xz|gz|lzo}} --output {{grub.iso}} {{경로/대상/소스파일}}`
+
+- 생성된 이미지에서 GRUB 명령줄 인터페이스 비활성화:
+
+`grub-mkrescue --disable-cli --output {{grub.iso}} {{경로/대상/소스파일}}`
+
+- 지정한 GRUB 모듈을 이미지에 미리 포함:
+
+`grub-mkrescue --modules "{{part_gpt iso9660}}" --output {{grub.iso}} {{경로/대상/소스파일}}`
+
+- 추가 옵션을 `xorriso`에 직접 전달:
+
+`grub-mkrescue --output {{grub.iso}} -- {{-volid}} {{볼륨_이름}} {{경로/대상/소스파일}}`
+
+- 도움말 표시:
+
+`grub-mkrescue {{[-?|--help]}}`
+
+- 버전 정보 표시:
+
+`grub-mkrescue --version`

--- a/pages.ko/linux/grub-mount.md
+++ b/pages.ko/linux/grub-mount.md
@@ -1,0 +1,36 @@
+# grub-mount
+
+> Mount a filesystem or filesystem image read-only using GRUB's filesystem drivers.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/grub.html#Invoking-grub_002dmount>.
+
+- 블록 장치 또는 파일 시스템 이미지를 지정한 마운트 지점에 마운트:
+
+`grub-mount {{/dev/sdXY}} {{/mnt}}`
+
+- 디스크 이미지의 2번째 파티션을 마운트 (`-r`: 이미지 내 파티션 번호 지정):
+
+`grub-mount {{[-r|--root]}} {{2}} {{disk.img}} {{/mnt}}`
+
+- 암호화된 장치를 마운트하고 암호 입력을 요청:
+
+`grub-mount {{[-C|--crypto]}} {{/dev/sdXY}} {{/mnt}}`
+
+- 파일에서 ZFS 암호화 키를 로드하여 마운트:
+
+`grub-mount {{[-K|--zfs-key]}} /{{path/to/zfs.key}} {{/dev/sdX}} {{/mnt}}`
+
+- 지정한 디버그 범위의 출력 표시:
+
+`grub-mount {{[-d|--debug]}} {{문자열}} {{이미지}} {{/mnt}}`
+
+- 상세 출력 활성화:
+
+`grub-mount {{[-v|--verbose]}} {{이미지}} {{/mnt}}`
+
+- 도움말 표시:
+
+`grub-mount {{[-?|--help]}}`
+
+- 버전 정보 표시:
+
+`grub-mount --version`

--- a/pages.ko/linux/grub-probe.md
+++ b/pages.ko/linux/grub-probe.md
@@ -1,0 +1,32 @@
+# grub-probe
+
+> 지정한 경로 또는 장치의 장치 정보를 조회.
+> 더 많은 정보: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dprobe.html>.
+
+- 경로에 해당하는 GRUB 파일 시스템 모듈 조회:
+
+`sudo grub-probe {{[-t|--target]}} fs {{/boot/grub}}`
+
+- 경로가 포함된 시스템 장치 조회:
+
+`sudo grub-probe {{[-t|--target]}} device {{/boot/grub}}`
+
+- 시스템 장치의 GRUB 디스크 이름 조회:
+
+`sudo grub-probe {{[-t|--target]}} drive {{/dev/sdX}} {{[-d|--device]}}`
+
+- 파일 시스템 UUID 조회:
+
+`sudo grub-probe {{[-t|--target]}} fs_uuid {{/boot/grub}}`
+
+- 파일 시스템 레이블 조회:
+
+`sudo grub-probe {{[-t|--target]}} fs_label {{/boot/grub}}`
+
+- MBR 파티션 유형 코드 (16진수 2자리) 조회:
+
+`sudo grub-probe {{[-t|--target]}} msdos_parttype {{/dev/sdX}}`
+
+- 사용자 지정 장치 매핑을 사용해 장치 정보 조회:
+
+`sudo grub-probe {{[-t|--target]}} drive {{/boot/grub}} {{[-m|--device-map]}} {{경로/대상/사용자지정_장치.map}}`

--- a/pages.ko/linux/grub2-mkpasswd-pbkdf2.md
+++ b/pages.ko/linux/grub2-mkpasswd-pbkdf2.md
@@ -1,0 +1,8 @@
+# grub2-mkpasswd-pbkdf2
+
+> GRUB용 기반 비밀번호 해시를 생성.
+> 더 많은 정보: <https://manned.org/grub2-mkpasswd-pbkdf2>.
+
+- PBKDF2를 사용하여 GRUB 2 비밀번호 해시를 생성하고 `stdout`으로 출력:
+
+`sudo grub2-mkpasswd-pbkdf2 {{[-c|--iteration-count]}} {{pbkdf2_이터레이션_횟수}} {{[-s|--salt]}} {{솔트_길이}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
