### PR TITLE
fmtutil, fmtutil-sys, fmtutil-user: add Korean translation

### DIFF
--- a/pages.ko/common/fmtutil-sys.md
+++ b/pages.ko/common/fmtutil-sys.md
@@ -1,0 +1,20 @@
+# fmtutil-sys
+
+> 시스템 전체의 TeX 포맷과 Metafont 베이스를 관리.
+> 더 많은 정보: <https://manned.org/fmtutil-sys>.
+
+- 모든 시스템 포맷 파일 다시 생성:
+
+`fmtutil-sys --all`
+
+- 누락된 모든 시스템 포맷 파일 다시 생성:
+
+`fmtutil-sys --missing`
+
+- 지정한 시스템 포맷 다시 생성:
+
+`fmtutil-sys --byfmt {{포맷}}`
+
+- 설정된 포맷 목록 표시:
+
+`fmtutil-sys --listcfg`

--- a/pages.ko/common/fmtutil-user.md
+++ b/pages.ko/common/fmtutil-user.md
@@ -1,0 +1,24 @@
+# fmtutil-user
+
+> 현재 사용자의 TeX 포맷과 Metafont 베이스를 관리.
+> 더 많은 정보: <https://manned.org/fmtutil-sys>.
+
+- 모든 사용자 포맷 파일 다시 생성:
+
+`fmtutil-user --all`
+
+- 누락된 모든 사용자 포맷 파일 다시 생성:
+
+`fmtutil-user --missing`
+
+- 지정한 사용자 포맷 다시 생성:
+
+`fmtutil-user --byfmt {{포맷}}`
+
+- 지정한 엔진으로 생성되는 모든 포맷 다시 생성:
+
+`fmtutil-user --byengine {{엔진}}`
+
+- 사용 가능한 모든 포맷 설정 목록 표시:
+
+`fmtutil-user --listcfg`

--- a/pages.ko/common/fmtutil.md
+++ b/pages.ko/common/fmtutil.md
@@ -1,0 +1,24 @@
+# fmtutil
+
+> TeX 포맷과 Metafont 베이스를 관리.
+> 더 많은 정보: <https://manned.org/fmtutil-sys>.
+
+- 모든 포맷 파일 다시 생성:
+
+`fmtutil --all`
+
+- 누락된 모든 포맷 파일 생성:
+
+`fmtutil --missing`
+
+- 사용 가능한 포맷 설정 목록 표시:
+
+`fmtutil --listcfg`
+
+- 지정한 엔진으로 생성되는 포맷 다시 생성:
+
+`fmtutil --byengine {{엔진}}`
+
+- 지정한 포맷 다시 생성:
+
+`fmtutil --byfmt {{포맷}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->
