### PR TITLE
grub-mkimage: add page

### DIFF
--- a/pages/linux/grub-mkimage.md
+++ b/pages/linux/grub-mkimage.md
@@ -1,0 +1,33 @@
+# grub-mkimage
+
+> Generate a bootable GRUB image from modules.
+> See also: `grub-install`, `grub-mkrescue`.
+> More information: <https://manpages.debian.org/unstable/grub2-common/grub-mkimage.1.en.html>.
+
+- Generate an `x86_64` UEFI image with specific modules:
+
+`grub-mkimage {{[-O|--format]}} {{x86_64-efi}} {{[-o|--output]}} {{path/to/grubx64.efi}} {{part_gpt fat normal}}`
+
+- Generate a network boot image with a `(tftp)/grub` prefix:
+
+`grub-mkimage {{[-O|--format]}} {{x86_64-efi}} {{[-o|--output]}} {{path/to/grubx64.efi}} {{[-p|--prefix]}} '(tftp)/grub' {{efinet tftp}}`
+
+- Embed an early configuration file in an image:
+
+`grub-mkimage {{[-O|--format]}} {{x86_64-efi}} {{[-o|--output]}} {{path/to/grubx64.efi}} {{[-c|--config]}} {{path/to/early.cfg}} {{normal}}`
+
+- Use modules from a custom directory:
+
+`grub-mkimage {{[-O|--format]}} {{i386-pc}} {{[-o|--output]}} {{path/to/core.img}} {{[-d|--directory]}} {{path/to/grub_modules}} {{biosdisk part_msdos ext2 normal}}`
+
+- Compress the core image with `xz`:
+
+`grub-mkimage {{[-O|--format]}} {{x86_64-efi}} {{[-o|--output]}} {{path/to/grubx64.efi}} {{[-C|--compression]}} xz {{normal}}`
+
+- Display help:
+
+`grub-mkimage {{[-?|--help]}}`
+
+- Display version:
+
+`grub-mkimage {{[-V|--version]}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [[content guidelines](app://-/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines)](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [[style guide](app://-/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md)](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [[templates](app://-/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title)](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** GNU GRUB 2.14
- Reference issue: #8080
- Closes:
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

Adds a Linux page for `grub-mkimage` with examples for UEFI image generation, TFTP network boot, embedded early configuration, custom module directories, and core image compression.

Validation completed:

- Structural TLDR page checks
- `git diff --check`
- Options checked against the current `grub-mkimage` manual