### PR TITLE
grafana-cli: scope to plugins and expand examples

### DIFF
--- a/pages/common/grafana-cli.md
+++ b/pages/common/grafana-cli.md
@@ -1,24 +1,37 @@
 # grafana cli
 
-> Administer Grafana.
+> Manage Grafana plugins from the command line.
+> See also: `grafana cli admin`.
 > More information: <https://grafana.com/docs/grafana/latest/administration/cli/>.
 
-- Install plugins:
+- Install one or more plugins:
 
 `grafana cli plugins install {{plugin_id1 plugin_id2 ...}}`
 
-- Specify a homepath when installing a plugin:
+- Install a plugin using a specific Grafana home directory:
 
 `grafana cli --homepath {{/usr/share/grafana}} plugins install {{plugin_id}}`
 
-- Update plugins:
+- List plugins available from the remote repository:
 
-`grafana cli plugins update {{plugin_id1 plugin_id2 ...}}`
-
-- Remove plugins:
-
-`grafana cli plugins remove {{plugin_id1 plugin_id2 ...}}`
+`grafana cli plugins list-remote`
 
 - List all installed plugins:
 
 `grafana cli plugins ls`
+
+- Update one or more plugins:
+
+`grafana cli plugins update {{plugin_id1 plugin_id2 ...}}`
+
+- Update all installed plugins:
+
+`grafana cli plugins update-all`
+
+- Remove one or more plugins:
+
+`grafana cli plugins remove {{plugin_id1 plugin_id2 ...}}`
+
+- Display help:
+
+`grafana cli {{[-h|--help]}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Grafana server CLI (current docs)
- Reference issue: #23030
- Closes: #23030

### Summary

The `grafana-cli` page described “Administer Grafana” but only showed plugin commands, while admin is covered by the existing `grafana-cli-admin` page.

This PR:

- Scopes the description to **plugin management**
- Adds `See also: grafana cli admin`
- Expands examples with verified plugin commands from the docs (`list-remote`, `update-all`, clearer install/update/remove wording, help)

Drafted with AI assistance; reviewed by me (KesleyDavid).
