### PR TITLE
aider: add Traditional Chinese translation

### DIFF
--- a/pages.zh_TW/common/aider.md
+++ b/pages.zh_TW/common/aider.md
@@ -1,0 +1,28 @@
+# aider
+
+> 與自選的大型語言模型進行結對程式設計。
+> 更多資訊：<https://github.com/Aider-AI/aider>。
+
+- 啟動新專案或在現有程式碼庫中工作：
+
+`aider --model {{model_name}} --api-key {{your_api_key}}`
+
+- 為指定檔案新增功能或測試案例：
+
+`aider {{path/to/file1 path/to/file2 ...}}`
+
+- 描述錯誤並讓 `aider` 修正：
+
+`aider {{path/to/file}} --describe "{{bug_description}}"`
+
+- 重構指定檔案中的程式碼：
+
+`aider {{path/to/file}} --refactor`
+
+- 更新文件：
+
+`aider {{path/to/file}} --update-docs`
+
+- 顯示說明：
+
+`aider --help`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** current English page at upstream commit `228ba0ab9`
- Reference issue: #
- Closes: #

### Additional details:

Adds the missing `zh_TW` translation for the existing `aider` page. The command lines, placeholders, example order, and official project link are unchanged from the English source. The page passes the repository translation lint configuration and markdownlint; the official link resolves with HTTP 200.

AI assistance disclosure: Codex helped compare translation coverage, draft the Traditional Chinese text, and run validation. Human review: project collaborator @emmanuel-ferdman approved this contribution.