### PR TITLE
xfreerdp: update page

### DIFF
--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -9,7 +9,7 @@
 
 - Connect to a FreeRDP server with a custom window width and height:
 
-`xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /w:{{1920}} /h:{{1080}}`
+`xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /w:{{width_in_pixels}} /h:{{height_in_pixels}}`
 
 - Connect to a FreeRDP server with dynamic resolution:
 

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -1,15 +1,15 @@
 # xfreerdp
 
 > Free Remote Desktop Protocol implementation.
-> More information: <https://github.com/FreeRDP/FreeRDP/wiki/CommandLineInterface-(possibly-not-up-to-date,-check-application-help-text-for-most-up-to-date-version)>.
+> More information: <https://www.freerdp.com>.
 
 - Connect to a FreeRDP server:
 
 `xfreerdp /u:{{username}} /p:{{password}} /v:{{ip_address}}`
 
-- Connect to a FreeRDP server and activate audio output redirection using `sys:alsa` device:
+- Connect to a FreeRDP server with a custom window width and height:
 
-`xfreerdp /u:{{username}} /p:{{password}} /v:{{ip_address}} /sound:{{sys:alsa}}`
+`xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /w:{{1920}} /h:{{1080}}`
 
 - Connect to a FreeRDP server with dynamic resolution:
 
@@ -26,3 +26,7 @@
 - Connect to a FreeRDP server with a shared directory:
 
 `xfreerdp /v:{{ip_address}} /u:{{username}} /p:{{password}} /drive:{{path/to/directory}},{{share_name}}`
+
+- Connect to a FreeRDP server and activate audio output redirection using `sys:alsa` device:
+
+`xfreerdp /u:{{username}} /p:{{password}} /v:{{ip_address}} /sound:{{sys:alsa}}`

--- a/pages/linux/xfreerdp.md
+++ b/pages/linux/xfreerdp.md
@@ -1,7 +1,7 @@
 # xfreerdp
 
 > Free Remote Desktop Protocol implementation.
-> More information: <https://www.freerdp.com>.
+> More information: <https://manned.org/xfreerdp>.
 
 - Connect to a FreeRDP server:
 


### PR DESCRIPTION
Updated xfreerdp documentation to include new command options for custom window size and moved audio output redirection to the bottom.

<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #

### Additional details:
- Added example for custom window width and height (`/w:` and `/h:`).
- Moved audio redirection example (`/sound:`) to align with common usage patterns 
- Updated main documentation URL from repository link to official website (`https://www.freerdp.com`).
