### PR TITLE
oras: add page

### DIFF
--- a/pages/common/oras.md
+++ b/pages/common/oras.md
@@ -1,0 +1,36 @@
+# oras
+
+> OCI Registry As Storage - manage OCI artifacts, images, and packages.
+> More information: <https://oras.land/docs/commands/use_oras_cli/>.
+
+- Log in to a remote OCI registry:
+
+`oras login --username {{username}} --password {{password}} {{registry.example.com}}`
+
+- Push files to a registry with a specific tag:
+
+`oras push {{registry.example.com/namespace/repo:tag}} {{path/to/file1 path/to/file2 ...}}`
+
+- Pull files from a registry:
+
+`oras pull {{registry.example.com/namespace/repo:tag}}`
+
+- Copy an artifact between registries:
+
+`oras copy {{registry1.example.com/namespace/repo:tag}} {{registry2.example.com/namespace/repo:tag}}`
+
+- Tag an existing artifact in a registry:
+
+`oras tag {{registry.example.com/namespace/repo:tag}} {{new_tag}}`
+
+- List repositories in a registry:
+
+`oras repo list {{registry.example.com}}`
+
+- List tags for a repository in a registry:
+
+`oras repo tags {{registry.example.com/namespace/repo}}`
+
+- Fetch and display the manifest of an artifact:
+
+`oras manifest fetch {{registry.example.com/namespace/repo:tag}}`


### PR DESCRIPTION
Closes #22180

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `oras`, OCI Registry As Storage CLI.

### Commands included
- Log in to a remote OCI registry (`oras login`)
- Push files to a registry with a specific tag (`oras push`)
- Pull files from a registry (`oras pull`)
- Copy an artifact between registries (`oras copy`)
- Tag an existing artifact in a registry (`oras tag`)
- List repositories in a registry (`oras repo list`)
- List tags for a repository in a registry (`oras repo tags`)
- Fetch and display the manifest of an artifact (`oras manifest fetch`)