### PR TITLE
git-{update-ref, symbolic-ref, show-ref, check-ref-format, credential}: add Japanese translation

### DIFF
--- a/pages.ja/common/git-check-ref-format.md
+++ b/pages.ja/common/git-check-ref-format.md
@@ -1,0 +1,16 @@
+# git check-ref-format
+
+> 参照名が許容される形式か確認し、許容されない場合は0以外のステータスで終了する。
+> 詳細情報: <https://git-scm.com/docs/git-check-ref-format>。
+
+- 指定した参照名の形式を確認する:
+
+`git check-ref-format {{refs/head/refname}}`
+
+- 最後にチェックアウトしたブランチ名を出力する:
+
+`git check-ref-format --branch @{-1}`
+
+- 参照名を正規化する:
+
+`git check-ref-format --normalize {{refs/head/refname}}`

--- a/pages.ja/common/git-credential.md
+++ b/pages.ja/common/git-credential.md
@@ -1,0 +1,16 @@
+# git credential
+
+> ユーザー認証情報を取得・保存する。
+> 詳細情報: <https://git-scm.com/docs/git-credential>。
+
+- 設定ファイルからユーザー名とパスワードを取得して認証情報を表示する:
+
+`echo "{{url=http://example.com}}" | git credential fill`
+
+- 後で使うため、設定済みのすべての認証情報ヘルパーに認証情報を送って保存する:
+
+`echo "{{url=http://example.com}}" | git credential approve`
+
+- 指定した認証情報を、設定済みのすべての認証情報ヘルパーから削除する:
+
+`echo "{{url=http://example.com}}" | git credential reject`

--- a/pages.ja/common/git-show-ref.md
+++ b/pages.ja/common/git-show-ref.md
@@ -1,0 +1,20 @@
+# git show-ref
+
+> 参照を一覧表示するGitコマンド。
+> 詳細情報: <https://git-scm.com/docs/git-show-ref>。
+
+- リポジトリ内のすべての参照を表示する:
+
+`git show-ref`
+
+- ブランチ参照だけを表示する:
+
+`git show-ref --branches`
+
+- タグ参照だけを表示する:
+
+`git show-ref --tags`
+
+- 指定した参照が存在することを検証する:
+
+`git show-ref --verify {{ディレクトリ/サブディレクトリ/参照}}`

--- a/pages.ja/common/git-symbolic-ref.md
+++ b/pages.ja/common/git-symbolic-ref.md
@@ -1,0 +1,24 @@
+# git symbolic-ref
+
+> 参照を保存するファイルを読み取り、変更、削除する。
+> 詳細情報: <https://git-scm.com/docs/git-symbolic-ref>。
+
+- 名前を指定して参照を保存する:
+
+`git symbolic-ref refs/{{名前}} {{参照}}`
+
+- 更新理由のメッセージを含め、名前を指定して参照を保存する:
+
+`git symbolic-ref -m "{{メッセージ}}" refs/{{名前}} refs/heads/{{ブランチ名}}`
+
+- 名前を指定して参照を読み取る:
+
+`git symbolic-ref refs/{{名前}}`
+
+- 名前を指定して参照を削除する:
+
+`git symbolic-ref {{[-d|--delete]}} refs/{{名前}}`
+
+- スクリプト用に `--quiet` でエラーを隠し、`--short` で簡潔にする ("refs/heads/X" は "X" と表示される):
+
+`git symbolic-ref {{[-q|--quiet]}} --short refs/{{名前}}`

--- a/pages.ja/common/git-update-ref.md
+++ b/pages.ja/common/git-update-ref.md
@@ -1,0 +1,12 @@
+# git update-ref
+
+> Git参照の作成、更新、削除を行うGitコマンド。
+> 詳細情報: <https://git-scm.com/docs/git-update-ref>。
+
+- 参照を削除する (最初のコミットをソフトリセットする場合に便利):
+
+`git update-ref -d {{HEAD}}`
+
+- メッセージ付きで参照を更新する:
+
+`git update-ref -m {{メッセージ}} {{HEAD}} {{4e95e05}}`


### PR DESCRIPTION
### Checklist
- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** N/A, translations of existing pages
- Reference issue:
- Closes:

### Additional details:
I added Japanese translations for these Git pages:

- `git-update-ref`
- `git-symbolic-ref`
- `git-show-ref`
- `git-check-ref-format`
- `git-credential`

I tried to keep the wording consistent with the existing Japanese Git pages while staying close to the original English examples. This only adds pages under `pages.ja/common`; I did not change the English pages.
