### PR TITLE
scripts: fix AttributeError when staging synced pages

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -66,7 +66,7 @@ def get_tldr_root(lookup_path: Optional[str] = None) -> Path:
 
 def test_get_tldr_root():
     tldr_root = get_tldr_root("/path/to/tldr/scripts/test_script.py")
-    assert tldr_root == Path("/path/to/tldr")
+    assert tldr_root == Path("/path/to/tldr").resolve()
 
     # Set TLDR_ROOT in the environment
     os.environ["TLDR_ROOT"] = "/path/to/tldr_clone"
@@ -177,7 +177,7 @@ def test_get_pages_dirs():
     # Call the function and verify the result
     result = get_pages_dirs(root)
     expected = [root / "pages", root / "pages.fr"]
-    assert result.sort() == expected.sort()  # the order differs on Unix / macOS
+    assert sorted(result) == sorted(expected)  # the order differs on Unix / macOS
 
     shutil.rmtree(root, True)
 
@@ -421,23 +421,25 @@ def test_create_argument_parser():
         assert action.default == default_value  # Check default value
 
 
-def stage(paths: list[Path]):
+def stage(paths: list[Path | str]):
     """
     Stage the given paths using Git.
 
     Parameters:
-    paths (list of Paths): the list of Path's to stage using Git.
+    paths (list of Paths or strings): the list of Path's or strings to stage using Git.
 
     """
-    subprocess.call(["git", "add", *(path.resolve() for path in paths)])
+    subprocess.call(["git", "add", *(Path(path).resolve() for path in paths)])
 
 
 @patch("subprocess.call")
 def test_stage(mock_subprocess_call):
-    paths = [Path("/path/to/file1"), Path("/path/to/file2")]
+    paths = [Path("/path/to/file1"), "/path/to/file2"]
 
     # Call the stage function
     stage(paths)
 
     # Verify that subprocess.call was called with the correct arguments
-    mock_subprocess_call.assert_called_once_with(["git", "add", *paths])
+    mock_subprocess_call.assert_called_once_with(
+        ["git", "add", *(Path(path).resolve() for path in paths)]
+    )

--- a/scripts/set-alias-page.py
+++ b/scripts/set-alias-page.py
@@ -295,11 +295,11 @@ def sync_alias_page_to_locale(pages_dir: Path, alias_page: AliasPage) -> list[Pa
     """
 
     paths = []
-    path = config.root / pages_dir / alias_page.page_path
+    path = pages_dir / alias_page.page_path
     status = set_alias_page(path, alias_page.content)
     if status != "":
         rel_path = "/".join(path.parts[-3:])
-        paths.append(rel_path)
+        paths.append(path)
         print(create_colored_line(Colors.GREEN, f"{rel_path} {status}"))
     return paths
 

--- a/scripts/set-more-info-link.py
+++ b/scripts/set-more-info-link.py
@@ -200,12 +200,12 @@ def sync(
     """
     paths = []
     for page_dir in pages_dirs:
-        path = root / page_dir / command
+        path = page_dir / command
         if path.exists():
             status = set_link(path, link, dry_run, language_to_update)
             if status != "":
                 rel_path = "/".join(path.parts[-3:])
-                paths.append(rel_path)
+                paths.append(path)
                 print(create_colored_line(Colors.GREEN, f"{rel_path} {status}"))
     return paths
 
@@ -269,6 +269,36 @@ def main():
     # Use '--stage' option
     if args.stage and not args.dry_run and len(target_paths) > 0:
         stage(target_paths)
+
+
+def test_sync():
+    import shutil
+
+    root = Path("test_root")
+    shutil.rmtree(root, True)
+    try:
+        pages_fr = root / "pages.fr"
+        (pages_fr / "common").mkdir(parents=True, exist_ok=True)
+        test_page = pages_fr / "common" / "tar.md"
+        test_page.write_text(
+            "# tar\n\n> Archiving utility.\n\n- Example:\n\n`tar`\n",
+            encoding="utf-8",
+        )
+
+        global config
+        config = Config(
+            root=root,
+            pages_dirs=[pages_fr],
+            templates={"fr": "> Plus d'informations : <https://example.com>.\n"},
+        )
+
+        results = sync(
+            root, [pages_fr], "common/tar.md", "https://example.com/doc", dry_run=True
+        )
+        assert results == [test_page]
+        assert isinstance(results[0], Path)
+    finally:
+        shutil.rmtree(root, True)
 
 
 if __name__ == "__main__":

--- a/scripts/set-page-title.py
+++ b/scripts/set-page-title.py
@@ -136,7 +136,7 @@ def sync(
     title: str,
     dry_run: bool = False,
     language_to_update: str = "",
-) -> list[str]:
+) -> list[Path]:
     """
     Synchronize a page title into all translations.
 
@@ -153,12 +153,12 @@ def sync(
     """
     paths = []
     for page_dir in pages_dirs:
