### PR TITLE
clinfo: add page

### DIFF
--- a/pages/common/clinfo.md
+++ b/pages/common/clinfo.md
@@ -1,0 +1,24 @@
+# clinfo
+
+> Display information about OpenCL platforms and devices.
+> More information: <https://github.com/Oblomov/clinfo>.
+
+- Display full OpenCL system information:
+
+`clinfo`
+
+- List all available platforms and devices by name:
+
+`clinfo --list`
+
+- Display detailed information for a specific platform and device:
+
+`clinfo --device {{platform_index}}:{{device_index}}`
+
+- Display raw property values without human-readable formatting:
+
+`clinfo --raw`
+
+- Output information in JSON format:
+
+`clinfo --json`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** clinfo 3.0+
- Reference issue: #23618
- Closes: #23618

### Additional details:
Added a new page for `clinfo` (an OpenCL platform and device enumerator utility) under `pages/common/clinfo.md`.
All linters and test suites (`tldr-lint`, `markdownlint`) passed cleanly locally.