### PR TITLE
kscreenctl: add page

### DIFF
--- a/pages/linux/kscreenctl.md
+++ b/pages/linux/kscreenctl.md
@@ -32,6 +32,6 @@
 
 `kscreenctl {{HDMI-A-1}} set-enabled false`
 
-- Turn all outputs off (DPMS):
+- Turn all outputs off through Display Power Management Signaling:
 
 `kscreenctl off`

--- a/pages/linux/kscreenctl.md
+++ b/pages/linux/kscreenctl.md
@@ -1,0 +1,37 @@
+# kscreenctl
+
+> Manage display outputs on KDE Plasma.
+> See also: `kscreen-doctor`, `kscreen-console`.
+> More information: <https://invent.kde.org/plasma/kscreen>.
+
+- List all connected outputs:
+
+`kscreenctl list-outputs`
+
+- Show an on-screen label on each monitor to identify connector names:
+
+`kscreenctl identify`
+
+- Show information about a specific output (or use `active-output` / `primary-output`):
+
+`kscreenctl {{DP-1}}`
+
+- Set the resolution and refresh rate of an output:
+
+`kscreenctl {{DP-1}} set-mode 1920x1080@60`
+
+- Set the scale of an output to 200%:
+
+`kscreenctl {{DP-1}} set-scale 200%`
+
+- Place an output to the right of another:
+
+`kscreenctl {{HDMI-A-1}} right-of {{DP-1}}`
+
+- Disable a specific output:
+
+`kscreenctl {{HDMI-A-1}} set-enabled false`
+
+- Turn all outputs off (DPMS):
+
+`kscreenctl off`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** current `master` of KDE Plasma KScreen (`kscreenctl` utility)
- Reference issue: #23313
- Closes: #23313

### Summary

Add a `kscreenctl` page under `pages/linux/` for the KDE Plasma display configuration CLI.

Examples cover common real-world flows, verified against the upstream source and help examples (`list-outputs`, `identify`, output query, `set-mode`, `set-scale`, `right-of`, `set-enabled`, DPMS `off`).

Platform is `linux` to match related tools (`kscreen-doctor`, `kscreen-console`).

Drafted with AI assistance; reviewed by me (KesleyDavid).
