### PR TITLE
bot-prevention: add issue writing permissions

### DIFF
--- a/.github/workflows/bot-prevention.yml
+++ b/.github/workflows/bot-prevention.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   check-pr-body:


### PR DESCRIPTION
For some reason writing to pull requests isn't enough permissions

As you can see in here https://github.com/tldr-pages/tldr/pull/23543

~~I don't understand why this worked in my fork but not here.~~
After a chat with copilot, I understand that it's because the workflows run on the permissions of the PR submitter.