### PR TITLE
garble: add page

### DIFF
--- a/pages/common/garble.md
+++ b/pages/common/garble.md
@@ -1,0 +1,28 @@
+# garble
+
+> Obfuscate Go builds by stripping information and renaming symbols.
+> More information: <https://github.com/burrowers/garble>.
+
+- Build an obfuscated binary for the package in the current directory:
+
+`garble build`
+
+- Build with obfuscated literals such as strings and numbers:
+
+`garble -literals build`
+
+- Build a stripped and minimized binary for extra obfuscation:
+
+`garble -tiny build`
+
+- Build an obfuscated binary with a custom seed for reproducible builds:
+
+`garble -seed={{seed}} build`
+
+- Run tests with obfuscated packages:
+
+`garble test`
+
+- De-obfuscate a stack trace from an obfuscated binary:
+
+`garble reverse < {{path/to/stack_trace.txt}}`


### PR DESCRIPTION
Closes #19654

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `garble`, Go build obfuscator.

### Commands included
- Build an obfuscated binary for the current package (`garble build`)
- Build with obfuscated literals (`garble -literals build`)
- Build a stripped and minimized binary (`garble -tiny build`)
- Build with a custom seed for reproducible obfuscation (`garble -seed`)
- Run tests with obfuscated packages (`garble test`)
- De-obfuscate a stack trace (`garble reverse`)