### PR TITLE
docker-compose-{down, logs, start, stop, up}: add pt_BR translations

### DIFF
--- a/pages.pt_BR/common/docker-compose-down.md
+++ b/pages.pt_BR/common/docker-compose-down.md
@@ -1,0 +1,36 @@
+# docker compose down
+
+> Para e remove contêineres, redes, imagens e volumes criados por `docker compose up`.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/compose/down/>.
+
+- Para e remove todos os contêineres e redes:
+
+`docker compose down`
+
+- Para e remove contêineres, redes e todas as imagens usadas pelos serviços:
+
+`docker compose down --rmi all`
+
+- Para e remove contêineres, redes e apenas imagens sem uma tag personalizada:
+
+`docker compose down --rmi local`
+
+- Para e remove contêineres, redes e todos os volumes:
+
+`docker compose down {{[-v|--volumes]}}`
+
+- Para e remove tudo, incluindo contêineres órfãos:
+
+`docker compose down --remove-orphans`
+
+- Para e remove contêineres usando um arquivo compose alternativo:
+
+`docker compose {{[-f|--file]}} {{caminho/para/config}} down`
+
+- Para e remove contêineres com um tempo limite personalizado em segundos:
+
+`docker compose down {{[-t|--timeout]}} {{tempo_limite}}`
+
+- Remove contêineres de serviços não definidos no arquivo Compose:
+
+`docker compose down --remove-orphans {{[-v|--volumes]}}`

--- a/pages.pt_BR/common/docker-compose-down.md
+++ b/pages.pt_BR/common/docker-compose-down.md
@@ -23,7 +23,7 @@
 
 `docker compose down --remove-orphans`
 
-- Para e remove contêineres usando um arquivo compose alternativo:
+- Para e remove contêineres usando um arquivo Compose alternativo:
 
 `docker compose {{[-f|--file]}} {{caminho/para/config}} down`
 

--- a/pages.pt_BR/common/docker-compose-logs.md
+++ b/pages.pt_BR/common/docker-compose-logs.md
@@ -1,36 +1,36 @@
 # docker compose logs
 
-> Visualiza a saída dos contêineres de uma aplicação Docker Compose.
+> Exibe a saída dos contêineres de uma aplicação Docker Compose.
 > Mais informações: <https://docs.docker.com/reference/cli/docker/compose/logs/>.
 
-- Visualiza os registros (logs) de todos os serviços:
+- Exibe os registros (logs) de todos os serviços:
 
 `docker compose logs`
 
-- Visualiza os registros de um serviço específico:
+- Exibe os registros de um serviço específico:
 
 `docker compose logs {{nome_do_serviço}}`
 
-- Visualiza os registros e acompanha novas saídas (como `tail --follow`):
+- Exibe os registros e acompanha novas saídas (como `tail --follow`):
 
 `docker compose logs {{[-f|--follow]}}`
 
-- Visualiza os registros com timestamps:
+- Exibe os registros com timestamps:
 
 `docker compose logs {{[-t|--timestamps]}}`
 
-- Visualiza apenas as últimas `n` linhas de registros de cada contêiner:
+- Exibe apenas as últimas `n` linhas de registros de cada contêiner:
 
 `docker compose logs {{[-n|--tail]}} {{n}}`
 
-- Visualiza os registros a partir de um horário específico:
+- Exibe os registros a partir de um horário específico:
 
 `docker compose logs --since {{timestamp}}`
 
-- Visualiza os registros até um horário específico:
+- Exibe os registros até um horário específico:
 
 `docker compose logs --until {{timestamp}}`
 
-- Visualiza os registros de vários serviços específicos:
+- Exibe os registros de vários serviços específicos:
 
 `docker compose logs {{serviço1 serviço2 ...}}`

--- a/pages.pt_BR/common/docker-compose-logs.md
+++ b/pages.pt_BR/common/docker-compose-logs.md
@@ -1,0 +1,36 @@
+# docker compose logs
+
+> Visualiza a saída dos contêineres de uma aplicação Docker Compose.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/compose/logs/>.
+
+- Visualiza os registros (logs) de todos os serviços:
+
+`docker compose logs`
+
+- Visualiza os registros de um serviço específico:
+
+`docker compose logs {{nome_do_serviço}}`
+
+- Visualiza os registros e acompanha novas saídas (como `tail --follow`):
+
+`docker compose logs {{[-f|--follow]}}`
+
+- Visualiza os registros com timestamps:
+
+`docker compose logs {{[-t|--timestamps]}}`
+
+- Visualiza apenas as últimas `n` linhas de registros de cada contêiner:
+
+`docker compose logs {{[-n|--tail]}} {{n}}`
+
+- Visualiza os registros a partir de um horário específico:
+
+`docker compose logs --since {{timestamp}}`
+
+- Visualiza os registros até um horário específico:
+
+`docker compose logs --until {{timestamp}}`
+
+- Visualiza os registros de vários serviços específicos:
+
+`docker compose logs {{serviço1 serviço2 ...}}`

