### PR TITLE
logcat: expand pid name placeholder

### DIFF
--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -17,7 +17,7 @@
 
 - Display logs for a specific PID:
 
-`logcat --pid {{pid}}`
+`logcat --pid {{process_id}}`
 
 - Display logs for the process of a specific package:
 


### PR DESCRIPTION
## Summary

Closes #23812 — renames the `{{pid}}` placeholder to `{{process_id}}` on `pages/android/logcat.md`, following the naming sweep in #22636 and the pattern merged in #23799 (`osx/*`).

## Changes

- `pages/android/logcat.md`: 1 placeholder `{{pid}}` → `{{process_id}}`

## Validation

- [x] `tldr-lint pages/android/logcat.md` — clean

## Notes

CLA signed on #23817 (same account).