### PR TITLE
llm-prompt: add page

### DIFF
--- a/pages/common/llm-prompt.md
+++ b/pages/common/llm-prompt.md
@@ -1,0 +1,28 @@
+# llm prompt
+
+> Execute a prompt using a Large Language Model.
+> More information: <https://llm.datasette.io/en/stable/usage.html#executing-a-prompt>.
+
+- Execute a prompt using the default model:
+
+`llm prompt "{{Ten fun names for a pet pelican}}"`
+
+- Execute a prompt with a specific model and system prompt:
+
+`llm prompt "{{Explain quantum entanglement}}" {{[-m|--model]}} {{model_name}} {{[-s|--system]}} "{{Answer concisely}}"`
+
+- Execute a prompt with an attachment:
+
+`llm prompt "{{Describe this image}}" {{[-a|--attachment]}} {{path/to/image.jpg}}`
+
+- Request structured JSON using a concise schema:
+
+`llm prompt "{{Invent a dog}}" --schema "{{name, age int, active bool}}"`
+
+- Continue the most recent conversation:
+
+`llm prompt "{{What about Germany?}}" {{[-c|--continue]}}`
+
+- Extract the first fenced code block from the response:
+
+`llm prompt "{{Write a JavaScript function that reverses a string}}" {{[-x|--extract]}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.33
- Reference issue: #11448
- Closes:

### Additional details:

Adds a focused page for the `llm prompt` subcommand covering the default model, model and system prompt selection, attachments, structured output schemas, conversation continuation, and fenced code extraction.

The commands were checked against the official LLM 0.33 CLI reference and usage documentation. The page was prepared with AI assistance, human-reviewed, and validated with `tldr-lint`, `markdownlint`, and the repository test suite.
