### PR TITLE
woodpecker-cli: add page

### DIFF
--- a/pages/common/woodpecker-cli.md
+++ b/pages/common/woodpecker-cli.md
@@ -1,0 +1,36 @@
+# woodpecker-cli
+
+> Manage, configure, and inspect Woodpecker CI servers, and run workflows locally.
+> More information: <https://woodpecker-ci.org/docs/cli>.
+
+- Lint all workflows in the current project:
+
+`woodpecker-cli lint`
+
+- Execute a workflow locally:
+
+`woodpecker-cli exec {{path/to/workflow.yml}}`
+
+- Execute a workflow locally with environment variables:
+
+`woodpecker-cli exec --env {{variable_name}}={{variable_value}} {{path/to/workflow.yml}}`
+
+- Execute a workflow locally with secrets:
+
+`woodpecker-cli exec --secrets {{name}}="{{value}}" {{path/to/workflow.yml}}`
+
+- Execute a workflow locally with multiple secrets:
+
+`woodpecker-cli exec --secrets {{name1="value1",name2="value2",...}} {{path/to/workflow.yml}}`
+
+- Setup woodpecker-cli for managing a Woodpecker CI server:
+
+`woodpecker-cli setup`
+
+- Show recent pipelines that have run on the remote Woodpecker CI server:
+
+`woodpecker-cli pipeline show`
+
+- Update woodpecker-cli to the latest version:
+
+`woodpecker-cli update`

--- a/pages/common/woodpecker-cli.md
+++ b/pages/common/woodpecker-cli.md
@@ -23,7 +23,7 @@
 
 `woodpecker-cli exec --secrets {{name1="value1",name2="value2",...}} {{path/to/workflow.yml}}`
 
-- Setup woodpecker-cli for managing a Woodpecker CI server:
+- Set up the command-line client to manage a Woodpecker CI server:
 
 `woodpecker-cli setup`
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** 3.18.0
- Reference issue: # N/A
- Closes: # N/A
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

This isn't exactly the place for it, but just some notes regarding a recent conversation in the Matrix chat room around mirroring to Codeberg.

Reference: https://matrix.to/#/!zXiOpjSkFTvtMpsenJ:gitter.im/$wWDjyOOxwtXB9XPV-GHmvAQmUqokmYiwXAmZ9BXNmsE?via=gitter.im&via=matrix.org&via=one.ems.host

_(After that conversation, I finally felt motivated to migrate all of my projects from GitLab to Codeberg.)_

On Codeberg the first-class options for CI are Woodpecker CI and Forejo Actions. It seems Woodpecker CI is the more thoroughly documented and stable approach for now.

- The first 5 commands (`… lint` and `… exec`) are commands I actually used while porting my `.gitlab-ci.yml` to `.woodpecker/*.yml` workflows.
- The last 3 (`… setup`, `… pipeline` and `… update`) are just padding to get to 8 examples, though I did test them ofc against my self-hosted Woodpecker CI instance.

The example for multiple secrets might be redundant, but I included that because it ended up being a pain point for me as the original documentation wasn't very clear. ^-^'

They document it like this:

> --secrets="": map of secrets, ex. 'secret="val",secret2="value2"'
> 
> \- [Woodpecker CI: CLI Documentation](https://woodpecker-ci.org/docs/cli#exec)

So I did `--secrets 'name1="value1",name2="value2"'` originally, but this fails as it includes the quotes in each secret value. We need it specifically without the outer single quotes for it to work, which was the motiviation for documenting it here.