### PR TITLE
git-pack-refs: add page

### DIFF
--- a/pages/common/git-pack-refs.md
+++ b/pages/common/git-pack-refs.md
@@ -1,0 +1,28 @@
+# git pack-refs
+
+> Pack heads and tags for efficient repository access.
+> More information: <https://git-scm.com/docs/git-pack-refs>.
+
+- Pack all tags and refs that are already packed, leaving other refs alone:
+
+`git pack-refs`
+
+- Pack all refs, including branch heads:
+
+`git pack-refs --all`
+
+- Pack all refs, without removing the loose refs afterward:
+
+`git pack-refs --all --no-prune`
+
+- Pack only refs matching a specific glob pattern:
+
+`git pack-refs --include {{glob_pattern}}`
+
+- Pack all refs except those matching a specific glob pattern:
+
+`git pack-refs --all --exclude {{glob_pattern}}`
+
+- Automatically pack refs as needed, based on the current state of the ref database:
+
+`git pack-refs --auto`


### PR DESCRIPTION
## What

Adds the tldr page for `git pack-refs`, one of the unclaimed subcommands tracked in #3953 (the "Let's document! Git edition" issue) — confirmed against the actual `pages/common/` directory that no page exists for it yet, and that no other open PR covers it.

## Testing

- Ran all six example commands against a real, throwaway git repository (with a branch and a tag) to confirm each one works exactly as documented: `git pack-refs`, `--all`, `--all --no-prune`, `--include <pattern>`, `--all --exclude <pattern>`, `--auto`.
- `npx tldr-lint pages/common/git-pack-refs.md` — passes.
- `npx markdownlint pages/common/git-pack-refs.md` — passes.
- `npm test` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)