### PR TITLE
pages*: unify PostgreSQL syntax

### DIFF
--- a/pages/common/clusterdb.md
+++ b/pages/common/clusterdb.md
@@ -13,4 +13,4 @@
 
 - Cluster a specific table in a database:
 
-`clusterdb {{[-t|--table]}} {{table_name}} {{database_name}}`
+`clusterdb {{database_name}} {{[-t|--table]}} {{table_name}}`

--- a/pages/common/createdb.md
+++ b/pages/common/createdb.md
@@ -9,8 +9,8 @@
 
 - Create a database owned by a specific user with a description:
 
-`createdb {{[-O|--owner]}} {{username}} {{database_name}} '{{description}}'`
+`createdb {{database_name}} '{{description}}' {{[-O|--owner]}} {{username}}`
 
 - Create a database from a template:
 
-`createdb {{[-T|--template]}} {{template_name}} {{database_name}}`
+`createdb {{database_name}} {{[-T|--template]}} {{template_name}}`

--- a/pages/common/createuser.md
+++ b/pages/common/createuser.md
@@ -5,7 +5,7 @@
 
 - Create a user interactively:
 
-`createuser --interactive {{username}}`
+`createuser {{username}} --interactive`
 
 - Create a user with no special rights:
 
@@ -13,12 +13,12 @@
 
 - Create a superuser:
 
-`createuser {{[-s|--superuser]}} {{username}}`
+`createuser {{username}} {{[-s|--superuser]}}`
 
 - Create a user allowed to create databases, manage roles, and prompt for a password:
 
-`createuser {{[-d|--createdb]}} {{[-r|--createrole]}} {{[-P|--pwprompt]}} {{username}}`
+`createuser {{username}} {{[-d|--createdb]}} {{[-r|--createrole]}} {{[-P|--pwprompt]}}`
 
 - Create a user without the ability to create databases or manage roles:
 
-`createuser {{[-D|--no-createdb]}} {{[-R|--no-createrole]}} {{username}}`
+`createuser {{username}} {{[-D|--no-createdb]}} {{[-R|--no-createrole]}}`

--- a/pages/common/dropdb.md
+++ b/pages/common/dropdb.md
@@ -10,28 +10,28 @@
 
 - Request a verification prompt before any destructive actions:
 
-`dropdb {{[-i|--interactive]}} {{database_name}}`
+`dropdb {{database_name}} {{[-i|--interactive]}}`
 
 - Connect with a specific username and destroy a database:
 
-`dropdb {{[-U|--username]}} {{username}} {{database_name}}`
+`dropdb {{database_name}} {{[-U|--username]}} {{username}}`
 
 - Force a password prompt before connecting to the database:
 
-`dropdb {{[-W|--password]}} {{database_name}}`
+`dropdb {{database_name}} {{[-W|--password]}}`
 
 - Suppress a password prompt before connecting to the database:
 
-`dropdb {{[-w|--no-password]}} {{database_name}}`
+`dropdb {{database_name}} {{[-w|--no-password]}}`
 
 - Specify the server host name:
 
-`dropdb {{[-h|--host]}} {{host}} {{database_name}}`
+`dropdb {{database_name}} {{[-h|--host]}} {{host}}`
 
 - Specify the server port:
 
-`dropdb {{[-p|--port]}} {{port}} {{database_name}}`
+`dropdb {{database_name}} {{[-p|--port]}} {{port}}`
 
 - Attempt to terminate existing connections before destroying the database:
 
-`dropdb {{[-f|--force]}} {{database_name}}`
+`dropdb {{database_name}} {{[-f|--force]}}`

--- a/pages/common/dropuser.md
+++ b/pages/common/dropuser.md
@@ -13,12 +13,12 @@
 
 - No error if the user to be removed doesn't exist:
 
-`dropuser --if-exists {{username}}`
+`dropuser {{username}} --if-exists`
 
 - Remove a user on the server with address 127.0.0.1 on port 4321:
 
-`dropuser {{[-h|--host]}} 127.0.0.1 {{[-p|--port]}} 4321 {{username}}`
+`dropuser {{username}} {{[-h|--host]}} 127.0.0.1 {{[-p|--port]}} 4321`
 
 - Remove a user on the server with address 127.0.0.1 on port 4321 as user "admin":
 
