### PR TITLE
pages.pt_BR: add apropos, amixer and adb-logcat

### DIFF
--- a/pages.pt_BR/common/adb-logcat.md
+++ b/pages.pt_BR/common/adb-logcat.md
@@ -1,0 +1,36 @@
+# adb logcat
+
+> Despeja um registro (log) de mensagens do sistema.
+> Mais informações: <https://developer.android.com/tools/logcat>.
+
+- Exibe registros (logs) do sistema:
+
+`adb logcat`
+
+- Exibe linhas que correspondem a uma `reg[e]x`:
+
+`adb logcat -e {{regex}}`
+
+- Exibe registros de uma tag em um modo específico ([V]erbose (detalhado), [D]ebug (depuração), [I]nfo (informação), [W]arning (aviso), [E]rror (erro), [F]atal (fatal), [S]ilent (silencioso)), filtrando outras tags:
+
+`adb logcat {{tag}}:{{mode}} *:S`
+
+- Exibe registros de aplicações React Native em modo [V]erbose, silenciando outras tags:
+
+`adb logcat ReactNative:V ReactNativeJS:V *:S`
+
+- Exibe registros de todas as tags com nível de prioridade [W]arning (aviso) ou superior:
+
+`adb logcat *:W`
+
+- Exibe registros de um PID específico:
+
+`adb logcat --pid {{pid}}`
+
+- Exibe registros do processo de um pacote específico:
+
+`adb logcat --pid $(adb shell pidof -s {{package}})`
+
+- Colore o registro (geralmente usado com filtros):
+
+`adb logcat -v color`

--- a/pages.pt_BR/common/amixer.md
+++ b/pages.pt_BR/common/amixer.md
@@ -1,0 +1,12 @@
+# amixer
+
+> Mixer (controlador de volume) do driver de som ALSA.
+> Mais informações: <https://manned.org/amixer>.
+
+- Aumenta o volume principal em 10%:
+
+`amixer -D pulse sset Master {{10%+}}`
+
+- Diminui o volume principal em 10%:
+
+`amixer -D pulse sset Master {{10%-}}`

--- a/pages.pt_BR/common/apropos.md
+++ b/pages.pt_BR/common/apropos.md
@@ -1,0 +1,17 @@
+# apropos
+
+> Busca nomes e descrições nas páginas de manual.
+> Veja também: `man`.
+> Mais informações: <https://manned.org/apropos>.
+
+- Busca por uma palavra-chave usando uma `regex`:
+
+`apropos {{regex}}`
+
+- Busca sem limitar a saída à largura do terminal (saída longa):
+
+`apropos {{[-l|--long]}} {{regex}}`
+
+- Busca páginas que correspondem a todas as `regex` fornecidas:
+
+`apropos {{regex_1}} {{[-a|--and]}} {{regex_2}} {{[-a|--and]}} {{regex_3}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Reference issue: #13575

Adds Portuguese (Brazilian) translations for:
- apropos
- amixer
- adb-logcat
