### PR TITLE
git-prune-packed: add page

### DIFF
--- a/pages/common/git-prune-packed.md
+++ b/pages/common/git-prune-packed.md
@@ -1,0 +1,16 @@
+# git prune-packed
+
+> Remove loose objects that already exist in a pack file.
+> More information: <https://git-scm.com/docs/git-prune-packed>.
+
+- Remove all loose objects that are already packed:
+
+`git prune-packed`
+
+- Show which loose objects would be removed, without actually removing them:
+
+`git prune-packed --dry-run`
+
+- Remove loose objects that are already packed, without showing progress:
+
+`git prune-packed --quiet`


### PR DESCRIPTION
## What

Adds the tldr page for `git prune-packed`, another unclaimed subcommand tracked in #3953 — confirmed missing from `pages/common/` and not covered by any other open PR.

## Testing

Ran all three examples against a real git repository to confirm each works as documented: bare invocation, `--dry-run`, and `--quiet`.

- `npx tldr-lint pages/common/git-prune-packed.md` — passes.
- `npx markdownlint pages/common/git-prune-packed.md` — passes.
- `npm test` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)