### PR TITLE
git-{branch, merge, show}: fix inaccurate descriptions

### DIFF
--- a/pages/common/git-branch.md
+++ b/pages/common/git-branch.md
@@ -23,7 +23,7 @@
 
 `git branch {{branch_name}} {{commit_hash}}`
 
-- Rename a branch (you must switch to a different branch before doing this):
+- Rename a branch:
 
 `git branch {{[-m|--move]}} {{old_branch_name}} {{new_branch_name}}`
 

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -27,6 +27,6 @@
 
 `git fetch --deepen 2`
 
-- Fast-forward the local `main` branch, when it is not checked out, from the remote `main` branch:
+- Fast-forward a local `main` branch that is not checked out from the remote `main` branch (fails if the update is not a fast-forward):
 
 `git fetch {{origin}} main:main`

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -27,6 +27,6 @@
 
 `git fetch --deepen 2`
 
-- Fast-forward the local `main` branch to the remote `main` branch without checking it out:
+- Update the `main` branch without switching to it (equivalent to `git pull`):
 
 `git fetch {{origin}} main:main`

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -27,6 +27,6 @@
 
 `git fetch --deepen 2`
 
-- Update the `main` branch without switching to it (equivalent to `git pull`):
+- Fast-forward the local `main` branch, when it is not checked out, from the remote `main` branch:
 
 `git fetch {{origin}} main:main`

--- a/pages/common/git-fetch.md
+++ b/pages/common/git-fetch.md
@@ -27,6 +27,6 @@
 
 `git fetch --deepen 2`
 
-- Fast-forward a local `main` branch that is not checked out from the remote `main` branch (fails if the update is not a fast-forward):
+- Fast-forward the local `main` branch to the remote `main` branch without checking it out:
 
 `git fetch {{origin}} main:main`

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -15,7 +15,7 @@
 
 `git merge --no-ff {{branch_name}}`
 
-- Merge a branch into the current branch and stage the result without creating a commit (use `git commit` to create the commit):
+- Produce the working tree and index state that would result from merging a branch into the current branch, without creating a commit (use `git commit` to create the commit):
 
 `git merge --squash {{branch_name}}`
 

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -15,7 +15,7 @@
 
 `git merge --no-ff {{branch_name}}`
 
-- Produce the working tree and index state that would result from merging a branch into the current branch, without creating a commit (use `git commit` to create the commit):
+- Stage the result of merging a branch without creating a commit:
 
 `git merge --squash {{branch_name}}`
 

--- a/pages/common/git-merge.md
+++ b/pages/common/git-merge.md
@@ -15,7 +15,7 @@
 
 `git merge --no-ff {{branch_name}}`
 
-- Copy the state of a branch into the working tree and stage it (Note: Use `git commit` to create the actual commit):
+- Merge a branch into the current branch and stage the result without creating a commit (use `git commit` to create the commit):
 
 `git merge --squash {{branch_name}}`
 

--- a/pages/common/git-show.md
+++ b/pages/common/git-show.md
@@ -23,7 +23,7 @@
 
 `git show --oneline {{[-s|--no-patch]}} {{commit}}`
 
-- Show only statistics (added/removed characters) about the changed files:
+- Show diff statistics for changed files (such as lines added and removed):
 
 `git show --stat {{commit}}`
 


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** Current Git documentation
- Reference issue:
- Closes:

### Additional details

Correct three inaccurate descriptions while leaving the command examples unchanged:

- `git branch -m` can rename a branch without first switching to another branch.
- `git merge --squash` prepares the working tree and index as if a merge occurred, but does not create a commit.
- `git show --stat` reports line-based diff statistics and also displays commit information.

Verified the three pages with `tldr-lint`, `markdownlint`, and `git diff --check`.