--- a/pages.pt_BR/common/docker-compose-start.md
+++ b/pages.pt_BR/common/docker-compose-start.md
@@ -15,7 +15,7 @@
 
 `docker compose start --dry-run`
 
-- Inicia os contêineres existentes e aguarda os serviços estarem em execução ou saudáveis:
+- Inicia os contêineres existentes e aguarda até que os serviços estejam em execução ou saudáveis:
 
 `docker compose start --wait`
 

--- a/pages.pt_BR/common/docker-compose-start.md
+++ b/pages.pt_BR/common/docker-compose-start.md
@@ -1,0 +1,24 @@
+# docker compose start
+
+> Inicia contêineres existentes dos serviços.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/compose/start/>.
+
+- Inicia os contêineres existentes de todos os serviços:
+
+`docker compose start`
+
+- Inicia os contêineres existentes de um ou mais serviços:
+
+`docker compose start {{serviço1 serviço2 ...}}`
+
+- Simula a inicialização dos contêineres existentes:
+
+`docker compose start --dry-run`
+
+- Inicia os contêineres existentes e aguarda os serviços estarem em execução ou saudáveis:
+
+`docker compose start --wait`
+
+- Inicia os contêineres existentes e aguarda por até um número especificado de segundos:
+
+`docker compose start --wait --wait-timeout {{segundos}}`

--- a/pages.pt_BR/common/docker-compose-stop.md
+++ b/pages.pt_BR/common/docker-compose-stop.md
@@ -19,7 +19,7 @@
 
 `docker compose {{[-f|--file]}} {{caminho/para/arquivo_compose}} stop`
 
-- Execução simulada (mostra as operações sem executá-las):
+- Executa de forma simulada (mostra as operações sem executá-las):
 
 `docker compose stop --dry-run`
 

--- a/pages.pt_BR/common/docker-compose-stop.md
+++ b/pages.pt_BR/common/docker-compose-stop.md
@@ -1,0 +1,28 @@
+# docker compose stop
+
+> Para contêineres em execução sem removê-los.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/compose/stop>.
+
+- Para todos os serviços em execução:
+
+`docker compose stop`
+
+- Para serviços específicos:
+
+`docker compose stop {{serviço_1 serviço_2 ...}}`
+
+- Para com um tempo limite de desligamento personalizado em segundos:
+
+`docker compose stop {{[-t|--timeout]}} {{segundos}}`
+
+- Para os serviços definidos em um arquivo compose específico:
+
+`docker compose {{[-f|--file]}} {{caminho/para/arquivo_compose}} stop`
+
+- Execução simulada (mostra as operações sem executá-las):
+
+`docker compose stop --dry-run`
+
+- Para serviços específicos com um tempo limite personalizado:
+
+`docker compose stop {{[-t|--timeout]}} {{segundos}} {{serviço_1 serviço_2 ...}}`

--- a/pages.pt_BR/common/docker-compose-up.md
+++ b/pages.pt_BR/common/docker-compose-up.md
@@ -7,7 +7,7 @@
 
 `docker compose up`
 
-- Inicia os serviços em segundo plano (modo destacado):
+- Inicia os serviços em segundo plano (modo desanexado):
 
 `docker compose up {{[-d|--detach]}}`
 

--- a/pages.pt_BR/common/docker-compose-up.md
+++ b/pages.pt_BR/common/docker-compose-up.md
@@ -1,0 +1,36 @@
+# docker compose up
+
+> Inicia e executa os serviços Docker definidos em um arquivo Compose.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/compose/up/>.
+
+- Inicia todos os serviços definidos no arquivo docker-compose:
+
+`docker compose up`
+
+- Inicia os serviços em segundo plano (modo destacado):
+
+`docker compose up {{[-d|--detach]}}`
+
+- Inicia os serviços e reconstrói as imagens antes de iniciar:
+
+`docker compose up --build`
+
+- Inicia apenas serviços específicos:
+
+`docker compose up {{serviço1 serviço2 ...}}`
+
+- Inicia os serviços com um arquivo compose personalizado:
+
+`docker compose {{[-f|--file]}} {{caminho/para/config}} up`
+
+- Inicia os serviços e remove contêineres órfãos:
+
+`docker compose up --remove-orphans`
+
+- Inicia os serviços com instâncias em escala:
+
+`docker compose up --scale {{serviço}}={{contagem}}`
+
+- Inicia os serviços e mostra os registros com timestamps:
+
+`docker compose up --timestamps`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Reference issue: #13575

Adds Portuguese (Brazilian) translations for the Docker Compose family:
- docker compose down
- docker compose logs
- docker compose start
- docker compose stop
- docker compose up
