### PR TITLE
asusctl: add page

### DIFF
--- a/pages/linux/asusctl.md
+++ b/pages/linux/asusctl.md
@@ -1,0 +1,36 @@
+# asusctl
+
+> Control ASUS ROG and TUF laptop settings on Linux.
+> More information: <https://asus-linux.org/asusctl/>.
+
+- Display the current power and fan profile:
+
+`asusctl profile -p`
+
+- Switch to the next power and fan profile:
+
+`asusctl profile -n`
+
+- Set a specific power and fan profile:
+
+`asusctl profile -s {{Quiet|Balanced|Performance}}`
+
+- Set the keyboard LED backlight mode:
+
+`asusctl led-mode {{static|breathe|rainbow|pulse}}`
+
+- Set the battery charge threshold limit:
+
+`asusctl -c {{80}}`
+
+- Display the current GPU graphics mode:
+
+`asusctl graphics -g`
+
+- Set the screen panel overdrive state:
+
+`asusctl bios --panel-od {{true|false}}`
+
+- Display current system information and capabilities:
+
+`asusctl info`


### PR DESCRIPTION
Closes #23662

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `asusctl`, system control utility for ASUS ROG and TUF laptops on Linux.

### Commands included
- Display the current power and fan profile (`asusctl profile -p`)
- Switch to the next power and fan profile (`asusctl profile -n`)
- Set a specific power and fan profile (`asusctl profile -s`)
- Set the keyboard LED backlight mode (`asusctl led-mode`)
- Set the battery charge threshold limit (`asusctl -c`)
- Display the current GPU graphics mode (`asusctl graphics -g`)
- Set the screen panel overdrive state (`asusctl bios --panel-od`)
- Display current system information and capabilities (`asusctl info`)