### PR TITLE
ocx: add page

### DIFF
--- a/pages/common/ocx.md
+++ b/pages/common/ocx.md
@@ -1,0 +1,32 @@
+# ocx
+
+> Manage opencodex, a local proxy that connects Codex to other model providers.
+> More information: <https://opencodex.me/reference/cli/>.
+
+- Set up providers and configure Codex interactively:
+
+`ocx setup`
+
+- Start the proxy and sync available models to Codex:
+
+`ocx start`
+
+- Start the proxy on a specific port:
+
+`ocx start --port {{8080}}`
+
+- Check whether the proxy is running:
+
+`ocx status`
+
+- Refresh provider models in the Codex configuration:
+
+`ocx sync`
+
+- Open the web dashboard:
+
+`ocx gui`
+
+- Stop the proxy and restore the native Codex configuration:
+
+`ocx stop`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** opencodex 2.45.0
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->

Add an English common-platform page for the ocx executable from @bitkyc08/opencodex (https://github.com/lidge-jun/opencodex). Examples cover setup, startup, a custom port, status, model sync, the dashboard, and restoring native Codex.

Checked against opencodex 2.45.0 top-level and subcommand help and https://opencodex.me/reference/cli/. No proxy lifecycle or configuration-changing examples were executed against the live installation.

The upstream repository was created on 2026-06-18 and has 13,781 stars as of 2026-09-07. Please consider this under the notable-project exception to the one-year maintenance guideline; eligibility is for maintainers to decide.

Validation: tldr-lint and markdownlint passed for this page. No existing page or matching open PR was found on 2026-09-07.

AI assistance: This draft was prepared with Codex. Mathias Jonsson reviewed and approved the page before submission.
