### PR TITLE
xbindkeys: add page

### DIFF
--- a/pages/linux/xbindkeys.md
+++ b/pages/linux/xbindkeys.md
@@ -1,0 +1,32 @@
+# xbindkeys
+
+> Grab keys and mouse buttons to run shell commands in X11.
+> More information: <https://manned.org/xbindkeys>.
+
+- Start the `xbindkeys` daemon:
+
+`xbindkeys`
+
+- Generate a default sample configuration file:
+
+`xbindkeys --defaults > {{path/to/xbindkeysrc}}`
+
+- Start `xbindkeys` using a specific configuration file:
+
+`xbindkeys -f {{path/to/file}}`
+
+- Interactively identify key codes and mouse button combinations:
+
+`xbindkeys -k`
+
+- Run `xbindkeys` in the foreground for debugging:
+
+`xbindkeys -n -v`
+
+- Reload configuration without restarting the daemon:
+
+`xbindkeys -p`
+
+- Display currently registered key bindings:
+
+`xbindkeys --show`


### PR DESCRIPTION
Closes #21329

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `xbindkeys`, X11 key and mouse binding daemon.

### Commands included
- Start the xbindkeys daemon (`xbindkeys`)
- Generate default sample configuration file (`xbindkeys --defaults`)
- Start with a specific configuration file (`xbindkeys -f`)
- Identify key codes and button combinations (`xbindkeys -k`)
- Run in foreground for debugging (`xbindkeys -n -v`)
- Reload configuration without restart (`xbindkeys -p`)
- Display current key bindings (`xbindkeys --show`)