### PR TITLE
mkfs.ext4, toolbox-init-container: expand gid and uid name placeholders

### DIFF
--- a/pages/linux/mkfs.ext4.md
+++ b/pages/linux/mkfs.ext4.md
@@ -13,4 +13,4 @@
 
 - Create an ext4 filesystem owned by a specific user and group:
 
-`sudo mkfs.ext4 -E root_owner={{uid}}:{{gid}} {{/dev/sdXY}}`
+`sudo mkfs.ext4 -E root_owner={{user_id}}:{{group_id}} {{/dev/sdXY}}`

--- a/pages/linux/toolbox-init-container.md
+++ b/pages/linux/toolbox-init-container.md
@@ -6,4 +6,4 @@
 
 - Initialize a running Toolbx container:
 
-`toolbox init-container --gid {{gid}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{uid}} --user {{user}}`
+`toolbox init-container --gid {{group_id}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{user_id}} --user {{user}}`


### PR DESCRIPTION
## Summary

Closes #23811 — renames `{{gid}}` → `{{group_id}}` and `{{uid}}` → `{{user_id}}` per the naming sweep in #22636 and the pattern merged in #23799 (`osx/*`).

## Changes

- `pages/linux/mkfs.ext4.md`: `-E root_owner={{uid}}:{{gid}}` → `-E root_owner={{user_id}}:{{group_id}}`
- `pages/linux/toolbox-init-container.md`: `--gid {{gid}}` / `--uid {{uid}}` → `--gid {{group_id}}` / `--uid {{user_id}}`

## Validation

- [x] `tldr-lint pages/linux/mkfs.ext4.md` — clean
- [x] `tldr-lint pages/linux/toolbox-init-container.md` — clean

## Notes

CLA signed on #23817 (same account).