### PR TITLE
logcat: expand pid name placeholder

### DIFF
--- a/pages/android/logcat.md
+++ b/pages/android/logcat.md
@@ -17,7 +17,7 @@
 
 - Display logs for a specific PID:
 
-`logcat --pid {{pid}}`
+`logcat --pid {{process_id}}`
 
 - Display logs for the process of a specific package:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** —
- Reference issue: #22636
- Closes: #23812

### Additional details:

Renames `{{pid}}` → `{{process_id}}` on `pages/android/logcat.md` (1 occurrence), following the naming sweep in #22636 and the pattern merged in #23799 (`osx/*`).

Validation: `tldr-lint pages/android/logcat.md` — clean.