### PR TITLE
docker-buildx-{create, du, ls, prune, rm}: add Portuguese (Brazilian) translation

### DIFF
--- a/pages.pt_BR/common/docker-buildx-create.md
+++ b/pages.pt_BR/common/docker-buildx-create.md
@@ -1,0 +1,36 @@
+# docker buildx create
+
+> Cria uma nova instância de builder.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/buildx/create/>.
+
+- Cria uma nova instância de builder usando o contexto Docker padrão:
+
+`docker buildx create`
+
+- Cria uma nova instância de builder com um nome específico:
+
+`docker buildx create --name {{nome_do_builder}}`
+
+- Cria uma nova instância de builder e a define imediatamente como o builder ativo atual:
+
+`docker buildx create --name {{nome_do_builder}} --use`
+
+- Cria uma nova instância de builder usando um driver específico (padrão: `docker`):
+
+`docker buildx create --driver {{docker-container|kubernetes|remote|...}}`
+
+- Cria uma nova instância de builder com plataformas suportadas específicas:
+
+`docker buildx create --platform {{linux/amd64,linux/arm64,...}}`
+
+- Adiciona um novo nó a um builder existente:
+
+`docker buildx create --name {{nome_do_builder}} --append {{contexto|endpoint}}`
+
+- Cria uma nova instância de builder com flags específicas do daemon BuildKit:
+
+`docker buildx create --buildkitd-flags "{{--debug --debugaddr 0.0.0.0:6666}}"`
+
+- Cria uma nova instância de builder e a inicia imediatamente:
+
+`docker buildx create --name {{nome_do_builder}} --bootstrap`

--- a/pages.pt_BR/common/docker-buildx-du.md
+++ b/pages.pt_BR/common/docker-buildx-du.md
@@ -1,0 +1,28 @@
+# docker buildx du
+
+> Exibe o uso de disco de um builder.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/buildx/du/>.
+
+- Exibe o uso de disco:
+
+`docker buildx du`
+
+- Filtra a saída com base em uma condição específica:
+
+`docker buildx du --filter "{{description~=golang}}"`
+
+- Exibe uma saída detalhada:
+
+`docker buildx du --verbose`
+
+- Formata a saída usando um template Go:
+
+`docker buildx du --format "table {{.ID}}    {{.Description}}"`
+
+- Exibe a saída formatada como JSON com o comando `jq`:
+
+`docker buildx du --format json | jq .`
+
+- Exibe o uso de disco de um builder específico:
+
+`docker buildx du --builder {{nome_do_builder}}`

--- a/pages.pt_BR/common/docker-buildx-ls.md
+++ b/pages.pt_BR/common/docker-buildx-ls.md
@@ -1,0 +1,12 @@
+# docker buildx ls
+
+> Lista as instâncias de builder e os nós associados.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/buildx/ls/>.
+
+- Lista as instâncias de builder:
+
+`docker buildx ls`
+
+- Formata a saída usando um template Go:
+
+`docker buildx ls --format "{{.NAME}}: {{.DriverEndpoint}}"`

--- a/pages.pt_BR/common/docker-buildx-prune.md
+++ b/pages.pt_BR/common/docker-buildx-prune.md
@@ -1,0 +1,20 @@
+# docker buildx prune
+
+> Remove o cache de build.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/buildx/prune/>.
+
+- Remove o cache de build do builder ativo atual:
+
+`docker buildx prune`
+
+- Remove os registros de cache com base em um filtro específico:
+
+`docker buildx prune --filter "{{type=source.local}}"`
+
+- Remove os registros de cache usados menos recentemente até que o tamanho do cache fique abaixo de um limite específico:
+
+`docker buildx prune --max-used-space {{128mb}}`
+
+- Remove os registros de cache usados menos recentemente até que uma quantidade específica de espaço livre em disco esteja disponível:
+
+`docker buildx prune --reserved-space {{2gb}}`

--- a/pages.pt_BR/common/docker-buildx-rm.md
+++ b/pages.pt_BR/common/docker-buildx-rm.md
@@ -1,0 +1,16 @@
+# docker buildx rm
+
+> Remove uma ou mais instâncias de builder.
+> Mais informações: <https://docs.docker.com/reference/cli/docker/buildx/rm/>.
+
+- Remove uma instância de builder:
+
+`docker buildx rm {{nome_do_builder}}`
+
+- Remove todos os builders inativos:
+
+`docker buildx rm --all-inactive`
+
+- Remove todos os builders inativos sem pedir confirmação:
+
+`docker buildx rm --all-inactive {{[-f|--force]}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- Reference issue: #13575

Adds Portuguese (Brazilian) translations for:
- docker buildx create
- docker buildx du
- docker buildx ls
- docker buildx prune
- docker buildx rm
