### PR TITLE
ps, pv, dlv: expand pid name placeholders

### DIFF
--- a/pages/common/dlv.md
+++ b/pages/common/dlv.md
@@ -21,7 +21,7 @@
 
 - Attach to a running process and begin debugging:
 
-`dlv attach {{pid}}`
+`dlv attach {{process_id}}`
 
 - Compile and begin tracing a program:
 

--- a/pages/common/ps.md
+++ b/pages/common/ps.md
@@ -25,7 +25,7 @@
 
 - Get the parent PID of a process:
 
-`ps {{[-o|--format]}} ppid= {{[-p|--pid]}} {{pid}}`
+`ps {{[-o|--format]}} ppid= {{[-p|--pid]}} {{process_id}}`
 
 - Sort processes by memory consumption:
 

--- a/pages/common/pv.md
+++ b/pages/common/pv.md
@@ -17,7 +17,7 @@
 
 - Attach to an already running process and see its file reading progress:
 
-`pv {{[-d|--watchfd]}} {{pid}}`
+`pv {{[-d|--watchfd]}} {{process_id}}`
 
 - Read an erroneous file, skip errors as `dd conv=sync,noerror` would:
 


### PR DESCRIPTION
## Summary

Closes #23814 — renames `{{pid}}` → `{{process_id}}` on `pages/common/{ps,pv,dlv}.md`, following the naming sweep in #22636 and the pattern merged in #23799 (`osx/*`). (I read the issue title's "pib" as a typo for "pid" — all three pages only contain `{{pid}}`.)

## Changes

- `pages/common/ps.md`, `pages/common/pv.md`, `pages/common/dlv.md`: 1 occurrence each

## Validation

- [x] `tldr-lint pages/common/ps.md pages/common/pv.md pages/common/dlv.md` — clean (run per-file)

## Notes

CLA signed on #23817 (same account).