### PR TITLE
otool: add page

### DIFF
--- a/pages/osx/otool.md
+++ b/pages/osx/otool.md
@@ -1,0 +1,36 @@
+# otool
+
+> Display specified parts of object files, libraries and executables.
+> More information: <https://keith.github.io/xcode-man-pages/otool.1.html>.
+
+- Display the shared libraries a binary is linked against:
+
+`otool -L {{path/to/binary}}`
+
+- Display the install name of a shared library:
+
+`otool -D {{path/to/library.dylib}}`
+
+- Display the Mach header:
+
+`otool -h {{path/to/binary}}`
+
+- Display the load commands:
+
+`otool -l {{path/to/binary}}`
+
+- Disassemble the text section, showing symbolic operands:
+
+`otool -tV {{path/to/binary}}`
+
+- Display the headers of a universal (fat) binary:
+
+`otool -f {{path/to/binary}}`
+
+- Display the contents of a specific section:
+
+`otool -s {{__TEXT}} {{__cstring}} {{path/to/binary}}`
+
+- Operate on one architecture within a universal binary:
+
+`otool -arch {{arm64}} -L {{path/to/binary}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Apple `otool(1)`, as shipped with the Xcode 16 command-line tools
- Reference issue: #
- Closes: #

### Additional details:

Adds a page for `otool`, the Mach-O inspector shipped with the Xcode command-line tools. It had no page under any platform directory.

**Disclosure on the unticked box:** this page was drafted with AI assistance and has not yet been reviewed by me, so I have left that item unchecked rather than tick it inaccurately. I will check it once I have reviewed the page myself. Please hold the PR until then.

Every example was executed against real binaries on macOS 15 (arm64) before submitting:

- `-L`, `-h`, `-l`, `-f`, `-tV`, and `-s __TEXT __cstring` were run against `/bin/ls`
- `-D` was run against a dylib built with a known `-install_name`, confirming it prints that install name
- The flag list was cross-checked against `otool`s own usage string. It has only single-dash options, so no `{{[-s|--long]}}` alternatives apply.

`tldr-lint` and `markdownlint` both pass locally. The reference link uses <https://keith.github.io/xcode-man-pages/>, per the style guide section on `osx` pages.