### PR TITLE
add opi, and eza french traduction

### DIFF
--- a/pages.fr/common/eza.md
+++ b/pages.fr/common/eza.md
@@ -27,10 +27,6 @@
 
 `eza {{[-l|--long]}} {{[-s|--sort]}} {{modified}}`
 
-- Liste les fichiers avec une icône et affiche en premier les dossiers (on peut ajouter -l après le eza pour afficher en liste)
-
-`eza --icons --group-directories-first`
-
 - Liste les fichiers avec leurs en-têtes, leurs icônes et leur statut Git:
 
 `eza {{[-lh|--long --header]}} --icons --git`

--- a/pages.fr/common/eza.md
+++ b/pages.fr/common/eza.md
@@ -1,0 +1,40 @@
+# eza
+
+> Une alternative moderne et régulièrement mise à jour à `ls`, basée sur `exa`.
+> Plus d'informations : <https://github.com/eza-community/eza>.
+
+- Liste les fichiers, un par ligne :
+
+`eza {{[-1|--oneline]}}`
+
+- Liste tous les fichiers, ainsi que les fichiers cachés :
+
+`eza {{[-a|--all]}}`
+
+- Liste tous les fichiers avec un format détaillé (permissions, propriétaire, taille et date de modification)
+
+`eza {{[-al|--all --long]}}`
+
+- Liste les fichiers les plus lourds en premier:
+
+`eza {{[-r|--reverse]}} {{[-s|--sort]}} {{size}}`
+
+- Affichez un arbre de fichiers, sur trois niveaux de profondeur:
+
+`eza {{[-lT|--long --tree]}} {{[-L|--level]}} {{3}}`
+
+- Liste les fichiers par date de modification (les plus âgés en premier)):
+
+`eza {{[-l|--long]}} {{[-s|--sort]}} {{modified}}`
+
+- Liste les fichiers avec une icône et affiche en premier les dossiers (on peut ajouter -l après le eza pour afficher en liste)
+
+`eza --icons --group-directories-first`
+
+- Liste les fichiers avec leurs en-têtes, leurs icônes et leur statut Git:
+
+`eza {{[-lh|--long --header]}} --icons --git`
+
+- Ne liste pas les fichiers qui sont inscrits dans `.gitignore`:
+
+`eza --git-ignore`

--- a/pages.fr/linux/opi.md
+++ b/pages.fr/linux/opi.md
@@ -3,10 +3,10 @@
 > Recherche et installation de paquets à partir des dépôts openSUSE, communautaires et propriétaires
 > Plus d'informations : <https://github.com/openSUSE/opi>.
 
-- Rechercher un paquet 
+- Recherche un paquet 
 
 `opi {{keyword}}`
 
-- Installer les codecs multimédia
+- Installe les codecs multimédias
 
 `opi codecs`

--- a/pages.fr/linux/opi.md
+++ b/pages.fr/linux/opi.md
@@ -1,0 +1,12 @@
+#opi 
+
+> Recherche et installation de paquets à partir des dépôts openSUSE, communautaires et propriétaires
+> Plus d'informations : <https://github.com/openSUSE/opi>.
+
+- Rechercher un paquet 
+
+`opi {{keyword}}`
+
+- Installer les codecs multimédia
+
+`opi codecs`

--- a/pages.fr/linux/zypper.md
+++ b/pages.fr/linux/zypper.md
@@ -20,6 +20,10 @@
 
 `sudo zypper {{[up|update]}}`
 
+- Réaliser une mise à niveau de la distribution :
+
+`sudo zypper {{[dup|dist-upgrade]}}`
+
 - Cherche un paquet par mot clef :
 
 `zypper {{[se|search]}} {{mot_clef}}`

--- a/pages.fr/linux/zypper.md
+++ b/pages.fr/linux/zypper.md
@@ -20,7 +20,7 @@
 
 `sudo zypper {{[up|update]}}`
 
-- Réaliser une mise à niveau de la distribution :
+- Réalise une mise à niveau de la distribution :
 
 `sudo zypper {{[dup|dist-upgrade]}}`
 

--- a/pages/linux/opi.md
+++ b/pages/linux/opi.md
@@ -1,0 +1,12 @@
+#opi 
+
+> Searching for and installing packages from openSUSE, community, and proprietary repositories
+> More information: <https://github.com/openSUSE/opi>.
+
+- Search package 
+
+`opi {{keyword}}`
+
+- Install media codecs
+
+`opi codecs`


### PR DESCRIPTION
### Checklist

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR contains at most 5 new pages.
- [ ] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
- Reference issue: #

Adds page for:
- opi 
- eza french tranlation

add zypper dup command in french translation