-`dropuser {{[-U|--username]}} admin {{[-h|--host]}} 127.0.0.1 {{[-p|--port]}} 4321 {{username}}`
+`dropuser {{username}} {{[-h|--host]}} 127.0.0.1 {{[-p|--port]}} 4321 {{[-U|--username]}} admin`

--- a/pages/common/ecpg.md
+++ b/pages/common/ecpg.md
@@ -5,7 +5,7 @@
 
 - Preprocess a specific file:
 
-`ecpg {{input.pgc}}`
+`ecpg {{path/to/input.pgc}}`
 
 - Preprocess from `stdin` and output to `stdout`:
 
@@ -13,20 +13,20 @@
 
 - Preprocess from `stdin` and write to a file:
 
-`cat input.pgc | ecpg -o output.c -`
+`cat {{path/to/input.pgc}} | ecpg -o {{path/to/output.c}} -`
 
 - Preprocess and specify an output file:
 
-`ecpg -o {{output.c}} {{input.pgc}}`
+`ecpg {{path/to/input.pgc}} -o {{path/to/output.c}}`
 
 - Preprocess a header file (`.pgh` extension):
 
-`ecpg {{input.pgh}}`
+`ecpg {{path/to/input.pgh}}`
 
 - Preprocess in a specific compatibility mode:
 
-`ecpg -C {{INFORMIX|INFORMIX_SE|ORACLE}} {{input.pgc}}`
+`ecpg {{path/to/input.pgc}} -C {{INFORMIX|INFORMIX_SE|ORACLE}}`
 
 - Preprocess with autocommit enabled:
 
-`ecpg -t {{input.pgc}}`
+`ecpg {{path/to/input.pgc}} -t`

--- a/pages/common/initdb.md
+++ b/pages/common/initdb.md
@@ -3,6 +3,6 @@
 > Create a PostgreSQL database cluster on disk.
 > More information: <https://www.postgresql.org/docs/current/app-initdb.html>.
 
-- Create a database cluster at `/usr/local/var/postgres`:
+- Create a database cluster in a specific directory:
 
-`initdb {{[-D|--pgdata]}} /usr/local/var/postgres`
+`initdb {{[-D|--pgdata]}} {{path/to/data_directory}}`

--- a/pages/common/pg_amcheck.md
+++ b/pages/common/pg_amcheck.md
@@ -5,7 +5,7 @@
 
 - Check a specific database:
 
-`pg_amcheck {{dbname}}`
+`pg_amcheck {{database_name}}`
 
 - Check all databases:
 
@@ -17,11 +17,11 @@
 
 - Check specific tables within a database:
 
-`pg_amcheck {{[-t|--table]}} {{pattern}} {{dbname}}`
+`pg_amcheck {{database_name}} {{[-t|--table]}} {{pattern}}`
 
 - Check specific schemas within a database:
 
-`pg_amcheck {{[-s|--schema]}} {{pattern}} {{dbname}}`
+`pg_amcheck {{database_name}} {{[-s|--schema]}} {{pattern}}`
 
 - Display help:
 

--- a/pages/common/pg_archivecleanup.md
+++ b/pages/common/pg_archivecleanup.md
@@ -5,20 +5,20 @@
 
 - Clean an archive directory up to a given WAL file:
 
-`pg_archivecleanup {{path/to/archive}} {{path/to/walfile}}`
+`pg_archivecleanup {{path/to/archive_directory}} {{path/to/wal_file}}`
 
 - Perform a dry run (list files that would be removed without actually doing it):
 
-`pg_archivecleanup {{[-n|--dry-run]}} {{path/to/archive}} {{path/to/walfile}}`
+`pg_archivecleanup {{path/to/archive_directory}} {{path/to/wal_file}} {{[-n|--dry-run]}}`
 
 - Strip a file extension before deciding deletion:
 
-`pg_archivecleanup {{[-x|--strip-extension]}} {{extension}} {{path/to/archive}} {{path/to/walfile}}`
+`pg_archivecleanup {{path/to/archive_directory}} {{path/to/wal_file}} {{[-x|--strip-extension]}} {{extension}}`
 
 - Remove backup history files too:
 
-`pg_archivecleanup {{[-b|--clean-backup-history]}} {{path/to/archive}} {{path/to/walfile}}`
+`pg_archivecleanup {{path/to/archive_directory}} {{path/to/wal_file}} {{[-b|--clean-backup-history]}}`
 
 - Enable debug logging output:
 
