### PR TITLE
clinfo: add page

### DIFF
--- a/pages/common/clinfo.md
+++ b/pages/common/clinfo.md
@@ -1,0 +1,28 @@
+# clinfo
+
+> Show OpenCL platforms and devices.
+> More information: <https://github.com/Oblomov/clinfo>.
+
+- Display information about all OpenCL platforms and devices:
+
+`clinfo`
+
+- List platforms and devices by name:
+
+`clinfo {{[-l|--list]}}`
+
+- Display information for a specific device:
+
+`clinfo {{[-d|--device]}} {{platform_index}}:{{device_index}}`
+
+- Display machine-friendly output:
+
+`clinfo --raw`
+
+- Include offline devices:
+
+`clinfo --offline`
+
+- Try to retrieve all properties, including unofficial ones:
+
+`clinfo {{[-a|--all-props]}}`

--- a/pages/common/clinfo.md
+++ b/pages/common/clinfo.md
@@ -1,7 +1,7 @@
 # clinfo
 
 > Show OpenCL platforms and devices.
-> More information: <https://github.com/Oblomov/clinfo>.
+> More information: <https://manned.org/man/clinfo>.
 
 - Display information about all OpenCL platforms and devices:
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** clinfo 3.0.25.02.14
- Reference issue: #23618
- Closes: #23618

### Additional details:

Adds `pages/common/clinfo.md` for the OpenCL enumerator requested in #23618.

Examples were checked against the upstream man page (`man1/clinfo.1` in Oblomov/clinfo): default listing, `--list`, `--device`, `--raw`, `--offline`, and `--all-props`. `--json` is omitted because the man page marks it experimental.

`tldr-lint` passed locally.

Made with [Cursor](https://cursor.com)