### PR TITLE
ufw-status: add page

### DIFF
--- a/pages/linux/ufw-status.md
+++ b/pages/linux/ufw-status.md
@@ -1,0 +1,20 @@
+# ufw status
+
+> Show the status of Uncomplicated Firewall and its rules.
+> More information: <https://manned.org/ufw>.
+
+- Show whether the firewall is active and list the rules:
+
+`sudo ufw status`
+
+- Show rules with numbers (useful before deleting a rule by number):
+
+`sudo ufw status numbered`
+
+- Show a verbose status, including default policies and listening ports:
+
+`sudo ufw status verbose`
+
+- Simulate a status report without changing anything:
+
+`sudo ufw --dry-run status`

--- a/pages/linux/ufw-status.md
+++ b/pages/linux/ufw-status.md
@@ -14,7 +14,3 @@
 - Show a verbose status, including default policies and listening ports:
 
 `sudo ufw status verbose`
-
-- Simulate a status report without changing anything:
-
-`sudo ufw --dry-run status`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** ufw (Uncomplicated Firewall)
- Reference issue: #23098
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:

Add a `ufw status` page for viewing firewall state and rules (`status`, `numbered`, `verbose`, and `--dry-run`). Part of the remaining checklist under #23098.

Drafted with AI assistance; reviewed by KesleyDavid.