-`pg_archivecleanup {{[-d|--debug]}} {{path/to/archive}} {{path/to/walfile}}`
+`pg_archivecleanup {{path/to/archive_directory}} {{path/to/wal_file}} {{[-d|--debug]}}`

--- a/pages/common/pg_basebackup.md
+++ b/pages/common/pg_basebackup.md
@@ -6,32 +6,32 @@
 
 - Take a base backup from a remote PostgreSQL server:
 
-`pg_basebackup {{[-h|--host]}} {{host}} {{[-D|--pgdata]}} {{path/to/backup_dir}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-h|--host]}} {{host}}`
 
 - Take a backup with progress shown:
 
-`pg_basebackup {{[-h|--host]}} {{host}} {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-P|--progress]}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-h|--host]}} {{host}} {{[-P|--progress]}}`
 
 - Create a compressed backup (`gzip`) in tar format:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-F|--format]}} {{[t|tar]}} {{[-z|--gzip]}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-F|--format]}} {{[t|tar]}} {{[-z|--gzip]}}`
 
 - Create an incremental backup using a previous manifest file:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-i|--incremental]}} {{path/to/old_manifest}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-i|--incremental]}} {{path/to/old_manifest}}`
 
 - Write a recovery configuration for setting up a standby:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-R|--write-recovery-conf]}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-R|--write-recovery-conf]}}`
 
 - Relocate a tablespace during backup:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-T|--tablespace-mapping]}} {{path/to/old_tablespace}}={{path/to/new_tablespace}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-T|--tablespace-mapping]}} {{path/to/old_tablespace}}={{path/to/new_tablespace}}`
 
 - Limit transfer rate to reduce server load:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-r|--max-rate]}} {{100M}}`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-r|--max-rate]}} {{100M}}`
 
 - Stream WAL logs while taking the backup:
 
-`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_dir}} {{[-X|--wal-method]}} stream`
+`pg_basebackup {{[-D|--pgdata]}} {{path/to/backup_directory}} {{[-X|--wal-method]}} stream`

--- a/pages/common/pg_checksums.md
+++ b/pages/common/pg_checksums.md
@@ -5,23 +5,23 @@
 
 - Check data checksums in a database cluster:
 
