### PR TITLE
linux/*: remove base command page from "See also"

### DIFF
--- a/pages/linux/dconf-read.md
+++ b/pages/linux/dconf-read.md
@@ -1,7 +1,6 @@
 # dconf read
 
 > Read key values from dconf databases.
-> See also: `dconf`.
 > More information: <https://manned.org/dconf>.
 
 - Print a specific key value:

--- a/pages/linux/dnf-builddep.md
+++ b/pages/linux/dnf-builddep.md
@@ -2,7 +2,6 @@
 
 > Install dependencies to build a given package.
 > Not default to `dnf` but supported via `dnf-plugins-core`.
-> See also: `dnf`.
 > More information: <https://dnf-plugins-core.readthedocs.io/en/latest/builddep.html>.
 
 - Install dependencies for a given package:

--- a/pages/linux/dnf-config-manager.md
+++ b/pages/linux/dnf-config-manager.md
@@ -2,7 +2,6 @@
 
 > Manage DNF configuration options and repositories on Fedora-based systems.
 > Not default to `dnf` but supported via `dnf-plugins-core`.
-> See also: `dnf`.
 > More information: <https://dnf-plugins-core.readthedocs.io/en/latest/config_manager.html>.
 
 - Add (and enable) a repository from a URL:

--- a/pages/linux/dnf-download.md
+++ b/pages/linux/dnf-download.md
@@ -2,7 +2,6 @@
 
 > Download RPM packages from the DNF repositories.
 > Not default to `dnf` but supported via `dnf-plugins-core`.
-> See also: `dnf`.
 > More information: <https://dnf-plugins-core.readthedocs.io/en/latest/download.html>.
 
 - Download the latest version of a package to the current directory:

--- a/pages/linux/pacman-database.md
+++ b/pages/linux/pacman-database.md
@@ -2,7 +2,6 @@
 
 > Operate on the Arch Linux package database.
 > Modify certain attributes of the installed packages.
-> See also: `pacman`.
 > More information: <https://manned.org/pacman.8>.
 
 - Mark a package as implicitly installed:

--- a/pages/linux/pacman-files.md
+++ b/pages/linux/pacman-files.md
@@ -1,7 +1,7 @@
 # pacman --files
 
 > Query the local files database.
-> See also: `pacman`, `pkgfile`.
+> See also: `pkgfile`.
 > More information: <https://manned.org/pacman.8>.
 
 - Update the package database:

--- a/pages/linux/pacman-query.md
+++ b/pages/linux/pacman-query.md
@@ -1,7 +1,6 @@
 # pacman --query
 
 > Query the local package database.
-> See also: `pacman`.
 > More information: <https://manned.org/pacman.8>.
 
 - [Q]uery the local package database and list installed packages and versions:

--- a/pages/linux/pacman-remove.md
+++ b/pages/linux/pacman-remove.md
@@ -1,7 +1,6 @@
 # pacman --remove
 
 > Remove packages from the system.
-> See also: `pacman`.
 > More information: <https://manned.org/pacman.8>.
 
 - [R]emove a package and its dependencies recur[s]ively:

--- a/pages/linux/pacman-upgrade.md
+++ b/pages/linux/pacman-upgrade.md
@@ -1,7 +1,6 @@
 # pacman --upgrade
 
 > Install packages manually from archive files.
-> See also: `pacman`.
 > More information: <https://manned.org/pacman.8>.
 
 - Install one or more packages from files:


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
<!-- If you have additional information that you need to give, write it under here. -->
