### PR TITLE
conan-{build, create, install, profile, remote}: add page

### DIFF
--- a/pages/common/conan-build.md
+++ b/pages/common/conan-build.md
@@ -1,0 +1,16 @@
+# conan build
+
+> Install dependencies and call the `build()` method of a recipe.
+> More information: <https://docs.conan.io/2/reference/commands/build.html>.
+
+- Build the package defined in the current directory:
+
+`conan build {{.}}`
+
+- Build the package and store the artifacts in a specific output folder:
+
+`conan build {{.}} --of {{path/to/output_folder}}`
+
+- Build the package using a specific profile:
+
+`conan build {{.}} {{[-pr|--profile]}} {{profile_name}}`

--- a/pages/common/conan-build.md
+++ b/pages/common/conan-build.md
@@ -9,7 +9,7 @@
 
 - Build the package and store the artifacts in a specific output folder:
 
-`conan build {{.}} --of {{path/to/output_folder}}`
+`conan build {{.}} {{[-of|--output-folder]}} {{path/to/output_folder}}`
 
 - Build the package using a specific profile:
 

--- a/pages/common/conan-create.md
+++ b/pages/common/conan-create.md
@@ -1,0 +1,16 @@
+# conan create
+
+> Create a package from a `conanfile.py` recipe.
+> More information: <https://docs.conan.io/2/reference/commands/create.html>.
+
+- Create a package from the recipe in the current directory:
+
+`conan create {{.}}`
+
+- Create a package with a specific name and version:
+
+`conan create {{.}} --name {{name}} --version {{version}}`
+
+- Create a package with a specific user and channel:
+
+`conan create {{.}} --user {{user}} --channel {{channel}}`

--- a/pages/common/conan-install.md
+++ b/pages/common/conan-install.md
@@ -1,0 +1,24 @@
+# conan install
+
+> Install the dependencies specified in a recipe or `conanfile.txt`.
+> More information: <https://docs.conan.io/2/reference/commands/install.html>.
+
+- Install dependencies for the current directory:
+
+`conan install {{.}}`
+
+- Install dependencies, building from source only when prebuilt binaries are missing:
+
+`conan install {{.}} --build {{missing}}`
+
+- Install dependencies using a specific profile:
+
+`conan install {{.}} {{[-pr|--profile]}} {{profile_name}}`
+
+- Install dependencies in Release mode:
+
+`conan install {{.}} {{[-s|--settings]}} {{build_type=Release}}`
+
+- Install dependencies into a specific output folder:
+
+`conan install {{.}} --of {{path/to/output_folder}}`

--- a/pages/common/conan-install.md
+++ b/pages/common/conan-install.md
@@ -9,7 +9,7 @@
 
 - Install dependencies, building from source only when prebuilt binaries are missing:
 
-`conan install {{.}} --build {{missing}}`
+`conan install {{.}} {{[-b|--build]}} {{missing}}`
 
 - Install dependencies using a specific profile:
 
@@ -21,4 +21,4 @@
 
 - Install dependencies into a specific output folder:
 
-`conan install {{.}} --of {{path/to/output_folder}}`
+`conan install {{.}} {{[-of|--output-folder]}} {{path/to/output_folder}}`

--- a/pages/common/conan-profile.md
+++ b/pages/common/conan-profile.md
@@ -1,0 +1,20 @@
+# conan profile
+
+> Manage Conan profiles, which define settings and options for building packages.
+> More information: <https://docs.conan.io/2/reference/commands/profile.html>.
+
+- Auto-detect the host environment and create a `default` profile:
+
+`conan profile detect`
+
+- List the profiles in the cache:
+
+`conan profile list`
+
+- Show the aggregated configuration of the current profiles:
+
+`conan profile show`
+
+- Show the path of a specific profile:
+
+`conan profile path {{profile_name}}`

--- a/pages/common/conan-remote.md
+++ b/pages/common/conan-remote.md
@@ -1,0 +1,24 @@
+# conan remote
+
+> Manage the list of Conan remotes and the users authenticated on them.
+> More information: <https://docs.conan.io/2/reference/commands/remote.html>.
+
+- List the configured remotes:
+
+`conan remote list`
+
+- Add a remote:
+
+`conan remote add {{remote_name}} {{url}}`
+
+- Disable a remote without removing it:
+
+`conan remote disable {{remote_name}}`
+
+- Log in to a remote:
+
+`conan remote login {{remote_name}}`
+
+- Remove a remote:
+
+`conan remote remove {{remote_name}}`

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -1,7 +1,7 @@
 # conan
 
 > The open source, decentralized, and cross-platform package manager to create and share all your native binaries.
