### PR TITLE
kubectl-krew: add Traditional Chinese translation

### DIFF
--- a/pages.zh_TW/common/kubectl-krew.md
+++ b/pages.zh_TW/common/kubectl-krew.md
@@ -1,0 +1,33 @@
+# kubectl krew
+
+> `kubectl` 的外掛程式管理工具。
+> 另請參閱：`kubectl-plugin`。
+> 更多資訊：<https://krew.sigs.k8s.io/docs/>。
+
+- 搜尋可用的外掛程式：
+
+`kubectl krew search`
+
+- 安裝外掛程式：
+
+`kubectl krew install {{外掛程式名稱}}`
+
+- 列出已安裝的外掛程式：
+
+`kubectl krew list`
+
+- 更新本機外掛程式索引：
+
+`kubectl krew update`
+
+- 升級所有已安裝的外掛程式：
+
+`kubectl krew upgrade`
+
+- 取得外掛程式的資訊：
+
+`kubectl krew info {{外掛程式名稱}}`
+
+- 解除安裝外掛程式：
+
+`kubectl krew uninstall {{外掛程式名稱}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** current English page at upstream commit `a15417085`
- Reference issue: #
- Closes: #

### Additional details:

Adds the missing `zh_TW` translation for the existing `kubectl krew` page. All seven command examples, ordering, and the official Krew documentation link remain aligned with the English source. The translation uses the repository's standard zh_TW templates for See also and More information. Page-specific markdownlint, translation-aware tldr-lint, Prettier, `git diff --check`, and the complete repository `npm test` suite pass. The official documentation link returns HTTP 200.

AI assistance disclosure: Codex helped compare translation coverage, draft the Traditional Chinese text, and run validation. Independent human review is still required before the human-review checklist item can be completed.