-        path = root / page_dir / command
+        path = page_dir / command
         if path.exists():
             status = set_page_title(path, title, dry_run, language_to_update)
             if status != "":
                 rel_path = "/".join(path.parts[-3:])
-                paths.append(rel_path)
+                paths.append(path)
                 print(create_colored_line(Colors.GREEN, f"{rel_path} {status}"))
     return paths
 
@@ -210,6 +210,24 @@ def main():
     # Use '--stage' option
     if args.stage and not args.dry_run and len(target_paths) > 0:
         stage(target_paths)
+
+
+def test_sync():
+    import shutil
+
+    root = Path("test_root")
+    shutil.rmtree(root, True)
+    try:
+        pages_fr = root / "pages.fr"
+        (pages_fr / "common").mkdir(parents=True, exist_ok=True)
+        test_page = pages_fr / "common" / "tar.md"
+        test_page.write_text("# old_title\n\n> Archiving utility.\n", encoding="utf-8")
+
+        results = sync(root, [pages_fr], "common/tar.md", "new_title", dry_run=True)
+        assert results == [test_page]
+        assert isinstance(results[0], Path)
+    finally:
+        shutil.rmtree(root, True)
 
 
 if __name__ == "__main__":

--- a/scripts/set-see-also.py
+++ b/scripts/set-see-also.py
@@ -208,12 +208,12 @@ def sync(
     """
     paths = []
     for page_dir in pages_dirs:
-        path = root / page_dir / command
+        path = page_dir / command
         if path.exists():
             status = set_see_also(path, see_also, dry_run, language_to_update)
             if status != "":
                 rel_path = "/".join(path.parts[-3:])
-                paths.append(rel_path)
+                paths.append(path)
                 print(create_colored_line(Colors.GREEN, f"{rel_path} {status}"))
     return paths
 
@@ -279,6 +279,34 @@ def main():
     # Use '--stage' option
     if args.stage and not args.dry_run and len(target_paths) > 0:
         stage(target_paths)
+
+
+def test_sync():
+    import shutil
+
+    root = Path("test_root")
+    shutil.rmtree(root, True)
+    try:
+        pages_fr = root / "pages.fr"
+        (pages_fr / "common").mkdir(parents=True, exist_ok=True)
+        test_page = pages_fr / "common" / "tar.md"
+        test_page.write_text(
+            "# tar\n\n> Archiving utility.\n\n- Example:\n\n`tar`\n",
+            encoding="utf-8",
+        )
+
+        global config
+        config = Config(
+            root=root,
+            pages_dirs=[pages_fr],
+            templates={"fr": "> Voir aussi : `example`.\n"},
+        )
+
+        results = sync(root, [pages_fr], "common/tar.md", "`gtar`", dry_run=True)
+        assert results == [test_page]
+        assert isinstance(results[0], Path)
+    finally:
+        shutil.rmtree(root, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
Fixes an `AttributeError: 'str' object has no attribute 'resolve'` that occurs when running synchronization scripts (`set-more-info-link.py`, `set-page-title.py`, `set-see-also.py`, and `set-alias-page.py`) with `--stage` (`-s`).

**Summary of changes:**
1. **`scripts/_common.py`**:
   - Made `stage(paths: list[Path | str])` defensively wrap elements with `Path(path).resolve()`.
   - Updated `test_stage` unit test to verify handling both `Path` and `str` elements against resolved paths.
   - Updated assertions in `test_get_tldr_root` and `test_get_pages_dirs`.
2. **`scripts/set-more-info-link.py`**, **`scripts/set-page-title.py`**, **`scripts/set-see-also.py`**, **`scripts/set-alias-page.py`**:
   - Changed `sync()` / `sync_alias_page_to_locale()` to return `list[Path]` by appending `path` (`Path` object) instead of `rel_path` (`str`).
   - Fixed `path` construction in `sync()` to use `page_dir / command`.
   - Added `test_sync()` unit regression tests.
3. All tests pass (`pytest scripts/`) and scripts conform to `flake8` and `black`.
