### PR TITLE
bot-prevention.yml: do not reveal to the bot why their PR was closed

### DIFF
--- a/.github/workflows/bot-prevention.yml
+++ b/.github/workflows/bot-prevention.yml
@@ -43,7 +43,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `This PR was automatically closed because the description is missing PR template text.`
+                body: `This PR was automatically closed due to suspected bot activity.`
               });
               await github.rest.pulls.update({
                 owner: context.repo.owner,


### PR DESCRIPTION
LLM bots are very adaptive nowadays especially when you tell them what went wrong. A real human will often try to contact someone to get things resolved.