### PR TITLE
kpsewhich: add page

### DIFF
--- a/pages/common/kpsewhich.md
+++ b/pages/common/kpsewhich.md
@@ -1,0 +1,29 @@
+# kpsewhich
+
+> Find TeX-related files and expand Kpathsea variables and paths.
+> See also: `tex`, `latex`, `mktexfmt`.
+> More information: <https://manned.org/kpsewhich>.
+
+- Find a file in the TeX search path (format inferred from the extension):
+
+`kpsewhich {{article.cls}}`
+
+- Find a file using a specific file format:
+
+`kpsewhich -format {{tex}} {{plain.tex}}`
+
+- Show the search path for a specific file format:
+
+`kpsewhich -show-path {{tex}}`
+
+- Print the expanded value of a Kpathsea variable:
+
+`kpsewhich -var-value {{TEXMFHOME}}`
+
+- Expand variables in a string:
+
+`kpsewhich -expand-var '{{$TEXMFDIST/tex}}'`
+
+- Search for a file only in a specific path:
+
+`kpsewhich -path {{path/to/directory}} {{filename}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Kpathsea (TeX Live; man page Kpathsea 6.4.2)
- Reference issue: #23049
- Closes: #23049

### Summary

Add a `kpsewhich` page under `pages/common/` for the standalone Kpathsea path lookup tool used with TeX Live.

Examples (verified against the man page):

- File lookup with format inferred from the extension
- Lookup with `-format`
- `-show-path` for a file type
- `-var-value` and `-expand-var`
- Lookup restricted with `-path`

Platform is `common` (available with TeX Live on multiple OSes).

Drafted with AI assistance; reviewed by me (KesleyDavid).