-> Some subcommands such as `frogarian` have their own usage documentation.
+> Some subcommands such as `install`, `create`, `profile`, `remote` have their own usage documentation.
 > More information: <https://docs.conan.io/2/reference/commands.html>.
 
 - Install packages based on `conanfile.txt`:

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -4,25 +4,29 @@
 > Some subcommands such as `install`, `create`, `profile`, `remote` have their own usage documentation.
 > More information: <https://docs.conan.io/2/reference/commands.html>.
 
-- Install packages based on `conanfile.txt`:
+- Auto-detect the host environment and create a `default` profile:
+
+`conan profile detect`
+
+- Install dependencies based on `conanfile.txt` or a `conanfile.py` recipe:
 
 `conan install {{.}}`
 
-- Install packages and create configuration files for a specific generator:
+- Install dependencies, building from source only when prebuilt binaries are missing:
 
-`conan install -g {{generator}}`
+`conan install {{.}} --build {{missing}}`
 
-- Install packages, building from source:
+- Create a package from a `conanfile.py` recipe in the current directory:
 
-`conan install {{.}} --build`
+`conan create {{.}}`
 
-- Search for locally installed packages:
+- Build a package locally from its recipe without creating it:
 
-`conan search {{package}}`
+`conan build {{.}}`
 
-- Search for remote packages:
+- List locally cached packages matching a pattern:
 
-`conan search {{package}} -r {{remote}}`
+`conan list {{pattern}}`
 
 - List remotes:
 

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -6,7 +6,7 @@
 
 - Scaffold a new project from a template recipe, e.g. a CMake library:
 
-`conan new {{cmake_lib}} -d name={{pkg_name}} -d version={{1.0}}`
+`conan new {{cmake_lib}} {{[-d|--define]}} name={{pkg_name}} {{[-d|--define]}} version={{1.0}}`
 
 - Auto-detect the host environment and create a `default` profile:
 
@@ -18,7 +18,7 @@
 
 - Install a package directly from the configured remotes:
 
-`conan install --requires={{zlib/1.3.1}}`
+`conan install --requires {{zlib/1.3.1}}`
 
 - Install dependencies, building from source only when prebuilt binaries are missing:
 

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -35,7 +35,3 @@
 - List locally cached packages matching a pattern:
 
 `conan list {{pattern}}`
-
-- List remotes:
-
-`conan remote list`

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -4,6 +4,10 @@
 > Some subcommands such as `install`, `create`, `profile`, `remote` have their own usage documentation.
 > More information: <https://docs.conan.io/2/reference/commands.html>.
 
+- Scaffold a new project from a template recipe, e.g. a CMake library:
+
+`conan new {{cmake_lib}} -d name={{pkg_name}} -d version={{1.0}}`
+
 - Auto-detect the host environment and create a `default` profile:
 
 `conan profile detect`
@@ -11,6 +15,10 @@
 - Install dependencies based on `conanfile.txt` or a `conanfile.py` recipe:
 
 `conan install {{.}}`
+
+- Install a package directly from the configured remotes:
+
+`conan install --requires={{zlib/1.3.1}}`
 
 - Install dependencies, building from source only when prebuilt binaries are missing:
 

--- a/pages/common/conan.md
+++ b/pages/common/conan.md
@@ -22,7 +22,7 @@
 
 - Install dependencies, building from source only when prebuilt binaries are missing:
 
-`conan install {{.}} --build {{missing}}`
+`conan install {{.}} {{[-b|--build]}} {{missing}}`
 
 - Create a package from a `conanfile.py` recipe in the current directory:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** conan 2.32.0
- Reference issue: #5070
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
Adds 5 missing subcommand pages for Dolt. Every page was written from the `--help` output of the respective subcommand of conan 2.32.0. `tldr-lint` passes on all pages.

Also updates the subcommand mention in the `conan` base page, which referred to a non-existent subcommand (`frogarian`).
