### PR TITLE
docker-buildx-bake: add page

### DIFF
--- a/pages/common/docker-buildx-bake.md
+++ b/pages/common/docker-buildx-bake.md
@@ -1,0 +1,36 @@
+# docker buildx bake
+
+> Build images from a Bake file using the BuildKit engine.
+> More information: <https://docs.docker.com/reference/cli/docker/buildx/bake>.
+
+- Build all targets defined in the default Bake file in the current directory:
+
+`docker buildx bake`
+
+- Build specific targets:
+
+`docker buildx bake {{target1 target2 ...}}`
+
+- Build using a specific Bake file:
+
+`docker buildx bake {{[-f|--file]}} {{path/to/docker-bake.hcl}}`
+
+- Build and load the resulting images into `docker images`:
+
+`docker buildx bake --load`
+
+- Build and push the resulting images to a registry:
+
+`docker buildx bake --push`
+
+- Print the resulting build options without building:
+
+`docker buildx bake --print`
+
+- List the available targets or variables:
+
+`docker buildx bake --list {{targets|variables}}`
+
+- Display help:
+
+`docker buildx bake {{[-h|--help]}}`

--- a/pages/common/docker-buildx-build.md
+++ b/pages/common/docker-buildx-build.md
@@ -1,0 +1,36 @@
+# docker buildx build
+
+> Build an image from a Dockerfile using the BuildKit engine.
+> More information: <https://docs.docker.com/reference/cli/docker/buildx/build/>.
+
+- Build an image from the Dockerfile in the current directory:
+
+`docker buildx build .`
+
+- Build an image and tag it:
+
+`docker buildx build -t {{image:tag}} .`
+
+- Build an image using a specific Dockerfile:
+
+`docker buildx build {{[-f|--file]}} {{path/to/Dockerfile}} .`
+
+- Build an image passing build-time variables:
+
+`docker buildx build --build-arg {{HTTP_PROXY=http://proxy.example.com}} --build-arg {{VERSION=1.0}} .`
+
+- Build an image without using the build cache:
+
+`docker buildx build --no-cache .`
+
+- Build an image and load it into `docker images`:
+
+`docker buildx build --load -t {{image:tag}} .`
+
+- Build for multiple platforms and push to a registry:
+
+`docker buildx build --platform {{linux/amd64,linux/arm64}} --push -t {{registry.example.com/image:tag}} .`
+
+- Build a specific stage from a multi-stage Dockerfile:
+
+`docker buildx build --target {{stage_name}} -t {{image:tag}} .`

--- a/pages/common/docker-buildx-build.md
+++ b/pages/common/docker-buildx-build.md
@@ -1,7 +1,7 @@
 # docker buildx build
 
 > Build an image from a Dockerfile using the BuildKit engine.
-> More information: <https://docs.docker.com/reference/cli/docker/buildx/build/>.
+> More information: <https://docs.docker.com/reference/cli/docker/buildx/build>.
 
 - Build an image from the Dockerfile in the current directory:
 

--- a/pages/common/docker-buildx-build.md
+++ b/pages/common/docker-buildx-build.md
@@ -9,7 +9,7 @@
 
 - Build an image and tag it:
 
-`docker buildx build -t {{image:tag}} .`
+`docker buildx build {{[-t|--tag]}} {{image:tag}} .`
 
 - Build an image using a specific Dockerfile:
 
@@ -25,12 +25,12 @@
 
 - Build an image and load it into `docker images`:
 
-`docker buildx build --load -t {{image:tag}} .`
+`docker buildx build --load {{[-t|--tag]}} {{image:tag}} .`
 
 - Build for multiple platforms and push to a registry:
 
-`docker buildx build --platform {{linux/amd64,linux/arm64}} --push -t {{registry.example.com/image:tag}} .`
+`docker buildx build --platform {{linux/amd64,linux/arm64}} --push {{[-t|--tag]}} {{registry.example.com/image:tag}} .`
 
 - Build a specific stage from a multi-stage Dockerfile:
 
-`docker buildx build --target {{stage_name}} -t {{image:tag}} .`
+`docker buildx build --target {{stage_name}} {{[-t|--tag]}} {{image:tag}} .`


### PR DESCRIPTION
### Checklist

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [x] The PR contains at most 5 new pages.
- [x] The PR is authored by me, or has been human-reviewed if it was created with AI or machine translation software (see [AI-Assisted Development Policy](/tldr-pages/tldr/blob/main/contributing-guides/AI-policy.md)).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):** docker buildx v0.30
- Reference issue: #20946

### Additional details:

Adds a page for `docker buildx bake`, the high-level build command that builds multiple targets in parallel from an HCL, JSON or Compose Bake file.

Follows up on previously merged Buildx pages (`build`, `create`, `du`, `inspect`, `ls`, `prune`, `rm`, `stop`, `use`, `version`) tracked in #20946. This PR documents one subcommand only, so it references the issue rather than closing it.
