### PR TITLE
kitty: add example

### DIFF
--- a/pages/common/kitty.md
+++ b/pages/common/kitty.md
@@ -22,3 +22,7 @@
 - Copy the contents of `stdin` to the clipboard:
 
 `echo {{example}} | kitty +kitten clipboard`
+
+- Start kitty without loading the user config:
+
+`kitty --config NONE`

--- a/pages/common/kitty.md
+++ b/pages/common/kitty.md
@@ -23,6 +23,6 @@
 
 `echo {{example}} | kitty +kitten clipboard`
 
-- Start kitty without loading the user config:
+- Open a terminal without loading the user config:
 
 `kitty --config NONE`


### PR DESCRIPTION
This command allows users to start kitty without their loading their config. Often used for debug purposes.

<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
