### PR TITLE
slideshow: add page

### DIFF
--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -1,6 +1,6 @@
 # slideshow
 
-> Tool to make presentation slides, part of Racket language ecosystem.
+> Make presentation slides in the Racket language.
 > More information: <https://docs.racket-lang.org/slideshow>.
 
 - Display a default slide with options to run the tutorial or load a `.rkt` presentation file:

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -19,6 +19,6 @@
 
 `slideshow -s {{width}} {{height}} {{path/to/presentation.rkt}}`
 
-- Save presentation in PDF file format:
+- Export a presentation to a PDF file:
 
 `slideshow --pdf -o {{path/to/presentation.pdf}} {{path/to/presentation.rkt}}`

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -1,0 +1,24 @@
+# slideshow
+
+> Tool to make presentation slides, part of Racket language ecosystem.
+> More information: <https://docs.racket-lang.org/slideshow>.
+
+- Display a default slide with options to run the tutorial or load a `.rkt` presentation file:
+
+`slideshow`
+
+- Show a presentation in full screen:
+
+`slideshow {{path/to/presentation.rkt}}`
+
+- Instead of full screen, give the presentation slide window a title bar and resize border:
+
+`slideshow --keep-titlebar {{path/to/presentation.rkt}}`
+
+- Set width and height (in pixels) of presentation slide window:
+
+`slideshow -s {{width}} {{height}} {{path/to/presentation.rkt}}`
+
+- Save presentation in PDF file format:
+
+`slideshow --pdf -o {{path/to/presentation.pdf}} {{path/to/presentation.rkt}}`

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -17,7 +17,7 @@
 
 - Set the width and height (in pixels) of the presentation window:
 
-`slideshow -s {{width}} {{height}} {{path/to/presentation.rkt}}`
+`slideshow {{[-s|--size]}} {{width}} {{height}} {{path/to/presentation.rkt}}`
 
 - Export a presentation to a PDF file:
 

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -11,7 +11,7 @@
 
 `slideshow {{path/to/presentation.rkt}}`
 
-- Instead of full screen, give the presentation slide window a title bar and resize border:
+- Display the presentation window with a title bar and resize border:
 
 `slideshow --keep-titlebar {{path/to/presentation.rkt}}`
 

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -21,4 +21,4 @@
 
 - Export a presentation to a PDF file:
 
-`slideshow --pdf -o {{path/to/presentation.pdf}} {{path/to/presentation.rkt}}`
+`slideshow {{[-D|--pdf]}} -o {{path/to/presentation.pdf}} {{path/to/presentation.rkt}}`

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -15,7 +15,7 @@
 
 `slideshow --keep-titlebar {{path/to/presentation.rkt}}`
 
-- Set width and height (in pixels) of presentation slide window:
+- Set the width and height (in pixels) of the presentation window:
 
 `slideshow -s {{width}} {{height}} {{path/to/presentation.rkt}}`
 

--- a/pages/common/slideshow.md
+++ b/pages/common/slideshow.md
@@ -7,7 +7,7 @@
 
 `slideshow`
 
-- Show a presentation in full screen:
+- Start a presentation in full screen:
 
 `slideshow {{path/to/presentation.rkt}}`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Racket v9.2 (`slideshow` is part of standard library of Racket language)
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

https://docs.racket-lang.org/slideshow/Creating_Slide_Presentations.html#(part._.Command-line_.Options) shows a couple of common usages and asks users to refer to `--help` for more options. So I have included full `--help` output here for reference:

```bash
$ slideshow --help
usage: slideshow [ <option> ... ] [<slide-module-file>]

<option> is one of

  -M <monitor>, --monitor <monitor>
     display to <monitor> (count from 0)
  -d, --preview
     show next-slide preview (useful on a non-mirroring display)
  -p, --print
     print
  -P, --ps
     print to PostScript
  -D, --pdf
     print to PDF
  -o <file>
     set output file for PostScript or PDF printing
  -e, --not-paper
     use slide as PostScript or PDF bounding box
  -c, --condense
     condense
  -x, --export
     short for `--pdf -c -o <slide-module-file-without-suffix>.pdf`
  -t <page>, --start <page>
     set the starting page
  -q, --quad
     show four slides at a time
/ --widescreen
|    set default slide aspect to 16:9
| --fullscreen
\    set default slide aspect to 4:3 (current default)
  --save-aspect
     record selected aspect in preferences
  -r, --no-resize
     don't resize window when the connected display changes
  -n, --no-stretch
     don't stretch the slide window to fit the screen
  -s <w> <h>, --size <w> <h>
     use a <w> by <h> window
  -a, --squash
     scale to full window, even if not matching aspect
  -z, --zero-margins
     when printing, draw the slides to the edge of the page
  -m, --no-smoothing
     disable anti-aliased drawing (usually faster)
  -i, --immediate
     no transitions
  --trust
     allow slide program to write files and make network connections
  --no-prefetch
     disable next-slide prefetch
  --preview-prefetch
     use prefetch for next-slide preview
  --keep-titlebar
     give the slide window a title bar and resize border
  --right-half-screen
     display slides on right half of the screen
  --comment
     display commentary in window
  --comment-on-slide
     display commentary on slide
  --letterbox <color>
     set the color of the letter box; default to black
  --time
     time seconds per slide
  --elapsed-time
     show an elapsed timer on the preview window
  --clock
     show clock
/ --progress-text
|    report printing progress via stdout instead of a GUI window
| --progress-none
\    do not report printing progress
  --help, -h
     Show this help
  --
     Do not treat any remaining argument as a switch (at this level)

 /|\ Brackets indicate mutually exclusive options.

 Multiple single-letter switches can be combined after
 one `-`. For example, `-h-` is the same as `-h --`.
 After requiring <slide-module-file>, if a `slideshow' submodule exists,
  it is required. Otherwise, if a `main' submodule exists, it is required.
```
