### PR TITLE
nvm, nvm.sh: add disambiguation page

### DIFF
--- a/pages/common/nvm.md
+++ b/pages/common/nvm.md
@@ -1,38 +1,11 @@
 # nvm
 
-> Install, uninstall, or switch between Node.js versions.
-> Supports version numbers like "12.8" or "v16.13.1", and labels like "node", "system", etc.
-> See also: `asdf`.
-> More information: <https://github.com/nvm-sh/nvm#usage>.
+> `nvm` can refer to multiple commands with the same name.
 
-- Install/uninstall a specific version of Node.js:
+- View documentation for the Node.js version manager for POSIX-compliant shells:
 
-`nvm {{install|uninstall}} {{node_version}}`
+`tldr nvm.sh`
 
-- Use a specific version of Node.js in the current shell:
+- View documentation for the Node.js version manager for the fish shell:
 
-`nvm use {{node_version}}`
-
-- Set the default Node.js version:
-
-`nvm alias default {{node_version}}`
-
-- List remote versions available for install, only show LTS (long-term support) versions:
-
-`nvm ls-remote --lts`
-
-- List installed versions:
-
-`nvm {{[ls|list]}}`
-
-- Launch the REPL of a specific version of Node.js:
-
-`nvm run {{node_version}}`
-
-- Execute a script in a specific version of Node.js:
-
-`nvm exec {{node_version}} node {{path/to/script.js}}`
-
-- Upgrade to the latest working npm version on the current Node.js version:
-
-`nvm install-latest-npm`
+`tldr nvm.fish`

--- a/pages/common/nvm.sh.md
+++ b/pages/common/nvm.sh.md
@@ -1,0 +1,38 @@
+# nvm
+
+> Install, uninstall, or switch between Node.js versions.
+> Supports version numbers like "12.8" or "v16.13.1", and labels like "node", "system", etc.
+> See also: `asdf`.
+> More information: <https://github.com/nvm-sh/nvm#usage>.
+
+- Install/uninstall a specific version of Node.js:
+
+`nvm {{install|uninstall}} {{node_version}}`
+
+- Use a specific version of Node.js in the current shell:
+
+`nvm use {{node_version}}`
+
+- Set the default Node.js version:
+
+`nvm alias default {{node_version}}`
+
+- List remote versions available for install, only show LTS (long-term support) versions:
+
+`nvm ls-remote --lts`
+
+- List installed versions:
+
+`nvm {{[ls|list]}}`
+
+- Launch the REPL of a specific version of Node.js:
+
+`nvm run {{node_version}}`
+
+- Execute a script in a specific version of Node.js:
+
+`nvm exec {{node_version}} node {{path/to/script.js}}`
+
+- Upgrade to the latest working npm version on the current Node.js version:
+
+`nvm install-latest-npm`


### PR DESCRIPTION
<!--
Thank you for contributing!
Please fill in the following checklist.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md.

Sign the CLA before submitting a pull request and do not modify the PR checklist or it will be closed after some time.
https://cla-assistant.io/tldr-pages/tldr
-->

### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A
- Reference issue: #19142
- Closes: #19142
<!-- Only use "Closes:" if this PR fixes the entire issue. -->

### Additional details:

`pages/common/nvm.md` now follows the disambiguation format from the style guide (the same shape as `just`), and the existing content for <https://github.com/nvm-sh/nvm> moved unchanged to `pages/common/nvm.sh.md`. `pages/common/nvm.fish.md` is untouched.

Notes on the choices made:

- The suffix is `.sh` with a dot, as the style guide prescribes, rather than a dash: `nvm-sh` would be resolved by clients as the `nvm sh` subcommand.
- The page title in `nvm.sh.md` stays `# nvm`, consistent with `just.1.md` and `nvm.fish.md`.
- The disambiguation page has no "More information" link, matching the template in the style guide; the link is preserved in `nvm.sh.md`.
- `pages/windows/nvm.md` documents <https://github.com/coreybutler/nvm-windows> and lives on a different platform, so it is not part of this collision.
- Translations under `pages.*/common/nvm.md` are left untouched, as suggested in CONTRIBUTING. Happy to rename them to `nvm.sh.md` in this PR too if you prefer, but the translated disambiguation pages themselves are better left to native speakers.

Disclosure: this change was drafted with AI assistance and reviewed by me before submitting, per the AI-Assisted Development Policy.
<!-- If you have additional information that you need to give, write it under here. -->
