### PR TITLE
xeyes: refer to xprop

### DIFF
--- a/pages/linux/xeyes.md
+++ b/pages/linux/xeyes.md
@@ -1,6 +1,7 @@
 # xeyes
 
 > Display eyes on the screen that follow the mouse cursor.
+> See also: `xprop`.
 > More information: <https://manned.org/xeyes>.
 
 - Launch xeyes on the local machine's default display:


### PR DESCRIPTION
`xeyes` is often used to detect if a window is x11 of wayland. I often forget what other tools there are. `xprop` is a much more sophisticated tool for that