### PR TITLE
vcpkg-{create, install, list, remove, search}: add page

### DIFF
--- a/pages/common/vcpkg-create.md
+++ b/pages/common/vcpkg-create.md
@@ -1,0 +1,12 @@
+# vcpkg create
+
+> Create a new port from a downloadable source archive.
+> More information: <https://learn.microsoft.com/vcpkg/commands/create>.
+
+- Create a new port with a specific name from a source archive URL:
+
+`vcpkg create {{port_name}} {{url}}`
+
+- Create a new port using a pre-downloaded source archive:
+
+`vcpkg create {{port_name}} {{url}} {{downloaded_filename}}.zip`

--- a/pages/common/vcpkg-install.md
+++ b/pages/common/vcpkg-install.md
@@ -1,0 +1,16 @@
+# vcpkg install
+
+> Install C and C++ library packages with `vcpkg`.
+> More information: <https://learn.microsoft.com/vcpkg/commands/install>.
+
+- Install one or more packages:
+
+`vcpkg install {{package1 package2 ...}}`
+
+- Install a package for a specific triplet:
+
+`vcpkg install {{package}}:{{x64-windows}}`
+
+- Install all packages listed in the `vcpkg.json` manifest:
+
+`vcpkg install`

--- a/pages/common/vcpkg-list.md
+++ b/pages/common/vcpkg-list.md
@@ -1,0 +1,12 @@
+# vcpkg list
+
+> List the libraries installed with `vcpkg`.
+> More information: <https://learn.microsoft.com/vcpkg/commands/list>.
+
+- List all installed libraries:
+
+`vcpkg list`
+
+- List installed libraries matching a filter:
+
+`vcpkg list {{pattern}}`

--- a/pages/common/vcpkg-remove.md
+++ b/pages/common/vcpkg-remove.md
@@ -1,0 +1,16 @@
+# vcpkg remove
+
+> Uninstall packages installed with `vcpkg`.
+> More information: <https://learn.microsoft.com/vcpkg/commands/remove>.
+
+- Remove one or more packages:
+
+`vcpkg remove {{package1 package2 ...}}`
+
+- Remove a package for a specific triplet:
+
+`vcpkg remove {{package}}:{{x64-windows}}`
+
+- Remove all outdated packages:
+
+`vcpkg remove --outdated`

--- a/pages/common/vcpkg-search.md
+++ b/pages/common/vcpkg-search.md
@@ -1,0 +1,12 @@
+# vcpkg search
+
+> Search for packages available to be built with `vcpkg`.
+> More information: <https://learn.microsoft.com/vcpkg/commands/search>.
+
+- Search for a package by name or description:
+
+`vcpkg search {{pattern}}`
+
+- List all available packages:
+
+`vcpkg search`

--- a/pages/common/vcpkg.md
+++ b/pages/common/vcpkg.md
@@ -4,13 +4,29 @@
 > Note: Packages are not installed in the system. To use them, you need to tell your build system (e.g. CMake) to use `vcpkg`.
 > More information: <https://learn.microsoft.com/vcpkg/>.
 
-- Build and add package `libcurl` to the `vcpkg` environment:
+- Build and add `curl` to the `vcpkg` environment:
 
 `vcpkg install curl`
 
 - Build and add `zlib` using the `emscripten` toolchain:
 
 `vcpkg install --triplet=wasm32-emscripten zlib`
+
+- Install all packages listed in the `vcpkg.json` manifest:
+
+`vcpkg install`
+
+- Add a port to the `vcpkg.json` manifest:
+
+`vcpkg add port {{package}}`
+
+- Remove a package from the `vcpkg` environment:
+
+`vcpkg remove {{package}}`
+
+- List installed packages:
+
+`vcpkg list`
 
 - Search for a package:
 

--- a/pages/common/vcpkg.md
+++ b/pages/common/vcpkg.md
@@ -1,7 +1,7 @@
 # vcpkg
 
 > Package manager for C/C++ libraries.
-> Note: Packages are not installed in the system. To use them, you need to tell your build system (e.g. CMake) to use `vckg`.
+> Note: Packages are not installed in the system. To use them, you need to tell your build system (e.g. CMake) to use `vcpkg`.
 > More information: <https://learn.microsoft.com/vcpkg/>.
 
 - Build and add package `libcurl` to the `vcpkg` environment:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** vcpkg (master, 2026-08)
- Reference issue: #5070
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
Adds 5 missing subcommand pages for Dolt. Every page was written from the `--help` output of the respective subcommand of vcpkg (master, 2026-08). `tldr-lint` passes on all pages.

Also fixes the `vckg` typo in the `vcpkg` base page description.
