### PR TITLE
age: add Traditional Chinese translation

### DIFF
--- a/pages.zh_TW/common/age.md
+++ b/pages.zh_TW/common/age.md
@@ -1,0 +1,25 @@
+# age
+
+> 一個簡潔、現代且安全的檔案加密工具。
+> 另請參閱：`age-keygen`、`age-inspect`。
+> 更多資訊：<https://github.com/FiloSottile/age#usage>。
+
+- 產生可使用密碼片語解密的加密檔案：
+
+`age {{[-p|--passphrase]}} {{[-o|--output]}} {{path/to/encrypted_file.age}} {{path/to/unencrypted_file}}`
+
+- 使用直接輸入的一個或多個公開金鑰加密檔案（重複使用 `--recipient` 旗標以指定多個公開金鑰）：
+
+`age {{[-r|--recipient]}} {{public_key}} {{[-o|--output]}} {{path/to/encrypted_file.age}} {{path/to/unencrypted_file}}`
+
+- 使用檔案中指定的公開金鑰為一個或多個收件者加密檔案（每行一個金鑰）：
+
+`age {{[-R|--recipients-file]}} {{path/to/recipients_file.txt}} {{[-o|--output]}} {{path/to/encrypted_file.age}} {{path/to/unencrypted_file}}`
+
+- 使用密碼片語解密檔案：
+
+`age {{[-d|--decrypt]}} {{[-o|--output]}} {{path/to/decrypted_file}} {{path/to/encrypted_file.age}}`
+
+- 使用私密金鑰檔案解密檔案：
+
+`age {{[-d|--decrypt]}} {{[-i|--identity]}} {{path/to/private_key_file}} {{[-o|--output]}} {{path/to/decrypted_file}} {{path/to/encrypted_file.age}}`


### PR DESCRIPTION
### Checklist\n\n- [x] The page(s) are in the correct platform directories: , , , , , , etc.\n- [x] The page description(s) have links to documentation or a homepage.\n- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).\n- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).\n- [x] The PR contains at most 5 new pages.\n- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.\n- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).\n- **Version of the command being documented (if known):**\n- Reference issue: #\n- Closes: #\n\n### Additional details:\n\nAdds the Traditional Chinese translation for the  page while preserving all five upstream commands, options, placeholders, and canonical links.\n\nValidation:\n- page-specific tldr-lint and markdownlint checks\n- exact command-line comparison against \n- repository-wide 
> test
> bash scripts/test.sh

Skipping black check, command not available.
Skipping flake8 check, command not available.
Skipping pytest check, command not available.
Skipping shellcheck check, command not available.
Test ran successfully!\n- official usage link returned HTTP 200\n- GitHub CI, PR-body, labeler, and CLA checks passed on the initial head\n\nFollow-up  changes the multi-command See also separator to the canonical form used by existing zh_TW pages; the repository-wide test script passes again.\n\nAI assistance disclosure: Codex was used to compare the page structure with current upstream, check the repository translation templates, run validation, and draft this description. The human-review checklist item intentionally remains unchecked pending independent human review of the Traditional Chinese wording.