### PR TITLE
clinfo: add page

### DIFF
--- a/pages/common/clinfo.md
+++ b/pages/common/clinfo.md
@@ -1,0 +1,36 @@
+# clinfo
+
+> Display information about all available OpenCL platforms and devices.
+> More information: <https://github.com/Oblomov/clinfo>.
+
+- Display all available information about all OpenCL platforms and devices:
+
+`clinfo`
+
+- List platform and device names only, without properties:
+
+`clinfo {{[-l|--list]}}`
+
+- Display properties of a specific device of a specific platform (indices as shown by `clinfo --list`):
+
+`clinfo {{[-d|--device]}} {{platform_index}}:{{device_index}}`
+
+- Display only properties whose symbolic name contains a specific substring:
+
+`clinfo --prop {{property_name}}`
+
+- Try to display all properties, even those not officially supported:
+
+`clinfo {{[-a|--all-props]}}`
+
+- Produce machine-friendly raw output:
+
+`clinfo --raw`
+
+- Produce output in JSON format (experimental):
+
+`clinfo --json`
+
+- Display version:
+
+`clinfo {{[-v|--version]}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 3.4.x
- Reference issue: #23618
- Closes: #23618

### Additional details:
Adds the `clinfo` page requested in #23618. Placed in `common` since clinfo is packaged for Linux, macOS (Homebrew), Windows, and the BSDs. All flags were verified against the upstream man page (`man1/clinfo.1` in Oblomov/clinfo): `-l`/`--list`, `-d`/`--device platform:device`, `--prop`, `-a`/`--all-props`, `--raw`, `--json` (experimental upstream), `-v`/`--version`. `tldr-lint` and `markdownlint` pass locally.