-`pg_checksums {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_checksums {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Enable data checksums in a database cluster:
 
-`pg_checksums {{[-e|--enable]}} {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_checksums {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-e|--enable]}}`
 
 - Disable data checksums in a database cluster:
 
-`pg_checksums {{[-d|--disable]}} {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_checksums {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-d|--disable]}}`
 
 - Check data checksums with verbose output:
 
-`pg_checksums {{[-v|--verbose]}} {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_checksums {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-v|--verbose]}}`
 
 - Check data checksums showing progress:
 
-`pg_checksums {{[-P|--progress]}} {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_checksums {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-P|--progress]}}`
 
 - Display help:
 

--- a/pages/common/pg_combinebackup.md
+++ b/pages/common/pg_combinebackup.md
@@ -10,19 +10,19 @@
 
 - Perform a dry run to show what would be done, without creating files:
 
-`pg_combinebackup {{[-n|--dry-run]}} {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}} {{[-n|--dry-run]}}`
 
 - Use hard links instead of copying files (faster, same filesystem required):
 
-`pg_combinebackup {{[-k|--link]}} {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}} {{[-k|--link]}}`
 
 - Use file cloning (reflinks) for efficient copy if supported:
 
-`pg_combinebackup --clone {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}} --clone`
 
 - Use the `copy_file_range` system call for efficient copying:
 
-`pg_combinebackup --copy-file-range {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/full_backup}} {{path/to/incremental_backup}} {{[-o|--output]}} {{path/to/output_directory}} --copy-file-range`
 
 - Relocate a tablespace during reconstruction:
 
@@ -30,8 +30,8 @@
 
 - Disable fsync for faster but unsafe writes (testing only):
 
-`pg_combinebackup {{[-N|--no-sync]}} {{path/to/backup1 path/to/backup2 ...}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/backup1 path/to/backup2 ...}} {{[-o|--output]}} {{path/to/output_directory}} {{[-N|--no-sync]}}`
 
 - Show detailed debug output:
 
-`pg_combinebackup {{[-d|--debug]}} {{path/to/backup1 path/to/backup2 ...}} {{[-o|--output]}} {{path/to/output_directory}}`
+`pg_combinebackup {{path/to/backup1 path/to/backup2 ...}} {{[-o|--output]}} {{path/to/output_directory}} {{[-d|--debug]}}`

--- a/pages/common/pg_controldata.md
+++ b/pages/common/pg_controldata.md
@@ -5,7 +5,7 @@
 
 - Display control information for a specific data directory:
 
-`pg_controldata {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_controldata {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Display help:
 

--- a/pages/common/pg_createsubscriber.md
+++ b/pages/common/pg_createsubscriber.md
@@ -5,19 +5,19 @@
 
 - Convert a physical replica to a logical replica for a specific database:
 
-`pg_createsubscriber {{[-d|--database]}} {{dbname}} {{[-D|--pgdata]}} {{path/to/data}} {{[-P|--publisher-server]}} {{connstr}}`
+`pg_createsubscriber {{[-d|--database]}} {{database_name}} {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-P|--publisher-server]}} {{connection_string}}`
 
 - Perform a dry run without modifying the target directory:
 
-`pg_createsubscriber {{[-n|--dry-run]}} {{[-d|--database]}} {{dbname}} {{[-D|--pgdata]}} {{path/to/data}} {{[-P|--publisher-server]}} {{connstr}}`
+`pg_createsubscriber {{[-d|--database]}} {{database_name}} {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-P|--publisher-server]}} {{connection_string}} {{[-n|--dry-run]}}`
 
 - Enable two-phase commit for the subscription:
 
-`pg_createsubscriber {{[-T|--enable-two-phase]}} {{[-d|--database]}} {{dbname}} {{[-D|--pgdata]}} {{path/to/data}} {{[-P|--publisher-server]}} {{connstr}}`
+`pg_createsubscriber {{[-d|--database]}} {{database_name}} {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-P|--publisher-server]}} {{connection_string}} {{[-T|--enable-two-phase]}}`
 
 - Convert with verbose output:
 
-`pg_createsubscriber {{[-v|--verbose]}} {{[-d|--database]}} {{dbname}} {{[-D|--pgdata]}} {{path/to/data}} {{[-P|--publisher-server]}} {{connstr}}`
+`pg_createsubscriber {{[-d|--database]}} {{database_name}} {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-P|--publisher-server]}} {{connection_string}} {{[-v|--verbose]}}`
 
 - Display help:
 

--- a/pages/common/pg_ctl.md
+++ b/pages/common/pg_ctl.md
@@ -5,20 +5,20 @@
 
 - Initialize a new PostgreSQL database cluster:
 
-`pg_ctl {{[-D|--pgdata]}} {{data_directory}} init`
+`pg_ctl init {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Start a PostgreSQL server:
 
-`pg_ctl {{[-D|--pgdata]}} {{data_directory}} start`
+`pg_ctl start {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Stop a PostgreSQL server:
 
-`pg_ctl {{[-D|--pgdata]}} {{data_directory}} stop`
+`pg_ctl stop {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Restart a PostgreSQL server:
 
-`pg_ctl {{[-D|--pgdata]}} {{data_directory}} restart`
+`pg_ctl restart {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Reload the PostgreSQL server configuration:
 
-`pg_ctl {{[-D|--pgdata]}} {{data_directory}} reload`
+`pg_ctl reload {{[-D|--pgdata]}} {{path/to/data_directory}}`

--- a/pages/common/pg_dump.md
+++ b/pages/common/pg_dump.md
@@ -5,24 +5,24 @@
 
 - Dump database into an SQL-script file:
 
-`pg_dump {{db_name}} > {{output_file.sql}}`
+`pg_dump {{database_name}} > {{path/to/output_file.sql}}`
 
 - Same as above, customize username:
 
-`pg_dump {{[-U|--username]}} {{username}} {{db_name}} > {{output_file.sql}}`
+`pg_dump {{database_name}} {{[-U|--username]}} {{username}} > {{path/to/output_file.sql}}`
 
 - Same as above, customize host and port:
 
-`pg_dump {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{db_name}} > {{output_file.sql}}`
+`pg_dump {{database_name}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} > {{path/to/output_file.sql}}`
 
 - Dump a database into a custom-format archive file:
 
-`pg_dump {{[-F|--format]}} {{[c|custom]}} {{db_name}} > {{output_file.dump}}`
+`pg_dump {{database_name}} {{[-F|--format]}} {{[c|custom]}} > {{path/to/output_file.dump}}`
 
 - Dump only database data into an SQL-script file:
 
-`pg_dump {{[-a|--data-only]}} {{db_name}} > {{path/to/output_file.sql}}`
+`pg_dump {{database_name}} {{[-a|--data-only]}} > {{path/to/output_file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 
-`pg_dump {{[-s|--schema-only]}} {{db_name}} > {{path/to/output_file.sql}}`
+`pg_dump {{database_name}} {{[-s|--schema-only]}} > {{path/to/output_file.sql}}`

--- a/pages/common/pg_dumpall.md
+++ b/pages/common/pg_dumpall.md
@@ -5,20 +5,20 @@
 
 - Dump all databases:
 
-`pg_dumpall > {{path/to/file.sql}}`
+`pg_dumpall > {{path/to/output_file.sql}}`
 
 - Dump all databases using a specific username:
 
-`pg_dumpall {{[-U|--username]}} {{username}} > {{path/to/file.sql}}`
+`pg_dumpall {{[-U|--username]}} {{username}} > {{path/to/output_file.sql}}`
 
 - Same as above, customize host and port:
 
-`pg_dumpall {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} > {{output_file.sql}}`
+`pg_dumpall {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} > {{path/to/output_file.sql}}`
 
 - Dump only database data into an SQL-script file:
 
-`pg_dumpall {{[-a|--data-only]}} > {{path/to/file.sql}}`
+`pg_dumpall {{[-a|--data-only]}} > {{path/to/output_file.sql}}`
 
 - Dump only schema (data definitions) into an SQL-script file:
 
-`pg_dumpall {{[-s|--schema-only]}} > {{output_file.sql}}`
+`pg_dumpall {{[-s|--schema-only]}} > {{path/to/output_file.sql}}`

--- a/pages/common/pg_isready.md
+++ b/pages/common/pg_isready.md
@@ -9,7 +9,7 @@
 
 - Check connection with a specific hostname and port:
 
-`pg_isready {{[-h|--host]}} {{hostname}} {{[-p|--port]}} {{port}}`
+`pg_isready {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}}`
 
 - Check connection displaying a message only when the connection fails:
 

--- a/pages/common/pg_receivewal.md
+++ b/pages/common/pg_receivewal.md
@@ -5,32 +5,32 @@
 
 - Stream WAL to a local directory (minimum required):
 
-`pg_receivewal {{[-D|--directory]}} {{directory}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}}`
 
 - Same as above, specify host, port, username including verbose output:
 
-`pg_receivewal {{[-v|--verbose]}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-D|--directory]}} {{directory}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-v|--verbose]}}`
 
 - Use replication slot (create-if-needed):
 
-`pg_receivewal {{[-S|--slot]}} {{slot_name}} --create-slot {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-D|--directory]}} {{directory}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-S|--slot]}} {{slot_name}} --create-slot`
 
 - Stop at a given WAL position (LSN):
 
-`pg_receivewal {{[-E|--endpos]}} {{lsn}} {{[-D|--directory]}} {{directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-E|--endpos]}} {{lsn}}`
 
 - Control looping on failure:
 
-`pg_receivewal {{[-n|--no-loop]}} {{[-D|--directory]}} {{directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-n|--no-loop]}}`
 
 - Flush data synchronously (force WAL writes immediately):
 
-`pg_receivewal --synchronous {{[-D|--directory]}} {{directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} --synchronous`
 
 - Compress WAL output (`gzip`, level 0-9):
 
-`pg_receivewal {{[-Z|--compress]}} {{level|method}} {{[-D|--directory]}} {{directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-Z|--compress]}} {{level|method}}`
 
 - Set status reporting interval:
 
-`pg_receivewal {{[-s|--status-interval]}} {{seconds}} {{[-D|--directory]}} {{directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`pg_receivewal {{[-D|--directory]}} {{path/to/directory}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-s|--status-interval]}} {{seconds}}`

--- a/pages/common/pg_recvlogical.md
+++ b/pages/common/pg_recvlogical.md
@@ -5,19 +5,19 @@
 
 - Create a new logical replication slot:
 
-`pg_recvlogical {{[-d|--dbname]}} {{dbname}} {{[-S|--slot]}} {{slot_name}} --create-slot`
+`pg_recvlogical {{[-d|--dbname]}} {{database_name}} {{[-S|--slot]}} {{slot_name}} --create-slot`
 
 - Start streaming changes from a logical replication slot to a file:
 
-`pg_recvlogical {{[-d|--dbname]}} {{dbname}} {{[-S|--slot]}} {{slot_name}} --start {{[-f|--file]}} {{filename}}`
+`pg_recvlogical {{[-d|--dbname]}} {{database_name}} {{[-S|--slot]}} {{slot_name}} --start {{[-f|--file]}} {{path/to/output_file}}`
 
 - Drop a logical replication slot:
 
-`pg_recvlogical {{[-d|--dbname]}} {{dbname}} {{[-S|--slot]}} {{slot_name}} --drop-slot`
+`pg_recvlogical {{[-d|--dbname]}} {{database_name}} {{[-S|--slot]}} {{slot_name}} --drop-slot`
 
 - Create a slot with two-phase commit enabled:
 
-`pg_recvlogical {{[-d|--dbname]}} {{dbname}} {{[-S|--slot]}} {{slot_name}} --create-slot {{[-t|--enable-two-phase]}}`
+`pg_recvlogical {{[-d|--dbname]}} {{database_name}} {{[-S|--slot]}} {{slot_name}} --create-slot {{[-t|--enable-two-phase]}}`
 
 - Display help:
 

--- a/pages/common/pg_resetwal.md
+++ b/pages/common/pg_resetwal.md
@@ -5,15 +5,15 @@
 
 - Reset the WAL and control information for a specific data directory:
 
-`pg_resetwal {{[-D|--pgdata]}} {{path/to/data}}`
+`pg_resetwal {{[-D|--pgdata]}} {{path/to/data_directory}}`
 
 - Perform a dry run:
 
-`pg_resetwal {{[-D|--pgdata]}} {{path/to/data}} {{[-n|--dry-run]}}`
+`pg_resetwal {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-n|--dry-run]}}`
 
 - Force the WAL and control information reset:
 
-`pg_resetwal {{[-D|--pgdata]}} {{path/to/data}} {{[-f|--force]}}`
+`pg_resetwal {{[-D|--pgdata]}} {{path/to/data_directory}} {{[-f|--force]}}`
 
 - Display help:
 

--- a/pages/common/pg_restore.md
+++ b/pages/common/pg_restore.md
@@ -5,24 +5,24 @@
 
 - Restore an archive into an existing database:
 
-`pg_restore {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-d|--dbname]}} {{database_name}}`
 
 - Same as above, customize username:
 
-`pg_restore {{[-U|--username]}} {{username}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-d|--dbname]}} {{database_name}} {{[-U|--username]}} {{username}}`
 
 - Same as above, customize host and port:
 
-`pg_restore {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-d|--dbname]}} {{database_name}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}}`
 
 - List database objects included in the archive:
 
-`pg_restore {{[-l|--list]}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-l|--list]}}`
 
 - Clean database objects before creating them:
 
-`pg_restore {{[-c|--clean]}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-d|--dbname]}} {{database_name}} {{[-c|--clean]}}`
 
 - Use multiple jobs to do the restoring:
 
-`pg_restore {{[-j|--jobs]}} {{2}} {{[-d|--dbname]}} {{db_name}} {{archive_file.dump}}`
+`pg_restore {{path/to/archive_file.dump}} {{[-d|--dbname]}} {{database_name}} {{[-j|--jobs]}} {{2}}`

--- a/pages/common/pg_rewind.md
+++ b/pages/common/pg_rewind.md
@@ -5,19 +5,19 @@
 
 - Synchronize target directory with source directory:
 
-`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data}} --source-pgdata {{path/to/source_data}}`
+`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data_directory}} --source-pgdata {{path/to/source_data_directory}}`
 
 - Synchronize target with source server using connection string:
 
-`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data}} --source-server {{connstr}}`
+`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data_directory}} --source-server {{connection_string}}`
 
 - Perform a dry run:
 
-`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data}} --source-pgdata {{path/to/source_data}} {{[-n|--dry-run]}}`
+`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data_directory}} --source-pgdata {{path/to/source_data_directory}} {{[-n|--dry-run]}}`
 
 - Show progress during synchronization:
 
-`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data}} --source-pgdata {{path/to/source_data}} {{[-P|--progress]}}`
+`pg_rewind {{[-D|--target-pgdata]}} {{path/to/target_data_directory}} --source-pgdata {{path/to/source_data_directory}} {{[-P|--progress]}}`
 
 - Display help:
 

--- a/pages/common/pg_upgrade.md
+++ b/pages/common/pg_upgrade.md
@@ -5,7 +5,7 @@
 
 - Check clusters before upgrading:
 
-`pg_upgrade {{[-c|--check]}} {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}}`
+`pg_upgrade {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}} {{[-c|--check]}}`
 
 - Perform the actual upgrade:
 
@@ -13,15 +13,15 @@
 
 - Use multiple parallel jobs during the upgrade:
 
-`pg_upgrade {{[-j|--jobs]}} {{njobs}} {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}}`
+`pg_upgrade {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}} {{[-j|--jobs]}} {{number_of_jobs}}`
 
 - Specify the old and new PostgreSQL ports:
 
-`pg_upgrade {{[-p|--old-port]}} {{port}} {{[-P|--new-port]}} {{port}} {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}}`
+`pg_upgrade {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}} {{[-p|--old-port]}} {{old_port}} {{[-P|--new-port]}} {{new_port}}`
 
 - Use hard links instead of copying files to the new cluster:
 
-`pg_upgrade {{[-k|--link]}} {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}}`
+`pg_upgrade {{[-b|--old-bindir]}} {{path/to/old_bin}} {{[-B|--new-bindir]}} {{path/to/new_bin}} {{[-d|--old-datadir]}} {{path/to/old_data}} {{[-D|--new-datadir]}} {{path/to/new_data}} {{[-k|--link]}}`
 
 - Display help:
 

--- a/pages/common/pg_verifybackup.md
+++ b/pages/common/pg_verifybackup.md
@@ -5,23 +5,23 @@
 
 - Verify a backup stored in a specific directory:
 
-`pg_verifybackup {{path/to/backup}}`
+`pg_verifybackup {{path/to/backup_directory}}`
 
 - Verify a backup showing progress information:
 
-`pg_verifybackup {{[-P|--progress]}} {{path/to/backup}}`
+`pg_verifybackup {{path/to/backup_directory}} {{[-P|--progress]}}`
 
 - Verify a backup and exit immediately on first error:
 
-`pg_verifybackup {{[-e|--exit-on-error]}} {{path/to/backup}}`
+`pg_verifybackup {{path/to/backup_directory}} {{[-e|--exit-on-error]}}`
 
 - Verify a backup ignoring specific files or directories:
 
-`pg_verifybackup {{[-i|--ignore]}} {{path/to/file_or_directory}} {{path/to/backup}}`
+`pg_verifybackup {{path/to/backup_directory}} {{[-i|--ignore]}} {{path/to/file_or_directory}}`
 
 - Verify a backup with a manifest file in a different location:
 
-`pg_verifybackup {{[-m|--manifest-path]}} {{path/to/backup_manifest}} {{path/to/backup}}`
+`pg_verifybackup {{path/to/backup_directory}} {{[-m|--manifest-path]}} {{path/to/backup_manifest}}`
 
 - Display help:
 

--- a/pages/common/pg_waldump.md
+++ b/pages/common/pg_waldump.md
@@ -13,7 +13,7 @@
 
 - Specify the WAL file directory:
 
-`pg_waldump {{start_segment}} {{end_segment}} {{[-p|--path]}} {{path}}`
+`pg_waldump {{start_segment}} {{end_segment}} {{[-p|--path]}} {{path/to/directory}}`
 
 - Follow new WAL entries as they arrive:
 

--- a/pages/common/pg_walsummary.md
+++ b/pages/common/pg_walsummary.md
@@ -9,8 +9,8 @@
 
 - Print one line per individual modified block (rather than ranges):
 
-`pg_walsummary {{[-i|--individual]}} {{path/to/file}}`
+`pg_walsummary {{path/to/file}} {{[-i|--individual]}}`
 
 - Suppress normal output (only errors):
 
-`pg_walsummary {{[-q|--quiet]}} {{path/to/file}}`
+`pg_walsummary {{path/to/file}} {{[-q|--quiet]}}`

--- a/pages/common/pgbench.md
+++ b/pages/common/pgbench.md
@@ -5,8 +5,8 @@
 
 - Initialize a database with a scale factor of 50 times the default size:
 
-`pgbench --initialize --scale={{50}} {{database_name}}`
+`pgbench {{database_name}} {{[-i|--initialize]}} {{[-s|--scale]}} {{50}}`
 
 - Benchmark a database with 10 clients, 2 worker threads, and 10,000 transactions per client:
 
-`pgbench --client={{10}} --jobs={{2}} --transactions={{10000}} {{database_name}}`
+`pgbench {{database_name}} {{[-c|--client]}} {{10}} {{[-j|--jobs]}} {{2}} {{[-t|--transactions]}} {{10000}}`

--- a/pages/common/postgres.md
+++ b/pages/common/postgres.md
@@ -17,4 +17,4 @@
 
 - Start in single-user mode for a specific database (defaults to the user name):
 
-`postgres --single -D {{path/to/datadir}} {{my_database}}`
+`postgres --single -D {{path/to/data_directory}} {{database_name}}`

--- a/pages/common/psql.md
+++ b/pages/common/psql.md
@@ -5,20 +5,20 @@
 
 - Connect to the database. By default, it connects to the local socket using port 5432 with the currently logged in user:
 
-`psql {{database}}`
+`psql {{database_name}}`
 
 - Connect to the database on given server host running on given port with given username, without a password prompt:
 
-`psql {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{database}}`
+`psql {{database_name}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
 
 - Connect to the database; user will be prompted for password:
 
-`psql {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-W|--password]}} {{database}}`
+`psql {{database_name}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}} {{[-W|--password]}}`
 
 - Execute a single SQL query or PostgreSQL command on the given database (useful in shell scripts):
 
-`psql {{[-c|--command]}} '{{query}}' {{database}}`
+`psql {{database_name}} {{[-c|--command]}} '{{query}}'`
 
 - Execute commands from a file on the given database:
 
-`psql {{database}} {{[-f|--file]}} {{path/to/file.sql}}`
+`psql {{database_name}} {{[-f|--file]}} {{path/to/input_file.sql}}`

--- a/pages/common/reindexdb.md
+++ b/pages/common/reindexdb.md
@@ -9,7 +9,7 @@
 
 - Reindex a specific database using connection options:
 
-`reindexdb {{database_name}} {{[-h|--host]}} {{hostname}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
+`reindexdb {{database_name}} {{[-h|--host]}} {{host}} {{[-p|--port]}} {{port}} {{[-U|--username]}} {{username}}`
 
 - Reindex all databases:
 

--- a/pages/common/vacuumdb.md
+++ b/pages/common/vacuumdb.md
@@ -13,20 +13,20 @@
 
 - Vacuum a specific table in a database:
 
-`vacuumdb {{[-t|--table]}} {{table_name}} {{database_name}}`
+`vacuumdb {{database_name}} {{[-t|--table]}} {{table_name}}`
 
 - Vacuum and update statistics for the query planner:
 
-`vacuumdb {{[-z|--analyze]}} {{database_name}}`
+`vacuumdb {{database_name}} {{[-z|--analyze]}}`
 
 - Perform a full vacuum (more aggressive, locks tables, rewrites the whole table):
 
-`vacuumdb {{[-f|--full]}} {{database_name}}`
+`vacuumdb {{database_name}} {{[-f|--full]}}`
 
 - Vacuum with verbose output:
 
-`vacuumdb {{[-v|--verbose]}} {{database_name}}`
+`vacuumdb {{database_name}} {{[-v|--verbose]}}`
 
 - Vacuum a database using multiple parallel jobs:
 
-`vacuumdb --jobs {{number_of_jobs}} {{database_name}}`
+`vacuumdb {{database_name}} {{[-j|--jobs]}} {{number_of_jobs}}`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** PostgreSQL 18 / current documentation
- Reference issue: #18985
- Closes: #18985

### Additional details:

This performs the PostgreSQL-wide consistency pass requested in #18985 across 32 existing pages:

- standardizes database, host, connection-string, data-directory, backup, and input/output path placeholders;
- keeps repeated required arguments in stable positions so examples scan vertically;
- replaces equals-style option arguments with the preferred spaced form and adds supported short/long option pairs where missing.

Validation:

- `npm run lint-tldr-pages`
- `npm run lint-markdown`

The unchecked human-review item is intentionally left for the account owner to complete after reviewing the generated changes.