### PR TITLE
nethack: add page

### DIFF
--- a/pages/common/nethack.md
+++ b/pages/common/nethack.md
@@ -1,0 +1,28 @@
+# nethack
+
+> A single-player roguelike dungeon exploration game.
+> More information: <https://nethack.org/>.
+
+- Start the game:
+
+`nethack`
+
+- Start the game with a specific character name:
+
+`nethack -u {{name}}`
+
+- Start the game with a specific profession and race:
+
+`nethack -p {{profession}} -r {{race}}`
+
+- Start in explore mode (discovery mode, non-scoring):
+
+`nethack -X`
+
+- Display the scoreboard:
+
+`nethack -s`
+
+- Start in wizard mode (debug mode, requires game administrator privileges):
+
+`nethack -D`


### PR DESCRIPTION
Adds a tldr page for `nethack`, the classic single-player roguelike dungeon exploration game.

The page covers the most common command-line options:
- Starting the game
- Setting a character name (`-u`)
- Choosing a profession and race (`-p`, `-r`)
- Explore/discovery mode (`-X`)
- Displaying the scoreboard (`-s`)
- Wizard/debug mode (`-D`)

References: [NetHack man page](https://www.nethack.org/download/5.0.0/nethack.txt)

Issue: closes #22118 (partially)