### PR TITLE
pw-link: fix Turkish translation

### DIFF
--- a/pages.tr/linux/pw-link.md
+++ b/pages.tr/linux/pw-link.md
@@ -11,7 +11,7 @@
 
 `pw-link {{çıktı_port_ismi}} {{girdi_port_ismi}}`
 
-- Disconnect two ports:
+- İki portun bağlantısını kesin:
 
 `pw-link {{[-d|--disconnect]}} {{çıktı_port_ismi}} {{girdi_port_ismi}}`
 


### PR DESCRIPTION
Since we don't have active turkish translators, I'll resort to doing a hackjob with machine translation.