### PR TITLE
git-interpret-trailers: add page

### DIFF
--- a/pages/common/git-interpret-trailers.md
+++ b/pages/common/git-interpret-trailers.md
@@ -1,0 +1,24 @@
+# git interpret-trailers
+
+> Add or parse structured trailer lines (like `Signed-off-by:` or `Reviewed-by:`) at the end of a commit message.
+> More information: <https://git-scm.com/docs/git-interpret-trailers>.
+
+- Add a trailer to a commit message file and print the result:
+
+`git interpret-trailers --trailer "{{key}}: {{value}}" {{path/to/file}}`
+
+- Add a trailer to a commit message file, modifying it in place:
+
+`git interpret-trailers --in-place --trailer "{{key}}: {{value}}" {{path/to/file}}`
+
+- Parse and print only the trailers already present in a commit message file:
+
+`git interpret-trailers --parse {{path/to/file}}`
+
+- Remove trailers that have an empty value from a commit message file:
+
+`git interpret-trailers --trim-empty {{path/to/file}}`
+
+- Add a trailer to the message of an existing commit, printing the result without modifying the commit:
+
+`git show --no-patch --format=%B {{commit_hash}} | git interpret-trailers --trailer "{{key}}: {{value}}"`


### PR DESCRIPTION
## What

Adds the tldr page for `git interpret-trailers`, another unclaimed subcommand tracked in #3953 — confirmed missing from `pages/common/` and not covered by any other open PR.

## Testing

Ran all five examples against real commit-message files / a real commit to confirm each works exactly as documented: adding a trailer (stdout and `--in-place`), `--parse`, `--trim-empty`, and piping `git show --format=%B` into it to add a trailer to an existing commit's message without modifying the commit.

- `npx tldr-lint pages/common/git-interpret-trailers.md` — passes.
- `npx markdownlint pages/common/git-interpret-trailers.md` — passes.
- `npm test` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)