### PR TITLE
xmake: fix create options and split build/run examples

### DIFF
--- a/pages/common/xmake.md
+++ b/pages/common/xmake.md
@@ -3,13 +3,17 @@
 > A cross-platform C & C++ build utility based on Lua.
 > More information: <https://xmake.io/#/getting_started>.
 
-- Create an Xmake C project, consisting of a hello world and `xmake.lua`:
+- Create an Xmake project, consisting of a hello world and `xmake.lua`:
 
-`xmake create {{[-l|--language]}} {{[c|clean]}} {{[-P|--project]}} {{project_name}}`
+`xmake create {{[-l|--language]}} {{c|c++|go|rust|...}} {{[-P|--project]}} {{project_name}}`
 
-- Build and run an Xmake project:
+- Build an Xmake project:
 
-`xmake {{[b|build]}} {{[r|run]}}`
+`xmake {{[b|build]}}`
+
+- Build and run an Xmake project (builds first if needed):
+
+`xmake {{[r|run]}}`
 
 - Run a compiled Xmake target directly:
 


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** xmake (dev branch, current)
- Reference issue: #
- Closes: #23801

### Additional details:

Two problems reported in #23801, both verified against the xmake source:

1. `xmake create` never accepted `clean` as a language — the `{{[c|clean]}}` placeholder was a typo. Valid `-l/--language` values are the template directories in xmake-io/xmake: `c`, `c++`, `csharp`, `cuda`, `dlang`, `fortran`, `go`, `kotlin`, `nim`, `objc`, `objc++`, `pascal`, `rust`, `swift`, `vala`, `zig` (`xmake/templates` on the `dev` branch; `xmake create -l` lists them). The example now shows `{{c|c++|go|rust|...}}`.
2. `xmake {{[b|build]}} {{[r|run]}}` chains two subcommands, which fails with `error: 'run' is not a valid target name for this project`. `build` and `run` are separate actions (`xmake/actions/build`, `xmake/actions/run`). Split into a build example and a run example; `xmake run` builds first when needed, and `xmake run {{target_name}}` keeps the run-a-specific-target case.

Changes: `pages/common/xmake.md` (create placeholder fixed, build/run split into three examples).

Validation: `tldr-lint pages/common/xmake.md` — clean.