### PR TITLE
translation-templates/common-arguments: clarify Japanese path placeholders

### DIFF
--- a/contributing-guides/translation-templates/common-arguments.md
+++ b/contributing-guides/translation-templates/common-arguments.md
@@ -25,7 +25,7 @@ There, the old table can be **imported**, **edited** in a WYSIWYG editor and **e
 | hi    | फ़ाइल/का/पथ           | निर्देशिका/का/पथ         | फ़ाइल_या_निर्देशिका/का/पथ            | पैकेज         | उपयोगकर्ता_नाम     |                   |          |        |          |
 | id    | jalan/menuju/berkas   | jalan/menuju/direktori   | jalan/menuju/berkas_atau_direktori   | paket         | nama_pengguna      | kata_sandi        | perintah | port   | nilai    |
 | it    | percorso/del/file     | percorso/della/directory | percorso/del/file_o_directory        | pacchetto     | nome_utente        | password          | comando  | porta  | valore   |
-| ja    | パス/宛先/ファイル         | パス/宛先/ディレクトリ        | パス/宛先/ファイル_または_ディレクトリ         | パッケージ      | ユーザー名          | パスワード          | コマンド  | ポート  | 値        |
+| ja    | ディレクトリ/サブディレクトリ/ファイル         | ディレクトリ/サブディレクトリ        | ディレクトリ/サブディレクトリ/ファイル_または_ディレクトリ         | パッケージ      | ユーザー名          | パスワード          | コマンド  | ポート  | 値        |
 | ko    | 경로/대상/파일              | 경로/대상/폴더                 | 경로/대상/파일_또는_폴더                       | 패키지           | 사용자 명              | 비밀번호              | 명령어      | 포트     | 값        |
 | lo    |                       |                          |                                      |               |                    |                   |          |        |          |
 | ml    | ഫയലിലേക്കുള്ള/പാത     | ഡയറക്ടറിയിലേക്കുള്ള/പാത  | ഫയലിലേക്കോ_ഡയറക്ടറിയിലേക്കോ/ഉള്ള/പാത | പാക്കേജ്      | ഉപയോക്തൃനാമം       |                   |          |        |          |


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [X] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [X] The page description(s) have links to documentation or a homepage.
- [X] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [X] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [X] The PR contains at most 5 new pages.
- [X] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [X] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #
- Closes: #
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:
The current Japanese placeholders use `宛先`, which means “destination” or “recipient.” This can misleadingly suggest a delivery destination, even when the argument identifies an existing file to operate on, such as in `git add`.

Replace the Japanese path placeholders with explicit directory hierarchies:

- `path/to/file` → `ディレクトリ/サブディレクトリ/ファイル`
- `path/to/directory` → `ディレクトリ/サブディレクトリ`
- `path/to/file_or_directory` → `ディレクトリ/サブディレクトリ/ファイル_または_ディレクトリ`

These retain the required slash separators while avoiding an unnatural word-for-word translation of “to.”

This change was discussed and agreed upon in:
https://github.com/tldr-pages/tldr/pull/23906#discussion_r3988547896

Only the Japanese row in `common-arguments.md` is changed. The Git page translations are updated separately in #23906.
