### PR TITLE
mkfs.ext4, toolbox-init-container: expand gid and uid name placeholders

### DIFF
--- a/pages/linux/mkfs.ext4.md
+++ b/pages/linux/mkfs.ext4.md
@@ -13,4 +13,4 @@
 
 - Create an ext4 filesystem owned by a specific user and group:
 
-`sudo mkfs.ext4 -E root_owner={{uid}}:{{gid}} {{/dev/sdXY}}`
+`sudo mkfs.ext4 -E root_owner={{user_id}}:{{group_id}} {{/dev/sdXY}}`

--- a/pages/linux/toolbox-init-container.md
+++ b/pages/linux/toolbox-init-container.md
@@ -6,4 +6,4 @@
 
 - Initialize a running Toolbx container:
 
-`toolbox init-container --gid {{gid}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{uid}} --user {{user}}`
+`toolbox init-container --gid {{group_id}} --home {{home}} --home-link --media-link --mnt-link --monitor-host --shell {{shell}} --uid {{user_id}} --user {{user}}`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** —
- Reference issue: #22636
- Closes: #23811

### Additional details:

Renames `{{gid}}` → `{{group_id}}` and `{{uid}}` → `{{user_id}}` per the naming sweep in #22636 and the pattern merged in #23799 (`osx/*`).

- `pages/linux/mkfs.ext4.md`: `-E root_owner={{uid}}:{{gid}}` → `-E root_owner={{user_id}}:{{group_id}}`
- `pages/linux/toolbox-init-container.md`: `--gid {{gid}}` / `--uid {{uid}}` → `--gid {{group_id}}` / `--uid {{user_id}}`

Validation: `tldr-lint` on both pages — clean.