### PR TITLE
uv: add Traditional Chinese translation

### DIFF
--- a/pages.zh_TW/common/uv.md
+++ b/pages.zh_TW/common/uv.md
@@ -1,0 +1,37 @@
+# uv
+
+> 快速的 Python 套件與專案管理器。
+> 此命令也有關於其子命令的文件，例如：`tool` 和 `python`.
+> 更多資訊：<https://docs.astral.sh/uv/reference/cli/>。
+
+- 在目前的目錄建立新的 Python 專案：
+
+`uv init`
+
+- 在指定路徑建立新的 Python 專案：
+
+`uv init {{路徑/至/目錄}}`
+
+- 將新的相依項加入專案：
+
+`uv add {{套件}}`
+
+- 從專案移除相依項：
+
+`uv remove {{套件}}`
+
+- 在專案環境中執行指令碼或命令：
+
+`uv run {{路徑/至/指令碼.py|命令}}`
+
+- 依照 `pyproject.toml` 更新專案環境：
+
+`uv sync`
+
+- 為專案的相依項建立鎖定檔案：
+
+`uv lock`
+
+- 建置專案的原始碼與二進位發行套件：
+
+`uv build`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Current uv CLI reference; translated from English page at base `a15417085548fd4f5cc2d21256f57e72aa1be6bf`.
- Reference issue: #
- Closes: #

### Additional details:

This adds the missing Traditional Chinese page for `uv`, preserving all eight examples and command structures from the current English page. It uses the repository zh-TW subcommand template and established Taiwan terminology for dependencies, lockfiles, scripts, and paths.

Verification:

- locale-aware `tldr-lint`
- `markdownlint`
- complete `npm test`
- 8/8 command structures compared with the English source
- all current open PR changed files checked for duplicates
- all command meanings cross-checked against the current official uv CLI reference

AI assistance disclosure: Codex was used to compare the English source, repository translation templates, existing zh-TW terminology, and open PR files, and to run validation. The Traditional Chinese page still requires independent human review before the human-review checklist item can be completed and the PR should be reopened.