### PR TITLE
makepkg: fix flag name in --skippgpcheck

### DIFF
--- a/pages/linux/makepkg.md
+++ b/pages/linux/makepkg.md
@@ -18,7 +18,7 @@
 
 - Make a package, but skip checking the source's hashes and PGP signatures:
 
-`makepkg --skipchecksums --skippgpchecks`
+`makepkg --skipchecksums --skippgpcheck`
 
 - Clean up work directories after a successful build:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

> --skippgpcheck
>    Do not verify PGP signatures of source files.

manual : https://man.archlinux.org/man/makepkg.8