### PR TITLE
jj-rebase: replace deprecated flag

### DIFF
--- a/pages/common/jj-rebase.md
+++ b/pages/common/jj-rebase.md
@@ -5,15 +5,15 @@
 
 - Move given revisions to a different parent(s):
 
-`jj rebase {{[-r|--revisions]}} {{revset}} {{[-d|--destination]}} {{revset}}`
+`jj rebase {{[-r|--revisions]}} {{revset}} {{[-o|--onto]}} {{revset}}`
 
 - Move given revisions and all their descendants:
 
-`jj rebase {{[-s|--source]}} {{revset}} {{[-d|--destination]}} {{revset}}`
+`jj rebase {{[-s|--source]}} {{revset}} {{[-o|--onto]}} {{revset}}`
 
 - Move all revisions in the branch containing given revisions:
 
-`jj rebase {{[-b|--branch]}} {{revset}} {{[-d|--destination]}} {{revset}}`
+`jj rebase {{[-b|--branch]}} {{revset}} {{[-o|--onto]}} {{revset}}`
 
 - Move revisions to before and/or after other revisions:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 0.44.0
- Reference issue: #17040 

### Additional details:
This flag was deprecated in [0.36.0](https://docs.jj-vcs.dev/latest/changelog/#0360-2025-12-03) and `--onto` is the preferred flag.
