### PR TITLE
scripts/wrong-filename: ignore report inconsistent-filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__
 
 # Generated log
 debug.log
+
+# Generated filename consistency report
+inconsistent-filenames.txt


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:

add `inconsistent-filenames.txt` to `.gitignore`, next to the existing
entry for `debug.log` because `scripts/wrong-filename.py` writes to
`inconsistent-filenames.txt` in the repository root:

```python
OUTPUT_FILE = Path("inconsistent-filenames.txt")
```

**Verification**

You can check with these:

```console
$ git status --porcelain
$ python3 scripts/wrong-filename.py
$ git status --porcelain
?? inconsistent-filenames.txt
$ git check-ignore -v inconsistent-filenames.txt; echo "exit=$?"
exit=1
```
