### PR TITLE
qm, pct: use vmid/ctid placeholders instead of bare 100

### DIFF
--- a/pages/linux/pct.md
+++ b/pages/linux/pct.md
@@ -9,28 +9,28 @@
 
 - Start/Stop/Reboot a specific container:
 
-`pct {{start|stop|reboot}} {{100}}`
+`pct {{start|stop|reboot}} {{ctid}}`
 
 - Access a specific container's shell:
 
-`pct {{[en|enter]}} {{100}}`
+`pct {{[en|enter]}} {{ctid}}`
 
 - Create a container from template with 4GB size:
 
-`pct {{[cr|create]}} {{100}} {{local:vztmpl/distro-name.tar.zst}} --rootfs {{local-lvm}}:4`
+`pct {{[cr|create]}} {{ctid}} {{local:vztmpl/distro-name.tar.zst}} --rootfs {{local-lvm}}:4`
 
 - Resize the container's disk to 20G:
 
-`pct {{[resi|resize]}} {{100}} {{rootfs|mpX}} {{20G}}`
+`pct {{[resi|resize]}} {{ctid}} {{rootfs|mpX}} {{20G}}`
 
 - Show the configuration of a container, specifying its ID:
 
-`pct {{[conf|config]}} {{100}}`
+`pct {{[conf|config]}} {{ctid}}`
 
 - Snapshot a specific container with description:
 
-`pct {{[sn|snapshot]}} {{100}} {{my-snapshot}} --description {{My snapshot description}}`
+`pct {{[sn|snapshot]}} {{ctid}} {{my-snapshot}} --description {{My snapshot description}}`
 
 - Destroy a container and remove all related resources:
 
-`pct {{[des|destroy]}} {{100}} --purge`
+`pct {{[des|destroy]}} {{ctid}} --purge`

--- a/pages/linux/qm.md
+++ b/pages/linux/qm.md
@@ -14,16 +14,16 @@
 
 - Show the configuration of a virtual machine, specifying its ID:
 
-`qm {{[co|config]}} {{100}}`
+`qm {{[co|config]}} {{vmid}}`
 
 - Start a specific virtual machine:
 
-`qm start {{100}}`
+`qm start {{vmid}}`
 
 - Send a shutdown request, then wait until the virtual machine is stopped:
 
-`qm {{[shu|shutdown]}} {{100}} && qm {{[w|wait]}} {{100}}`
+`qm {{[shu|shutdown]}} {{vmid}} && qm {{[w|wait]}} {{vmid}}`
 
 - Destroy a virtual machine and remove all related resources:
 
-`qm {{[des|destroy]}} {{100}} --purge`
+`qm {{[des|destroy]}} {{vmid}} --purge`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Proxmox VE (current)
- Reference issue: #22114
- Closes: #22200

### Additional details:

Fixes #22200 (follow-up to #22114): `{{100}}` on the `qm` and `pct` pages reads as a magic number — it is not obvious that readers should substitute their own guest ID there.

The repo already uses `{{vm_id}}` on the `vzdump` page and `{{vmid}}` on the `qm-remote-migrate` page, so this applies the same convention: `{{vmid}}` for `qm` (VMs) and `{{ctid}}` for `pct` (containers). The `qm create` example keeps its literal `100` since the prose above it already explains the ID.

Changes: `pages/linux/qm.md` (5 × `{{100}}` → `{{vmid}}`), `pages/linux/pct.md` (7 × `{{100}}` → `{{ctid}}`).

Validation: `tldr-lint pages/linux/qm.md` and `tldr-lint pages/linux/pct.md` — both clean.

CLA: signed via comment on the earlier attempt (#23817, auto-closed for a missing checklist before I saw the bot-prevention requirement).