### PR TITLE
tflint: add page and German translation

### DIFF
--- a/pages.de/common/tflint.md
+++ b/pages.de/common/tflint.md
@@ -1,0 +1,36 @@
+# tflint
+
+> Ein erweiterbarer Terraform-Linter zum Finden von Fehlern, Warnen vor veralteter Syntax und Durchsetzen von Best Practices.
+> Weitere Informationen: <https://github.com/terraform-linters/tflint>.
+
+- Plugin-Konfiguration initialisieren und deklarierte Plugins installieren:
+
+`tflint --init`
+
+- Die Terraform-Konfiguration im aktuellen Verzeichnis linten:
+
+`tflint`
+
+- Mit einer bestimmten Konfigurationsdatei linten:
+
+`tflint --config {{pfad/zu/.tflint.hcl}}`
+
+- Rekursiv in jedem Unterverzeichnis ausführen:
+
+`tflint --recursive`
+
+- Nur eine bestimmte Regel aktivieren, alle anderen Standards deaktivieren:
+
+`tflint --only {{regelname}}`
+
+- Eine bestimmte Regel deaktivieren:
+
+`tflint --disable-rule {{regelname}}`
+
+- Probleme automatisch beheben, wo möglich:
+
+`tflint --fix`
+
+- Ergebnisse im JSON-Format ausgeben (nützlich für CI/CD):
+
+`tflint --format json`

--- a/pages/common/tflint.md
+++ b/pages/common/tflint.md
@@ -1,0 +1,36 @@
+# tflint
+
+> A pluggable Terraform linter to find errors, warn about deprecated syntax, and enforce best practices.
+> More information: <https://github.com/terraform-linters/tflint>.
+
+- Initialize plugin configuration and install declared plugins:
+
+`tflint --init`
+
+- Lint the Terraform configuration in the current directory:
+
+`tflint`
+
+- Lint with a specific config file:
+
+`tflint --config {{path/to/.tflint.hcl}}`
+
+- Run recursively in each subdirectory:
+
+`tflint --recursive`
+
+- Enable only a specific rule, disabling all other defaults:
+
+`tflint --only {{rule_name}}`
+
+- Disable a specific rule:
+
+`tflint --disable-rule {{rule_name}}`
+
+- Automatically fix issues where possible:
+
+`tflint --fix`
+
+- Output results in JSON format (useful for CI/CD):
+
+`tflint --format json`


### PR DESCRIPTION
## Description

Adds a tldr page for `tflint` (a pluggable Terraform linter) in English and German.

- `pages/common/tflint.md` — English page with 8 examples
- `pages.de/common/tflint.md` — German translation