### PR TITLE
ufw-{status,reload,reset}: add pages

### DIFF
--- a/pages/linux/ufw-reload.md
+++ b/pages/linux/ufw-reload.md
@@ -1,0 +1,13 @@
+# ufw reload
+
+> Reload the firewall and re-apply rules.
+> See also: `ufw`.
+> More information: <https://manned.org/ufw>.
+
+- Reload firewall rules:
+
+`sudo ufw reload`
+
+- Simulate a reload without applying changes:
+
+`sudo ufw --dry-run reload`

--- a/pages/linux/ufw-reset.md
+++ b/pages/linux/ufw-reset.md
@@ -1,0 +1,13 @@
+# ufw reset
+
+> Disable the firewall and delete all rules.
+> See also: `ufw`.
+> More information: <https://manned.org/ufw>.
+
+- Reset `ufw` to installation defaults (prompts for confirmation):
+
+`sudo ufw reset`
+
+- Reset without interactive confirmation:
+
+`sudo ufw --force reset`

--- a/pages/linux/ufw-status.md
+++ b/pages/linux/ufw-status.md
@@ -1,0 +1,21 @@
+# ufw status
+
+> Show the status of Uncomplicated Firewall.
+> See also: `ufw`.
+> More information: <https://manned.org/ufw>.
+
+- Show whether the firewall is active and list rules:
+
+`sudo ufw status`
+
+- Show rules with numbers (useful before `ufw delete`):
+
+`sudo ufw status numbered`
+
+- Show a verbose status including default policies and listening services:
+
+`sudo ufw status verbose`
+
+- Check status without elevated privileges when permitted:
+
+`ufw status`


### PR DESCRIPTION
## Description
Add Linux tldr pages for three common `ufw` subcommands that were still missing:

- `ufw status` (including `numbered` / `verbose`)
- `ufw reload`
- `ufw reset`

Related to the documentation request in #23098.

## Checklist
- [x] The page(s) are in the correct platform directory (`pages/linux`)
- [x] Follows the style guide