### PR TITLE
xmake: fix create options and split build/run examples

### DIFF
--- a/pages/common/xmake.md
+++ b/pages/common/xmake.md
@@ -3,13 +3,17 @@
 > A cross-platform C & C++ build utility based on Lua.
 > More information: <https://xmake.io/#/getting_started>.
 
-- Create an Xmake C project, consisting of a hello world and `xmake.lua`:
+- Create an Xmake project, consisting of a hello world and `xmake.lua`:
 
-`xmake create {{[-l|--language]}} {{[c|clean]}} {{[-P|--project]}} {{project_name}}`
+`xmake create {{[-l|--language]}} {{c|c++|go|rust|...}} {{[-P|--project]}} {{project_name}}`
 
-- Build and run an Xmake project:
+- Build an Xmake project:
 
-`xmake {{[b|build]}} {{[r|run]}}`
+`xmake {{[b|build]}}`
+
+- Build and run an Xmake project (builds first if needed):
+
+`xmake {{[r|run]}}`
 
 - Run a compiled Xmake target directly:
 


### PR DESCRIPTION
## Summary

Closes #23801.

Two problems reported there, both verified against the xmake source:

1. `xmake create` never accepted `clean` as a language — the `{{[c|clean]}}` placeholder was a typo. Valid `-l/--language` values are the template directories in xmake-io/xmake: `c`, `c++`, `csharp`, `cuda`, `dlang`, `fortran`, `go`, `kotlin`, `nim`, `objc`, `objc++`, `pascal`, `rust`, `swift`, `vala`, `zig` (`xmake/templates` on the `dev` branch; `xmake create -l` lists them). The example now shows `{{c|c++|go|rust|...}}`.
2. `xmake {{[b|build]}} {{[r|run]}}` chains two subcommands, which fails with `error: 'run' is not a valid target name for this project`. `build` and `run` are separate actions (`xmake/actions/build`, `xmake/actions/run`). Split into a build example and a run example; `xmake run` builds first when needed, and `xmake run {{target_name}}` keeps the run-a-specific-target case.

## Changes

- `pages/common/xmake.md`: fixed the `create` language placeholder, split the build/run example into three examples

## Validation

- [x] `tldr-lint pages/common/xmake.md` — clean
- [x] Language list verified against `xmake-io/xmake` `xmake/templates` directory (`dev` branch) and `xmake/actions/create/template.lua`
- [x] Subcommand split verified against `xmake/actions/build` and `xmake/actions/run`

## Notes

CLA signed on #23817 (same account).