### PR TITLE
trash: fix typo

### DIFF
--- a/pages/linux/trash.md
+++ b/pages/linux/trash.md
@@ -23,7 +23,7 @@
 
 `trash-empty 10`
 
-- Remove all files in the trash, which match a specific blob pattern:
+- Remove all files in the trash, which match a specific glob pattern:
 
 `trash-rm "{{*.o}}"`
 


### PR DESCRIPTION
I think it was referring to

> use of pattern matching against the names in a filesystem directory such that a name pattern is expanded into a list of names matching that pattern.

which is glob and not blob, must be a typo

https://en.wikipedia.org/wiki/Glob_(programming)

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

