### PR TITLE
vllm, vllm chat: add pages

### DIFF
--- a/pages/common/vllm-chat.md
+++ b/pages/common/vllm-chat.md
@@ -1,0 +1,28 @@
+# vllm chat
+
+> Generate chat completions via the running API server using the OpenAI-compatible REST API.
+> More information: <https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html>.
+
+- Send a single chat prompt to the API server and get a response:
+
+`vllm chat --quick "{{message}}"`
+
+- Chat with a specific model name:
+
+`vllm chat --model-name {{model_name}} --quick "{{message}}"`
+
+- Chat with a custom system prompt:
+
+`vllm chat --system-prompt "{{system_prompt}}" --quick "{{message}}"`
+
+- Chat using a custom API server URL:
+
+`vllm chat --url {{http://custom-host:port/v1}} --quick "{{message}}"`
+
+- Chat with an API key for authentication:
+
+`vllm chat --api-key {{your_api_key}} --quick "{{message}}"`
+
+- Start an interactive chat session:
+
+`vllm chat`


### PR DESCRIPTION
## Description

Adds a new tldr page for `vllm chat`, which generates chat completions via the running vLLM OpenAI-compatible API server. Examples are based on `vllm chat --help=all` output.

## Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
