### PR TITLE
kpsewhich: add page

### DIFF
--- a/pages/common/kpsewhich.md
+++ b/pages/common/kpsewhich.md
@@ -1,0 +1,24 @@
+# kpsewhich
+
+> Standalone path lookup and variable expansion for the Kpathsea TeX library.
+> More information: <https://manned.org/kpsewhich>.
+
+- Locate a TeX or LaTeX file in the TeX directory structure:
+
+`kpsewhich {{file_or_package.sty}}`
+
+- Locate all matches for a specific file:
+
+`kpsewhich --all {{file_or_package.sty}}`
+
+- Locate a file with a specific format:
+
+`kpsewhich --format={{tfm|bib|sty|cls|tex}} {{filename}}`
+
+- Print the value of a specific TeX configuration variable:
+
+`kpsewhich --var-value={{TEXMFDIST}}`
+
+- Locate a file under a specific TeX engine context:
+
+`kpsewhich --progname={{pdflatex}} {{filename}}`


### PR DESCRIPTION
Closes #23049

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

---

### Description
Add documentation page for `kpsewhich`, Kpathsea TeX library path lookup and variable expansion tool.

### Commands included
- Locate a TeX or LaTeX file (`kpsewhich`)
- Locate all matches for a specific file (`kpsewhich --all`)
- Locate a file with a specific format (`kpsewhich --format`)
- Print the value of a specific TeX configuration variable (`kpsewhich --var-value`)
- Locate a file under a specific TeX engine context (`kpsewhich --progname`)