### PR TITLE
duff: add page

### DIFF
--- a/pages.da/common/duff.md
+++ b/pages.da/common/duff.md
@@ -1,0 +1,20 @@
+# duff
+
+> Command-line utility for identifying duplicate files in a set of directories.
+> More information: <https://github.com/elbohs/duff>.
+
+- Search specified directories for duplicate files:
+
+`duff {{path/to/directory1 path/to/directory2 ...}}`
+
+- Search directories recursively:
+
+`duff -r {{path/to/directory}}`
+
+- Search for duplicates while ignoring empty files:
+
+`duff -e {{path/to/directory}}`
+
+- Excessively quiet mode (suppress header information):
+
+`duff -q {{path/to/directory}}`


### PR DESCRIPTION
### Description
This PR adds the command-line page for `duff`, a utility for identifying duplicate files across directories.

### Checklist
- [x] The page follows the [page layout guidelines](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md#page-layout).
- [x] The page title is lowercase and matches the filename (`duff`).
- [x] The description ends with a period and starts with a capital letter.
- [x] The `More information` link points to the official repository/documentation.
- [x] All examples are concise, idiomatic, and use standard placeholder formatting (`{{placeholder}}`).
- [x] Tested with `tldr-lint` / `markdownlint`.