### PR TITLE
govulncheck: fix extract mode description

### DIFF
--- a/pages/common/govulncheck.md
+++ b/pages/common/govulncheck.md
@@ -16,7 +16,7 @@
 
 `govulncheck -mode binary {{path/to/binary}}`
 
-- Extract build information and build information from a go binary:
+- Extract the information needed to analyze a Go binary:
 
 `govulncheck -mode extract {{path/to/binary}}`
 

--- a/pages/common/govulncheck.md
+++ b/pages/common/govulncheck.md
@@ -16,7 +16,7 @@
 
 `govulncheck -mode binary {{path/to/binary}}`
 
-- Extract the information needed to analyze a Go binary:
+- Extract build information and build dependencies from a Go binary:
 
 `govulncheck -mode extract {{path/to/binary}}`
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** `golang.org/x/vuln/cmd/govulncheck` v1.7.0 documentation
- Reference issue: #
- Closes: #

### Additional details:

The extract-mode example currently repeats “build information” twice and calls the executable a lowercase “go binary.” The official govulncheck documentation instead defines extract mode as extracting the minimal information needed to analyze a Go binary. This patch makes the description accurate without changing the accepted command.

Page-specific tldr-lint, markdownlint, Prettier, `git diff --check`, and the complete repository `npm test` suite pass. The official documentation link returns HTTP 200, and there is no open PR for this page.

AI assistance disclosure: Codex helped trace the sentence to its introducing PR, compare it with the official Go documentation, and run validation. Independent human review is still required before the human-review checklist item can be completed.
