### PR TITLE
vagrant-{validate, version}, vainfo, valkey-cli, vcluster: add Korean translation

### DIFF
--- a/pages.ko/common/vagrant-validate.md
+++ b/pages.ko/common/vagrant-validate.md
@@ -1,0 +1,13 @@
+# vagrant validate
+
+> Vagrantfile의 유효성을 검사.
+> 관련 항목: `vagrant`, `vagrant box`, `vagrant plugin`.
+> 더 많은 정보: <https://developer.hashicorp.com/vagrant/docs/cli/validate>.
+
+- Vagrantfile의 구문과 구조가 올바르고 오류 없는지 검사:
+
+`vagrant validate`
+
+- 지정한 provider의 설정 옵션을 무시하며 Vagrantfile의 구조가 올바른지 검사:
+
+`vagrant validate {{[-p|--ignore-provider]}} {{docker|hypervlibvirt|parallels|qemu|virtualbox|vmware_desktop}}`

--- a/pages.ko/common/vagrant-version.md
+++ b/pages.ko/common/vagrant-version.md
@@ -1,0 +1,13 @@
+# vagrant version
+
+> Vagrant 버전 정보 표시.
+> 참고: vagrant version으로 사용 가능한 최신 버전 확인하려면 인터넷 연결이 필요.
+> 더 많은 정보: <https://developer.hashicorp.com/vagrant/docs/cli/version>.
+
+- 현재 설치된 Vagrant 버전과 사용 가능한 최신 버전 표시:
+
+`vagrant version`
+
+- 버전 정보 표시:
+
+`vagrant --version`

--- a/pages.ko/common/vainfo.md
+++ b/pages.ko/common/vainfo.md
@@ -1,0 +1,24 @@
+# vainfo
+
+> VA API 드라이버 정보 표시.
+> 더 많은 정보: <https://wiki.archlinux.org/title/Hardware_video_acceleration#Verifying_VA-API>.
+
+- 버전과 지원되는 entrypoint 표시:
+
+`vainfo`
+
+- 지정한 디스플레이 protocol 테스트:
+
+`vainfo --display {{wayland|x11|drm|...}}`
+
+- 사용 가능한 디스플레이 protocol 표시:
+
+`vainfo --display help`
+
+- 지원되는 entrypoint 표시:
+
+`vainfo {{[-a|--all]}}`
+
+- 도움말 표시:
+
+`vainfo --help`

--- a/pages.ko/common/valkey-cli.md
+++ b/pages.ko/common/valkey-cli.md
@@ -1,0 +1,32 @@
+# valkey-cli
+
+> Valkey 서버에 연결.
+> 더 많은 정보: <https://valkey.io/topics/cli/>.
+
+- 로컬 서버에 연결:
+
+`valkey-cli`
+
+- 기본 포트 (6379)를 사용하여 원격 서버에 연결:
+
+`valkey-cli -h {{호스트}}`
+
+- 포트 번호를 지정하여 원격 서버에 연결:
+
+`valkey-cli -h {{호스트}} -p {{포트}}`
+
+- URI를 지정하여 원격 서버에 연결:
+
+`valkey-cli -u {{uri}}`
+
+- 비밀번호 지정:
+
+`valkey-cli -a {{비밀번호}}`
+
+- valkey 명령 실행:
+
+`valkey-cli {{valkey_명령어}}`
+
+- 로컬 클러스터에 연결:
+
+`valkey-cli -c`

--- a/pages.ko/common/vcluster.md
+++ b/pages.ko/common/vcluster.md
@@ -1,0 +1,36 @@
+# vcluster
+
+> 네임스페이스 내에서 경량 가상 Kubernetes 클러스터를 생성하고 관리.
+> 더 많은 정보: <https://www.vcluster.com/docs/vcluster>.
+
+- 지정한 네임스페이스에 가상 클러스터 생성:
+
+`vcluster create {{vcluster_이름}} {{[-n|--namespace]}} {{네임스페이스}}`
+
+- 로컬 포트와 Insecure 모드를 사용하여 가상 클러스터에 연결:
+
+`vcluster connect {{vcluster_이름}} {{[-n|--namespace]}} {{네임스페이스}} --local-port {{port}} --insecure`
+
+- 모든 가상 클러스터 목록 표시:
+
+`vcluster list`
+
+- 가상 클러스터 삭제:
+
+`vcluster delete {{vcluster_이름}}`
+
+- 플랫폼에서 관리하는 가상 클러스터 목록 표시:
+
+`vcluster platform list`
+
+- 플랫폼에서 관리하는 가상 클러스터 생성:
+
+`vcluster platform create {{vcluster_이름}} {{[-n|--namespace]}} {{네임스페이스}}`
+
+- 플랫폼에서 관리하는 가상 클러스터에 연결:
+
+`vcluster platform connect {{vcluster_이름}} {{[-n|--namespace]}} {{네임스페이스}}`
+
+- 플랫폼에서 관리하는 가상 클러스터 삭제:
+
+`vcluster platform delete {{vcluster_이름}} {{[-n|--namespace]}} {{네임스페이스}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->
