### PR TITLE
git-status: add Japanese translation

### DIFF
--- a/pages.ja/common/git-status.md
+++ b/pages.ja/common/git-status.md
@@ -1,0 +1,33 @@
+# git status
+
+> Git リポジトリ内のファイルの変更状況を表示する。
+> 現在の `HEAD`、ステージング領域、作業ツリー、未追跡ファイルの状態を一覧表示する。
+> 詳細情報: <https://git-scm.com/docs/git-status>。
+
+- まだコミット対象に追加されていない変更済みファイルを表示する:
+
+`git status`
+
+- 短い形式で表示する:
+
+`git status {{[-s|--short]}}`
+
+- ステージング領域と作業ツリーの変更内容を詳細表示する:
+
+`git status {{[-vv|--verbose --verbose]}}`
+
+- ブランチと追跡情報を表示する:
+
+`git status {{[-b|--branch]}}`
+
+- 短い形式でブランチ情報を表示する:
+
+`git status {{[-sb|--short --branch]}}`
+
+- 現在スタッシュに保存されているエントリ数を表示する:
+
+`git status --show-stash`
+
+- 未追跡ファイルを表示しない:
+
+`git status {{[-uno|--untracked-files=no]}}`


### PR DESCRIPTION
Add Japanese translation for `git status`.

The examples follow the current English page.

<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A
- Reference issue: N/A

### Additional details:

N/A