### PR TITLE
gtrash: add page

### DIFF
--- a/pages/common/gtrash.md
+++ b/pages/common/gtrash.md
@@ -1,0 +1,28 @@
+# gtrash
+
+> Fast CLI trash manager written in Go.
+> More information: <https://github.com/umlx5h/gtrash>.
+
+- Move files or directories to the trash:
+
+`gtrash put {{path/to/file_or_directory1 path/to/file_or_directory2 ...}}`
+
+- Open an interactive TUI to restore trashed files:
+
+`gtrash restore`
+
+- Find and list trashed files:
+
+`gtrash find`
+
+- Permanently delete specific files from the trash:
+
+`gtrash rm {{file_name}}`
+
+- Empty all items from the trash:
+
+`gtrash clear`
+
+- Display trash summary and disk usage statistics:
+
+`gtrash summary`


### PR DESCRIPTION
Closes #23645

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `gtrash`, fast CLI trash manager written in Go.

### Commands included
- Move files or directories to the trash (`gtrash put`)
- Open an interactive TUI to restore trashed files (`gtrash restore`)
- Find and list trashed files (`gtrash find`)
- Permanently delete specific files from the trash (`gtrash rm`)
- Empty all items from the trash (`gtrash clear`)
- Display trash summary and disk usage statistics (`gtrash summary`)