### PR TITLE
xmake: fix create options and split build/run examples

### DIFF
--- a/pages/common/xmake.md
+++ b/pages/common/xmake.md
@@ -5,11 +5,15 @@
 
 - Create an Xmake C project, consisting of a hello world and `xmake.lua`:
 
-`xmake create {{[-l|--language]}} {{[c|clean]}} {{[-P|--project]}} {{project_name}}`
+`xmake create {{[-l|--language]}} {{[-P|--project]}} {{project_name}}`
 
-- Build and run an Xmake project:
+- Build an Xmake project:
 
-`xmake {{[b|build]}} {{[r|run]}}`
+`xmake {{[b|build]}}`
+
+- Run an Xmake project:
+
+`xmake {{[r|run]}}`
 
 - Run a compiled Xmake target directly:
 

--- a/pages/common/xmake.md
+++ b/pages/common/xmake.md
@@ -5,7 +5,7 @@
 
 - Create an Xmake C project, consisting of a hello world and `xmake.lua`:
 
-`xmake create {{[-l|--language]}} {{[-P|--project]}} {{project_name}}`
+`xmake create {{[-l|--language]}} c {{[-P|--project]}} {{project_name}}`
 
 - Build an Xmake project:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

`xmake create` does not accept clean.

`xmake build run` reports error:
```
error: 'run' is not a valid target name for this project.
```
