### PR TITLE
kernelstub, keyd, kinfocenter, kmod, kmscon: add Korean translation

### DIFF
--- a/pages.ko/linux/kernelstub.md
+++ b/pages.ko/linux/kernelstub.md
@@ -1,0 +1,32 @@
+# kernelstub
+
+> (U)EFI 환경에서 Linux 커널 부팅 구성을 자동으로 관리.
+> 더 많은 정보: <https://github.com/isantop/kernelstub#usage>.
+
+- 기본 옵션으로 현재 커널 구성:
+
+`sudo kernelstub`
+
+- 사용자 지정 커널 옵션 추가:
+
+`sudo kernelstub {{[-o|--options]}} "{{quiet splash mitigations=off}}"`
+
+- 상세 출력과 함께 `systemd-boot` 설정 사용:
+
+`sudo kernelstub {{[-v|--verbose]}} {{[-l|--loader]}}`
+
+- NVRAM은 변경 없이 ESP에 커널만 복사:
+
+`sudo kernelstub {{[-m|--manage-only]}}`
+
+- 실제 변경 없이 시뮬레이션 실행:
+
+`sudo kernelstub {{[-c|--dry-run]}}`
+
+- 커널, initrd 및 ESP 경로를 직접 지정:
+
+`sudo kernelstub {{[-k|--kernel-path]}} /{{경로/대상/vmlinuz}} {{[-i|--initrd-path]}} /{{경로/대상/initrd.img}} {{[-e|--esp-path]}} /{{경로/대상/efi_partition}}`
+
+- 현재 설정 표시:
+
+`sudo kernelstub {{[-p|--print-config]}}`

--- a/pages.ko/linux/keyd.md
+++ b/pages.ko/linux/keyd.md
@@ -1,0 +1,28 @@
+# keyd
+
+> 키 매핑을 변경.
+> 더 많은 정보: <https://manned.org/keyd>.
+
+- `keyd` 서비스를 활성화하고 시작:
+
+`systemctl enable keyd --now`
+
+- 키 입력 정보 표시:
+
+`sudo keyd {{[-m|monitor]}}`
+
+- 바인딩을 초기화하고 `/etc/keyd`의 설정 파일 다시 불러오기:
+
+`sudo keyd reload`
+
+- 사용 가능한 모든 키 이름 목록 표시:
+
+`keyd list-keys`
+
+- 감지된 설정 파일의 오류 검사:
+
+`keyd check`
+
+- 임시 키 바인딩 생성:
+
+`sudo keyd bind "{{누른_키}} = {{출력_키}}"`

--- a/pages.ko/linux/kinfocenter.md
+++ b/pages.ko/linux/kinfocenter.md
@@ -1,0 +1,16 @@
+# kinfocenter
+
+> 시스템 정보를 표시하는 KDE 정보 센터.
+> 더 많은 정보: <https://manned.org/kinfocenter>.
+
+- GUI 실행:
+
+`kinfocenter`
+
+- `kinfocenter`에서 사용할 수 있는 모든 KCM 모듈 목록 표시:
+
+`kinfocenter --list`
+
+- 도움말 표시:
+
+`kinfocenter {{[-h|--help]}}`

--- a/pages.ko/linux/kmod.md
+++ b/pages.ko/linux/kmod.md
@@ -1,0 +1,14 @@
+# kmod
+
+> Linux kernel 모듈을 관리.
+> 이 프로그램은 일반적으로 `lsmod`, `rmmod`, `insmod`, `modinfo`, `modprobe`, `depmod` 심볼릭 링크를 통해 호출됨.
+> 자세한 내용은 각 명령의 문서를 참고.
+> 더 많은 정보: <https://manned.org/kmod>.
+
+- 현재 로드된 커널 모듈 목록 표시:
+
+`kmod list`
+
+- 현재 실행 중인 커널 모듈이 제공하는 정적 장치 노드 정보 표시:
+
+`kmod static-nodes`

--- a/pages.ko/linux/kmscon.md
+++ b/pages.ko/linux/kmscon.md
@@ -1,0 +1,24 @@
+# kmscon
+
+> TTY에서 텍스트 모드 대신 프레임버퍼를 사용하여 터미널을 표시.
+> 더 많은 정보: <https://manned.org/kmscon>.
+
+- 사용 가능한 첫 번째 TTY에서 `kmscon` 시작:
+
+`sudo kmscon`
+
+- 지정한 TTY에서 `kmscon` 시작:
+
+`sudo kmscon --vt {{/dev/ttyX|ttyX|X}}`
+
+- 마우스 지원 활성화:
+
+`sudo kmscon --mouse`
+
+- 로그인에 사용할 명령 지정:
+
+`sudo kmscon {{[-l|--login]}} {{명령어}}`
+
+- 지정한 터미널에서 항상 `kmscon` 시작:
+
+`systemctl enable --now kmsconvt@{{ttyX}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
