### PR TITLE
hyprlock, hypridle, hyprcursor-util: add pages

### DIFF
--- a/pages/linux/hyprcursor-util.md
+++ b/pages/linux/hyprcursor-util.md
@@ -1,0 +1,20 @@
+# hyprcursor-util
+
+> Utility to create and extract Hyprcursor cursor themes for Hyprland.
+> More information: <https://github.com/hyprwm/hyprcursor/blob/main/hyprcursor-util/README.md>.
+
+- Compile a working directory into a Hyprcursor theme:
+
+`hyprcursor-util {{[-c|--create]}} {{path/to/theme_directory}}`
+
+- Extract an XCursor theme into a Hyprcursor working directory:
+
+`hyprcursor-util {{[-e|--extract]}} {{path/to/xcursor_theme}}`
+
+- Specify the output directory:
+
+`hyprcursor-util {{[-c|--create]}} {{path/to/theme_directory}} {{[-o|--output]}} {{path/to/output}}`
+
+- Extract a theme with a specific resize mode:
+
+`hyprcursor-util --extract {{path/to/xcursor_theme}} --resize {{none|nearest|bilinear}}`

--- a/pages/linux/hypridle.md
+++ b/pages/linux/hypridle.md
@@ -1,0 +1,22 @@
+# hypridle
+
+> Idle management daemon for the Hyprland Wayland compositor.
+> Executes commands based on inactivity timeouts.
+> Configured via `~/.config/hypr/hypridle.conf`.
+> More information: <https://wiki.hypr.land/Hypr-Ecosystem/hypridle/>.
+
+- Start the idle daemon using the default configuration:
+
+`hypridle`
+
+- Start the idle daemon using a specific configuration file:
+
+`hypridle {{[-c|--config]}} {{path/to/hypridle.conf}}`
+
+- Start the idle daemon with verbose output:
+
+`hypridle {{[-v|--verbose]}}`
+
+- Display help:
+
+`hypridle {{[-h|--help]}}`

--- a/pages/linux/hyprlock.md
+++ b/pages/linux/hyprlock.md
@@ -1,0 +1,25 @@
+# hyprlock
+
+> GPU-accelerated screen locker for the Hyprland Wayland compositor.
+> Configured via `~/.config/hypr/hyprlock.conf`.
+> More information: <https://wiki.hypr.land/Hypr-Ecosystem/hyprlock/>.
+
+- Lock the screen using the default configuration:
+
+`hyprlock`
+
+- Lock the screen using a specific configuration file:
+
+`hyprlock {{[-c|--config]}} {{path/to/hyprlock.conf}}`
+
+- Lock the screen immediately, bypassing the grace period:
+
+`hyprlock --grace 0`
+
+- Disable the fade-in animation when locking:
+
+`hyprlock --no-fade-in`
+
+- Display help:
+
+`hyprlock {{[-h|--help]}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A (version-independent)
- Reference issue: #21928
- Closes: 

### Additional details:

Added three missing pages for the Hypr Ecosystem (`hyprlock`, `hypridle`, `hyprcursor-util`). All pages pass `tldr-lint` locally.