### PR TITLE
flux-{delete,export,get,reconcile,resume,suspend,uninstall}: add pages

### DIFF
--- a/pages/common/flux-delete.md
+++ b/pages/common/flux-delete.md
@@ -1,0 +1,24 @@
+# flux delete
+
+> Delete Flux sources and resources from a cluster.
+> More information: <https://fluxcd.io/flux/cmd/flux_delete/>.
+
+- Delete a Kustomization:
+
+`flux delete kustomization {{name}}`
+
+- Delete a source of a specific kind:
+
+`flux delete source {{git|helm|bucket|oci}} {{name}}`
+
+- Delete a HelmRelease:
+
+`flux delete helmrelease {{name}}`
+
+- Delete a resource in a specific namespace:
+
+`flux delete kustomization {{name}} --namespace {{namespace}}`
+
+- Delete a resource without asking for confirmation:
+
+`flux delete kustomization {{name}} --silent`

--- a/pages/common/flux-export.md
+++ b/pages/common/flux-export.md
@@ -1,0 +1,24 @@
+# flux export
+
+> Export Flux resources in YAML format.
+> More information: <https://fluxcd.io/flux/cmd/flux_export/>.
+
+- Export a Kustomization:
+
+`flux export kustomization {{name}}`
+
+- Export a source of a specific kind:
+
+`flux export source {{git|helm|bucket|oci}} {{name}}`
+
+- Export all Kustomizations in the current namespace:
+
+`flux export kustomization --all`
+
+- Export all sources of a specific kind to a file:
+
+`flux export source git --all > {{path/to/sources.yaml}}`
+
+- Export a HelmRelease from a specific namespace:
+
+`flux export helmrelease {{name}} --namespace {{namespace}}`

--- a/pages/common/flux-get.md
+++ b/pages/common/flux-get.md
@@ -1,0 +1,36 @@
+# flux get
+
+> Get the statuses of Flux resources.
+> More information: <https://fluxcd.io/flux/cmd/flux_get/>.
+
+- List all Flux resources in the current namespace:
+
+`flux get all`
+
+- List all Flux resources across every namespace:
+
+`flux get all --all-namespaces`
+
+- List Kustomizations and their reconciliation status:
+
+`flux get kustomizations`
+
+- List sources of a specific kind:
+
+`flux get sources {{git|helm|bucket|oci|chart}}`
+
+- List HelmReleases in a specific namespace:
+
+`flux get helmreleases --namespace {{namespace}}`
+
+- List only the resources that are not ready:
+
+`flux get all --status-selector {{ready=false}}`
+
+- Filter resources by label:
+
+`flux get kustomizations --label-selector {{key=value}}`
+
+- Watch resources for status changes:
+
+`flux get kustomizations --watch`

--- a/pages/common/flux-reconcile.md
+++ b/pages/common/flux-reconcile.md
@@ -1,0 +1,32 @@
+# flux reconcile
+
+> Trigger a reconciliation of Flux sources and resources.
+> More information: <https://fluxcd.io/flux/cmd/flux_reconcile/>.
+
+- Reconcile a Kustomization:
+
+`flux reconcile kustomization {{name}}`
+
+- Reconcile a Kustomization together with its source:
+
+`flux reconcile kustomization {{name}} --with-source`
+
+- Reconcile a source of a specific kind:
+
+`flux reconcile source {{git|helm|bucket|oci|chart}} {{name}}`
+
+- Reconcile a HelmRelease:
+
+`flux reconcile helmrelease {{name}}`
+
+- Reconcile a HelmRelease and its source:
+
+`flux reconcile helmrelease {{name}} --with-source`
+
+- Reconcile an image repository to scan for new tags:
+
+`flux reconcile image repository {{name}}`
+
+- Reconcile a resource in a specific namespace:
+
+`flux reconcile kustomization {{name}} --namespace {{namespace}}`

--- a/pages/common/flux-resume.md
+++ b/pages/common/flux-resume.md
@@ -1,0 +1,29 @@
+# flux resume
+
+> Resume the reconciliation of suspended Flux resources.
+> See also: `flux suspend`.
+> More information: <https://fluxcd.io/flux/cmd/flux_resume/>.
+
+- Resume a Kustomization:
+
+`flux resume kustomization {{name}}`
+
+- Resume a HelmRelease:
+
+`flux resume helmrelease {{name}}`
+
+- Resume a source of a specific kind:
+
+`flux resume source {{git|helm|bucket|oci|chart}} {{name}}`
+
+- Resume all Kustomizations in the current namespace:
+
+`flux resume kustomization --all`
+
+- Resume all Kustomizations, waiting for each one to reconcile before moving on to the next:
+
+`flux resume kustomization --all --wait`
+
+- Resume a resource in a specific namespace:
+
+`flux resume kustomization {{name}} --namespace {{namespace}}`

--- a/pages/common/flux-suspend.md
+++ b/pages/common/flux-suspend.md
@@ -1,0 +1,25 @@
+# flux suspend
+
+> Suspend the reconciliation of Flux resources.
+> See also: `flux resume`.
+> More information: <https://fluxcd.io/flux/cmd/flux_suspend/>.
+
+- Suspend a Kustomization:
+
+`flux suspend kustomization {{name}}`
+
+- Suspend a HelmRelease:
+
+`flux suspend helmrelease {{name}}`
+
+- Suspend a source of a specific kind:
+
+`flux suspend source {{git|helm|bucket|oci|chart}} {{name}}`
+
+- Suspend all Kustomizations in the current namespace:
+
+`flux suspend kustomization --all`
+
+- Suspend a resource in a specific namespace:
+
+`flux suspend kustomization {{name}} --namespace {{namespace}}`

--- a/pages/common/flux-uninstall.md
+++ b/pages/common/flux-uninstall.md
@@ -1,0 +1,25 @@
+# flux uninstall
+
+> Remove the Flux components and custom resources from a cluster.
+> See also: `flux bootstrap`.
+> More information: <https://fluxcd.io/flux/cmd/flux_uninstall/>.
+
+- Display the objects that would be deleted, without removing them:
+
+`flux uninstall --dry-run`
+
+- Remove the Flux components and custom resources:
+
+`flux uninstall`
+
+- Remove Flux from a specific namespace:
+
+`flux uninstall --namespace {{namespace}}`
+
+- Remove the Flux components but keep the namespace:
+
+`flux uninstall --keep-namespace`
+
+- Remove Flux without asking for confirmation:
+
+`flux uninstall --silent`


### PR DESCRIPTION
Completes the remaining unchecked subcommands from #22184.

`flux`, `flux bootstrap`, `flux build`, `flux check`, and `flux create` were added in #22295. This adds pages for the seven subcommands that were still outstanding:

- `flux delete`
- `flux export`
- `flux get`
- `flux reconcile`
- `flux resume`
- `flux suspend`
- `flux uninstall`

Examples are based on the upstream CLI reference at <https://fluxcd.io/flux/cmd/>, and each page links to its corresponding reference page. `flux suspend` and `flux resume` cross-reference each other, and `flux uninstall` references `flux bootstrap`.