### PR TITLE
gtrash: add page

### DIFF
--- a/pages/common/gtrash.md
+++ b/pages/common/gtrash.md
@@ -1,0 +1,37 @@
+# gtrash
+
+> A trash CLI manager following the FreeDesktop.org Trash specification.
+> Trashed files can be found, restored, and removed permanently.
+> More information: <https://github.com/umlx5h/gtrash>.
+
+- Move specific files to the trash can:
+
+`gtrash put {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
+
+- Select files to restore from the trash can interactively:
+
+`gtrash restore`
+
+- Restore files trashed by the last `gtrash put` execution:
+
+`gtrash restore-group`
+
+- List all trashed files:
+
+`gtrash find`
+
+- List trashed files matching specific names:
+
+`gtrash find {{file1 dir1 ...}}`
+
+- Restore trashed files matching a specific name:
+
+`gtrash find {{file1}} --restore`
+
+- Permanently remove trashed files matching a specific name:
+
+`gtrash find {{file1}} --rm`
+
+- Display a summary of all trash cans:
+
+`gtrash summary`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 1.x
- Reference issue: #23645
- Closes: #23645

### Additional details:
Adds the `gtrash` page requested in #23645. `gtrash` is a Go trash CLI implementing the FreeDesktop.org Trash specification; first released January 2024, so it meets the one-year maintenance requirement. Placed in `common` per upstream support (Linux and macOS). Commands verified against the upstream README and the cobra command sources (`internal/cmd/`: put, restore, restore-group, find [--restore/--rm], summary). `tldr-lint` and `markdownlint` pass locally.

Resubmission of #23688, which was auto-closed because I had rewritten the checklist section instead of keeping the template text intact — the page itself passed full CI (CI=SUCCESS) and the CLA is signed.
